### PR TITLE
MCP proper object and enum arg types support

### DIFF
--- a/agents/agents-mcp/Module.md
+++ b/agents/agents-mcp/Module.md
@@ -1,5 +1,139 @@
 # Module agents-mcp
 
-Provides facilities to integrate agents with Model Context Protocol (MCP) servers via Tools API.
+A module provides integration with [Model Context Protocol (MCP)](https://modelcontextprotocol.io) servers.
+The main components of the MCP integration in Koog are:
+- [**McpToolRegistryProvider**](src/jvmMain/kotlin/ai/koog/agents/mcp/McpToolRegistryProvider.kt): Creates tool registries that connect to MCP servers
+- [**McpTool**](src/jvmMain/kotlin/ai/koog/agents/mcp/McpTool.kt): A bridge between the Koog agent framework's Tool interface and the MCP SDK
+- [**McpToolDescriptorParser**](src/jvmMain/kotlin/ai/koog/agents/mcp/McpToolDefinitionParser.kt): Parses tool definitions from the MCP SDK to the Koog tool descriptor format
 
-<!-- TODO -->
+
+## Overview
+
+### What is MCP?
+
+The Model Context Protocol (MCP) is a standardized protocol that enables AI agents to interact with external tools and services through a consistent interface.
+MCP works by exposing tools and prompts as API endpoints that can be called by AI agents.
+Each tool has a defined name and input schema that describes its inputs and outputs in JSON SHEMA format.
+To read more about MCP visit [https://modelcontextprotocol.io](https://modelcontextprotocol.io)
+
+### How to use MCP servers?
+You can find ready-to-use mcp servers in the [MCP Marketplace](https://mcp.so/) or [MCP DockerHub](https://hub.docker.com/u/mcp).
+MCP servers support stdio transport and optionally sse transport protocols to communicate with the agent.
+
+### How MCP is integrated with Koog?
+
+The Koog framework integrates with MCP using the [MCP SDK](https://github.com/modelcontextprotocol/kotlin-sdk) with the additional api extensions presented in module `agent-mcp`.
+This integration allows Koog agents to:
+
+1. Connect to MCP servers through various transport mechanisms (stdio, SSE)
+2. Retrieve available tools from the MCP server
+3. Transform MCP tools into the Koog agent framework's Tool interface
+4. Register the transformed tools in a ToolRegistry
+5. Call MCP tools with arguments provided by the LLM
+
+### How to Use MCP with Koog?
+
+#### Setting Up an MCP Connection
+
+To use MCP with Koog, you need to:
+
+1. Start an MCP server (either as a process, Docker container, or web service)
+2. Create a transport to communicate with the server
+3. Create a ToolRegistry with tools from the MCP server
+4. Use the tools in an AI agent
+
+Here's a basic example of setting up an MCP connection:
+
+```kotlin
+// Start the MCP server (e.g., as a process)
+val process = ProcessBuilder("path/to/mcp/server").start()
+
+// Create a ToolRegistry with tools from the MCP server
+val toolRegistry = McpToolRegistryProvider.fromTransport(
+    transport = McpToolRegistryProvider.defaultStdioTransport(process)
+)
+
+// Use the tools in an AI agent
+val agent = AIAgent(
+    promptExecutor = executor,
+    strategy = strategy,
+    agentConfig = agentConfig,
+    toolRegistry = toolRegistry
+)
+
+// Run the agent
+agent.runAndGetResult("Your task here")
+```
+
+#### Transport Types
+
+MCP supports different transport mechanisms for communication:
+
+##### Standard Input/Output (stdio)
+
+Use stdio transport when the MCP server is running as a separate process:
+
+```kotlin
+val process = ProcessBuilder("path/to/mcp/server").start()
+val transport = McpToolRegistryProvider.defaultStdioTransport(process)
+```
+
+##### Server-Sent Events (SSE)
+
+Use SSE transport when the MCP server is running as a web service:
+
+```kotlin
+val transport = McpToolRegistryProvider.defaultSseTransport("http://localhost:8931")
+```
+
+### Examples
+
+#### Google Maps MCP Integration
+
+This example demonstrates using MCP to connect to a [Google Maps](https://mcp.so/server/google-maps/modelcontextprotocol) server for geographic data:
+
+```kotlin
+// Start the Docker container with the Google Maps MCP server
+val process = ProcessBuilder(
+    "docker", "run", "-i",
+    "-e", "GOOGLE_MAPS_API_KEY=$googleMapsApiKey",
+    "mcp/google-maps"
+).start()
+
+// Create the ToolRegistry with tools from the MCP server
+val toolRegistry = McpToolRegistryProvider.fromTransport(
+    transport = McpToolRegistryProvider.defaultStdioTransport(process)
+)
+
+// Create and run the agent
+val agent = simpleSingleRunAgent(
+    executor = simpleOpenAIExecutor(openAIApiToken),
+    llmModel = OpenAIModels.Chat.GPT4o,
+    toolRegistry = toolRegistry,
+)
+agent.run("Get elevation of the Jetbrains Office in Munich, Germany?")
+```
+
+#### Playwright MCP Integration
+
+This example demonstrates using MCP to connect to a [Playwright](https://mcp.so/server/playwright-mcp/microsoft) server for web automation:
+
+```kotlin
+// Start the Playwright MCP server
+val process = ProcessBuilder(
+    "npx", "@playwright/mcp@latest", "--port", "8931"
+).start()
+
+// Create the ToolRegistry with tools from the MCP server
+val toolRegistry = McpToolRegistryProvider.fromTransport(
+    transport = McpToolRegistryProvider.defaultSseTransport("http://localhost:8931")
+)
+
+// Create and run the agent
+val agent = simpleSingleRunAgent(
+    executor = simpleOpenAIExecutor(openAIApiToken),
+    llmModel = OpenAIModels.Chat.GPT4o,
+    toolRegistry = toolRegistry,
+)
+agent.run("Open a browser, navigate to jetbrains.com, accept all cookies, click AI in toolbar")
+```

--- a/agents/agents-mcp/src/jvmMain/kotlin/ai/koog/agents/mcp/McpToolDefinitionParser.kt
+++ b/agents/agents-mcp/src/jvmMain/kotlin/ai/koog/agents/mcp/McpToolDefinitionParser.kt
@@ -6,9 +6,6 @@ import ai.koog.agents.core.tools.ToolParameterType
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import kotlin.collections.component1
-import kotlin.collections.component2
-import kotlin.collections.contains
 import io.modelcontextprotocol.kotlin.sdk.Tool as SDKTool
 
 /**
@@ -77,16 +74,27 @@ public object DefaultMcpToolDescriptorParser : McpToolDescriptorParser {
 
             // Object type
             "object" -> {
-                val properties = if ("properties" in element) {
-                    element.getValue("properties").jsonObject
+                if ("additionalProperties" in element) {
+                    ToolParameterType.Object(
+                        emptyList(),
+                        true)
                 } else {
-                    throw IllegalArgumentException("Object type parameters must have properties property")
-                }
+                    val properties = if ("properties" in element) {
+                        element.getValue("properties").jsonObject
+                    } else {
+                        return ToolParameterType.Object(
+                            emptyList(),
+                            true)
+                    }
 
-                ToolParameterType.Object(properties.map { (name, property) ->
-                    val description = element["description"]?.jsonPrimitive?.content.orEmpty()
-                    ToolParameterDescriptor(name, description, parseParameterType(property.jsonObject))
-                })
+                    ToolParameterType.Object(
+                        properties.map { (name, property) ->
+                            val description = element["description"]?.jsonPrimitive?.content.orEmpty()
+                            ToolParameterDescriptor(name, description, parseParameterType(property.jsonObject))
+                        },
+                        additionalProperties = true
+                    )
+                }
             }
 
             // Unsupported type

--- a/agents/agents-mcp/src/jvmMain/kotlin/ai/koog/agents/mcp/McpToolDefinitionParser.kt
+++ b/agents/agents-mcp/src/jvmMain/kotlin/ai/koog/agents/mcp/McpToolDefinitionParser.kt
@@ -48,6 +48,9 @@ public object DefaultMcpToolDescriptorParser : McpToolDescriptorParser {
         // Extract the type string from the JSON object
         val typeStr = if ("type" in element) {
             element.getValue("type").jsonPrimitive.content
+        } else if ("\$ref" in element) {
+//           TODO("Support \$ref") 
+            "object"
         } else {
             throw IllegalArgumentException("Parameter type must have type property")
         }

--- a/agents/agents-mcp/src/jvmMain/kotlin/ai/koog/agents/mcp/McpToolRegistryProvider.kt
+++ b/agents/agents-mcp/src/jvmMain/kotlin/ai/koog/agents/mcp/McpToolRegistryProvider.kt
@@ -1,6 +1,7 @@
 package ai.koog.agents.mcp
 
 import ai.koog.agents.core.tools.ToolRegistry
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.*
 import io.ktor.client.plugins.sse.*
 import io.modelcontextprotocol.kotlin.sdk.Implementation
@@ -22,6 +23,8 @@ import kotlinx.io.buffered
  * 4. Registering the transformed tools in a ToolRegistry
  */
 public object McpToolRegistryProvider {
+    private val logger = KotlinLogging.logger (McpToolRegistryProvider::class.qualifiedName!!)
+
     /**
      * Default name for the MCP client when connecting to an MCP server.
      */
@@ -78,8 +81,12 @@ public object McpToolRegistryProvider {
         val sdkTools = mcpClient.listTools()?.tools.orEmpty()
         return ToolRegistry {
             sdkTools.forEach { sdkTool ->
-                val toolDescriptor = mcpToolParser.parse(sdkTool)
-                tool(McpTool(mcpClient, toolDescriptor))
+                try {
+                    val toolDescriptor = mcpToolParser.parse(sdkTool)
+                    tool(McpTool(mcpClient, toolDescriptor))
+                } catch (e: Exception) {
+                    logger.error(e) { "Failed to register tool: ${sdkTool.name}" }
+                }
             }
         }
     }

--- a/agents/agents-mcp/src/jvmMain/kotlin/ai/koog/agents/mcp/McpToolRegistryProvider.kt
+++ b/agents/agents-mcp/src/jvmMain/kotlin/ai/koog/agents/mcp/McpToolRegistryProvider.kt
@@ -84,8 +84,8 @@ public object McpToolRegistryProvider {
                 try {
                     val toolDescriptor = mcpToolParser.parse(sdkTool)
                     tool(McpTool(mcpClient, toolDescriptor))
-                } catch (e: Exception) {
-                    logger.error(e) { "Failed to register tool: ${sdkTool.name}" }
+                } catch (e: Throwable) {
+                    logger.error(e) { "Failed to parse descriptor parameters for tool: ${sdkTool.name}" }
                 }
             }
         }

--- a/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/DefaultMcpToolDescriptorParserTest.kt
+++ b/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/DefaultMcpToolDescriptorParserTest.kt
@@ -307,8 +307,7 @@ class DefaultMcpToolDescriptorParserTest {
     }
 
     @Test
-    fun `test error cases`() {
-        // Test case 1: Parameter type is missing
+    fun `test parameter type is missing`() {
         val missingTypeToolSdk = createSdkTool(
             name = "test-tool",
             description = "A test tool",
@@ -324,8 +323,10 @@ class DefaultMcpToolDescriptorParserTest {
         assertFailsWith<IllegalArgumentException>("Should fail when parameter type is missing") {
             parser.parse(missingTypeToolSdk)
         }
+    }
 
-        // Test case 2: Array items property is missing
+    @Test
+    fun `test array items property is missing`() {
         val missingArrayItemsToolSdk = createSdkTool(
             name = "test-tool",
             description = "A test tool",
@@ -342,8 +343,10 @@ class DefaultMcpToolDescriptorParserTest {
         assertFailsWith<IllegalArgumentException>("Should fail when array items property is missing") {
             parser.parse(missingArrayItemsToolSdk)
         }
+    }
 
-        // Test case 3: Object without properties property should return empty properties list
+    @Test
+    fun `test object without properties returns empty properties list`() {
         val missingObjectPropertiesToolSdk = createSdkTool(
             name = "test-tool",
             description = "A test tool",
@@ -361,8 +364,10 @@ class DefaultMcpToolDescriptorParserTest {
         val objectParam = toolDescriptor.optionalParameters.first()
         val objectType = objectParam.type as ToolParameterType.Object
         assertEquals(emptyList(), objectType.properties, "Object without properties should have empty properties list")
+    }
 
-        // Test case 4: Parameter type is unsupported
+    @Test
+    fun `test parameter type is unsupported`() {
         val unsupportedTypeToolSdk = createSdkTool(
             name = "test-tool",
             description = "A test tool",

--- a/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/DefaultMcpToolDescriptorParserTest.kt
+++ b/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/DefaultMcpToolDescriptorParserTest.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.json.*
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class DefaultMcpToolDescriptorParserTest {
 
@@ -196,6 +197,116 @@ class DefaultMcpToolDescriptorParserTest {
     }
 
     @Test
+    fun `test parsing enum parameter type`() {
+        // Create an SDK Tool with an enum parameter
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "A test tool with enum parameter",
+            properties = buildJsonObject {
+                putJsonObject("enumParam") {
+                    put("type", "enum")
+                    put("description", "Enum parameter")
+                    putJsonArray("enum") {
+                        add("option1")
+                        add("option2")
+                        add("option3")
+                    }
+                }
+            },
+            required = listOf("enumParam")
+        )
+
+        // Parse the tool
+        val toolDescriptor = parser.parse(sdkTool)
+
+        // Verify the basic properties
+        assertEquals("test-tool", toolDescriptor.name)
+        assertEquals("A test tool with enum parameter", toolDescriptor.description)
+        assertEquals(1, toolDescriptor.requiredParameters.size)
+        assertEquals(0, toolDescriptor.optionalParameters.size)
+
+        // Verify the enum parameter
+        val enumParam = toolDescriptor.requiredParameters.first()
+        assertEquals("enumParam", enumParam.name)
+        assertEquals("Enum parameter", enumParam.description)
+        assertTrue(enumParam.type is ToolParameterType.Enum)
+
+        // Verify the enum values
+        val enumType = enumParam.type as ToolParameterType.Enum
+        val expectedOptions = arrayOf("option1", "option2", "option3")
+        assertEquals(expectedOptions.size, enumType.entries.size)
+        expectedOptions.forEachIndexed { index, option ->
+            assertEquals(option, enumType.entries[index])
+        }
+    }
+
+    @Test
+    fun `test parsing object parameter with additional properties`() {
+        // Create an SDK Tool with an object parameter that has additional properties
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "A test tool with object parameter",
+            properties = buildJsonObject {
+                putJsonObject("objectParam") {
+                    put("type", "object")
+                    put("description", "Object parameter")
+                    putJsonObject("properties") {
+                        putJsonObject("name") {
+                            put("type", "string")
+                            put("description", "Name property")
+                        }
+                        putJsonObject("age") {
+                            put("type", "integer")
+                            put("description", "Age property")
+                        }
+                    }
+                    putJsonArray("required") {
+                        add("name")
+                    }
+                    putJsonObject("additionalProperties") {
+                        put("type", "string")
+                    }
+                }
+            },
+            required = listOf("objectParam")
+        )
+
+        // Parse the tool
+        val toolDescriptor = parser.parse(sdkTool)
+
+        // Verify the result
+        val expectedToolDescriptor = ToolDescriptor(
+            name = "test-tool",
+            description = "A test tool with object parameter",
+            requiredParameters = listOf(
+                ToolParameterDescriptor(
+                    name = "objectParam",
+                    description = "Object parameter",
+                    type = ToolParameterType.Object(
+                        properties = listOf(
+                            ToolParameterDescriptor(
+                                name = "name",
+                                description = "Object parameter",
+                                type = ToolParameterType.String
+                            ),
+                            ToolParameterDescriptor(
+                                name = "age",
+                                description = "Object parameter",
+                                type = ToolParameterType.Integer
+                            )
+                        ),
+                        requiredProperties = listOf("name"),
+                        additionalPropertiesType = ToolParameterType.String,
+                        additionalProperties = true
+                    )
+                )
+            ),
+            optionalParameters = emptyList()
+        )
+        assertEquals(expectedToolDescriptor, toolDescriptor)
+    }
+
+    @Test
     fun `test error cases`() {
         // Test case 1: Parameter type is missing
         val missingTypeToolSdk = createSdkTool(
@@ -232,23 +343,24 @@ class DefaultMcpToolDescriptorParserTest {
             parser.parse(missingArrayItemsToolSdk)
         }
 
-        // Test case 3: Object properties property is missing
+        // Test case 3: Object without properties property should return empty properties list
         val missingObjectPropertiesToolSdk = createSdkTool(
             name = "test-tool",
             description = "A test tool",
             properties = buildJsonObject {
-                putJsonObject("invalidObjectParam") {
+                putJsonObject("objectParam") {
                     put("type", "object")
-                    put("description", "Invalid object parameter")
+                    put("description", "Object parameter without properties")
                     // Missing properties property
                 }
             },
             required = emptyList()
         )
 
-        assertFailsWith<IllegalArgumentException>("Should fail when object properties property is missing") {
-            parser.parse(missingObjectPropertiesToolSdk)
-        }
+        val toolDescriptor = parser.parse(missingObjectPropertiesToolSdk)
+        val objectParam = toolDescriptor.optionalParameters.first()
+        val objectType = objectParam.type as ToolParameterType.Object
+        assertEquals(emptyList(), objectType.properties, "Object without properties should have empty properties list")
 
         // Test case 4: Parameter type is unsupported
         val unsupportedTypeToolSdk = createSdkTool(

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolDescriptors.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolDescriptors.kt
@@ -91,7 +91,8 @@ public sealed class ToolParameterType(public val name: kotlin.String) {
      */
     public data class Object(
         val properties: kotlin.collections.List<ToolParameterDescriptor>,
-        val additionalProperties: kotlin.Boolean = false
+        val requiredProperties: kotlin.collections.List<kotlin.String>,
+        val additionalProperties: kotlin.Boolean?
 
     ) : ToolParameterType("OBJECT")
 

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolDescriptors.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolDescriptors.kt
@@ -91,9 +91,9 @@ public sealed class ToolParameterType(public val name: kotlin.String) {
      */
     public data class Object(
         val properties: kotlin.collections.List<ToolParameterDescriptor>,
-        val requiredProperties: kotlin.collections.List<kotlin.String>,
-        val additionalProperties: kotlin.Boolean?
-
+        val requiredProperties: kotlin.collections.List<kotlin.String> = listOf(),
+        val additionalProperties: kotlin.Boolean? = null,
+        val additionalPropertiesType: ToolParameterType? = null,
     ) : ToolParameterType("OBJECT")
 
 

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolDescriptors.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolDescriptors.kt
@@ -89,7 +89,12 @@ public sealed class ToolParameterType(public val name: kotlin.String) {
      *
      * @property properties The properties of the object type.
      */
-    public data class Object(val properties: kotlin.collections.List<ToolParameterDescriptor>) : ToolParameterType("OBJECT")
+    public data class Object(
+        val properties: kotlin.collections.List<ToolParameterDescriptor>,
+        val additionalProperties: kotlin.Boolean = false
+
+    ) : ToolParameterType("OBJECT")
+
 
     public companion object {
         public fun Enum(entries: EnumEntries<*>): Enum = Enum(entries.map { it.name }.toTypedArray())

--- a/examples/src/main/kotlin/ai/koog/agents/example/mcp/GoogleMapsMcpClient.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/mcp/GoogleMapsMcpClient.kt
@@ -40,6 +40,11 @@ fun main() {
                 transport = McpToolRegistryProvider.defaultStdioTransport(process)
             )
 
+            toolRegistry.tools.forEach {
+                println(it.name)
+                println(it.descriptor)
+            }
+
             // Create the runner
             val agent = AIAgent(
                 executor = simpleOpenAIExecutor(openAIApiToken),

--- a/examples/src/main/kotlin/ai/koog/agents/example/mcp/UnityMcpAgent.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/mcp/UnityMcpAgent.kt
@@ -39,8 +39,7 @@ fun main() {
 //        "/Users/Maria.Tigina/Applications/UnityMCP/UnityMcpServer/src",
 //        "run",
 //        "server.py"
-//    )
-//        .start()
+//    ).start()
 
     val process = ProcessBuilder(
         "/Users/Maria.Tigina/IdeaProjects/TowerDefense/My project/Library/com.ivanmurzak.unity.mcp.server/bin~/Release/net9.0/com.IvanMurzak.Unity.MCP.Server",

--- a/examples/src/main/kotlin/ai/koog/agents/example/mcp/UnityMcpAgent.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/mcp/UnityMcpAgent.kt
@@ -41,6 +41,13 @@ fun main() {
         "server.py"
     )
         .start()
+    
+    // MCP github: https://github.com/IvanMurzak/Unity-MCP
+    // Demo project: https://github.com/citizenmatt/TowerDefense
+//    val process = ProcessBuilder(
+//        "/Users/heorhii.lemeshko/projects/unity/Unity-MCP/Library/com.ivanmurzak.unity.mcp.server/bin~/Release/net9.0/com.IvanMurzak.Unity.MCP.Server",
+//        "60606"
+//    )
 
     // Wait for the server to start
     Thread.sleep(2000)
@@ -96,7 +103,7 @@ fun main() {
                         }
 
                         onAfterLLMWithToolsCall = { response, tools ->
-                            println("LLM response: $response, Tools: $tools")
+                            println("LLM response: $response, Tools: ${tools.map{it.name}}")
                         }
 
                         onAgentFinished = { strategyName: String, result: String? ->
@@ -109,6 +116,12 @@ fun main() {
                     }
                 }
             )
+            
+            val runAndGetResult = agent.runAndGetResult(" extend current opened scene for the towerdefence game. " +
+                    "Add more placements for the towers, change the path for the enemies")
+            println(runAndGetResult)
+
+
         }
     } finally {
         // Shutdown the Docker container

--- a/examples/src/main/kotlin/ai/koog/agents/example/mcp/UnityMcpAgent.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/mcp/UnityMcpAgent.kt
@@ -2,6 +2,7 @@ package ai.koog.agents.example.mcp
 
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.agent.entity.AIAgentStrategy
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
@@ -33,16 +34,19 @@ import kotlinx.coroutines.runBlocking
  * and task automation.
  */
 fun main() {
-    // Start the Docker container with the Google Maps MCP server
+    // https://github.com/justinpbarnett/unity-mcp
+//    val pathToUnityServer= "path/to/unity/server"
 //    val process = ProcessBuilder(
 //        "uv", "--directory",
-//        "/Users/Maria.Tigina/Applications/UnityMCP/UnityMcpServer/src",
+//        pathToUnityServer,
 //        "run",
 //        "server.py"
 //    ).start()
 
+    // https://github.com/IvanMurzak/Unity-MCP
+    val pathToUnityProject = "path/to/unity/project"
     val process = ProcessBuilder(
-        "/Users/Maria.Tigina/IdeaProjects/TowerDefense/My project/Library/com.ivanmurzak.unity.mcp.server/bin~/Release/net9.0/com.IvanMurzak.Unity.MCP.Server",
+        "$pathToUnityProject/com.ivanmurzak.unity.mcp.server/bin~/Release/net9.0/com.IvanMurzak.Unity.MCP.Server",
         "60606"
     ).start()
 
@@ -98,31 +102,25 @@ fun main() {
                     install(Tracing)
 
                     install(EventHandler) {
-                        onToolCallResult = { tool, toolArgs, result ->
-                            println("Tool: ${tool.name}, Args: $toolArgs, Result: $result")
+                        onBeforeAgentStarted { strategy: AIAgentStrategy, agent: AIAgent ->
+                            println("OnBeforeAgentStarted first (strategy: ${strategy.name})")
                         }
 
-                        onBeforeLLMCall  = { prompt, tools ->
-                            println("Before LLM call: prompt=$prompt, tools: [${tools.joinToString { it.name }}]")
+                        onBeforeAgentStarted { strategy: AIAgentStrategy, agent: AIAgent ->
+                            println("OnBeforeAgentStarted second (strategy: ${strategy.name})")
                         }
 
-                        onAfterLLMCall  = { responses ->
-                            println("After LLM call: ${responses.joinToString("\n") { it.content }}")
-                        }
-
-                        onAgentFinished = { strategyName: String, result: String? ->
-                            println("Result: $result")
-                        }
-
-                        onAgentRunError = { strategyName, throwable ->
-                            println("An error occurred: ${throwable.message}\n${throwable.stackTraceToString()}")
+                        onAgentFinished { strategyName: String, result: String? ->
+                            println("OnAgentFinished (strategy: $strategyName, result: $result)")
                         }
                     }
                 }
             )
-            
-            val runAndGetResult = agent.runAndGetResult(" extend current opened scene for the towerdefence game. " +
-                    "Add more placements for the towers, change the path for the enemies")
+
+            val runAndGetResult = agent.runAndGetResult(
+                " extend current opened scene for the towerdefence game. " +
+                        "Add more placements for the towers, change the path for the enemies"
+            )
             println(runAndGetResult)
 
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -441,19 +441,17 @@ public open class OpenAILLMClient(
 
             is ToolParameterType.Object -> {
                 put("type", JsonPrimitive("object"))
-                if (type.additionalProperties) {
-                    put("additionalProperties", true)
-                } else {
-                    put("properties", buildJsonObject {
-                        type.properties.forEach { property ->
-                            put(property.name, buildJsonObject {
-                                fillOpenAIParamType(property.type)
-                                put("description", property.description)
-                            })
-                        }
-                    }
-                    )
+                type.additionalProperties?.let {
+                    put("additionalProperties", type.additionalProperties)
                 }
+                put("properties", buildJsonObject {
+                    type.properties.forEach { property ->
+                        put(property.name, buildJsonObject {
+                            fillOpenAIParamType(property.type)
+                            put("description", property.description)
+                        })
+                    }
+                })
             }
         }
     }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -441,15 +441,19 @@ public open class OpenAILLMClient(
 
             is ToolParameterType.Object -> {
                 put("type", JsonPrimitive("object"))
-                put("properties", buildJsonObject {
-                    type.properties.forEach { property ->
-                        put(property.name, buildJsonObject {
-                            fillOpenAIParamType(property.type)
-                            put("description", property.description)
-                        })
+                if (type.additionalProperties) {
+                    put("additionalProperties", true)
+                } else {
+                    put("properties", buildJsonObject {
+                        type.properties.forEach { property ->
+                            put(property.name, buildJsonObject {
+                                fillOpenAIParamType(property.type)
+                                put("description", property.description)
+                            })
+                        }
                     }
+                    )
                 }
-                )
             }
         }
     }


### PR DESCRIPTION
One more step to cover all possible arg types for the MCP tools
- Support enum arg type parsing
- Support object additionalParameters flag with types/bool parsing
- Add try/catch wrapper to skip tools which we are not able to parse for now
- Add MCP docs

Resolves part of the https://github.com/JetBrains/koog/issues/233