### PR TITLE
Fix grammar and punctuation in StructureParser prompt 

### DIFF
--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/StructureParser.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/StructureParser.kt
@@ -57,14 +57,14 @@ public class StructureParser(
             system {
                 markdown {
                     +"You are agent responsible for converting incorrectly generated LLM Structured Output into valid JSON that adheres to the given JSON schema."
-                    +"Your sole responsibility is to fix the generated JSON to conform to the given schema"
+                    +"Your sole responsibility is to fix the generated JSON to conform to the given schema."
                     newline()
 
                     h2("PROCESS")
                     bulleted {
                         item("Evaluate what parts are incorrect and fix them.")
-                        item("Drop unknown fields and come-up with values for missing fields based on semantics")
-                        item("Carefully check the types of the fields and fix if any are incorrect")
+                        item("Drop unknown fields and come-up with values for missing fields based on semantics.")
+                        item("Carefully check the types of the fields and fix if any are incorrect.")
                         item("Utilize the provided exception to determine the possible error, but do not forget about other possible mistakes.")
                     }
 

--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/StructureParser.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/StructureParser.kt
@@ -70,7 +70,7 @@ public class StructureParser(
 
                     h2("KEY PRINCIPLES")
                     bulleted {
-                        item("You MUST stick to the original data, make as less changes as possible to convert it into valid JSON.")
+                        item("You MUST stick to the original data, make as few changes as possible to convert it into valid JSON.")
                         item("Do not drop, alter or change any semantic data unless it is necessary to fit into JSON schema.")
                     }
 


### PR DESCRIPTION
Fixes the grammar and adds missing punctuation in the `code-engine-structure-fixing` prompt. 


---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
