### PR TITLE
Tweak prompt for test & remove windows heavy tests

### DIFF
--- a/.github/workflows/heavy-tests.yml
+++ b/.github/workflows/heavy-tests.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest ]
 
     steps:
       - name: Configure Git

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/AIAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/AIAgentIntegrationTest.kt
@@ -99,6 +99,8 @@ class AIAgentIntegrationTest {
         I need you to perform two operations:
         1. Calculate 7 times 2
         2. Wait for 500 milliseconds
+        
+        Respond briefly after completing both tasks. DO NOT EXCEED THE LIMIT OF 20 WORDS.
         """.trimIndent()
 
         fun getExecutor(model: LLModel): SingleLLMPromptExecutor = when (model.provider) {

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/AIAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/AIAgentIntegrationTest.kt
@@ -467,6 +467,7 @@ class AIAgentIntegrationTest {
     @MethodSource("openAIModels", "anthropicModels", "googleModels")
     fun integration_AIAgentSingleRunNoParallelTools(model: LLModel) = runTest(timeout = 120.seconds) {
         assumeTrue(model.capabilities.contains(LLMCapability.Tools), "Model $model does not support tools")
+        assumeTrue(model.id != OpenAIModels.Audio.GPT4oAudio.id, "See KG-124")
 
         withRetry {
             val sequentialAgent = getSingleRunAgentWithRunMode(


### PR DESCRIPTION
1. Tweak the prompt to handle long responses from OpenAI `audio` LLMs.
2. Increase test timeouts for audio models (from time to time they took longer than 2 minutes).
3. Remove windows runs from heavy tests (agreed with @skarpovdev that this makes sense for integration checks).

---

#### Type of the change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation fix
- [x] Tests fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
