### PR TITLE
Declare empty Space credentials to unlock the project import

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,6 @@ kotlin.daemon.jvmargs=-Xmx4096M
 #Gradle
 org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8
 org.gradle.parallel=true
+
+spaceUsername=
+spacePassword=


### PR DESCRIPTION
Without Space credentials declared (empty username/password will work), it's impossible neither import a project, nor build it locally. That's a blocker for external contributors (and me as well :) ).

Later, we can consider updating the publishing plugin, to simply abstain from creating publishing tasks unless credentials were declared (that's how kotlinx-team-infra plugin works), but for now it should be enough to declare empty creds.