### PR TITLE
Rename OpenAI embedding model names

### DIFF
--- a/embeddings/embeddings-llm/src/commonTest/kotlin/ai/koog/embeddings/local/OpenAIEmbedderTest.kt
+++ b/embeddings/embeddings-llm/src/commonTest/kotlin/ai/koog/embeddings/local/OpenAIEmbedderTest.kt
@@ -12,7 +12,7 @@ class OpenAIEmbedderTest {
     @Test
     fun testEmbed() = runTest {
         val mockClient = MockOpenAIEmbedderClient()
-        val embedder = LLMEmbedder(mockClient, OpenAIModels.Embeddings.TextEmbeddingAda3Small)
+        val embedder = LLMEmbedder(mockClient, OpenAIModels.Embeddings.TextEmbedding3Small)
 
         val text = "Hello, world!"
         val expectedVector = Vector(listOf(0.1, 0.2, 0.3))
@@ -25,7 +25,7 @@ class OpenAIEmbedderTest {
     @Test
     fun testDiff_identicalVectors() = runTest {
         val mockClient = MockOpenAIEmbedderClient()
-        val embedder = LLMEmbedder(mockClient, OpenAIModels.Embeddings.TextEmbeddingAda3Small)
+        val embedder = LLMEmbedder(mockClient, OpenAIModels.Embeddings.TextEmbedding3Small)
 
         val vector1 = Vector(listOf(1.0, 2.0, 3.0))
         val vector2 = Vector(listOf(1.0, 2.0, 3.0))
@@ -37,7 +37,7 @@ class OpenAIEmbedderTest {
     @Test
     fun testDiff_differentVectors() = runTest {
         val mockClient = MockOpenAIEmbedderClient()
-        val embedder = LLMEmbedder(mockClient, OpenAIModels.Embeddings.TextEmbeddingAda3Small)
+        val embedder = LLMEmbedder(mockClient, OpenAIModels.Embeddings.TextEmbedding3Small)
 
         val vector1 = Vector(listOf(1.0, 0.0, 0.0))
         val vector2 = Vector(listOf(0.0, 1.0, 0.0))
@@ -49,7 +49,7 @@ class OpenAIEmbedderTest {
     @Test
     fun testDiff_oppositeVectors() = runTest {
         val mockClient = MockOpenAIEmbedderClient()
-        val embedder = LLMEmbedder(mockClient, OpenAIModels.Embeddings.TextEmbeddingAda3Small)
+        val embedder = LLMEmbedder(mockClient, OpenAIModels.Embeddings.TextEmbedding3Small)
 
         val vector1 = Vector(listOf(1.0, 2.0, 3.0))
         val vector2 = Vector(listOf(-1.0, -2.0, -3.0))

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OpenAIEmbeddingsIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OpenAIEmbeddingsIntegrationTest.kt
@@ -18,7 +18,7 @@ class OpenAIEmbeddingsIntegrationTest {
         val client = OpenAILLMClient(apiKey)
 
         val text = "This is a test text for embedding."
-        val embedding = client.embed(text, OpenAIModels.Embeddings.TextEmbeddingAda3Small)
+        val embedding = client.embed(text, OpenAIModels.Embeddings.TextEmbedding3Small)
 
         // Verify the embedding is not null and has the expected structure
         assertNotNull(embedding)
@@ -41,7 +41,7 @@ class OpenAIEmbeddingsIntegrationTest {
         val client = OpenAILLMClient(apiKey)
 
         val text = "This is a test text for embedding with a custom model."
-        val embedding = client.embed(text, OpenAIModels.Embeddings.TextEmbeddingAda3Large)
+        val embedding = client.embed(text, OpenAIModels.Embeddings.TextEmbedding3Large)
 
         // Verify the embedding is not null and has the expected structure
         assertNotNull(embedding)

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/Module.md
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/Module.md
@@ -145,7 +145,7 @@ val pdfResponse = client.execute(
 // Embedding example
 val embedding = client.embed(
     text = "This is a sample text for embedding",
-    model = OpenAIModels.Embeddings.TextEmbeddingAda3Small
+    model = OpenAIModels.Embeddings.TextEmbedding3Small
 )
 
 // Mixed content (image + PDF)

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIModels.kt
@@ -28,8 +28,8 @@ import ai.koog.prompt.llm.LLModel
  * | [CostOptimized.GPT4oMini]           | Fast      | $0.15-$0.6         | Text, Image, Tools | Text, Tools        |
  * | [CostOptimized.O1Mini]              | Slow      | $1.1-$4.4          | Text               | Text               |
  * | [CostOptimized.O3Mini]              | Medium    | $1.1-$4.4          | Text, Tools        | Text, Tools        |
- * | [Embeddings.TextEmbeddingAda3Small] | Medium    | $0.02              | Text               | Text               |
- * | [Embeddings.TextEmbeddingAda3Large] | Slow      | $0.13              | Text               | Text               |
+ * | [Embeddings.TextEmbedding3Small]    | Medium    | $0.02              | Text               | Text               |
+ * | [Embeddings.TextEmbedding3Large]    | Slow      | $0.13              | Text               | Text               |
  * | [Embeddings.TextEmbeddingAda002]    | Slow      | $0.1               | Text               | Text               |
  */
 public object OpenAIModels: LLModelDefinitions {
@@ -330,7 +330,7 @@ public object OpenAIModels: LLModelDefinitions {
          *
          * @see <a href="https://platform.openai.com/docs/models/text-embedding-3-small">
          */
-        public val TextEmbeddingAda3Small: LLModel = LLModel(
+        public val TextEmbedding3Small: LLModel = LLModel(
             provider = LLMProvider.OpenAI, id = "text-embedding-3-small", capabilities = listOf(
                 LLMCapability.Schema.JSON.Full, LLMCapability.Embed
             )
@@ -355,7 +355,7 @@ public object OpenAIModels: LLModelDefinitions {
          *
          * @see <a href="https://platform.openai.com/docs/models/text-embedding-3-large">
          */
-        public val TextEmbeddingAda3Large: LLModel = LLModel(
+        public val TextEmbedding3Large: LLModel = LLModel(
             provider = LLMProvider.OpenAI, id = "text-embedding-3-large", capabilities = listOf(
                 LLMCapability.Schema.JSON.Full, LLMCapability.Embed
             )
@@ -363,7 +363,7 @@ public object OpenAIModels: LLModelDefinitions {
 
         /**
          * text-embedding-ada-002 is more performant version of the initial ada embedding model. But it's an older
-         * model compared to [TextEmbeddingAda3Small] and [TextEmbeddingAda3Large].
+         * model compared to [TextEmbedding3Small] and [TextEmbedding3Large].
          *
          * Fast, cheap, good for many general tasks
          *


### PR DESCRIPTION
Rename the OpenAI embedding models to their exact names as OpenAI official doc.
The issue for this renaming task is https://github.com/JetBrains/koog/issues/341

#### Type of the change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation fix
- [X] Renaming

#### Checklist for all pull requests
- [ ] The pull request has a description of the proposed change
- [X] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [X] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [X] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [X] An issue describing the proposed change exists
- [X] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [X] Docs have been added / updated
