### PR TITLE
Run Qodana only in `jetbrains`/`koog` repository

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -91,6 +91,7 @@ jobs:
             **/build/reports/
   qodana:
     needs: [tests]
+    if: github.repository == 'jetbrains/koog'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/checks.yml` file. The change adds a conditional statement to ensure the `qodana` job only runs if the repository is `jetbrains/koog`.

https://jetbrains.slack.com/archives/C012623KPGQ/p1750073453072309
---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [x] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
