### PR TITLE
Fix incorrect acronym in README: "Model Control Protocol" → "Model Context Protocol"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Koog is a Kotlin-based framework designed to build and run AI agents entirely in
 Key features of Koog include:
 
 - **Pure Kotlin implementation**: Build AI agents entirely in natural and idiomatic Kotlin.
-- **MCP integration**: Connect to Model Control Protocol for enhanced model management.
+- **MCP integration**: Connect to Model Context Protocol for enhanced model management.
 - **Embedding capabilities**: Use vector embeddings for semantic search and knowledge retrieval.
 - **Custom tool creation**: Extend your agents with tools that access external systems and APIs.
 - **Ready-to-use components**: Speed up development with pre-built solutions for common AI engineering challenges.


### PR DESCRIPTION
This pull request corrects an incorrect acronym in the `README.md` file.

The term **"Model Control Protocol"** was mistakenly used and has been updated to the correct term **"Model Context Protocol"**.

No functional changes were made—this is a documentation fix only.
---

#### Type of the change
- [ ] New feature
- [ ] Bug fix
- [x] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
