### PR TITLE
Enable Mac support for tests and adjust Gradle test execution to run without parallelism

### DIFF
--- a/.github/workflows/heavy-tests.yml
+++ b/.github/workflows/heavy-tests.yml
@@ -45,7 +45,7 @@ jobs:
           GEMINI_API_TEST_KEY: ${{ secrets.GEMINI_API_TEST_KEY }}
           OLLAMA_IMAGE_URL: ${{ vars.OLLAMA_IMAGE_URL }}
           OPEN_ROUTER_API_TEST_KEY: ${{ vars.OPEN_ROUTER_API_TEST_KEY }}
-        run: ./gradlew jvmIntegrationTest --continue
+        run: ./gradlew jvmIntegrationTest --no-parallel --continue
 
       - name: Collect reports
         if: always()

--- a/.github/workflows/heavy-tests.yml
+++ b/.github/workflows/heavy-tests.yml
@@ -8,6 +8,7 @@
 name: Heavy Tests
 
 on:
+  workflow_dispatch:  # Manual trigger
   push:
     branches: [ "main", "develop" ]
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OllamaAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OllamaAgentIntegrationTest.kt
@@ -25,7 +25,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
-@EnabledOnOs(OS.LINUX)
+@EnabledOnOs(OS.LINUX, OS.MAC)
 @ExtendWith(OllamaTestFixtureExtension::class)
 class OllamaAgentIntegrationTest {
     companion object {

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OllamaClientIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OllamaClientIntegrationTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
-@EnabledOnOs(OS.LINUX)
+@EnabledOnOs(OS.LINUX, OS.MAC)
 @ExtendWith(OllamaTestFixtureExtension::class)
 class OllamaClientIntegrationTest {
     companion object {

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OllamaSimpleAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OllamaSimpleAgentIntegrationTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
 @ExtendWith(OllamaTestFixtureExtension::class)
-@EnabledOnOs(OS.LINUX)
+@EnabledOnOs(OS.LINUX, OS.MAC)
 class OllamaSimpleAgentIntegrationTest {
     companion object {
         @field:InjectOllamaTestFixture


### PR DESCRIPTION
As Ollama tests are quite unstable, and the supposed reason is that they are interfering with each other while running in parallel.
I'll try to make them run sequentially. If it helps, the next step will be separating Ollama tests into another test configuration (and run them sequentially while tests for other executors are still running in parallel).
---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
