### PR TITLE
#293 Refactor `AIAgentException` and add unit tests

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentException.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentException.kt
@@ -2,13 +2,12 @@ package ai.koog.agents.core.agent
 
 import ai.koog.agents.core.agent.entity.AIAgentNodeBase
 
-// TODO: why it extends Throwable? Should it be a RuntimeException instead?
 // TODO: how it differs from AgentRuntimeException?
 /**
  * Represents a custom exception class for use in AI Agent-related processes.
  *
  * This exception is thrown when the AI Agent encounters a specific problem
- * that requires handling or reporting. It extends the base `Throwable` class
+ * that requires handling or reporting. It extends the base `Exception` class
  * and provides a detailed message for easier identification of the issue.
  *
  * @constructor Creates an instance of `AgentException`.
@@ -17,7 +16,7 @@ import ai.koog.agents.core.agent.entity.AIAgentNodeBase
  * context about the error.
  */
 public open class AIAgentException(problem: String, throwable: Throwable? = null) :
-    Throwable("AI Agent has run into a problem: $problem", throwable)
+    Exception("AI Agent has run into a problem: $problem", throwable)
 
 /**
  * Exception thrown when an agent becomes stuck in a specific node during the execution

--- a/agents/agents-test/src/jvmTest/kotlin/ai/koog/agents/test/AIAgentExceptionTest.kt
+++ b/agents/agents-test/src/jvmTest/kotlin/ai/koog/agents/test/AIAgentExceptionTest.kt
@@ -1,0 +1,46 @@
+package ai.koog.agents.test
+
+import ai.koog.agents.core.agent.AIAgentException
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class AIAgentExceptionTest {
+    fun formErrorMessage(problem: String) = "AI Agent has run into a problem: $problem"
+
+    @Test
+    fun `test AIAgentException with problem only`() {
+        val problems = listOf(
+            "Error in processing request",
+            "Invalid input data",
+            "Network connection failed",
+            "Timeout occurred",
+            ""
+        )
+        for (problem in problems) {
+            val exception = AIAgentException(problem)
+            assertEquals(formErrorMessage(problem), exception.message)
+            assertEquals(null, exception.cause)
+        }
+    }
+
+    @Test
+    fun `test AIAgentException with problem and throwable`() {
+        val problem = "Error in processing request"
+        val cause = RuntimeException("Test error cause")
+        val exception = AIAgentException(problem, cause)
+        assertEquals(formErrorMessage(problem), exception.message)
+        assertSame(cause, exception.cause)
+    }
+
+    @Test
+    fun `test AIAgentException with cause chain`() {
+        val rootCause = IllegalArgumentException("Root cause")
+        val intermediateCause = IllegalStateException("Intermediate cause", rootCause)
+        val problem = "Top level problem"
+        val exception = AIAgentException(problem, intermediateCause)
+        assertEquals(formErrorMessage(problem), exception.message)
+        assertSame(intermediateCause, exception.cause)
+        assertSame(rootCause, exception.cause?.cause)
+    }
+}


### PR DESCRIPTION
Fixes #293 ai.koog.agents.core.agent.AIAgentException should be Exception, not Throwable

---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
