### PR TITLE
JBAI-14066 Remove deprecated gemini-pro-vision model

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleModels.kt
@@ -185,16 +185,6 @@ public object GoogleModels {
     )
 
     /**
-     * Gemini Pro Vision is the multimodal version of the Gemini 1.0 Pro model.
-     * Capable of processing both text and images.
-     */
-    public val GeminiProVision: LLModel = LLModel(
-        provider = LLMProvider.Google,
-        id = "gemini-pro-vision",
-        capabilities = multimodalCapabilities
-    )
-
-    /**
      * Gemini 2.5 Pro Preview 05-06 is one of the Gemini 2.5 Pro preview versions.
      * It offers advanced capabilities for complex tasks.
      */


### PR DESCRIPTION
- remove the deprecated pro-vision model
- check the other models: only Gemini 1.0 Pro Vision is marked as deprecated 

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog-agents/blob/main/CONTRIBUTING.md) before opening the pull request
- [ ] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed
