### PR TITLE
feat: OpenAI user parameter

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/DataModel.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/DataModel.kt
@@ -21,7 +21,8 @@ internal data class OpenAIRequest(
     val modalities: List<OpenAIModalities>? = null,
     val audio: OpenAIAudioConfig? = null,
     val stream: Boolean = false,
-    val toolChoice: OpenAIToolChoice? = null
+    val toolChoice: OpenAIToolChoice? = null,
+    val user: String? = null,
 )
 
 @Serializable

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -309,6 +309,7 @@ public open class OpenAILLMClient(
             audio = audio,
             stream = stream,
             toolChoice = toolChoice,
+            user = prompt.params.user,
         )
     }
 

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/params/LLMParams.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/params/LLMParams.kt
@@ -16,6 +16,8 @@ import kotlinx.serialization.json.JsonObject
  *
  * @property toolChoice Used to switch tool calling behavior of LLM.
  *
+ * @property user An optional identifier for the user making the request, which can be used for tracking purposes.
+ *
  * This class also includes a nested `Builder` class to facilitate constructing instances in a more
  * customizable and incremental way.
  */
@@ -26,6 +28,7 @@ public data class LLMParams(
     val speculation: String? = null,
     val schema: Schema? = null,
     val toolChoice: ToolChoice? = null,
+    val user: String? = null,
 ) {
     /**
      * Combines the parameters of the current `LLMParams` instance with the provided default `LLMParams`
@@ -39,7 +42,8 @@ public data class LLMParams(
         temperature = temperature ?: default.temperature,
         numberOfChoices = numberOfChoices ?: default.numberOfChoices,
         speculation = speculation ?: default.speculation,
-        schema = schema ?: default.schema
+        schema = schema ?: default.schema,
+        user = user ?: default.user,
     )
 
     /**


### PR DESCRIPTION
Fixes #375 

Implementing OpenAI `user` parameter according to documentation: https://platform.openai.com/docs/guides/safety-best-practices#end-user-ids

---

#### Type of the change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
