### PR TITLE
Improve edge creation DSL [Demo]

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentNode.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentNode.kt
@@ -2,8 +2,8 @@ package ai.koog.agents.core.agent.entity
 
 import ai.koog.agents.core.agent.context.AIAgentContextBase
 import ai.koog.agents.core.annotation.InternalAgentsApi
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.isActive
+import ai.koog.agents.core.dsl2.builder.AIAgentEdgeBuilder
+import ai.koog.agents.core.utils.Some
 
 /**
  * Represents an abstract node in an AI agent strategy graph, responsible for executing a specific
@@ -12,7 +12,11 @@ import kotlinx.coroutines.isActive
  * @param Input The type of input data this node processes.
  * @param Output The type of output data this node produces.
  */
-public abstract class AIAgentNodeBase<Input, Output> internal constructor() {
+public abstract class AIAgentNodeBase<Input, Output> internal constructor() : AIAgentEdgeBuilder<Output, Output>(
+    forwardOutput = { _, output -> Some(output) },
+) {
+    override val sourceNode: AIAgentNodeBase<*, Output> get() = this
+
     /**
      * The name of the AI agent node.
      * This property serves as a unique identifier for the node within the strategy graph
@@ -213,4 +217,3 @@ internal class StartNode internal constructor() : StartAIAgentNodeBase<String>()
  * This node is critical to denote the completion of localized processing within a subgraph context.
  */
 internal class FinishNode internal constructor() : FinishAIAgentNodeBase<String>()
-

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl2/builder/AIAgentEdgeBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl2/builder/AIAgentEdgeBuilder.kt
@@ -1,0 +1,67 @@
+package ai.koog.agents.core.dsl2.builder
+
+import ai.koog.agents.core.agent.context.AIAgentContextBase
+import ai.koog.agents.core.utils.Option
+import ai.koog.agents.core.agent.entity.AIAgentEdge
+import ai.koog.agents.core.agent.entity.AIAgentNodeBase
+
+/**
+ * A builder class for constructing an `AIAgentEdge` instance, which represents a directed edge
+ * connecting two nodes in a graph of an AI agent's processing pipeline. This edge defines
+ * the flow of data from a source node to a target node, enabling transformation or filtering
+ * of the source node's output before passing it to the target node.
+ *
+ * @param IncomingOutput The type of output produced by the source node connected to this edge.
+ * @param OutgoingInput The type of input accepted by the target node connected to this edge.
+ * @constructor This builder should only be constructed internally using intermediate configuration.
+ *
+ * @property edgeIntermediateBuilder The intermediate configuration used for building the edge. It includes
+ * the source and target nodes, as well as the functionality for processing the output of the source node.
+ */
+public abstract class AIAgentEdgeBuilder<SourceOutput, TargetInput> internal constructor(
+    internal val forwardOutput: suspend (context: AIAgentContextBase, output: SourceOutput) -> Option<TargetInput>,
+) {
+    internal abstract val sourceNode: AIAgentNodeBase<*, SourceOutput>
+}
+
+public infix fun <SourceInput, SourceOutput, TargetOutput> AIAgentEdgeBuilder<SourceInput, SourceOutput>.forwardTo(
+    target: AIAgentNodeBase<SourceOutput, TargetOutput>,
+): AIAgentNodeBase<SourceOutput, TargetOutput> {
+    sourceNode.addEdge(AIAgentEdge(target, forwardOutput))
+    return target
+}
+
+/**
+ * Filters the intermediate outputs of the [ai.koog.agents.core.agent.entity.AIAgentNode] based on a specified condition.
+ *
+ * @param block A suspending lambda function that takes the AI agent's context and an intermediate output as parameters.
+ *              It returns `true` if the given intermediate output satisfies the condition, and `false` otherwise.
+ * @return A new instance of `AIAgentEdgeBuilderIntermediate` that includes only the filtered intermediate outputs
+ *         satisfying the specified condition.
+ */
+public infix fun <SourceOutput, TargetInput> AIAgentEdgeBuilder<SourceOutput, TargetInput>.onCondition(
+    block: suspend AIAgentContextBase.(output: TargetInput) -> Boolean,
+): AIAgentEdgeBuilder<SourceOutput, TargetInput> {
+    return object : AIAgentEdgeBuilder<SourceOutput, TargetInput>(
+        forwardOutput = { ctx, output -> forwardOutput(ctx, output).filter { ctx.block(it) } },
+    ) {
+        override val sourceNode: AIAgentNodeBase<*, SourceOutput> get() = this@onCondition.sourceNode
+    }
+}
+
+/**
+ * Transforms the intermediate output of the [ai.koog.agents.core.agent.entity.AIAgentNode] by applying a given transformation block.
+ *
+ * @param block A suspending lambda that defines the transformation to be applied to the intermediate output.
+ *              It takes the AI agent's context and the intermediate output as parameters and returns a new intermediate output.
+ * @return A new instance of `AIAgentEdgeBuilderIntermediate` with the transformed intermediate output type.
+ */
+public infix fun <SourceOutput, TargetInput, TransformedInput> AIAgentEdgeBuilder<SourceOutput, TargetInput>.transformed(
+    block: suspend AIAgentContextBase.(TargetInput) -> TransformedInput,
+): AIAgentEdgeBuilder<SourceOutput, TransformedInput> {
+    return object : AIAgentEdgeBuilder<SourceOutput, TransformedInput>(
+        forwardOutput = { ctx, output -> forwardOutput(ctx, output).map { ctx.block(it) } },
+    ) {
+        override val sourceNode: AIAgentNodeBase<*, SourceOutput> get() = this@transformed.sourceNode
+    }
+}

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl2/extension/AIAgentEdges.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl2/extension/AIAgentEdges.kt
@@ -1,0 +1,204 @@
+package ai.koog.agents.core.dsl2.extension
+
+import ai.koog.agents.core.dsl2.builder.AIAgentEdgeBuilder
+import ai.koog.agents.core.dsl2.builder.onCondition
+import ai.koog.agents.core.dsl2.builder.transformed
+import ai.koog.agents.core.environment.ReceivedToolResult
+import ai.koog.agents.core.environment.SafeTool
+import ai.koog.agents.core.environment.toSafeResult
+import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
+import ai.koog.agents.core.tools.ToolResult
+import ai.koog.prompt.message.MediaContent
+import ai.koog.prompt.message.Message
+import kotlin.reflect.KClass
+
+/**
+ * Creates an edge that filters outputs based on their type.
+ *
+ * @param klass The class to check instance against (not actually used, see implementation comment)
+ */
+public inline infix fun <SourceOutput, TargetInput, reified T : Any>
+        AIAgentEdgeBuilder<SourceOutput, TargetInput>.onIsInstance(
+    /*
+     klass is not used, but we need to use this trick to avoid passing all generic parameters on the usage side.
+     Removing this parameter and just passing the correct type via generic reified parameter won't work, it requires all
+     generic types in this case, which is not nice from the API perspective (trust me, I tried).
+     */
+    @Suppress("unused")
+    klass: KClass<T>,
+): AIAgentEdgeBuilder<SourceOutput, T> {
+    return onCondition { output -> output is T }.transformed { it as T }
+}
+
+
+/**
+ * Filters and transforms the intermediate outputs of the AI agent node based on the success results of a tool operation.
+ *
+ * This method is used to create a conditional path in the agent's execution by selecting only the successful results
+ * of type [SafeTool.Result.Success] and evaluating them against a provided condition.
+ *
+ * @param condition A suspending lambda function that accepts a result of type [TResult]
+ *                  and evaluates it to a Boolean value. Returns `true` if the condition is satisfied,
+ *                  and `false` otherwise.
+ * @return An instance of [AIAgentEdgeBuilder] configured to handle only successful tool results
+ *         that satisfy the specified condition, with output type adjusted to [SafeTool.Result.Success].
+ */
+@Suppress("UNCHECKED_CAST")
+public inline infix fun <SourceOutput, reified TResult : ToolResult>
+        AIAgentEdgeBuilder<SourceOutput, SafeTool.Result<TResult>>.onSuccessful(
+    crossinline condition: suspend (TResult) -> Boolean,
+): AIAgentEdgeBuilder<SourceOutput, SafeTool.Result.Success<TResult>> =
+    onIsInstance(SafeTool.Result.Success::class).transformed { it as SafeTool.Result.Success<TResult> }
+        .onCondition { condition(it.result) }
+
+/**
+ * Defines a handler to process failure cases in a directed edge strategy by applying a condition
+ * to filter intermediate results of type `SafeTool.Result.Failure`. This method is used to specialize
+ * processing for failure results and to propagate or transform them based on the provided condition.
+ *
+ * @param condition A suspending lambda function that takes an error message string as input and returns a boolean.
+ *                  It specifies whether the error should be further processed based on the condition provided.
+ * @return A new instance of `AIAgentEdgeBuilder`, where the intermediate output type is restricted
+ *         to `SafeTool.Result.Failure` containing the specified `TResult` for failure results that match the condition.
+ */
+@Suppress("UNCHECKED_CAST")
+public inline infix fun <SourceOutput, reified TResult : ToolResult>
+        AIAgentEdgeBuilder<SourceOutput, SafeTool.Result<TResult>>.onFailure(
+    crossinline condition: suspend (error: String) -> Boolean,
+): AIAgentEdgeBuilder<SourceOutput, SafeTool.Result.Failure<TResult>> =
+    onIsInstance(SafeTool.Result.Failure::class).transformed { it as SafeTool.Result.Failure<TResult> }
+        .onCondition { condition(it.message) }
+
+/**
+ * Creates an edge that filters tool call messages based on a custom condition.
+ *
+ * @param block A function that evaluates whether to accept a tool call message
+ */
+public infix fun <SourceOutput, TargetInput>
+        AIAgentEdgeBuilder<SourceOutput, TargetInput>.onToolCall(
+    block: suspend (Message.Tool.Call) -> Boolean,
+): AIAgentEdgeBuilder<SourceOutput, Message.Tool.Call> =
+    onIsInstance(Message.Tool.Call::class).onCondition { toolCall -> block(toolCall) }
+
+/**
+ * Creates an edge that filters tool call messages for a specific tool and arguments condition.
+ *
+ * @param tool The tool to match against
+ * @param block A function that evaluates the tool arguments to determine if the edge should accept the message
+ */
+public inline fun <SourceOutput, TargetInput, reified Args : ToolArgs>
+        AIAgentEdgeBuilder<SourceOutput, TargetInput>.onToolCall(
+    tool: Tool<Args, *>,
+    crossinline block: suspend (Args) -> Boolean,
+): AIAgentEdgeBuilder<SourceOutput, Message.Tool.Call> {
+    return onIsInstance(Message.Tool.Call::class)
+        .onCondition { it.tool == tool.name }
+        .onCondition { toolCall ->
+            val args = tool.decodeArgs(toolCall.contentJson)
+            block(args)
+        }
+}
+
+/**
+ * Creates an edge that filters tool call messages for a specific tool.
+ *
+ * @param tool The tool to match against
+ */
+public infix fun <SourceOutput, TargetInput>
+        AIAgentEdgeBuilder<SourceOutput, TargetInput>.onToolCall(
+    tool: Tool<*, *>,
+): AIAgentEdgeBuilder<SourceOutput, Message.Tool.Call> {
+    return onIsInstance(Message.Tool.Call::class).onCondition { it.tool == tool.name }
+}
+
+/**
+ * Creates an edge that filters tool call messages to NOT be a specific tool
+ *
+ * @param tool The tool to match against
+ */
+public infix fun <SourceOutput, TargetInput>
+        AIAgentEdgeBuilder<SourceOutput, TargetInput>.onToolNotCalled(
+    tool: Tool<*, *>,
+): AIAgentEdgeBuilder<SourceOutput, Message.Tool.Call> {
+    return onIsInstance(Message.Tool.Call::class).onCondition { it.tool != tool.name }
+}
+
+/**
+ * Creates an edge that filters tool result messages for a specific tool and result condition.
+ *
+ * @param tool The tool to match against
+ * @param block A function that evaluates the tool result to determine if the edge should accept the message
+ */
+public inline fun <SourceOutput, TargetInput, reified Result : ToolResult>
+        AIAgentEdgeBuilder<SourceOutput, TargetInput>.onToolResult(
+    tool: Tool<*, Result>,
+    crossinline block: suspend (SafeTool.Result<Result>) -> Boolean,
+): AIAgentEdgeBuilder<SourceOutput, ReceivedToolResult> {
+    return onIsInstance(ReceivedToolResult::class)
+        .onCondition { toolResult ->
+            (toolResult.tool == tool.name) && block(toolResult.toSafeResult())
+        }
+}
+
+/**
+ * Creates an edge that filters lists of tool call messages based on a custom condition.
+ *
+ * @param block A function that evaluates whether to accept a list of tool call messages
+ */
+public infix fun <SourceOutput, TargetInput>
+        AIAgentEdgeBuilder<SourceOutput, TargetInput>.onMultipleToolCalls(
+    block: suspend (List<Message.Tool.Call>) -> Boolean,
+): AIAgentEdgeBuilder<SourceOutput, List<Message.Tool.Call>> {
+    return onIsInstance(List::class)
+        .transformed { it to it.filterIsInstance<Message.Tool.Call>() }
+        .onCondition { (original, filtered) -> original == filtered }
+        .transformed { (_, filtered) -> filtered }
+        .onCondition { toolCalls -> block(toolCalls) }
+}
+
+/**
+ * Creates an edge that filters lists of tool result messages based on a custom condition.
+ *
+ * @param block A function that evaluates whether to accept a list of tool result messages
+ */
+@Suppress("unused")
+public infix fun <SourceOutput, TargetInput>
+        AIAgentEdgeBuilder<SourceOutput, TargetInput>.onMultipleToolResults(
+    block: suspend (List<ReceivedToolResult>) -> Boolean,
+): AIAgentEdgeBuilder<SourceOutput, List<ReceivedToolResult>> {
+    return onIsInstance(List::class)
+        .transformed { it to it.filterIsInstance<ReceivedToolResult>() }
+        .onCondition { (original, filtered) -> original == filtered }
+        .transformed { (_, filtered) -> filtered }
+        .onCondition { toolResults -> block(toolResults) }
+}
+
+/**
+ * Creates an edge that filters assistant messages based on a custom condition and extracts their content.
+ *
+ * @param block A function that evaluates whether to accept an assistant message
+ */
+public infix fun <SourceOutput, TargetInput>
+        AIAgentEdgeBuilder<SourceOutput, TargetInput>.onAssistantMessage(
+    block: suspend (Message.Assistant) -> Boolean,
+): AIAgentEdgeBuilder<SourceOutput, String> {
+    return onIsInstance(Message.Assistant::class)
+        .onCondition { signature -> block(signature) }
+        .transformed { it.content }
+}
+
+/**
+ * Creates an edge that filters assistant messages based on a custom condition and provides access to media content.
+ *
+ * @param block A function that evaluates whether to accept an assistant message with media
+ */
+public infix fun <SourceOutput, TargetInput>
+        AIAgentEdgeBuilder<SourceOutput, TargetInput>.onAssistantMessageWithMedia(
+    block: suspend (Message.Assistant) -> Boolean,
+): AIAgentEdgeBuilder<SourceOutput, MediaContent> {
+    return onIsInstance(Message.Assistant::class)
+        .onCondition { it.mediaContent != null }
+        .onCondition { signature -> block(signature) }
+        .transformed { it.mediaContent!! }
+}


### PR DESCRIPTION
This PR presents an alternative DSL design for the graph edge creation. It solves part of #217.

## Explanation of the current situation

Currently, edge creation requires a call to `AIAgentSubgraphBuilderBase<*,*>.edge(...)`.
IMO this leads to overly verbose code, and forces having public APIs to do back and forth calls between the graph and the node recipient of the edge.

#221 tried a first alternative DSL design to fix these issues, but:
- it was forced to mutably replace edges when further `onCondition`/`transformed` calls were made to modify those,
- there were type-safety issues

## Proposed change

To achieve the same expressibility while not having edge-replacing or type-safety issues, the trick is to swap the order of `onCondition`/`transformed` calls w.r.t. the `forwardTo` call.

That is, we move from
```kotlin
edge(source forwardTo target transformed { ... } onCondition { ... })
```
to
```kotlin
source transformed { ... } onCondition { ... } forwardTo target
```

Not only does it fix all the above problems, but I believe it does also read better, as the transforms and conditions to walk through an edge comes before the target of the edge, and the edge can be naturally read from left-to-right.

So we introduce an alternate `AIAgentEdgeBuilder` which `AIAgentNode` inherits from.
This `AIAgentEdgeBuilder<I, O>` can create wrapping `AIAgentEdgeBuilder<I, O'>`s via calls to `transformed` and `onCondition`, or create the final edge via a call to `forwardTo`.

Note that `forwardTo` also returns the target node, which does also render `then` obsolete. And you can write similar chains as with `then`, but with the added possibility to transform/condition edges:
```kotlin
node1 forwardTo node2 onCondition { ... } forwardTo node3 forwardTo node4
```

> [WARNING] I did not fix the Kdocs for now.

## Additional benefits:

### Far less type-parameters and cleaner API

- `AIAgentEdgeBuilderIntermediate`, which has three type-parameters, can be removed.
- `AIAgentEdgeBuilder` doesn't extend `BuilderBase`, which does remove some API bloat
- `edge` and `then` can be removed
- I believe it does also improve type-inference, as the right operand types are now fully depend on the left operand types and additional parameters

### Unfinished edges error at build time

With the upcoming "Unused return value checker", we will have the opportunity to catch unfinished edges at build time.

We would annotate `transformed` and `onCondition` with `@MustUseReturnValue`. It is not clear to me yet, whether this `@MustUseReturnValue` will be inherited by methods wrapping `transformed` and `onCondition` (i.e. `onToolCall`, etc.), but we might have to annotate all the transform/condition methods. This should be discussed with the Kotlin team and bring our use-case, but I don't how far they are yet in their design.

The `forwardTo` method in turn, would be annotated with `@IgnorableReturnValue`, in order to allow the end of `forwardTo` chains.

### `addEdge` could be made internal

Both `AIAgentNode<>.addEdge` and `AIAgentEdge` could potentially be made internal and become an implementation detail. This would simplify the API a lot and avoid exposing the internal edge management.

### Using a `context(GraphBuilder)` marker in the future

When context parameters are a thing, we will be able to mark `forwardTo` and others with this `context(GraphBuilder` parameter, in addition to using `@GraphDsl`, in order to restrict their use when inside a graph builder.

## Conclusion

I really believe this is the way to go, as it does greatly simplify the API and improve readability, while still preserving the same expressibility.

In this PR, I only modified `singleRunStrategy()` as to demonstrate the concept. It is fully functional and the tests in `SimpleAgentMockedTest` pass as they were before. That means the DSL changes do not impact any other features.

I placed the new DSL stuff in a `dsl2` because there cannot be any possible migration from the current situation to the proposed change if we want to keep the `forwardTo` name (which IMO, and until someone convinces me otherwise, is the right name). I tried playing with `@Deprecated` to make the transition smooth, but this is not easy as we are swapping the `forwardTo` and `transformed`/`onCondition` calls.

However, I think such a big improvement to the API might call for a breaking change in `0.3`.

Also, while making a breaking change, we should take the opportunity to improve the whole graph DSL further (cf. #216 and #217).

@Ololoshechkin , @tiginamaria , @EugeneTheDev , @Rizzen please guys tell me what you think about this.

---

#### Type of the change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
