### PR TITLE
Fix requestLLMWithoutTools generating tool calls

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMSession.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMSession.kt
@@ -137,7 +137,7 @@ public sealed class AIAgentLLMSession(
             .withUpdatedParams { toolChoice = null }
             .let { preparePrompt(it, emptyList()) }
 
-        return executeSingle(promptWithDisabledTools, tools)
+        return executeSingle(promptWithDisabledTools, emptyList())
     }
 
     /**


### PR DESCRIPTION
[#300](https://github.com/JetBrains/koog/issues/300)

Fixed ai.koog.agents.core.agent.session.AIAgentLLMSession.requestLLMWithoutTools, which previously sometimes generated tool calls, by providing an empty list of available tools to the model.


---

#### Type of the change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [ ] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [ ] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
