### PR TITLE
[agents] Support custom LLModel and LLMParams in subgraphs, make nodeUpdatePrompt a pass-through node

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentContext.kt
@@ -171,7 +171,7 @@ public class AIAgentContext(
      * This method is used to update the current context with values from another context,
      * particularly useful in scenarios like parallel node execution where contexts need to be merged.
      *
-     * @param context The context to replace the current context with.]]
+     * @param context The context to replace the current context with.
      */
     override suspend fun replace(context: AIAgentContextBase) {
         mutableAIAgentContext.replace(

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentContext.kt
@@ -8,7 +8,6 @@ import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.environment.AIAgentEnvironment
 import ai.koog.agents.core.feature.AIAgentFeature
 import ai.koog.agents.core.feature.AIAgentPipeline
-import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.utils.RWLock
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -123,18 +122,6 @@ public class AIAgentContext(
     override fun <Feature : Any> feature(feature: AIAgentFeature<*, Feature>): Feature? = feature(feature.key)
 
     /**
-     * Creates a new instance of [AIAgentContextBase] with an updated list of tools, replacing the current tools
-     * in the LLM context with the provided list.
-     *
-     * @param tools The new list of tools to be used in the LLM context, represented as [ToolDescriptor] objects.
-     * @return A new instance of [AIAgentContextBase] with the updated tools configuration.
-     */
-    @InternalAgentsApi
-    override fun copyWithTools(tools: List<ToolDescriptor>): AIAgentContextBase {
-        return this.copy(llm = llm.copy(tools = tools))
-    }
-
-    /**
      * Creates a copy of the current [AIAgentContext], allowing for selective overriding of its properties.
      *
      * @param environment The [AIAgentEnvironment] to be used in the new context, or `null` to retain the current one.
@@ -147,25 +134,25 @@ public class AIAgentContext(
      * @param pipeline The [AIAgentPipeline] to be used, or `null` to retain the current pipeline.
      */
     override fun copy(
-        environment: AIAgentEnvironment?,
-        agentInput: String?,
-        config: AIAgentConfigBase?,
-        llm: AIAgentLLMContext?,
-        stateManager: AIAgentStateManager?,
-        storage: AIAgentStorage?,
-        sessionUuid: Uuid?,
-        strategyId: String?,
-        pipeline: AIAgentPipeline?,
+        environment: AIAgentEnvironment,
+        agentInput: String,
+        config: AIAgentConfigBase,
+        llm: AIAgentLLMContext,
+        stateManager: AIAgentStateManager,
+        storage: AIAgentStorage,
+        sessionUuid: Uuid,
+        strategyId: String,
+        pipeline: AIAgentPipeline,
     ): AIAgentContextBase = AIAgentContext(
-        environment = environment ?: this.environment,
-        agentInput = agentInput ?: this.agentInput,
-        config = config ?: this.config,
-        llm = llm ?: this.llm,
-        stateManager = stateManager ?: this.stateManager,
-        storage = storage ?: this.storage,
-        sessionUuid = sessionUuid ?: this.sessionUuid,
-        strategyId = strategyId ?: this.strategyId,
-        pipeline = pipeline ?: @OptIn(InternalAgentsApi::class) this.pipeline,
+        environment = environment,
+        agentInput = agentInput,
+        config = config,
+        llm = llm,
+        stateManager = stateManager,
+        storage = storage,
+        sessionUuid = sessionUuid,
+        strategyId = strategyId,
+        pipeline = pipeline,
     )
 
     /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentContextBase.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentContextBase.kt
@@ -142,43 +142,30 @@ public interface AIAgentContextBase {
             ?: throw IllegalStateException("Feature `${feature::class.simpleName}` is not installed to the agent")
 
     /**
-     * Creates a new instance of [AIAgentContext] with updated tools, while preserving the other properties
-     * of the original context.
-     *
-     * @param tools The new list of [ToolDescriptor] instances to be set in the context.
-     * @return A new [AIAgentContext] instance with the specified tools.
-     *
-     * @suppress
-     */
-    @InternalAgentsApi
-    public fun copyWithTools(tools: List<ToolDescriptor>): AIAgentContextBase {
-        return this.copy(llm = llm.copy(tools = tools))
-    }
-
-    /**
      * Creates a copy of the current [AIAgentContext] with optional overrides for its properties.
      *
-     * @param environment The agent environment to be used, or null to retain the current environment.
-     * @param agentInput The agent input to be used, or null to retain the current input.
-     * @param config The AI agent configuration, or null to retain the current configuration.
-     * @param llm The AI agent LLM context, or null to retain the current LLM context.
-     * @param stateManager The state manager for the AI agent, or null to retain the current state manager.
-     * @param storage The AI agent's key-value storage, or null to retain the current storage.
-     * @param sessionUuid The UUID of the session, or null to retain the current session UUID.
-     * @param strategyId The strategy ID, or null to retain the current strategy ID.
-     * @param pipeline The AI agent pipeline, or null to retain the current pipeline.
+     * @param environment The agent environment to be used
+     * @param agentInput The agent input to be used
+     * @param config The AI agent configuration
+     * @param llm The AI agent LLM context
+     * @param stateManager The state manager for the AI agent
+     * @param storage The AI agent's key-value storage
+     * @param sessionUuid The UUID of the session
+     * @param strategyId The strategy ID
+     * @param pipeline The AI agent pipeline
      * @return A new instance of [AIAgentContext] with the specified overrides.
      */
+    @OptIn(InternalAgentsApi::class)
     public fun copy(
-        environment: AIAgentEnvironment? = null,
-        agentInput: String? = null,
-        config: AIAgentConfigBase? = null,
-        llm: AIAgentLLMContext? = null,
-        stateManager: AIAgentStateManager? = null,
-        storage: AIAgentStorage? = null,
-        sessionUuid: Uuid? = null,
-        strategyId: String? = null,
-        pipeline: AIAgentPipeline? = null,
+        environment: AIAgentEnvironment = this.environment,
+        agentInput: String = this.agentInput,
+        config: AIAgentConfigBase = this.config,
+        llm: AIAgentLLMContext = this.llm,
+        stateManager: AIAgentStateManager = this.stateManager,
+        storage: AIAgentStorage = this.storage,
+        sessionUuid: Uuid = this.sessionUuid,
+        strategyId: String = this.strategyId,
+        pipeline: AIAgentPipeline = this.pipeline,
     ): AIAgentContextBase
 
     /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
@@ -25,35 +25,50 @@ import kotlinx.datetime.Clock
  * @property environment The environment that manages tool execution and interaction with external dependencies.
  * @property clock The clock used for timestamps of messages
  */
-public data class AIAgentLLMContext(
-    internal var tools: List<ToolDescriptor>,
-    val toolRegistry: ToolRegistry = ToolRegistry.Companion.EMPTY,
-    private var prompt: Prompt,
-    private var model: LLModel,
+public class AIAgentLLMContext(
+    tools: List<ToolDescriptor>,
+    public val toolRegistry: ToolRegistry = ToolRegistry.Companion.EMPTY,
+    prompt: Prompt,
+    model: LLModel,
     internal val promptExecutor: PromptExecutor,
     private val environment: AIAgentEnvironment,
     private val config: AIAgentConfigBase,
     private val clock: Clock
 ) {
+    internal var tools: List<ToolDescriptor> = tools
+        private set
+
+    internal var prompt: Prompt = prompt
+        private set
+
+    internal var model: LLModel = model
+        private set
 
     /**
      * Creates a deep copy of this LLM context.
      *
      * @return A new instance of [AIAgentLLMContext] with deep copies of mutable properties.
      */
-    public suspend fun copy(): AIAgentLLMContext {
-        return rwLock.withReadLock {
-            AIAgentLLMContext(
-                tools.toList(),
-                toolRegistry,
-                prompt.copy(),
-                model.copy(),
-                promptExecutor,
-                environment,
-                config,
-                clock
-            )
-        }
+    public suspend fun copy(
+        tools: List<ToolDescriptor> = this.tools,
+        toolRegistry: ToolRegistry = this.toolRegistry,
+        prompt: Prompt = this.prompt,
+        model: LLModel = this.model,
+        promptExecutor: PromptExecutor = this.promptExecutor,
+        environment: AIAgentEnvironment = this.environment,
+        config: AIAgentConfigBase = this.config,
+        clock: Clock = this.clock,
+    ): AIAgentLLMContext = rwLock.withReadLock {
+        AIAgentLLMContext(
+            tools = tools,
+            toolRegistry = toolRegistry,
+            prompt = prompt,
+            model = model,
+            promptExecutor = promptExecutor,
+            environment = environment,
+            config = config,
+            clock = clock
+        )
     }
 
     private val rwLock = RWLock()

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentSubgraph.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentSubgraph.kt
@@ -8,6 +8,8 @@ import ai.koog.agents.core.dsl.extension.replaceHistoryWithTLDR
 import ai.koog.agents.core.prompt.Prompts.selectRelevantTools
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.structure.json.JsonSchemaGenerator
 import ai.koog.prompt.structure.json.JsonStructuredData
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -25,12 +27,16 @@ import kotlin.uuid.ExperimentalUuidApi
  * @param start The starting node of the subgraph, which initiates the processing.
  * @param finish The finishing node of the subgraph, which concludes the processing.
  * @param toolSelectionStrategy Strategy determining which tools should be available during this subgraph's execution.
+ * @param llmModel Optional [LLModel] override for the subgraph execution.
+ * @param llmParams Optional [LLMParams] override for the prompt for the subgraph execution.
  */
 public open class AIAgentSubgraph<Input, Output>(
     override val name: String,
     public val start: AIAgentStartNodeBase<Input>,
     public val finish: AIAgentFinishNodeBase<Output>,
     private val toolSelectionStrategy: ToolSelectionStrategy,
+    private val llmModel: LLModel? = null,
+    private val llmParams: LLMParams? = null,
 ) : AIAgentNodeBase<Input, Output>() {
     private companion object {
         private val logger = KotlinLogging.logger("ai.koog.agents.core.agent.entity.${AIAgentSubgraph::class.simpleName}")
@@ -52,45 +58,60 @@ public open class AIAgentSubgraph<Input, Output>(
      */
     @OptIn(InternalAgentsApi::class, ExperimentalUuidApi::class)
     override suspend fun execute(context: AIAgentContextBase, input: Input): Output {
-        val innerContext = when (toolSelectionStrategy) {
-            ToolSelectionStrategy.ALL -> context
-            ToolSelectionStrategy.NONE -> context.copy(llm = context.llm.copy(tools = emptyList()))
-            is ToolSelectionStrategy.Tools -> context.copy(llm = context.llm.copy(tools = toolSelectionStrategy.tools))
-            is ToolSelectionStrategy.AutoSelectForTask -> {
-                val newTools = context.llm.writeSession {
-                    val initialPrompt = prompt
+        val newTools = when (toolSelectionStrategy) {
+            ToolSelectionStrategy.ALL -> context.llm.tools
 
-                    replaceHistoryWithTLDR()
-                    updatePrompt {
-                        user {
-                            selectRelevantTools(tools, toolSelectionStrategy.subtaskDescription)
-                        }
+            ToolSelectionStrategy.NONE -> emptyList()
+
+            is ToolSelectionStrategy.Tools -> toolSelectionStrategy.tools
+
+            is ToolSelectionStrategy.AutoSelectForTask -> context.llm.writeSession {
+                val initialPrompt = prompt
+
+                replaceHistoryWithTLDR()
+
+                updatePrompt {
+                    user {
+                        selectRelevantTools(tools, toolSelectionStrategy.subtaskDescription)
                     }
-
-                    val selectedTools = this.requestLLMStructured(
-                        structure = JsonStructuredData.createJsonStructure<SelectedTools>(
-                            schemaFormat = JsonSchemaGenerator.SchemaFormat.JsonSchema,
-                            examples = listOf(SelectedTools(listOf()), SelectedTools(tools.map { it.name }.take(3))),
-                        ),
-                        retries = toolSelectionStrategy.maxRetries,
-                    ).getOrThrow()
-
-                    rewritePrompt { initialPrompt }
-
-                    tools.filter { it.name in selectedTools.structure.tools.toSet() }
                 }
-                context.copy(llm = context.llm.copy(tools = newTools))
+
+                val selectedTools = this.requestLLMStructured(
+                    structure = JsonStructuredData.createJsonStructure<SelectedTools>(
+                        schemaFormat = JsonSchemaGenerator.SchemaFormat.JsonSchema,
+                        examples = listOf(SelectedTools(listOf()), SelectedTools(tools.map { it.name }.take(3))),
+                    ),
+                    retries = toolSelectionStrategy.maxRetries,
+                ).getOrThrow()
+
+                prompt = initialPrompt
+
+                tools.filter { it.name in selectedTools.structure.tools.toSet() }
             }
         }
 
-        val subgraphResult = doExecute(innerContext, input)
-        val newPrompt = innerContext.llm.readSession { prompt }
-        context.llm.writeSession {
-            rewritePrompt {
-                newPrompt
-            }
+        // Copy inner context with new tools, model and LLM params
+        val innerContext = with(context) {
+            copy(
+                llm = llm.copy(
+                    tools = newTools,
+                    model = llmModel ?: llm.model,
+                    prompt = llm.prompt.copy(params = llmParams ?: llm.prompt.params)
+                )
+            )
         }
-        return subgraphResult
+
+        /*
+         Execute subgraph with inner context and get result and updated prompt.
+         Restore original LLM params on the new prompt.
+        */
+        val result = doExecute(innerContext, input)
+        val newPrompt = innerContext.llm.readSession { prompt.copy(params = context.llm.prompt.params) }
+
+        // Update outer context with new prompt
+        context.llm.writeSession { prompt = newPrompt }
+
+        return result
     }
 
     @OptIn(InternalAgentsApi::class)

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentSubgraph.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentSubgraph.kt
@@ -36,6 +36,12 @@ public open class AIAgentSubgraph<Input, Output>(
         private val logger = KotlinLogging.logger("ai.koog.agents.core.agent.entity.${AIAgentSubgraph::class.simpleName}")
     }
 
+    @Serializable
+    private data class SelectedTools(
+        @property:LLMDescription("List of selected tools for the given subtask")
+        val tools: List<String>
+    )
+
     /**
      * Executes the desired operation based on the input and the provided context.
      * This function determines the execution strategy based on the tool selection strategy configured in the class.
@@ -44,15 +50,48 @@ public open class AIAgentSubgraph<Input, Output>(
      * @param input The input object representing the data to be processed by the AI agent.
      * @return The output of the AI agent execution, generated after processing the input.
      */
+    @OptIn(InternalAgentsApi::class, ExperimentalUuidApi::class)
     override suspend fun execute(context: AIAgentContextBase, input: Input): Output {
-        if (toolSelectionStrategy == ToolSelectionStrategy.ALL) return doExecute(context, input)
+        val innerContext = when (toolSelectionStrategy) {
+            ToolSelectionStrategy.ALL -> context
+            ToolSelectionStrategy.NONE -> context.copy(llm = context.llm.copy(tools = emptyList()))
+            is ToolSelectionStrategy.Tools -> context.copy(llm = context.llm.copy(tools = toolSelectionStrategy.tools))
+            is ToolSelectionStrategy.AutoSelectForTask -> {
+                val newTools = context.llm.writeSession {
+                    val initialPrompt = prompt
 
-        return doExecuteWithCustomTools(context, input)
+                    replaceHistoryWithTLDR()
+                    updatePrompt {
+                        user {
+                            selectRelevantTools(tools, toolSelectionStrategy.subtaskDescription)
+                        }
+                    }
+
+                    val selectedTools = this.requestLLMStructured(
+                        structure = JsonStructuredData.createJsonStructure<SelectedTools>(
+                            schemaFormat = JsonSchemaGenerator.SchemaFormat.JsonSchema,
+                            examples = listOf(SelectedTools(listOf()), SelectedTools(tools.map { it.name }.take(3))),
+                        ),
+                        retries = toolSelectionStrategy.maxRetries,
+                    ).getOrThrow()
+
+                    rewritePrompt { initialPrompt }
+
+                    tools.filter { it.name in selectedTools.structure.tools.toSet() }
+                }
+                context.copy(llm = context.llm.copy(tools = newTools))
+            }
+        }
+
+        val subgraphResult = doExecute(innerContext, input)
+        val newPrompt = innerContext.llm.readSession { prompt }
+        context.llm.writeSession {
+            rewritePrompt {
+                newPrompt
+            }
+        }
+        return subgraphResult
     }
-
-    @OptIn(ExperimentalUuidApi::class)
-    private fun formatLog(context: AIAgentContextBase, message: String): String =
-        "$message [$name, ${context.strategyId}, ${context.sessionUuid}]"
 
     @OptIn(InternalAgentsApi::class)
     protected suspend fun doExecute(context: AIAgentContextBase, initialInput: Input): Output {
@@ -103,54 +142,9 @@ public open class AIAgentSubgraph<Input, Output>(
         }
     }
 
-    @Serializable
-    private data class SelectedTools(
-        @property:LLMDescription("List of selected tools for the given subtask")
-        val tools: List<String>
-    )
-
-    private suspend fun doExecuteWithCustomTools(context: AIAgentContextBase, input: Input): Output {
-        @OptIn(InternalAgentsApi::class)
-        val innerContext = when (toolSelectionStrategy) {
-            ToolSelectionStrategy.ALL -> context
-            ToolSelectionStrategy.NONE -> context.copyWithTools(emptyList())
-            is ToolSelectionStrategy.Tools -> context.copyWithTools(toolSelectionStrategy.tools)
-            is ToolSelectionStrategy.AutoSelectForTask -> {
-                val newTools = context.llm.writeSession {
-                    val initialPrompt = prompt
-
-                    replaceHistoryWithTLDR()
-                    updatePrompt {
-                        user {
-                            selectRelevantTools(tools, toolSelectionStrategy.subtaskDescription)
-                        }
-                    }
-
-                    val selectedTools = this.requestLLMStructured(
-                        structure = JsonStructuredData.createJsonStructure<SelectedTools>(
-                            schemaFormat = JsonSchemaGenerator.SchemaFormat.JsonSchema,
-                            examples = listOf(SelectedTools(listOf()), SelectedTools(tools.map { it.name }.take(3))),
-                        ),
-                        retries = toolSelectionStrategy.maxRetries,
-                    ).getOrThrow()
-
-                    rewritePrompt { initialPrompt }
-
-                    tools.filter { it.name in selectedTools.structure.tools.toSet() }
-                }
-                context.copyWithTools(newTools)
-            }
-        }
-
-        val subgraphResult = doExecute(innerContext, input)
-        val newPrompt = innerContext.llm.readSession { prompt }
-        context.llm.writeSession {
-            rewritePrompt {
-                newPrompt
-            }
-        }
-        return subgraphResult
-    }
+    @OptIn(ExperimentalUuidApi::class)
+    private fun formatLog(context: AIAgentContextBase, message: String): String =
+        "$message [$name, ${context.strategyId}, ${context.sessionUuid}]"
 }
 
 /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/builder/AIAgentParallelNodesMergeContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/builder/AIAgentParallelNodesMergeContext.kt
@@ -10,7 +10,6 @@ import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.environment.AIAgentEnvironment
 import ai.koog.agents.core.feature.AIAgentFeature
 import ai.koog.agents.core.feature.AIAgentPipeline
-import ai.koog.agents.core.tools.ToolDescriptor
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -51,22 +50,26 @@ public class AIAgentParallelNodesMergeContext<Input, Output>(
     override fun <Feature : Any> featureOrThrow(feature: AIAgentFeature<*, Feature>): Feature =
         underlyingContextBase.featureOrThrow(feature)
 
-    override fun copyWithTools(tools: List<ToolDescriptor>): AIAgentContextBase =
-        underlyingContextBase.copyWithTools(tools)
-
     override fun copy(
-        environment: AIAgentEnvironment?,
-        agentInput: String?,
-        config: AIAgentConfigBase?,
-        llm: AIAgentLLMContext?,
-        stateManager: AIAgentStateManager?,
-        storage: AIAgentStorage?,
-        sessionUuid: Uuid?,
-        strategyId: String?,
-        pipeline: AIAgentPipeline?
+        environment: AIAgentEnvironment,
+        agentInput: String,
+        config: AIAgentConfigBase,
+        llm: AIAgentLLMContext,
+        stateManager: AIAgentStateManager,
+        storage: AIAgentStorage,
+        sessionUuid: Uuid,
+        strategyId: String,
+        pipeline: AIAgentPipeline
     ): AIAgentContextBase = underlyingContextBase.copy(
-        environment, agentInput, config, llm, stateManager,
-        storage, sessionUuid, strategyId, pipeline
+        environment = environment,
+        agentInput = agentInput,
+        config = config,
+        llm = llm,
+        stateManager = stateManager,
+        storage = storage,
+        sessionUuid = sessionUuid,
+        strategyId = strategyId,
+        pipeline = pipeline
     )
 
     override suspend fun fork(): AIAgentContextBase = underlyingContextBase.fork()

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
@@ -32,20 +32,23 @@ public fun <T> AIAgentSubgraphBuilderBase<*, *>.nodeDoNothing(name: String? = nu
 
 /**
  * A node that adds messages to the LLM prompt using the provided prompt builder.
+ * The input is passed as it is to the output.
  *
  * @param name Optional node name, defaults to delegate's property name.
  * @param body Lambda to modify the prompt using PromptBuilder.
  */
-public fun AIAgentSubgraphBuilderBase<*, *>.nodeUpdatePrompt(
+public fun <T> AIAgentSubgraphBuilderBase<*, *>.nodeUpdatePrompt(
     name: String? = null,
     body: PromptBuilder.() -> Unit
-): AIAgentNodeDelegateBase<Unit, Unit> =
-    node(name) {
+): AIAgentNodeDelegateBase<T, T> =
+    node(name) { input ->
         llm.writeSession {
             updatePrompt {
                 body()
             }
         }
+
+        input
     }
 
 /**

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/feature/AIAgentPipelineTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/feature/AIAgentPipelineTest.kt
@@ -229,6 +229,7 @@ class AIAgentPipelineTest {
         val actualEvents = interceptedEvents.filter { it.startsWith("Agent Context: ") }
         val expectedEvents = listOf(
             "Agent Context: request features from agent context",
+            "Agent Context: request features from agent context",
         )
 
         assertEquals(

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/feature/TestingFeature.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/feature/TestingFeature.kt
@@ -4,10 +4,12 @@ package ai.koog.agents.testing.feature
 
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.AIAgent.FeatureContext
+import ai.koog.agents.core.agent.config.AIAgentConfigBase
 import ai.koog.agents.core.agent.context.AIAgentContextBase
 import ai.koog.agents.core.agent.context.AIAgentLLMContext
 import ai.koog.agents.core.agent.entity.*
 import ai.koog.agents.core.annotation.InternalAgentsApi
+import ai.koog.agents.core.environment.AIAgentEnvironment
 import ai.koog.agents.core.environment.ReceivedToolResult
 import ai.koog.agents.core.feature.AIAgentFeature
 import ai.koog.agents.core.feature.AIAgentPipeline
@@ -28,6 +30,7 @@ import ai.koog.prompt.tokenizer.Tokenizer
 import kotlinx.datetime.Clock
 import org.jetbrains.annotations.TestOnly
 import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 
 /**
@@ -733,7 +736,16 @@ public class Testing {
                  * @return a new NodeOutputAssertionsBuilder that contains a copy of the current stageBuilder
                  * and a copied context.
                  */
-                override fun copy(): NodeOutputAssertionsBuilder =
+                override fun copy(
+                    environment: AIAgentEnvironment?,
+                    agentInput: String?,
+                    config: AIAgentConfigBase?,
+                    llm: AIAgentLLMContext?,
+                    stateManager: AIAgentStateManager?,
+                    storage: AIAgentStorage?,
+                    sessionUuid: Uuid?,
+                    strategyId: String?,
+                ): NodeOutputAssertionsBuilder =
                     NodeOutputAssertionsBuilder(stageBuilder, context.copy())
 
                 /**
@@ -831,7 +843,16 @@ public class Testing {
                  *
                  * @return A new EdgeAssertionsBuilder instance with the same stageBuilder and a copied context.
                  */
-                override fun copy(): EdgeAssertionsBuilder = EdgeAssertionsBuilder(stageBuilder, context.copy())
+                override fun copy(
+                    environment: AIAgentEnvironment?,
+                    agentInput: String?,
+                    config: AIAgentConfigBase?,
+                    llm: AIAgentLLMContext?,
+                    stateManager: AIAgentStateManager?,
+                    storage: AIAgentStorage?,
+                    sessionUuid: Uuid?,
+                    strategyId: String?,
+                ): EdgeAssertionsBuilder = EdgeAssertionsBuilder(stageBuilder, context.copy())
 
                 /**
                  * Executes a given block of logic within the context of a copied instance of the current `EdgeAssertionsBuilder`.

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/DummyAIAgentContext.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/DummyAIAgentContext.kt
@@ -92,26 +92,26 @@ public class DummyAIAgentContext(
         throw NotImplementedError("feature()  getting in runtime is not supported for mock")
 
     override fun copy(
-        environment: AIAgentEnvironment?,
-        agentInput: String?,
-        config: AIAgentConfigBase?,
-        llm: AIAgentLLMContext?,
-        stateManager: AIAgentStateManager?,
-        storage: AIAgentStorage?,
-        sessionUuid: Uuid?,
-        strategyId: String?,
-        pipeline: AIAgentPipeline?
+        environment: AIAgentEnvironment,
+        agentInput: String,
+        config: AIAgentConfigBase,
+        llm: AIAgentLLMContext,
+        stateManager: AIAgentStateManager,
+        storage: AIAgentStorage,
+        sessionUuid: Uuid,
+        strategyId: String,
+        pipeline: AIAgentPipeline
     ): AIAgentContextBase = DummyAIAgentContext(
-        builder.copy().apply {
-            environment?.let { this.environment = it }
-            agentInput?.let { this.agentInput = it }
-            config?.let { this.config = it }
-            llm?.let { this.llm = it }
-            stateManager?.let { this.stateManager = it }
-            storage?.let { this.storage = it }
-            sessionUuid?.let { this.sessionUuid = it }
-            strategyId?.let { this.strategyId = it }
-        }
+        builder.copy(
+            environment = environment,
+            agentInput = agentInput,
+            config = config,
+            llm = llm,
+            stateManager = stateManager,
+            storage = storage,
+            sessionUuid = sessionUuid,
+            strategyId = strategyId,
+        )
     )
 
     override suspend fun fork(): AIAgentContextBase {
@@ -222,7 +222,16 @@ public interface AIAgentContextMockBuilderBase : BaseBuilder<AIAgentContextBase>
      *
      * @return A new instance of `AIAgentContextMockBuilderBase` with the same properties as the original.
      */
-    public fun copy(): AIAgentContextMockBuilderBase
+    public fun copy(
+        environment: AIAgentEnvironment? = this.environment,
+        agentInput: String? = this.agentInput,
+        config: AIAgentConfigBase? = this.config,
+        llm: AIAgentLLMContext? = this.llm,
+        stateManager: AIAgentStateManager? = this.stateManager,
+        storage: AIAgentStorage? = this.storage,
+        sessionUuid: Uuid? = this.sessionUuid,
+        strategyId: String? = this.strategyId,
+    ): AIAgentContextMockBuilderBase
 
     /**
      * Builds and returns an instance of [AIAgentContextBase] based on the current properties
@@ -335,7 +344,16 @@ public class AIAgentContextMockBuilder() : AIAgentContextMockBuilderBase {
      *
      * @return a new `AIAgentContextMockBuilder` instance with the same properties as the original.
      */
-    override fun copy(): AIAgentContextMockBuilder {
+    override fun copy(
+        environment: AIAgentEnvironment?,
+        agentInput: String?,
+        config: AIAgentConfigBase?,
+        llm: AIAgentLLMContext?,
+        stateManager: AIAgentStateManager?,
+        storage: AIAgentStorage?,
+        sessionUuid: Uuid?,
+        strategyId: String?,
+    ): AIAgentContextMockBuilder {
         return AIAgentContextMockBuilder().also {
             it.environment = environment
             it.agentInput = agentInput

--- a/examples/src/main/kotlin/ai/koog/agents/example/banking/routing/RoutingViaGraph.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/banking/routing/RoutingViaGraph.kt
@@ -78,7 +78,7 @@ fun main() = runBlocking {
 
         val transferMoney by subgraphWithTask<ClassifiedBankRequest>(
             tools = MoneyTransferTools().asTools() + AskUser,
-            model = OpenAIModels.Chat.GPT4o
+            llmModel = OpenAIModels.Chat.GPT4o
         ) { request ->
             """
                 ${bankingAssistantSystemPrompt}

--- a/examples/src/main/kotlin/ai/koog/agents/example/subgraphwithtask/CustomStrategy.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/subgraphwithtask/CustomStrategy.kt
@@ -17,7 +17,7 @@ fun customWizardStrategy(
 ) = strategy("wizard-with-checkstyle") {
     val generate by subgraphWithTask<Unit>(
         generateTools,
-        model = OpenAIModels.Chat.GPT4o,
+        llmModel = OpenAIModels.Chat.GPT4o,
     ) { input ->
         """
             You are an AI agent that can create files and folders inside some empty project repository.
@@ -35,7 +35,7 @@ fun customWizardStrategy(
 
     val fix by subgraphWithTask<VerifiedSubgraphResult>(
         tools = fixTools,
-        model = AnthropicModels.Sonnet_3_7,
+        llmModel = AnthropicModels.Sonnet_3_7,
     ) { verificationResult ->
         """
             You are an AI agent that can create files, delete files, create folders, and delete folders.


### PR DESCRIPTION
Support settings custom `LLModel` and `LLMParams` overrides for subgraphs, to allow delegating different tasks to different LLMs with different parameters. 
Fixes #338 