### PR TITLE
Move Tool.Args from Tool

### DIFF
--- a/agents/agents-core/QuickstartGuide.md
+++ b/agents/agents-core/QuickstartGuide.md
@@ -76,9 +76,9 @@ The SimpleAPI provides the following built-in tools:
 You can create custom tools by extending the `SimpleTool` class:
 
 ```kotlin
-object CalculatorTool : SimpleTool<CalculatorTool.Args>() {
+object CalculatorTool : SimpleTool<CalculatorToolArgs>() {
     @Serializable
-    data class Args(val expression: String) : Tool.Args
+    data class Args(val expression: String) : ToolArgs
 
     override val argsSerializer = Args.serializer()
 
@@ -138,9 +138,9 @@ val agent = AIAgent(
 ## Example: Creating a Code Assistant
 
 ```kotlin
-object GenerateCodeTool : SimpleTool<GenerateCodeTool.Args>() {
+object GenerateCodeTool : SimpleTool<GenerateCodeToolArgs>() {
     @Serializable
-    data class Args(val language: String, val task: String) : Tool.Args
+    data class Args(val language: String, val task: String) : ToolArgs
 
     override val argsSerializer = Args.serializer()
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
@@ -319,9 +319,9 @@ public open class AIAgent(
             pipeline.onToolCall(tool = tool, toolArgs = toolArgs)
 
             // Tool Execution
-            val (toolResult, serializedResult) = try {
+            val toolResult = try {
                 @Suppress("UNCHECKED_CAST")
-                (tool as Tool<ToolArgs, ToolResult>).executeAndSerialize(toolArgs, toolEnabler)
+                (tool as Tool<ToolArgs, ToolResult>).execute(toolArgs, toolEnabler)
             } catch (e: ToolException) {
 
                 pipeline.onToolValidationError(tool = tool, toolArgs = toolArgs, error = e.message)

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
@@ -321,7 +321,7 @@ public open class AIAgent(
             // Tool Execution
             val (toolResult, serializedResult) = try {
                 @Suppress("UNCHECKED_CAST")
-                (tool as Tool<Tool.Args, ToolResult>).executeAndSerialize(toolArgs, toolEnabler)
+                (tool as Tool<ToolArgs, ToolResult>).executeAndSerialize(toolArgs, toolEnabler)
             } catch (e: ToolException) {
 
                 pipeline.onToolValidationError(tool = tool, toolArgs = toolArgs, error = e.message)
@@ -357,7 +357,7 @@ public open class AIAgent(
                 toolCallId = content.toolCallId,
                 toolName = content.toolName,
                 agentId = strategy.name,
-                message = serializedResult,
+                message = toolResult.toStringDefault(),
                 result = toolResult
             )
         }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentTool.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentTool.kt
@@ -53,7 +53,7 @@ public class AIAgentTool(
      * @property request The input data or parameters needed for the agent tool to perform its operation.
      */
     @Serializable
-    public data class AgentToolArgs(val request: String) : Args
+    public data class AgentToolArgs(val request: String) : ToolArgs
 
     /**
      * Represents the result of executing an agent tool operation.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
@@ -4,6 +4,7 @@ import ai.koog.agents.core.agent.config.AIAgentConfigBase
 import ai.koog.agents.core.environment.AIAgentEnvironment
 import ai.koog.agents.core.environment.SafeTool
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.ToolResult
@@ -79,13 +80,13 @@ public class AIAgentLLMWriteSession internal constructor(
     /**
      * Executes the specified tool with the given arguments and returns the result within a [SafeTool.Result] wrapper.
      *
-     * @param TArgs the type of arguments required by the tool, extending `Tool.Args`.
+     * @param TArgs the type of arguments required by the tool, extending `ToolArgs`.
      * @param TResult the type of result returned by the tool, implementing `ToolResult`.
      * @param tool the tool to be executed.
      * @param args the arguments required to execute the tool.
      * @return a `SafeTool.Result` containing the tool's execution result of type `TResult`.
      */
-    public suspend inline fun <reified TArgs : Tool.Args, reified TResult : ToolResult> callTool(
+    public suspend inline fun <reified TArgs : ToolArgs, reified TResult : ToolResult> callTool(
         tool: Tool<TArgs, TResult>,
         args: TArgs
     ): SafeTool.Result<TResult> {
@@ -96,10 +97,10 @@ public class AIAgentLLMWriteSession internal constructor(
      * Executes a tool by its name with the provided arguments.
      *
      * @param toolName The name of the tool to be executed.
-     * @param args The arguments required to execute the tool, which must be a subtype of [Tool.Args].
+     * @param args The arguments required to execute the tool, which must be a subtype of [ToolArgs].
      * @return A [SafeTool.Result] containing the result of the tool execution, which is a subtype of [ToolResult].
      */
-    public suspend inline fun <reified TArgs : Tool.Args> callTool(
+    public suspend inline fun <reified TArgs : ToolArgs> callTool(
         toolName: String,
         args: TArgs
     ): SafeTool.Result<out ToolResult> {
@@ -110,10 +111,10 @@ public class AIAgentLLMWriteSession internal constructor(
      * Executes a tool identified by its name with the provided arguments and returns the raw string result.
      *
      * @param toolName The name of the tool to be executed.
-     * @param args The arguments to be passed to the tool, conforming to the [Tool.Args] type.
+     * @param args The arguments to be passed to the tool, conforming to the [ToolArgs] type.
      * @return The raw result of the tool's execution as a String.
      */
-    public suspend inline fun <reified TArgs : Tool.Args> callToolRaw(
+    public suspend inline fun <reified TArgs : ToolArgs> callToolRaw(
         toolName: String,
         args: TArgs
     ): String {
@@ -129,7 +130,7 @@ public class AIAgentLLMWriteSession internal constructor(
      * @param args The arguments to be passed to the tool for its execution.
      * @return A result wrapper containing either the successful result of the tool's execution or an error.
      */
-    public suspend inline fun <reified TArgs : Tool.Args, reified TResult : ToolResult> callTool(
+    public suspend inline fun <reified TArgs : ToolArgs, reified TResult : ToolResult> callTool(
         toolClass: KClass<out Tool<TArgs, TResult>>,
         args: TArgs
     ): SafeTool.Result<TResult> {
@@ -140,13 +141,13 @@ public class AIAgentLLMWriteSession internal constructor(
     /**
      * Finds and retrieves a tool of the specified type from the tool registry.
      *
-     * @param TArgs The type of arguments the tool accepts, extending from Tool.Args.
+     * @param TArgs The type of arguments the tool accepts, extending from ToolArgs.
      * @param TResult The type of result the tool produces, extending from ToolResult.
      * @param toolClass The KClass reference that specifies the type of tool to find.
      * @return A SafeTool instance wrapping the found tool and its environment.
      * @throws IllegalArgumentException if the specified tool is not found in the tool registry.
      */
-    public inline fun <reified TArgs : Tool.Args, reified TResult : ToolResult> findTool(toolClass: KClass<out Tool<TArgs, TResult>>): SafeTool<TArgs, TResult> {
+    public inline fun <reified TArgs : ToolArgs, reified TResult : ToolResult> findTool(toolClass: KClass<out Tool<TArgs, TResult>>): SafeTool<TArgs, TResult> {
         @Suppress("UNCHECKED_CAST")
         val tool = (toolRegistry.tools.find(toolClass::isInstance) as? Tool<TArgs, TResult>
             ?: throw IllegalArgumentException("Tool with type ${toolClass.simpleName} is not defined"))
@@ -157,11 +158,11 @@ public class AIAgentLLMWriteSession internal constructor(
     /**
      * Invokes a tool of the specified type with the provided arguments.
      *
-     * @param args The input arguments required for the tool execution, represented as an instance of `Tool.Args`.
+     * @param args The input arguments required for the tool execution, represented as an instance of `ToolArgs`.
      * @return A `SafeTool.Result` containing the outcome of the tool's execution, which may be of any type that extends `ToolResult`.
      */
     public suspend inline fun <reified ToolT : Tool<*, *>> callTool(
-        args: Tool.Args
+        args: ToolArgs
     ): SafeTool.Result<out ToolResult> {
         val tool = findTool<ToolT>()
         return tool.executeUnsafe(args)
@@ -184,13 +185,13 @@ public class AIAgentLLMWriteSession internal constructor(
     /**
      * Transforms a flow of arguments into a flow of results by asynchronously executing the given tool in parallel.
      *
-     * @param TArgs the type of the arguments required by the tool, extending Tool.Args.
+     * @param TArgs the type of the arguments required by the tool, extending ToolArgs.
      * @param TResult the type of the result produced by the tool, extending ToolResult.
      * @param safeTool the tool to be executed for each input argument.
      * @param concurrency the maximum number of parallel executions allowed. Defaults to 16.
      * @return a flow of results wrapped in SafeTool.Result for each input argument.
      */
-    public inline fun <reified TArgs : Tool.Args, reified TResult : ToolResult> Flow<TArgs>.toParallelToolCalls(
+    public inline fun <reified TArgs : ToolArgs, reified TResult : ToolResult> Flow<TArgs>.toParallelToolCalls(
         safeTool: SafeTool<TArgs, TResult>,
         concurrency: Int = 16
     ): Flow<SafeTool.Result<TResult>> = flatMapMerge(concurrency) { args ->
@@ -207,7 +208,7 @@ public class AIAgentLLMWriteSession internal constructor(
      * @param concurrency The maximum number of parallel calls to the tool. Default is 16.
      * @return A flow of string results derived from executing the tool's raw method.
      */
-    public inline fun <reified TArgs : Tool.Args, reified TResult : ToolResult> Flow<TArgs>.toParallelToolCallsRaw(
+    public inline fun <reified TArgs : ToolArgs, reified TResult : ToolResult> Flow<TArgs>.toParallelToolCallsRaw(
         safeTool: SafeTool<TArgs, TResult>,
         concurrency: Int = 16
     ): Flow<String> = flatMapMerge(concurrency) { args ->
@@ -225,7 +226,7 @@ public class AIAgentLLMWriteSession internal constructor(
      * @param concurrency The maximum number of concurrent executions. Default value is 16.
      * @return A flow emitting the results of the tool executions wrapped in a SafeTool.Result object.
      */
-    public inline fun <reified TArgs : Tool.Args, reified TResult : ToolResult> Flow<TArgs>.toParallelToolCalls(
+    public inline fun <reified TArgs : ToolArgs, reified TResult : ToolResult> Flow<TArgs>.toParallelToolCalls(
         tool: Tool<TArgs, TResult>,
         concurrency: Int = 16
     ): Flow<SafeTool.Result<TResult>> = flatMapMerge(concurrency) { args ->
@@ -244,7 +245,7 @@ public class AIAgentLLMWriteSession internal constructor(
      * @param concurrency The maximum number of parallel executions allowed. Default is 16.
      * @return A Flow containing the results of the tool executions, wrapped in `SafeTool.Result`.
      */
-    public inline fun <reified TArgs : Tool.Args, reified TResult : ToolResult> Flow<TArgs>.toParallelToolCalls(
+    public inline fun <reified TArgs : ToolArgs, reified TResult : ToolResult> Flow<TArgs>.toParallelToolCalls(
         toolClass: KClass<out Tool<TArgs, TResult>>,
         concurrency: Int = 16
     ): Flow<SafeTool.Result<TResult>> {
@@ -261,7 +262,7 @@ public class AIAgentLLMWriteSession internal constructor(
      * @param concurrency the number of concurrent tool calls to be executed. Defaults to 16.
      * @return a flow of raw string results from the parallel tool calls.
      */
-    public inline fun <reified TArgs : Tool.Args, reified TResult : ToolResult> Flow<TArgs>.toParallelToolCallsRaw(
+    public inline fun <reified TArgs : ToolArgs, reified TResult : ToolResult> Flow<TArgs>.toParallelToolCallsRaw(
         toolClass: KClass<out Tool<TArgs, TResult>>,
         concurrency: Int = 16
     ): Flow<String> {
@@ -280,7 +281,7 @@ public class AIAgentLLMWriteSession internal constructor(
      * @return the tool that matches the specified name and types
      * @throws IllegalArgumentException if the tool is not defined or the types are incompatible
      */
-    public inline fun <reified TArgs : Tool.Args, reified TResult : ToolResult> findToolByNameAndArgs(toolName: String): Tool<TArgs, TResult> =
+    public inline fun <reified TArgs : ToolArgs, reified TResult : ToolResult> findToolByNameAndArgs(toolName: String): Tool<TArgs, TResult> =
         @Suppress("UNCHECKED_CAST")
         (toolRegistry.getTool(toolName) as? Tool<TArgs, TResult>
             ?: throw IllegalArgumentException("Tool \"$toolName\" is not defined or has incompatible arguments"))
@@ -293,7 +294,7 @@ public class AIAgentLLMWriteSession internal constructor(
      * @throws IllegalArgumentException If the tool with the specified name is not defined or its arguments
      * are incompatible with the expected type.
      */
-    public inline fun <reified TArgs : Tool.Args> findToolByName(toolName: String): SafeTool<TArgs, *> {
+    public inline fun <reified TArgs : ToolArgs> findToolByName(toolName: String): SafeTool<TArgs, *> {
         @Suppress("UNCHECKED_CAST")
         val tool = (toolRegistry.getTool(toolName) as? Tool<TArgs, *>
             ?: throw IllegalArgumentException("Tool \"$toolName\" is not defined or has incompatible arguments"))

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentEdges.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentEdges.kt
@@ -5,6 +5,7 @@ import ai.koog.agents.core.environment.ReceivedToolResult
 import ai.koog.agents.core.environment.SafeTool
 import ai.koog.agents.core.environment.toSafeResult
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolResult
 import ai.koog.prompt.message.MediaContent
 import ai.koog.prompt.message.Message
@@ -91,7 +92,7 @@ public infix fun <IncomingOutput, IntermediateOutput, OutgoingInput>
  * @param tool The tool to match against
  * @param block A function that evaluates the tool arguments to determine if the edge should accept the message
  */
-public inline fun <IncomingOutput, IntermediateOutput, OutgoingInput, reified Args : Tool.Args>
+public inline fun <IncomingOutput, IntermediateOutput, OutgoingInput, reified Args : ToolArgs>
         AIAgentEdgeBuilderIntermediate<IncomingOutput, IntermediateOutput, OutgoingInput>.onToolCall(
     tool: Tool<Args, *>,
     crossinline block: suspend (Args) -> Boolean

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
@@ -7,6 +7,7 @@ import ai.koog.agents.core.environment.SafeTool
 import ai.koog.agents.core.environment.executeTool
 import ai.koog.agents.core.environment.result
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolResult
 import ai.koog.prompt.structure.StructuredData
@@ -295,7 +296,7 @@ public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMSendMultipleToolResults(
  * @param tool The tool to execute.
  * @param doUpdatePrompt Specifies whether to add tool call details to the prompt.
  */
-public inline fun <reified ToolArg : Tool.Args, reified TResult : ToolResult> AIAgentSubgraphBuilderBase<*, *>.nodeExecuteSingleTool(
+public inline fun <reified ToolArg : ToolArgs, reified TResult : ToolResult> AIAgentSubgraphBuilderBase<*, *>.nodeExecuteSingleTool(
     name: String? = null,
     tool: Tool<ToolArg, TResult>,
     doUpdatePrompt: Boolean = true

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
@@ -309,7 +309,7 @@ public inline fun <reified ToolArg : ToolArgs, reified TResult : ToolResult> AIA
                     // The only workaround is to generate it
                     user(
                         "Tool call: ${tool.name} was explicitly called with args: ${
-                            tool.encodeArgsToString(toolArgs)
+                            tool.encodeArgs(toolArgs)
                         }"
                     )
                 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/SafeTool.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/SafeTool.kt
@@ -3,6 +3,7 @@
 package ai.koog.agents.core.environment
 
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolResult
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
@@ -13,13 +14,13 @@ import kotlinx.datetime.Clock
  * It provides mechanisms for handling tool execution results and differentiating between
  * success and failure cases.
  *
- * @param TArgs The type of arguments accepted by the underlying tool. Must extend [Tool.Args].
+ * @param TArgs The type of arguments accepted by the underlying tool. Must extend [ToolArgs].
  * @param TResult The type of result produced by the underlying tool. Must extend [ToolResult].
  * @property tool The tool instance to be executed. Defines the operation and its required input/output behavior.
  * @property clock The clock used to determine tool call message timestamps
  * @property environment The environment in which the tool operates. Handles the execution of tool logic.
  */
-public data class SafeTool<TArgs : Tool.Args, TResult : ToolResult>(
+public data class SafeTool<TArgs : ToolArgs, TResult : ToolResult>(
     private val tool: Tool<TArgs, TResult>,
     private val environment: AIAgentEnvironment,
     private val clock: Clock
@@ -152,11 +153,11 @@ public data class SafeTool<TArgs : Tool.Args, TResult : ToolResult>(
      * Executes a tool with the provided arguments in an unsafe manner.
      * This method does not enforce type safety for the arguments provided to the tool.
      *
-     * @param args The arguments to be passed to the tool, represented as a Tool.Args object.
+     * @param args The arguments to be passed to the tool, represented as a ToolArgs object.
      * @return A Result containing the outcome of the tool execution with TResult as the result type.
      */
     @Suppress("UNCHECKED_CAST")
-    public suspend fun executeUnsafe(args: Tool.Args): Result<TResult> {
+    public suspend fun executeUnsafe(args: ToolArgs): Result<TResult> {
         return environment.executeTool(
             Message.Tool.Call(
                 id = null,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/AIAgentPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/AIAgentPipeline.kt
@@ -11,6 +11,7 @@ import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.environment.AIAgentEnvironment
 import ai.koog.agents.core.feature.handler.*
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolResult
 import ai.koog.agents.features.common.config.FeatureConfig
@@ -317,7 +318,7 @@ public class AIAgentPipeline {
      * @param tool The tool that is being called
      * @param toolArgs The arguments provided to the tool
      */
-    public suspend fun onToolCall(tool: Tool<*, *>, toolArgs: Tool.Args) {
+    public suspend fun onToolCall(tool: Tool<*, *>, toolArgs: ToolArgs) {
         executeToolHandlers.values.forEach { handler -> handler.toolCallHandler.handle(tool, toolArgs) }
     }
 
@@ -328,7 +329,7 @@ public class AIAgentPipeline {
      * @param toolArgs The arguments that failed validation
      * @param error The validation error message
      */
-    public suspend fun onToolValidationError(tool: Tool<*, *>, toolArgs: Tool.Args, error: String) {
+    public suspend fun onToolValidationError(tool: Tool<*, *>, toolArgs: ToolArgs, error: String) {
         executeToolHandlers.values.forEach { handler ->
             handler.toolValidationErrorHandler.handle(
                 tool,
@@ -345,7 +346,7 @@ public class AIAgentPipeline {
      * @param toolArgs The arguments provided to the tool
      * @param throwable The exception that caused the failure
      */
-    public suspend fun onToolCallFailure(tool: Tool<*, *>, toolArgs: Tool.Args, throwable: Throwable) {
+    public suspend fun onToolCallFailure(tool: Tool<*, *>, toolArgs: ToolArgs, throwable: Throwable) {
         executeToolHandlers.values.forEach { handler ->
             handler.toolCallFailureHandler.handle(
                 tool,
@@ -362,7 +363,7 @@ public class AIAgentPipeline {
      * @param toolArgs The arguments that were provided to the tool
      * @param result The result produced by the tool, or null if no result was produced
      */
-    public suspend fun onToolCallResult(tool: Tool<*, *>, toolArgs: Tool.Args, result: ToolResult?) {
+    public suspend fun onToolCallResult(tool: Tool<*, *>, toolArgs: ToolArgs, result: ToolResult?) {
         executeToolHandlers.values.forEach { handler -> handler.toolCallResultHandler.handle(tool, toolArgs, result) }
     }
 
@@ -669,7 +670,7 @@ public class AIAgentPipeline {
      */
     public fun <TFeature : Any> interceptToolCall(
         interceptContext: InterceptContext<TFeature>,
-        handle: suspend TFeature.(tool: Tool<*, *>, toolArgs: Tool.Args) -> Unit
+        handle: suspend TFeature.(tool: Tool<*, *>, toolArgs: ToolArgs) -> Unit
     ) {
         val existingHandler = executeToolHandlers.getOrPut(interceptContext.feature.key) { ExecuteToolHandler() }
 
@@ -693,7 +694,7 @@ public class AIAgentPipeline {
      */
     public fun <TFeature : Any> interceptToolValidationError(
         interceptContext: InterceptContext<TFeature>,
-        handle: suspend TFeature.(tool: Tool<*, *>, toolArgs: Tool.Args, value: String) -> Unit
+        handle: suspend TFeature.(tool: Tool<*, *>, toolArgs: ToolArgs, value: String) -> Unit
     ) {
         val existingHandler = executeToolHandlers.getOrPut(interceptContext.feature.key) { ExecuteToolHandler() }
 
@@ -717,7 +718,7 @@ public class AIAgentPipeline {
      */
     public fun <TFeature : Any> interceptToolCallFailure(
         interceptContext: InterceptContext<TFeature>,
-        handle: suspend TFeature.(tool: Tool<*, *>, toolArgs: Tool.Args, throwable: Throwable) -> Unit
+        handle: suspend TFeature.(tool: Tool<*, *>, toolArgs: ToolArgs, throwable: Throwable) -> Unit
     ) {
         val existingHandler = executeToolHandlers.getOrPut(interceptContext.feature.key) { ExecuteToolHandler() }
 
@@ -742,7 +743,7 @@ public class AIAgentPipeline {
      */
     public fun <TFeature : Any> interceptToolCallResult(
         interceptContext: InterceptContext<TFeature>,
-        handle: suspend TFeature.(tool: Tool<*, *>, toolArgs: Tool.Args, result: ToolResult?) -> Unit
+        handle: suspend TFeature.(tool: Tool<*, *>, toolArgs: ToolArgs, result: ToolResult?) -> Unit
     ) {
         val existingHandler = executeToolHandlers.getOrPut(interceptContext.feature.key) { ExecuteToolHandler() }
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/ExecuteToolHandler.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/ExecuteToolHandler.kt
@@ -1,6 +1,7 @@
 package ai.koog.agents.core.feature.handler
 
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolResult
 
 /**
@@ -72,7 +73,7 @@ public fun interface ToolCallHandler {
      * @param toolArgs The arguments required for executing the tool. These arguments are
      *                 used to configure or supply information needed for the tool's operation.
      */
-    public suspend fun handle(tool: Tool<*, *>, toolArgs: Tool.Args)
+    public suspend fun handle(tool: Tool<*, *>, toolArgs: ToolArgs)
 }
 
 /**
@@ -87,7 +88,7 @@ public fun interface ToolValidationErrorHandler {
      * @param toolArgs The arguments passed to the tool when the error occurred.
      * @param error The error message describing the validation issue.
      */
-    public suspend fun handle(tool: Tool<*, *>, toolArgs: Tool.Args, error: String)
+    public suspend fun handle(tool: Tool<*, *>, toolArgs: ToolArgs, error: String)
 }
 
 /**
@@ -103,7 +104,7 @@ public fun interface ToolCallFailureHandler {
      * @param toolArgs The arguments that were passed to the tool during execution.
      * @param throwable The exception or error that caused the failure.
      */
-    public suspend fun handle(tool: Tool<*, *>, toolArgs: Tool.Args, throwable: Throwable)
+    public suspend fun handle(tool: Tool<*, *>, toolArgs: ToolArgs, throwable: Throwable)
 }
 
 /**
@@ -119,5 +120,5 @@ public fun interface ToolCallResultHandler {
      * @param toolArgs The arguments required by the tool for execution.
      * @param result An optional result produced by the tool after execution, can be null if not applicable.
      */
-    public suspend fun handle(tool: Tool<*, *>, toolArgs: Tool.Args, result: ToolResult?)
+    public suspend fun handle(tool: Tool<*, *>, toolArgs: ToolArgs, result: ToolResult?)
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/featureEventTypes.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/featureEventTypes.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.core.feature.model
 
-import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolResult
 import ai.koog.agents.features.common.message.FeatureEvent

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/featureEventTypes.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/featureEventTypes.kt
@@ -1,6 +1,7 @@
 package ai.koog.agents.core.feature.model
 
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolResult
 import ai.koog.agents.features.common.message.FeatureEvent
 import ai.koog.agents.features.common.message.FeatureMessage
@@ -254,7 +255,7 @@ public data class LLMCallEndEvent(
 @Serializable
 public data class ToolCallEvent(
     val toolName: String,
-    val toolArgs: Tool.Args,
+    val toolArgs: ToolArgs,
     override val eventId: String = ToolCallEvent::class.simpleName!!,
 ) : DefinedFeatureEvent()
 
@@ -272,7 +273,7 @@ public data class ToolCallEvent(
 @Serializable
 public data class ToolValidationErrorEvent(
     val toolName: String,
-    val toolArgs: Tool.Args,
+    val toolArgs: ToolArgs,
     val errorMessage: String,
     override val eventId: String = ToolValidationErrorEvent::class.simpleName!!,
 ) : DefinedFeatureEvent()
@@ -292,7 +293,7 @@ public data class ToolValidationErrorEvent(
 @Serializable
 public data class ToolCallFailureEvent(
     val toolName: String,
-    val toolArgs: Tool.Args,
+    val toolArgs: ToolArgs,
     val error: AIAgentError,
     override val eventId: String = ToolCallFailureEvent::class.simpleName!!,
 ) : DefinedFeatureEvent()
@@ -312,7 +313,7 @@ public data class ToolCallFailureEvent(
 @Serializable
 public data class ToolCallResultEvent(
     val toolName: String,
-    val toolArgs: Tool.Args,
+    val toolArgs: ToolArgs,
     val result: ToolResult?,
     override val eventId: String = ToolCallResultEvent::class.simpleName!!,
 ) : DefinedFeatureEvent()

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/CalculatorTools.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/CalculatorTools.kt
@@ -11,7 +11,7 @@ object CalculatorTools {
         description: String,
     ) : Tool<CalculatorTool.Args, CalculatorTool.Result>() {
         @Serializable
-        data class Args(val a: Float, val b: Float) : Tool.Args
+        data class Args(val a: Float, val b: Float) : ToolArgs
 
         @Serializable
         @JvmInline

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionTest.kt
@@ -61,7 +61,7 @@ class AIAgentLLMWriteSessionTest {
 
     class TestTool : SimpleTool<TestTool.Args>() {
         @Serializable
-        data class Args(val input: String) : Tool.Args
+        data class Args(val input: String) : ToolArgs
 
         override val argsSerializer: KSerializer<Args> = Args.serializer()
 
@@ -84,7 +84,7 @@ class AIAgentLLMWriteSessionTest {
 
     class CustomTool : Tool<CustomTool.Args, CustomTool.Result>() {
         @Serializable
-        data class Args(val input: String) : Tool.Args
+        data class Args(val input: String) : ToolArgs
 
         data class Result(val output: String) : ToolResult {
             override fun toStringDefault(): String = output

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionTest.kt
@@ -38,7 +38,7 @@ class AIAgentLLMWriteSessionTest {
         override suspend fun executeTools(toolCalls: List<Message.Tool.Call>): List<ReceivedToolResult> {
             return toolCalls.map { toolCall ->
                 val tool = toolRegistry.getTool(toolCall.tool)
-                val args = tool.decodeArgsFromString(toolCall.content)
+                val args = tool.decodeArgs(toolCall.contentJson)
                 val result = tool.executeUnsafe(args, TestToolsEnabler)
 
                 ReceivedToolResult(

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
@@ -45,12 +45,12 @@ internal suspend fun AIAgentContextBase.promptWithTLDR(
 /**
  * The result which subgraphs can return.
  */
-public interface SubgraphResult : Tool.Args, ToolResult
+public interface SubgraphResult : ToolArgs, ToolResult
 
 /**
  * The result which subgraphs can return.
  */
-public interface SerializableSubgraphResult<T : SerializableSubgraphResult<T>> : Tool.Args, ToolResult.JSONSerializable<T>
+public interface SerializableSubgraphResult<T : SerializableSubgraphResult<T>> : ToolArgs, ToolResult.JSONSerializable<T>
 
 /**
  * Represents the result of a verified subgraph execution.

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/AskUser.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/AskUser.kt
@@ -15,7 +15,7 @@ public object AskUser : SimpleTool<AskUser.Args>() {
      * @property message The message to be used as an argument for the tool's execution.
      */
     @Serializable
-    public data class Args(val message: String) : Tool.Args
+    public data class Args(val message: String) : ToolArgs
 
     override val argsSerializer: KSerializer<Args> = Args.serializer()
 

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/ExitTool.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/ExitTool.kt
@@ -21,7 +21,7 @@ public object ExitTool : SimpleTool<ExitTool.Args>() {
      * @property message The input message provided as an argument for the tool.
      */
     @Serializable
-    public data class Args(val message: String) : Tool.Args
+    public data class Args(val message: String) : ToolArgs
 
     override suspend fun doExecute(args: Args): String {
         return "DONE"

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/SayToUser.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/SayToUser.kt
@@ -15,7 +15,7 @@ public object SayToUser : SimpleTool<SayToUser.Args>() {
      * required for tool execution.
      */
     @Serializable
-    public data class Args(val message: String) : Tool.Args
+    public data class Args(val message: String) : ToolArgs
 
     override val argsSerializer: KSerializer<Args> = Args.serializer()
 

--- a/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerConfig.kt
+++ b/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerConfig.kt
@@ -5,6 +5,7 @@ import ai.koog.agents.core.agent.context.AIAgentContextBase
 import ai.koog.agents.core.agent.entity.AIAgentNodeBase
 import ai.koog.agents.core.agent.entity.AIAgentStrategy
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolResult
 import ai.koog.agents.features.common.config.FeatureConfig
@@ -85,17 +86,17 @@ public class EventHandlerConfig : FeatureConfig() {
 
     //region Tool Call Handlers
 
-    private var _onToolCall: suspend (tool: Tool<*, *>, toolArgs: Tool.Args) -> Unit =
-        { tool: Tool<*, *>, toolArgs: Tool.Args -> }
+    private var _onToolCall: suspend (tool: Tool<*, *>, toolArgs: ToolArgs) -> Unit =
+        { tool: Tool<*, *>, toolArgs: ToolArgs -> }
 
-    private var _onToolValidationError: suspend (tool: Tool<*, *>, toolArgs: Tool.Args, value: String) -> Unit =
-        { tool: Tool<*, *>, toolArgs: Tool.Args, value: String -> }
+    private var _onToolValidationError: suspend (tool: Tool<*, *>, toolArgs: ToolArgs, value: String) -> Unit =
+        { tool: Tool<*, *>, toolArgs: ToolArgs, value: String -> }
 
-    private var _onToolCallFailure: suspend (tool: Tool<*, *>, toolArgs: Tool.Args, throwable: Throwable) -> Unit =
-        { tool: Tool<*, *>, toolArgs: Tool.Args, throwable: Throwable -> }
+    private var _onToolCallFailure: suspend (tool: Tool<*, *>, toolArgs: ToolArgs, throwable: Throwable) -> Unit =
+        { tool: Tool<*, *>, toolArgs: ToolArgs, throwable: Throwable -> }
 
-    private var _onToolCallResult: suspend (tool: Tool<*, *>, toolArgs: Tool.Args, result: ToolResult?) -> Unit =
-        { tool: Tool<*, *>, toolArgs: Tool.Args, result: ToolResult? -> }
+    private var _onToolCallResult: suspend (tool: Tool<*, *>, toolArgs: ToolArgs, result: ToolResult?) -> Unit =
+        { tool: Tool<*, *>, toolArgs: ToolArgs, result: ToolResult? -> }
 
     //endregion Tool Call Handlers
 

--- a/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerConfig.kt
+++ b/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerConfig.kt
@@ -254,7 +254,7 @@ public class EventHandlerConfig : FeatureConfig() {
      * @deprecated Use `onToolCall(handler)` instead for appending handlers in a preferred manner.
      */
     @Deprecated(message = "Please use onToolCall() instead", replaceWith = ReplaceWith("onToolCall(handler)"))
-    public var onToolCall: suspend (tool: Tool<*, *>, toolArgs: Tool.Args) -> Unit = { tool: Tool<*, *>, toolArgs: Tool.Args -> }
+    public var onToolCall: suspend (tool: Tool<*, *>, toolArgs: ToolArgs) -> Unit = { tool: Tool<*, *>, toolArgs: ToolArgs -> }
         set(value) = this.onToolCall(value)
 
     /**
@@ -269,7 +269,7 @@ public class EventHandlerConfig : FeatureConfig() {
      * This property is deprecated and maintained for backward compatibility.
      */
     @Deprecated(message = "Please use onToolValidationError() instead", replaceWith = ReplaceWith("onToolValidationError(handler)"))
-    public var onToolValidationError: suspend (tool: Tool<*, *>, toolArgs: Tool.Args, value: String) -> Unit = { tool: Tool<*, *>, toolArgs: Tool.Args, value: String -> }
+    public var onToolValidationError: suspend (tool: Tool<*, *>, toolArgs: ToolArgs, value: String) -> Unit = { tool: Tool<*, *>, toolArgs: ToolArgs, value: String -> }
         set(value) = this.onToolValidationError(value)
 
     /**
@@ -282,7 +282,7 @@ public class EventHandlerConfig : FeatureConfig() {
      * Replacing this property with the newer `onToolCallFailure` function ensures better consistency and management of handlers.
      */
     @Deprecated(message = "Please use onToolCallFailure() instead", replaceWith = ReplaceWith("onToolCallFailure(handler)"))
-    public var onToolCallFailure: suspend (tool: Tool<*, *>, toolArgs: Tool.Args, throwable: Throwable) -> Unit = { tool: Tool<*, *>, toolArgs: Tool.Args, throwable: Throwable -> }
+    public var onToolCallFailure: suspend (tool: Tool<*, *>, toolArgs: ToolArgs, throwable: Throwable) -> Unit = { tool: Tool<*, *>, toolArgs: ToolArgs, throwable: Throwable -> }
         set(value) = this.onToolCallFailure(value)
 
     /**
@@ -293,7 +293,7 @@ public class EventHandlerConfig : FeatureConfig() {
      * @see onToolCallResult
      */
     @Deprecated(message = "Please use onToolCallResult() instead", replaceWith = ReplaceWith("onToolCallResult(handler)"))
-    public var onToolCallResult: suspend (tool: Tool<*, *>, toolArgs: Tool.Args, result: ToolResult?) -> Unit = { tool: Tool<*, *>, toolArgs: Tool.Args, result: ToolResult? -> }
+    public var onToolCallResult: suspend (tool: Tool<*, *>, toolArgs: ToolArgs, result: ToolResult?) -> Unit = { tool: Tool<*, *>, toolArgs: ToolArgs, result: ToolResult? -> }
         set(value) = this.onToolCallResult(value)
 
     //endregion Deprecated Tool Call Handlers
@@ -419,9 +419,9 @@ public class EventHandlerConfig : FeatureConfig() {
     /**
      * Append handler called when a tool is about to be called.
      */
-    public fun onToolCall(handler: suspend (tool: Tool<*, *>, toolArgs: Tool.Args) -> Unit) {
+    public fun onToolCall(handler: suspend (tool: Tool<*, *>, toolArgs: ToolArgs) -> Unit) {
         val originalHandler = this._onToolCall
-        this._onToolCall = { tool: Tool<*, *>, toolArgs: Tool.Args ->
+        this._onToolCall = { tool: Tool<*, *>, toolArgs: ToolArgs ->
             originalHandler(tool, toolArgs)
             handler.invoke(tool, toolArgs)
         }
@@ -430,9 +430,9 @@ public class EventHandlerConfig : FeatureConfig() {
     /**
      * Append handler called when a validation error occurs during a tool call.
      */
-    public fun onToolValidationError(handler: suspend (tool: Tool<*, *>, toolArgs: Tool.Args, value: String) -> Unit) {
+    public fun onToolValidationError(handler: suspend (tool: Tool<*, *>, toolArgs: ToolArgs, value: String) -> Unit) {
         val originalHandler = this._onToolValidationError
-        this._onToolValidationError = { tool: Tool<*, *>, toolArgs: Tool.Args, value: String ->
+        this._onToolValidationError = { tool: Tool<*, *>, toolArgs: ToolArgs, value: String ->
             originalHandler(tool, toolArgs, value)
             handler.invoke(tool, toolArgs, value)
         }
@@ -441,9 +441,9 @@ public class EventHandlerConfig : FeatureConfig() {
     /**
      * Append handler called when a tool call fails with an exception.
      */
-    public fun onToolCallFailure(handler: suspend (tool: Tool<*, *>, toolArgs: Tool.Args, throwable: Throwable) -> Unit) {
+    public fun onToolCallFailure(handler: suspend (tool: Tool<*, *>, toolArgs: ToolArgs, throwable: Throwable) -> Unit) {
         val originalHandler = this._onToolCallFailure
-        this._onToolCallFailure = { tool: Tool<*, *>, toolArgs: Tool.Args, throwable: Throwable ->
+        this._onToolCallFailure = { tool: Tool<*, *>, toolArgs: ToolArgs, throwable: Throwable ->
             originalHandler(tool, toolArgs, throwable)
             handler.invoke(tool, toolArgs, throwable)
         }
@@ -452,9 +452,9 @@ public class EventHandlerConfig : FeatureConfig() {
     /**
      * Append handler called when a tool call completes successfully.
      */
-    public fun onToolCallResult(handler: suspend (tool: Tool<*, *>, toolArgs: Tool.Args, result: ToolResult?) -> Unit) {
+    public fun onToolCallResult(handler: suspend (tool: Tool<*, *>, toolArgs: ToolArgs, result: ToolResult?) -> Unit) {
         val originalHandler = this._onToolCallResult
-        this._onToolCallResult = { tool: Tool<*, *>, toolArgs: Tool.Args, result: ToolResult? ->
+        this._onToolCallResult = { tool: Tool<*, *>, toolArgs: ToolArgs, result: ToolResult? ->
             originalHandler(tool, toolArgs, result)
             handler.invoke(tool, toolArgs, result)
         }
@@ -547,28 +547,28 @@ public class EventHandlerConfig : FeatureConfig() {
     /**
      * Invoke handlers for tool call event.
      */
-    internal suspend fun invokeOnToolCall(tool: Tool<*, *>, toolArgs: Tool.Args) {
+    internal suspend fun invokeOnToolCall(tool: Tool<*, *>, toolArgs: ToolArgs) {
         _onToolCall.invoke(tool, toolArgs)
     }
 
     /**
      * Invoke handlers for a validation error during a tool call event.
      */
-    internal suspend fun invokeOnToolValidationError(tool: Tool<*, *>, toolArgs: Tool.Args, value: String) {
+    internal suspend fun invokeOnToolValidationError(tool: Tool<*, *>, toolArgs: ToolArgs, value: String) {
         _onToolValidationError.invoke(tool, toolArgs, value)
     }
 
     /**
      * Invoke handlers for a tool call failure with an exception event.
      */
-    internal suspend fun invokeOnToolCallFailure(tool: Tool<*, *>, toolArgs: Tool.Args, throwable: Throwable) {
+    internal suspend fun invokeOnToolCallFailure(tool: Tool<*, *>, toolArgs: ToolArgs, throwable: Throwable) {
         _onToolCallFailure.invoke(tool, toolArgs, throwable)
     }
 
     /**
      * Invoke handlers for an event when a tool call is completed successfully.
      */
-    internal suspend fun invokeOnToolCallResult(tool: Tool<*, *>, toolArgs: Tool.Args, result: ToolResult?) {
+    internal suspend fun invokeOnToolCallResult(tool: Tool<*, *>, toolArgs: ToolArgs, result: ToolResult?) {
         _onToolCallResult.invoke(tool, toolArgs, result)
     }
 

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/TestEventsCollector.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/TestEventsCollector.kt
@@ -5,6 +5,7 @@ import ai.koog.agents.core.agent.context.AIAgentContextBase
 import ai.koog.agents.core.agent.entity.AIAgentNodeBase
 import ai.koog.agents.core.agent.entity.AIAgentStrategy
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolResult
 import ai.koog.prompt.dsl.Prompt
@@ -62,19 +63,19 @@ class TestEventsCollector {
             _collectedEvents.add("OnAfterLLMCall (responses: [${responses.joinToString { "${it.role.name}: ${it.content}" }}])")
         }
 
-        onToolCall { tool: Tool<*, *>, toolArgs: Tool.Args ->
+        onToolCall { tool: Tool<*, *>, toolArgs: ToolArgs ->
             _collectedEvents.add("OnToolCall (tool: ${tool.name}, args: $toolArgs)")
         }
 
-        onToolValidationError { tool: Tool<*, *>, toolArgs: Tool.Args, value: String ->
+        onToolValidationError { tool: Tool<*, *>, toolArgs: ToolArgs, value: String ->
             _collectedEvents.add("OnToolValidationError (tool: ${tool.name}, args: $toolArgs, value: $value)")
         }
 
-        onToolCallFailure { tool: Tool<*, *>, toolArgs: Tool.Args, throwable: Throwable ->
+        onToolCallFailure { tool: Tool<*, *>, toolArgs: ToolArgs, throwable: Throwable ->
             _collectedEvents.add("OnToolCallFailure (tool: ${tool.name}, args: $toolArgs, throwable: ${throwable.message})")
         }
 
-        onToolCallResult { tool: Tool<*, *>, toolArgs: Tool.Args, result: ToolResult? ->
+        onToolCallResult { tool: Tool<*, *>, toolArgs: ToolArgs, result: ToolResult? ->
             _collectedEvents.add("OnToolCallResult (tool: ${tool.name}, args: $toolArgs, result: $result)")
         }
     }

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/TestTools.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/TestTools.kt
@@ -2,6 +2,7 @@ package ai.koog.agents.features.eventHandler.feature
 
 import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
@@ -9,7 +10,7 @@ import kotlinx.serialization.Serializable
 
 class DummyTool : SimpleTool<DummyTool.Args>() {
     @Serializable
-    data class Args(val dummy: String = "") : Tool.Args
+    data class Args(val dummy: String = "") : ToolArgs
 
     override val argsSerializer = Args.serializer()
 

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/TestTools.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/TestTools.kt
@@ -1,7 +1,6 @@
 package ai.koog.agents.features.eventHandler.feature
 
 import ai.koog.agents.core.tools.SimpleTool
-import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor

--- a/agents/agents-features/agents-features-tokenizer/src/jvmTest/kotlin/ai/koog/agents/features/tokenizer/feature/TestTools.kt
+++ b/agents/agents-features/agents-features-tokenizer/src/jvmTest/kotlin/ai/koog/agents/features/tokenizer/feature/TestTools.kt
@@ -1,7 +1,6 @@
 package ai.koog.agents.features.tokenizer.feature
 
 import ai.koog.agents.core.tools.SimpleTool
-import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor

--- a/agents/agents-features/agents-features-tokenizer/src/jvmTest/kotlin/ai/koog/agents/features/tokenizer/feature/TestTools.kt
+++ b/agents/agents-features/agents-features-tokenizer/src/jvmTest/kotlin/ai/koog/agents/features/tokenizer/feature/TestTools.kt
@@ -2,6 +2,7 @@ package ai.koog.agents.features.tokenizer.feature
 
 import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
@@ -10,7 +11,7 @@ import kotlinx.serialization.Serializable
 
 abstract class TestTool(toolName: String) : SimpleTool<TestTool.Args>() {
     @Serializable
-    data class Args(val question: String) : Tool.Args
+    data class Args(val question: String) : ToolArgs
 
     override val argsSerializer: KSerializer<Args> = Args.serializer()
 

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TestTools.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TestTools.kt
@@ -2,6 +2,7 @@ package ai.koog.agents.features.tracing.writer
 
 import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
@@ -9,7 +10,7 @@ import kotlinx.serialization.Serializable
 
 class DummyTool : SimpleTool<DummyTool.Args>() {
     @Serializable
-    data class Args(val dummy: String = "") : Tool.Args
+    data class Args(val dummy: String = "") : ToolArgs
 
     override val argsSerializer = Args.serializer()
 

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TestTools.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TestTools.kt
@@ -1,7 +1,6 @@
 package ai.koog.agents.features.tracing.writer
 
 import ai.koog.agents.core.tools.SimpleTool
-import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor

--- a/agents/agents-mcp/src/jvmMain/kotlin/ai/koog/agents/mcp/McpTool.kt
+++ b/agents/agents-mcp/src/jvmMain/kotlin/ai/koog/agents/mcp/McpTool.kt
@@ -1,6 +1,7 @@
 package ai.koog.agents.mcp
 
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolResult
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -44,7 +45,7 @@ public class McpTool(
      * @property arguments The JsonObject containing the arguments for the MCP tool.
      */
     @Serializable(with = ArgsSerializer::class)
-    public data class Args(val arguments: JsonObject) : Tool.Args
+    public data class Args(val arguments: JsonObject) : ToolArgs
 
     /**
      * Custom serializer for the Args class.

--- a/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/McpToolTest.kt
+++ b/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/McpToolTest.kt
@@ -73,9 +73,9 @@ class McpToolTest {
         val greetingTool = toolRegistry.getTool("greeting") as McpTool
         val args = McpTool.Args(buildJsonObject { put("name", "Test") })
 
-        val (result, _) = withContext(Dispatchers.Default.limitedParallelism(1)) {
+        val result = withContext(Dispatchers.Default.limitedParallelism(1)) {
             withTimeout(1.minutes) {
-                greetingTool.executeAndSerialize(args, TestToolEnabler)
+                greetingTool.execute(args, TestToolEnabler)
             }
         }
 

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/feature/TestingFeature.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/feature/TestingFeature.kt
@@ -18,6 +18,7 @@ import ai.koog.agents.core.feature.InterceptContext
 import ai.koog.agents.core.feature.PromptExecutorProxy
 import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolResult
 import ai.koog.agents.features.common.config.FeatureConfig
 import ai.koog.agents.testing.tools.MockEnvironment
@@ -1576,7 +1577,7 @@ public class Testing {
  * }
  * ```
  */
-public fun <Args : Tool.Args> Testing.Config.SubgraphAssertionsBuilder<*, *>.toolCallMessage(
+public fun <Args : ToolArgs> Testing.Config.SubgraphAssertionsBuilder<*, *>.toolCallMessage(
     tool: Tool<Args, *>,
     args: Args
 ): Message.Tool.Call {

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/DummyTool.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/DummyTool.kt
@@ -15,7 +15,7 @@ public class DummyTool : SimpleTool<DummyTool.Args>() {
      * @property dummy A dummy string parameter that can be optionally specified.
      */
     @Serializable
-    public data class Args(val dummy: String = "") : Tool.Args
+    public data class Args(val dummy: String = "") : ToolArgs
 
     override val argsSerializer: KSerializer<Args> = Args.serializer()
 

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockEnvironment.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockEnvironment.kt
@@ -97,7 +97,7 @@ internal class MockEnvironment(
         }
         val tool = toolRegistry.getTool(functionCall.tool)
 
-        val args = tool.decodeArgsFromString(functionCall.content)
+        val args = tool.decodeArgs(functionCall.contentJson)
         val result = tool.executeUnsafe(args, MockToolsEnabler)
 
 

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMBuilder.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMBuilder.kt
@@ -35,7 +35,7 @@ public class ToolCondition<Args : ToolArgs, Result : ToolResult>(
      * @return True if the tool name matches and the arguments satisfy the condition
      */
     internal suspend fun satisfies(toolCall: Message.Tool.Call) =
-        tool.name == toolCall.tool && argsCondition(tool.decodeArgsFromString(toolCall.content))
+        tool.name == toolCall.tool && argsCondition(tool.decodeArgs(toolCall.contentJson))
 
     /**
      * Invokes the tool with the arguments from the tool call.
@@ -44,7 +44,7 @@ public class ToolCondition<Args : ToolArgs, Result : ToolResult>(
      * @return The result produced by the tool
      */
     internal suspend fun invoke(toolCall: Message.Tool.Call) =
-        produceResult(tool.decodeArgsFromString(toolCall.content))
+        produceResult(tool.decodeArgs(toolCall.contentJson))
 
     /**
      * Invokes the tool and serializes the result.
@@ -53,7 +53,7 @@ public class ToolCondition<Args : ToolArgs, Result : ToolResult>(
      * @return A pair of the result object and its serialized string representation
      */
     internal suspend fun invokeAndSerialize(toolCall: Message.Tool.Call): Pair<Result, String> {
-        val toolResult = produceResult(tool.decodeArgsFromString(toolCall.content))
+        val toolResult = produceResult(tool.decodeArgs(toolCall.contentJson))
         return toolResult to tool.encodeResultToString(toolResult)
     }
 }

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMBuilder.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMBuilder.kt
@@ -1,6 +1,7 @@
 package ai.koog.agents.testing.tools
 
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.ToolResult
 import ai.koog.prompt.executor.model.PromptExecutor
@@ -22,7 +23,7 @@ import kotlinx.datetime.Clock
  * @property argsCondition A function that determines if the tool call matches this condition
  * @property produceResult A function that produces the result when the condition is satisfied
  */
-public class ToolCondition<Args : Tool.Args, Result : ToolResult>(
+public class ToolCondition<Args : ToolArgs, Result : ToolResult>(
     public val tool: Tool<Args, Result>,
     public val argsCondition: suspend (Args) -> Boolean,
     public val produceResult: suspend (Args) -> Result
@@ -130,7 +131,7 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param tool The tool to be called when the input matches
      * @param args The arguments to pass to the tool
      */
-    public fun <Args : Tool.Args> addLLMAnswerExactPattern(llmAnswer: String, tool: Tool<Args, *>, args: Args) {
+    public fun <Args : ToolArgs> addLLMAnswerExactPattern(llmAnswer: String, tool: Tool<Args, *>, args: Args) {
         toolCallExactMatches[llmAnswer] = tool.encodeArgsToString(args).let { toolContent ->
             Message.Tool.Call(
                 id = null,
@@ -148,7 +149,7 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param argsCondition A function that determines if the tool call arguments match this action
      * @param action A function that produces the result when the condition is satisfied
      */
-    public fun <Args : Tool.Args, Result : ToolResult> addToolAction(
+    public fun <Args : ToolArgs, Result : ToolResult> addToolAction(
         tool: Tool<Args, Result>,
         argsCondition: suspend (Args) -> Boolean = { true },
         action: suspend (Args) -> Result
@@ -166,7 +167,7 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param args The arguments to pass to the tool
      * @return A [ToolCallReceiver] for further configuration
      */
-    public fun <Args : Tool.Args> mockLLMToolCall(tool: Tool<Args, *>, args: Args): ToolCallReceiver<Args> {
+    public fun <Args : ToolArgs> mockLLMToolCall(tool: Tool<Args, *>, args: Args): ToolCallReceiver<Args> {
         return ToolCallReceiver(tool, args, this)
     }
 
@@ -179,7 +180,7 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param tool The tool to be mocked
      * @return A [MockToolReceiver] for further configuration
      */
-    public fun <Args : Tool.Args, Result : ToolResult> mockTool(tool: Tool<Args, Result>): MockToolReceiver<Args, Result> {
+    public fun <Args : ToolArgs, Result : ToolResult> mockTool(tool: Tool<Args, Result>): MockToolReceiver<Args, Result> {
         return MockToolReceiver(tool, this)
     }
 
@@ -227,7 +228,7 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @property args The arguments to pass to the tool
      * @property builder The parent MockLLMBuilder instance
      */
-    public class ToolCallReceiver<Args : Tool.Args>(
+    public class ToolCallReceiver<Args : ToolArgs>(
         private val tool: Tool<Args, *>,
         private val args: Args,
         private val builder: MockLLMBuilder
@@ -258,7 +259,7 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @property tool The tool to be mocked
      * @property builder The parent MockLLMBuilder instance
      */
-    public class MockToolReceiver<Args : Tool.Args, Result : ToolResult>(
+    public class MockToolReceiver<Args : ToolArgs, Result : ToolResult>(
         internal val tool: Tool<Args, Result>,
         internal val builder: MockLLMBuilder
     ) {
@@ -274,7 +275,7 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
          * @property action A function that produces the result
          * @property builder The parent MockLLMBuilder instance
          */
-        public class MockToolResponseBuilder<Args : Tool.Args, Result : ToolResult>(
+        public class MockToolResponseBuilder<Args : ToolArgs, Result : ToolResult>(
             private val tool: Tool<Args, Result>,
             private val action: suspend () -> Result,
             private val builder: MockLLMBuilder
@@ -341,7 +342,7 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param response The string to return
      * @return The result of the alwaysReturns call
      */
-    public infix fun <Args : Tool.Args> MockToolReceiver<Args, ToolResult.Text>.alwaysReturns(response: String): Unit =
+    public infix fun <Args : ToolArgs> MockToolReceiver<Args, ToolResult.Text>.alwaysReturns(response: String): Unit =
         alwaysReturns(ToolResult.Text(response))
 
     /**
@@ -351,7 +352,7 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param action A function that produces the string result
      * @return The result of the alwaysDoes call
      */
-    public infix fun <Args : Tool.Args> MockToolReceiver<Args, ToolResult.Text>.alwaysTells(action: suspend () -> String): Unit =
+    public infix fun <Args : ToolArgs> MockToolReceiver<Args, ToolResult.Text>.alwaysTells(action: suspend () -> String): Unit =
         alwaysDoes { ToolResult.Text(action()) }
 
     /**
@@ -361,7 +362,7 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param action A function that produces the string result
      * @return The result of the does call
      */
-    public infix fun <Args : Tool.Args> MockToolReceiver<Args, ToolResult.Text>.doesStr(action: suspend () -> String): MockLLMBuilder.MockToolReceiver.MockToolResponseBuilder<Args, ToolResult.Text> =
+    public infix fun <Args : ToolArgs> MockToolReceiver<Args, ToolResult.Text>.doesStr(action: suspend () -> String): MockLLMBuilder.MockToolReceiver.MockToolResponseBuilder<Args, ToolResult.Text> =
         does { ToolResult.Text(action()) }
 
     /**

--- a/agents/agents-test/src/commonTest/kotlin/ai/koog/agents/testing/feature/Tools.kt
+++ b/agents/agents-test/src/commonTest/kotlin/ai/koog/agents/testing/feature/Tools.kt
@@ -3,8 +3,8 @@ package ai.koog.agents.testing.feature
 import ai.koog.agents.core.tools.*
 import kotlinx.serialization.Serializable
 
-object DummyTool : SimpleTool<Tool.EmptyArgs>() {
-    override val argsSerializer = EmptyArgs.serializer()
+object DummyTool : SimpleTool<ToolArgs.Empty>() {
+    override val argsSerializer = ToolArgs.Empty.serializer()
 
     override val descriptor = ToolDescriptor(
         name = "dummy",
@@ -12,12 +12,12 @@ object DummyTool : SimpleTool<Tool.EmptyArgs>() {
         requiredParameters = emptyList()
     )
 
-    override suspend fun doExecute(args: EmptyArgs): String = "Dummy result"
+    override suspend fun doExecute(args: ToolArgs.Empty): String = "Dummy result"
 }
 
 object CreateTool : SimpleTool<CreateTool.Args>() {
     @Serializable
-    data class Args(val name: String) : Tool.Args
+    data class Args(val name: String) : ToolArgs
 
     override val argsSerializer = Args.serializer()
 
@@ -38,7 +38,7 @@ object CreateTool : SimpleTool<CreateTool.Args>() {
 
 object SolveTool : SimpleTool<SolveTool.Args>() {
     @Serializable
-    data class Args(val name: String) : Tool.Args
+    data class Args(val name: String) : ToolArgs
 
     override val argsSerializer = Args.serializer()
 

--- a/agents/agents-test/src/jvmTest/kotlin/ai/koog/agents/test/SimpleAgentMockedTest.kt
+++ b/agents/agents-test/src/jvmTest/kotlin/ai/koog/agents/test/SimpleAgentMockedTest.kt
@@ -3,13 +3,7 @@
 package ai.koog.agents.test
 
 import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.tools.SimpleTool
-import ai.koog.agents.core.tools.Tool
-import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.agents.core.tools.ToolException
-import ai.koog.agents.core.tools.ToolParameterDescriptor
-import ai.koog.agents.core.tools.ToolParameterType
-import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.core.tools.*
 import ai.koog.agents.ext.tool.ExitTool
 import ai.koog.agents.ext.tool.SayToUser
 import ai.koog.agents.features.eventHandler.feature.EventHandler
@@ -113,7 +107,7 @@ class SimpleAgentMockedTest {
 
     object ErrorTool : SimpleTool<ErrorTool.Args>() {
         @Serializable
-        data class Args(val message: String) : Tool.Args
+        data class Args(val message: String) : ToolArgs
 
         override val argsSerializer: KSerializer<Args> = Args.serializer()
 
@@ -136,7 +130,7 @@ class SimpleAgentMockedTest {
 
     object ConditionalTool : SimpleTool<ConditionalTool.Args>() {
         @Serializable
-        data class Args(val condition: String) : Tool.Args
+        data class Args(val condition: String) : ToolArgs
 
         override val argsSerializer: KSerializer<Args> = Args.serializer()
 

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/SimpleTool.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/SimpleTool.kt
@@ -3,9 +3,9 @@ package ai.koog.agents.core.tools
 /**
  * Represents a simplified tool base class that processes specific arguments and produces a textual result.
  *
- * @param TArgs The type of arguments the tool accepts, which must be a subtype of `Tool.Args`.
+ * @param TArgs The type of arguments the tool accepts, which must be a subtype of `ToolArgs`.
  */
-public abstract class SimpleTool<TArgs : Tool.Args> : Tool<TArgs, ToolResult.Text>() {
+public abstract class SimpleTool<TArgs : ToolArgs> : Tool<TArgs, ToolResult.Text>() {
     override fun encodeResultToString(result: ToolResult.Text): String = result.text
 
     final override suspend fun execute(args: TArgs): ToolResult.Text = ToolResult.Text(doExecute(args))

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/Tool.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/Tool.kt
@@ -3,7 +3,6 @@ package ai.koog.agents.core.tools
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.core.tools.serialization.ToolJson
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 
@@ -32,7 +31,7 @@ public interface DirectToolCallsEnabler
  * Represents a tool that, when executed, makes changes to the environment.
  */
 @Suppress("UNCHECKED_CAST", "unused")
-public abstract class Tool<TArgs : Tool.Args, TResult : ToolResult> {
+public abstract class Tool<TArgs : ToolArgs, TResult : ToolResult> {
     /**
      * Serializer responsible for encoding and decoding the arguments required for the tool execution.
      * This abstract property is used to define the specific [KSerializer] corresponding to the type of arguments
@@ -212,15 +211,4 @@ public abstract class Tool<TArgs : Tool.Args, TResult : ToolResult> {
      * @return A JSON string representation of the provided result.
      */
     public fun encodeResultToStringUnsafe(result: ToolResult): String = encodeResultToString(result as TResult)
-
-    /**
-     * Base type, representing tool arguments.
-     */
-    public interface Args
-
-    /**
-     * Args implementation that can be used for tools that expect no arguments.
-     */
-    @Serializable
-    public data object EmptyArgs : Args
 }

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/Tool.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/Tool.kt
@@ -3,6 +3,7 @@ package ai.koog.agents.core.tools
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.core.tools.serialization.ToolJson
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 
@@ -173,4 +174,17 @@ public abstract class Tool<TArgs : ToolArgs, TResult : ToolResult> {
      * @return A JSON string representation of the provided result.
      */
     public fun encodeResultToStringUnsafe(result: ToolResult): String = encodeResultToString(result as TResult)
+
+    /**
+     * Base type, representing tool arguments.
+     */
+    @Deprecated("Use ToolArgs instead", ReplaceWith("ToolArgs", "ai.koog.agents.core.tools.ToolArgs"))
+    public interface Args
+
+    /**
+     * Args implementation that can be used for tools that expect no arguments.
+     */
+    @Serializable
+    @Deprecated("Use ToolArgs.Empty instead", ReplaceWith("ToolArgs.Empty", "ai.koog.agents.core.tools.ToolArgs.Empty"))
+    public data object EmptyArgs : Args
 }

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/Tool.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/Tool.kt
@@ -27,6 +27,7 @@ import kotlinx.serialization.json.jsonObject
 @InternalAgentToolsApi
 public interface DirectToolCallsEnabler
 
+
 /**
  * Represents a tool that, when executed, makes changes to the environment.
  */

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolArgs.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolArgs.kt
@@ -4,6 +4,8 @@ import kotlinx.serialization.Serializable
 
 /**
  * Represents the arguments for a tool operation.
+ * Args should be serializable, serializer should be presented in the Tool the arguments belong to.
+ *
  */
 public interface ToolArgs {
 

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolArgs.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolArgs.kt
@@ -2,8 +2,14 @@ package ai.koog.agents.core.tools
 
 import kotlinx.serialization.Serializable
 
+/**
+ * Represents the arguments for a tool operation.
+ */
 public interface ToolArgs {
 
+    /**
+     * Represents an empty implementation of the ToolArgs interface.
+     */
     @Serializable
     public class Empty : ToolArgs
 }

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolArgs.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolArgs.kt
@@ -1,0 +1,9 @@
+package ai.koog.agents.core.tools
+
+import kotlinx.serialization.Serializable
+
+public interface ToolArgs {
+
+    @Serializable
+    public class Empty : ToolArgs
+}

--- a/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/serialization/SampleTool.kt
+++ b/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/serialization/SampleTool.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 internal class SampleTool(name: String) : SimpleTool<SampleTool.Args>() {
     @Serializable
-    data class Args(val arg1: String, val arg2: Int) : Tool.Args
+    data class Args(val arg1: String, val arg2: Int) : ToolArgs
 
     override val argsSerializer = Args.serializer()
 

--- a/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/serialization/ToolTest.kt
+++ b/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/serialization/ToolTest.kt
@@ -22,15 +22,15 @@ object Enabler: DirectToolCallsEnabler
 class ToolTest {
     // Unstructured tool
 
-    private object UnstructuredTool : SimpleTool<Tool.EmptyArgs>() {
-        override val argsSerializer = EmptyArgs.serializer()
+    private object UnstructuredTool : SimpleTool<ToolArgs.Empty>() {
+        override val argsSerializer = ToolArgs.Empty.serializer()
 
         override val descriptor = ToolDescriptor(
             name = "unstructured_tool",
             description = "Unstructured tool"
         )
 
-        override suspend fun doExecute(args: EmptyArgs): String = "Simple result"
+        override suspend fun doExecute(args: ToolArgs.Empty): String = "Simple result"
     }
 
     @Test
@@ -45,7 +45,7 @@ class ToolTest {
 
     private object SampleStructuredTool : Tool<SampleStructuredTool.Args, SampleStructuredTool.Result>(){
         @Serializable
-        data class Args(val arg1: String, val arg2: Int) : Tool.Args
+        data class Args(val arg1: String, val arg2: Int) : ToolArgs
 
         @Serializable
         data class Result(val first: String, val second: Int) : ToolResult {
@@ -105,20 +105,20 @@ class ToolTest {
         }
     }
 
-    private object CustomFormatTool : Tool<Tool.EmptyArgs, CustomFormatTool.Result>() {
+    private object CustomFormatTool : Tool<ToolArgs.Empty, CustomFormatTool.Result>() {
         @Serializable
         data class Result(val foo: String, val bar: String) : ToolResult {
             override fun toStringDefault(): String = "Foo: $foo | Bar: $bar"
         }
 
-        override val argsSerializer = EmptyArgs.serializer()
+        override val argsSerializer = ToolArgs.Empty.serializer()
 
         override val descriptor = ToolDescriptor(
             name = "custom_format_tool",
             description = "Custom format tool",
         )
 
-        override suspend fun execute(args: EmptyArgs): Result {
+        override suspend fun execute(args: ToolArgs.Empty): Result {
             return Result("first result", "second result")
         }
     }

--- a/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/serialization/ToolTest.kt
+++ b/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/serialization/ToolTest.kt
@@ -36,9 +36,9 @@ class ToolTest {
     @Test
     fun testSimpleUnstructuredToolSerialization() = runTest {
         val args = JsonObject(emptyMap())
-        val (_, result) = UnstructuredTool.executeAndSerialize(UnstructuredTool.decodeArgs(args), Enabler)
+        val result = UnstructuredTool.execute(UnstructuredTool.decodeArgs(args), Enabler)
 
-        assertEquals("Simple result", result)
+        assertEquals("Simple result", result.toStringDefault())
     }
 
     // Structured tool
@@ -80,12 +80,12 @@ class ToolTest {
             put("arg1", "argument")
             put("arg2", 15)
         }
-        val (_, result) = SampleStructuredTool.executeAndSerialize(SampleStructuredTool.decodeArgs(args), Enabler)
+        val result = SampleStructuredTool.execute(SampleStructuredTool.decodeArgs(args), Enabler)
 
         assertEquals(
             //language=JSON
             expected = """{"first":"result","second":1}""",
-            actual = result
+            actual = result.toStringDefault()
         )
     }
 
@@ -126,7 +126,7 @@ class ToolTest {
     @Test
     fun testCustomFormatToolSerialization() = runTest {
         val args = JsonObject(emptyMap())
-        val (_, result) = CustomFormatTool.executeAndSerialize(CustomFormatTool.decodeArgs(args), Enabler)
-        assertEquals("Foo: first result | Bar: second result", result)
+        val result = CustomFormatTool.execute(CustomFormatTool.decodeArgs(args), Enabler)
+        assertEquals("Foo: first result | Bar: second result", result.toStringDefault())
     }
 }

--- a/agents/agents-tools/src/jvmMain/kotlin/ai/koog/agents/core/tools/reflect/ToolFromCallable.kt
+++ b/agents/agents-tools/src/jvmMain/kotlin/ai/koog/agents/core/tools/reflect/ToolFromCallable.kt
@@ -1,6 +1,7 @@
 package ai.koog.agents.core.tools.reflect
 
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolResult
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
@@ -46,7 +47,7 @@ public class ToolFromCallable(
      * @property args A map of parameters to their respective values.
      * Each key is a KParameter, matched with a value which can potentially be null.
      */
-    public data class VarArgs(val args: Map<KParameter, Any?>) : Args {
+    public data class VarArgs(val args: Map<KParameter, Any?>) : ToolArgs {
         /**
          * Converts a map of parameters and their corresponding values into a list of pairs,
          * where each pair consists of a parameter name and its associated value.

--- a/examples/demo-android-app/app/src/main/java/com/jetbrains/example/kotlin_agents_demo_app/agents/calculator/CalculatorAgentProvider.kt
+++ b/examples/demo-android-app/app/src/main/java/com/jetbrains/example/kotlin_agents_demo_app/agents/calculator/CalculatorAgentProvider.kt
@@ -122,7 +122,7 @@ object CalculatorAgentProvider : AgentProvider {
             toolRegistry = toolRegistry,
         ) {
             handleEvents {
-                onToolCall { tool: Tool<*, *>, toolArgs: Tool.Args ->
+                onToolCall { tool: Tool<*, *>, toolArgs: ToolArgs ->
                     onToolCallEvent("Tool ${tool.name}, args $toolArgs")
                 }
 

--- a/examples/demo-android-app/app/src/main/java/com/jetbrains/example/kotlin_agents_demo_app/agents/calculator/CalculatorTools.kt
+++ b/examples/demo-android-app/app/src/main/java/com/jetbrains/example/kotlin_agents_demo_app/agents/calculator/CalculatorTools.kt
@@ -9,7 +9,7 @@ object CalculatorTools {
         description: String,
     ) : Tool<CalculatorTool.Args, CalculatorTool.Result>() {
         @Serializable
-        data class Args(val a: Float, val b: Float) : Tool.Args
+        data class Args(val a: Float, val b: Float) : ToolArgs
 
         @Serializable
         @JvmInline

--- a/examples/demo-android-app/app/src/main/java/com/jetbrains/example/kotlin_agents_demo_app/agents/common/ExitTool.kt
+++ b/examples/demo-android-app/app/src/main/java/com/jetbrains/example/kotlin_agents_demo_app/agents/common/ExitTool.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 object ExitTool : SimpleTool<ExitTool.Args>() {
     @Serializable
-    data class Args(val result: String = ""): Tool.Args
+    data class Args(val result: String = ""): ToolArgs
     override val argsSerializer = Args.serializer()
 
     override val descriptor = ToolDescriptor(

--- a/examples/demo-android-app/app/src/main/java/com/jetbrains/example/kotlin_agents_demo_app/agents/weather/WeatherAgentProvider.kt
+++ b/examples/demo-android-app/app/src/main/java/com/jetbrains/example/kotlin_agents_demo_app/agents/weather/WeatherAgentProvider.kt
@@ -128,7 +128,7 @@ object WeatherAgentProvider : AgentProvider {
             toolRegistry = toolRegistry,
         ) {
             handleEvents {
-                onToolCall { tool: Tool<*, *>, toolArgs: Tool.Args ->
+                onToolCall { tool: Tool<*, *>, toolArgs: ToolArgs ->
                     onToolCallEvent("Tool ${tool.name}, args $toolArgs")
                 }
 

--- a/examples/demo-android-app/app/src/main/java/com/jetbrains/example/kotlin_agents_demo_app/agents/weather/WeatherTools.kt
+++ b/examples/demo-android-app/app/src/main/java/com/jetbrains/example/kotlin_agents_demo_app/agents/weather/WeatherTools.kt
@@ -40,7 +40,7 @@ object WeatherTools {
         @Serializable
         data class Args(
             val timezone: String = "UTC"
-        ) : Tool.Args
+        ) : ToolArgs
 
         @Serializable
         data class Result(
@@ -96,7 +96,7 @@ object WeatherTools {
             val days: Int,
             val hours: Int,
             val minutes: Int
-        ) : Tool.Args
+        ) : ToolArgs
 
         @Serializable
         data class Result(

--- a/examples/src/main/kotlin/ai/koog/agents/example/calculator/Calculator.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/calculator/Calculator.kt
@@ -9,6 +9,7 @@ import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.*
 import ai.koog.agents.core.environment.ReceivedToolResult
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.reflect.asTools
 import ai.koog.agents.example.ApiKeyService
@@ -98,7 +99,7 @@ fun main() = runBlocking {
         toolRegistry = toolRegistry
     ) {
         handleEvents {
-            onToolCall { tool: Tool<*, *>, toolArgs: Tool.Args ->
+            onToolCall { tool: Tool<*, *>, toolArgs: ToolArgs ->
                 println("Tool called: tool ${tool.name}, args $toolArgs")
             }
 

--- a/examples/src/main/kotlin/ai/koog/agents/example/guesser/GuesserTools.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/guesser/GuesserTools.kt
@@ -9,7 +9,7 @@ abstract class GuesserTool(
     description: String,
 ) : SimpleTool<GuesserTool.Args>() {
     @Serializable
-    data class Args(val value: Int) : Tool.Args
+    data class Args(val value: Int) : ToolArgs
 
     final override val argsSerializer = Args.serializer()
 

--- a/examples/src/main/kotlin/ai/koog/agents/example/structureddata/BookMdStructure.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/structureddata/BookMdStructure.kt
@@ -1,7 +1,7 @@
 package ai.koog.agents.example.structureddata
 
 import ai.koog.agents.core.tools.SimpleTool
-import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.prompt.markdown.markdown
 import ai.koog.prompt.structure.markdown.MarkdownStructuredDataDefinition
@@ -19,7 +19,7 @@ data class Book(
     val bookName: String,
     val author: String,
     val description: String
-): Tool.Args
+): ToolArgs
 
 class BookTool(): SimpleTool<Book>() {
     companion object {

--- a/examples/src/main/kotlin/ai/koog/agents/example/subgraphwithtask/ProjectGeneratorTools.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/subgraphwithtask/ProjectGeneratorTools.kt
@@ -12,7 +12,7 @@ import kotlin.io.path.pathString
 object ProjectGeneratorTools {
     class CreateFileTool(val rootProjectPath: Path) : Tool<CreateFileTool.Args, CreateFileTool.Result>() {
         @Serializable
-        data class Args(val path: String, val content: String) : Tool.Args
+        data class Args(val path: String, val content: String) : ToolArgs
 
         @Serializable
         data class Result(val successful: Boolean, val comment: String? = null) : ToolResult {
@@ -56,7 +56,7 @@ object ProjectGeneratorTools {
 
     class ReadFileTool(val rootProjectPath: Path) : Tool<ReadFileTool.Args, ReadFileTool.Result>() {
         @Serializable
-        data class Args(val path: String) : Tool.Args
+        data class Args(val path: String) : ToolArgs
 
         @Serializable
         data class Result(
@@ -112,7 +112,7 @@ object ProjectGeneratorTools {
 
     class LSDirectoriesTool(val rootProjectPath: Path) : Tool<LSDirectoriesTool.Args, LSDirectoriesTool.Result>() {
         @Serializable
-        data class Args(val path: String) : Tool.Args
+        data class Args(val path: String) : ToolArgs
 
         @Serializable
         data class Result(
@@ -169,7 +169,7 @@ object ProjectGeneratorTools {
     class CreateDirectoryTool(val rootProjectPath: Path) :
         Tool<CreateDirectoryTool.Args, CreateDirectoryTool.Result>() {
         @Serializable
-        data class Args(val path: String) : Tool.Args
+        data class Args(val path: String) : ToolArgs
 
         @Serializable
         data class Result(val successful: Boolean, val comment: String? = null) : ToolResult {
@@ -207,7 +207,7 @@ object ProjectGeneratorTools {
     class DeleteDirectoryTool(val rootProjectPath: Path) :
         Tool<DeleteDirectoryTool.Args, DeleteDirectoryTool.Result>() {
         @Serializable
-        data class Args(val path: String) : Tool.Args
+        data class Args(val path: String) : ToolArgs
 
         @Serializable
         data class Result(val successful: Boolean, val comment: String? = null) : ToolResult {
@@ -250,7 +250,7 @@ object ProjectGeneratorTools {
 
     class DeleteFileTool(val rootProjectPath: Path) : Tool<DeleteFileTool.Args, DeleteFileTool.Result>() {
         @Serializable
-        data class Args(val path: String) : Tool.Args
+        data class Args(val path: String) : ToolArgs
 
         @Serializable
         data class Result(val successful: Boolean, val comment: String? = null) : ToolResult {
@@ -291,7 +291,7 @@ object ProjectGeneratorTools {
 
     class RunCommand(val rootProjectPath: Path) : Tool<RunCommand.Args, RunCommand.Result>() {
         @Serializable
-        data class Args(val bashCommand: String) : Tool.Args
+        data class Args(val bashCommand: String) : ToolArgs
 
         @Serializable
         data class Result(val successful: Boolean, val comment: String? = null) : ToolResult {

--- a/examples/src/main/kotlin/ai/koog/agents/example/tone/ToneAgent.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/tone/ToneAgent.kt
@@ -5,6 +5,7 @@ package ai.koog.agents.example.tone
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.example.ApiKeyService
 import ai.koog.agents.example.tone.ToneTools.NegativeToneTool
@@ -67,7 +68,7 @@ fun main() {
             toolRegistry = toolRegistry
         ) {
             handleEvents {
-                onToolCall { tool: Tool<*, *>, toolArgs: Tool.Args ->
+                onToolCall { tool: Tool<*, *>, toolArgs: ToolArgs ->
                     println("Tool called: tool ${tool.name}, args $toolArgs")
                 }
 

--- a/examples/src/main/kotlin/ai/koog/agents/example/tone/ToneTools.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/tone/ToneTools.kt
@@ -19,7 +19,7 @@ object ToneTools {
         private val toneType: String
     ) : SimpleTool<ToneTool.Args>() {
         @Serializable
-        data class Args(val text: String) : Tool.Args
+        data class Args(val text: String) : ToolArgs
 
         override val argsSerializer = Args.serializer()
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/KotlinAIAgentWithMultipleLLMIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/KotlinAIAgentWithMultipleLLMIntegrationTest.kt
@@ -152,7 +152,7 @@ class KotlinAIAgentWithMultipleLLMIntegrationTest {
 
     class CreateFile(private val fs: MockFileSystem) : Tool<CreateFile.Args, CreateFile.Result>() {
         @Serializable
-        data class Args(val path: String, val content: String) : Tool.Args
+        data class Args(val path: String, val content: String) : ToolArgs
 
         @Serializable
         data class Result(
@@ -192,7 +192,7 @@ class KotlinAIAgentWithMultipleLLMIntegrationTest {
 
     class DeleteFile(private val fs: MockFileSystem) : Tool<DeleteFile.Args, DeleteFile.Result>() {
         @Serializable
-        data class Args(val path: String) : Tool.Args
+        data class Args(val path: String) : ToolArgs
 
         @Serializable
         data class Result(
@@ -227,7 +227,7 @@ class KotlinAIAgentWithMultipleLLMIntegrationTest {
 
     class ReadFile(private val fs: MockFileSystem) : Tool<ReadFile.Args, ReadFile.Result>() {
         @Serializable
-        data class Args(val path: String) : Tool.Args
+        data class Args(val path: String) : ToolArgs
 
         @Serializable
         data class Result(
@@ -263,7 +263,7 @@ class KotlinAIAgentWithMultipleLLMIntegrationTest {
 
     class ListFiles(private val fs: MockFileSystem) : Tool<ListFiles.Args, ListFiles.Result>() {
         @Serializable
-        data class Args(val path: String) : Tool.Args
+        data class Args(val path: String) : ToolArgs
 
         @Serializable
         data class Result(
@@ -671,7 +671,7 @@ class KotlinAIAgentWithMultipleLLMIntegrationTest {
 
     object CalculatorTool : Tool<CalculatorTool.Args, ToolResult.Number>() {
         @Serializable
-        data class Args(val operation: CalculatorOperation, val a: Int, val b: Int) : Tool.Args
+        data class Args(val operation: CalculatorOperation, val a: Int, val b: Int) : ToolArgs
 
         override val argsSerializer = Args.serializer()
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/tools/AnswerVerificationTool.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/tools/AnswerVerificationTool.kt
@@ -1,7 +1,6 @@
 package ai.koog.integration.tests.tools
 
 import ai.koog.agents.core.tools.SimpleTool
-import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/tools/AnswerVerificationTool.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/tools/AnswerVerificationTool.kt
@@ -2,6 +2,7 @@ package ai.koog.integration.tests.tools
 
 import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
@@ -12,7 +13,7 @@ object AnswerVerificationTool : SimpleTool<AnswerVerificationTool.Args>() {
     data class Args(
         val answer: String,
         val confidence: Int? = null
-    ) : Tool.Args
+    ) : ToolArgs
 
     override val argsSerializer = Args.serializer()
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/tools/GenericParameterTool.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/tools/GenericParameterTool.kt
@@ -2,6 +2,7 @@ package ai.koog.integration.tests.tools
 
 import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
@@ -12,7 +13,7 @@ object GenericParameterTool : SimpleTool<GenericParameterTool.Args>() {
     data class Args(
         val requiredArg: String,
         val optionalArg: String? = null
-    ) : Tool.Args
+    ) : ToolArgs
 
     override val argsSerializer = Args.serializer()
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/tools/GenericParameterTool.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/tools/GenericParameterTool.kt
@@ -1,7 +1,6 @@
 package ai.koog.integration.tests.tools
 
 import ai.koog.agents.core.tools.SimpleTool
-import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/tools/GeographyQueryTool.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/tools/GeographyQueryTool.kt
@@ -2,6 +2,7 @@ package ai.koog.integration.tests.tools
 
 import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
@@ -12,7 +13,7 @@ object GeographyQueryTool : SimpleTool<GeographyQueryTool.Args>() {
     data class Args(
         val query: String,
         val language: String? = null
-    ) : Tool.Args
+    ) : ToolArgs
 
     override val argsSerializer = Args.serializer()
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/tools/GeographyQueryTool.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/tools/GeographyQueryTool.kt
@@ -1,7 +1,6 @@
 package ai.koog.integration.tests.tools
 
 import ai.koog.agents.core.tools.SimpleTool
-import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/TestUtils.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/TestUtils.kt
@@ -41,7 +41,7 @@ internal object TestUtils {
         val operation: CalculatorOperation,
         val a: Int,
         val b: Int
-    ) : Tool.Args
+    ) : ToolArgs
 
     object CalculatorTool : SimpleTool<CalculatorArgs>() {
         override val argsSerializer = CalculatorArgs.serializer()


### PR DESCRIPTION
- [x] Move `Tool.Args` from Tool to separate `ToolArgs` class
- [ ] Remove explicit args serialized from `Tool` class 

The numerous attempts to fix the second bullet like showed that this refactoring can not be done due to the `TArgs` type erasure in `Tool` -> we are not able to create object from string (received from LLM). So the only way to have the **serializer** in singleton instance of the `Tool` class in `ToolRegistry`