### PR TITLE
Skip OpenAI audio models in streaming integration tests in MultipleLLMPromptExecutorIntegrationTest

### DIFF
--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/MultipleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/MultipleLLMPromptExecutorIntegrationTest.kt
@@ -9,6 +9,7 @@ import ai.koog.integration.tests.utils.TestUtils.readTestAnthropicKeyFromEnv
 import ai.koog.integration.tests.utils.TestUtils.readTestGoogleAIKeyFromEnv
 import ai.koog.integration.tests.utils.TestUtils.readTestOpenAIKeyFromEnv
 import ai.koog.integration.tests.utils.annotations.Retry
+import ai.koog.integration.tests.utils.annotations.RetryExtension
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
 import ai.koog.prompt.executor.clients.google.GoogleLLMClient
@@ -25,6 +26,7 @@ import ai.koog.prompt.params.LLMParams.ToolChoice
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
@@ -33,6 +35,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
+@ExtendWith(RetryExtension::class)
 class MultipleLLMPromptExecutorIntegrationTest {
     // API keys for testing
     private val geminiApiKey: String get() = readTestGoogleAIKeyFromEnv()

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/MultipleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/MultipleLLMPromptExecutorIntegrationTest.kt
@@ -14,6 +14,7 @@ import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
 import ai.koog.prompt.executor.clients.google.GoogleLLMClient
 import ai.koog.prompt.executor.clients.google.GoogleModels
 import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.executor.llms.all.DefaultMultiLLMPromptExecutor
 import ai.koog.prompt.llm.LLMCapability
@@ -86,6 +87,10 @@ class MultipleLLMPromptExecutorIntegrationTest {
     @ParameterizedTest
     @MethodSource("openAIModels", "anthropicModels", "googleModels")
     fun integration_testExecuteStreaming(model: LLModel) = runTest(timeout = 300.seconds) {
+        if (model.id == OpenAIModels.Audio.GPT4oAudio.id || model.id == OpenAIModels.Audio.GPT4oMiniAudio.id) {
+            assumeTrue(false, "https://github.com/JetBrains/koog/issues/231")
+        }
+
         val executor = DefaultMultiLLMPromptExecutor(openAIClient, anthropicClient, googleClient)
 
         val prompt = Prompt.build("test-streaming") {
@@ -402,10 +407,13 @@ class MultipleLLMPromptExecutorIntegrationTest {
         assertTrue(response.isNotEmpty(), "Response should not be empty")
     }
 
-    @Retry(3)
+    @Retry(5)
     @ParameterizedTest
     @MethodSource("openAIModels", "anthropicModels", "googleModels")
     fun integration_testRawStringStreaming(model: LLModel) = runTest(timeout = 600.seconds) {
+        if (model.id == OpenAIModels.Audio.GPT4oAudio.id || model.id == OpenAIModels.Audio.GPT4oMiniAudio.id) {
+            assumeTrue(false, "https://github.com/JetBrains/koog/issues/231")
+        }
         val prompt = Prompt.build("test-streaming") {
             system("You are a helpful assistant. You have NO output length limitations.")
             user("Count from 1 to 5.")
@@ -440,6 +448,9 @@ class MultipleLLMPromptExecutorIntegrationTest {
     @ParameterizedTest
     @MethodSource("openAIModels", "anthropicModels", "googleModels")
     fun integration_testStructuredDataStreaming(model: LLModel) = runTest(timeout = 300.seconds) {
+        if (model.id == OpenAIModels.Audio.GPT4oAudio.id || model.id == OpenAIModels.Audio.GPT4oMiniAudio.id) {
+            assumeTrue(false, "https://github.com/JetBrains/koog/issues/231")
+        }
         val countries = mutableListOf<TestUtils.Country>()
         val countryDefinition = TestUtils.markdownCountryDefinition()
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/MultipleSystemMessagesPromptIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/MultipleSystemMessagesPromptIntegrationTest.kt
@@ -4,6 +4,7 @@ import ai.koog.integration.tests.utils.TestUtils.readTestAnthropicKeyFromEnv
 import ai.koog.integration.tests.utils.TestUtils.readTestGoogleAIKeyFromEnv
 import ai.koog.integration.tests.utils.TestUtils.readTestOpenAIKeyFromEnv
 import ai.koog.integration.tests.utils.annotations.Retry
+import ai.koog.integration.tests.utils.annotations.RetryExtension
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.model.PromptExecutorExt.execute
 import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
@@ -15,9 +16,11 @@ import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.llm.LLMProvider
 import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
+@ExtendWith(RetryExtension::class)
 class MultipleSystemMessagesPromptIntegrationTest {
     private val openAIApiKey = readTestOpenAIKeyFromEnv()
     private val anthropicApiKey = readTestAnthropicKeyFromEnv()

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/MultipleSystemMessagesPromptIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/MultipleSystemMessagesPromptIntegrationTest.kt
@@ -26,7 +26,7 @@ class MultipleSystemMessagesPromptIntegrationTest {
     private val anthropicApiKey = readTestAnthropicKeyFromEnv()
     private val googleApiKey = readTestGoogleAIKeyFromEnv()
 
-    @Retry(3)
+    @Retry
     @Test
     fun integration_testMultipleSystemMessages() = runBlocking {
         val openAIClient = OpenAILLMClient(openAIApiKey)

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OllamaAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OllamaAgentIntegrationTest.kt
@@ -174,7 +174,7 @@ class OllamaAgentIntegrationTest {
         }
     }
 
-    @Retry(3)
+    @Retry
     @Test
     fun ollama_testAgentClearContext() = runTest(timeout = 600.seconds) {
         val strategy = createTestStrategy()

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OllamaSimpleAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OllamaSimpleAgentIntegrationTest.kt
@@ -6,6 +6,7 @@ import ai.koog.agents.ext.tool.SayToUser
 import ai.koog.agents.features.eventHandler.feature.EventHandler
 import ai.koog.agents.features.eventHandler.feature.EventHandlerConfig
 import ai.koog.integration.tests.utils.annotations.Retry
+import ai.koog.integration.tests.utils.annotations.RetryExtension
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.test.AfterTest
@@ -16,6 +17,7 @@ import kotlin.uuid.ExperimentalUuidApi
 
 @OptIn(ExperimentalUuidApi::class)
 @ExtendWith(OllamaTestFixtureExtension::class)
+@ExtendWith(RetryExtension::class)
 class OllamaSimpleAgentIntegrationTest {
     companion object {
         @field:InjectOllamaTestFixture

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OllamaSimpleAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OllamaSimpleAgentIntegrationTest.kt
@@ -89,7 +89,7 @@ class OllamaSimpleAgentIntegrationTest {
         actualToolCalls.clear()
     }
 
-    @Retry(3)
+    @Retry
     @Test
     fun ollama_simpleTest() = runTest(timeout = 600.seconds) {
         val toolRegistry = ToolRegistry.Companion {

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SimpleAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SimpleAgentIntegrationTest.kt
@@ -5,12 +5,11 @@ import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.features.eventHandler.feature.EventHandler
 import ai.koog.agents.features.eventHandler.feature.EventHandlerConfig
 import ai.koog.integration.tests.utils.Models
+import ai.koog.integration.tests.utils.RetryUtils.withRetry
 import ai.koog.integration.tests.utils.TestUtils.CalculatorTool
 import ai.koog.integration.tests.utils.TestUtils.readTestAnthropicKeyFromEnv
 import ai.koog.integration.tests.utils.TestUtils.readTestGoogleAIKeyFromEnv
 import ai.koog.integration.tests.utils.TestUtils.readTestOpenAIKeyFromEnv
-import ai.koog.integration.tests.utils.annotations.Retry
-import ai.koog.integration.tests.utils.annotations.RetryExtension
 import ai.koog.prompt.executor.clients.google.GoogleModels
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.llms.all.simpleAnthropicExecutor
@@ -21,7 +20,6 @@ import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assumptions.assumeTrue
-import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
@@ -30,7 +28,6 @@ import kotlin.test.assertTrue
 import kotlin.uuid.ExperimentalUuidApi
 
 @OptIn(ExperimentalUuidApi::class)
-@ExtendWith(RetryExtension::class)
 class SimpleAgentIntegrationTest {
     val systemPrompt = "You are a helpful assistant."
 
@@ -119,7 +116,6 @@ class SimpleAgentIntegrationTest {
         results.clear()
     }
 
-    @Retry(3)
     @ParameterizedTest
     @MethodSource("openAIModels", "anthropicModels", "googleModels")
     fun integration_AIAgentShouldNotCallToolsByDefault(model: LLModel) = runBlocking {
@@ -138,13 +134,13 @@ class SimpleAgentIntegrationTest {
             installFeatures = { install(EventHandler.Feature, eventHandlerConfig) }
         )
 
-        agent.run("Repeat what I say: hello, I'm good.")
-
-        // by default, AIAgent has no tools underneath
-        assertTrue(actualToolCalls.isEmpty(), "No tools should be called for model $model")
+        withRetry(times = 3, testName = "integration_AIAgentShouldNotCallToolsByDefault[${model.id}]") {
+            agent.run("Repeat what I say: hello, I'm good.")
+            // by default, AIAgent has no tools underneath
+            assertTrue(actualToolCalls.isEmpty(), "No tools should be called for model $model")
+        }
     }
 
-    @Retry(3)
     @ParameterizedTest
     @MethodSource("openAIModels", "anthropicModels", "googleModels")
     fun integration_AIAgentShouldCallCustomTool(model: LLModel) = runBlocking {
@@ -175,13 +171,13 @@ class SimpleAgentIntegrationTest {
             installFeatures = { install(EventHandler.Feature, eventHandlerConfig) }
         )
 
-
-        agent.run("How much is 3 times 5?")
-
-        assertTrue(actualToolCalls.isNotEmpty(), "No tools were called for model $model")
-        assertTrue(
-            actualToolCalls.contains(CalculatorTool.name),
-            "The ${CalculatorTool.name} tool was not called for model $model"
-        )
+        withRetry(times = 3, testName = "integration_AIAgentShouldCallCustomTool[${model.id}]") {
+            agent.run("How much is 3 times 5?")
+            assertTrue(actualToolCalls.isNotEmpty(), "No tools were called for model $model")
+            assertTrue(
+                actualToolCalls.contains(CalculatorTool.name),
+                "The ${CalculatorTool.name} tool was not called for model $model"
+            )
+        }
     }
 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SimpleAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SimpleAgentIntegrationTest.kt
@@ -10,6 +10,7 @@ import ai.koog.integration.tests.utils.TestUtils.readTestAnthropicKeyFromEnv
 import ai.koog.integration.tests.utils.TestUtils.readTestGoogleAIKeyFromEnv
 import ai.koog.integration.tests.utils.TestUtils.readTestOpenAIKeyFromEnv
 import ai.koog.integration.tests.utils.annotations.Retry
+import ai.koog.integration.tests.utils.annotations.RetryExtension
 import ai.koog.prompt.executor.clients.google.GoogleModels
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.llms.all.simpleAnthropicExecutor
@@ -20,6 +21,7 @@ import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
@@ -28,6 +30,7 @@ import kotlin.test.assertTrue
 import kotlin.uuid.ExperimentalUuidApi
 
 @OptIn(ExperimentalUuidApi::class)
+@ExtendWith(RetryExtension::class)
 class SimpleAgentIntegrationTest {
     val systemPrompt = "You are a helpful assistant."
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SingleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SingleLLMPromptExecutorIntegrationTest.kt
@@ -358,6 +358,10 @@ class SingleLLMPromptExecutorIntegrationTest {
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
     fun integration_testRawStringStreaming(model: LLModel, client: LLMClient) = runTest(timeout = 600.seconds) {
+        if (model.id == OpenAIModels.Audio.GPT4oAudio.id || model.id == OpenAIModels.Audio.GPT4oMiniAudio.id) {
+            assumeTrue(false, "https://github.com/JetBrains/koog/issues/231")
+        }
+
         val prompt = Prompt.build("test-streaming") {
             system("You are a helpful assistant. You have NO output length limitations.")
             user("Count from 1 to 5.")

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SingleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SingleLLMPromptExecutorIntegrationTest.kt
@@ -13,6 +13,7 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
 import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.clients.openrouter.OpenRouterLLMClient
 import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
 import ai.koog.prompt.llm.LLMCapability
@@ -73,6 +74,10 @@ class SingleLLMPromptExecutorIntegrationTest {
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
     fun integration_testExecuteStreaming(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
+        if (model.id == OpenAIModels.Audio.GPT4oAudio.id || model.id == OpenAIModels.Audio.GPT4oMiniAudio.id) {
+            assumeTrue(false, "https://github.com/JetBrains/koog/issues/231")
+        }
+
         val executor = SingleLLMPromptExecutor(client)
 
         val prompt = Prompt.build("test-streaming") {
@@ -382,6 +387,10 @@ class SingleLLMPromptExecutorIntegrationTest {
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
     fun integration_testStructuredDataStreaming(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
+        if (model.id == OpenAIModels.Audio.GPT4oAudio.id || model.id == OpenAIModels.Audio.GPT4oMiniAudio.id) {
+            assumeTrue(false, "https://github.com/JetBrains/koog/issues/231")
+        }
+
         val countries = mutableListOf<TestUtils.Country>()
         val countryDefinition = TestUtils.markdownCountryDefinition()
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SingleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SingleLLMPromptExecutorIntegrationTest.kt
@@ -1,8 +1,6 @@
 package ai.koog.integration.tests
 
 import ai.koog.integration.tests.utils.Models
-import ai.koog.integration.tests.utils.annotations.Retry
-import ai.koog.integration.tests.utils.annotations.RetryExtension
 import ai.koog.integration.tests.utils.TestUtils
 import ai.koog.integration.tests.utils.TestUtils.readTestAnthropicKeyFromEnv
 import ai.koog.integration.tests.utils.TestUtils.readTestOpenAIKeyFromEnv
@@ -10,6 +8,7 @@ import ai.koog.integration.tests.utils.TestUtils.readTestOpenRouterKeyFromEnv
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
+import ai.koog.integration.tests.utils.RetryUtils.withRetry
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
@@ -24,7 +23,6 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assumptions.assumeTrue
-import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -33,7 +31,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
-@ExtendWith(RetryExtension::class)
 class SingleLLMPromptExecutorIntegrationTest {
     companion object {
         @JvmStatic
@@ -51,7 +48,6 @@ class SingleLLMPromptExecutorIntegrationTest {
         }
     }
 
-    @Retry(3)
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
     fun integration_testExecute(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
@@ -62,18 +58,18 @@ class SingleLLMPromptExecutorIntegrationTest {
             user("What is the capital of France?")
         }
 
-        val response = executor.execute(prompt, model, emptyList())
-
-        assertNotNull(response, "Response should not be null")
-        assertTrue(response.isNotEmpty(), "Response should not be empty")
-        assertTrue(response.first() is Message.Assistant, "Response should be an Assistant message")
-        assertTrue(
-            (response.first() as Message.Assistant).content.contains("Paris", ignoreCase = true),
-            "Response should contain 'Paris'"
-        )
+        withRetry(times = 3, testName = "integration_testExecute[${model.id}]") {
+            val response = executor.execute(prompt, model, emptyList())
+            assertNotNull(response, "Response should not be null")
+            assertTrue(response.isNotEmpty(), "Response should not be empty")
+            assertTrue(response.first() is Message.Assistant, "Response should be an Assistant message")
+            assertTrue(
+                (response.first() as Message.Assistant).content.contains("Paris", ignoreCase = true),
+                "Response should contain 'Paris'"
+            )
+        }
     }
 
-    @Retry(3)
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
     fun integration_testExecuteStreaming(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
@@ -84,24 +80,24 @@ class SingleLLMPromptExecutorIntegrationTest {
             user("Count from 1 to 5.")
         }
 
-        val responseChunks = executor.executeStreaming(prompt, model).toList()
+        withRetry(times = 3, testName = "integration_testExecuteStreaming[${model.id}]") {
+            val responseChunks = executor.executeStreaming(prompt, model).toList()
+            assertNotNull(responseChunks, "Response chunks should not be null")
+            assertTrue(responseChunks.isNotEmpty(), "Response chunks should not be empty")
 
-        assertNotNull(responseChunks, "Response chunks should not be null")
-        assertTrue(responseChunks.isNotEmpty(), "Response chunks should not be empty")
-
-        // Combine all chunks to check the full response
-        val fullResponse = responseChunks.joinToString("")
-        assertTrue(
-            fullResponse.contains("1") &&
-                    fullResponse.contains("2") &&
-                    fullResponse.contains("3") &&
-                    fullResponse.contains("4") &&
-                    fullResponse.contains("5"),
-            "Full response should contain numbers 1 through 5"
-        )
+            // Combine all chunks to check the full response
+            val fullResponse = responseChunks.joinToString("")
+            assertTrue(
+                fullResponse.contains("1") &&
+                        fullResponse.contains("2") &&
+                        fullResponse.contains("3") &&
+                        fullResponse.contains("4") &&
+                        fullResponse.contains("5"),
+                "Full response should contain numbers 1 through 5"
+            )
+        }
     }
 
-    @Retry(times = 3)
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
     fun integration_testCodeGeneration(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
@@ -112,28 +108,24 @@ class SingleLLMPromptExecutorIntegrationTest {
             user("Write a simple Kotlin function to calculate the factorial of a number. Make sure the name of the function starts with 'factorial'.")
         }
 
-        val maxRetries = 3
-        var attempts = 0
         var response: List<Message>
 
-        do {
-            attempts++
+        withRetry(times = 3, testName = "integration_testCodeGeneration[${model.id}]") {
             response = executor.execute(prompt, model, emptyList())
-        } while (response.isEmpty() && attempts < maxRetries)
 
-        assertNotNull(response, "Response should not be null")
-        assertTrue(response.isNotEmpty(), "Response should not be empty")
-        assertTrue(response.first() is Message.Assistant, "Response should be an Assistant message")
+            assertNotNull(response, "Response should not be null")
+            assertTrue(response.isNotEmpty(), "Response should not be empty")
+            assertTrue(response.first() is Message.Assistant, "Response should be an Assistant message")
 
-        val content = (response.first() as Message.Assistant).content
-        assertTrue(
-            content.contains("fun factorial"),
-            "Response should contain a factorial function. Response: $response. Content: $content"
-        )
-        assertTrue(content.contains("return"), "Response should contain a return statement")
+            val content = (response.first() as Message.Assistant).content
+            assertTrue(
+                content.contains("fun factorial"),
+                "Response should contain a factorial function. Response: $response. Content: $content"
+            )
+            assertTrue(content.contains("return"), "Response should contain a return statement")
+        }
     }
 
-    @Retry(3)
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
     fun integration_testToolsWithRequiredParams(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
@@ -166,13 +158,13 @@ class SingleLLMPromptExecutorIntegrationTest {
             user("What is 123 + 456?")
         }
 
-        val executor = SingleLLMPromptExecutor(client)
-
-        val response = executor.execute(prompt, model, listOf(calculatorTool))
-        assertTrue(response.isNotEmpty(), "Response should not be empty")
+        withRetry(times = 3, testName = "integration_testToolsWithRequiredParams[${model.id}]") {
+            val executor = SingleLLMPromptExecutor(client)
+            val response = executor.execute(prompt, model, listOf(calculatorTool))
+            assertTrue(response.isNotEmpty(), "Response should not be empty")
+        }
     }
 
-    @Retry(3)
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
     fun integration_testToolsWithRequiredOptionalParams(model: LLModel, client: LLMClient) =
@@ -216,11 +208,12 @@ class SingleLLMPromptExecutorIntegrationTest {
 
             val executor = SingleLLMPromptExecutor(client)
 
-            val response = executor.execute(prompt, model, listOf(calculatorTool))
-            assertTrue(response.isNotEmpty(), "Response should not be empty")
+            withRetry(times = 3, testName = "integration_testToolsWithRequiredOptionalParams[${model.id}]") {
+                val response = executor.execute(prompt, model, listOf(calculatorTool))
+                assertTrue(response.isNotEmpty(), "Response should not be empty")
+            }
         }
 
-    @Retry(3)
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
     fun integration_testToolsWithOptionalParams(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
@@ -259,12 +252,12 @@ class SingleLLMPromptExecutorIntegrationTest {
         }
 
         val executor = SingleLLMPromptExecutor(client)
-
-        val response = executor.execute(prompt, model, listOf(calculatorTool))
-        assertTrue(response.isNotEmpty(), "Response should not be empty")
+        withRetry(times = 3, testName = "integration_testToolsWithOptionalParams[${model.id}]") {
+            val response = executor.execute(prompt, model, listOf(calculatorTool))
+            assertTrue(response.isNotEmpty(), "Response should not be empty")
+        }
     }
 
-    @Retry(3)
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
     fun integration_testToolsWithNoParams(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
@@ -289,12 +282,13 @@ class SingleLLMPromptExecutorIntegrationTest {
 
         val executor = SingleLLMPromptExecutor(client)
 
-        val response =
-            executor.execute(prompt, model, listOf(calculatorTool, calculatorToolBetter))
-        assertTrue(response.isNotEmpty(), "Response should not be empty")
+        withRetry(times = 3, testName = "integration_testToolsWithNoParams[${model.id}]") {
+            val response =
+                executor.execute(prompt, model, listOf(calculatorTool, calculatorToolBetter))
+            assertTrue(response.isNotEmpty(), "Response should not be empty")
+        }
     }
 
-    @Retry(3)
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
     fun integration_testToolsWithListEnumParams(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
@@ -320,11 +314,12 @@ class SingleLLMPromptExecutorIntegrationTest {
 
         val executor = SingleLLMPromptExecutor(client)
 
-        val response = executor.execute(prompt, model, listOf(colorPickerTool))
-        assertTrue(response.isNotEmpty(), "Response should not be empty")
+        withRetry(times = 3, testName = "integration_testToolsWithListEnumParams[${model.id}]") {
+            val response = executor.execute(prompt, model, listOf(colorPickerTool))
+            assertTrue(response.isNotEmpty(), "Response should not be empty")
+        }
     }
 
-    @Retry(3)
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
     fun integration_testToolsWithNestedListParams(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
@@ -349,12 +344,12 @@ class SingleLLMPromptExecutorIntegrationTest {
 
         val executor = SingleLLMPromptExecutor(client)
 
-        val response = executor.execute(prompt, model, listOf(lotteryPickerTool))
-
-        assertTrue(response.isNotEmpty(), "Response should not be empty")
+        withRetry(times = 3, testName = "integration_testToolsWithNestedListParams[${model.id}]") {
+            val response = executor.execute(prompt, model, listOf(lotteryPickerTool))
+            assertTrue(response.isNotEmpty(), "Response should not be empty")
+        }
     }
 
-    @Retry(3)
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
     fun integration_testRawStringStreaming(model: LLModel, client: LLMClient) = runTest(timeout = 600.seconds) {
@@ -365,24 +360,25 @@ class SingleLLMPromptExecutorIntegrationTest {
 
         val responseChunks = mutableListOf<String>()
 
-        client.executeStreaming(prompt, model).collect { chunk ->
-            responseChunks.add(chunk)
+        withRetry(times = 3, testName = "integration_testRawStringStreaming[${model.id}]") {
+            client.executeStreaming(prompt, model).collect { chunk ->
+                responseChunks.add(chunk)
+            }
+
+            assertTrue(responseChunks.isNotEmpty(), "Response chunks should not be empty")
+
+            val fullResponse = responseChunks.joinToString("")
+            assertTrue(
+                fullResponse.contains("1") &&
+                        fullResponse.contains("2") &&
+                        fullResponse.contains("3") &&
+                        fullResponse.contains("4") &&
+                        fullResponse.contains("5"),
+                "Full response should contain numbers 1 through 5"
+            )
         }
-
-        assertTrue(responseChunks.isNotEmpty(), "Response chunks should not be empty")
-
-        val fullResponse = responseChunks.joinToString("")
-        assertTrue(
-            fullResponse.contains("1") &&
-                    fullResponse.contains("2") &&
-                    fullResponse.contains("3") &&
-                    fullResponse.contains("4") &&
-                    fullResponse.contains("5"),
-            "Full response should contain numbers 1 through 5"
-        )
     }
 
-    @Retry(3)
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
     fun integration_testStructuredDataStreaming(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
@@ -402,13 +398,15 @@ class SingleLLMPromptExecutorIntegrationTest {
             )
         }
 
-        val markdownStream = client.executeStreaming(prompt, model)
+        withRetry(times = 3, testName = "integration_testStructuredDataStreaming[${model.id}]") {
+            val markdownStream = client.executeStreaming(prompt, model)
 
-        TestUtils.parseMarkdownStreamToCountries(markdownStream).collect { country ->
-            countries.add(country)
+            TestUtils.parseMarkdownStreamToCountries(markdownStream).collect { country ->
+                countries.add(country)
+            }
+
+            assertTrue(countries.isNotEmpty(), "Countries list should not be empty")
         }
-
-        assertTrue(countries.isNotEmpty(), "Countries list should not be empty")
     }
 
     // Common helper methods for tool choice tests
@@ -441,7 +439,6 @@ class SingleLLMPromptExecutorIntegrationTest {
         user("What is 123 + 456?")
     }
 
-    @Retry(3)
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
     fun integration_testToolChoiceRequired(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
@@ -452,21 +449,22 @@ class SingleLLMPromptExecutorIntegrationTest {
 
         /** tool choice auto is default and thus is tested by [integration_testToolsWithRequiredParams] */
 
-        val response = client.execute(
-            prompt.withParams(
-                prompt.params.copy(
-                    toolChoice = ToolChoice.Required
-                )
-            ),
-            model,
-            listOf(calculatorTool)
-        )
+        withRetry(times = 3, testName = "integration_testToolChoiceRequired[${model.id}]") {
+            val response = client.execute(
+                prompt.withParams(
+                    prompt.params.copy(
+                        toolChoice = ToolChoice.Required
+                    )
+                ),
+                model,
+                listOf(calculatorTool)
+            )
 
-        assertTrue(response.isNotEmpty(), "Response should not be empty")
-        assertTrue(response.first() is Message.Tool.Call)
+            assertTrue(response.isNotEmpty(), "Response should not be empty")
+            assertTrue(response.first() is Message.Tool.Call)
+        }
     }
 
-    @Retry(3)
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
     fun integration_testToolChoiceNone(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
@@ -475,24 +473,25 @@ class SingleLLMPromptExecutorIntegrationTest {
         val calculatorTool = createCalculatorTool()
         val prompt = createCalculatorPrompt()
 
-        val response = client.execute(
-            Prompt.build("test-tools") {
-                system("You are a helpful assistant. Do not use calculator tool, it's broken!")
-                user("What is 123 + 456?")
-            }.withParams(
-                prompt.params.copy(
-                    toolChoice = ToolChoice.None
-                )
-            ),
-            model,
-            listOf(calculatorTool)
-        )
+        withRetry(times = 3, testName = "integration_testToolChoiceNone[${model.id}]") {
+            val response = client.execute(
+                Prompt.build("test-tools") {
+                    system("You are a helpful assistant. Do not use calculator tool, it's broken!")
+                    user("What is 123 + 456?")
+                }.withParams(
+                    prompt.params.copy(
+                        toolChoice = ToolChoice.None
+                    )
+                ),
+                model,
+                listOf(calculatorTool)
+            )
 
-        assertTrue(response.isNotEmpty(), "Response should not be empty")
-        assertTrue(response.first() is Message.Assistant)
+            assertTrue(response.isNotEmpty(), "Response should not be empty")
+            assertTrue(response.first() is Message.Assistant)
+        }
     }
 
-    @Retry(3)
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
     fun integration_testToolChoiceNamed(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
@@ -506,20 +505,22 @@ class SingleLLMPromptExecutorIntegrationTest {
             description = "A tool that does nothing",
         )
 
-        val response = client.execute(
-            prompt.withParams(
-                prompt.params.copy(
-                    toolChoice = ToolChoice.Named(nothingTool.name)
-                )
-            ),
-            model,
-            listOf(calculatorTool, nothingTool)
-        )
+        withRetry(times = 3, testName = "integration_testToolChoiceNamed[${model.id}]") {
+            val response = client.execute(
+                prompt.withParams(
+                    prompt.params.copy(
+                        toolChoice = ToolChoice.Named(nothingTool.name)
+                    )
+                ),
+                model,
+                listOf(calculatorTool, nothingTool)
+            )
 
-        assertNotNull(response, "Response should not be null")
-        assertTrue(response.isNotEmpty(), "Response should not be empty")
-        assertTrue(response.first() is Message.Tool.Call)
-        val toolCall = response.first() as Message.Tool.Call
-        assertEquals("nothing", toolCall.tool, "Tool name should be 'nothing'")
+            assertNotNull(response, "Response should not be null")
+            assertTrue(response.isNotEmpty(), "Response should not be empty")
+            assertTrue(response.first() is Message.Tool.Call)
+            val toolCall = response.first() as Message.Tool.Call
+            assertEquals("nothing", toolCall.tool, "Tool name should be 'nothing'")
+        }
     }
 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/RetryUtils.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/RetryUtils.kt
@@ -1,0 +1,78 @@
+package ai.koog.integration.tests.utils
+
+import kotlinx.coroutines.delay
+import org.junit.jupiter.api.Assumptions
+
+/*
+* The RetryExtension is not working with JUnit parametrized tests,
+* so I had to add this workaround to skip/retry tests with @ParametrizedTest annotation.
+* */
+object RetryUtils {
+    private const val GOOGLE_API_ERROR = "Field 'parts' is required for type with serial name"
+    private const val GOOGLE_429_ERROR = "Error from GoogleAI API: 429 Too Many Requests"
+    private const val GOOGLE_500_ERROR = "Error from GoogleAI API: 500 Internal Server Error"
+    private const val GOOGLE_503_ERROR = "Error from GoogleAI API: 503 Service Unavailable"
+    private const val ANTHROPIC_502_ERROR = "Error from Anthropic API: 502 Bad Gateway"
+    private const val OPENAI_500_ERROR = "Error from OpenAI API: 500 Internal Server Error"
+    private const val OPENAI_503_ERROR = "Error from OpenAI API: 503 Service Unavailable"
+
+    private fun isThirdPartyError(e: Throwable): Boolean {
+        val errorMessages = listOf(
+            GOOGLE_API_ERROR,
+            GOOGLE_429_ERROR,
+            GOOGLE_500_ERROR,
+            GOOGLE_503_ERROR,
+            ANTHROPIC_502_ERROR,
+            OPENAI_500_ERROR,
+            OPENAI_503_ERROR
+        )
+
+        val message = e.message
+        return message != null && errorMessages.any { errorPattern ->
+            message.contains(errorPattern, ignoreCase = true)
+        }
+    }
+
+    suspend fun <T> withRetry(
+        times: Int = 3,
+        delayMs: Long = 1000,
+        testName: String = "test",
+        action: suspend () -> T
+    ): T {
+        var lastException: Throwable? = null
+
+        for (attempt in 1..times) {
+            try {
+                println("[DEBUG_LOG] Test '$testName' - attempt $attempt of $times")
+                val result = action()
+                println("[DEBUG_LOG] Test '$testName' succeeded on attempt $attempt")
+                return result
+            } catch (throwable: Throwable) {
+                lastException = throwable
+
+                if (isThirdPartyError(throwable)) {
+                    println("[DEBUG_LOG] Skipping test due to third-party service error: ${throwable.message}")
+                    Assumptions.assumeTrue(
+                        false,
+                        "Skipping test due to third-party service error: ${throwable.message}"
+                    )
+                    return action()
+                }
+
+                println("[DEBUG_LOG] Test '$testName' failed on attempt $attempt: ${throwable.message}")
+
+                if (attempt < times) {
+                    println("[DEBUG_LOG] Retrying test '$testName' (attempt ${attempt + 1} of $times)")
+
+                    if (delayMs > 0) {
+                        delay(delayMs)
+                    }
+                } else {
+                    println("[DEBUG_LOG] Maximum retry attempts ($times) reached for test '$testName'")
+                }
+            }
+        }
+
+        throw lastException!!
+    }
+}

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/annotations/Retry.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/annotations/Retry.kt
@@ -1,5 +1,10 @@
 package ai.koog.integration.tests.utils.annotations
 
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
+@TestTemplate
+@ExtendWith(RetryExtension::class)
 annotation class Retry(val times: Int = 3)

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/annotations/Retry.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/annotations/Retry.kt
@@ -1,10 +1,11 @@
 package ai.koog.integration.tests.utils.annotations
 
-import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.extension.ExtendWith
 
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-@TestTemplate
 @ExtendWith(RetryExtension::class)
-annotation class Retry(val times: Int = 3)
+annotation class Retry(
+    val times: Int = 3,
+    val delayMs: Long = 1000
+)

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/annotations/RetryExtension.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/annotations/RetryExtension.kt
@@ -13,11 +13,21 @@ class RetryExtension : InvocationInterceptor {
         private const val GOOGLE_500_ERROR = "Error from GoogleAI API: 500 Internal Server Error"
         private const val GOOGLE_503_ERROR = "Error from GoogleAI API: 503 Service Unavailable"
         private const val ANTHROPIC_502_ERROR = "Error from Anthropic API: 502 Bad Gateway"
+        private const val OPENAI_500_ERROR = "Error from OpenAI API: 500 Internal Server Error"
+        private const val OPENAI_503_ERROR = "Error from OpenAI API: 503 Service Unavailable"
     }
 
     private fun isThirdPartyError(e: Throwable): Boolean {
         val errorMessages =
-            listOf(GOOGLE_API_ERROR, GOOGLE_429_ERROR, GOOGLE_500_ERROR, GOOGLE_503_ERROR, ANTHROPIC_502_ERROR)
+            listOf(
+                GOOGLE_API_ERROR,
+                GOOGLE_429_ERROR,
+                GOOGLE_500_ERROR,
+                GOOGLE_503_ERROR,
+                ANTHROPIC_502_ERROR,
+                OPENAI_500_ERROR,
+                OPENAI_503_ERROR
+            )
         return e.message?.let { message -> message in errorMessages } == true
     }
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/annotations/RetryExtension.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/annotations/RetryExtension.kt
@@ -15,12 +15,10 @@ class RetryExtension : InvocationInterceptor {
         private const val ANTHROPIC_502_ERROR = "Error from Anthropic API: 502 Bad Gateway"
     }
 
-    private fun isThirdSideError(e: Throwable): Boolean {
-        return e.message?.contains(GOOGLE_429_ERROR) == true
-                || e.message?.contains(GOOGLE_500_ERROR) == true
-                || e.message?.contains(GOOGLE_503_ERROR) == true
-                || e.message?.contains(GOOGLE_API_ERROR) == true
-                || e.message?.contains(ANTHROPIC_502_ERROR) == true
+    private fun isThirdPartyError(e: Throwable): Boolean {
+        val errorMessages =
+            listOf(GOOGLE_API_ERROR, GOOGLE_429_ERROR, GOOGLE_500_ERROR, GOOGLE_503_ERROR, ANTHROPIC_502_ERROR)
+        return e.message?.let { message -> message in errorMessages } == true
     }
 
     override fun interceptTestMethod(
@@ -46,7 +44,7 @@ class RetryExtension : InvocationInterceptor {
             } catch (throwable: Throwable) {
                 lastException = throwable
 
-                if (isThirdSideError(throwable)) {
+                if (isThirdPartyError(throwable)) {
                     println("[DEBUG_LOG] Third-party service error detected: ${throwable.message}")
                     assumeTrue(false, "Skipping test due to ${throwable.message}")
                     return

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/annotations/RetryExtension.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/annotations/RetryExtension.kt
@@ -12,20 +12,22 @@ class RetryExtension : TestExecutionExceptionHandler {
         private const val GOOGLE_429_ERROR = "Error from GoogleAI API: 429 Too Many Requests"
         private const val GOOGLE_500_ERROR = "Error from GoogleAI API: 500 Internal Server Error"
         private const val GOOGLE_503_ERROR = "Error from GoogleAI API: 503 Service Unavailable"
+        private const val ANTHROPIC_502_ERROR = "Error from Anthropic API: 502 Bad Gateway"
     }
 
-    private fun isGoogleSideError(e: Throwable): Boolean {
+    private fun isThirdSideError(e: Throwable): Boolean {
         return e.message?.contains(GOOGLE_429_ERROR) == true
                 || e.message?.contains(GOOGLE_500_ERROR) == true
                 || e.message?.contains(GOOGLE_503_ERROR) == true
                 || e.message?.contains(GOOGLE_API_ERROR) == true
+                || e.message?.contains(ANTHROPIC_502_ERROR) == true
     }
 
     override fun handleTestExecutionException(
         context: ExtensionContext,
         throwable: Throwable
     ) {
-        if (isGoogleSideError(throwable)) {
+        if (isThirdSideError(throwable)) {
             println("[DEBUG_LOG] Google-side known error detected: ${throwable.message}")
             assumeTrue(false, "Skipping test due to ${throwable.message}")
             return

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/annotations/RetryExtension.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/annotations/RetryExtension.kt
@@ -1,13 +1,13 @@
 package ai.koog.integration.tests.utils.annotations
 
 import org.junit.jupiter.api.Assumptions.assumeTrue
-import org.junit.jupiter.api.extension.*
-import java.util.stream.Stream
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.InvocationInterceptor
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext
+import java.lang.reflect.Method
 
-class RetryExtension : TestTemplateInvocationContextProvider, TestExecutionExceptionHandler {
+class RetryExtension : InvocationInterceptor {
     companion object {
-        private val NAMESPACE = ExtensionContext.Namespace.create(RetryExtension::class.java)
-
         private const val GOOGLE_API_ERROR = "Field 'parts' is required for type with serial name"
         private const val GOOGLE_429_ERROR = "Error from GoogleAI API: 429 Too Many Requests"
         private const val GOOGLE_500_ERROR = "Error from GoogleAI API: 500 Internal Server Error"
@@ -23,60 +23,54 @@ class RetryExtension : TestTemplateInvocationContextProvider, TestExecutionExcep
                 || e.message?.contains(ANTHROPIC_502_ERROR) == true
     }
 
-    override fun supportsTestTemplate(context: ExtensionContext): Boolean {
-        return context.requiredTestMethod.isAnnotationPresent(Retry::class.java)
-    }
-
-    override fun provideTestTemplateInvocationContexts(context: ExtensionContext): Stream<TestTemplateInvocationContext> {
-        val retry = context.requiredTestMethod.getAnnotation(Retry::class.java)
-        return Stream.generate { createInvocationContext(context, retry) }
-            .limit(retry.times.toLong())
-    }
-
-    private fun createInvocationContext(context: ExtensionContext, retry: Retry): TestTemplateInvocationContext {
-        return object : TestTemplateInvocationContext {
-            override fun getDisplayName(invocationIndex: Int): String {
-                return "${context.displayName} [attempt ${invocationIndex}]"
-            }
-
-            override fun getAdditionalExtensions(): List<Extension> {
-                return listOf(RetryExecutionExtension(retry))
-            }
-        }
-    }
-
-    override fun handleTestExecutionException(
-        context: ExtensionContext,
-        throwable: Throwable
+    override fun interceptTestMethod(
+        invocation: InvocationInterceptor.Invocation<Void>,
+        invocationContext: ReflectiveInvocationContext<Method>,
+        extensionContext: ExtensionContext
     ) {
-        if (isThirdSideError(throwable)) {
-            println("[DEBUG_LOG] Google-side known error detected: ${throwable.message}")
-            assumeTrue(false, "Skipping test due to ${throwable.message}")
+        val retry = extensionContext.requiredTestMethod.getAnnotation(Retry::class.java)
+
+        if (retry == null) {
+            invocation.proceed()
             return
         }
 
-        throw throwable
-    }
+        var lastException: Throwable? = null
 
-    private class RetryExecutionExtension(private val retry: Retry) : TestExecutionExceptionHandler {
-        override fun handleTestExecutionException(
-            context: ExtensionContext,
-            throwable: Throwable
-        ) {
-            val retryStore = context.getStore(NAMESPACE)
-            val key = "${context.requiredTestClass.name}.${context.requiredTestMethod.name}"
-            val currentAttempt = retryStore.getOrComputeIfAbsent(key, { 0 }, Int::class.java) as Int
-
-            println("[DEBUG_LOG] Test '${context.displayName}' failed. Attempt ${currentAttempt + 1} of ${retry.times}")
-
-            if (currentAttempt < retry.times - 1) {
-                retryStore.put(key, currentAttempt + 1)
-                println("[DEBUG_LOG] Retrying test '${context.displayName}'")
+        for (attempt in 1..retry.times) {
+            try {
+                println("[DEBUG_LOG] Test '${extensionContext.displayName}' - attempt $attempt of ${retry.times}")
+                invocation.proceed()
+                println("[DEBUG_LOG] Test '${extensionContext.displayName}' succeeded on attempt $attempt")
                 return
-            } else {
-                println("[DEBUG_LOG] Maximum retry attempts (${retry.times}) reached for test '${context.displayName}'")
-                throw throwable
+            } catch (throwable: Throwable) {
+                lastException = throwable
+
+                if (isThirdSideError(throwable)) {
+                    println("[DEBUG_LOG] Third-party service error detected: ${throwable.message}")
+                    assumeTrue(false, "Skipping test due to ${throwable.message}")
+                    return
+                }
+
+                println("[DEBUG_LOG] Test '${extensionContext.displayName}' failed on attempt $attempt: ${throwable.message}")
+
+                if (attempt < retry.times) {
+                    println("[DEBUG_LOG] Retrying test '${extensionContext.displayName}' (attempt ${attempt + 1} of ${retry.times})")
+
+                    if (retry.delayMs > 0) {
+                        try {
+                            Thread.sleep(retry.delayMs)
+                        } catch (e: InterruptedException) {
+                            Thread.currentThread().interrupt()
+                            throw e
+                        }
+                    }
+                } else {
+                    println("[DEBUG_LOG] Maximum retry attempts (${retry.times}) reached for test '${extensionContext.displayName}'")
+                }
             }
         }
+
+        throw lastException!!
     }
 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/annotations/RetryExtension.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/annotations/RetryExtension.kt
@@ -1,10 +1,10 @@
 package ai.koog.integration.tests.utils.annotations
 
 import org.junit.jupiter.api.Assumptions.assumeTrue
-import org.junit.jupiter.api.extension.ExtensionContext
-import org.junit.jupiter.api.extension.TestExecutionExceptionHandler
+import org.junit.jupiter.api.extension.*
+import java.util.stream.Stream
 
-class RetryExtension : TestExecutionExceptionHandler {
+class RetryExtension : TestTemplateInvocationContextProvider, TestExecutionExceptionHandler {
     companion object {
         private val NAMESPACE = ExtensionContext.Namespace.create(RetryExtension::class.java)
 
@@ -23,6 +23,28 @@ class RetryExtension : TestExecutionExceptionHandler {
                 || e.message?.contains(ANTHROPIC_502_ERROR) == true
     }
 
+    override fun supportsTestTemplate(context: ExtensionContext): Boolean {
+        return context.requiredTestMethod.isAnnotationPresent(Retry::class.java)
+    }
+
+    override fun provideTestTemplateInvocationContexts(context: ExtensionContext): Stream<TestTemplateInvocationContext> {
+        val retry = context.requiredTestMethod.getAnnotation(Retry::class.java)
+        return Stream.generate { createInvocationContext(context, retry) }
+            .limit(retry.times.toLong())
+    }
+
+    private fun createInvocationContext(context: ExtensionContext, retry: Retry): TestTemplateInvocationContext {
+        return object : TestTemplateInvocationContext {
+            override fun getDisplayName(invocationIndex: Int): String {
+                return "${context.displayName} [attempt ${invocationIndex}]"
+            }
+
+            override fun getAdditionalExtensions(): List<Extension> {
+                return listOf(RetryExecutionExtension(retry))
+            }
+        }
+    }
+
     override fun handleTestExecutionException(
         context: ExtensionContext,
         throwable: Throwable
@@ -33,8 +55,14 @@ class RetryExtension : TestExecutionExceptionHandler {
             return
         }
 
-        val retry = context.requiredTestMethod.getAnnotation(Retry::class.java)
-        if (retry != null) {
+        throw throwable
+    }
+
+    private class RetryExecutionExtension(private val retry: Retry) : TestExecutionExceptionHandler {
+        override fun handleTestExecutionException(
+            context: ExtensionContext,
+            throwable: Throwable
+        ) {
             val retryStore = context.getStore(NAMESPACE)
             val key = "${context.requiredTestClass.name}.${context.requiredTestMethod.name}"
             val currentAttempt = retryStore.getOrComputeIfAbsent(key, { 0 }, Int::class.java) as Int
@@ -44,11 +72,11 @@ class RetryExtension : TestExecutionExceptionHandler {
             if (currentAttempt < retry.times - 1) {
                 retryStore.put(key, currentAttempt + 1)
                 println("[DEBUG_LOG] Retrying test '${context.displayName}'")
-                return // Don't throw the exception to allow retry
+                return
             } else {
                 println("[DEBUG_LOG] Maximum retry attempts (${retry.times}) reached for test '${context.displayName}'")
+                throw throwable
             }
         }
-        throw throwable
     }
 }


### PR DESCRIPTION
Implements #242

Skipping OpenAI audio models in streaming tests in `MultipleLLMPromptExecutorIntegrationTest`.

---

#### Type of the change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation fix
- [x] Tests' adjustment

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
