### PR TITLE
Update Gemini 2.5 Pro capabilities for tool support

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleModels.kt
@@ -192,7 +192,7 @@ public object GoogleModels {
     public val Gemini2_5ProPreview0506: LLModel = LLModel(
         provider = LLMProvider.Google,
         id = "gemini-2.5-pro-preview-05-06",
-        capabilities = multimodalCapabilities
+        capabilities = fullCapabilities // 2.5 Pro Preview has tool support
     )
 
     /**


### PR DESCRIPTION
Changed the capabilities of the "Gemini 2.5 Pro Preview 05-06" model from multimodal to full capabilities, reflecting its support for tools.

fixes #156