### PR TITLE
Workaround the stale badge being cached

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![JetBrains incubator project](https://jb.gg/badges/incubator.svg)](https://github.com/JetBrains#jetbrains-on-github)
 [![Kotlin](https://img.shields.io/badge/kotlin-2.1-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![CI status](https://img.shields.io/github/checks-status/JetBrains/koog/main)](https://github.com/JetBrains/koog/actions?query=branch%3Amain)
-[![GitHub license](https://img.shields.io/github/license/JetBrains/koog)](LICENSE.txt)
+[![GitHub license](https://img.shields.io/github/license/JetBrains/koog?)](LICENSE.txt)
 [![docs](https://img.shields.io/badge/documentation-blue)](https://docs.koog.ai)
 [![Slack channel](https://img.shields.io/badge/chat-slack-green.svg?logo=slack)](https://kotlinlang.slack.com/messages/koog-agentic-framework/)
 <!-- TODO: maven central link -->


### PR DESCRIPTION
Shields IO caches badges for some time, so I tweaked the badge URL to get an up-to-date picture.
---

#### Type of the change
- [ ] New feature
- [ ] Bug fix
- [x] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

