### PR TITLE
OllamaClient: send image attachments in chat request

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaConverters.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaConverters.kt
@@ -3,6 +3,7 @@ package ai.koog.prompt.executor.ollama.client.dto
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.ollama.tools.json.toJSONSchema
+import ai.koog.prompt.message.MediaContent
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.params.LLMParams
@@ -26,7 +27,9 @@ internal fun Prompt.toOllamaChatMessages(): List<OllamaChatMessageDTO> {
 
             is Message.User -> OllamaChatMessageDTO(
                 role = "user",
-                content = message.content
+                content = message.content,
+                images = message.mediaContent
+                    .filterIsInstance<MediaContent.Image>().map { it.toBase64() }.takeIf { it.isNotEmpty() },
             )
 
             is Message.Assistant -> OllamaChatMessageDTO(


### PR DESCRIPTION
This PR adds the image attachments in user messages to the chat requests of OllamaClient.

Fixes #249 

I did not know where to add integration tests. Please tell me where, and I will add to this PR.

In the meantime, I tested the change locally with the following program:
```kotlin
suspend fun main() {
    val client = OllamaClient()

    val models = mapOf(
        "gemma3_4b" to client.getModelOrNull("gemma3:4b")!!.toLLModel(),
        "llava_7b" to client.getModelOrNull("llava:7b")!!.toLLModel(),
        "llava_llama3" to client.getModelOrNull("llava-llama3:8b")!!.toLLModel(),
        "llama3_2_vision_11b" to client.getModelOrNull("llama3.2-vision:11b")!!.toLLModel(),
    )

    val kotlinLogo = "/home/didier/Pictures/kotlin-logo.jpg"

    val results = models.mapValues { (_, model) ->
        val prompt = prompt("test") {
            user {
                text("What does this image contain?")
                attachments { image(kotlinLogo) }
            }
        }
        val responses = client.execute(prompt, model)
        responses.joinToString("\n") { it.content }
    }

    val json = Json { prettyPrint = true }
    println(json.encodeToString(results))
}
```
It works as expected and prints:
```json
{
  "gemma3_4b": "The image contains the logo of **Klaviyo**. \n\nIt's a stylized letter \"K\" with a gradient from blue to purple. Klaviyo is a marketing automation platform focused on email and SMS marketing.",
  "llava_7b": " The image displays a logo consisting of the letters \"K\" with a stylized 'K' that has an additional horizontal line connecting the two vertical lines. The background is white, and the 'K' is colored in purple. This design could represent a brand or company, but without further context, it's not possible to determine its specific meaning or association. ",
  "llava_llama3": "The image contains a single object, which is a letter \"K\". The letter is designed in the form of an arrowhead and has a gradient background. The color of the letter transitions from purple at the base to pink at the top. The entire figure is set against a white background. The \"K\" is positioned centrally within the frame of the image, occupying most of the space. There are no other discernible objects or actions in the image. The simplicity and minimalism of the image make it easy to focus on the letter \"K\".",
  "llama3_2_vision_11b": "The image contains a purple and pink gradient letter \"K\" on a white background."
}
```

---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
