### PR TITLE
AIAgent: complete a deferred result on error

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/grazie/code/agents/core/AIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/grazie/code/agents/core/AIAgent.kt
@@ -83,6 +83,11 @@ abstract class AIAgent<TStrategy : AIAgentStrategy<TConfig>, TConfig : AIAgentCo
                 }
 
                 null -> {
+                    // If execution is stopped by an error (and we didn't throw an exception up to this point),
+                    // let's complete the deferred with null to unblock any awaiting coroutines.
+                    if (!agentResultDeferred.isCompleted) {
+                        agentResultDeferred.complete(null)
+                    }
                     logger.debug { "Agent execution completed. Stopping..." }
                     runningMutex.withLock {
                         isRunning = false


### PR DESCRIPTION
Fixed the issue with `AIAgent::runAndGetResult` hanging if an error occurred during agent execution. 
Also, updated a test to avoid a deadlock: by contract, event handler runs in the same coroutine context as the agent, and the test was sending a message into a rendezvous-channel on events. The channel was updated to be unlimited to avoid the deadlock.