### PR TITLE
Fixed an issue where structured data examples were prompted wrong

### DIFF
--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/JsonStructuredData.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/JsonStructuredData.kt
@@ -55,10 +55,20 @@ public class JsonStructuredData<TStruct>(
         +"You must adhere to the following JSON schema:"
         +structureLanguage.pretty(jsonSchema.schema)
 
-        +"Here are the examples of valid responses:"
-        examples.forEach {
-            structure(structureLanguage, it, serializer)
+        when {
+            examples.isEmpty() -> {}
+            examples.size == 1 -> {
+                +"Here is an example of a valid response:"
+                structure(structureLanguage, examples.first(), serializer)
+            }
+            else -> {
+                +"Here are some examples of valid responses:"
+                examples.forEach {
+                    structure(structureLanguage, it, serializer)
+                }
+            }
         }
+
         newline()
     }
 

--- a/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/StructuredDataTest.kt
+++ b/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/StructuredDataTest.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.Serializable
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 
@@ -99,6 +100,16 @@ class JsonStructuredDataTest {
         examples = listOf(SimpleData("example1"), SimpleData("example2"))
     )
 
+    private val structuredSimpleOneExample = JsonStructuredData.createJsonStructure<SimpleData>(
+        id = "simple",
+        examples = listOf(SimpleData("example1"))
+    )
+
+    private val structuredSimpleNoExample = JsonStructuredData.createJsonStructure<SimpleData>(
+        id = "simple",
+        examples = listOf()
+    )
+
     @Test
     fun testSimpleParseValid() {
         val json = """{"value":"test"}"""
@@ -132,6 +143,47 @@ class JsonStructuredDataTest {
         assertTrue(content.contains("SimpleData description"))
         assertTrue(content.contains("SimpleData.value description"))
         assertTrue(content.contains("is defined only and solely with JSON, without any additional characters, backticks or anything similar."))
+    }
+
+    @Test
+    fun testSimpleDefinitionWithExamples() {
+        val builder = TextContentBuilder()
+        structuredSimple.definition(builder)
+        val content = builder.build()
+
+        assertTrue(content.contains("""
+            Here are some examples of valid responses:
+            {
+              "value": "example1"
+            }
+            {
+              "value": "example2"
+            }
+        """.trimIndent()))
+    }
+
+    @Test
+    fun testSimpleDefinitionWithOneExample() {
+        val builder = TextContentBuilder()
+        structuredSimpleOneExample.definition(builder)
+        val content = builder.build()
+
+        assertTrue(content.contains("""
+            Here is an example of a valid response:
+            {
+              "value": "example1"
+            }
+        """.trimIndent()))
+    }
+
+    @Test
+    fun testSimpleDefinitionWithNoExamples() {
+        val builder = TextContentBuilder()
+        structuredSimpleNoExample.definition(builder)
+        val content = builder.build()
+
+        assertFalse(content.contains("Here are some examples of valid responses"))
+        assertFalse(content.contains("Here is an example of a valid response"))
     }
 
     // Array data tests


### PR DESCRIPTION
Fixed an issue where structured data examples were prompted wrong.
---
The LLM was always prompted "Here are the examples of valid responses:" even if there were no examples provided or if only one example was provided.

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
