### PR TITLE
[agent] [prompt] Fixes: structured LLM request, subgraphWithTask. Undeprecate PromptBuilder methods

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMSession.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMSession.kt
@@ -230,7 +230,7 @@ public sealed class AIAgentLLMSession(
         fixingModel: LLModel = OpenAIModels.Chat.GPT4o
     ): Result<StructuredResponse<T>> {
         validateSession()
-        val preparedPrompt = preparePrompt(prompt, tools)
+        val preparedPrompt = preparePrompt(prompt, tools = emptyList())
         return executor.executeStructured(preparedPrompt, model, structure, retries, fixingModel)
     }
 
@@ -242,7 +242,7 @@ public sealed class AIAgentLLMSession(
      */
     public open suspend fun <T> requestLLMStructuredOneShot(structure: StructuredData<T>): StructuredResponse<T> {
         validateSession()
-        val preparedPrompt = preparePrompt(prompt, tools)
+        val preparedPrompt = preparePrompt(prompt, tools = emptyList())
         return executor.executeStructuredOneShot(preparedPrompt, model, structure)
     }
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/SafeTool.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/SafeTool.kt
@@ -62,9 +62,13 @@ public data class SafeTool<TArgs : ToolArgs, TResult : ToolResult>(
          * Casts the current instance of `Result` to a `Success` type if it is a successful result.
          *
          * @return The current instance cast to `Success<TResult>`.
-         * @throws ClassCastException If the current instance is not of type `Success<TResult>`.
+         * @throws IllegalStateException if not [Success]
          */
-        public fun asSuccessful(): Success<TResult> = this as Success<TResult>
+        public fun asSuccessful(): Success<TResult> = when (this) {
+            is Success<TResult> -> this
+            is Failure<TResult> -> throw IllegalStateException("Result is not a success: $this")
+        }
+
         /**
          * Casts the current object to a `Failure` type.
          *
@@ -72,9 +76,12 @@ public data class SafeTool<TArgs : ToolArgs, TResult : ToolResult>(
          * Use it to retrieve the object as a `Failure` and access its specific properties and behaviors.
          *
          * @return The current instance cast to `Failure<TResult>`.
-         * @throws ClassCastException if the current instance is not of type `Failure<TResult>`.
+         * @throws IllegalStateException if not [Failure]
          */
-        public fun asFailure(): Failure<TResult> = this as Failure<TResult>
+        public fun asFailure(): Failure<TResult> = when (this) {
+            is Success<TResult> -> throw IllegalStateException("Result is not a failure: $this")
+            is Failure<TResult> -> this
+        }
 
         /**
          * Represents a successful result of an operation, wrapping a specific tool result and its corresponding content.

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/PromptBuilder.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/PromptBuilder.kt
@@ -224,7 +224,6 @@ public class PromptBuilder internal constructor(
          *
          * @param call The tool call message to add
          */
-        @Deprecated("Use call(id, tool, content) instead", ReplaceWith("call(id, tool, content)"))
         public fun call(call: Message.Tool.Call) {
             this@PromptBuilder.messages.add(call)
         }
@@ -250,7 +249,6 @@ public class PromptBuilder internal constructor(
          *
          * @param result The tool result message to add
          */
-        @Deprecated("Use result(id, tool, content) instead", ReplaceWith("result(id, tool, content)"))
         public fun result(result: Message.Tool.Result) {
             this@PromptBuilder.messages
                 .indexOfLast { it is Message.Tool.Call && it.id == result.id }


### PR DESCRIPTION
* Properly handle tools in history when calling request structured
* Append `finishTool` result in zsubgraphWithTask` to prompt, otherwise subsequent LLM calls fail
* Undeprecate `result` and `call` `PromptBuilder` methods