### PR TITLE
[agents] [prompt] Fix LLM requests with disabled tools, fix prompt messages update

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/config/MissingToolsConversionStrategy.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/config/MissingToolsConversionStrategy.kt
@@ -30,7 +30,7 @@ public abstract class MissingToolsConversionStrategy(private val format: ToolCal
      */
     public class All(format: ToolCallDescriber) : MissingToolsConversionStrategy(format) {
         override fun convertPrompt(prompt: Prompt, tools: List<ToolDescriptor>): Prompt {
-            return prompt.withUpdatedMessages { map { convertMessage(it) } }
+            return prompt.withMessages { messages -> messages.map { convertMessage(it) } }
         }
     }
 
@@ -42,14 +42,13 @@ public abstract class MissingToolsConversionStrategy(private val format: ToolCal
     public class Missing(format: ToolCallDescriber) : MissingToolsConversionStrategy(format) {
         override fun convertPrompt(prompt: Prompt, tools: List<ToolDescriptor>): Prompt {
             val toolNames = tools.map { it.name }
-            return prompt.withUpdatedMessages {
-                map { message ->
-                    if (message is Message.Tool) {
-                        if (message.tool !in toolNames) {
-                            return@map convertMessage(message)
-                        }
+            return prompt.withMessages { messages ->
+                messages.map { message ->
+                    if (message is Message.Tool && message.tool !in toolNames) {
+                        convertMessage(message)
+                    } else {
+                        message
                     }
-                    return@map message
                 }
             }
         }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMSession.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMSession.kt
@@ -117,8 +117,15 @@ public sealed class AIAgentLLMSession(
 
     public open suspend fun requestLLMWithoutTools(): Message.Response {
         validateSession()
-        val promptWithDisabledTools = prompt.withUpdatedParams { toolChoice = null }
-        return executeSingle(promptWithDisabledTools, emptyList())
+        val promptWithDisabledTools = prompt.withUpdatedParams {
+            /*
+              If tools are empty, they will not be added by the LLM client to the requests,
+              which means tool choice parameter cannot be used (it throws an exception without a tools parameter present).
+              So instead set it to null in this case, which behaves the same (there are no tools to call, after all).
+            */
+            toolChoice = if (tools.isNotEmpty()) LLMParams.ToolChoice.None else null
+        }
+        return executeSingle(promptWithDisabledTools, tools)
     }
 
     public open suspend fun requestLLMOnlyCallingTools(): Message.Response {

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentLLMActions.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentLLMActions.kt
@@ -4,11 +4,11 @@ import ai.koog.agents.core.agent.session.AIAgentLLMWriteSession
 import ai.koog.prompt.params.LLMParams
 
 public fun AIAgentLLMWriteSession.clearHistory() {
-    prompt = prompt.withMessages(emptyList())
+    prompt = prompt.withMessages { emptyList() }
 }
 
 public fun AIAgentLLMWriteSession.leaveLastNMessages(n: Int) {
-    prompt = prompt.withUpdatedMessages { takeLast(n) }
+    prompt = prompt.withMessages { it.takeLast(n) }
 }
 
 /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/HistoryCompressionStrategies.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/HistoryCompressionStrategies.kt
@@ -71,7 +71,7 @@ public abstract class HistoryCompressionStrategy {
                 addAll(systemMessages)
                 // Restore memory messages if needed
                 if (preserveMemory && memoryMessages.isNotEmpty()) {
-                    prompt = prompt.withUpdatedMessages { addAll(memoryMessages) }
+                    addAll(memoryMessages)
                 }
 
                 if (firstUserMessage != null) add(firstUserMessage)

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/HistoryCompressionStrategies.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/HistoryCompressionStrategies.kt
@@ -38,7 +38,7 @@ public abstract class HistoryCompressionStrategy {
      */
     protected suspend fun compressPromptIntoTLDR(llmSession: AIAgentLLMWriteSession): List<Message.Response> {
         return with(llmSession) {
-            prompt = prompt.withUpdatedMessages { dropLastWhile { it is Message.Tool.Call } }
+            prompt = prompt.withMessages { messages -> messages.dropLastWhile { it is Message.Tool.Call } }
             updatePrompt {
                 user {
                     summarizeInTLDR()
@@ -67,7 +67,7 @@ public abstract class HistoryCompressionStrategy {
             val systemMessages = prompt.messages.filterIsInstance<Message.System>()
             val firstUserMessage = prompt.messages.firstOrNull { it is Message.User }
 
-            prompt = prompt.withMessages(buildList {
+            prompt = prompt.withMessages { buildList {
                 addAll(systemMessages)
                 // Restore memory messages if needed
                 if (preserveMemory && memoryMessages.isNotEmpty()) {
@@ -76,7 +76,7 @@ public abstract class HistoryCompressionStrategy {
 
                 if (firstUserMessage != null) add(firstUserMessage)
                 addAll(tldrMessages)
-            })
+            }}
         }
     }
 
@@ -162,7 +162,7 @@ public abstract class HistoryCompressionStrategy {
             val chunkedTLDR = llmSession.prompt.messages.chunked(chunkSize).flatMap { chunk ->
                 llmSession.clearHistory()
 
-                llmSession.prompt = llmSession.prompt.withMessages(chunk)
+                llmSession.prompt = llmSession.prompt.withMessages { chunk }
 
                 compressPromptIntoTLDR(llmSession)
             }

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
@@ -6,7 +6,6 @@ import ai.koog.agents.core.dsl.builder.AIAgentSubgraphBuilderBase
 import ai.koog.agents.core.dsl.builder.AIAgentSubgraphDelegateBase
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.extension.nodeExecuteTool
-import ai.koog.agents.core.dsl.extension.nodeLLMRequestMultiple
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResult
 import ai.koog.agents.core.dsl.extension.onToolCall
 import ai.koog.agents.core.dsl.extension.onToolNotCalled
@@ -32,7 +31,7 @@ internal suspend fun AIAgentContextBase.promptWithTLDR(
         if (shouldTLDRHistory) replaceHistoryWithTLDR()
         rewritePrompt { prompt ->
             prompt
-                .withUpdatedMessages { filterNot { it is Message.System } }
+                .withMessages { messages -> messages.filterNot { it is Message.System } }
                 .withParams(params ?: prompt.params)
         }
         if (model != null) changeModel(model)

--- a/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/AgentMemory.kt
+++ b/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/AgentMemory.kt
@@ -490,7 +490,7 @@ internal suspend fun AIAgentLLMWriteSession.retrieveFactsFromHistory(
     // Remove the fact extraction messages if not preserving them
     if (!preserveQuestionsInLLMChat) {
         rewritePrompt { oldPrompt ->
-            oldPrompt.withUpdatedMessages { dropLast(2) }
+            oldPrompt.withMessages { it.dropLast(2) }
         }
     }
     return facts

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/Prompt.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/Prompt.kt
@@ -74,11 +74,11 @@ public data class Prompt(
     /**
      * Creates a copy of the `Prompt` with updated messages, allowing modifications to the current messages.
      *
-     * @param update A lambda function that operates on a mutable list of `Message` to apply modifications.
+     * @param update A lambda function that returns the updated list of messages.
      * @return A new `Prompt` instance with the modified list of messages.
      */
-    public fun withUpdatedMessages(update: MutableList<Message>.() -> Unit): Prompt =
-        this.copy(messages = messages.toMutableList().apply { update() })
+    public fun withUpdatedMessages(update: List<Message>.() -> List<Message>): Prompt =
+        this.copy(messages = update(this.messages))
 
     /**
      * Returns a new instance of the `Prompt` class with updated language model parameters.

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/Prompt.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/Prompt.kt
@@ -64,20 +64,12 @@ public data class Prompt(
     }
 
     /**
-     * Creates a copy of the current Prompt instance with updated messages.
+     * Creates a copy of the `Prompt` with updated messages, allowing to modify the existing list of messages or provide a new one.
      *
-     * @param newMessages A list of Message instances that will replace the current messages in the Prompt.
-     * @return A new Prompt instance with the updated list of messages.
-     */
-    public fun withMessages(newMessages: List<Message>): Prompt = copy(messages = newMessages)
-
-    /**
-     * Creates a copy of the `Prompt` with updated messages, allowing modifications to the current messages.
-     *
-     * @param update A lambda function that returns the updated list of messages.
+     * @param update A lambda function that returns the new list of messages.
      * @return A new `Prompt` instance with the modified list of messages.
      */
-    public fun withUpdatedMessages(update: List<Message>.() -> List<Message>): Prompt =
+    public fun withMessages(update: (List<Message>) -> List<Message>): Prompt =
         this.copy(messages = update(this.messages))
 
     /**


### PR DESCRIPTION
* Fixes prompt messages updates to make them actually work, removes reduntant update function replacing it with unified one
* More robust LLM requests with disabled tools:
    * Current approach: set tool choice to null and don't pass tool list to LLM client call, which fails on some providers currently with "unknown tool in tool message". It would require removing tool messages or rewriting them to assistant ones (via missing tools conversion strategy).
    * New approach: let's just set tool choice to `None` and pass tool list to the LLM client call as it is. This way, models can see the tools and don't get confused by "unknown" tool calls in the message history. And we don't have to rewrite message history to replace tool with assistant messages.