### PR TITLE
Take count into account in mostRelevantDocuments

### DIFF
--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/RankedDocumentStorage.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/RankedDocumentStorage.kt
@@ -35,31 +35,32 @@ public interface RankedDocumentStorage<Document> : DocumentStorage<Document> {
      * @return A flow emitting ranked documents, where each document is paired with its similarity score.
      */
     public fun rankDocuments(query: String): Flow<RankedDocument<Document>>
-
-    /**
-     * Retrieves the most relevant documents matching the provided query, ranked by their similarity scores
-     * in descending order. Only documents with a similarity score greater than or equal to the specified
-     * similarity threshold are included, and the result set is limited to the specified count.
-     *
-     * Example:
-     *  - `mostRelevantDocuments("tigers in the wild nature", 10)` - returns top-10 most relevant documents about tigers in the wild nature
-     *  - `mostRelevantDocuments("tigers in the wild nature", similarityThreshold = 0.7)` - returns all documents about tigers in the wild nature that have at least 70% similarity (relevance) score
-     *  - `mostRelevantDocuments("tigers in the wild nature", similarityThreshold = 0.7, count = 10)` - returns no more than 10 most relevant documents about tigers in the wild nature that have at least 70% similarity (relevance) score
-     *
-     * @param query The search query used to find relevant documents.
-     * @param count The maximum number of documents to return. Defaults to Int.MAX_VALUE if not specified.
-     * @param similarityThreshold The minimum similarity score a document must have to be considered relevant.
-     *        Defaults to 0.0 if not specified.
-     * @return An iterable collection of the most relevant documents that satisfy the specified filters and rankings.
-     */
-    public suspend fun mostRelevantDocuments(
-        query: String,
-        count: Int = Int.MAX_VALUE,
-        similarityThreshold: Double = 0.0
-    ): Iterable<Document> = rankDocuments(query)
-        .filter { it.similarity >= similarityThreshold }
-        .toList()
-        .sortedByDescending { it.similarity }
-        .map { it.document }
-        .toList()
 }
+
+/**
+ * Retrieves the most relevant documents matching the provided query, ranked by their similarity scores
+ * in descending order. Only documents with a similarity score greater than or equal to the specified
+ * similarity threshold are included, and the result set is limited to the specified count.
+ *
+ * Example:
+ *  - `mostRelevantDocuments("tigers in the wild nature", 10)` - returns top-10 most relevant documents about tigers in the wild nature
+ *  - `mostRelevantDocuments("tigers in the wild nature", similarityThreshold = 0.7)` - returns all documents about tigers in the wild nature that have at least 70% similarity (relevance) score
+ *  - `mostRelevantDocuments("tigers in the wild nature", similarityThreshold = 0.7, count = 10)` - returns no more than 10 most relevant documents about tigers in the wild nature that have at least 70% similarity (relevance) score
+ *
+ * @param query The search query used to find relevant documents.
+ * @param count The maximum number of documents to return. Defaults to Int.MAX_VALUE if not specified.
+ * @param similarityThreshold The minimum similarity score a document must have to be considered relevant.
+ *        Defaults to 0.0 if not specified.
+ * @return An iterable collection of the most relevant documents that satisfy the specified filters and rankings.
+ */
+public suspend fun <Document> RankedDocumentStorage<Document>.mostRelevantDocuments(
+    query: String,
+    count: Int = Int.MAX_VALUE,
+    similarityThreshold: Double = 0.0
+): Iterable<Document> = rankDocuments(query)
+    .filter { it.similarity >= similarityThreshold }
+    .toList()
+    .sortedByDescending { it.similarity }
+    .take(count)
+    .map { it.document }
+    .toList()


### PR DESCRIPTION
This is a quick fix for `mostRelevantDocuments` as explained in #397.

I also made `mostRelevantDocuments` an extension rather than a final member of `RankedDocumentStorage`.

---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
