### PR TITLE
Simple single run strategy working with multiple message

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
@@ -7,22 +7,9 @@ import ai.koog.agents.core.agent.context.AIAgentLLMContext
 import ai.koog.agents.core.agent.entity.AIAgentStateManager
 import ai.koog.agents.core.agent.entity.AIAgentStorage
 import ai.koog.agents.core.agent.entity.AIAgentStrategy
-import ai.koog.agents.core.dsl.builder.forwardTo
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.nodeExecuteMultipleTools
-import ai.koog.agents.core.dsl.extension.nodeExecuteTool
-import ai.koog.agents.core.dsl.extension.nodeLLMRequest
-import ai.koog.agents.core.dsl.extension.nodeLLMRequestMultiple
-import ai.koog.agents.core.dsl.extension.nodeLLMSendMultipleToolResults
-import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResult
-import ai.koog.agents.core.dsl.extension.onAssistantMessage
-import ai.koog.agents.core.dsl.extension.onMultipleAssistantMessages
-import ai.koog.agents.core.dsl.extension.onMultipleToolCalls
-import ai.koog.agents.core.dsl.extension.onToolCall
 import ai.koog.agents.core.environment.AIAgentEnvironment
 import ai.koog.agents.core.environment.AIAgentEnvironmentUtils.mapToToolResult
 import ai.koog.agents.core.environment.ReceivedToolResult
-import ai.koog.agents.core.environment.TerminationTool
 import ai.koog.agents.core.exception.AgentEngineException
 import ai.koog.agents.core.feature.AIAgentFeature
 import ai.koog.agents.core.feature.AIAgentPipeline
@@ -40,14 +27,12 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.params.LLMParams
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.datetime.Clock
-import kotlinx.serialization.json.Json
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
@@ -368,8 +368,8 @@ public fun AIAgent(
     installFeatures = installFeatures
 )
 public fun singleRunStrategy(): AIAgentStrategy = strategy("single_run") {
-    val nodeCallLLMMultiple by nodeLLMRequestMultiple("sendInput")
-    val executeToolAndSendResult by nodeLLMExecuteMultipleToolsAndSendResults("executeToolAndSendResult")
+    val nodeCallLLMMultiple by nodeLLMRequestMultiple()
+    val executeToolAndSendResult by nodeLLMExecuteMultipleToolsAndSendResults()
 
     edge(nodeStart forwardTo nodeCallLLMMultiple)
     edge(nodeCallLLMMultiple forwardTo executeToolAndSendResult onMultipleToolCalls { true })

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
@@ -7,6 +7,18 @@ import ai.koog.agents.core.agent.context.AIAgentLLMContext
 import ai.koog.agents.core.agent.entity.AIAgentStateManager
 import ai.koog.agents.core.agent.entity.AIAgentStorage
 import ai.koog.agents.core.agent.entity.AIAgentStrategy
+import ai.koog.agents.core.dsl.builder.forwardTo
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.core.dsl.extension.nodeExecuteMultipleTools
+import ai.koog.agents.core.dsl.extension.nodeExecuteTool
+import ai.koog.agents.core.dsl.extension.nodeLLMRequest
+import ai.koog.agents.core.dsl.extension.nodeLLMRequestMultiple
+import ai.koog.agents.core.dsl.extension.nodeLLMSendMultipleToolResults
+import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResult
+import ai.koog.agents.core.dsl.extension.onAssistantMessage
+import ai.koog.agents.core.dsl.extension.onMultipleAssistantMessages
+import ai.koog.agents.core.dsl.extension.onMultipleToolCalls
+import ai.koog.agents.core.dsl.extension.onToolCall
 import ai.koog.agents.core.environment.AIAgentEnvironment
 import ai.koog.agents.core.environment.AIAgentEnvironmentUtils.mapToToolResult
 import ai.koog.agents.core.environment.ReceivedToolResult
@@ -367,67 +379,3 @@ public fun AIAgent(
     toolRegistry = toolRegistry,
     installFeatures = installFeatures
 )
-
-/**
- * Creates an AI agent strategy based on the specified single-run mode.
- *
- * This method determines the type of strategy to be used for executing single-run tasks,
- * depending on the provided mode. It supports sequential, parallel, and single execution modes.
- *
- * @param runMode The mode in which the single-run strategy should operate. Defaults to SingleRunMode.SINGLE.
- *                - SingleRunMode.SINGLE: Executes without allowing multiple simultaneous tool calls.
- *                - SingleRunMode.SEQUENTIAL: Executes simultaneous tool calls sequentially.
- *                - SingleRunMode.PARALLEL: Executes multiple tool calls in parallel.
- * @return An instance of AIAgentStrategy configured according to the specified single-run mode.
- */
-public fun singleRunStrategy(runMode: ToolCalls = ToolCalls.SINGLE): AIAgentStrategy =
-    when (runMode) {
-        ToolCalls.SEQUENTIAL -> singleRunWithParallelAbility(false)
-        ToolCalls.PARALLEL   -> singleRunWithParallelAbility(true)
-        ToolCalls.SINGLE     -> singleRunModeStrategy()
-    }
-
-private fun singleRunWithParallelAbility(parallelTools: Boolean) = strategy("single_run_sequential") {
-    val nodeCallLLM by nodeLLMRequestMultiple()
-    val nodeExecuteTool by nodeExecuteMultipleTools(parallelTools = parallelTools)
-    val nodeSendToolResult by nodeLLMSendMultipleToolResults()
-
-    edge(nodeStart forwardTo nodeCallLLM)
-    edge(nodeCallLLM forwardTo nodeExecuteTool onMultipleToolCalls { true })
-    edge(nodeCallLLM forwardTo nodeFinish
-                                        onMultipleAssistantMessages { true }
-                                        transformed { it.joinToString("\n") { message -> message.content } })
-
-    edge(nodeExecuteTool forwardTo nodeSendToolResult)
-
-    edge(nodeSendToolResult forwardTo nodeFinish
-                                                onMultipleAssistantMessages { true }
-                                                transformed { it.joinToString("\n") { message -> message.content } })
-
-    edge(nodeSendToolResult forwardTo nodeExecuteTool onMultipleToolCalls { true })
-}
-
-private fun singleRunModeStrategy() = strategy("single_run") {
-    val nodeCallLLM by nodeLLMRequest()
-    val nodeExecuteTool by nodeExecuteTool()
-    val nodeSendToolResult by nodeLLMSendToolResult()
-
-    edge(nodeStart forwardTo nodeCallLLM)
-    edge(nodeCallLLM forwardTo nodeExecuteTool onToolCall { true })
-    edge(nodeCallLLM forwardTo nodeFinish onAssistantMessage { true })
-    edge(nodeExecuteTool forwardTo nodeSendToolResult)
-    edge(nodeSendToolResult forwardTo nodeFinish onAssistantMessage { true })
-    edge(nodeSendToolResult forwardTo nodeExecuteTool onToolCall { true })
-}
-
-/**
- * Enum representing the modes in which a single-run strategy for an AI agent can be executed.
- *
- * These modes define how tasks or operations are processed during the agent's run:
- * - SEQUENTIAL: Multiple tool calls allowed but will be executed sequentially.
- * - PARALLEL: Tool calls executed in parallel.
- * - SINGLE: Multiple tool calls are not allowed.
- */
-public enum class ToolCalls {
-    SEQUENTIAL, PARALLEL, SINGLE
-}

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
@@ -367,3 +367,14 @@ public fun AIAgent(
     toolRegistry = toolRegistry,
     installFeatures = installFeatures
 )
+public fun singleRunStrategy(): AIAgentStrategy = strategy("single_run") {
+    val nodeCallLLMMultiple by nodeLLMRequestMultiple("sendInput")
+    val executeToolAndSendResult by nodeLLMExecuteMultipleToolsAndSendResults("executeToolAndSendResult")
+
+    edge(nodeStart forwardTo nodeCallLLMMultiple)
+    edge(nodeCallLLMMultiple forwardTo executeToolAndSendResult onMultipleToolCalls { true })
+    edge((nodeCallLLMMultiple forwardTo nodeFinish) transformed { it.first() } onAssistantMessage { true })
+
+    edge(executeToolAndSendResult forwardTo executeToolAndSendResult onMultipleToolCalls { true })
+    edge((executeToolAndSendResult forwardTo nodeFinish) transformed { it.first()} onAssistantMessage { true })
+}

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
@@ -380,12 +380,11 @@ public fun AIAgent(
  *                - SingleRunMode.PARALLEL: Executes multiple tool calls in parallel.
  * @return An instance of AIAgentStrategy configured according to the specified single-run mode.
  */
-
-public fun singleRunStrategy(runMode: SingleRunMode = SingleRunMode.SINGLE): AIAgentStrategy =
+public fun singleRunStrategy(runMode: ToolCalls = ToolCalls.SINGLE): AIAgentStrategy =
     when (runMode) {
-        SingleRunMode.SEQUENTIAL -> singleRunWithParallelAbility(false)
-        SingleRunMode.PARALLEL   -> singleRunWithParallelAbility(true)
-        SingleRunMode.SINGLE     -> singleRunModeStrategy()
+        ToolCalls.SEQUENTIAL -> singleRunWithParallelAbility(false)
+        ToolCalls.PARALLEL   -> singleRunWithParallelAbility(true)
+        ToolCalls.SINGLE     -> singleRunModeStrategy()
     }
 
 private fun singleRunWithParallelAbility(parallelTools: Boolean) = strategy("single_run_sequential") {
@@ -429,6 +428,6 @@ private fun singleRunModeStrategy() = strategy("single_run") {
  * - PARALLEL: Tool calls executed in parallel.
  * - SINGLE: Multiple tool calls are not allowed.
  */
-public enum class SingleRunMode {
+public enum class ToolCalls {
     SEQUENTIAL, PARALLEL, SINGLE
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
@@ -367,14 +367,68 @@ public fun AIAgent(
     toolRegistry = toolRegistry,
     installFeatures = installFeatures
 )
-public fun singleRunStrategy(): AIAgentStrategy = strategy("single_run") {
-    val nodeCallLLMMultiple by nodeLLMRequestMultiple()
-    val executeToolAndSendResult by nodeLLMExecuteMultipleToolsAndSendResults()
 
-    edge(nodeStart forwardTo nodeCallLLMMultiple)
-    edge(nodeCallLLMMultiple forwardTo executeToolAndSendResult onMultipleToolCalls { true })
-    edge((nodeCallLLMMultiple forwardTo nodeFinish) transformed { it.first() } onAssistantMessage { true })
+/**
+ * Creates an AI agent strategy based on the specified single-run mode.
+ *
+ * This method determines the type of strategy to be used for executing single-run tasks,
+ * depending on the provided mode. It supports sequential, parallel, and single execution modes.
+ *
+ * @param runMode The mode in which the single-run strategy should operate. Defaults to SingleRunMode.SINGLE.
+ *                - SingleRunMode.SINGLE: Executes without allowing multiple simultaneous tool calls.
+ *                - SingleRunMode.SEQUENTIAL: Executes simultaneous tool calls sequentially.
+ *                - SingleRunMode.PARALLEL: Executes multiple tool calls in parallel.
+ * @return An instance of AIAgentStrategy configured according to the specified single-run mode.
+ */
 
-    edge(executeToolAndSendResult forwardTo executeToolAndSendResult onMultipleToolCalls { true })
-    edge((executeToolAndSendResult forwardTo nodeFinish) transformed { it.first()} onAssistantMessage { true })
+public fun singleRunStrategy(runMode: SingleRunMode = SingleRunMode.SINGLE): AIAgentStrategy =
+    when (runMode) {
+        SingleRunMode.SEQUENTIAL -> singleRunWithParallelAbility(false)
+        SingleRunMode.PARALLEL   -> singleRunWithParallelAbility(true)
+        SingleRunMode.SINGLE     -> singleRunModeStrategy()
+    }
+
+private fun singleRunWithParallelAbility(parallelTools: Boolean) = strategy("single_run_sequential") {
+    val nodeCallLLM by nodeLLMRequestMultiple()
+    val nodeExecuteTool by nodeExecuteMultipleTools(parallelTools = parallelTools)
+    val nodeSendToolResult by nodeLLMSendMultipleToolResults()
+
+    edge(nodeStart forwardTo nodeCallLLM)
+    edge(nodeCallLLM forwardTo nodeExecuteTool onMultipleToolCalls { true })
+    edge(nodeCallLLM forwardTo nodeFinish
+                                        onMultipleAssistantMessages { true }
+                                        transformed { it.joinToString("\n") { message -> message.content } })
+
+    edge(nodeExecuteTool forwardTo nodeSendToolResult)
+
+    edge(nodeSendToolResult forwardTo nodeFinish
+                                                onMultipleAssistantMessages { true }
+                                                transformed { it.joinToString("\n") { message -> message.content } })
+
+    edge(nodeSendToolResult forwardTo nodeExecuteTool onMultipleToolCalls { true })
+}
+
+private fun singleRunModeStrategy() = strategy("single_run") {
+    val nodeCallLLM by nodeLLMRequest()
+    val nodeExecuteTool by nodeExecuteTool()
+    val nodeSendToolResult by nodeLLMSendToolResult()
+
+    edge(nodeStart forwardTo nodeCallLLM)
+    edge(nodeCallLLM forwardTo nodeExecuteTool onToolCall { true })
+    edge(nodeCallLLM forwardTo nodeFinish onAssistantMessage { true })
+    edge(nodeExecuteTool forwardTo nodeSendToolResult)
+    edge(nodeSendToolResult forwardTo nodeFinish onAssistantMessage { true })
+    edge(nodeSendToolResult forwardTo nodeExecuteTool onToolCall { true })
+}
+
+/**
+ * Enum representing the modes in which a single-run strategy for an AI agent can be executed.
+ *
+ * These modes define how tasks or operations are processed during the agent's run:
+ * - SEQUENTIAL: Multiple tool calls allowed but will be executed sequentially.
+ * - PARALLEL: Tool calls executed in parallel.
+ * - SINGLE: Multiple tool calls are not allowed.
+ */
+public enum class SingleRunMode {
+    SEQUENTIAL, PARALLEL, SINGLE
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentSimpleStrategies.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentSimpleStrategies.kt
@@ -29,13 +29,12 @@ import ai.koog.agents.core.dsl.extension.onToolCall
  *                - SingleRunMode.SEQUENTIAL: Executes simultaneous tool calls sequentially.
  *                - SingleRunMode.PARALLEL: Executes multiple tool calls in parallel.
  * @return An instance of AIAgentStrategy configured according to the specified single-run mode.
-
  */
-public fun singleRunStrategy(runMode: ToolCalls = ToolCalls.SINGLE): AIAgentStrategy<String, String> =
+public fun singleRunStrategy(runMode: ToolCalls = ToolCalls.SINGLE_RUN_SEQUENTIAL): AIAgentStrategy<String, String> =
     when (runMode) {
         ToolCalls.SEQUENTIAL -> singleRunWithParallelAbility(false)
         ToolCalls.PARALLEL   -> singleRunWithParallelAbility(true)
-        ToolCalls.SINGLE     -> singleRunModeStrategy()
+        ToolCalls.SINGLE_RUN_SEQUENTIAL     -> singleRunModeStrategy()
     }
 
 
@@ -81,5 +80,5 @@ private fun singleRunModeStrategy() = strategy("single_run") {
  * - SINGLE: Multiple tool calls are not allowed.
  */
 public enum class ToolCalls {
-    SEQUENTIAL, PARALLEL, SINGLE
+    SEQUENTIAL, PARALLEL, SINGLE_RUN_SEQUENTIAL
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentSimpleStrategies.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentSimpleStrategies.kt
@@ -3,10 +3,15 @@ package ai.koog.agents.core.agent
 import ai.koog.agents.core.agent.entity.AIAgentStrategy
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.core.dsl.extension.nodeExecuteMultipleTools
 import ai.koog.agents.core.dsl.extension.nodeExecuteTool
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
+import ai.koog.agents.core.dsl.extension.nodeLLMRequestMultiple
+import ai.koog.agents.core.dsl.extension.nodeLLMSendMultipleToolResults
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResult
 import ai.koog.agents.core.dsl.extension.onAssistantMessage
+import ai.koog.agents.core.dsl.extension.onMultipleAssistantMessages
+import ai.koog.agents.core.dsl.extension.onMultipleToolCalls
 import ai.koog.agents.core.dsl.extension.onToolCall
 
 /**
@@ -19,11 +24,45 @@ import ai.koog.agents.core.dsl.extension.onToolCall
  * 3. Execute a tool based on the LLM's response.
  * 4. Send the tool result back to the LLM.
  * 5. Repeat until LLM indicates no further tool calls are needed or the agent finishes.
+ * @param runMode The mode in which the single-run strategy should operate. Defaults to SingleRunMode.SINGLE.
+ *                - SingleRunMode.SINGLE: Executes without allowing multiple simultaneous tool calls.
+ *                - SingleRunMode.SEQUENTIAL: Executes simultaneous tool calls sequentially.
+ *                - SingleRunMode.PARALLEL: Executes multiple tool calls in parallel.
+ * @return An instance of AIAgentStrategy configured according to the specified single-run mode.
+
  */
-public fun singleRunStrategy(): AIAgentStrategy<String, String> = strategy("single_run") {
-    val nodeCallLLM by nodeLLMRequest("sendInput")
-    val nodeExecuteTool by nodeExecuteTool("nodeExecuteTool")
-    val nodeSendToolResult by nodeLLMSendToolResult("nodeSendToolResult")
+public fun singleRunStrategy(runMode: ToolCalls = ToolCalls.SINGLE): AIAgentStrategy<String, String> =
+    when (runMode) {
+        ToolCalls.SEQUENTIAL -> singleRunWithParallelAbility(false)
+        ToolCalls.PARALLEL   -> singleRunWithParallelAbility(true)
+        ToolCalls.SINGLE     -> singleRunModeStrategy()
+    }
+
+
+private fun singleRunWithParallelAbility(parallelTools: Boolean) = strategy("single_run_sequential") {
+    val nodeCallLLM by nodeLLMRequestMultiple()
+    val nodeExecuteTool by nodeExecuteMultipleTools(parallelTools = parallelTools)
+    val nodeSendToolResult by nodeLLMSendMultipleToolResults()
+
+    edge(nodeStart forwardTo nodeCallLLM)
+    edge(nodeCallLLM forwardTo nodeExecuteTool onMultipleToolCalls { true })
+    edge(nodeCallLLM forwardTo nodeFinish
+            onMultipleAssistantMessages { true }
+            transformed { it.joinToString("\n") { message -> message.content } })
+
+    edge(nodeExecuteTool forwardTo nodeSendToolResult)
+
+    edge(nodeSendToolResult forwardTo nodeFinish
+            onMultipleAssistantMessages { true }
+            transformed { it.joinToString("\n") { message -> message.content } })
+
+    edge(nodeSendToolResult forwardTo nodeExecuteTool onMultipleToolCalls { true })
+}
+
+private fun singleRunModeStrategy() = strategy("single_run") {
+    val nodeCallLLM by nodeLLMRequest()
+    val nodeExecuteTool by nodeExecuteTool()
+    val nodeSendToolResult by nodeLLMSendToolResult()
 
     edge(nodeStart forwardTo nodeCallLLM)
     edge(nodeCallLLM forwardTo nodeExecuteTool onToolCall { true })
@@ -31,4 +70,16 @@ public fun singleRunStrategy(): AIAgentStrategy<String, String> = strategy("sing
     edge(nodeExecuteTool forwardTo nodeSendToolResult)
     edge(nodeSendToolResult forwardTo nodeFinish onAssistantMessage { true })
     edge(nodeSendToolResult forwardTo nodeExecuteTool onToolCall { true })
+}
+
+/**
+ * Enum representing the modes in which a single-run strategy for an AI agent can be executed.
+ *
+ * These modes define how tasks or operations are processed during the agent's run:
+ * - SEQUENTIAL: Multiple tool calls allowed but will be executed sequentially.
+ * - PARALLEL: Tool calls executed in parallel.
+ * - SINGLE: Multiple tool calls are not allowed.
+ */
+public enum class ToolCalls {
+    SEQUENTIAL, PARALLEL, SINGLE
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentEdges.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentEdges.kt
@@ -206,8 +206,8 @@ public infix fun <IncomingOutput, IntermediateOutput, OutgoingInput>
  *
  * @param block A function that evaluates whether to accept an assistant message
  */
-public infix fun <IncomingOutput, IntermediateOutput, OutgoingInput>
-        AIAgentEdgeBuilderIntermediate<IncomingOutput, IntermediateOutput, OutgoingInput>.onMultipleAssistantMessages(
+public infix fun <IncomingOutput, OutgoingInput>
+        AIAgentEdgeBuilderIntermediate<IncomingOutput, List<Message.Response>, OutgoingInput>.onMultipleAssistantMessages(
     block: suspend (List<Message.Assistant>) -> Boolean
 ): AIAgentEdgeBuilderIntermediate<IncomingOutput, List<Message.Assistant>, OutgoingInput> {
     return onIsInstance(List::class)

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentEdges.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentEdges.kt
@@ -157,13 +157,14 @@ public inline fun <IncomingOutput, IntermediateOutput, OutgoingInput, reified Re
  *
  * @param block A function that evaluates whether to accept a list of tool call messages
  */
-public infix fun <IncomingOutput, IntermediateOutput, OutgoingInput>
-        AIAgentEdgeBuilderIntermediate<IncomingOutput, IntermediateOutput, OutgoingInput>.onMultipleToolCalls(
+public infix fun <IncomingOutput, OutgoingInput>
+        AIAgentEdgeBuilderIntermediate<IncomingOutput, List<Message.Response>, OutgoingInput>.onMultipleToolCalls(
     block: suspend (List<Message.Tool.Call>) -> Boolean
 ): AIAgentEdgeBuilderIntermediate<IncomingOutput, List<Message.Tool.Call>, OutgoingInput> {
     return onIsInstance(List::class)
         .transformed { it to it.filterIsInstance<Message.Tool.Call>() }
-        .onCondition { (original, filtered) -> original == filtered }
+        // skipping this edge in case we have list of only assistant messages
+        .onCondition { (_, filtered) -> filtered.any() }
         .transformed { (_, filtered) -> filtered }
         .onCondition { toolCalls -> block(toolCalls) }
 }
@@ -197,6 +198,24 @@ public infix fun <IncomingOutput, IntermediateOutput, OutgoingInput>
     return onIsInstance(Message.Assistant::class)
         .onCondition { signature -> block(signature) }
         .transformed { it.content }
+}
+
+
+/**
+ * Creates an edge that filters assistant messages based on a custom condition and extracts their content.
+ *
+ * @param block A function that evaluates whether to accept an assistant message
+ */
+public infix fun <IncomingOutput, IntermediateOutput, OutgoingInput>
+        AIAgentEdgeBuilderIntermediate<IncomingOutput, IntermediateOutput, OutgoingInput>.onMultipleAssistantMessages(
+    block: suspend (List<Message.Assistant>) -> Boolean
+): AIAgentEdgeBuilderIntermediate<IncomingOutput, List<Message.Assistant>, OutgoingInput> {
+    return onIsInstance(List::class)
+        .transformed { it to it.filterIsInstance<Message.Assistant>() }
+        .onCondition { (original, filtered) -> original == filtered }
+        .transformed { (_, filtered) -> filtered }
+        .onCondition { toolResults -> block(toolResults) }
+        .transformed { it }
 }
 
 /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
@@ -274,7 +274,12 @@ public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMExecuteToolAndSendResult(
     }
 
 /**
+ * Defines a node in the AI agent graph that executes multiple tools and sends the results
+ * to the language model for processing.
  *
+ * @param name An optional name for the node. If not provided, a default name will be generated.
+ * @param parallelTools If true, tools are executed in parallel. If false, tools are executed sequentially.
+ * @return A node which manages the execution of tools and their results processing
  */
 public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMExecuteMultipleToolsAndSendResults(
     name: String? = null,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
@@ -255,6 +255,50 @@ public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMSendToolResult(
     }
 
 /**
+ * Combination of [nodeExecuteTool] and [nodeLLMSendToolResult]
+ */
+public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMExecuteToolAndSendResult(
+    name: String? = null
+): AIAgentNodeDelegateBase<Message.Tool.Call, Message.Response> =
+    node(name) { tc ->
+        val toolExecResult = environment.executeTool(tc)
+        return@node llm.writeSession {
+            updatePrompt {
+                tool {
+                    result(toolExecResult)
+                }
+            }
+
+            requestLLM()
+        }
+    }
+
+/**
+ *
+ */
+public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMExecuteMultipleToolsAndSendResults(
+    name: String? = null,
+    parallelTools: Boolean = false
+): AIAgentNodeDelegateBase<List<Message.Tool.Call>, List<Message.Response>> =
+    node(name) { tc ->
+        val tcResults = if (parallelTools) {
+            environment.executeTools(tc)
+        } else {
+            tc.map { environment.executeTool(it) }
+        }
+
+        return@node llm.writeSession {
+            updatePrompt {
+                tool {
+                    tcResults.forEach { result(it) }
+                }
+            }
+
+            requestLLMMultiple()
+        }
+    }
+
+/**
  * A node that executes multiple tool calls. These calls can optionally be executed in parallel.
  *
  * @param name Optional node name.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
@@ -255,55 +255,6 @@ public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMSendToolResult(
     }
 
 /**
- * Combination of [nodeExecuteTool] and [nodeLLMSendToolResult]
- */
-public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMExecuteToolAndSendResult(
-    name: String? = null
-): AIAgentNodeDelegateBase<Message.Tool.Call, Message.Response> =
-    node(name) { tc ->
-        val toolExecResult = environment.executeTool(tc)
-        return@node llm.writeSession {
-            updatePrompt {
-                tool {
-                    result(toolExecResult)
-                }
-            }
-
-            requestLLM()
-        }
-    }
-
-/**
- * Defines a node in the AI agent graph that executes multiple tools and sends the results
- * to the language model for processing.
- *
- * @param name An optional name for the node. If not provided, a default name will be generated.
- * @param parallelTools If true, tools are executed in parallel. If false, tools are executed sequentially.
- * @return A node which manages the execution of tools and their results processing
- */
-public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMExecuteMultipleToolsAndSendResults(
-    name: String? = null,
-    parallelTools: Boolean = false
-): AIAgentNodeDelegateBase<List<Message.Tool.Call>, List<Message.Response>> =
-    node(name) { tc ->
-        val tcResults = if (parallelTools) {
-            environment.executeTools(tc)
-        } else {
-            tc.map { environment.executeTool(it) }
-        }
-
-        return@node llm.writeSession {
-            updatePrompt {
-                tool {
-                    tcResults.forEach { result(it) }
-                }
-            }
-
-            requestLLMMultiple()
-        }
-    }
-
-/**
  * A node that executes multiple tool calls. These calls can optionally be executed in parallel.
  *
  * @param name Optional node name.

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/DummyTools.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/DummyTools.kt
@@ -1,0 +1,41 @@
+package ai.koog.agents.core.agent
+
+import ai.koog.agents.core.tools.SimpleTool
+import ai.koog.agents.core.tools.ToolArgs
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolParameterDescriptor
+import ai.koog.agents.core.tools.ToolParameterType
+import kotlinx.serialization.Serializable
+
+object DummyTool : SimpleTool<ToolArgs.Empty>() {
+    override val argsSerializer = ToolArgs.Empty.serializer()
+
+    override val descriptor = ToolDescriptor(
+        name = "dummy",
+        description = "Dummy tool for testing",
+        requiredParameters = emptyList()
+    )
+
+    override suspend fun doExecute(args: ToolArgs.Empty): String = "Dummy result"
+}
+
+object CreateTool : SimpleTool<CreateTool.Args>() {
+    @Serializable
+    data class Args(val name: String) : ToolArgs
+
+    override val argsSerializer = Args.serializer()
+
+    override val descriptor = ToolDescriptor(
+        name = "create",
+        description = "Create something",
+        requiredParameters = listOf(
+            ToolParameterDescriptor(
+                name = "name",
+                description = "Name of the entity to create",
+                type = ToolParameterType.String
+            )
+        )
+    )
+
+    override suspend fun doExecute(args: Args): String = "created"
+}

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/SingleRunStrategyTests.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/SingleRunStrategyTests.kt
@@ -87,7 +87,7 @@ class SingleRunStrategyTests {
         val agent = AIAgent(
             mockLLMApi,
             OllamaModels.Meta.LLAMA_3_2,
-            strategy = singleRunStrategy(SingleRunMode.SEQUENTIAL),
+            strategy = singleRunStrategy(ToolCalls.SEQUENTIAL),
             toolRegistry = testToolRegistry) {
             install(EventHandler) {
                 onToolCall { _, args -> actualToolCalls += args.toString() }
@@ -116,7 +116,7 @@ class SingleRunStrategyTests {
         val agent = AIAgent(
             mockLLMApi,
             OllamaModels.Meta.LLAMA_3_2,
-            strategy = singleRunStrategy(SingleRunMode.PARALLEL),
+            strategy = singleRunStrategy(ToolCalls.PARALLEL),
             toolRegistry = testToolRegistry) {
             install(EventHandler) {
                 onToolCall { _, args -> actualToolCalls += args.toString() }
@@ -154,7 +154,7 @@ class SingleRunStrategyTests {
         val agent = AIAgent(
             mockLLMApi,
             OllamaModels.Meta.LLAMA_3_2,
-            strategy = singleRunStrategy(SingleRunMode.SEQUENTIAL),
+            strategy = singleRunStrategy(ToolCalls.SEQUENTIAL),
             toolRegistry = testToolRegistry) {
             install(EventHandler) {
                 onToolCall { _, args -> actualToolCalls += args.toString() }
@@ -192,7 +192,7 @@ class SingleRunStrategyTests {
         val agent = AIAgent(
             mockLLMApi,
             OllamaModels.Meta.LLAMA_3_2,
-            strategy = singleRunStrategy(SingleRunMode.PARALLEL),
+            strategy = singleRunStrategy(ToolCalls.PARALLEL),
             toolRegistry = testToolRegistry) {
             install(EventHandler) {
                 onToolCall { _, args -> actualToolCalls += args.toString() }
@@ -231,7 +231,7 @@ class SingleRunStrategyTests {
         val agent = AIAgent(
             mockLLMApi,
             OllamaModels.Meta.LLAMA_3_2,
-            strategy = singleRunStrategy(SingleRunMode.SEQUENTIAL),
+            strategy = singleRunStrategy(ToolCalls.SEQUENTIAL),
             toolRegistry = testToolRegistry) {
             install(EventHandler) {
                 onToolCall { _, args -> actualToolCalls += args.toString() }
@@ -270,7 +270,7 @@ class SingleRunStrategyTests {
         val agent = AIAgent(
             mockLLMApi,
             OllamaModels.Meta.LLAMA_3_2,
-            strategy = singleRunStrategy(SingleRunMode.PARALLEL),
+            strategy = singleRunStrategy(ToolCalls.PARALLEL),
             toolRegistry = testToolRegistry) {
             install(EventHandler) {
                 onToolCall { _, args -> actualToolCalls += args.toString() }

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/SingleRunStrategyTests.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/SingleRunStrategyTests.kt
@@ -12,7 +12,37 @@ import kotlin.test.assertEquals
 class SingleRunStrategyTests {
 
     @Test
-    fun testSingleRunStrategyWithToolCall() = runTest {
+    fun test_SingleRunStrategy_Single_AssistantMessages() = runTest {
+        val actualToolCalls = mutableListOf<String>()
+
+        val testToolRegistry = ToolRegistry {
+            tool(CreateTool)
+        }
+
+        val mockLLMApi = getMockExecutor {
+            mockLLMAnswer("Hello!") onRequestContains "Hello"
+            mockLLMAnswer("Tools called!") onRequestContains "created"
+            mockLLMAnswer("Task solved!!") onRequestContains "Solve task"
+            mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            mockLLMApi,
+            OllamaModels.Meta.LLAMA_3_2,
+            toolRegistry = testToolRegistry) {
+            install(EventHandler) {
+                onToolCall { _, args -> actualToolCalls += args.toString() }
+            }
+        }
+
+        val result = agent.runAndGetResult("Solve task")
+
+        assertEquals(0, actualToolCalls.size)
+        assertEquals("Task solved!!", result)
+    }
+
+    @Test
+    fun test_SingleRunStrategy_Single_WithToolCall() = runTest {
         val actualToolCalls = mutableListOf<String>()
 
         val testToolRegistry = ToolRegistry {
@@ -42,7 +72,65 @@ class SingleRunStrategyTests {
     }
 
     @Test
-    fun testSingleRunStrategyWithParallelToolCalls() = runTest {
+    fun test_SingleRunStrategy_Sequential_AssistantMessages() = runTest {
+        val actualToolCalls = mutableListOf<String>()
+
+        val testToolRegistry = ToolRegistry {
+            tool(CreateTool)
+        }
+
+        val mockLLMApi = getMockExecutor {
+            mockLLMAnswer("Task solved!") onRequestContains "Solve task"
+            mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            mockLLMApi,
+            OllamaModels.Meta.LLAMA_3_2,
+            strategy = singleRunStrategy(SingleRunMode.SEQUENTIAL),
+            toolRegistry = testToolRegistry) {
+            install(EventHandler) {
+                onToolCall { _, args -> actualToolCalls += args.toString() }
+            }
+        }
+
+        val result = agent.runAndGetResult("Solve task")
+
+        assertEquals(0, actualToolCalls.size)
+        assertEquals("Task solved!", result)
+    }
+
+    @Test
+    fun test_SingleRunStrategy_Parallel_AssistantMessages() = runTest {
+        val actualToolCalls = mutableListOf<String>()
+
+        val testToolRegistry = ToolRegistry {
+            tool(CreateTool)
+        }
+
+        val mockLLMApi = getMockExecutor {
+            mockLLMAnswer("Task solved!") onRequestContains "Solve task"
+            mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            mockLLMApi,
+            OllamaModels.Meta.LLAMA_3_2,
+            strategy = singleRunStrategy(SingleRunMode.PARALLEL),
+            toolRegistry = testToolRegistry) {
+            install(EventHandler) {
+                onToolCall { _, args -> actualToolCalls += args.toString() }
+            }
+        }
+
+        val result = agent.runAndGetResult("Solve task")
+
+        assertEquals(0, actualToolCalls.size)
+        assertEquals("Task solved!", result)
+    }
+
+    @Test
+    fun test_SingleRunStrategy_Sequential_WithParallelToolCalls() = runTest {
         val actualToolCalls = mutableListOf<String>()
 
         val testToolRegistry = ToolRegistry {
@@ -66,6 +154,7 @@ class SingleRunStrategyTests {
         val agent = AIAgent(
             mockLLMApi,
             OllamaModels.Meta.LLAMA_3_2,
+            strategy = singleRunStrategy(SingleRunMode.SEQUENTIAL),
             toolRegistry = testToolRegistry) {
             install(EventHandler) {
                 onToolCall { _, args -> actualToolCalls += args.toString() }
@@ -77,4 +166,121 @@ class SingleRunStrategyTests {
         assertEquals(3, actualToolCalls.size)
         assertEquals("Tools called!", result)
     }
+
+    @Test
+    fun test_SingleRunStrategy_Parallel_WithParallelToolCalls() = runTest {
+        val actualToolCalls = mutableListOf<String>()
+
+        val testToolRegistry = ToolRegistry {
+            tool(CreateTool)
+        }
+
+        val mockLLMApi = getMockExecutor {
+            mockLLMAnswer("Hello!") onRequestContains "Hello"
+            mockLLMAnswer("Tools called!") onRequestContains "created"
+            mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+
+            // Mock LLM tool calls
+            val toolCalls = listOf(
+                CreateTool to CreateTool.Args("solve"),
+                CreateTool to CreateTool.Args("solve2"),
+                CreateTool to CreateTool.Args("solve3"),
+            )
+            mockLLMToolCall(toolCalls) onRequestEquals "Solve task"
+        }
+
+        val agent = AIAgent(
+            mockLLMApi,
+            OllamaModels.Meta.LLAMA_3_2,
+            strategy = singleRunStrategy(SingleRunMode.PARALLEL),
+            toolRegistry = testToolRegistry) {
+            install(EventHandler) {
+                onToolCall { _, args -> actualToolCalls += args.toString() }
+            }
+        }
+
+        val result = agent.runAndGetResult("Solve task")
+
+        assertEquals(3, actualToolCalls.size)
+        assertEquals("Tools called!", result)
+    }
+
+    @Test
+    fun test_SingleRunStrategy_Sequential_MixedResults() = runTest {
+        val actualToolCalls = mutableListOf<String>()
+
+        val testToolRegistry = ToolRegistry {
+            tool(CreateTool)
+        }
+
+        val assistantResponse = "Hey, I want to call following tools:"
+        val mockLLMApi = getMockExecutor(handleLastAssistantMessage = true) {
+            mockLLMAnswer(assistantResponse) onRequestContains assistantResponse
+            mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+
+            // Mock LLM tool calls
+            val toolCalls = listOf(
+                CreateTool to CreateTool.Args("solve"),
+                CreateTool to CreateTool.Args("solve2"),
+                CreateTool to CreateTool.Args("solve3"),
+            )
+            val assistantResponses = listOf(assistantResponse)
+            mockLLMMixedResponse(toolCalls, assistantResponses) onRequestEquals "Solve task"
+        }
+
+        val agent = AIAgent(
+            mockLLMApi,
+            OllamaModels.Meta.LLAMA_3_2,
+            strategy = singleRunStrategy(SingleRunMode.SEQUENTIAL),
+            toolRegistry = testToolRegistry) {
+            install(EventHandler) {
+                onToolCall { _, args -> actualToolCalls += args.toString() }
+            }
+        }
+
+        val result = agent.runAndGetResult("Solve task")
+
+        assertEquals(3, actualToolCalls.size)
+        assertEquals(assistantResponse, result)
+    }
+
+    @Test
+    fun test_SingleRunStrategy_Parallel_MixedResults() = runTest {
+        val actualToolCalls = mutableListOf<String>()
+
+        val testToolRegistry = ToolRegistry {
+            tool(CreateTool)
+        }
+
+        val assistantResponse = "Hey, I want to call following tools:"
+        val mockLLMApi = getMockExecutor(handleLastAssistantMessage = true) {
+            mockLLMAnswer(assistantResponse) onRequestContains assistantResponse
+            mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+
+            // Mock LLM tool calls
+            val toolCalls = listOf(
+                CreateTool to CreateTool.Args("solve"),
+                CreateTool to CreateTool.Args("solve2"),
+                CreateTool to CreateTool.Args("solve3"),
+            )
+            val assistantResponses = listOf(assistantResponse)
+            mockLLMMixedResponse(toolCalls, assistantResponses) onRequestEquals "Solve task"
+        }
+
+        val agent = AIAgent(
+            mockLLMApi,
+            OllamaModels.Meta.LLAMA_3_2,
+            strategy = singleRunStrategy(SingleRunMode.PARALLEL),
+            toolRegistry = testToolRegistry) {
+            install(EventHandler) {
+                onToolCall { _, args -> actualToolCalls += args.toString() }
+            }
+        }
+
+        val result = agent.runAndGetResult("Solve task")
+
+        assertEquals(3, actualToolCalls.size)
+        assertEquals(assistantResponse, result)
+    }
+
 }

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/SingleRunStrategyTests.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/SingleRunStrategyTests.kt
@@ -1,0 +1,80 @@
+package ai.koog.agents.core.agent
+
+import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.features.eventHandler.feature.EventHandler
+import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.agents.testing.tools.mockLLMAnswer
+import ai.koog.prompt.llm.OllamaModels
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SingleRunStrategyTests {
+
+    @Test
+    fun testSingleRunStrategyWithToolCall() = runTest {
+        val actualToolCalls = mutableListOf<String>()
+
+        val testToolRegistry = ToolRegistry {
+            tool(CreateTool)
+        }
+
+        val mockLLMApi = getMockExecutor {
+            mockLLMAnswer("Hello!") onRequestContains "Hello"
+            mockLLMAnswer("Tools called!") onRequestContains "created"
+            mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+            mockLLMToolCall(CreateTool, CreateTool.Args("solve")) onRequestEquals "Solve task"
+        }
+
+        val agent = AIAgent(
+            mockLLMApi,
+            OllamaModels.Meta.LLAMA_3_2,
+            toolRegistry = testToolRegistry) {
+            install(EventHandler) {
+                onToolCall { _, args -> actualToolCalls += args.toString() }
+            }
+        }
+
+        val result = agent.runAndGetResult("Solve task")
+
+        assertEquals(1, actualToolCalls.size)
+        assertEquals("Tools called!", result)
+    }
+
+    @Test
+    fun testSingleRunStrategyWithParallelToolCalls() = runTest {
+        val actualToolCalls = mutableListOf<String>()
+
+        val testToolRegistry = ToolRegistry {
+            tool(CreateTool)
+        }
+
+        val mockLLMApi = getMockExecutor {
+            mockLLMAnswer("Hello!") onRequestContains "Hello"
+            mockLLMAnswer("Tools called!") onRequestContains "created"
+            mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+
+            // Mock LLM tool calls
+            val toolCalls = listOf(
+                CreateTool to CreateTool.Args("solve"),
+                CreateTool to CreateTool.Args("solve2"),
+                CreateTool to CreateTool.Args("solve3"),
+            )
+            mockLLMToolCall(toolCalls) onRequestEquals "Solve task"
+        }
+
+        val agent = AIAgent(
+            mockLLMApi,
+            OllamaModels.Meta.LLAMA_3_2,
+            toolRegistry = testToolRegistry) {
+            install(EventHandler) {
+                onToolCall { _, args -> actualToolCalls += args.toString() }
+            }
+        }
+
+        val result = agent.runAndGetResult("Solve task")
+
+        assertEquals(3, actualToolCalls.size)
+        assertEquals("Tools called!", result)
+    }
+}

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/SingleRunStrategyTests.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/SingleRunStrategyTests.kt
@@ -35,7 +35,7 @@ class SingleRunStrategyTests {
             }
         }
 
-        val result = agent.runAndGetResult("Solve task")
+        val result = agent.run("Solve task")
 
         assertEquals(0, actualToolCalls.size)
         assertEquals("Task solved!!", result)
@@ -65,7 +65,7 @@ class SingleRunStrategyTests {
             }
         }
 
-        val result = agent.runAndGetResult("Solve task")
+        val result = agent.run("Solve task")
 
         assertEquals(1, actualToolCalls.size)
         assertEquals("Tools called!", result)
@@ -94,7 +94,7 @@ class SingleRunStrategyTests {
             }
         }
 
-        val result = agent.runAndGetResult("Solve task")
+        val result = agent.run("Solve task")
 
         assertEquals(0, actualToolCalls.size)
         assertEquals("Task solved!", result)
@@ -123,7 +123,7 @@ class SingleRunStrategyTests {
             }
         }
 
-        val result = agent.runAndGetResult("Solve task")
+        val result = agent.run("Solve task")
 
         assertEquals(0, actualToolCalls.size)
         assertEquals("Task solved!", result)
@@ -161,7 +161,7 @@ class SingleRunStrategyTests {
             }
         }
 
-        val result = agent.runAndGetResult("Solve task")
+        val result = agent.run("Solve task")
 
         assertEquals(3, actualToolCalls.size)
         assertEquals("Tools called!", result)
@@ -199,7 +199,7 @@ class SingleRunStrategyTests {
             }
         }
 
-        val result = agent.runAndGetResult("Solve task")
+        val result = agent.run("Solve task")
 
         assertEquals(3, actualToolCalls.size)
         assertEquals("Tools called!", result)
@@ -238,7 +238,7 @@ class SingleRunStrategyTests {
             }
         }
 
-        val result = agent.runAndGetResult("Solve task")
+        val result = agent.run("Solve task")
 
         assertEquals(3, actualToolCalls.size)
         assertEquals(assistantResponse, result)
@@ -277,7 +277,7 @@ class SingleRunStrategyTests {
             }
         }
 
-        val result = agent.runAndGetResult("Solve task")
+        val result = agent.run("Solve task")
 
         assertEquals(3, actualToolCalls.size)
         assertEquals(assistantResponse, result)

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/SimpleGraphCheckpointTest.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/SimpleGraphCheckpointTest.kt
@@ -1,0 +1,224 @@
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.dsl.builder.AIAgentNodeDelegateBase
+import ai.koog.agents.core.dsl.builder.AIAgentSubgraphBuilderBase
+import ai.koog.agents.core.dsl.builder.forwardTo
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.ext.tool.SayToUser
+import ai.koog.agents.snapshot.feature.AgentCheckpoint
+import ai.koog.agents.snapshot.feature.withCheckpoints
+import ai.koog.agents.snapshot.providers.InMemoryAgentCheckpointStorageProvider
+import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.llm.OllamaModels
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for the Snapshot feature.
+ * These tests verify that the agent can create checkpoints and jump to specific execution points.
+ */
+class SimpleGraphCheckpointTest {
+
+    /**
+     * Test that the agent jumps to a specific execution point when using the checkpoint feature.
+     * This test verifies that after setting an execution point, the agent continues execution from that point.
+     */
+    @Test
+    fun `test agent jumps to execution point when using checkpoint`() = runTest {
+        // Create a snapshot provider to store checkpoints
+        val snapshotProvider = InMemoryAgentCheckpointStorageProvider()
+
+        // Create a mock executor for testing
+        val mockExecutor: PromptExecutor = getMockExecutor {
+            // No specific mock responses needed for this test
+        }
+
+        // Create a tool registry with the SayToUser tool
+        val toolRegistry = ToolRegistry {
+            tool(SayToUser)
+        }
+
+        // Create agent config
+        val agentConfig = AIAgentConfig(
+            prompt = prompt("test") {
+                system("You are a test agent.")
+            },
+            model = OllamaModels.Meta.LLAMA_3_2,
+            maxAgentIterations = 10
+        )
+
+        // Create an agent with the teleport strategy
+        val agent = AIAgent(
+            promptExecutor = mockExecutor,
+            strategy = createTeleportStrategy(),
+            agentConfig = agentConfig,
+            toolRegistry = toolRegistry
+        ) {
+            install(AgentCheckpoint) {
+                snapshotProvider(snapshotProvider)
+            }
+        }
+
+        // Run the agent
+        val result = agent.runAndGetResult("Start the test")
+
+        // Verify that the result contains the expected output from the teleported node
+        assertEquals(
+                "Start the test\n" +
+                "Node 1 output\n" +
+                "Teleported\n" +
+                "Node 1 output\n" +
+                "Already teleported, passing by\n" +
+                "Node 2 output", result)
+    }
+
+    /**
+     * Test that the agent can create and save checkpoints.
+     * This test verifies that after creating a checkpoint, it can be retrieved from the provider.
+     */
+    @Test
+    fun `test agent creates and saves checkpoints`() = runTest {
+        // Create a snapshot provider to store checkpoints
+        val checkpointStorageProvider = InMemoryAgentCheckpointStorageProvider()
+
+        // Create a mock executor for testing
+        val mockExecutor: PromptExecutor = getMockExecutor {
+            // No specific mock responses needed for this test
+        }
+
+        // Create a tool registry with the SayToUser tool
+        val toolRegistry = ToolRegistry {
+            tool(SayToUser)
+        }
+
+        // Create agent config
+        val agentConfig = AIAgentConfig(
+            prompt = prompt("test") {
+                system("You are a test agent.")
+            },
+            model = OllamaModels.Meta.LLAMA_3_2,
+            maxAgentIterations = 10
+        )
+
+        // Create an agent with the checkpoint strategy
+        val agent = AIAgent(
+            promptExecutor = mockExecutor,
+            strategy = createCheckpointStrategy(),
+            agentConfig = agentConfig,
+            toolRegistry = toolRegistry
+        ) {
+            install(AgentCheckpoint) {
+                snapshotProvider(checkpointStorageProvider)
+            }
+        }
+
+        // Run the agent
+        agent.run("Start the test")
+
+        // Verify that a checkpoint was created and saved
+        val checkpoint = checkpointStorageProvider.getCheckpoint("snapshot-id")
+        assertNotNull(checkpoint, "No checkpoint was created")
+        assertEquals("checkpointNode", checkpoint?.nodeId, "Checkpoint has incorrect node ID")
+    }
+
+    /**
+     * Creates a strategy with a teleport node that jumps to a specific execution point.
+     */
+    private fun createTeleportStrategy() = strategy("teleport-test") {
+        val node1 by simpleNode(
+            "Node1",
+            output = "Node 1 output"
+        )
+
+        val node2 by simpleNode(
+            "Node2",
+            output = "Node 2 output"
+        )
+        val teleportNode by teleportNode()
+
+        edge(nodeStart forwardTo node1)
+        edge(node1 forwardTo teleportNode)
+        edge(teleportNode forwardTo node2)
+        edge(node2 forwardTo nodeFinish)
+    }
+
+    /**
+     * Creates a strategy with a checkpoint node that creates and saves a checkpoint.
+     */
+    private fun createCheckpointStrategy() = strategy("checkpoint-test") {
+        val node1 by simpleNode(
+            "Node1",
+            output = "Node 1 output"
+        )
+
+        val checkpointNode by nodeCreateCheckpoint(
+            "checkpointNode"
+        )
+
+        val node2 by simpleNode(
+            "Node2",
+            output = "Node 2 output"
+        )
+
+        edge(nodeStart forwardTo node1)
+        edge(node1 forwardTo checkpointNode)
+        edge(checkpointNode forwardTo node2)
+        edge(node2 forwardTo nodeFinish)
+    }
+
+    /**
+     * Creates a simple node that appends the output to the input.
+     */
+    private fun AIAgentSubgraphBuilderBase<*, *>.simpleNode(
+        name: String? = null,
+        output: String,
+    ): AIAgentNodeDelegateBase<String, String> = node(name) {
+        return@node it + "\n" + output
+    }
+
+    // Flag to track whether teleportation has occurred
+    private var hasTeleported = false
+
+    /**
+     * Creates a teleport node that jumps to a specific execution point.
+     * Only teleports once to avoid infinite loops.
+     */
+    private fun AIAgentSubgraphBuilderBase<*, *>.teleportNode(
+        name: String? = null,
+    ): AIAgentNodeDelegateBase<String, String> = node(name) {
+        val ctx = this
+        if (!hasTeleported) {
+            hasTeleported = true
+            withCheckpoints {
+                val history = llm.readSession { this.prompt.messages }
+                setExecutionPoint(ctx, "Node1", history, "$it\nTeleported")
+                return@withCheckpoints "Teleported"
+            }
+        } else {
+            // If we've already teleported, just return the input
+            return@node "$it\nAlready teleported, passing by"
+        }
+    }
+
+    /**
+     * Creates a checkpoint node that creates and saves a checkpoint.
+     */
+    private fun AIAgentSubgraphBuilderBase<*, *>.nodeCreateCheckpoint(
+        name: String? = null,
+    ): AIAgentNodeDelegateBase<String, String> = node(name) {
+        val ctx = this
+        val input = it
+        withCheckpoints {
+            val checkpoint = createCheckpoint("snapshot-id", ctx, currentNodeId ?: error("currentNodeId not set"), input)
+            saveCheckpoint(checkpoint.checkpointId, checkpoint)
+
+            val snapshot = it + "Snapshot created"
+            return@withCheckpoints snapshot
+        }
+    }
+}

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMBuilder.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMBuilder.kt
@@ -89,14 +89,16 @@ public class ToolCondition<Args : ToolArgs, Result : ToolResult>(
  * @property tokenizer: Tokenizer that will be used to estimate token counts in mock messages
  */
 public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tokenizer? = null) {
-    private val assistantPartialMatches = mutableMapOf<String, String>()
-    private val assistantExactMatches = mutableMapOf<String, String>()
+    private val assistantPartialMatches = mutableMapOf<String, List<String>>()
+    private val assistantExactMatches = mutableMapOf<String, List<String>>()
     private val conditional = mutableMapOf<(String) -> Boolean, String>()
     private val toolCallExactMatches = mutableMapOf<String, List<Message.Tool.Call>>()
     private val toolCallPartialMatches = mutableMapOf<String, List<Message.Tool.Call>>()
     private var defaultResponse: String = ""
     private var toolRegistry: ToolRegistry? = null
     private var toolActions: MutableList<ToolCondition<*, *>> = mutableListOf()
+
+    public var handleLastAssistantMessage: Boolean = false
 
     /**
      * Companion object for the MockLLMBuilder class.
@@ -187,7 +189,7 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param toolCalls Tool calls with args
      */
     public fun <Args : ToolArgs> addLLMAnswerExactPattern(pattern: String, toolCalls: List<Pair<Tool<Args, *>, Args>>) {
-        toolCallExactMatches[pattern] = toolCalls.map<Pair<Tool<Args, *>, Args>, Message.Tool.Call> { (tool, args) ->
+        toolCallExactMatches[pattern] = toolCalls.map { (tool, args) ->
             tool.encodeArgsToString(args).let { toolContent ->
                 Message.Tool.Call(
                     id = null,
@@ -197,6 +199,52 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
                 )
             }
         }
+    }
+
+    /**
+     * Adds an exact pattern match for an LLM answer that triggers a set of tool calls
+     * with predefined responses.
+     *
+     * @param pattern The exact input string to match.
+     * @param toolCalls A list of tool call and argument pairs to be triggered when the input matches.
+     * @param responses A list of response strings corresponding to each tool call.
+     */
+    public fun <Args : ToolArgs> addLLMAnswerExactPattern(pattern: String, toolCalls: List<Pair<Tool<Args, *>, Args>>, responses: List<String>) {
+        toolCallExactMatches[pattern] = toolCalls.map { (tool, args) ->
+            tool.encodeArgsToString(args).let { toolContent ->
+                Message.Tool.Call(
+                    id = null,
+                    tool = tool.name,
+                    content = toolContent,
+                    metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(toolContent))
+                )
+            }
+        }
+
+        assistantExactMatches[pattern] = responses
+    }
+
+    /**
+     * Adds a partial pattern match for an LLM answer that triggers a set of tool calls
+     * with predefined responses.
+     *
+     * @param pattern The substring pattern to partially match in the user request.
+     * @param toolCalls A list of tool call and argument pairs to be triggered when the input matches.
+     * @param responses A list of response strings corresponding to each tool call.
+     */
+    public fun <Args : ToolArgs> addLLMAnswerPartialPattern(pattern: String, toolCalls: List<Pair<Tool<Args, *>, Args>>, responses: List<String>) {
+        toolCallPartialMatches[pattern] = toolCalls.map { (tool, args) ->
+            tool.encodeArgsToString(args).let { toolContent ->
+                Message.Tool.Call(
+                    id = null,
+                    tool = tool.name,
+                    content = toolContent,
+                    metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(toolContent))
+                )
+            }
+        }
+
+        assistantPartialMatches[pattern] = responses
     }
 
     /**
@@ -241,6 +289,20 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
         MultiToolCallReceiver(toolCalls, this)
 
     /**
+     * Creates a mock response with a combination of tool calls and predefined string responses.
+     *
+     * This method is used to define a mixed behavior where the LLM produces a sequence of tool
+     * calls along with corresponding responses for testing purposes.
+     *
+     * @param toolCalls A list of pairs, where each pair consists of a tool and the corresponding arguments.
+     * @param responses A list of response strings corresponding to the provided tool calls. These define
+     *                  what the LLM should output for each tool call.
+     * @return A [MixedResultsReceiver] to configure further mock behavior for the provided tool calls and responses.
+     */
+    public fun <Args : ToolArgs> mockLLMMixedResponse(toolCalls: List<Pair<Tool<Args, *>, Args>>, responses: List<String>): MixedResultsReceiver<Args> =
+        MixedResultsReceiver(toolCalls, responses, this)
+
+    /**
      * Creates a mock for a tool.
      *
      * This method is used to define how a tool should behave when it is called
@@ -260,7 +322,7 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @return The MockLLMBuilder instance for method chaining
      */
     public infix fun String.onUserRequestContains(pattern: String): MockLLMBuilder {
-        assistantPartialMatches[pattern] = this
+        assistantPartialMatches[pattern] = listOf(this)
         return this@MockLLMBuilder
     }
 
@@ -271,7 +333,7 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @return The MockLLMBuilder instance for method chaining
      */
     public infix fun String.onUserRequestEquals(pattern: String): MockLLMBuilder {
-        assistantExactMatches[pattern] = this
+        assistantExactMatches[pattern] = listOf(this)
         return this@MockLLMBuilder
     }
 
@@ -325,6 +387,48 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
          */
         public infix fun onRequestContains(pattern: String): String {
             builder.addLLMAnswerPartialPattern(pattern, tool, args)
+
+            return pattern
+        }
+    }
+
+    /**
+     * Represents a class responsible for handling and managing mixed tool call results
+     * based on mock responses and predefined configurations.
+     *
+     * @param Args The type of tool arguments extending [ToolArgs].
+     * @property toolCalls A list of tool-arguments pairs representing mocked tool calls and their configurations.
+     * @property responses A list of response strings to be used when handling tool call results.
+     * @property builder An instance of [MockLLMBuilder] used to configure and mock behaviors.
+     */
+    public class MixedResultsReceiver<Args : ToolArgs>(
+        private val toolCalls: List<Pair<Tool<Args, *>, Args>>,
+        private val responses: List<String>,
+        private val builder: MockLLMBuilder
+    ) {
+        /**
+         * Configures the LLM to respond with a tool call when the user request exactly matches the specified pattern.
+         *
+         * @param pattern The exact string to match in the user request
+         * @return The [pattern] string for method chaining
+         */
+        public infix fun onRequestEquals(pattern: String): String {
+            // Using the llmAnswer directly as the response, which should contain the tool call JSON
+            builder.addLLMAnswerExactPattern(pattern, toolCalls, responses)
+
+            // Return the llmAnswer as is, which should be a valid tool call JSON
+            return pattern
+        }
+
+        /**
+         * Configures the system to partially match user requests containing the specified pattern.
+         * If the pattern is found within a user request, the associated tool call response will be triggered.
+         *
+         * @param pattern The substring pattern to match within user requests.
+         * @return The [pattern] string for method chaining
+         */
+        public infix fun onRequestContains(pattern: String): String {
+            builder.addLLMAnswerPartialPattern(pattern, toolCalls, responses)
 
             return pattern
         }
@@ -481,7 +585,7 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param action A function that produces the string result
      * @return The result of the does call
      */
-    public infix fun <Args : ToolArgs> MockToolReceiver<Args, ToolResult.Text>.doesStr(action: suspend () -> String): MockLLMBuilder.MockToolReceiver.MockToolResponseBuilder<Args, ToolResult.Text> =
+    public infix fun <Args : ToolArgs> MockToolReceiver<Args, ToolResult.Text>.doesStr(action: suspend () -> String): MockToolReceiver.MockToolResponseBuilder<Args, ToolResult.Text> =
         does { ToolResult.Text(action()) }
 
     /**
@@ -493,22 +597,34 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @return A configured MockLLMExecutor instance
      */
     public fun build(): PromptExecutor {
-        val combinedExactMatches = assistantExactMatches.mapValues {
-            val text = it.value.trimIndent()
-            listOf(Message.Assistant(
-                content = text,
-                metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(text))
-            ))
-        } + toolCallExactMatches
-        val combinedPartialMatches = assistantPartialMatches.mapValues {
-            val text = it.value.trimIndent()
-            listOf(Message.Assistant(
-                content = text,
-                metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(text))
-            ))
-        } + toolCallPartialMatches
+        val processedAssistantMatches = assistantExactMatches.mapValues { (_, value) ->
+            val texts = value.map { text -> text.trimIndent() }
+            texts.map { text ->
+                Message.Assistant(text, ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(text)))
+            }
+        }
+
+        val combinedExactMatches = (processedAssistantMatches.keys + toolCallExactMatches.keys).associateWith { key ->
+            val assistantList = processedAssistantMatches[key] ?: emptyList()
+            val toolCallList = toolCallExactMatches[key] ?: emptyList()
+            assistantList + toolCallList
+        }
+
+        val processedAssistantPartialMatches = assistantPartialMatches.mapValues { (_, value) ->
+            val texts = value.map { text -> text.trimIndent() }
+            texts.map { text ->
+                Message.Assistant(text, ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(text)))
+            }
+        }
+
+        val combinedPartialMatches = (processedAssistantPartialMatches.keys + toolCallPartialMatches.keys).associateWith { key ->
+            val assistantList = processedAssistantPartialMatches[key] ?: emptyList()
+            val toolCallList = toolCallPartialMatches[key] ?: emptyList()
+            assistantList + toolCallList
+        }
 
         return MockLLMExecutor(
+            handleLastAssistantMessage,
             partialMatches = combinedPartialMatches.takeIf { it.isNotEmpty() },
             exactMatches = combinedExactMatches.takeIf { it.isNotEmpty() },
             conditional = conditional.takeIf { it.isNotEmpty() },
@@ -688,6 +804,7 @@ public fun getMockExecutor(
     toolRegistry: ToolRegistry? = null,
     clock: Clock = Clock.System,
     tokenizer: Tokenizer? = null,
+    handleLastAssistantMessage: Boolean = false,
     init: MockLLMBuilder.() -> Unit
 ): PromptExecutor {
 
@@ -696,6 +813,7 @@ public fun getMockExecutor(
 
     // Call MockLLMBuilder and apply toolRegistry, eventHandler and set currentBuilder to this (to add mocked tool calls)
     val builder = MockLLMBuilder(clock, tokenizer).apply {
+        this.handleLastAssistantMessage  = handleLastAssistantMessage
         toolRegistry?.let { setToolRegistry(it) }
         MockLLMBuilder.currentBuilder = this
         init()

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMBuilder.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMBuilder.kt
@@ -92,8 +92,8 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
     private val assistantPartialMatches = mutableMapOf<String, String>()
     private val assistantExactMatches = mutableMapOf<String, String>()
     private val conditional = mutableMapOf<(String) -> Boolean, String>()
-    private val toolCallExactMatches = mutableMapOf<String, Message.Tool.Call>()
-    private val toolCallPartialMatches = mutableMapOf<String, Message.Tool.Call>()
+    private val toolCallExactMatches = mutableMapOf<String, List<Message.Tool.Call>>()
+    private val toolCallPartialMatches = mutableMapOf<String, List<Message.Tool.Call>>()
     private var defaultResponse: String = ""
     private var toolRegistry: ToolRegistry? = null
     private var toolActions: MutableList<ToolCondition<*, *>> = mutableListOf()
@@ -133,12 +133,12 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      */
     public fun <Args : ToolArgs> addLLMAnswerExactPattern(pattern: String, tool: Tool<Args, *>, args: Args) {
         toolCallExactMatches[pattern] = tool.encodeArgsToString(args).let { toolContent ->
-            Message.Tool.Call(
+            listOf(Message.Tool.Call(
                 id = null,
                 tool = tool.name,
                 content = toolContent,
                 metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(toolContent))
-            )
+            ))
         }
     }
 
@@ -151,12 +151,51 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      */
     public fun <Args : ToolArgs> addLLMAnswerPartialPattern(pattern: String, tool: Tool<Args, *>, args: Args) {
         toolCallPartialMatches[pattern] = tool.encodeArgsToString(args).let { toolContent ->
-            Message.Tool.Call(
+            listOf(Message.Tool.Call(
                 id = null,
                 tool = tool.name,
                 content = toolContent,
                 metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(toolContent))
-            )
+            ))
+        }
+    }
+
+    /**
+     * Adds a partial pattern match for an LLM answer that triggers a tool call.
+     *
+     * @param pattern The exact input string to match
+     * @param tool The tool to be called when the input matches
+     * @param args The arguments to pass to the tool
+     */
+    public fun <Args : ToolArgs> addLLMAnswerPartialPattern(pattern: String, toolCalls: List<Pair<Tool<Args, *>, Args>>) {
+        toolCallPartialMatches[pattern] = toolCalls.map { (tool, args) ->
+            tool.encodeArgsToString(args).let { toolContent ->
+                Message.Tool.Call(
+                    id = null,
+                    tool = tool.name,
+                    content = toolContent,
+                    metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(toolContent))
+                )
+            }
+        }
+    }
+
+    /**
+     * Adds an exact pattern match for an LLM answer that triggers a set of tool calls.
+     *
+     * @param pattern The exact input string to match
+     * @param toolCalls Tool calls with args
+     */
+    public fun <Args : ToolArgs> addLLMAnswerExactPattern(pattern: String, toolCalls: List<Pair<Tool<Args, *>, Args>>) {
+        toolCallExactMatches[pattern] = toolCalls.map<Pair<Tool<Args, *>, Args>, Message.Tool.Call> { (tool, args) ->
+            tool.encodeArgsToString(args).let { toolContent ->
+                Message.Tool.Call(
+                    id = null,
+                    tool = tool.name,
+                    content = toolContent,
+                    metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(toolContent))
+                )
+            }
         }
     }
 
@@ -185,9 +224,21 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param args The arguments to pass to the tool
      * @return A [ToolCallReceiver] for further configuration
      */
-    public fun <Args : ToolArgs> mockLLMToolCall(tool: Tool<Args, *>, args: Args): ToolCallReceiver<Args> {
-        return ToolCallReceiver(tool, args, this)
-    }
+    public fun <Args : ToolArgs> mockLLMToolCall(tool: Tool<Args, *>, args: Args): ToolCallReceiver<Args> =
+        ToolCallReceiver(tool, args, this)
+
+    /**
+     * Creates a mock for a list of LLM tool calls.
+     *
+     * This method is used to define how the LLM should respond with multiple tool calls
+     * when specific inputs or conditions are encountered during testing.
+     *
+     * @param toolCalls A list of pairs, where each pair consists of a tool and corresponding arguments.
+     *                  These define the mock calls to be returned by the LLM.
+     * @return A [MultiToolCallReceiver] to configure further mock behavior for the provided tool calls.
+     */
+    public fun <Args : ToolArgs> mockLLMToolCall(toolCalls: List<Pair<Tool<Args, *>, Args>>): MultiToolCallReceiver<Args> =
+        MultiToolCallReceiver(toolCalls, this)
 
     /**
      * Creates a mock for a tool.
@@ -274,6 +325,43 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
          */
         public infix fun onRequestContains(pattern: String): String {
             builder.addLLMAnswerPartialPattern(pattern, tool, args)
+
+            return pattern
+        }
+    }
+
+    /**
+     * Receiver class for configuring tool call responses from the LLM.
+     * This class is part of the fluent API for configuring how the LLM should respond
+     * with tool calls when it receives specific inputs.
+     */
+    public class MultiToolCallReceiver<Args : ToolArgs>(
+        private val toolCalls: List<Pair<Tool<Args, *>, Args>>,
+        private val builder: MockLLMBuilder
+    ) {
+        /**
+         * Configures the LLM to respond with a tool call when the user request exactly matches the specified pattern.
+         *
+         * @param pattern The exact string to match in the user request
+         * @return The [pattern] string for method chaining
+         */
+        public infix fun onRequestEquals(pattern: String): String {
+            // Using the llmAnswer directly as the response, which should contain the tool call JSON
+            builder.addLLMAnswerExactPattern(pattern, toolCalls)
+
+            // Return the llmAnswer as is, which should be a valid tool call JSON
+            return pattern
+        }
+
+        /**
+         * Configures the system to partially match user requests containing the specified pattern.
+         * If the pattern is found within a user request, the associated tool call response will be triggered.
+         *
+         * @param pattern The substring pattern to match within user requests.
+         * @return The [pattern] string for method chaining
+         */
+        public infix fun onRequestContains(pattern: String): String {
+            builder.addLLMAnswerPartialPattern(pattern, toolCalls)
 
             return pattern
         }
@@ -407,17 +495,17 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
     public fun build(): PromptExecutor {
         val combinedExactMatches = assistantExactMatches.mapValues {
             val text = it.value.trimIndent()
-            Message.Assistant(
+            listOf(Message.Assistant(
                 content = text,
                 metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(text))
-            )
+            ))
         } + toolCallExactMatches
         val combinedPartialMatches = assistantPartialMatches.mapValues {
             val text = it.value.trimIndent()
-            Message.Assistant(
+            listOf(Message.Assistant(
                 content = text,
                 metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(text))
-            )
+            ))
         } + toolCallPartialMatches
 
         return MockLLMExecutor(

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMBuilder.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMBuilder.kt
@@ -98,6 +98,14 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
     private var toolRegistry: ToolRegistry? = null
     private var toolActions: MutableList<ToolCondition<*, *>> = mutableListOf()
 
+    /**
+     * Determines whether the last message handled in a sequence should focus specifically on
+     * the most recent message categorized as `Message.Assistant` when resolving mock responses.
+     *
+     * Useful in scenarios where the mock response handling involves mixed results
+     * from the LLM, and there is a need to differentiate between handling the general
+     * last message vs the last assistant-specific message.
+     */
     public var handleLastAssistantMessage: Boolean = false
 
     /**
@@ -163,11 +171,11 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
     }
 
     /**
-     * Adds a partial pattern match for an LLM answer that triggers a tool call.
+     * Adds a partial pattern match for an LLM answer that triggers a set of tool calls.
      *
-     * @param pattern The exact input string to match
-     * @param tool The tool to be called when the input matches
-     * @param args The arguments to pass to the tool
+     * @param pattern The substring pattern to partially match in the user request.
+     * @param toolCalls A list of pairs, where each pair consists of a tool and the arguments
+     *                  to pass to the tool. These tool calls will be triggered when the input matches the pattern.
      */
     public fun <Args : ToolArgs> addLLMAnswerPartialPattern(pattern: String, toolCalls: List<Pair<Tool<Args, *>, Args>>) {
         toolCallPartialMatches[pattern] = toolCalls.map { (tool, args) ->

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMExecutor.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMExecutor.kt
@@ -38,8 +38,8 @@ import kotlinx.datetime.Clock
  * @property tokenizer: Tokenizer that will be used to estimate token counts in mock messages
  */
 internal class MockLLMExecutor(
-    private val partialMatches: Map<String, Message.Response>? = null,
-    private val exactMatches: Map<String, Message.Response>? = null,
+    private val partialMatches: Map<String, List<Message.Response>>? = null,
+    private val exactMatches: Map<String, List<Message.Response>>? = null,
     private val conditional: Map<(String) -> Boolean, String>? = null,
     private val defaultResponse: String = "",
     private val toolRegistry: ToolRegistry? = null,
@@ -60,8 +60,7 @@ internal class MockLLMExecutor(
     override suspend fun execute(prompt: Prompt, model: LLModel, tools: List<ToolDescriptor>): List<Message.Response> {
         logger.debug { "Executing prompt with tools: ${tools.map { it.name }}" }
 
-        val response = handlePrompt(prompt)
-        return listOf(response)
+        return handlePrompt(prompt)
     }
 
     /**
@@ -90,13 +89,13 @@ internal class MockLLMExecutor(
      * @param prompt The prompt to handle
      * @return The appropriate response based on the configured matches
      */
-    suspend fun handlePrompt(prompt: Prompt): Message.Response {
+    suspend fun handlePrompt(prompt: Prompt): List<Message.Response> {
         logger.debug { "Handling prompt with messages:" }
         prompt.messages.forEach { logger.debug { "Message content: ${it.content.take(300)}..." } }
 
         val inputTokensCount = tokenizer?.let { prompt.messages.map { it.content }.sumOf(it::countTokens) }
 
-        val lastMessage = prompt.messages.lastOrNull() ?: return Message.Assistant(
+        val lastMessage = prompt.messages.lastOrNull() ?: return listOf(Message.Assistant(
             defaultResponse,
             metaInfo = ResponseMetaInfo.create(
                 clock,
@@ -104,7 +103,7 @@ internal class MockLLMExecutor(
                 inputTokensCount = inputTokensCount,
                 outputTokensCount = tokenizer?.countTokens(defaultResponse),
             )
-        )
+        ))
 
         // Check the exact response match
         val exactMatchedResponse = findExactResponse(lastMessage, exactMatches)
@@ -130,7 +129,7 @@ internal class MockLLMExecutor(
                 logger.debug { "Returning response for conditional match: $response" }
 
                 // Check if LLM messages contain any of the patterns and call the corresponding tool if they do
-                return Message.Assistant(
+                return listOf(Message.Assistant(
                     response,
                     metaInfo = ResponseMetaInfo.create(
                         clock,
@@ -138,12 +137,12 @@ internal class MockLLMExecutor(
                         inputTokensCount = inputTokensCount,
                         outputTokensCount = tokenizer?.countTokens(response)
                     )
-                )
+                ))
             }
         }
 
         // Process the default LLM response
-        return Message.Assistant(
+        return listOf(Message.Assistant(
             defaultResponse,
             metaInfo = ResponseMetaInfo.create(
                 clock,
@@ -151,7 +150,7 @@ internal class MockLLMExecutor(
                 inputTokensCount = inputTokensCount,
                 outputTokensCount = tokenizer?.countTokens(defaultResponse),
             )
-        )
+        ))
     }
 
 
@@ -168,8 +167,8 @@ internal class MockLLMExecutor(
      */
     private fun findPartialResponse(
         message: Message,
-        partialMatches: Map<String, Message.Response>?
-    ): Message.Response? {
+        partialMatches: Map<String, List<Message.Response>>?
+    ): List<Message.Response>? {
         return partialMatches?.entries?.firstNotNullOfOrNull { (pattern, response) ->
             if (message.content.contains(pattern)) {
                 response
@@ -184,7 +183,7 @@ internal class MockLLMExecutor(
      * @param exactMatches Map of patterns to responses for exact matching
      * @return The matching response, or null if no match is found
      */
-    private fun findExactResponse(message: Message, exactMatches: Map<String, Message.Response>?): Message.Response? {
+    private fun findExactResponse(message: Message, exactMatches: Map<String, List<Message.Response>>?): List<Message.Response>? {
         return exactMatches?.entries?.firstNotNullOfOrNull { (pattern, response) ->
             if (message.content == pattern) {
                 response

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMExecutor.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMExecutor.kt
@@ -38,6 +38,7 @@ import kotlinx.datetime.Clock
  * @property tokenizer: Tokenizer that will be used to estimate token counts in mock messages
  */
 internal class MockLLMExecutor(
+    private val handleLastAssistantMessage: Boolean,
     private val partialMatches: Map<String, List<Message.Response>>? = null,
     private val exactMatches: Map<String, List<Message.Response>>? = null,
     private val conditional: Map<(String) -> Boolean, String>? = null,
@@ -77,6 +78,13 @@ internal class MockLLMExecutor(
         return flowOf(response.content)
     }
 
+    private fun getLastMessage(prompt: Prompt): Message? {
+        return if (handleLastAssistantMessage && prompt.messages.any { it is Message.Assistant })
+            prompt.messages.lastOrNull { it is Message.Assistant }
+        else
+            prompt.messages.lastOrNull()
+    }
+
     /**
      * Handles a prompt and returns an appropriate response based on the configured matches.
      *
@@ -95,7 +103,7 @@ internal class MockLLMExecutor(
 
         val inputTokensCount = tokenizer?.let { prompt.messages.map { it.content }.sumOf(it::countTokens) }
 
-        val lastMessage = prompt.messages.lastOrNull() ?: return listOf(Message.Assistant(
+        val lastMessage = getLastMessage(prompt) ?: return listOf(Message.Assistant(
             defaultResponse,
             metaInfo = ResponseMetaInfo.create(
                 clock,
@@ -109,36 +117,20 @@ internal class MockLLMExecutor(
         val exactMatchedResponse = findExactResponse(lastMessage, exactMatches)
         if (exactMatchedResponse != null) {
             logger.debug { "Returning response for exact prompt match: $exactMatchedResponse" }
-
-            // Check if LLM messages contain any of the patterns and call the corresponding tool if they do
-            return exactMatchedResponse
         }
 
         // Check partial response match
-        val partiallyMatchedResponse = findPartialResponse(lastMessage, partialMatches)
-        if (partiallyMatchedResponse != null) {
+        val partiallyMatchedResponse = if (exactMatchedResponse == null) findPartialResponse(lastMessage, partialMatches) ?: listOf() else listOf()
+        if (partiallyMatchedResponse.any()) {
             logger.debug { "Returning response for partial prompt match: $partiallyMatchedResponse" }
-
-            // Check if LLM messages contain any of the patterns and call the corresponding tool if they do
-            return partiallyMatchedResponse
         }
 
         // Check request conditions
-        if (!conditional.isNullOrEmpty()) {
-            conditional.entries.firstOrNull { it.key(lastMessage.content) }?.let { (_, response) ->
-                logger.debug { "Returning response for conditional match: $response" }
+        val conditionals = getConditionalResponse(lastMessage, inputTokensCount) ?: listOf()
 
-                // Check if LLM messages contain any of the patterns and call the corresponding tool if they do
-                return listOf(Message.Assistant(
-                    response,
-                    metaInfo = ResponseMetaInfo.create(
-                        clock,
-                        totalTokensCount = tokenizer?.countTokens(response)?.let { it + inputTokensCount!! },
-                        inputTokensCount = inputTokensCount,
-                        outputTokensCount = tokenizer?.countTokens(response)
-                    )
-                ))
-            }
+        val result = (exactMatchedResponse ?: listOf()) + partiallyMatchedResponse + conditionals
+        if (result.any()) {
+            return result
         }
 
         // Process the default LLM response
@@ -152,6 +144,26 @@ internal class MockLLMExecutor(
             )
         ))
     }
+
+    private fun getConditionalResponse(
+        lastMessage: Message,
+        inputTokensCount: Int?
+    ): List<Message.Response>? = if (!conditional.isNullOrEmpty()) {
+        conditional.entries.firstOrNull { it.key(lastMessage.content) }?.let { (_, response) ->
+            logger.debug { "Returning response for conditional match: $response" }
+            listOf(
+                Message.Assistant(
+                    response,
+                    metaInfo = ResponseMetaInfo.create(
+                        clock,
+                        totalTokensCount = tokenizer?.countTokens(response)?.let { it + inputTokensCount!! },
+                        inputTokensCount = inputTokensCount,
+                        outputTokensCount = tokenizer?.countTokens(response)
+                    )
+                )
+            )
+        }
+    } else emptyList()
 
 
     /*

--- a/agents/agents-test/src/commonTest/kotlin/ai/koog/agents/testing/tools/MockLLMBuilderTests.kt
+++ b/agents/agents-test/src/commonTest/kotlin/ai/koog/agents/testing/tools/MockLLMBuilderTests.kt
@@ -1,0 +1,340 @@
+package ai.koog.agents.testing.tools
+
+import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.core.tools.ToolResult
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.model.PromptExecutorExt.execute
+import ai.koog.prompt.llm.OllamaModels
+import ai.koog.prompt.message.Message
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.serializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@Suppress("USELESS_CAST")
+class MockLLMBuilderTests {
+
+    // Sample tool for testing
+    private object TestTool : Tool<TestTool.Args, ToolResult.Text>() {
+        @Serializable
+        data class Args(val input: String) : ToolArgs
+
+        override val argsSerializer: KSerializer<Args> = serializer()
+
+        override val descriptor: ToolDescriptor = ToolDescriptor(
+            name = "test_tool",
+            description = "A test tool for testing"
+        )
+
+        override suspend fun execute(args: Args): ToolResult.Text {
+            return ToolResult.Text("Executed with: ${args.input}")
+        }
+    }
+
+    @Test
+    fun testBasicMockLLMAnswer() = runTest {
+        // Create a mock executor with a simple response
+        val mockExecutor = getMockExecutor {
+            mockLLMAnswer("Hello, world!") onRequestContains "hello"
+            mockLLMAnswer("Default response").asDefaultResponse
+        }
+
+        // Test that the executor returns the expected response
+        val prompt = prompt("test") {
+            user("Say hello to me")
+        }
+
+        val response = mockExecutor.execute(prompt, OllamaModels.Meta.LLAMA_3_2)
+        assertEquals("Hello, world!", response.content)
+
+        // Test default response
+        val prompt2 = prompt("test2") {
+            user("Something unrelated")
+        }
+
+        val response2 = mockExecutor.execute(prompt2, OllamaModels.Meta.LLAMA_3_2)
+        assertEquals("Default response", response2.content)
+    }
+
+    @Test
+    fun testExactMatchResponse() = runTest {
+        val mockExecutor = getMockExecutor {
+            mockLLMAnswer("Exact match response") onRequestEquals "exact match query"
+            mockLLMAnswer("Default response").asDefaultResponse
+        }
+
+        val prompt = prompt("test-exact") {
+            user("exact match query")
+        }
+
+        val response = mockExecutor.execute(prompt, OllamaModels.Meta.LLAMA_3_2)
+        assertEquals("Exact match response", response.content)
+
+        // Test that partial match doesn't work for exact matching
+        val prompt2 = prompt("test-exact-partial") {
+            user("This contains exact match query somewhere")
+        }
+
+        val response2 = mockExecutor.execute(prompt2, OllamaModels.Meta.LLAMA_3_2)
+        assertEquals("Default response", response2.content)
+    }
+
+    @Test
+    fun testPartialMatchResponse() = runTest {
+        val mockExecutor = getMockExecutor {
+            mockLLMAnswer("Partial match response") onRequestContains "partial match"
+            mockLLMAnswer("Default response").asDefaultResponse
+        }
+
+        // Test that partial match works
+        val prompt = prompt("test-partial") {
+            user("This contains partial match somewhere")
+        }
+
+        val response = mockExecutor.execute(prompt, OllamaModels.Meta.LLAMA_3_2)
+        assertEquals("Partial match response", response.content)
+    }
+
+    @Test
+    fun testConditionalMatchResponse() = runTest {
+        val mockExecutor = getMockExecutor {
+            mockLLMAnswer("Conditional response") onCondition { it.length > 20 }
+            mockLLMAnswer("Default response").asDefaultResponse
+        }
+
+        // Test that conditional match works
+        val prompt = prompt("test-conditional") {
+            user("This is a long message that should match the condition")
+        }
+
+        val response = mockExecutor.execute(prompt, OllamaModels.Meta.LLAMA_3_2)
+        assertEquals("Conditional response", response.content)
+
+        // Test that condition not matching returns default
+        val prompt2 = prompt("test-conditional-short") {
+            user("Short message")
+        }
+
+        val response2 = mockExecutor.execute(prompt2, OllamaModels.Meta.LLAMA_3_2)
+        assertEquals("Default response", response2.content)
+    }
+
+    @Test
+    fun testToolCallMocking() = runTest {
+        val toolRegistry = ToolRegistry {
+            tool(TestTool)
+        }
+
+        val mockExecutor = getMockExecutor(toolRegistry) {
+            mockLLMToolCall(TestTool, TestTool.Args("test input")) onRequestContains "use tool"
+            mockLLMAnswer("Default response").asDefaultResponse
+        }
+
+        val prompt = prompt("test-tool") {
+            user("Please use tool to do something")
+        }
+
+        val response = mockExecutor.execute(prompt, OllamaModels.Meta.LLAMA_3_2)
+        assertTrue(response is Message.Tool.Call)
+        val toolCall = response as Message.Tool.Call
+        assertEquals("test_tool", toolCall.tool)
+    }
+
+    @Test
+    fun testMultipleToolCallsMocking() = runTest {
+        val toolRegistry = ToolRegistry {
+            tool(TestTool)
+        }
+
+        val toolCalls = listOf(
+            TestTool to TestTool.Args("first input"),
+            TestTool to TestTool.Args("second input")
+        )
+
+        val mockExecutor = getMockExecutor(toolRegistry) {
+            mockLLMToolCall(toolCalls) onRequestContains "use multiple tools"
+            mockLLMAnswer("Default response").asDefaultResponse
+        }
+
+        val prompt = prompt("test-multiple-tools") {
+            user("Please use multiple tools to do something")
+        }
+
+        // In this case, we expect a list of responses with tool calls
+        val responses = mockExecutor.execute(prompt, OllamaModels.Meta.LLAMA_3_2, listOf())
+
+        // Verify we have the expected number of tool calls
+        val responseToolCalls = responses.filterIsInstance<Message.Tool.Call>()
+        assertEquals(2, responseToolCalls.size)
+        assertEquals("test_tool", responseToolCalls[0].tool)
+        assertEquals("test_tool", responseToolCalls[1].tool)
+    }
+
+    @Test
+    fun testMixedResponseMocking() = runTest {
+        val toolRegistry = ToolRegistry {
+            tool(TestTool)
+        }
+
+        val mixedToolCalls = listOf(
+            TestTool to TestTool.Args("mixed input")
+        )
+
+        val textResponses = listOf("This is a mixed response with tool calls")
+
+        val mockExecutor = getMockExecutor(toolRegistry) {
+            mockLLMMixedResponse(mixedToolCalls, textResponses) onRequestContains "mixed response"
+            mockLLMAnswer("Default response").asDefaultResponse
+        }
+
+        val prompt = prompt("test-mixed") {
+            user("I need a mixed response with tools")
+        }
+
+        val responses = mockExecutor.execute(prompt, OllamaModels.Meta.LLAMA_3_2, listOf())
+        assertEquals(2, responses.size)
+
+        // Check that we have both text and tool responses
+        assertTrue(responses.any { it is Message.Assistant })
+        assertTrue(responses.any { it is Message.Tool.Call })
+
+        val textResponse = responses.first { it is Message.Assistant } as Message.Assistant
+        assertEquals("This is a mixed response with tool calls", textResponse.content)
+
+        val toolCall = responses.first { it is Message.Tool.Call } as Message.Tool.Call
+        assertEquals("test_tool", toolCall.tool)
+    }
+
+    @Test
+    fun testToolBehaviorMocking() = runTest {
+        val toolRegistry = ToolRegistry {
+            tool(TestTool)
+        }
+
+        val mockExecutor = getMockExecutor(toolRegistry) {
+            // Mock the tool behavior
+            mockTool(TestTool) alwaysReturns ToolResult.Text("Mocked result")
+
+            // Set up a tool call that will use the mocked tool
+            mockLLMToolCall(TestTool, TestTool.Args("test input")) onRequestContains "use tool"
+        }
+
+        val prompt = prompt("test-tool-behavior") {
+            user("Please use tool to do something")
+        }
+
+        // Execute the prompt to get a tool call
+        val response = mockExecutor.execute(prompt, OllamaModels.Meta.LLAMA_3_2)
+        assertTrue(response is Message.Tool.Call)
+
+        // Now simulate executing the tool
+        val toolCall = response as Message.Tool.Call
+
+        // Find the tool condition that matches this call
+        val toolCondition = (mockExecutor as MockLLMExecutor).toolActions.firstOrNull { 
+            it.tool.name == toolCall.tool 
+        }
+
+        assertNotNull(toolCondition)
+
+        // Execute the tool and check the result
+        val result = toolCondition.invoke(toolCall)
+        assertTrue(result is ToolResult.Text)
+        assertEquals("Mocked result", (result as ToolResult.Text).text)
+    }
+
+    @Test
+    fun testToolBehaviorWithCondition() = runTest {
+        val toolRegistry = ToolRegistry {
+            tool(TestTool)
+        }
+
+        val mockExecutor = getMockExecutor(toolRegistry) {
+            // Mock the tool behavior with a condition
+            mockTool(TestTool).returns(ToolResult.Text("Specific result")).onArguments(TestTool.Args("specific input"))
+            mockTool(TestTool) alwaysReturns ToolResult.Text("Default result")
+
+            // Set up tool calls
+            mockLLMToolCall(TestTool, TestTool.Args("specific input")) onRequestContains "specific"
+            mockLLMToolCall(TestTool, TestTool.Args("other input")) onRequestContains "other"
+        }
+
+        // Test the specific input
+        val specificPrompt = prompt("test-specific") {
+            user("Please use tool with specific input")
+        }
+
+        val specificResponse = mockExecutor.execute(specificPrompt, OllamaModels.Meta.LLAMA_3_2)
+        assertTrue(specificResponse is Message.Tool.Call)
+
+        val specificToolCall = specificResponse as Message.Tool.Call
+        val specificToolCondition = (mockExecutor as MockLLMExecutor).toolActions.first { 
+            it.satisfies(specificToolCall)
+        }
+
+        val specificResult = specificToolCondition.invoke(specificToolCall)
+        assertTrue(specificResult is ToolResult.Text)
+        assertEquals("Specific result", (specificResult as ToolResult.Text).text)
+
+        // Test the default behavior
+        val otherPrompt = prompt("test-other") {
+            user("Please use tool with other input")
+        }
+
+        val otherResponse = mockExecutor.execute(otherPrompt, OllamaModels.Meta.LLAMA_3_2)
+        assertTrue(otherResponse is Message.Tool.Call)
+
+        val otherToolCall = otherResponse as Message.Tool.Call
+        val otherToolCondition = (mockExecutor as MockLLMExecutor).toolActions.first { 
+            it.satisfies(otherToolCall)
+        }
+
+        val otherResult = otherToolCondition.invoke(otherToolCall)
+        assertTrue(otherResult is ToolResult.Text)
+        assertEquals("Default result", (otherResult as ToolResult.Text).text)
+    }
+
+    @Test
+    fun testToolBehaviorWithCustomAction() = runTest {
+        val toolRegistry = ToolRegistry {
+            tool(TestTool)
+        }
+
+        var actionCalled = false
+
+        val mockExecutor = getMockExecutor(toolRegistry) {
+            // Mock the tool behavior with a custom action
+            mockTool(TestTool) alwaysDoes {
+                actionCalled = true
+                ToolResult.Text("Custom action result")
+            }
+
+            // Set up a tool call
+            mockLLMToolCall(TestTool, TestTool.Args("test input")) onRequestContains "use tool"
+        }
+
+        val prompt = prompt("test-custom-action") {
+            user("Please use tool to do something")
+        }
+
+        val response = mockExecutor.execute(prompt, OllamaModels.Meta.LLAMA_3_2)
+        assertTrue(response is Message.Tool.Call)
+
+        val toolCall = response
+        val toolCondition = (mockExecutor as MockLLMExecutor).toolActions.first { 
+            it.satisfies(toolCall)
+        }
+
+        val result = toolCondition.invoke(toolCall)
+        assertTrue(actionCalled)
+        assertTrue(result is ToolResult.Text)
+        assertEquals("Custom action result", (result as ToolResult.Text).text)
+    }
+}

--- a/agents/agents-test/src/jvmTest/kotlin/ai/koog/agents/test/SimpleAgentMockedTest.kt
+++ b/agents/agents-test/src/jvmTest/kotlin/ai/koog/agents/test/SimpleAgentMockedTest.kt
@@ -295,7 +295,7 @@ class SimpleAgentMockedTest {
             llmModel = OpenAIModels.Reasoning.GPT4oMini,
             temperature = 1.0,
             toolRegistry = toolRegistry,
-            maxIterations = 3,
+            maxIterations = 2,
             executor = loopExecutor,
             installFeatures = { install(EventHandler, eventHandlerConfig) }
         )

--- a/examples/src/main/kotlin/ai/koog/agents/example/calculator/OllamaCalculatorExample.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/calculator/OllamaCalculatorExample.kt
@@ -2,6 +2,7 @@ package ai.koog.agents.example.calculator
 
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.agent.singleRunStrategy
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolRegistry
@@ -13,6 +14,7 @@ import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.OllamaModels
+import ai.koog.prompt.params.LLMParams
 import kotlinx.coroutines.runBlocking
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -31,7 +33,7 @@ fun main(): Unit = runBlocking {
 
     // Create agent config with proper prompt
     val agentConfig = AIAgentConfig(
-        prompt = prompt("test") {
+        prompt = prompt("test", LLMParams(temperature = 0.0)) {
             system("You are a calculator.")
         },
         model = OllamaModels.Meta.LLAMA_3_2,
@@ -40,7 +42,7 @@ fun main(): Unit = runBlocking {
 
     val agent = AIAgent(
         promptExecutor = executor,
-        strategy = CalculatorStrategy.strategy,
+        strategy = singleRunStrategy(),
         agentConfig = agentConfig,
         toolRegistry = toolRegistry
     ) {
@@ -60,6 +62,6 @@ fun main(): Unit = runBlocking {
     }
 
     runBlocking {
-        agent.run("(10 + 20) * (5 + 5) / (2 - 11)")
+        agent.run("Use provided tools to calculate (10 + 20) * (5 + 5) / (2 - 11). Please call all the tools at once")
     }
 }

--- a/examples/src/main/kotlin/ai/koog/agents/example/calculator/OllamaCalculatorExample.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/calculator/OllamaCalculatorExample.kt
@@ -42,7 +42,7 @@ fun main(): Unit = runBlocking {
 
     val agent = AIAgent(
         promptExecutor = executor,
-        strategy = singleRunStrategy(),
+        strategy = CalculatorStrategy.strategy,
         agentConfig = agentConfig,
         toolRegistry = toolRegistry
     ) {

--- a/examples/src/main/kotlin/ai/koog/agents/example/calculator/OllamaCalculatorExample.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/calculator/OllamaCalculatorExample.kt
@@ -2,7 +2,6 @@ package ai.koog.agents.example.calculator
 
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
-import ai.koog.agents.core.agent.singleRunStrategy
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolRegistry


### PR DESCRIPTION
Modified singleRunStrategy in order to support parallel tools calls.
Also introduced node that calls tools and sends results to back to LLM.
To test it I modified MockLLMExecutor a little bit to support mocking multiresponses.

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
