### PR TITLE
Skip Gemini2_5FlashPreview0417 in integration tests

### DIFF
--- a/integration-tests/src/jvmTest/kotlin/ai/jetbrains/code/integration/tests/MultipleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/jetbrains/code/integration/tests/MultipleLLMPromptExecutorIntegrationTest.kt
@@ -10,6 +10,7 @@ import ai.koog.agents.core.tools.ToolParameterType
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
 import ai.koog.prompt.executor.clients.google.GoogleLLMClient
+import ai.koog.prompt.executor.clients.google.GoogleModels
 import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
 import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.executor.llms.all.DefaultMultiLLMPromptExecutor
@@ -374,6 +375,9 @@ class MultipleLLMPromptExecutorIntegrationTest {
     @ParameterizedTest
     @MethodSource("openAIModels", "anthropicModels", "googleModels")
     fun integration_testRawStringStreaming(model: LLModel) = runTest(timeout = 600.seconds) {
+        // skip until JBAI-14082 is fixed
+        assumeTrue { model != GoogleModels.Gemini2_5FlashPreview0417 }
+
         val prompt = Prompt.build("test-streaming") {
             system("You are a helpful assistant. You have NO output length limitations.")
             user("Count from 1 to 5.")


### PR DESCRIPTION
Temporarily exclude the GoogleModels.Gemini2_5FlashPreview0417 model from the `integration_testRawStringStreaming` test due to an unresolved issue (JBAI-14082).

Thank you for opening a pull request! Please add a brief description of the proposed change here.

Also, please tick the appropriate points in the checklist below.


---

#### Type of the change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [ ] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog-agents/blob/main/CONTRIBUTING.md) before opening the pull request
- [ ] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
