### PR TITLE
Add SpringAI client implementation for prompt execution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -174,6 +174,7 @@ dependencies {
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client"))
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openrouter-client"))
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-ollama-client"))
+    dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-springai-client"))
     dokka(project(":prompt:prompt-executor:prompt-executor-llms"))
     dokka(project(":prompt:prompt-executor:prompt-executor-llms-all"))
     dokka(project(":prompt:prompt-executor:prompt-executor-model"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,8 +12,10 @@ lettuce = "6.5.5.RELEASE"
 logback = "1.5.13"
 oshai-logging = "7.0.7"
 mockk = "1.13.8"
+mokksy = "0.4.1"
 shadow = "8.1.1"
 slf4j = "2.0.17"
+spring-ai = "1.0.0"
 mcp = "0.5.0"
 dokka = "2.0.0"
 jetsign = "45.47"
@@ -42,9 +44,12 @@ lettuce-core = { module = "io.lettuce:lettuce-core", version.ref = "lettuce" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 oshai-kotlin-logging = { module = "io.github.oshai:kotlin-logging", version.ref = "oshai-logging" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+mokksy-openai = { group = "me.kpavlov.aimocks", name = "ai-mocks-openai", version.ref = "mokksy" }
 dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 mcp = { module = "io.modelcontextprotocol:kotlin-sdk", version.ref = "mcp" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
+spring-ai-client-chat = { group = "org.springframework.ai", name = "spring-ai-client-chat", version.ref = "spring-ai" }
+spring-ai-openai = { group = "org.springframework.ai", name = "spring-ai-openai", version.ref = "spring-ai" }
 jetsign-gradle-plugin = { module = "com.jetbrains:jet-sign", version.ref = "jetsign" }
 testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
 

--- a/koog-agents/build.gradle.kts
+++ b/koog-agents/build.gradle.kts
@@ -36,6 +36,7 @@ val included = setOf(
     ":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client",
     ":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openrouter-client",
     ":prompt:prompt-executor:prompt-executor-clients:prompt-executor-ollama-client",
+    ":prompt:prompt-executor:prompt-executor-clients:prompt-executor-springai-client",
     ":prompt:prompt-executor:prompt-executor-llms",
     ":prompt:prompt-executor:prompt-executor-llms-all",
     ":prompt:prompt-executor:prompt-executor-model",

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-springai-client/Module.md
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-springai-client/Module.md
@@ -1,0 +1,3 @@
+# Module prompt-executor-springai-client
+
+A client implementation for executing prompts by delegating to [Spring-AI](https://spring.io/projects/spring-ai).

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-springai-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-springai-client/build.gradle.kts
@@ -5,35 +5,43 @@ version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")
+    alias(libs.plugins.kotlin.serialization)
 }
 
 kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                api(project(":prompt:prompt-executor:prompt-executor-clients"))
-                api(project(":prompt:prompt-executor:prompt-executor-model"))
                 api(project(":agents:agents-tools"))
+                api(project(":agents:agents-utils"))
+                api(project(":prompt:prompt-executor:prompt-executor-clients"))
                 api(project(":prompt:prompt-llm"))
                 api(project(":prompt:prompt-model"))
                 api(libs.kotlinx.coroutines.core)
                 implementation(libs.oshai.kotlin.logging)
             }
         }
+
+        jvmMain {
+            dependencies {
+                api(libs.spring.ai.client.chat)
+                api(libs.kotlinx.coroutines.reactive)
+            }
+        }
+
         commonTest {
             dependencies {
                 implementation(kotlin("test"))
-                implementation(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client"))
-                implementation(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-anthropic-client"))
-                implementation(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-google-client"))
                 implementation(libs.kotlinx.coroutines.test)
             }
         }
+
         jvmTest {
             dependencies {
                 implementation(kotlin("test-junit5"))
-                implementation(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-springai-client"))
-                implementation(libs.ktor.client.cio)
+                implementation(libs.mokksy.openai)
+                implementation(libs.spring.ai.openai)
+                runtimeOnly(libs.slf4j.simple)
             }
         }
     }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-springai-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/springai/SpringAiLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-springai-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/springai/SpringAiLLMClient.kt
@@ -1,0 +1,91 @@
+package ai.koog.prompt.executor.clients.springai
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.executor.clients.LLMClient
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.Message
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.reactive.asFlow
+import org.springframework.ai.chat.client.ChatClient
+import org.springframework.ai.chat.messages.SystemMessage
+import org.springframework.ai.chat.messages.UserMessage
+import org.springframework.ai.chat.prompt.ChatOptions
+
+/**
+ * A client implementation for interacting with an AI language model via a chat-based API.
+ * Provides execution capabilities for handling prompts and generating responses from the language model.
+ *
+ * This class is designed to integrate with a `ChatClient` for handling requests and responses
+ * to and from the underlying large language model.
+ *
+ * Implements the `LLMClient` interface, offering both standard and streaming-based execution methods.
+ *
+ * @param chatClient The chat client used to facilitate communication with the LLM service.
+ */
+public class SpringAiLLMClient(
+    private val chatClient: ChatClient
+) : LLMClient {
+
+    override suspend fun execute(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>
+    ): List<Message.Response> {
+        val chatResponse = prepareClientRequest(prompt, model)
+            .call()
+            .chatResponse()!!
+        val text = chatResponse.result.output.text!!
+        return listOf(
+            Message.Assistant(
+                content = text,
+                finishReason = chatResponse.result.metadata.finishReason
+            )
+        )
+    }
+
+    override suspend fun executeStreaming(
+        prompt: Prompt,
+        model: LLModel
+    ): Flow<String> {
+        return prepareClientRequest(prompt, model)
+            .stream()
+            .chatResponse()
+            .asFlow()
+            .map { it.result?.output?.text }
+            .filterNotNull()
+    }
+
+    private fun prepareClientRequest(
+        prompt: Prompt,
+        model: LLModel,
+    ): ChatClient.ChatClientRequestSpec {
+        val springAiMessages = prompt.messages.map {
+            when (it.role) {
+                Message.Role.System -> {
+                    SystemMessage(it.content)
+                }
+
+                Message.Role.User -> {
+                    UserMessage(it.content)
+                }
+
+                else -> {
+                    throw kotlin.IllegalArgumentException("Unsupported message role: ${it.role}")
+                }
+            }
+        }
+
+        return chatClient
+            .prompt()
+            .messages(springAiMessages)
+            .options(
+                ChatOptions
+                    .builder()
+                    .model(model.id)
+                    .build(),
+            )
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-springai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/springai/SpringOpenAiTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-springai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/springai/SpringOpenAiTest.kt
@@ -1,0 +1,95 @@
+package ai.koog.prompt.executor.clients.springai
+
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import me.kpavlov.aimocks.openai.MockOpenai
+import org.springframework.ai.chat.client.ChatClient
+import org.springframework.ai.openai.OpenAiChatModel
+import org.springframework.ai.openai.api.OpenAiApi
+import kotlin.test.Test
+
+private val mockOpenai = MockOpenai(verbose = true)
+
+internal class SpringOpenAiTest {
+
+    private val chatClient = ChatClient.builder(
+        OpenAiChatModel
+            .builder()
+            .openAiApi(
+                OpenAiApi
+                    .builder()
+                    .apiKey("demo-key")
+                    .baseUrl("http://127.0.0.1:${mockOpenai.port()}")
+                    .build(),
+            ).build(),
+    ).build()
+
+    private val subject = SpringAiLLMClient(chatClient)
+
+    @Test
+    fun `Should execute completion request`() = runTest {
+        // Given
+        mockOpenai.completion {
+            model("gpt-4.1-mini")
+            systemMessageContains("helpful pirate")
+            userMessageContains("say 'Hello!'")
+        } responds {
+            assistantContent = "Ahoy there, matey! Hello!"
+            finishReason = "stop"
+        }
+
+        val prompt = Prompt.build("clientRequest") {
+            system("You are a helpful pirate")
+            user("Just say 'Hello!'")
+        }
+        val model = LLModel(
+            LLMProvider.OpenAI, "gpt-4.1-mini", listOf(
+                LLMCapability.Completion,
+            )
+        )
+        // when
+        val responses = subject.execute(prompt, model)
+
+        responses.first() shouldNotBeNull {
+            content shouldBe "Ahoy there, matey! Hello!"
+        }
+    }
+
+    @Test
+    fun `Should execute stream completion request`() = runTest {
+        // Given
+        mockOpenai.completion {
+            model("gpt-4.1-nano")
+            systemMessageContains("angry pirate")
+            userMessageContains("say 'Ahoy!'")
+        } respondsStream {
+            responseFlow = flow {
+                emit("Ahoy")
+                emit("there!")
+            }
+        }
+
+        val prompt = Prompt.build("clientRequest") {
+            system("You are a angry pirate")
+            user("Just say 'Ahoy!'")
+        }
+        val model = LLModel(
+            LLMProvider.OpenAI, "gpt-4.1-nano", listOf(
+                LLMCapability.Completion,
+            )
+        )
+        // when
+        val responseFlow = subject.executeStreaming(prompt, model)
+
+        val resultList = mutableListOf<String>()
+        responseFlow.toList(resultList)
+        resultList.joinToString(separator = " ") shouldBe " Ahoy there!"
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-springai-client/src/jvmTest/resources/simplelogger.properties
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-springai-client/src/jvmTest/resources/simplelogger.properties
@@ -1,0 +1,14 @@
+# Level of logging for the ROOT logger: ERROR, WARN, INFO, DEBUG, TRACE (default is INFO)
+org.slf4j.simpleLogger.defaultLogLevel=DEBUG
+
+# Log level for specific packages or classes (optional)
+org.slf4j.simpleLogger.log.ai.koog=TRACE
+
+# Whether to display the thread name in log messages (true/false)
+org.slf4j.simpleLogger.showThreadName=true
+
+# Display the date and time in log messages (true/false)
+org.slf4j.simpleLogger.showDateTime=false
+
+# Whether to enable stack traces for exceptions (true/false, default is true)
+org.slf4j.simpleLogger.showShortLogName=false

--- a/prompt/prompt-executor/prompt-executor-llms-all/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-llms-all/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
                 api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client"))
                 api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openrouter-client"))
                 api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-ollama-client"))
+                api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-springai-client"))
                 api(project(":prompt:prompt-executor:prompt-executor-llms"))
                 api(project(":agents:agents-core"))
                 api(project(":agents:agents-ext"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -49,6 +49,7 @@ include(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-google-
 include(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client")
 include(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openrouter-client")
 include(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-ollama-client")
+include(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-springai-client")
 
 include(":prompt:prompt-executor:prompt-executor-llms")
 include(":prompt:prompt-executor:prompt-executor-llms-all")


### PR DESCRIPTION
Introduce `SpringAiLLMClient`, a new client for handling prompt execution using the Spring-AI library. It includes support for both standard and streaming responses, associated tests, and integration into the build system and project structure.

---

#### Type of the change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [ ] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [ ] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
