### PR TITLE
[prompt] Fix Ollama function schema generation

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/tools/json/JSONSchemaFunctionConverter.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/tools/json/JSONSchemaFunctionConverter.kt
@@ -44,33 +44,26 @@ public fun ToolDescriptor.toJSONSchema(): JsonObject {
 
             is ToolParameterType.Object -> {
                 put("type", JsonPrimitive("object"))
+
                 put("properties", buildJsonObject {
                     type.properties.forEach { property ->
-                        put(property.name, buildJsonObject {
-                            toolParameterToSchema(property.type)
-                            put("description", property.description)
-                        })
+                        put(property.name, toolParameterToSchema(property.type, property.description))
                     }
-                }
-                )
+                })
+
+                put("required", JsonArray(type.requiredProperties.map { JsonPrimitive(it) }))
             }
         }
 
         if (description != null) {
-            put("description", JsonPrimitive(description))
+            put("description", description)
         }
     }
 
     // Build the properties object by converting each parameter to its JSON schema.
-    val properties = mutableMapOf<String, JsonElement>()
-
-    // Process required parameters.
-    for (param in requiredParameters) {
-        properties[param.name] = toolParameterToSchema(param.type)
-    }
-    // Process optional parameters.
-    for (param in optionalParameters) {
-        properties[param.name] = toolParameterToSchema(param.type)
+    val properties: JsonObject = buildJsonObject {
+        (requiredParameters + optionalParameters)
+            .map { param -> put(param.name, toolParameterToSchema(param.type, param.description)) }
     }
 
     // Build the outer JSON schema.

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/JSONSchemaFunctionConverterTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/JSONSchemaFunctionConverterTest.kt
@@ -1,0 +1,120 @@
+package ai.koog.prompt.executor.ollama.client
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolParameterDescriptor
+import ai.koog.agents.core.tools.ToolParameterType
+import ai.koog.prompt.executor.ollama.tools.json.toJSONSchema
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JSONSchemaFunctionConverterTest {
+    val json = Json {
+        prettyPrint = true
+    }
+
+    @Test
+    fun `test function definition json schema generation`() {
+        val toolDescriptor = ToolDescriptor(
+            name = "weather_forecast_result",
+            description = """
+                Finish tool to compile final weather forecast results for the user's requested locations and dates.
+                Call to provide the final forecast results.
+            """.trimIndent(),
+            requiredParameters = listOf(
+                ToolParameterDescriptor(
+                    name = "locations",
+                    description = "The list of locations and their forecasts",
+                    type = ToolParameterType.List(
+                        ToolParameterType.Object(
+                            properties = listOf(
+                                ToolParameterDescriptor(
+                                    name = "name",
+                                    description = "The name of the location",
+                                    type = ToolParameterType.String
+                                ),
+                                ToolParameterDescriptor(
+                                    name = "forecasts",
+                                    description = "The list of forecasts for the location",
+                                    type = ToolParameterType.List(
+                                        ToolParameterType.Object(
+                                            properties = listOf(
+                                                ToolParameterDescriptor(
+                                                    name = "date",
+                                                    description = "The date of the forecast",
+                                                    type = ToolParameterType.String
+                                                ),
+                                                ToolParameterDescriptor(
+                                                    name = "forecastDescription",
+                                                    description = "The forecast description",
+                                                    type = ToolParameterType.String
+                                                )
+                                            ),
+                                            requiredProperties = listOf("date", "forecastDescription")
+                                        )
+                                    )
+                                )
+                            ),
+                            requiredProperties = listOf("name", "forecasts")
+                        )
+                    ),
+                )
+            ),
+        )
+
+        val generatedSchema = json.encodeToString(toolDescriptor.toJSONSchema())
+
+        val expectedSchema = """
+        {
+            "title": "weather_forecast_result",
+            "description": "Finish tool to compile final weather forecast results for the user's requested locations and dates.\nCall to provide the final forecast results.",
+            "type": "object",
+            "properties": {
+                "locations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "The name of the location"
+                            },
+                            "forecasts": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "date": {
+                                            "type": "string",
+                                            "description": "The date of the forecast"
+                                        },
+                                        "forecastDescription": {
+                                            "type": "string",
+                                            "description": "The forecast description"
+                                        }
+                                    },
+                                    "required": [
+                                        "date",
+                                        "forecastDescription"
+                                    ]
+                                },
+                                "description": "The list of forecasts for the location"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "forecasts"
+                        ]
+                    },
+                    "description": "The list of locations and their forecasts"
+                }
+            },
+            "required": [
+                "locations"
+            ]
+        }
+        """.trimIndent()
+
+        assertEquals(expectedSchema, generatedSchema)
+    }
+}


### PR DESCRIPTION
There was a problem with Ollama function schema generation from `ToolDescriptor`: some fields and descriptions were not processed correctly and therefore were missing from the resulting function JSON schema.
