### PR TITLE
Isolate Ollama integration test logic

### DIFF
--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OllamaSimpleAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OllamaSimpleAgentIntegrationTest.kt
@@ -1,0 +1,140 @@
+package ai.koog.integration.tests
+
+import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.ext.agent.simpleSingleRunAgent
+import ai.koog.agents.ext.tool.SayToUser
+import ai.koog.agents.features.eventHandler.feature.EventHandler
+import ai.koog.agents.features.eventHandler.feature.EventHandlerConfig
+import ai.koog.integration.tests.utils.TestUtils.runWithRetry
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+@ExtendWith(OllamaTestFixtureExtension::class)
+@EnabledOnOs(OS.LINUX)
+class OllamaSimpleAgentIntegrationTest {
+    companion object {
+        @field:InjectOllamaTestFixture
+        private lateinit var fixture: OllamaTestFixture
+        private val ollamaSimpleExecutor get() = fixture.executor
+        private val ollamaModel get() = fixture.model
+    }
+
+    val eventHandlerConfig: EventHandlerConfig.() -> Unit = {
+        onBeforeAgentStarted = { strategy, agent ->
+            println("Agent started: strategy=${strategy.javaClass.simpleName}, agent=${agent.javaClass.simpleName}")
+        }
+
+        onAgentFinished = { strategyName, result ->
+            println("Agent finished: strategy=$strategyName, result=$result")
+        }
+
+        onAgentRunError = { strategyName, throwable ->
+            println("Agent error: strategy=$strategyName, error=${throwable.message}")
+        }
+
+        onStrategyStarted = { strategy ->
+            println("Strategy started: ${strategy.javaClass.simpleName}")
+        }
+
+        onStrategyFinished = { strategyName, result ->
+            println("Strategy finished: strategy=$strategyName, result=$result")
+        }
+
+        onBeforeNode = { node, context, input ->
+            println("Before node: node=${node.javaClass.simpleName}, input=$input")
+        }
+
+        onAfterNode = { node, context, input, output ->
+            println("After node: node=${node.javaClass.simpleName}, input=$input, output=$output")
+        }
+
+        onBeforeLLMCall = { prompt ->
+            println("Before LLM call: prompt=$prompt")
+        }
+
+        onBeforeLLMWithToolsCall = { prompt, tools ->
+            println("Before LLM call with tools: prompt=$prompt, tools=${tools.map { it.name }}")
+        }
+
+        onAfterLLMCall = { response ->
+            println("After LLM call: response=${response.take(100)}${if (response.length > 100) "..." else ""}")
+        }
+
+        onAfterLLMWithToolsCall = { response, tools ->
+            println("After LLM call with tools: response=${response.map { it.content?.take(50) }}, tools=${tools.map { it.name }}")
+        }
+
+        onToolCall = { tool, args ->
+            println("Tool called: tool=${tool.name}, args=$args")
+            actualToolCalls.add(tool.name)
+        }
+
+        onToolValidationError = { tool, args, value ->
+            println("Tool validation error: tool=${tool.name}, args=$args, value=$value")
+        }
+
+        onToolCallFailure = { tool, args, throwable ->
+            println("Tool call failure: tool=${tool.name}, args=$args, error=${throwable.message}")
+        }
+
+        onToolCallResult = { tool, args, result ->
+            println("Tool call result: tool=${tool.name}, args=$args, result=$result")
+        }
+    }
+
+    val actualToolCalls = mutableListOf<String>()
+
+    @AfterTest
+    fun teardown() {
+        actualToolCalls.clear()
+    }
+
+    @Test
+    fun integration_simpleOllamaTest() = runTest(timeout = 600.seconds) {
+        val toolRegistry = ToolRegistry.Companion {
+            tool(SayToUser)
+        }
+
+        val bookwormPrompt = """
+            You're top librarian, helping user to find books.
+            ALWAYS communicate to user via tools!!!
+            ALWAYS use tools you've been provided.
+            ALWAYS generate valid JSON responses.
+            ALWAYS call tool correctly, with valid arguments.
+            NEVER provide tool call in result body.
+            
+            Example tool call:
+            {
+                "id":"ollama_tool_call_3743609160",
+                "tool":"say_to_user",
+                "content":{"message":"The top 10 books of all time are:\n 1. Don Quixote by Miguel de Cervantes\n 2. A Tale of Two Cities by Charles Dickens\n 3. The Lord of the Rings by J.R.R. Tolkien\n 4. Pride and Prejudice by Jane Austen\n 5. To Kill a Mockingbird by Harper Lee\n 6. The Catcher in the Rye by J.D. Salinger\n 7. 1984 by George Orwell\n 8. The Great Gatsby by F. Scott Fitzgerald\n 9. War and Peace by Leo Tolstoy\n 10. Alice’s Adventures in Wonderland by Lewis Carroll"})
+            }
+        """.trimIndent()
+
+        val agent = simpleSingleRunAgent(
+            executor = ollamaSimpleExecutor,
+            systemPrompt = bookwormPrompt,
+            llmModel = ollamaModel,
+            temperature = 1.0,
+            toolRegistry = toolRegistry,
+            maxIterations = 10,
+            installFeatures = { install(EventHandler.Feature, eventHandlerConfig) }
+        )
+
+        runWithRetry {
+            agent.run("Give me top 10 books of the all time.")
+        }
+
+        assertTrue(actualToolCalls.isNotEmpty(), "No tools were called for model")
+        assertTrue(
+            actualToolCalls.contains(SayToUser.name),
+            "The ${SayToUser.name} tool was not called for model"
+        )
+    }
+}


### PR DESCRIPTION
Isolated Ollama test because apparently the integration tests were failing because of the test fixture initialization on Windows. However, I didn't want to exclude the whole class from the Windows run.

---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
