### PR TITLE
Add assertion for schema description in StructuredDataTest.kt

### DIFF
--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/annotations/LLMDescription.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/annotations/LLMDescription.kt
@@ -1,11 +1,14 @@
 package ai.koog.agents.core.tools.annotations
 
+import kotlinx.serialization.SerialInfo
+
 /**
  * Description for an entity that can be provided to LLMs.
  * You may use it to annotate properties, functions, parameters, classes, return types, etc.
  *
  * @property description The description of the entity.
  */
+@SerialInfo
 @Target(
     AnnotationTarget.PROPERTY,
     AnnotationTarget.CLASS,

--- a/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/StructuredDataTest.kt
+++ b/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/StructuredDataTest.kt
@@ -1,5 +1,6 @@
 package ai.koog.prompt.structure
 
+import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.prompt.structure.json.JsonStructuredData
 import ai.koog.prompt.text.TextContentBuilder
 import kotlinx.serialization.SerialName
@@ -13,7 +14,11 @@ import kotlin.test.assertTrue
 class JsonStructuredDataTest {
     // Simple data structure for basic tests
     @Serializable
-    data class SimpleData(val value: String)
+    @LLMDescription("SimpleData description")
+    data class SimpleData(
+        @property:LLMDescription("SimpleData.value description")
+        val value: String
+    )
 
     // Array data structure
     @Serializable
@@ -124,6 +129,8 @@ class JsonStructuredDataTest {
         val content = builder.build()
 
         assertTrue(content.contains("DEFINITION OF simple"))
+        assertTrue(content.contains("SimpleData description"))
+        assertTrue(content.contains("SimpleData.value description"))
         assertTrue(content.contains("is defined only and solely with JSON, without any additional characters, backticks or anything similar."))
     }
 


### PR DESCRIPTION
Schema descriptions added with the `@LLMDescription` annotation are currently not included in the generated JSON Schema. This PR adds an assertion to one of the structured data tests to demonstrate the behavior.

The reason it isn't included is that `kotlinx.serialization` only includes annotations relevant for serialization when generating the descriptor. Adding the `@SerialInfo` annotation to `LLMDescription` ensures that it is included, and should solve this problem. The only potential issue I see with that is that it requires opting into `ExperimentalSerializationApi`, and I'm not sure what the maintainers' stance on that is.

An alternate solution could be to not use the descriptor to extract the annotations, but to use the Kotlin reflection API, as is done for tools. I don't know how viable that is though.

Related to #178 

---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
