### PR TITLE
Fix - Allow host config for FeatureMessageRemoteServer 

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/remote/server/config/AIAgentFeatureServerConnectionConfig.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/remote/server/config/AIAgentFeatureServerConnectionConfig.kt
@@ -3,7 +3,8 @@ package ai.koog.agents.core.feature.remote.server.config
 import ai.koog.agents.core.feature.agentFeatureMessageSerializersModule
 import ai.koog.agents.features.common.remote.server.config.ServerConnectionConfig
 
-public class AIAgentFeatureServerConnectionConfig(port: Int) : ServerConnectionConfig(port) {
+public class AIAgentFeatureServerConnectionConfig(host: String, port: Int) :
+    ServerConnectionConfig(host = host, port = port) {
 
     init {
         appendSerializersModule(agentFeatureMessageSerializersModule)

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/remote/server/config/AIAgentFeatureServerConnectionConfig.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/remote/server/config/AIAgentFeatureServerConnectionConfig.kt
@@ -3,6 +3,12 @@ package ai.koog.agents.core.feature.remote.server.config
 import ai.koog.agents.core.feature.agentFeatureMessageSerializersModule
 import ai.koog.agents.features.common.remote.server.config.ServerConnectionConfig
 
+/**
+ * Configuration class for setting up an agent feature server connection.
+ * Properties:
+ * host - The host on which the server will listen to.
+ * port - The port number on which the server will listen to.
+ */
 public class AIAgentFeatureServerConnectionConfig(host: String, port: Int) :
     ServerConnectionConfig(host = host, port = port) {
 

--- a/agents/agents-features/agents-features-common/src/commonMain/kotlin/ai/koog/agents/features/common/remote/server/FeatureMessageRemoteServer.kt
+++ b/agents/agents-features/agents-features-common/src/commonMain/kotlin/ai/koog/agents/features/common/remote/server/FeatureMessageRemoteServer.kt
@@ -81,7 +81,7 @@ public class FeatureMessageRemoteServer(
             return
         }
 
-        startServer(port = connectionConfig.port)
+        startServer(host = connectionConfig.host, port = connectionConfig.port)
         logger.debug { "Feature Message Remote Server. Initialized successfully on port ${connectionConfig.port}" }
 
         isInitialized = true
@@ -112,9 +112,9 @@ public class FeatureMessageRemoteServer(
 
     //region Private Methods
 
-    private fun startServer(port: Int) {
+    private fun startServer(host: String, port: Int) {
         try {
-            val server = createServer(port = port)
+            val server = createServer(host = host, port = port)
             server.start(wait = false)
         }
         catch (t: CancellationException) {
@@ -131,12 +131,12 @@ public class FeatureMessageRemoteServer(
         }
     }
 
-    private fun createServer(port: Int): EmbeddedServer<ApplicationEngine, ApplicationEngine.Configuration> {
+    private fun createServer(host: String, port: Int): EmbeddedServer<ApplicationEngine, ApplicationEngine.Configuration> {
 
         logger.debug { "Feature Message Remote Server. Start creating server on port: $port" }
 
         val factory = engineFactoryProvider()
-        server = embeddedServer(factory = factory, host = "127.0.0.1", port = port) {
+        server = embeddedServer(factory = factory, host = host, port = port) {
             install(SSE)
 
             routing {

--- a/agents/agents-features/agents-features-common/src/commonMain/kotlin/ai/koog/agents/features/common/remote/server/config/ServerConnectionConfig.kt
+++ b/agents/agents-features/agents-features-common/src/commonMain/kotlin/ai/koog/agents/features/common/remote/server/config/ServerConnectionConfig.kt
@@ -5,13 +5,18 @@ import ai.koog.agents.features.common.remote.ConnectionConfig
 /**
  * Configuration class for setting up a server connection.
  *
+ * @property host The host on which the server will listen to. Defaults to 127.0.0.1 (localhost);
  * @property port The port number on which the server will listen to. Defaults to 8080;
  * @property jsonConfig The effective JSON configuration to be used, falling back to a default configuration
  *                      if a custom configuration is not provided;
  */
-public abstract class ServerConnectionConfig(public val port: Int = DEFAULT_PORT) : ConnectionConfig() {
+public abstract class ServerConnectionConfig(
+    public val host: String = DEFAULT_HOST,
+    public val port: Int = DEFAULT_PORT
+) : ConnectionConfig() {
 
     private companion object {
         private const val DEFAULT_PORT = 8080
+        private const val DEFAULT_HOST = "127.0.0.1"
     }
 }

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageRemoteWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageRemoteWriterTest.kt
@@ -26,6 +26,7 @@ class TraceFeatureMessageRemoteWriterTest {
     companion object {
         private val logger = KotlinLogging.logger { }
         private val defaultClientServerTimeout = 5.seconds
+        private val host = "127.0.0.1"
     }
 
     private class TestFeatureMessageWriter : FeatureMessageProcessor() {
@@ -43,9 +44,9 @@ class TraceFeatureMessageRemoteWriterTest {
     fun `test health check on agent run`() = runBlocking {
 
         val port = findAvailablePort()
-        val serverConfig = AIAgentFeatureServerConnectionConfig(port = port)
+        val serverConfig = AIAgentFeatureServerConnectionConfig(host = host, port = port)
         val clientConfig =
-            AIAgentFeatureClientConnectionConfig(host = "127.0.0.1", port = port, protocol = URLProtocol.HTTP)
+            AIAgentFeatureClientConnectionConfig(host = host, port = port, protocol = URLProtocol.HTTP)
 
         val isServerStarted = CompletableDeferred<Boolean>()
         val isClientFinished = CompletableDeferred<Boolean>()
@@ -98,9 +99,9 @@ class TraceFeatureMessageRemoteWriterTest {
         val strategyName = "tracing-test-strategy"
 
         val port = findAvailablePort()
-        val serverConfig = AIAgentFeatureServerConnectionConfig(port = port)
+        val serverConfig = AIAgentFeatureServerConnectionConfig(host = host, port = port)
         val clientConfig =
-            AIAgentFeatureClientConnectionConfig(host = "127.0.0.1", port = port, protocol = URLProtocol.HTTP)
+            AIAgentFeatureClientConnectionConfig(host = host, port = port, protocol = URLProtocol.HTTP)
 
         val userPrompt = "Test user prompt"
         val systemPrompt = "Test system prompt"
@@ -225,9 +226,9 @@ class TraceFeatureMessageRemoteWriterTest {
         val strategyName = "tracing-test-strategy"
 
         val port = findAvailablePort()
-        val serverConfig = AIAgentFeatureServerConnectionConfig(port = port)
+        val serverConfig = AIAgentFeatureServerConnectionConfig(host = host, port = port)
         val clientConfig =
-            AIAgentFeatureClientConnectionConfig(host = "127.0.0.1", port = port, protocol = URLProtocol.HTTP)
+            AIAgentFeatureClientConnectionConfig(host = host, port = port, protocol = URLProtocol.HTTP)
 
         val actualEvents = mutableListOf<FeatureMessage>()
 
@@ -304,9 +305,9 @@ class TraceFeatureMessageRemoteWriterTest {
         val strategyName = "tracing-test-strategy"
 
         val port = findAvailablePort()
-        val serverConfig = AIAgentFeatureServerConnectionConfig(port = port)
+        val serverConfig = AIAgentFeatureServerConnectionConfig(host = host, port = port)
         val clientConfig =
-            AIAgentFeatureClientConnectionConfig(host = "127.0.0.1", port = port, protocol = URLProtocol.HTTP)
+            AIAgentFeatureClientConnectionConfig(host = host, port = port, protocol = URLProtocol.HTTP)
 
         val userPrompt = "Test user prompt"
         val systemPrompt = "Test system prompt"


### PR DESCRIPTION
  ✅ What: Added host property to ServerConnectionConfig
  ✅ Why: To allow proper host configuration for FeatureMessageRemoteServer
  ✅ Type: Fix addresses the 127.0.0.1 binding issue

---

#### Type of the change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [X] The pull request has a description of the proposed change
- [X] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [X] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [X] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
