### PR TITLE
#288: Support providing custom LLM for fact retrieval in the history

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentLLMActions.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentLLMActions.kt
@@ -25,6 +25,15 @@ public fun AIAgentLLMWriteSession.leaveLastNMessages(n: Int) {
 }
 
 /**
+ * Removes the last `n` messages from the current prompt in the write session.
+ *
+ * @param n The number of messages to remove from the end of the current message list.
+ */
+public fun AIAgentLLMWriteSession.dropLastNMessages(n: Int) {
+    prompt = prompt.withMessages { it.dropLast(n) }
+}
+
+/**
  * Removes all messages from the current session's prompt that have a timestamp
  * earlier than the specified timestamp.
  *

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
@@ -17,6 +17,7 @@ import ai.koog.prompt.message.Message
 import ai.koog.prompt.structure.StructuredData
 import ai.koog.prompt.structure.StructuredDataDefinition
 import ai.koog.prompt.structure.StructuredResponse
+import io.github.oshai.kotlinlogging.KotlinLogging.logger
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -215,16 +216,26 @@ public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMRequestMultiple(name: String?
  *
  * @param name Optional node name.
  * @param strategy Determines which messages to include in compression.
+ * @param retrievalModel An optional [LLModel] that will be used for retrieval of the facts from memory.
+ *                       By default, the same model will be used as the current one in the agent's strategy.
  * @param preserveMemory Specifies whether to retain message memory after compression.
  */
 @AIAgentBuilderDslMarker
 public fun <T> AIAgentSubgraphBuilderBase<*, *>.nodeLLMCompressHistory(
     name: String? = null,
     strategy: HistoryCompressionStrategy = HistoryCompressionStrategy.WholeHistory,
+    retrievalModel: LLModel? = null,
     preserveMemory: Boolean = true
 ): AIAgentNodeDelegate<T, T> = node(name) { input ->
     llm.writeSession {
+        val initialModel = model
+        if (retrievalModel != null) {
+            model = retrievalModel
+        }
+
         replaceHistoryWithTLDR(strategy, preserveMemory)
+
+        model = initialModel
     }
 
     input

--- a/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/nodes/MemoryNodes.kt
+++ b/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/nodes/MemoryNodes.kt
@@ -157,6 +157,7 @@ public fun <T> AIAgentSubgraphBuilderBase<*, *>.nodeSaveToMemoryAutoDetectFacts(
 ): AIAgentNodeDelegate<T, T> = node(name) { input ->
     llm.writeSession {
         val initialModel = model
+        val initialPrompt = prompt.copy()
         if (retrievalModel != null) {
             model = retrievalModel
         }
@@ -176,7 +177,7 @@ public fun <T> AIAgentSubgraphBuilderBase<*, *>.nodeSaveToMemoryAutoDetectFacts(
             }
         }
 
-        dropLastNMessages(2) // remove the prompt and LLM response
+        rewritePrompt { initialPrompt } // Revert the prompt to the original one
         if (retrievalModel != null) {
             model = initialModel
         }

--- a/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/nodes/MemoryNodes.kt
+++ b/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/nodes/MemoryNodes.kt
@@ -3,10 +3,14 @@ package ai.koog.agents.memory.feature.nodes
 import ai.koog.agents.core.dsl.builder.AIAgentBuilderDslMarker
 import ai.koog.agents.core.dsl.builder.AIAgentNodeDelegate
 import ai.koog.agents.core.dsl.builder.AIAgentSubgraphBuilderBase
+import ai.koog.agents.core.dsl.extension.dropLastNMessages
+import ai.koog.agents.core.dsl.extension.leaveLastNMessages
 import ai.koog.agents.memory.config.MemoryScopeType
 import ai.koog.agents.memory.feature.withMemory
 import ai.koog.agents.memory.model.*
 import ai.koog.agents.memory.prompts.MemoryPrompts
+import ai.koog.prompt.llm.LLModel
+import io.github.oshai.kotlinlogging.KotlinLogging.logger
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -93,6 +97,7 @@ public fun <T> AIAgentSubgraphBuilderBase<*, *>.nodeLoadAllFactsFromMemory(
  * @param subject The subject scope of the memory (USER, PROJECT, etc.)
  * @param scope The scope of the memory (Agent, Feature, etc.)
  * @param concepts List of concepts to save in memory
+ * @param retrievalModel LLM that will be used for fact retrieval from the history (by default, the same model as the current one will be used)
  */
 @AIAgentBuilderDslMarker
 public fun <T> AIAgentSubgraphBuilderBase<*, *>.nodeSaveToMemory(
@@ -100,6 +105,7 @@ public fun <T> AIAgentSubgraphBuilderBase<*, *>.nodeSaveToMemory(
     subject: MemorySubject,
     scope: MemoryScopeType,
     concepts: List<Concept>,
+    retrievalModel: LLModel? = null
 ): AIAgentNodeDelegate<T, T> = node(name) { input ->
     withMemory {
         concepts.forEach { concept ->
@@ -107,6 +113,7 @@ public fun <T> AIAgentSubgraphBuilderBase<*, *>.nodeSaveToMemory(
                 concept = concept,
                 subject = subject,
                 scope = scopesProfile.getScope(scope) ?: return@forEach,
+                retrievalModel = retrievalModel
             )
         }
     }
@@ -120,6 +127,7 @@ public fun <T> AIAgentSubgraphBuilderBase<*, *>.nodeSaveToMemory(
  * @param subject The subject scope of the memory (USER, PROJECT, etc.)
  * @param scope The scope of the memory (Agent, Feature, etc.)
  * @param concept The concept to save in memory
+ * @param retrievalModel LLM that will be used for fact retrieval from the history (by default, the same model as the current one will be used)
  */
 @AIAgentBuilderDslMarker
 public fun <T> AIAgentSubgraphBuilderBase<*, *>.nodeSaveToMemory(
@@ -127,7 +135,8 @@ public fun <T> AIAgentSubgraphBuilderBase<*, *>.nodeSaveToMemory(
     concept: Concept,
     subject: MemorySubject,
     scope: MemoryScopeType,
-): AIAgentNodeDelegate<T, T> = nodeSaveToMemory(name, subject, scope, listOf(concept))
+    retrievalModel: LLModel? = null
+): AIAgentNodeDelegate<T, T> = nodeSaveToMemory(name, subject, scope, listOf(concept), retrievalModel)
 
 /**
  * Node that automatically detects and extracts facts from the chat history and saves them to memory.
@@ -137,14 +146,20 @@ public fun <T> AIAgentSubgraphBuilderBase<*, *>.nodeSaveToMemory(
  * @param scopes List of memory scopes (Agent, Feature, etc.). By default only Agent scope would be chosen
  * @param subjects List of subjects (user, project, organization, etc.) to look for.
  * By default, all subjects will be included and looked for.
+ * @param retrievalModel LLM that will be used for fact retrieval from the history (by default, the same model as the current one will be used)
  */
 @AIAgentBuilderDslMarker
 public fun <T> AIAgentSubgraphBuilderBase<*, *>.nodeSaveToMemoryAutoDetectFacts(
     name: String? = null,
     scopes: List<MemoryScopeType> = listOf(MemoryScopeType.AGENT),
-    subjects: List<MemorySubject> = MemorySubject.registeredSubjects
+    subjects: List<MemorySubject> = MemorySubject.registeredSubjects,
+    retrievalModel: LLModel? = null
 ): AIAgentNodeDelegate<T, T> = node(name) { input ->
     llm.writeSession {
+        val initialModel = model
+        if (retrievalModel != null) {
+            model = retrievalModel
+        }
         updatePrompt {
             val prompt = MemoryPrompts.autoDetectFacts(subjects)
             user(prompt)
@@ -159,6 +174,11 @@ public fun <T> AIAgentSubgraphBuilderBase<*, *>.nodeSaveToMemoryAutoDetectFacts(
                     agentMemory.save(fact, subject, scope)
                 }
             }
+        }
+
+        dropLastNMessages(2) // remove the prompt and LLM response
+        if (retrievalModel != null) {
+            model = initialModel
         }
     }
 


### PR DESCRIPTION
Fixes #288 

Allows to select an optional custom model for fact retrieval from the history in memory nodes and history compression nodes

---

#### Type of the change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [x] The change was discussed and approved in the issue
- [x] Docs have been added / updated
