### PR TITLE
Add tests for multi-LLM agents and direct OpenAI/Anthropic providers

### DIFF
--- a/prompt/prompt-executor/prompt-executor-llms-all/src/jvmTest/kotlin/ai/jetbrains/code/prompt/executor/llms/all/MultipleLLMPromptExecutorIntegrationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-llms-all/src/jvmTest/kotlin/ai/jetbrains/code/prompt/executor/llms/all/MultipleLLMPromptExecutorIntegrationTest.kt
@@ -1,48 +1,57 @@
 package ai.jetbrains.code.prompt.executor.llms.all
 
+import ai.grazie.code.agents.core.tools.ToolDescriptor
+import ai.grazie.code.agents.core.tools.ToolParameterDescriptor
+import ai.grazie.code.agents.core.tools.ToolParameterType
 import ai.jetbrains.code.prompt.dsl.Prompt
 import ai.jetbrains.code.prompt.executor.clients.anthropic.AnthropicModels
 import ai.jetbrains.code.prompt.executor.clients.anthropic.AnthropicDirectLLMClient
 import ai.jetbrains.code.prompt.executor.clients.openai.OpenAIModels
 import ai.jetbrains.code.prompt.executor.clients.openai.OpenAIDirectLLMClient
+import ai.jetbrains.code.prompt.executor.llms.MultiLLMPromptExecutor
+import ai.jetbrains.code.prompt.llm.LLMProvider
 import ai.jetbrains.code.prompt.message.Message
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
 class MultipleLLMPromptExecutorIntegrationTest {
 
     // API keys for testing
     private val openAIApiKey: String get() = readTestOpenAIKeyFromEnv()
     private val anthropicApiKey: String get() = readTestAnthropicKeyFromEnv()
-    
+
 
     @Test
     fun testExecuteWithOpenAI() = runTest {
         // TODO: pass the `OPEN_AI_API_TEST_KEY` and `ANTHROPIC_API_TEST_KEY`
         return@runTest
 
-        val openAIClient = OpenAIDirectLLMClient(openAIApiKey,)
+        val openAIClient = OpenAIDirectLLMClient(openAIApiKey)
         val anthropicClient = AnthropicDirectLLMClient(anthropicApiKey)
-        
+
         val executor = DefaultMultiLLMPromptExecutor(openAIClient, anthropicClient)
-        
+
         val prompt = Prompt.build(OpenAIModels.GPT4o, "test-prompt") {
             system("You are a helpful assistant.")
             user("What is the capital of France?")
         }
-        
+
         val response = executor.execute(prompt, emptyList())
-        
+
         assertNotNull(response, "Response should not be null")
         assertTrue(response.isNotEmpty(), "Response should not be empty")
         assertTrue(response.first() is Message.Assistant, "Response should be an Assistant message")
-        assertTrue((response.first() as Message.Assistant).content.contains("Paris", ignoreCase = true), 
-            "Response should contain 'Paris'")
+        assertTrue(
+            (response.first() as Message.Assistant).content.contains("Paris", ignoreCase = true),
+            "Response should contain 'Paris'"
+        )
     }
-    
+
     @Test
     fun testExecuteWithAnthropic() = runTest {
         // TODO: pass the `OPEN_AI_API_TEST_KEY` and `ANTHROPIC_API_TEST_KEY`
@@ -50,23 +59,25 @@ class MultipleLLMPromptExecutorIntegrationTest {
 
         val openAIClient = OpenAIDirectLLMClient(openAIApiKey)
         val anthropicClient = AnthropicDirectLLMClient(anthropicApiKey)
-        
+
         val executor = DefaultMultiLLMPromptExecutor(openAIClient, anthropicClient)
-        
+
         val prompt = Prompt.build(AnthropicModels.Sonnet_3_7, "test-prompt") {
             system("You are a helpful assistant.")
             user("What is the capital of France?")
         }
-        
+
         val response = executor.execute(prompt, emptyList())
-        
+
         assertNotNull(response, "Response should not be null")
         assertTrue(response.isNotEmpty(), "Response should not be empty")
         assertTrue(response.first() is Message.Assistant, "Response should be an Assistant message")
-        assertTrue((response.first() as Message.Assistant).content.contains("Paris", ignoreCase = true), 
-            "Response should contain 'Paris'")
+        assertTrue(
+            (response.first() as Message.Assistant).content.contains("Paris", ignoreCase = true),
+            "Response should contain 'Paris'"
+        )
     }
-    
+
     @Test
     fun testExecuteStreamingWithOpenAI() = runTest {
         // TODO: pass the `OPEN_AI_API_TEST_KEY` and `ANTHROPIC_API_TEST_KEY`
@@ -74,29 +85,31 @@ class MultipleLLMPromptExecutorIntegrationTest {
 
         val openAIClient = OpenAIDirectLLMClient(openAIApiKey)
         val anthropicClient = AnthropicDirectLLMClient(anthropicApiKey)
-        
+
         val executor = DefaultMultiLLMPromptExecutor(openAIClient, anthropicClient)
-        
+
         val prompt = Prompt.build(OpenAIModels.GPT4o, "test-streaming") {
             system("You are a helpful assistant.")
             user("Count from 1 to 5.")
         }
-        
+
         val responseChunks = executor.executeStreaming(prompt).toList()
-        
+
         assertNotNull(responseChunks, "Response chunks should not be null")
         assertTrue(responseChunks.isNotEmpty(), "Response chunks should not be empty")
-        
+
         // Combine all chunks to check the full response
         val fullResponse = responseChunks.joinToString("")
-        assertTrue(fullResponse.contains("1") && 
-                   fullResponse.contains("2") && 
-                   fullResponse.contains("3") && 
-                   fullResponse.contains("4") && 
-                   fullResponse.contains("5"), 
-            "Full response should contain numbers 1 through 5")
+        assertTrue(
+            fullResponse.contains("1") &&
+                    fullResponse.contains("2") &&
+                    fullResponse.contains("3") &&
+                    fullResponse.contains("4") &&
+                    fullResponse.contains("5"),
+            "Full response should contain numbers 1 through 5"
+        )
     }
-    
+
     @Test
     fun testExecuteStreamingWithAnthropic() = runTest {
         // TODO: pass the `OPEN_AI_API_TEST_KEY` and `ANTHROPIC_API_TEST_KEY`
@@ -104,29 +117,31 @@ class MultipleLLMPromptExecutorIntegrationTest {
 
         val openAIClient = OpenAIDirectLLMClient(openAIApiKey)
         val anthropicClient = AnthropicDirectLLMClient(anthropicApiKey)
-        
+
         val executor = DefaultMultiLLMPromptExecutor(openAIClient, anthropicClient)
-        
+
         val prompt = Prompt.build(AnthropicModels.Sonnet_3_7, "test-streaming") {
             system("You are a helpful assistant.")
             user("Count from 1 to 5.")
         }
-        
+
         val responseChunks = executor.executeStreaming(prompt).toList()
-        
+
         assertNotNull(responseChunks, "Response chunks should not be null")
         assertTrue(responseChunks.isNotEmpty(), "Response chunks should not be empty")
-        
+
         // Combine all chunks to check the full response
         val fullResponse = responseChunks.joinToString("")
-        assertTrue(fullResponse.contains("1") && 
-                   fullResponse.contains("2") && 
-                   fullResponse.contains("3") && 
-                   fullResponse.contains("4") && 
-                   fullResponse.contains("5"), 
-            "Full response should contain numbers 1 through 5")
+        assertTrue(
+            fullResponse.contains("1") &&
+                    fullResponse.contains("2") &&
+                    fullResponse.contains("3") &&
+                    fullResponse.contains("4") &&
+                    fullResponse.contains("5"),
+            "Full response should contain numbers 1 through 5"
+        )
     }
-    
+
     @Test
     fun testCodeGenerationWithOpenAI() = runTest {
         // TODO: pass the `OPEN_AI_API_TEST_KEY` and `ANTHROPIC_API_TEST_KEY`
@@ -134,25 +149,25 @@ class MultipleLLMPromptExecutorIntegrationTest {
 
         val openAIClient = OpenAIDirectLLMClient(openAIApiKey)
         val anthropicClient = AnthropicDirectLLMClient(anthropicApiKey)
-        
+
         val executor = DefaultMultiLLMPromptExecutor(openAIClient, anthropicClient)
-        
+
         val prompt = Prompt.build(OpenAIModels.GPT4o, "test-code") {
             system("You are a helpful coding assistant.")
             user("Write a simple Kotlin function to calculate the factorial of a number.")
         }
-        
+
         val response = executor.execute(prompt, emptyList())
-        
+
         assertNotNull(response, "Response should not be null")
         assertTrue(response.isNotEmpty(), "Response should not be empty")
         assertTrue(response.first() is Message.Assistant, "Response should be an Assistant message")
-        
+
         val content = (response.first() as Message.Assistant).content
         assertTrue(content.contains("fun factorial"), "Response should contain a factorial function")
         assertTrue(content.contains("return"), "Response should contain a return statement")
     }
-    
+
     @Test
     fun testCodeGenerationWithAnthropic() = runTest {
         // TODO: pass the `OPEN_AI_API_TEST_KEY` and `ANTHROPIC_API_TEST_KEY`
@@ -160,22 +175,425 @@ class MultipleLLMPromptExecutorIntegrationTest {
 
         val openAIClient = OpenAIDirectLLMClient(openAIApiKey)
         val anthropicClient = AnthropicDirectLLMClient(anthropicApiKey)
-        
+
         val executor = DefaultMultiLLMPromptExecutor(openAIClient, anthropicClient)
-        
+
         val prompt = Prompt.build(AnthropicModels.Sonnet_3_7, "test-code") {
             system("You are a helpful coding assistant.")
             user("Write a simple Kotlin function to calculate the factorial of a number.")
         }
-        
+
         val response = executor.execute(prompt, emptyList())
-        
+
         assertNotNull(response, "Response should not be null")
         assertTrue(response.isNotEmpty(), "Response should not be empty")
         assertTrue(response.first() is Message.Assistant, "Response should be an Assistant message")
-        
+
         val content = (response.first() as Message.Assistant).content
         assertTrue(content.contains("fun factorial"), "Response should contain a factorial function")
         assertTrue(content.contains("return"), "Response should contain a return statement")
+    }
+
+    @Disabled
+    @Test
+    fun `test execute tools with required parameters`() = runTest {
+        val openAIClient = OpenAIDirectLLMClient(openAIApiKey)
+        val anthropicClient = AnthropicDirectLLMClient(anthropicApiKey)
+
+        val calculatorTool = ToolDescriptor(
+            name = "calculator",
+            description = "A simple calculator that can add, subtract, multiply, and divide two numbers.",
+            requiredParameters = listOf(
+                ToolParameterDescriptor(
+                    name = "operation",
+                    description = "The operation to perform.",
+                    type = ToolParameterType.Enum(TestUtils.CalculatorOperation.entries.map { it.name }.toTypedArray())
+                ),
+                ToolParameterDescriptor(
+                    name = "a",
+                    description = "The first argument (number)",
+                    type = ToolParameterType.Integer
+                ),
+                ToolParameterDescriptor(
+                    name = "b",
+                    description = "The second argument (number)",
+                    type = ToolParameterType.Integer
+                )
+            )
+        )
+
+        val promptOpenAI = Prompt.build(OpenAIModels.GPT4oMini, "test-tools") {
+            system("You are a helpful assistant with access to a calculator tool.")
+            user("What is 123 + 456?")
+        }
+
+        val promptAnthropic = Prompt.build(AnthropicModels.Sonnet_3_7, "test-tools") {
+            system("You are a helpful assistant with access to a calculator tool.")
+            user("What is 123 + 456?")
+        }
+
+        val executor = MultiLLMPromptExecutor(
+            LLMProvider.OpenAI to openAIClient, LLMProvider.Anthropic to anthropicClient
+        )
+        val responseOpenAI = executor.execute(promptOpenAI, listOf(calculatorTool))
+        val responseAnthropic = executor.execute(promptAnthropic, listOf(calculatorTool))
+        assertTrue(responseOpenAI.isNotEmpty(), "Response should not be empty")
+        assertTrue(responseAnthropic.isNotEmpty(), "Response should not be empty")
+    }
+
+    @Disabled
+    @Test
+    fun `test execute tools with required and optional parameters`() = runTest {
+        val openAIClient = OpenAIDirectLLMClient(openAIApiKey)
+        val anthropicClient = AnthropicDirectLLMClient(anthropicApiKey)
+
+        val calculatorTool = ToolDescriptor(
+            name = "calculator",
+            description = "A simple calculator that can add, subtract, multiply, and divide two numbers.",
+            requiredParameters = listOf(
+                ToolParameterDescriptor(
+                    name = "operation",
+                    description = "The operation to perform.",
+                    type = ToolParameterType.Enum(TestUtils.CalculatorOperation.entries.map { it.name }.toTypedArray())
+                ),
+                ToolParameterDescriptor(
+                    name = "a",
+                    description = "The first argument (number)",
+                    type = ToolParameterType.Float
+                ),
+                ToolParameterDescriptor(
+                    name = "b",
+                    description = "The second argument (number)",
+                    type = ToolParameterType.Float
+                )
+            ),
+            optionalParameters = listOf(
+                ToolParameterDescriptor(
+                    name = "comment",
+                    description = "Comment to the result (string)",
+                    type = ToolParameterType.String
+                )
+            )
+        )
+
+        val promptOpenAI = Prompt.build(OpenAIModels.GPT4oMini, "test-tools") {
+            system("You are a helpful assistant with access to a calculator tool. ALWAYS CALL TOOL FIRST.")
+            user("What is 12,3 + 45,,6?")
+        }
+
+        val promptAnthropic = Prompt.build(AnthropicModels.Sonnet_3_7, "test-tools") {
+            system("You are a helpful assistant with access to a calculator tool. Don't use optional params if possible. ALWAYS CALL TOOL FIRST.")
+            user("What is 1 23 + 456,.1?")
+        }
+
+        val executor = MultiLLMPromptExecutor(
+            LLMProvider.OpenAI to openAIClient, LLMProvider.Anthropic to anthropicClient
+        )
+        val responseOpenAI = executor.execute(promptOpenAI, listOf(calculatorTool))
+        val responseAnthropic = executor.execute(promptAnthropic, listOf(calculatorTool))
+        assertTrue(responseOpenAI.isNotEmpty(), "Response should not be empty")
+        assertTrue(responseAnthropic.isNotEmpty(), "Response should not be empty")
+    }
+
+    @Disabled
+    @Test
+    fun `test execute tools with optional parameters`() = runTest {
+        val openAIClient = OpenAIDirectLLMClient(openAIApiKey)
+        val anthropicClient = AnthropicDirectLLMClient(anthropicApiKey)
+
+        val calculatorTool = ToolDescriptor(
+            name = "calculator",
+            description = "A simple calculator that can add, subtract, multiply, and divide two numbers.",
+            optionalParameters = listOf(
+                ToolParameterDescriptor(
+                    name = "operation",
+                    description = "The operation to perform.",
+                    type = ToolParameterType.Enum(TestUtils.CalculatorOperation.entries.map { it.name }.toTypedArray())
+                ),
+                ToolParameterDescriptor(
+                    name = "a",
+                    description = "The first argument (number)",
+                    type = ToolParameterType.Integer
+                ),
+                ToolParameterDescriptor(
+                    name = "b",
+                    description = "The second argument (number)",
+                    type = ToolParameterType.Integer
+                ),
+                ToolParameterDescriptor(
+                    name = "comment",
+                    description = "Comment to the result (string)",
+                    type = ToolParameterType.String
+                )
+            )
+        )
+
+        val promptOpenAI = Prompt.build(OpenAIModels.GPT4oMini, "test-tools") {
+            system("You are a helpful assistant with access to a calculator tool.")
+            user("What is 123 + 456?")
+        }
+
+        val promptAnthropic = Prompt.build(AnthropicModels.Sonnet_3_7, "test-tools") {
+            system("You are a helpful assistant with access to a calculator tool. Don't use optional params if possible.")
+            user("What is 123 + 456?")
+        }
+
+
+        val executor = MultiLLMPromptExecutor(
+            LLMProvider.OpenAI to openAIClient, LLMProvider.Anthropic to anthropicClient
+        )
+        val responseOpenAI = executor.execute(promptOpenAI, listOf(calculatorTool))
+        val responseAnthropic = executor.execute(promptAnthropic, listOf(calculatorTool))
+        assertTrue(responseOpenAI.isNotEmpty(), "Response should not be empty")
+        assertTrue(responseAnthropic.isNotEmpty(), "Response should not be empty")
+    }
+
+    @Disabled
+    @Test
+    fun `test execute tools with no parameters`() = runTest {
+        val openAIClient = OpenAIDirectLLMClient(openAIApiKey)
+        val anthropicClient = AnthropicDirectLLMClient(anthropicApiKey)
+
+        val calculatorTool = ToolDescriptor(
+            name = "calculator",
+            description = "A simple calculator that can add, subtract, multiply, and divide two numbers.",
+        )
+
+        val calculatorToolBetter = ToolDescriptor(
+            name = "calculatorBetter",
+            description = "A better calculator that can add, subtract, multiply, and divide two numbers.",
+            requiredParameters = emptyList(),
+            optionalParameters = emptyList()
+        )
+
+        val promptOpenAI = Prompt.build(OpenAIModels.GPT4oMini, "test-tools") {
+            system("You are a helpful assistant with access to calculator tools. Use the best one.")
+            user("What is 123 + 456?")
+        }
+
+        val promptAnthropic = Prompt.build(AnthropicModels.Sonnet_3_7, "test-tools") {
+            system("You are a helpful assistant with access to calculator tools. Use the best one.")
+            user("What is 123 + 456?")
+        }
+
+        val executor = MultiLLMPromptExecutor(
+            LLMProvider.OpenAI to openAIClient, LLMProvider.Anthropic to anthropicClient
+        )
+        val responseOpenAI = executor.execute(promptOpenAI, listOf(calculatorTool, calculatorToolBetter))
+        val responseAnthropic = executor.execute(promptAnthropic, listOf(calculatorTool, calculatorToolBetter))
+        assertTrue(responseOpenAI.isNotEmpty(), "Response should not be empty")
+        assertTrue(responseAnthropic.isNotEmpty(), "Response should not be empty")
+    }
+
+    @Disabled
+    @Test
+    fun `test execute tools with list enum parameter`() = runTest {
+        val openAIClient = OpenAIDirectLLMClient(openAIApiKey)
+        val anthropicClient = AnthropicDirectLLMClient(anthropicApiKey)
+
+        val colorPickerTool = ToolDescriptor(
+            name = "colorPicker",
+            description = "A tool that can randomly pick a color from a list of colors.",
+            requiredParameters = listOf(
+                ToolParameterDescriptor(
+                    name = "color",
+                    description = "The color to be picked.",
+                    type = ToolParameterType.List(ToolParameterType.Enum(TestUtils.Colors.entries.map { it.name }
+                        .toTypedArray()))
+                )
+            )
+        )
+
+        val promptOpenAI = Prompt.build(OpenAIModels.GPT4o, "test-tools") {
+            system("You are a helpful assistant with access to a color picker tool. ALWAYS CALL TOOL FIRST.")
+            user("Pick me a color!")
+        }
+
+        val promptAnthropic = Prompt.build(AnthropicModels.Sonnet_3_7, "test-tools") {
+            system("You are a helpful assistant with access to a color picker tool. ALWAYS CALL TOOL FIRST.")
+            user("Pick me a color!")
+        }
+
+        val executor = MultiLLMPromptExecutor(
+            LLMProvider.OpenAI to openAIClient, LLMProvider.Anthropic to anthropicClient
+        )
+        val responseOpenAI = executor.execute(promptOpenAI, listOf(colorPickerTool))
+        val responseAnthropic = executor.execute(promptAnthropic, listOf(colorPickerTool))
+
+        assertTrue(responseOpenAI.isNotEmpty(), "Response should not be empty")
+        assertTrue(responseAnthropic.isNotEmpty(), "Response should not be empty")
+    }
+
+    @Disabled
+    @Test
+    fun `test execute tools with list of lists parameter`() = runTest {
+        val openAIClient = OpenAIDirectLLMClient(openAIApiKey)
+        val anthropicClient = AnthropicDirectLLMClient(anthropicApiKey)
+
+        val lotteryPickerTool = ToolDescriptor(
+            name = "lotteryPicker",
+            description = "A tool that can randomly you some lottery winners and losers",
+            requiredParameters = listOf(
+                ToolParameterDescriptor(
+                    name = "Numbers",
+                    description = "A list of the numbers for lottery winners and losers from 1 to 100",
+                    type = ToolParameterType.List(ToolParameterType.List(ToolParameterType.Integer))
+                )
+            )
+        )
+
+        val promptOpenAI = Prompt.build(OpenAIModels.GPT4o, "test-tools") {
+            system("You are a helpful assistant. ALWAYS CALL TOOL FIRST.")
+            user("Pick me lottery winners and losers! 5 of each")
+        }
+
+        val promptAnthropic = Prompt.build(AnthropicModels.Sonnet_3_7, "test-tools") {
+            system("You are a helpful assistant. ALWAYS CALL TOOL FIRST.")
+            user("Pick me lottery winners and losers! 5 of each")
+        }
+
+        val executor = MultiLLMPromptExecutor(
+            LLMProvider.OpenAI to openAIClient, LLMProvider.Anthropic to anthropicClient
+        )
+        val responseOpenAI = executor.execute(promptOpenAI, listOf(lotteryPickerTool))
+        println(responseOpenAI)
+        val responseAnthropic = executor.execute(promptAnthropic, listOf(lotteryPickerTool))
+        println(responseAnthropic)
+
+        assertTrue(responseOpenAI.isNotEmpty(), "Response should not be empty")
+        assertTrue(responseAnthropic.isNotEmpty(), "Response should not be empty")
+    }
+
+    @Disabled
+    @Test
+    fun `test openai client with streaming API raw string`() = runTest(timeout = 600.seconds) {
+        val openAIClient = OpenAIDirectLLMClient(openAIApiKey)
+
+        val prompt = Prompt.build(OpenAIModels.GPT4o, "test-streaming") {
+            system("You are a helpful assistant. You have NO output length limitations.")
+            user("Please provide information about 200 countries.")
+        }
+
+        val responseChunks = mutableListOf<String>()
+        openAIClient.executeStreaming(prompt).collect { chunk ->
+            responseChunks.add(chunk)
+            println("Received chunk: $chunk")
+        }
+
+        assertTrue(responseChunks.isNotEmpty(), "Response chunks should not be empty")
+
+        val fullResponse = responseChunks.joinToString("")
+        assertTrue(
+            fullResponse.contains("1") &&
+                    fullResponse.contains("2") &&
+                    fullResponse.contains("3") &&
+                    fullResponse.contains("4") &&
+                    fullResponse.contains("5"),
+            "Full response should contain numbers 1 through 5"
+        )
+    }
+
+    @Disabled
+    @Test
+    fun `test anthropic client with streaming API raw string`() = runTest(timeout = 600.seconds) {
+        val anthropicClient = AnthropicDirectLLMClient(anthropicApiKey)
+
+        val prompt = Prompt.build(AnthropicModels.Sonnet_3_7, "test-streaming") {
+            system("You are a helpful assistant. You have NO output length limitations.")
+            user("Please provide information about 200 countries.")
+        }
+
+        val responseChunks = mutableListOf<String>()
+        anthropicClient.executeStreaming(prompt).collect { chunk ->
+            responseChunks.add(chunk)
+            println("Received chunk: $chunk")
+        }
+
+        assertTrue(responseChunks.isNotEmpty(), "Response chunks should not be empty")
+
+        val fullResponse = responseChunks.joinToString("")
+
+        assertTrue(
+            fullResponse.contains("1") &&
+                    fullResponse.contains("2") &&
+                    fullResponse.contains("3") &&
+                    fullResponse.contains("4") &&
+                    fullResponse.contains("5"),
+            "Full response should contain numbers 1 through 5"
+        )
+    }
+
+    @Disabled
+    @Test
+    fun `test openai client with streaming API structured data`() = runTest {
+        val openAIClient = OpenAIDirectLLMClient(openAIApiKey)
+        val countries = mutableListOf<TestUtils.Country>()
+        val countryDefinition = TestUtils().markdownCountryDefinition()
+
+        val prompt = Prompt.build(OpenAIModels.GPT4o, "test-structured-streaming") {
+            system("You are a helpful assistant.")
+            user(
+                """
+                Please provide information about 3 European countries in this format:
+
+                $countryDefinition
+
+                Make sure to follow this exact format with the # for country names and * for details.
+            """.trimIndent()
+            )
+        }
+
+        val markdownStream = openAIClient.executeStreaming(prompt)
+
+        TestUtils().parseMarkdownStreamToCountries(markdownStream).collect { country ->
+            countries.add(country)
+        }
+
+        assertTrue(countries.isNotEmpty(), "Countries list should not be empty")
+
+        countries.forEach { country ->
+            println("Country: ${country.name}")
+            println("  Capital: ${country.capital}")
+            println("  Population: ${country.population}")
+            println("  Language: ${country.language}")
+            println()
+        }
+    }
+
+    @Disabled
+    @Test
+    fun `test anthropic client with streaming API structured data`() = runTest {
+        val anthropicClient = AnthropicDirectLLMClient(anthropicApiKey)
+        val countries = mutableListOf<TestUtils.Country>()
+        val countryDefinition = TestUtils().markdownCountryDefinition()
+
+        val prompt = Prompt.build(AnthropicModels.Sonnet_3_7, "test-structured-streaming") {
+            system("You are a helpful assistant.")
+            user(
+                """
+                Please provide information about 30 European countries in this format:
+
+                $countryDefinition
+
+                Make sure to follow this exact format with the # for country names and * for details.
+            """.trimIndent()
+            )
+        }
+
+        val markdownStream = anthropicClient.executeStreaming(prompt)
+
+        TestUtils().parseMarkdownStreamToCountries(markdownStream).collect { country ->
+            countries.add(country)
+        }
+
+        assertTrue(countries.isNotEmpty(), "Countries list should not be empty")
+
+        countries.forEach { country ->
+            println("Country: ${country.name}")
+            println("  Capital: ${country.capital}")
+            println("  Population: ${country.population}")
+            println("  Language: ${country.language}")
+            println()
+        }
     }
 }

--- a/prompt/prompt-executor/prompt-executor-llms-all/src/jvmTest/kotlin/ai/jetbrains/code/prompt/executor/llms/all/TestUtils.kt
+++ b/prompt/prompt-executor/prompt-executor-llms-all/src/jvmTest/kotlin/ai/jetbrains/code/prompt/executor/llms/all/TestUtils.kt
@@ -1,0 +1,277 @@
+package ai.jetbrains.code.prompt.executor.llms.all
+
+import ai.grazie.code.agents.core.tools.SimpleTool
+import ai.grazie.code.agents.core.tools.Tool
+import ai.grazie.code.agents.core.tools.ToolDescriptor
+import ai.grazie.code.agents.core.tools.ToolParameterDescriptor
+import ai.grazie.code.agents.core.tools.ToolParameterType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.serialization.Serializable
+import kotlin.apply
+import kotlin.collections.dropLast
+import kotlin.collections.forEach
+import kotlin.collections.getOrNull
+import kotlin.collections.isNotEmpty
+import kotlin.collections.last
+import kotlin.collections.map
+import kotlin.collections.random
+import kotlin.collections.toTypedArray
+import kotlin.text.clear
+import kotlin.text.isNotEmpty
+import kotlin.text.split
+import kotlin.text.startsWith
+import kotlin.text.substring
+import kotlin.text.substringAfter
+import kotlin.text.trim
+import kotlin.text.trimIndent
+
+class TestUtils {
+    @Serializable
+    enum class CalculatorOperation {
+        ADD, SUBTRACT, MULTIPLY, DIVIDE
+    }
+
+    @Serializable
+    enum class Colors {
+        WHITE, BLACK, RED, ORANGE, YELLOW, GREEN, BLUE, INDIGO, VIOLET
+    }
+
+    @Serializable
+    data class CalculatorArgs(
+        val operation: CalculatorOperation,
+        val a: Int,
+        val b: Int
+    ) : Tool.Args
+
+    class CalculatorTool : SimpleTool<CalculatorArgs>() {
+        override val argsSerializer = CalculatorArgs.serializer()
+
+        val calculatorToolDescriptor = ToolDescriptor(
+            name = "calculator",
+            description = "A simple calculator that can add, subtract, multiply, and divide two numbers.",
+            requiredParameters = listOf(
+                ToolParameterDescriptor(
+                    name = "operation",
+                    description = "The operation to perform.",
+                    type = ToolParameterType.Enum(CalculatorOperation.entries.map { it.name }.toTypedArray())
+                ),
+                ToolParameterDescriptor(
+                    name = "a",
+                    description = "The first argument (number)",
+                    type = ToolParameterType.Integer
+                ),
+                ToolParameterDescriptor(
+                    name = "b",
+                    description = "The second argument (number)",
+                    type = ToolParameterType.Integer
+                )
+            )
+        )
+
+        override val descriptor = calculatorToolDescriptor
+
+        override suspend fun doExecute(args: CalculatorArgs): String {
+            return when (args.operation) {
+                CalculatorOperation.ADD -> (args.a + args.b).toString()
+                CalculatorOperation.SUBTRACT -> (args.a - args.b).toString()
+                CalculatorOperation.MULTIPLY -> (args.a * args.b).toString()
+                CalculatorOperation.DIVIDE -> {
+                    if (args.b == 0) {
+                        "Error: Division by zero"
+                    } else {
+                        (args.a / args.b).toString()
+                    }
+                }
+            }
+        }
+    }
+
+    @Serializable
+    data class ColorPickerArgs(
+        val color: List<String>
+    ) : Tool.Args
+
+    class ColorPickerTool : SimpleTool<ColorPickerArgs>() {
+        override val argsSerializer = ColorPickerArgs.serializer()
+
+        val colorPickerToolDescriptor = ToolDescriptor(
+            name = "colorPicker",
+            description = "A tool that can randomly pick a color from a list of colors.",
+            requiredParameters = listOf(
+                ToolParameterDescriptor(
+                    name = "color",
+                    description = "The color to be picked.",
+                    type = ToolParameterType.List(ToolParameterType.Enum(Colors.entries.map { it.name }.toTypedArray()))
+                )
+            )
+        )
+
+        override val descriptor = colorPickerToolDescriptor
+
+        override suspend fun doExecute(args: ColorPickerArgs): String {
+            return if (args.color.isEmpty()) {
+                "No colors provided to pick from"
+            } else {
+                val selectedColor = args.color.random()
+                "Selected color: $selectedColor"
+            }
+        }
+    }
+
+    class SummaryTool : SimpleTool<Tool.EmptyArgs>() {
+        override val argsSerializer = EmptyArgs.serializer()
+
+        override val descriptor = ToolDescriptor(
+            name = "summary",
+            description = "A tool that summarizes the results of previous operations."
+        )
+
+        override suspend fun doExecute(args: EmptyArgs): String {
+            return "Summary of previous operations"
+        }
+    }
+
+    @Serializable
+    data class Country(
+        val name: String,
+        val capital: String,
+        val population: String,
+        val language: String
+    )
+
+    fun markdownCountryDefinition(): String {
+        return """
+            # Country Name
+            * Capital: [capital city]
+            * Population: [approximate population]
+            * Language: [official language]
+        """.trimIndent()
+    }
+
+    fun markdownStreamingParser(block: MarkdownParserBuilder.() -> Unit): MarkdownParser {
+        val builder = MarkdownParserBuilder().apply(block)
+        return builder.build()
+    }
+
+    class MarkdownParserBuilder {
+        private var headerHandler: ((String) -> Unit)? = null
+        private var bulletHandler: ((String) -> Unit)? = null
+        private var finishHandler: (() -> Unit)? = null
+
+        fun onHeader(level: Int, handler: (String) -> Unit) {
+            headerHandler = handler
+        }
+
+        fun onBullet(handler: (String) -> Unit) {
+            bulletHandler = handler
+        }
+
+        fun onFinishStream(handler: () -> Unit) {
+            finishHandler = handler
+        }
+
+        fun build(): MarkdownParser {
+            return MarkdownParser(headerHandler, bulletHandler, finishHandler)
+        }
+    }
+
+    class MarkdownParser(
+        private val headerHandler: ((String) -> Unit)?,
+        private val bulletHandler: ((String) -> Unit)?,
+        private val finishHandler: (() -> Unit)?
+    ) {
+        suspend fun parseStream(stream: Flow<String>) {
+            val buffer = kotlin.text.StringBuilder()
+
+            stream.collect { chunk ->
+                buffer.append(chunk)
+                processBuffer(buffer)
+            }
+
+            processBuffer(buffer, isEnd = true)
+
+            finishHandler?.invoke()
+        }
+
+        private fun processBuffer(buffer: StringBuilder, isEnd: Boolean = false) {
+            val text = buffer.toString()
+            val lines = text.split("\n")
+
+            val completeLines = lines.dropLast(1)
+
+            for (line in completeLines) {
+                val trimmedLine = line.trim()
+
+                if (trimmedLine.startsWith("# ")) {
+                    val headerText = trimmedLine.substring(2).trim()
+                    headerHandler?.invoke(headerText)
+                } else if (trimmedLine.startsWith("* ")) {
+                    val bulletText = trimmedLine.substring(2).trim()
+                    bulletHandler?.invoke(bulletText)
+                }
+            }
+
+            if (completeLines.isNotEmpty()) {
+                buffer.clear()
+                buffer.append(lines.last())
+            }
+
+            if (isEnd) {
+                val lastLine = buffer.toString().trim()
+                if (lastLine.isNotEmpty()) {
+                    if (lastLine.startsWith("# ")) {
+                        val headerText = lastLine.substring(2).trim()
+                        headerHandler?.invoke(headerText)
+                    } else if (lastLine.startsWith("* ")) {
+                        val bulletText = lastLine.substring(2).trim()
+                        bulletHandler?.invoke(bulletText)
+                    }
+                }
+                buffer.clear()
+            }
+
+        }
+    }
+
+    fun parseMarkdownStreamToCountries(markdownStream: Flow<String>): Flow<Country> {
+        return flow {
+            val countries = mutableListOf<Country>()
+            var currentCountryName = ""
+            val bulletPoints = mutableListOf<String>()
+
+            val parser = markdownStreamingParser {
+                onHeader(1) { headerText ->
+                    if (currentCountryName.isNotEmpty() && bulletPoints.size >= 3) {
+                        val capital = bulletPoints.getOrNull(0)?.substringAfter("Capital: ")?.trim() ?: ""
+                        val population = bulletPoints.getOrNull(1)?.substringAfter("Population: ")?.trim() ?: ""
+                        val language = bulletPoints.getOrNull(2)?.substringAfter("Language: ")?.trim() ?: ""
+                        val country = Country(currentCountryName, capital, population, language)
+                        countries.add(country)
+                    }
+
+                    currentCountryName = headerText
+                    bulletPoints.clear()
+                }
+
+                onBullet { bulletText ->
+                    bulletPoints.add(bulletText)
+                }
+
+                onFinishStream {
+                    if (currentCountryName.isNotEmpty() && bulletPoints.size >= 3) {
+                        val capital = bulletPoints.getOrNull(0)?.substringAfter("Capital: ")?.trim() ?: ""
+                        val population = bulletPoints.getOrNull(1)?.substringAfter("Population: ")?.trim() ?: ""
+                        val language = bulletPoints.getOrNull(2)?.substringAfter("Language: ")?.trim() ?: ""
+                        val country = Country(currentCountryName, capital, population, language)
+                        countries.add(country)
+                    }
+                }
+            }
+
+            parser.parseStream(markdownStream)
+
+            countries.forEach { emit(it) }
+        }
+    }
+}


### PR DESCRIPTION
I added the code of part of the tests that I performed manually to verify direct OpenAI / Anthropic providers work. I didn't add all of them to avoid code duplication: in most scenarios, I just tweaked executors, added printing out the execution results, or modified prompts/strategies.

Also, all new tests are marked as @Disabled right now, because apparently the API tokens are not passed to the code. I'd also argue the necessity of running all of them without mocks in the future.

Anyways, right now it's a kind of saving the artifacts of performed checks. The test code was written by me (but, sure, partially copied from the files in the same module); the tools and parsers were created using Junie (but I did my best to review them).

Original PR: https://github.com/JetBrains/code-engine/pull/512