### PR TITLE
[.github] Add demo android app assemble check step in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,6 +41,13 @@ jobs:
       - name: TestClasses with Gradle Wrapper
         run: ./gradlew jvmTestClasses jsTestClasses
 
+      # Check that demo android app in examples compiles successfully.
+      # It is an independent Gradle project, so it has to be checked separately.
+      - name: "[Examples] Assemble demo android app"
+        run: |
+          cd ./examples/demo-android-app
+          ./gradlew :app:assemble 
+
   tests:
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Related to #336. Add a separate CI check to verify that demo android app in examples assembles.