### PR TITLE
Fix compilation errors in OllamaIntegrationTest

### DIFF
--- a/prompt/prompt-executor/prompt-executor-ollama/src/jvmTest/kotlin/ai/jetbrains/code/prompt/executor/ollama/OllamaIntegrationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-ollama/src/jvmTest/kotlin/ai/jetbrains/code/prompt/executor/ollama/OllamaIntegrationTest.kt
@@ -12,7 +12,7 @@ import ai.grazie.code.agents.core.dsl.extension.onAssistantMessage
 import ai.grazie.code.agents.core.dsl.extension.onToolCall
 import ai.grazie.code.agents.core.tools.ToolRegistry
 import ai.grazie.code.agents.core.tools.tools.ToolStage
-import ai.grazie.code.agents.local.features.eventHandler.feature.EventHandlerFeature
+import ai.grazie.code.agents.local.features.eventHandler.feature.EventHandler
 import ai.jetbrains.code.prompt.dsl.prompt
 import ai.jetbrains.code.prompt.executor.ollama.client.OllamaClient
 import ai.jetbrains.code.prompt.llm.OllamaModels
@@ -113,7 +113,7 @@ class OllamaIntegrationTest {
             agentConfig = LocalAgentConfig(prompt("test-ollama") {}, model, 15),
             toolRegistry = toolRegistry
         ) {
-            install(EventHandlerFeature) {
+            install(EventHandler) {
                 onToolCall = { stage, tool, arguments ->
                     println(
                         "[$stage] Calling tool ${tool.name} with arguments ${


### PR DESCRIPTION
Caused by clash of changes because of EventHandler refactoring