### PR TITLE
[prompt] Fix OpenAI and OpenRouter clients to produce simple text user message when no attachments are present

### DIFF
--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -71,7 +71,7 @@ registerRunExampleTask("runExampleMarkdownStreamingWithTool", "ai.koog.agents.ex
 registerRunExampleTask("runExampleRiderProjectTemplate", "ai.koog.agents.example.rider.project.template.RiderProjectTemplateKt")
 registerRunExampleTask("runExampleExecSandbox", "ai.koog.agents.example.execsandbox.ExecSandboxKt")
 registerRunExampleTask("runExampleLoopComponent", "ai.koog.agents.example.components.loop.ProjectGeneratorKt")
-registerRunExampleTask("runExampleInstagramPostDescriber", "ai.koog.agents.example.media.InstagramPostDescriberKt")
+registerRunExampleTask("runExampleInstagramPostDescriber", "ai.koog.agents.example.attachments.InstagramPostDescriberKt")
 registerRunExampleTask("runExampleRoutingViaGraph", "ai.koog.agents.example.banking.routing.RoutingViaGraphKt")
 registerRunExampleTask("runExampleRoutingViaAgentsAsTools", "ai.koog.agents.example.banking.routing.RoutingViaAgentsAsToolsKt")
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
@@ -276,63 +276,69 @@ public class OpenRouterLLMClient(
     }
 
     private fun Message.User.toOpenRouterMessage(model: LLModel): OpenRouterMessage {
-        val listOfContent = buildList {
-            if (content.isNotEmpty() || attachments.isEmpty()) {
-                add(ContentPart.Text(content))
-            }
+        val messageContent: Content = if (attachments.isEmpty()) {
+            Content.Text(content)
+        } else {
+            val parts = buildList {
+                if (content.isNotEmpty()) {
+                    add(ContentPart.Text(content))
+                }
 
-            attachments.forEach { attachment ->
-                when (attachment) {
-                    is Attachment.Image -> {
-                        require(model.capabilities.contains(LLMCapability.Vision.Image)) {
-                            "Model ${model.id} does not support images"
+                attachments.forEach { attachment ->
+                    when (attachment) {
+                        is Attachment.Image -> {
+                            require(model.capabilities.contains(LLMCapability.Vision.Image)) {
+                                "Model ${model.id} does not support images"
+                            }
+
+                            val imageUrl: String = when (val content = attachment.content) {
+                                is AttachmentContent.URL -> content.url
+                                is AttachmentContent.Binary -> "data:${attachment.mimeType};base64,${content.base64}"
+                                else -> throw IllegalArgumentException("Unsupported image attachment content: ${content::class}")
+                            }
+
+                            add(ContentPart.Image(ContentPart.ImageUrl(imageUrl)))
                         }
 
-                        val imageUrl: String = when (val content = attachment.content) {
-                            is AttachmentContent.URL -> content.url
-                            is AttachmentContent.Binary -> "data:${attachment.mimeType};base64,${content.base64}"
-                            else -> throw IllegalArgumentException("Unsupported image attachment content: ${content::class}")
+                        is Attachment.Audio -> {
+                            require(model.capabilities.contains(LLMCapability.Audio)) {
+                                "Model ${model.id} does not support audio"
+                            }
+
+                            val inputAudio: ContentPart.InputAudio = when (val content = attachment.content) {
+                                is AttachmentContent.Binary -> ContentPart.InputAudio(content.base64, attachment.format)
+                                else -> throw IllegalArgumentException("Unsupported audio attachment content: ${content::class}")
+                            }
+
+                            add(ContentPart.Audio(inputAudio))
                         }
 
-                        add(ContentPart.Image(ContentPart.ImageUrl(imageUrl)))
+                        is Attachment.File -> {
+                            require(model.capabilities.contains(LLMCapability.Document)) {
+                                "Model ${model.id} does not support files"
+                            }
+
+                            val fileData: ContentPart.FileData = when (val content = attachment.content) {
+                                is AttachmentContent.Binary -> ContentPart.FileData(
+                                    fileData = "data:${attachment.mimeType};base64,${content.base64}",
+                                    filename = attachment.fileName
+                                )
+
+                                else -> throw IllegalArgumentException("Unsupported file attachment content: ${content::class}")
+                            }
+
+                            add(ContentPart.File(fileData))
+                        }
+
+                        else -> throw IllegalArgumentException("Unsupported attachment type: $attachment")
                     }
-
-                    is Attachment.Audio -> {
-                        require(model.capabilities.contains(LLMCapability.Audio)) {
-                            "Model ${model.id} does not support audio"
-                        }
-
-                        val inputAudio: ContentPart.InputAudio = when (val content = attachment.content) {
-                            is AttachmentContent.Binary -> ContentPart.InputAudio(content.base64, attachment.format)
-                            else -> throw IllegalArgumentException("Unsupported audio attachment content: ${content::class}")
-                        }
-
-                        add(ContentPart.Audio(inputAudio))
-                    }
-
-                    is Attachment.File -> {
-                        require(model.capabilities.contains(LLMCapability.Document)) {
-                            "Model ${model.id} does not support files"
-                        }
-
-                        val fileData: ContentPart.FileData = when (val content = attachment.content) {
-                            is AttachmentContent.Binary -> ContentPart.FileData(
-                                fileData = "data:${attachment.mimeType};base64,${content.base64}",
-                                filename = attachment.fileName
-                            )
-
-                            else -> throw IllegalArgumentException("Unsupported file attachment content: ${content::class}")
-                        }
-
-                        add(ContentPart.File(fileData))
-                    }
-
-                    else -> throw IllegalArgumentException("Unsupported attachment content: $attachment")
                 }
             }
+
+            Content.Parts(parts)
         }
 
-        return OpenRouterMessage(role = "user", content = Content.Parts(listOfContent))
+        return OpenRouterMessage(role = "user", content = messageContent)
     }
 
     private fun buildOpenRouterParam(param: ToolParameterDescriptor): JsonObject = buildJsonObject {


### PR DESCRIPTION
OpenAI and OpenRouter clients should product simple test user message when there are no attachments. This complies with OpenAI API specs, otherwise some OpenAI compatible providers that do no support attachments can break.

Fixes #390