### PR TITLE
Change OPEN_AI_TOKEN to OPENAI_API_KEY

### DIFF
--- a/examples/src/main/kotlin/ai/koog/agents/example/ApiKeyService.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/ApiKeyService.kt
@@ -2,7 +2,7 @@ package ai.koog.agents.example
 
 internal object ApiKeyService {
     val openAIApiKey: String
-        get() = System.getenv("OPEN_AI_TOKEN") ?: throw IllegalArgumentException("OPENAI_API_KEY env is not set")
+        get() = System.getenv("OPENAI_API_KEY") ?: throw IllegalArgumentException("OPENAI_API_KEY env is not set")
 
     val anthropicApiKey: String
         get() = System.getenv("ANTHROPIC_API_KEY") ?: throw IllegalArgumentException("ANTHROPIC_API_KEY env is not set")


### PR DESCRIPTION
The examples use `ai.koog.agents.example.ApiKeyService` to pull model keys from environment variables. When open ai isn't found, you get an exception with 'OPENAI_API_KEY env is not set'. It took some extra time to debug because 'OPENAI_API_KEY' isn't actually the name of the value that `ApiKeyService` is looking for, but 'OPEN_AI_TOKEN'.

Since other docs use 'OPENAI_API_KEY', I figured that was the convention to use. If somebody has the examples currently running with 'OPEN_AI_TOKEN', the change will break that, but it seems more consistent to use 'OPENAI_API_KEY'.
---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added (doesn't really seem like a thing to "test")
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature (not a new feature so N/A)