### PR TITLE
Update maven publishing configuration

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -69,10 +69,6 @@ jobs:
         uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
       - name: JvmTest with Gradle Wrapper
-        env:
-          JB_SPACE_CLIENT_ID: ${{ secrets.JB_SPACE_CLIENT_ID }}
-          JB_SPACE_CLIENT_SECRET: ${{ secrets.JB_SPACE_CLIENT_SECRET }}
-          USER_STGN_JWT_TOKEN: ${{ secrets.USER_STGN_JWT_TOKEN }}
         run: ./gradlew jvmTest --continue
 
       - name: Collect reports

--- a/agents/agents-core/build.gradle.kts
+++ b/agents/agents-core/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.agents"
 version = rootProject.version

--- a/agents/agents-features/agents-features-common/build.gradle.kts
+++ b/agents/agents-features/agents-features-common/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.agents"
 version = rootProject.version

--- a/agents/agents-features/agents-features-event-handler/build.gradle.kts
+++ b/agents/agents-features/agents-features-event-handler/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.agents"
 version = rootProject.version

--- a/agents/agents-features/agents-features-memory/build.gradle.kts
+++ b/agents/agents-features/agents-features-memory/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.agents"
 version = rootProject.version

--- a/agents/agents-features/agents-features-trace/build.gradle.kts
+++ b/agents/agents-features/agents-features-trace/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.agents"
 version = rootProject.version

--- a/agents/agents-mcp/build.gradle.kts
+++ b/agents/agents-mcp/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.agents"
 version = rootProject.version

--- a/agents/agents-test/build.gradle.kts
+++ b/agents/agents-test/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.agents"
 version = rootProject.version

--- a/agents/agents-tools/build.gradle.kts
+++ b/agents/agents-tools/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.agents"
 version = rootProject.version

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,14 +67,6 @@ subprojects {
             showExceptions = true
             exceptionFormat = FULL
         }
-        environment.putAll(
-            mapOf(
-                "USER_STGN_JWT_TOKEN" to
-                        (project.properties["grazieUserStgnToken"] ?: System.getenv("USER_STGN_JWT_TOKEN")),
-                "JB_SPACE_CLIENT_ID" to Secrets.Space.Maven.username(project),
-                "JB_SPACE_CLIENT_SECRET" to Secrets.Space.Maven.password(project),
-            )
-        )
     }
 }
 

--- a/buildSrc/src/main/kotlin/ai.kotlin.jvm.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/ai.kotlin.jvm.publish.gradle.kts
@@ -1,3 +1,5 @@
+import ai.grazie.gradle.publish.maven.configureJvmJarManifest
+
 plugins {
     kotlin("jvm")
     `maven-publish`
@@ -14,3 +16,5 @@ publishing {
         }
     }
 }
+
+configureJvmJarManifest("jar")

--- a/buildSrc/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
@@ -1,4 +1,5 @@
 //import ai.grazie.gradle.tests.setupKarmaConfigs
+import ai.grazie.gradle.publish.maven.configureJvmJarManifest
 import ai.grazie.gradle.tests.configureTests
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
@@ -22,6 +23,8 @@ kotlin {
         configureTests()
     }
 }
+
+configureJvmJarManifest("jvmJar")
 
 //setupKarmaConfigs()
 

--- a/buildSrc/src/main/kotlin/ai/grazie/gradle/publish/maven/JvmConfig.kt
+++ b/buildSrc/src/main/kotlin/ai/grazie/gradle/publish/maven/JvmConfig.kt
@@ -1,0 +1,20 @@
+package ai.grazie.gradle.publish.maven
+
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.jvm.tasks.Jar
+import org.gradle.kotlin.dsl.attributes
+
+internal fun Project.configureJvmJarManifest(taskName: String) {
+    tasks.named(taskName, Jar::class.java) {
+        manifest(
+            Action {
+                attributes(
+                    "Implementation-Title" to project.name,
+                    "Implementation-Version" to project.version,
+                    "Automatic-Module-Name" to project.name.replace("-", ".") + ".jvm",
+                )
+            }
+        )
+    }
+}

--- a/buildSrc/src/main/kotlin/ai/grazie/gradle/publish/maven/Publishing.kt
+++ b/buildSrc/src/main/kotlin/ai/grazie/gradle/publish/maven/Publishing.kt
@@ -1,0 +1,110 @@
+package ai.grazie.gradle.publish.maven
+
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import java.net.URL
+
+
+object Publishing {
+    fun Project.publishToGraziePublicMaven() {
+        publishTo({
+            it.graziePublic(project)
+        }) {
+            it.publications(
+                Action {
+                    val publications = this
+
+                    publications.forEach {
+                        val p = it as MavenPublication
+                        p.pom(
+                            Action {
+                                val pom = this
+
+                                pom.name.set(this@publishToGraziePublicMaven.name)
+                                pom.description.set("Koog is a framework for quickly creating AI agents in Kotlin with minimal effort.")
+                                pom.url.set("https://github.com/JetBrains/koog-agents")
+
+                                pom.licenses(
+                                    Action {
+                                        val licenses = this
+
+                                        licenses.license(
+                                            Action {
+                                                val license = this
+
+                                                license.name.set("The Apache License, Version 2.0")
+                                                license.url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                                            }
+                                        )
+                                    }
+                                )
+
+                                pom.developers(
+                                    Action {
+                                        val developers = this
+
+                                        developers.developer(
+                                            Action {
+                                                val developer = this
+
+                                                developer.id.set("JetBrains")
+                                                developer.name.set("JetBrains Team")
+                                                developer.organization.set("JetBrains")
+                                                developer.organizationUrl.set("https://www.jetbrains.com")
+                                            }
+                                        )
+                                    }
+                                )
+
+                                pom.scm(
+                                    Action {
+                                        val scm = this
+                                        scm.url.set("https://github.com/JetBrains/koog-agents.git")
+                                    }
+                                )
+                            }
+                        )
+                    }
+                }
+            )
+        }
+    }
+
+    private fun Project.publishTo(
+        configureRepository: (RepositoryHandler) -> Unit,
+        configurePublish: (PublishingExtension) -> Unit = {}
+    ) {
+        pluginManager.apply("maven-publish")
+
+        extensions.configure<PublishingExtension>("publishing") {
+            repositories(Action { configureRepository(this) })
+            configurePublish(this)
+        }
+    }
+
+    private fun RepositoryHandler.graziePublic(project: Project) {
+        maven(
+            Action {
+                val repo = this
+
+                repo.name = "GraziePublicMaven"
+                repo.url = URL("https://packages.jetbrains.team/maven/p/grazi/grazie-platform-public").toURI()
+
+                repo.credentials(
+                    Action {
+                        val cred = this
+
+                        cred.username = project.properties["spaceUsername"]?.toString()
+                            ?: System.getenv("JB_SPACE_CLIENT_ID")
+
+                        cred.password = project.properties["spacePassword"]?.toString()
+                            ?: System.getenv("JB_SPACE_CLIENT_SECRET")
+                    }
+                )
+            }
+        )
+    }
+}

--- a/embeddings/embeddings-base/build.gradle.kts
+++ b/embeddings/embeddings-base/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.embeddings"
 version = rootProject.version

--- a/embeddings/embeddings-llm-remote/build.gradle.kts
+++ b/embeddings/embeddings-llm-remote/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.embeddings"
 version = rootProject.version

--- a/embeddings/embeddings-local/build.gradle.kts
+++ b/embeddings/embeddings-local/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.embeddings"
 version = rootProject.version

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,8 +6,5 @@ kotlin.daemon.jvmargs=-Xmx4096M
 org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 
-spaceUsername=
-spacePassword=
-
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/prompt/prompt-cache/prompt-cache-files/build.gradle.kts
+++ b/prompt/prompt-cache/prompt-cache-files/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.prompt.cache"
 version = rootProject.version

--- a/prompt/prompt-cache/prompt-cache-model/build.gradle.kts
+++ b/prompt/prompt-cache/prompt-cache-model/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.prompt.cache"
 version = rootProject.version

--- a/prompt/prompt-cache/prompt-cache-redis/build.gradle.kts
+++ b/prompt/prompt-cache/prompt-cache-redis/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.prompt.cache"
 version = rootProject.version

--- a/prompt/prompt-executor/prompt-executor-cached/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-cached/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.prompt"
 version = rootProject.version

--- a/prompt/prompt-executor/prompt-executor-clients/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.prompt"
 version = rootProject.version

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.prompt"
 version = rootProject.version

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.prompt"
 version = rootProject.version

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.prompt"
 version = rootProject.version

--- a/prompt/prompt-executor/prompt-executor-llms-all/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-llms-all/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.prompt"
 version = rootProject.version

--- a/prompt/prompt-executor/prompt-executor-llms/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-llms/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.prompt"
 version = rootProject.version

--- a/prompt/prompt-executor/prompt-executor-model/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-model/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.prompt"
 version = rootProject.version

--- a/prompt/prompt-executor/prompt-executor-ollama/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-ollama/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.prompt"
 version = rootProject.version

--- a/prompt/prompt-llm/build.gradle.kts
+++ b/prompt/prompt-llm/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.prompt"
 version = rootProject.version

--- a/prompt/prompt-markdown/build.gradle.kts
+++ b/prompt/prompt-markdown/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.prompt"
 version = rootProject.version

--- a/prompt/prompt-model/build.gradle.kts
+++ b/prompt/prompt-model/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.prompt"
 version = rootProject.version

--- a/prompt/prompt-structure/build.gradle.kts
+++ b/prompt/prompt-structure/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 import org.gradle.kotlin.dsl.project
 
 group = "${rootProject.group}.prompt"

--- a/prompt/prompt-xml/build.gradle.kts
+++ b/prompt/prompt-xml/build.gradle.kts
@@ -1,4 +1,4 @@
-import ai.grazie.gradle.publish.maven.publishToGraziePublicMaven
+import ai.grazie.gradle.publish.maven.Publishing.publishToGraziePublicMaven
 
 group = "${rootProject.group}.prompt"
 version = rootProject.version


### PR DESCRIPTION
`spaceUsername` and `spacePassword` are no longer required. POM files are adjusted to the current repository, no longer inheriting the grazie platform data.