### PR TITLE
Add support for excluding properties in JSON schema generation

### DIFF
--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/JsonSchemaGenerator.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/JsonSchemaGenerator.kt
@@ -76,7 +76,8 @@ public class JsonSchemaGenerator(
     public fun generate(
         id: String,
         serializer: KSerializer<*>,
-        descriptionOverrides: Map<String, String> = emptyMap()
+        descriptionOverrides: Map<String, String> = emptyMap(),
+        excludedProperties: Set<String> = emptySet(),
     ): JsonObject {
         val rootSchema: JsonObject
         val definitions = buildJsonObject {
@@ -84,6 +85,7 @@ public class JsonSchemaGenerator(
                 rootDefsBuilder = this,
                 processedDefs = emptySet(),
                 descriptionOverrides = descriptionOverrides,
+                excludedProperties = excludedProperties,
                 descriptor = serializer.descriptor,
                 currentDepth = 0,
             )
@@ -122,6 +124,7 @@ public class JsonSchemaGenerator(
         rootDefsBuilder: JsonObjectBuilder,
         processedDefs: Set<String>,
         descriptionOverrides: Map<String, String>,
+        excludedProperties: Set<String>,
         descriptor: SerialDescriptor,
         currentDepth: Int,
         isPolymorphicSubtype: Boolean = false,
@@ -159,6 +162,7 @@ public class JsonSchemaGenerator(
                             rootDefsBuilder = rootDefsBuilder,
                             processedDefs = processedDefs,
                             descriptionOverrides = descriptionOverrides,
+                            excludedProperties = excludedProperties,
                             descriptor = itemDescriptor,
                             currentDepth = currentDepth + 1,
                         )
@@ -181,6 +185,7 @@ public class JsonSchemaGenerator(
                             rootDefsBuilder = rootDefsBuilder,
                             processedDefs = processedDefs,
                             descriptionOverrides = descriptionOverrides,
+                            excludedProperties = excludedProperties,
                             descriptor = valueDescriptor,
                             currentDepth = currentDepth + 1,
                         )
@@ -208,9 +213,16 @@ public class JsonSchemaGenerator(
                                 val propertyName = descriptor.getElementName(i)
                                 val propertyDescriptor = descriptor.getElementDescriptor(i)
                                 val propertyAnnotations = descriptor.getElementAnnotations(i)
+                                val lookupKey = "${descriptor.serialName}.$propertyName"
+
+                                // Check if the property is excluded
+                                if (excludedProperties.contains(lookupKey)) {
+                                    if (!descriptor.isElementOptional(i))
+                                        throw IllegalArgumentException("Property '$lookupKey' is marked as excluded, but it is required in the schema.")
+                                    continue
+                                }
 
                                 // Description for a property
-                                val lookupKey = "${descriptor.serialName}.$propertyName"
                                 val propertyDescriptionOverride = descriptionOverrides[lookupKey]
                                 val propertyDescriptionAnnotation = propertyAnnotations
                                     .filterIsInstance<LLMDescription>()
@@ -227,6 +239,7 @@ public class JsonSchemaGenerator(
                                             rootDefsBuilder = rootDefsBuilder,
                                             processedDefs = updatedProcessedDefs,
                                             descriptionOverrides = descriptionOverrides,
+                                            excludedProperties = excludedProperties,
                                             descriptor = propertyDescriptor,
                                             currentDepth = currentDepth + 1,
                                         ).let { propertySchema ->
@@ -299,6 +312,7 @@ public class JsonSchemaGenerator(
                                     rootDefsBuilder = rootDefsBuilder,
                                     processedDefs = processedDefs,
                                     descriptionOverrides = descriptionOverrides,
+                                    excludedProperties = excludedProperties,
                                     descriptor = polymorphicDescriptor,
                                     currentDepth = currentDepth + 1,
                                     isPolymorphicSubtype = true,

--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/JsonStructuredData.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/JsonStructuredData.kt
@@ -150,11 +150,12 @@ public class JsonStructuredData<TStruct>(
             schemaFormat: JsonSchemaGenerator.SchemaFormat = JsonSchemaGenerator.SchemaFormat.Simple,
             maxDepth: Int = 20,
             descriptionOverrides: Map<String, String> = emptyMap(),
+            excludedProperties: Set<String> = emptySet(),
             examples: List<T> = emptyList(),
             schemaType: JsonSchemaType = JsonSchemaType.SIMPLE
         ): StructuredData<T> {
             val structureLanguage = JsonStructureLanguage(json)
-            val schema = JsonSchemaGenerator(json, schemaFormat, maxDepth).generate(id, serializer, descriptionOverrides)
+            val schema = JsonSchemaGenerator(json, schemaFormat, maxDepth).generate(id, serializer, descriptionOverrides, excludedProperties)
 
             return JsonStructuredData(
                 id = id,

--- a/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/json/JsonSchemaGeneratorTest.kt
+++ b/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/json/JsonSchemaGeneratorTest.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.serializer
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class JsonSchemaGeneratorTest {
     private val json = Json {
@@ -212,6 +213,65 @@ class JsonSchemaGeneratorTest {
         """.trimIndent()
 
         assertEquals(expectedSchema, schema)
+    }
+
+    @Test
+    fun testGenerateSimpleSchemaExcludingProperties() {
+        val schema = json.encodeToString(simpleSchemaGenerator.generate(
+            "TestClass",
+            serializer<TestClass>(),
+            excludedProperties = setOf("TestClass.nullableProperty")
+        ))
+
+        val expectedSchema = """
+            {
+              "type": "object",
+              "description": "A test class",
+              "properties": {
+                "stringProperty": {
+                  "type": "string",
+                  "description": "A string property"
+                },
+                "intProperty": {
+                  "type": "integer"
+                },
+                "booleanProperty": {
+                  "type": "boolean"
+                },
+                "listProperty": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "mapProperty": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "integer"
+                  }
+                }
+              },
+              "required": [
+                "stringProperty",
+                "intProperty",
+                "booleanProperty"
+              ]
+            }
+        """.trimIndent()
+
+        assertEquals(expectedSchema, schema)
+    }
+
+    @Test
+    fun testGenerateSimpleSchemaExcludingRequiredProperties() {
+        val exception = assertFailsWith<IllegalArgumentException> {
+            json.encodeToString(simpleSchemaGenerator.generate(
+                "TestClass",
+                serializer<TestClass>(),
+                excludedProperties = setOf("TestClass.stringProperty")
+            ))
+        }
+        assertEquals("Property 'TestClass.stringProperty' is marked as excluded, but it is required in the schema.", exception.message)
     }
 
     @Test


### PR DESCRIPTION
Fixes #377 

Proposed changes:
Add an `excludedProperties` parameter like this:
```kotlin
simpleSchemaGenerator.generate(
    "TestClass",
    serializer<TestClass>(),
    excludedProperties = setOf("TestClass.someProperty")
)
```

---

#### Type of the change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
