### PR TITLE
Add new LLM configurations for Groq, Meta, and Alibaba

### DIFF
--- a/prompt/prompt-llm/src/commonMain/kotlin/ai/koog/prompt/llm/OllamaModels.kt
+++ b/prompt/prompt-llm/src/commonMain/kotlin/ai/koog/prompt/llm/OllamaModels.kt
@@ -6,11 +6,63 @@ package ai.koog.prompt.llm
  */
 public object OllamaModels {
     /**
+     *  The Groq object represents the configuration for the Groq large language model (LLM).
+     *  It contains the predefined model specifications for Groq's LLMs, including their identifiers
+     *  and supported capabilities.
+     */
+    public object Groq {
+        /**
+         * Represents the LLAMA version 3.0 model provided by Groq.
+         *
+         * This variable defines an instance of the `LLModel` class with the Ollama provider, a unique identifier "llama3",
+         * and a set of capabilities. The supported capabilities include:
+         *  - Temperature adjustment.
+         *  - JSON Schema-based tasks (Not very clear).
+         *  - Tool utilization.
+         *
+         * LLAMA 3 is designed to support these specified features, enabling developers to utilize the model for tasks
+         * that require dynamic behavior adjustments, schema adherence, and tool-based interactions.
+         */
+        public val LLAMA_3_GROK_TOOL_USE: LLModel = LLModel(
+            provider = LLMProvider.Ollama,
+            id = "llama3-groq-tool-use:latest",
+            capabilities = listOf(
+                LLMCapability.Temperature,
+                LLMCapability.Schema.JSON.Full,
+                LLMCapability.Tools
+            )
+        )
+    }
+
+
+    /**
      * The `Meta` object represents the configuration for the Meta large language models (LLMs).
      * It contains the predefined model specifications for Meta's LLMs, including their identifiers
      * and supported capabilities.
      */
     public object Meta {
+        /**
+         * Represents the LLAMA version 3.2.3b model provided by Meta.
+         *
+         * This variable defines an instance of the `LLModel` class with the Ollama provider, a unique identifier "llama3.2:3b",
+         * and a set of capabilities. The supported capabilities include:
+         *  - Temperature adjustment.
+         *  - JSON Schema-based tasks (Simple Schema).
+         *  - Tool utilization.
+         *
+         * LLAMA 3.2.3b is designed to support these specified features, enabling developers to utilize the model for tasks
+         * that require dynamic behavior adjustments, schema adherence, and tool-based interactions.
+         */
+        public val LLAMA_3_2_3B: LLModel = LLModel(
+            provider = LLMProvider.Ollama,
+            id = "llama3.2:3b",
+            capabilities = listOf(
+                LLMCapability.Temperature,
+                LLMCapability.Schema.JSON.Simple,
+                LLMCapability.Tools
+            )
+        )
+
         /**
          * Represents the LLAMA version 3.2 model provided by Meta.
          *
@@ -58,6 +110,46 @@ public object OllamaModels {
      * These models are configured with Ollama as the provider and are characterized by their unique capabilities.
      */
     public object Alibaba {
+        /**
+         * Represents the Qwen-2.5 model with 0.5 billion parameters.
+         *
+         * This predefined instance of `LLModel` is provided by Alibaba and supports the following capabilities:
+         * - `Temperature`: Allows adjustment of the temperature setting for controlling the randomness in responses.
+         * - `Schema.JSON.Simple`: Supports tasks requiring JSON schema validation and handling in a simplified manner.
+         * - `Tools`: Enables interaction with external tools or functionalities within the model's ecosystem.
+         *
+         * The model is identified by the unique ID "qwen2.5:0.5b" and categorized under the Ollama provider.
+         */
+        public val QWEN_2_5_05B: LLModel = LLModel(
+            provider = LLMProvider.Ollama,
+            id = "qwen2.5:0.5b",
+            capabilities = listOf(
+                LLMCapability.Temperature,
+                LLMCapability.Schema.JSON.Simple,
+                LLMCapability.Tools
+            )
+        )
+
+        /**
+         * Represents the Qwen-3.06b model with 0.6 billion parameters.
+         *
+         * This predefined instance of `LLModel` is provided by Alibaba and supports the following capabilities:
+         * - `Temperature`: Allows adjustment of the temperature setting for controlling the randomness in responses.
+         * - `Schema.JSON.Simple`: Supports tasks requiring JSON schema validation and handling in a simplified manner.
+         * - `Tools`: Enables interaction with external tools or functionalities within the model's ecosystem.
+         *
+         * The model is identified by the unique ID "qwen3:0.6b" and categorized under the Ollama provider.
+         */
+        public val QWEN_3_06B: LLModel = LLModel(
+            provider = LLMProvider.Ollama,
+            id = "qwen3:0.6b",
+            capabilities = listOf(
+                LLMCapability.Temperature,
+                LLMCapability.Schema.JSON.Simple,
+                LLMCapability.Tools
+            )
+        )
+
         /**
          * Represents the `QWQ` language model instance provided by Alibaba with specific capabilities.
          *

--- a/prompt/prompt-llm/src/commonMain/kotlin/ai/koog/prompt/llm/OllamaModels.kt
+++ b/prompt/prompt-llm/src/commonMain/kotlin/ai/koog/prompt/llm/OllamaModels.kt
@@ -12,7 +12,7 @@ public object OllamaModels {
      */
     public object Groq {
         /**
-         * Represents the LLAMA version 3.0 model provided by Groq.
+         * Represents the LLAMA version 3.0 model provided by Groq with 8B parameters.
          *
          * This variable defines an instance of the `LLModel` class with the Ollama provider, a unique identifier "llama3",
          * and a set of capabilities. The supported capabilities include:
@@ -23,9 +23,31 @@ public object OllamaModels {
          * LLAMA 3 is designed to support these specified features, enabling developers to utilize the model for tasks
          * that require dynamic behavior adjustments, schema adherence, and tool-based interactions.
          */
-        public val LLAMA_3_GROK_TOOL_USE: LLModel = LLModel(
+        public val LLAMA_3_GROK_TOOL_USE_8B: LLModel = LLModel(
             provider = LLMProvider.Ollama,
-            id = "llama3-groq-tool-use:latest",
+            id = "llama3-groq-tool-use:8b",
+            capabilities = listOf(
+                LLMCapability.Temperature,
+                LLMCapability.Schema.JSON.Full,
+                LLMCapability.Tools
+            )
+        )
+
+        /**
+         * Represents the LLAMA version 3.0 model provided by Groq with 70B parameters.
+         *
+         * This variable defines an instance of the `LLModel` class with the Ollama provider, a unique identifier "llama3",
+         * and a set of capabilities. The supported capabilities include:
+         *  - Temperature adjustment.
+         *  - JSON Schema-based tasks (Not very clear).
+         *  - Tool utilization.
+         *
+         * LLAMA 3 is designed to support these specified features, enabling developers to utilize the model for tasks
+         * that require dynamic behavior adjustments, schema adherence, and tool-based interactions.
+         */
+        public val LLAMA_3_GROK_TOOL_USE_70B: LLModel = LLModel(
+            provider = LLMProvider.Ollama,
+            id = "llama3-groq-tool-use:70b",
             capabilities = listOf(
                 LLMCapability.Temperature,
                 LLMCapability.Schema.JSON.Full,


### PR DESCRIPTION
Added new predefined models LLAMA_3_GROK_TOOL_USE, LLAMA_3_2_3B (not sure if the LLAMA_3_2 is the 3B params), QWEN_2_5_05B, and QWEN_3_06B under their respective providers. All models with capabilities such as temperature adjustment, simplified and full JSON schema support (even if the Grok model was not clear about it), and tool utilization.

I opened the issue here: https://github.com/JetBrains/koog/issues/154
---

#### Type of the change
- [X] New feature
- [ ] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [X] The pull request has a description of the proposed change
- [X] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [X] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [X] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [X] An issue describing the proposed change exists
- [X] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
