### PR TITLE
Fix - add missing tool events to agentFeatureMessageSerializersModule

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/jsonConfig.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/jsonConfig.kt
@@ -24,6 +24,10 @@ import kotlinx.serialization.modules.polymorphic
  * - [AIAgentNodeExecutionEndEvent]
  * - [LLMCallStartEvent]
  * - [LLMCallEndEvent]
+ * - [ToolCallEvent]
+ * - [ToolCallResultEvent]
+ * - [ToolCallFailureEvent]
+ * - [ToolValidationErrorEvent]
  *
  * This configuration enables proper handling of the diverse event types encountered in the system by ensuring
  * that the polymorphic serialization framework can correctly serialize and deserialize each subclass.
@@ -39,6 +43,11 @@ public val agentFeatureMessageSerializersModule: SerializersModule
                 subclass(AIAgentNodeExecutionEndEvent::class, AIAgentNodeExecutionEndEvent.serializer())
                 subclass(LLMCallStartEvent::class, LLMCallStartEvent.serializer())
                 subclass(LLMCallEndEvent::class, LLMCallEndEvent.serializer())
+                // tool tracing events
+                subclass(ToolCallEvent::class, ToolCallEvent.serializer())
+                subclass(ToolCallResultEvent::class, ToolCallResultEvent.serializer())
+                subclass(ToolCallFailureEvent::class, ToolCallFailureEvent.serializer())
+                subclass(ToolValidationErrorEvent::class, ToolValidationErrorEvent.serializer())
             }
 
             polymorphic(FeatureEvent::class) {
@@ -50,6 +59,11 @@ public val agentFeatureMessageSerializersModule: SerializersModule
                 subclass(AIAgentNodeExecutionEndEvent::class, AIAgentNodeExecutionEndEvent.serializer())
                 subclass(LLMCallStartEvent::class, LLMCallStartEvent.serializer())
                 subclass(LLMCallEndEvent::class, LLMCallEndEvent.serializer())
+                // tool tracing events
+                subclass(ToolCallEvent::class, ToolCallEvent.serializer())
+                subclass(ToolCallResultEvent::class, ToolCallResultEvent.serializer())
+                subclass(ToolCallFailureEvent::class, ToolCallFailureEvent.serializer())
+                subclass(ToolValidationErrorEvent::class, ToolValidationErrorEvent.serializer())
             }
 
             polymorphic(DefinedFeatureEvent::class) {
@@ -61,5 +75,10 @@ public val agentFeatureMessageSerializersModule: SerializersModule
                 subclass(AIAgentNodeExecutionEndEvent::class, AIAgentNodeExecutionEndEvent.serializer())
                 subclass(LLMCallStartEvent::class, LLMCallStartEvent.serializer())
                 subclass(LLMCallEndEvent::class, LLMCallEndEvent.serializer())
+                // tool tracing events
+                subclass(ToolCallEvent::class, ToolCallEvent.serializer())
+                subclass(ToolCallResultEvent::class, ToolCallResultEvent.serializer())
+                subclass(ToolCallFailureEvent::class, ToolCallFailureEvent.serializer())
+                subclass(ToolValidationErrorEvent::class, ToolValidationErrorEvent.serializer())
             }
         }


### PR DESCRIPTION
Add missing ToolCallEvent,  ToolCallResultEvent , ToolCallFailureEvent , & ToolValidationErrorEvent to agentFeatureMessageSerializersModule.

Fixes related error message when tracing:
Serializer for subclass 'ToolCallEvent' is not found in the polymorphic scope of 'FeatureMessage'.
Check if class with serial name 'ToolCallEvent' exists and serializer is registered in a corresponding SerializersModule.
To be registered automatically, class 'ToolCallEvent' has to be '@Serializable', and the base class 'FeatureMessage' has to be sealed and '@Serializable'.

---

#### Type of the change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [X] The pull request has a description of the proposed change
- [X] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [X] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [X] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
