### PR TITLE
Add SLF4J Simple logger to tests

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ logback = "1.5.13"
 oshai-logging = "7.0.7"
 mockk = "1.13.8"
 shadow = "8.1.1"
+slf4j = "2.0.17"
 mcp = "0.5.0"
 dokka = "2.0.0"
 jetsign = "45.47"
@@ -43,6 +44,7 @@ oshai-kotlin-logging = { module = "io.github.oshai:kotlin-logging", version.ref 
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 mcp = { module = "io.modelcontextprotocol:kotlin-sdk", version.ref = "mcp" }
+slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 jetsign-gradle-plugin = { module = "com.jetbrains:jet-sign", version.ref = "jetsign" }
 testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
 

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
                 implementation("org.junit.jupiter:junit-jupiter-params:5.9.2")
                 implementation(libs.kotlinx.coroutines.test)
                 implementation(libs.ktor.client.content.negotiation)
+                runtimeOnly(libs.slf4j.simple)
             }
         }
     }

--- a/integration-tests/src/jvmTest/resources/simplelogger.properties
+++ b/integration-tests/src/jvmTest/resources/simplelogger.properties
@@ -1,0 +1,14 @@
+# Level of logging for the ROOT logger: ERROR, WARN, INFO, DEBUG, TRACE (default is INFO)
+org.slf4j.simpleLogger.defaultLogLevel=DEBUG
+
+# Log level for specific packages or classes (optional)
+org.slf4j.simpleLogger.log.ai.koog=TRACE
+
+# Whether to display the thread name in log messages (true/false)
+org.slf4j.simpleLogger.showThreadName=true
+
+# Display the date and time in log messages (true/false)
+org.slf4j.simpleLogger.showDateTime=false
+
+# Whether to enable stack traces for exceptions (true/false, default is true)
+org.slf4j.simpleLogger.showShortLogName=false

--- a/prompt/prompt-executor/prompt-executor-llms-all/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-llms-all/build.gradle.kts
@@ -44,6 +44,7 @@ kotlin {
         jvmTest {
             dependencies {
                 implementation(kotlin("test-junit5"))
+                runtimeOnly(libs.slf4j.simple)
             }
         }
     }

--- a/prompt/prompt-executor/prompt-executor-llms-all/src/jvmTest/resources/simplelogger.properties
+++ b/prompt/prompt-executor/prompt-executor-llms-all/src/jvmTest/resources/simplelogger.properties
@@ -1,0 +1,14 @@
+# Level of logging for the ROOT logger: ERROR, WARN, INFO, DEBUG, TRACE (default is INFO)
+org.slf4j.simpleLogger.defaultLogLevel=DEBUG
+
+# Log level for specific packages or classes (optional)
+org.slf4j.simpleLogger.log.ai.koog=TRACE
+
+# Whether to display the thread name in log messages (true/false)
+org.slf4j.simpleLogger.showThreadName=true
+
+# Display the date and time in log messages (true/false)
+org.slf4j.simpleLogger.showDateTime=false
+
+# Whether to enable stack traces for exceptions (true/false, default is true)
+org.slf4j.simpleLogger.showShortLogName=false


### PR DESCRIPTION
# Add SLF4J Simple logger to tests

- Added SLF4J Simple as a test runtime dependency in relevant Gradle modules with jvmTests sourceSets.
- Included default `simplelogger.properties` with custom log level and formatting settings for testing environments.

---

#### Type of the change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
