### PR TITLE
Extend Retry logic and add retries to Ollama tests

### DIFF
--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/SayToUser.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/SayToUser.kt
@@ -14,7 +14,7 @@ public object SayToUser : SimpleTool<SayToUser.Args>() {
     override val argsSerializer: KSerializer<Args> = Args.serializer()
 
     override val descriptor: ToolDescriptor = ToolDescriptor(
-        name = "__say_to_user__", description = "Service tool, used by the agent to talk.",
+        name = "say_to_user", description = "Service tool, used by the agent to talk.",
         requiredParameters = listOf(
             ToolParameterDescriptor(
                 name = "message", description = "Message from the agent", type = ToolParameterType.String

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OllamaAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OllamaAgentIntegrationTest.kt
@@ -11,6 +11,7 @@ import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.*
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.features.eventHandler.feature.EventHandler
+import ai.koog.integration.tests.utils.TestUtils.runWithRetry
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.OllamaModels
@@ -170,7 +171,7 @@ class OllamaAgentIntegrationTest {
         val toolRegistry = createToolRegistry()
         val agent = createAgent(executor, strategy, toolRegistry)
 
-        val result = agent.runAndGetResult("What is the capital of France?")
+        val result = runWithRetry { agent.runAndGetResult("What is the capital of France?") }
 
         assertNotNull(result, "Result should not be empty")
         assertTrue(result.isNotEmpty(), "Result should not be empty")

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SimpleAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SimpleAgentIntegrationTest.kt
@@ -204,8 +204,18 @@ class SimpleAgentIntegrationTest {
 
         val bookwormPrompt = """
             You're top librarian, helping user to find books.
-            Only communicate to user via tools.
-            Only use tools you've been provided by system.
+            ALWAYS communicate to user via tools!!!
+            ALWAYS use tools you've been provided.
+            ALWAYS generate valid JSON responses.
+            ALWAYS call tool correctly, with valid arguments.
+            NEVER provide tool call in result body.
+            
+            Example tool call:
+            {
+                id=ollama_tool_call_3743609160,
+                tool=say_to_user,
+                content={"message":"The top 10 books of all time are:\n 1. Don Quixote by Miguel de Cervantes\n 2. A Tale of Two Cities by Charles Dickens\n 3. The Lord of the Rings by J.R.R. Tolkien\n 4. Pride and Prejudice by Jane Austen\n 5. To Kill a Mockingbird by Harper Lee\n 6. The Catcher in the Rye by J.D. Salinger\n 7. 1984 by George Orwell\n 8. The Great Gatsby by F. Scott Fitzgerald\n 9. War and Peace by Leo Tolstoy\n 10. Alice’s Adventures in Wonderland by Lewis Carroll"})
+            }
         """.trimIndent()
 
         val executor = simpleOllamaAIExecutor()
@@ -224,8 +234,8 @@ class SimpleAgentIntegrationTest {
 
         assertTrue(actualToolCalls.isNotEmpty(), "No tools were called for model")
         assertTrue(
-            actualToolCalls.contains("__say_to_user__"),
-            "The __say_to_user__ tool was not called for model"
+            actualToolCalls.contains("say_to_user"),
+            "The say_to_user tool was not called for model"
         )
     }
 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SimpleAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SimpleAgentIntegrationTest.kt
@@ -20,7 +20,6 @@ import ai.koog.prompt.llm.LLModel
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assumptions.assumeTrue
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.condition.EnabledOnOs
 import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.api.extension.ExtendWith
@@ -207,7 +206,6 @@ class SimpleAgentIntegrationTest {
         )
     }
 
-    @Disabled("JBAI-14328")
     @EnabledOnOs(OS.LINUX)
     @Test
     fun integration_simpleOllamaTest() = runTest(timeout = 600.seconds) {

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SingleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SingleLLMPromptExecutorIntegrationTest.kt
@@ -49,7 +49,7 @@ class SingleLLMPromptExecutorIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
-    fun integration_testExecute(model: LLModel, client: LLMClient) = runTest {
+    fun integration_testExecute(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
         val executor = SingleLLMPromptExecutor(client)
 
         val prompt = Prompt.build("test-prompt") {
@@ -70,7 +70,7 @@ class SingleLLMPromptExecutorIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
-    fun integration_testExecuteStreaming(model: LLModel, client: LLMClient) = runTest {
+    fun integration_testExecuteStreaming(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
         val executor = SingleLLMPromptExecutor(client)
 
         val prompt = Prompt.build("test-streaming") {
@@ -97,7 +97,7 @@ class SingleLLMPromptExecutorIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
-    fun integration_testCodeGeneration(model: LLModel, client: LLMClient) = runTest {
+    fun integration_testCodeGeneration(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
         val executor = SingleLLMPromptExecutor(client)
 
         val prompt = Prompt.build("test-code") {
@@ -128,7 +128,7 @@ class SingleLLMPromptExecutorIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
-    fun integration_testToolsWithRequiredParams(model: LLModel, client: LLMClient) = runTest {
+    fun integration_testToolsWithRequiredParams(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
         assumeTrue(model.capabilities.contains(LLMCapability.Tools), "Model $model does not support tools")
 
         val calculatorTool = ToolDescriptor(
@@ -166,7 +166,7 @@ class SingleLLMPromptExecutorIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
-    fun integration_testToolsWithRequiredOptionalParams(model: LLModel, client: LLMClient) = runTest {
+    fun integration_testToolsWithRequiredOptionalParams(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
         assumeTrue(model.capabilities.contains(LLMCapability.Tools), "Model $model does not support tools")
 
         val calculatorTool = ToolDescriptor(
@@ -211,7 +211,7 @@ class SingleLLMPromptExecutorIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
-    fun integration_testToolsWithOptionalParams(model: LLModel, client: LLMClient) = runTest {
+    fun integration_testToolsWithOptionalParams(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
         assumeTrue(model.capabilities.contains(LLMCapability.Tools), "Model $model does not support tools")
 
         val calculatorTool = ToolDescriptor(
@@ -254,7 +254,7 @@ class SingleLLMPromptExecutorIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
-    fun integration_testToolsWithNoParams(model: LLModel, client: LLMClient) = runTest {
+    fun integration_testToolsWithNoParams(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
         assumeTrue(model.capabilities.contains(LLMCapability.Tools), "Model $model does not support tools")
 
         val calculatorTool = ToolDescriptor(
@@ -282,7 +282,7 @@ class SingleLLMPromptExecutorIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
-    fun integration_testToolsWithListEnumParams(model: LLModel, client: LLMClient) = runTest {
+    fun integration_testToolsWithListEnumParams(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
         assumeTrue(model.capabilities.contains(LLMCapability.Tools), "Model $model does not support tools")
 
         val colorPickerTool = ToolDescriptor(
@@ -311,7 +311,7 @@ class SingleLLMPromptExecutorIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
-    fun integration_testToolsWithNestedListParams(model: LLModel, client: LLMClient) = runTest {
+    fun integration_testToolsWithNestedListParams(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
         assumeTrue(model.capabilities.contains(LLMCapability.Tools), "Model $model does not support tools")
 
         val lotteryPickerTool = ToolDescriptor(
@@ -369,7 +369,7 @@ class SingleLLMPromptExecutorIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
-    fun integration_testStructuredDataStreaming(model: LLModel, client: LLMClient) = runTest {
+    fun integration_testStructuredDataStreaming(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
         val countries = mutableListOf<TestUtils.Country>()
         val countryDefinition = TestUtils.markdownCountryDefinition()
 
@@ -405,7 +405,7 @@ class SingleLLMPromptExecutorIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
-    fun integration_testToolChoice(model: LLModel, client: LLMClient) = runTest {
+    fun integration_testToolChoice(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
         assumeTrue(model.capabilities.contains(LLMCapability.Tools), "Model $model does not support tools")
 
         val calculatorTool = ToolDescriptor(


### PR DESCRIPTION
As Ollama integration tests weren't quite stable, I added `runWithRetry` method to the test utils and also added a fixture usage for the Simple API test that uses Ollama. Besides, I added some timeouts to the tests.

The MR also contains a one-shot fix from @Rizzen to ensure better Ollama responsiveness.

---

#### Type of the change
- [x] New feature
- [x] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
