### PR TITLE
Added support for nullable tool parameters

### DIFF
--- a/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/DefaultMcpToolDescriptorParserTest.kt
+++ b/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/DefaultMcpToolDescriptorParserTest.kt
@@ -93,17 +93,61 @@ class DefaultMcpToolDescriptorParserTest {
                     put("type", "string")
                     put("description", "String parameter")
                 }
+                putJsonObject("nullableStringParam") {
+                    putJsonArray("anyOf") {
+                        addJsonObject {
+                            put("type", "null")
+                        }
+                        addJsonObject {
+                            put("type", "string")
+                        }
+                    }
+                    put("description", "Nullable string parameter")
+                }
                 putJsonObject("integerParam") {
                     put("type", "integer")
                     put("description", "Integer parameter")
+                }
+                putJsonObject("nullableIntegerParam") {
+                    putJsonArray("anyOf") {
+                        addJsonObject {
+                            put("type", "null")
+                        }
+                        addJsonObject {
+                            put("type", "integer")
+                        }
+                    }
+                    put("description", "Nullable integer parameter")
                 }
                 putJsonObject("numberParam") {
                     put("type", "number")
                     put("description", "Number parameter")
                 }
+                putJsonObject("nullableNumberParam") {
+                    putJsonArray("anyOf") {
+                        addJsonObject {
+                            put("type", "null")
+                        }
+                        addJsonObject {
+                            put("type", "number")
+                        }
+                    }
+                    put("description", "Nullable number parameter")
+                }
                 putJsonObject("booleanParam") {
                     put("type", "boolean")
                     put("description", "Boolean parameter")
+                }
+                putJsonObject("nullableBooleanParam") {
+                    putJsonArray("anyOf") {
+                        addJsonObject {
+                            put("type", "null")
+                        }
+                        addJsonObject {
+                            put("type", "boolean")
+                        }
+                    }
+                    put("description", "Nullable boolean parameter")
                 }
 
                 // Array types
@@ -113,6 +157,22 @@ class DefaultMcpToolDescriptorParserTest {
                     putJsonObject("items") {
                         put("type", "string")
                     }
+                }
+
+                putJsonObject("nullableArrayParam") {
+                    putJsonArray("anyOf") {
+                        addJsonObject {
+                            put("type", "null")
+                        }
+                        addJsonObject {
+                            put("type", "array")
+                            put("description", "Array parameter")
+                            putJsonObject("items") {
+                                put("type", "string")
+                            }
+                        }
+                    }
+                    put("description", "Nullable array parameter")
                 }
 
                 // Object type
@@ -150,8 +210,18 @@ class DefaultMcpToolDescriptorParserTest {
                     type = ToolParameterType.String
                 ),
                 ToolParameterDescriptor(
+                    name = "nullableStringParam",
+                    description = "Nullable string parameter",
+                    type = ToolParameterType.String
+                ),
+                ToolParameterDescriptor(
                     name = "integerParam",
                     description = "Integer parameter",
+                    type = ToolParameterType.Integer
+                ),
+                ToolParameterDescriptor(
+                    name = "nullableIntegerParam",
+                    description = "Nullable integer parameter",
                     type = ToolParameterType.Integer
                 ),
                 ToolParameterDescriptor(
@@ -160,8 +230,18 @@ class DefaultMcpToolDescriptorParserTest {
                     type = ToolParameterType.Float
                 ),
                 ToolParameterDescriptor(
+                    name = "nullableNumberParam",
+                    description = "Nullable number parameter",
+                    type = ToolParameterType.Float
+                ),
+                ToolParameterDescriptor(
                     name = "booleanParam",
                     description = "Boolean parameter",
+                    type = ToolParameterType.Boolean
+                ),
+                ToolParameterDescriptor(
+                    name = "nullableBooleanParam",
+                    description = "Nullable boolean parameter",
                     type = ToolParameterType.Boolean
                 ),
 
@@ -169,6 +249,11 @@ class DefaultMcpToolDescriptorParserTest {
                 ToolParameterDescriptor(
                     name = "arrayParam",
                     description = "Array parameter",
+                    type = ToolParameterType.List(ToolParameterType.String)
+                ),
+                ToolParameterDescriptor(
+                    name = "nullableArrayParam",
+                    description = "Nullable array parameter",
                     type = ToolParameterType.List(ToolParameterType.String)
                 ),
 

--- a/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/McpToolTest.kt
+++ b/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/McpToolTest.kt
@@ -61,6 +61,13 @@ class McpToolTest {
                         type = ToolParameterType.String,
                         description = "A name to greet",
                     )
+                ),
+                optionalParameters = listOf(
+                    ToolParameterDescriptor(
+                        name = "title",
+                        type = ToolParameterType.String,
+                        description = "Title to use in the greeting",
+                    )
                 )
             )
         )
@@ -81,5 +88,18 @@ class McpToolTest {
 
         val content = result.promptMessageContents.first() as TextContent
         assertEquals("Hello, Test!", content.text)
+
+        val argsWithTitle = McpTool.Args(buildJsonObject {
+            put("name", "Test")
+            put("title", "Mr.")
+        })
+        val (resultWithTitle, _) = withContext(Dispatchers.Default.limitedParallelism(1)) {
+            withTimeout(1.minutes) {
+                greetingTool.executeAndSerialize(argsWithTitle, TestToolEnabler)
+            }
+        }
+
+        val contentWithTitle = resultWithTitle.promptMessageContents.first() as TextContent
+        assertEquals("Hello, Mr. Test!", contentWithTitle.text)
     }
 }

--- a/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/TestMcpServer.kt
+++ b/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/TestMcpServer.kt
@@ -10,9 +10,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
 
 /**
@@ -51,13 +53,25 @@ class TestMcpServer(private val port: Int) {
                     put("type", "string")
                     put("description", "A name to greet")
                 }
+                putJsonObject("title") {
+                    putJsonArray("anyOf") {
+                        addJsonObject {
+                            put("type", "null")
+                        }
+                        addJsonObject {
+                            put("type", "string")
+                        }
+                    }
+                    put("description", "Title to use in the greeting")
+                }
             },
             required = listOf("name")
         )
         ) { request ->
             val name = request.arguments["name"]?.jsonPrimitive?.content
+            val title = request.arguments["title"]?.jsonPrimitive?.content
             CallToolResult(
-                content = listOf(TextContent("Hello, $name!"))
+                content = listOf(TextContent("Hello, ${if (title.isNullOrEmpty()) "" else "$title "}$name!"))
             )
         }
 


### PR DESCRIPTION
Added support for nullable tool parameters. A lot of useful MCP servers are developed with popular Python FastMCP library. For ex., this [graphiti_mcp_server.py#L675](https://github.com/getzep/graphiti/blob/e839c774aa50cfc4abd5757a340d56396302afe0/mcp_server/graphiti_mcp_server.py#L675). FastMCP treats nullable params as `anyOf`, i.e. `my_param: str | None = None` is getting translated into 
```
            "my_param": {
              "anyOf": [{
                          "type": "string"
            		     },
                       {
                          "type": "null"
                       }],
              "title": "Nullable string parameter"
            }
```

kotlinx.serialization.json.JsonBuilder#getExplicitNulls is not disabled, hence null Args are not getting serialized by `ai.koog.agents.mcp.McpTool.ArgsSerializer`
---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
