### PR TITLE
[agent] Refactor subgraph with task. Simplify message handling to make it more straightforward and easier to use.

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentStorage.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentStorage.kt
@@ -52,6 +52,19 @@ public class AIAgentStorage internal constructor() {
         storage[key] as T?
     }
 
+
+    /**
+     * Retrieves the non-null value associated with the given key from the storage.
+     * If the key does not exist in the storage, a [NoSuchElementException] is thrown.
+     *
+     * @param key The key of type [AIAgentStorageKey] used to identify the value in the storage.
+     * @return The value associated with the key, of type [T].
+     * @throws NoSuchElementException if the key does not exist in the storage.
+     */
+    public suspend fun <T : Any> getValue(key: AIAgentStorageKey<T>): T {
+        return get(key) ?: throw NoSuchElementException("Key $key not found in storage")
+    }
+
     /**
      * Removes the value associated with the given key from the storage.
      *

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -72,6 +72,8 @@ registerRunExampleTask("runExampleRiderProjectTemplate", "ai.koog.agents.example
 registerRunExampleTask("runExampleExecSandbox", "ai.koog.agents.example.execsandbox.ExecSandboxKt")
 registerRunExampleTask("runExampleLoopComponent", "ai.koog.agents.example.components.loop.ProjectGeneratorKt")
 registerRunExampleTask("runExampleInstagramPostDescriber", "ai.koog.agents.example.media.InstagramPostDescriberKt")
+registerRunExampleTask("runExampleRoutingViaGraph", "ai.koog.agents.example.banking.routing.RoutingViaGraphKt")
+registerRunExampleTask("runExampleRoutingViaAgentsAsTools", "ai.koog.agents.example.banking.routing.RoutingViaAgentsAsToolsKt")
 
 dokka {
     dokkaSourceSets.named("main") {

--- a/examples/src/main/kotlin/ai/koog/agents/example/mcp/UnityMcpAgent.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/mcp/UnityMcpAgent.kt
@@ -7,6 +7,8 @@ import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.onAssistantMessage
+import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.ext.agent.ProvideStringSubgraphResult
 import ai.koog.agents.ext.agent.subgraphWithTask
 import ai.koog.agents.features.eventHandler.feature.EventHandler
 import ai.koog.agents.features.tracing.feature.Tracing
@@ -58,11 +60,15 @@ fun main() {
             // Create the ToolRegistry with tools from the MCP server
             val toolRegistry = McpToolRegistryProvider.fromTransport(
                 transport = McpToolRegistryProvider.defaultStdioTransport(process)
-            )
+            ) + ToolRegistry {
+                tool(ProvideStringSubgraphResult)
+            }
+
             toolRegistry.tools.forEach {
                 println(it.name)
                 println(it.descriptor)
             }
+
             val agentConfig = AIAgentConfig(
                 prompt = prompt("cook_agent_system_prompt") {
                     system { "Your are a unity assistant. You can exucute different tasks by interacting with the tools from Unity3d engine." }
@@ -80,7 +86,6 @@ fun main() {
                 val interactionWithUnity by subgraphWithTask<String>(
                     //work with plan 
                     tools = toolRegistry.tools,
-                    shouldTLDRHistory = false,
                 ) { input ->
                     "Start interact with Unity according to the plan: $input"
                 }

--- a/examples/src/main/kotlin/ai/koog/agents/example/memory/CustomerSupportAgent.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/memory/CustomerSupportAgent.kt
@@ -11,6 +11,7 @@ import ai.koog.agents.example.ApiKeyService
 import ai.koog.agents.example.memory.tools.DiagnosticToolSet
 import ai.koog.agents.example.memory.tools.KnowledgeBaseToolSet
 import ai.koog.agents.example.memory.tools.UserInfoToolSet
+import ai.koog.agents.ext.agent.ProvideStringSubgraphResult
 import ai.koog.agents.ext.agent.StringSubgraphResult
 import ai.koog.agents.ext.agent.subgraphWithTask
 import ai.koog.agents.memory.config.MemoryScopeType
@@ -250,6 +251,8 @@ fun createCustomerSupportAgent(
             tools(userInfoToolSet.asTools())
             tools(diagnosticToolSet.asTools())
             tools(knowledgeBaseToolSet.asTools())
+
+            tool(ProvideStringSubgraphResult)
         }
     ) {
         install(AgentMemory) {

--- a/examples/src/main/kotlin/ai/koog/agents/example/subgraphwithtask/CustomStrategy.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/subgraphwithtask/CustomStrategy.kt
@@ -36,7 +36,6 @@ fun customWizardStrategy(
     val fix by subgraphWithTask<VerifiedSubgraphResult>(
         tools = fixTools,
         model = AnthropicModels.Sonnet_3_7,
-        shouldTLDRHistory = true
     ) { verificationResult ->
         """
             You are an AI agent that can create files, delete files, create folders, and delete folders.

--- a/examples/src/main/kotlin/ai/koog/agents/example/subgraphwithtask/ProjectGenerator.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/subgraphwithtask/ProjectGenerator.kt
@@ -12,6 +12,8 @@ import ai.koog.agents.example.subgraphwithtask.ProjectGeneratorTools.DeleteFileT
 import ai.koog.agents.example.subgraphwithtask.ProjectGeneratorTools.LSDirectoriesTool
 import ai.koog.agents.example.subgraphwithtask.ProjectGeneratorTools.ReadFileTool
 import ai.koog.agents.example.subgraphwithtask.ProjectGeneratorTools.RunCommand
+import ai.koog.agents.ext.agent.ProvideStringSubgraphResult
+import ai.koog.agents.ext.agent.ProvideVerifiedSubgraphResult
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
@@ -53,6 +55,9 @@ fun main() {
     val toolRegistry = ToolRegistry {
         verifyTools.forEach { tool(it) }
         fixTools.forEach { tool(it) }
+
+        tool(ProvideStringSubgraphResult)
+        tool(ProvideVerifiedSubgraphResult)
     }
 
     runBlocking {

--- a/examples/src/test/kotlin/ai/koog/agents/example/memory/CustomerSupportTest.kt
+++ b/examples/src/test/kotlin/ai/koog/agents/example/memory/CustomerSupportTest.kt
@@ -270,37 +270,37 @@ class CustomerSupportTest {
         mockExecutor = getMockExecutor(toolRegistry) {
             // Mock responses for memory-related queries
             // Diagnostic tool calls
-            mockLLMToolCall(MockDiagnosticToolSet()::runDiagnosticTest, "device-123", "connectivity") onRequestEquals "I need to check the connectivity of device-123"
-            mockLLMToolCall(MockDiagnosticToolSet()::runDiagnostic, "device-456", "ERR-1001") onRequestEquals "I need to diagnose error ERR-1001 on device-456"
-            mockLLMToolCall(MockDiagnosticToolSet()::analyzeError, "ERR-1001") onRequestEquals "I need to analyze error code ERR-1001"
+            mockLLMToolCall(MockDiagnosticToolSet()::runDiagnosticTest, "device-123", "connectivity") onRequestContains "I need to check the connectivity of device-123"
+            mockLLMToolCall(MockDiagnosticToolSet()::runDiagnostic, "device-456", "ERR-1001") onRequestContains "I need to diagnose error ERR-1001 on device-456"
+            mockLLMToolCall(MockDiagnosticToolSet()::analyzeError, "ERR-1001") onRequestContains "I need to analyze error code ERR-1001"
 
             // User info tool calls
-            mockLLMToolCall(MockUserInfoToolSet()::getUserContactInfo, "user-789") onRequestEquals "I need contact information for user-789"
-            mockLLMToolCall(MockUserInfoToolSet()::getUserIssueHistory, "user-789") onRequestEquals "I need issue history for user-789"
-            mockLLMToolCall(MockUserInfoToolSet()::getUserPreferences, "user-789") onRequestEquals "I need preferences for user-789"
+            mockLLMToolCall(MockUserInfoToolSet()::getUserContactInfo, "user-789") onRequestContains "I need contact information for user-789"
+            mockLLMToolCall(MockUserInfoToolSet()::getUserIssueHistory, "user-789") onRequestContains "I need issue history for user-789"
+            mockLLMToolCall(MockUserInfoToolSet()::getUserPreferences, "user-789") onRequestContains "I need preferences for user-789"
 
             // Knowledge base tool calls
-            mockLLMToolCall(MockKnowledgeBaseToolSet()::getProductInfo, "prod-101") onRequestEquals "I need information about product prod-101"
-            mockLLMToolCall(MockKnowledgeBaseToolSet()::searchSolutions, "connectivity issues ERR-1001") onRequestEquals "I need solutions for connectivity issues with error ERR-1001"
-            mockLLMToolCall(MockKnowledgeBaseToolSet()::getOrganizationSolutions, "org-202") onRequestEquals "I need solutions for organization org-202"
+            mockLLMToolCall(MockKnowledgeBaseToolSet()::getProductInfo, "prod-101") onRequestContains "I need information about product prod-101"
+            mockLLMToolCall(MockKnowledgeBaseToolSet()::searchSolutions, "connectivity issues ERR-1001") onRequestContains "I need solutions for connectivity issues with error ERR-1001"
+            mockLLMToolCall(MockKnowledgeBaseToolSet()::getOrganizationSolutions, "org-202") onRequestContains "I need solutions for organization org-202"
 
             // Final result
-            mockLLMToolCall(ProvideStringSubgraphResult, StringSubgraphResult("I've analyzed the information and stored it in memory for future reference.")) onRequestEquals "I need to provide a summary of my findings"
+            mockLLMToolCall(ProvideStringSubgraphResult, StringSubgraphResult("I've analyzed the information and stored it in memory for future reference.")) onRequestContains "I need to provide a summary of my findings"
 
             // Instead of text responses, mock tool calls directly
-            mockLLMToolCall(ProvideStringSubgraphResult, StringSubgraphResult("I've analyzed your device issue and here are the diagnostic results...")) onRequestEquals "I'm getting error ERR-1001 on my device"
-            mockLLMToolCall(ProvideStringSubgraphResult, StringSubgraphResult("I've analyzed your product issue and here is the product information...")) onRequestEquals "I'm from Acme Corp and we're having issues with product prod789"
+            mockLLMToolCall(ProvideStringSubgraphResult, StringSubgraphResult("I've analyzed your device issue and here are the diagnostic results...")) onRequestContains "I'm getting error ERR-1001 on my device"
+            mockLLMToolCall(ProvideStringSubgraphResult, StringSubgraphResult("I've analyzed your product issue and here is the product information...")) onRequestContains "I'm from Acme Corp and we're having issues with product prod789"
 
             // For the first agent, we'll make multiple tool calls
-            mockLLMToolCall(MockUserInfoToolSet()::getUserContactInfo, "user-789") onRequestEquals "I need to get user contact info for the first time"
-            mockLLMToolCall(MockUserInfoToolSet()::getUserIssueHistory, "user-789") onRequestEquals "I need to get user issue history for the first time"
-            mockLLMToolCall(MockDiagnosticToolSet()::runDiagnosticTest, "device-123", "connectivity") onRequestEquals "I need to run a diagnostic test for the first time"
-            mockLLMToolCall(MockKnowledgeBaseToolSet()::searchSolutions, "connectivity issues") onRequestEquals "I need to search for solutions for the first time"
-            mockLLMToolCall(ProvideStringSubgraphResult, StringSubgraphResult("I've analyzed your issue and here's what I found...")) onRequestEquals "I'm having trouble with my device"
+            mockLLMToolCall(MockUserInfoToolSet()::getUserContactInfo, "user-789") onRequestContains "I need to get user contact info for the first time"
+            mockLLMToolCall(MockUserInfoToolSet()::getUserIssueHistory, "user-789") onRequestContains "I need to get user issue history for the first time"
+            mockLLMToolCall(MockDiagnosticToolSet()::runDiagnosticTest, "device-123", "connectivity") onRequestContains "I need to run a diagnostic test for the first time"
+            mockLLMToolCall(MockKnowledgeBaseToolSet()::searchSolutions, "connectivity issues") onRequestContains "I need to search for solutions for the first time"
+            mockLLMToolCall(ProvideStringSubgraphResult, StringSubgraphResult("I've analyzed your issue and here's what I found...")) onRequestContains "I'm having trouble with my device"
 
             // For the second agent, we'll make fewer tool calls since it should use memory
-            mockLLMToolCall(MockUserInfoToolSet()::getUserContactInfo, "user-789") onRequestEquals "I need to get user contact info again"
-            mockLLMToolCall(ProvideStringSubgraphResult, StringSubgraphResult("I've analyzed your issue again and here's what I found using the information from memory...")) onRequestEquals "I'm having the same issue again"
+            mockLLMToolCall(MockUserInfoToolSet()::getUserContactInfo, "user-789") onRequestContains "I need to get user contact info again"
+            mockLLMToolCall(ProvideStringSubgraphResult, StringSubgraphResult("I've analyzed your issue again and here's what I found using the information from memory...")) onRequestContains "I'm having the same issue again"
 
         }
     }
@@ -448,28 +448,28 @@ class CustomerSupportTest {
         val customMockExecutor = getMockExecutor(toolRegistry) {
             // Mock responses for memory-related queries
             // Diagnostic tool calls
-            mockLLMToolCall(MockDiagnosticToolSet()::runDiagnosticTest, "device-123", "connectivity") onRequestEquals "I need to check the connectivity of device-123"
-            mockLLMToolCall(MockDiagnosticToolSet()::runDiagnostic, "device-456", "ERR-1001") onRequestEquals "I need to diagnose error ERR-1001 on device-456"
-            mockLLMToolCall(MockDiagnosticToolSet()::analyzeError, "ERR-1001") onRequestEquals "I need to analyze error code ERR-1001"
+            mockLLMToolCall(MockDiagnosticToolSet()::runDiagnosticTest, "device-123", "connectivity") onRequestContains "I need to check the connectivity of device-123"
+            mockLLMToolCall(MockDiagnosticToolSet()::runDiagnostic, "device-456", "ERR-1001") onRequestContains "I need to diagnose error ERR-1001 on device-456"
+            mockLLMToolCall(MockDiagnosticToolSet()::analyzeError, "ERR-1001") onRequestContains "I need to analyze error code ERR-1001"
 
             // User info tool calls
-            mockLLMToolCall(MockUserInfoToolSet()::getUserContactInfo, "user-789") onRequestEquals "I need contact information for user-789"
-            mockLLMToolCall(MockUserInfoToolSet()::getUserIssueHistory, "user-789") onRequestEquals "I need issue history for user-789"
-            mockLLMToolCall(MockUserInfoToolSet()::getUserPreferences, "user-789") onRequestEquals "I need preferences for user-789"
+            mockLLMToolCall(MockUserInfoToolSet()::getUserContactInfo, "user-789") onRequestContains "I need contact information for user-789"
+            mockLLMToolCall(MockUserInfoToolSet()::getUserIssueHistory, "user-789") onRequestContains "I need issue history for user-789"
+            mockLLMToolCall(MockUserInfoToolSet()::getUserPreferences, "user-789") onRequestContains "I need preferences for user-789"
 
             // Knowledge base tool calls
-            mockLLMToolCall(MockKnowledgeBaseToolSet()::getProductInfo, "prod-101") onRequestEquals "I need information about product prod-101"
-            mockLLMToolCall(MockKnowledgeBaseToolSet()::searchSolutions, "connectivity issues ERR-1001") onRequestEquals "I need solutions for connectivity issues with error ERR-1001"
-            mockLLMToolCall(MockKnowledgeBaseToolSet()::getOrganizationSolutions, "org-202") onRequestEquals "I need solutions for organization org-202"
+            mockLLMToolCall(MockKnowledgeBaseToolSet()::getProductInfo, "prod-101") onRequestContains "I need information about product prod-101"
+            mockLLMToolCall(MockKnowledgeBaseToolSet()::searchSolutions, "connectivity issues ERR-1001") onRequestContains "I need solutions for connectivity issues with error ERR-1001"
+            mockLLMToolCall(MockKnowledgeBaseToolSet()::getOrganizationSolutions, "org-202") onRequestContains "I need solutions for organization org-202"
 
             // Final result
-            mockLLMToolCall(ProvideStringSubgraphResult, StringSubgraphResult("I've analyzed the information and stored it in memory for future reference.")) onRequestEquals "I need to provide a summary of my findings"
+            mockLLMToolCall(ProvideStringSubgraphResult, StringSubgraphResult("I've analyzed the information and stored it in memory for future reference.")) onRequestContains "I need to provide a summary of my findings"
 
             // Instead of text responses, mock tool calls directly
-            mockLLMToolCall(ProvideStringSubgraphResult, StringSubgraphResult("I've analyzed your device issue and here are the diagnostic results...")) onRequestEquals "I'm getting error ERR-1001 on my device"
-            mockLLMToolCall(ProvideStringSubgraphResult, StringSubgraphResult("I've analyzed your product issue and here is the product information...")) onRequestEquals "I'm from Acme Corp and we're having issues with product prod789"
-            mockLLMToolCall(ProvideStringSubgraphResult, StringSubgraphResult("I've analyzed your issue and here's what I found...")) onRequestEquals "I'm having trouble with my device"
-            mockLLMToolCall(ProvideStringSubgraphResult, StringSubgraphResult("I've analyzed your issue again and here's what I found...")) onRequestEquals "I'm having the same issue again"
+            mockLLMToolCall(ProvideStringSubgraphResult, StringSubgraphResult("I've analyzed your device issue and here are the diagnostic results...")) onRequestContains "I'm getting error ERR-1001 on my device"
+            mockLLMToolCall(ProvideStringSubgraphResult, StringSubgraphResult("I've analyzed your product issue and here is the product information...")) onRequestContains "I'm from Acme Corp and we're having issues with product prod789"
+            mockLLMToolCall(ProvideStringSubgraphResult, StringSubgraphResult("I've analyzed your issue and here's what I found...")) onRequestContains "I'm having trouble with my device"
+            mockLLMToolCall(ProvideStringSubgraphResult, StringSubgraphResult("I've analyzed your issue again and here's what I found...")) onRequestContains "I'm having the same issue again"
 
             mockTool(MockUserInfoToolSet()::getUserContactInfo).does {
                 userInfoToolCallsCount++


### PR DESCRIPTION
* Refactor the implementation of `subgraphWithTask` to make the code more readable 
* Don't make a task message `system`, it's just a `user` message now
* Remove built-in complicated message history handling logic, make the whole process more straightforward to avoid non-obvious side-effects 
* It's mandatory now to add your `finishTool` to the global agent tool registry, since it is actually executed now as a regular tool
* Also, turns it `onRequestContains` in `MockLLMBuilder` for mocking tool calls was missing, which was required to adjust tests in this PR. So I added it as well