### PR TITLE
Link to the publicly viewable slack channel in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ To help you get started with AI agents, here is a quick example:
 fun main() = runBlocking {
     // Before you run the example, assign a corresponding API key as an environment variable.
    val apiKey = System.getenv("OPENAI_API_KEY") // or Anthropic, Google, OpenRouter, etc.
-   
+
    val agent = simpleSingleRunAgent(
       executor = simpleOpenAIExecutor(apiKey), // or Anthropic, Google, OpenRouter, etc.
       systemPrompt = "You are a helpful assistant. Answer user questions concisely.",
       llmModel = OpenAIModels.Chat.GPT4o
    )
-   
+
    val result = agent.runAndGetResult("Hello! How can you help me?")
    println(result)
 }
@@ -113,5 +113,5 @@ Koog is licensed under the [Apache 2.0 License](LICENSE.txt).
 
 ## Support
 
-Please feel free to ask any questions in our official Slack channel ([link](https://kotlinlang.slack.com/archives/C08SLB97W23))
+Please feel free to ask any questions in our official Slack channel ([link](https://kotlinlang.slack.com/messages/koog-agentic-framework/))
 


### PR DESCRIPTION
The link to the Slack channel for support in the README requires being logged in to the Slack workspace already which requires an invite or having an `@jetbrains` email.

This PR updates the link to point to the publicly accessible readonly version of the Slack workspace, which also includes a link for how to request to join.

It also follows the same link used in CONTRIBUTING.md to be consistent

Triggered by https://github.com/JetBrains/koog/issues/166

---

#### Type of the change
- [ ] New feature
- [ ] Bug fix
- [x] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
