### PR TITLE
Fix CachedPromptExecutor / PromptCache so that it works with timestamps correctly

### DIFF
--- a/prompt/prompt-cache/prompt-cache-files/src/jvmMain/kotlin/ai/koog/prompt/cache/files/FilePromptCache.kt
+++ b/prompt/prompt-cache/prompt-cache-files/src/jvmMain/kotlin/ai/koog/prompt/cache/files/FilePromptCache.kt
@@ -1,7 +1,6 @@
 package ai.koog.prompt.cache.files
 
 import ai.koog.prompt.cache.model.PromptCache
-import ai.koog.prompt.cache.model.Request
 import ai.koog.prompt.message.Message
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -73,9 +72,9 @@ public class FilePromptCache(
     private val lock = Mutex()
 
     @Serializable
-    private data class CachedElement(val response: List<Message.Response>, val request: Request)
+    private data class CachedElement(val response: List<Message.Response>, val request: PromptCache.Request)
 
-    override suspend fun get(request: Request): List<Message.Response>? {
+    override suspend fun get(request: PromptCache.Request): List<Message.Response>? {
         val response = getOrNull(request)
 
         if (response != null) {
@@ -85,7 +84,7 @@ public class FilePromptCache(
         return response
     }
 
-    override suspend fun put(request: Request, response: List<Message.Response>): Unit = lock.withLock {
+    override suspend fun put(request: PromptCache.Request, response: List<Message.Response>): Unit = lock.withLock {
         // Check if we need to remove old files before adding a new one
         enforceFileLimit()
 
@@ -100,9 +99,9 @@ public class FilePromptCache(
         access[request.asCacheKey] = now
     }
 
-    private fun file(request: Request): Path = requestsDir / request.asCacheKey
+    private fun file(request: PromptCache.Request): Path = requestsDir / request.asCacheKey
 
-    private fun getOrNull(request: Request): List<Message.Response>? {
+    private fun getOrNull(request: PromptCache.Request): List<Message.Response>? {
         val file = file(request)
         if (!file.exists()) return null
 

--- a/prompt/prompt-cache/prompt-cache-files/src/jvmMain/kotlin/ai/koog/prompt/cache/files/FilePromptCache.kt
+++ b/prompt/prompt-cache/prompt-cache-files/src/jvmMain/kotlin/ai/koog/prompt/cache/files/FilePromptCache.kt
@@ -1,21 +1,16 @@
 package ai.koog.prompt.cache.files
 
-import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.prompt.cache.model.PromptCache
-import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.cache.model.Request
 import ai.koog.prompt.message.Message
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonObject
 import java.nio.file.Path
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.io.path.*
-import kotlin.math.absoluteValue
 
 internal val defaultJson = Json {
     ignoreUnknownKeys = true
@@ -80,40 +75,17 @@ public class FilePromptCache(
     @Serializable
     private data class CachedElement(val response: List<Message.Response>, val request: Request)
 
-    @Serializable
-    private data class Request(val prompt: Prompt, val tools: List<JsonObject> = emptyList()) {
-        val id: String
-            get() = defaultJson.encodeToString(this).hashCode().absoluteValue.toString(36)
-    }
-
-    override suspend fun get(prompt: Prompt, tools: List<ToolDescriptor>): List<Message.Response>? {
-        val request = Request(prompt, tools.map { toolToJsonObject(it) })
+    override suspend fun get(request: Request): List<Message.Response>? {
         val response = getOrNull(request)
 
         if (response != null) {
-            access[request.id] = Instant.now()
+            access[request.asCacheKey] = Instant.now()
         }
 
         return response
     }
 
-    override suspend fun put(prompt: Prompt, tools: List<ToolDescriptor>, response: List<Message.Response>) {
-        val request = Request(prompt, tools.map { toolToJsonObject(it) })
-        put(request, response)
-    }
-    
-    /**
-     * Convert a ToolDescriptor to a JsonObject representation.
-     * This is a simplified version that just captures the tool name for caching purposes.
-     */
-    private fun toolToJsonObject(tool: ToolDescriptor): JsonObject = buildJsonObject {
-        put("name", JsonPrimitive(tool.name))
-        put("description", JsonPrimitive(tool.description))
-    }
-
-    private fun file(request: Request): Path = requestsDir / request.id
-
-    private suspend fun put(request: Request, response: List<Message.Response>) = lock.withLock {
+    override suspend fun put(request: Request, response: List<Message.Response>): Unit = lock.withLock {
         // Check if we need to remove old files before adding a new one
         enforceFileLimit()
 
@@ -125,8 +97,10 @@ public class FilePromptCache(
 
         // Update timestamps
         val now = Instant.now()
-        access[request.id] = now
+        access[request.asCacheKey] = now
     }
+
+    private fun file(request: Request): Path = requestsDir / request.asCacheKey
 
     private fun getOrNull(request: Request): List<Message.Response>? {
         val file = file(request)

--- a/prompt/prompt-cache/prompt-cache-files/src/jvmTest/kotlin/ai/koog/prompt/cache/files/FilePromptCacheTest.kt
+++ b/prompt/prompt-cache/prompt-cache-files/src/jvmTest/kotlin/ai/koog/prompt/cache/files/FilePromptCacheTest.kt
@@ -30,6 +30,8 @@ class FilePromptCacheTest {
         override fun now(): Instant = Instant.parse("2023-01-01T00:00:00Z")
     }
 
+    private val realClock: Clock = Clock.System
+
     @BeforeEach
     fun setUp() {
         cache = FilePromptCache(tempDir)
@@ -148,5 +150,26 @@ class FilePromptCacheTest {
         field.isAccessible = true
         val maxFiles = field.get(defaultCache) as Int
         assertEquals(3000, maxFiles, "Default maxFiles should be 3000")
+    }
+
+    @Test
+    fun `test cache retrieval with different timestamps`() = runBlocking {
+        // Create and cache a prompt with testClock
+        val content = "test prompt"
+        val id = "test-id-${content.hashCode()}"
+
+        val originalPrompt = prompt(id, clock = realClock) { user(content) }
+        delay(1.milliseconds)
+        val samePromptDifferentTime = prompt(id, clock = realClock) { user(content) }
+
+        val response = listOf(assistantMessage("test response"))
+        cache.put(originalPrompt, emptyList(), response)
+
+        // Try to retrieve the cached response
+        val cachedResponse = cache.get(samePromptDifferentTime, emptyList())
+
+        // Verify the response is retrieved successfully
+        assertNotNull(cachedResponse, "Should retrieve cache entry despite different timestamps")
+        assertEquals(response, cachedResponse, "Retrieved response should match original")
     }
 }

--- a/prompt/prompt-cache/prompt-cache-files/src/jvmTest/kotlin/ai/koog/prompt/cache/files/FilePromptCacheTest.kt
+++ b/prompt/prompt-cache/prompt-cache-files/src/jvmTest/kotlin/ai/koog/prompt/cache/files/FilePromptCacheTest.kt
@@ -19,6 +19,7 @@ import java.nio.file.Path
 import kotlin.io.path.exists
 import kotlin.io.path.listDirectoryEntries
 import kotlin.time.Duration.Companion.milliseconds
+import ai.koog.prompt.cache.model.*
 
 class FilePromptCacheTest {
     @TempDir
@@ -30,7 +31,9 @@ class FilePromptCacheTest {
         override fun now(): Instant = Instant.parse("2023-01-01T00:00:00Z")
     }
 
-    private val realClock: Clock = Clock.System
+    private val differentTestClock: Clock = object : Clock {
+        override fun now(): Instant = testClock.now().plus(1.milliseconds)
+    }
 
     @BeforeEach
     fun setUp() {
@@ -158,15 +161,14 @@ class FilePromptCacheTest {
         val content = "test prompt"
         val id = "test-id-${content.hashCode()}"
 
-        val originalPrompt = prompt(id, clock = realClock) { user(content) }
-        delay(1.milliseconds)
-        val samePromptDifferentTime = prompt(id, clock = realClock) { user(content) }
+        val originalPrompt = prompt(id, clock = testClock) { user(content) }
+        val samePromptDifferentTime = prompt(id, clock = differentTestClock) { user(content) }
 
         val response = listOf(assistantMessage("test response"))
         cache.put(originalPrompt, emptyList(), response)
 
         // Try to retrieve the cached response
-        val cachedResponse = cache.get(samePromptDifferentTime, emptyList())
+        val cachedResponse = cache.get(samePromptDifferentTime, emptyList(), clock = testClock)
 
         // Verify the response is retrieved successfully
         assertNotNull(cachedResponse, "Should retrieve cache entry despite different timestamps")

--- a/prompt/prompt-cache/prompt-cache-files/src/jvmTest/kotlin/ai/koog/prompt/cache/files/FilePromptCacheTest.kt
+++ b/prompt/prompt-cache/prompt-cache-files/src/jvmTest/kotlin/ai/koog/prompt/cache/files/FilePromptCacheTest.kt
@@ -31,10 +31,6 @@ class FilePromptCacheTest {
         override fun now(): Instant = Instant.parse("2023-01-01T00:00:00Z")
     }
 
-    private val differentTestClock: Clock = object : Clock {
-        override fun now(): Instant = testClock.now().plus(1.milliseconds)
-    }
-
     @BeforeEach
     fun setUp() {
         cache = FilePromptCache(tempDir)
@@ -153,25 +149,5 @@ class FilePromptCacheTest {
         field.isAccessible = true
         val maxFiles = field.get(defaultCache) as Int
         assertEquals(3000, maxFiles, "Default maxFiles should be 3000")
-    }
-
-    @Test
-    fun `test cache retrieval with different timestamps`() = runBlocking {
-        // Create and cache a prompt with testClock
-        val content = "test prompt"
-        val id = "test-id-${content.hashCode()}"
-
-        val originalPrompt = prompt(id, clock = testClock) { user(content) }
-        val samePromptDifferentTime = prompt(id, clock = differentTestClock) { user(content) }
-
-        val response = listOf(assistantMessage("test response"))
-        cache.put(originalPrompt, emptyList(), response)
-
-        // Try to retrieve the cached response
-        val cachedResponse = cache.get(samePromptDifferentTime, emptyList(), clock = testClock)
-
-        // Verify the response is retrieved successfully
-        assertNotNull(cachedResponse, "Should retrieve cache entry despite different timestamps")
-        assertEquals(response, cachedResponse, "Retrieved response should match original")
     }
 }

--- a/prompt/prompt-cache/prompt-cache-model/build.gradle.kts
+++ b/prompt/prompt-cache/prompt-cache-model/build.gradle.kts
@@ -17,6 +17,13 @@ kotlin {
                 api(libs.kotlinx.datetime)
             }
         }
+
+        jvmTest {
+            dependencies {
+                implementation(kotlin("test-junit5"))
+                implementation(libs.kotlinx.coroutines.test)
+            }
+        }
     }
 
     explicitApi()

--- a/prompt/prompt-cache/prompt-cache-model/src/commonMain/kotlin/ai/koog/prompt/cache/memory/InMemoryPromptCache.kt
+++ b/prompt/prompt-cache/prompt-cache-model/src/commonMain/kotlin/ai/koog/prompt/cache/memory/InMemoryPromptCache.kt
@@ -1,7 +1,6 @@
 package ai.koog.prompt.cache.memory
 
 import ai.koog.prompt.cache.model.PromptCache
-import ai.koog.prompt.cache.model.Request
 import ai.koog.prompt.message.Message
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -39,7 +38,7 @@ public class InMemoryPromptCache(private val maxEntries: Int?) : PromptCache {
         var accessed: Instant = Clock.System.now()
     )
 
-    override suspend fun get(request: Request): List<Message.Response>? {
+    override suspend fun get(request: PromptCache.Request): List<Message.Response>? {
         val entry = cache[request.asCacheKey] ?: return null
 
         // Update last accessed time
@@ -48,7 +47,7 @@ public class InMemoryPromptCache(private val maxEntries: Int?) : PromptCache {
         return entry.response
     }
 
-    override suspend fun put(request: Request, response: List<Message.Response>) {
+    override suspend fun put(request: PromptCache.Request, response: List<Message.Response>) {
         val key = request.asCacheKey
 
         // Enforce size limit if specified

--- a/prompt/prompt-cache/prompt-cache-model/src/commonMain/kotlin/ai/koog/prompt/cache/memory/InMemoryPromptCache.kt
+++ b/prompt/prompt-cache/prompt-cache-model/src/commonMain/kotlin/ai/koog/prompt/cache/memory/InMemoryPromptCache.kt
@@ -1,12 +1,10 @@
 package ai.koog.prompt.cache.memory
 
-import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.prompt.cache.model.PromptCache
-import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.cache.model.Request
 import ai.koog.prompt.message.Message
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
-import kotlin.math.absoluteValue
 
 /**
  * In-memory implementation of [PromptCache].
@@ -41,17 +39,8 @@ public class InMemoryPromptCache(private val maxEntries: Int?) : PromptCache {
         var accessed: Instant = Clock.System.now()
     )
 
-    /**
-     * Generate a cache key for a prompt with tools.
-     */
-    private fun cacheKey(prompt: Prompt, tools: List<ToolDescriptor>): String {
-        val toolsString = tools.joinToString { it.name }
-        return (prompt.toString() + toolsString).hashCode().absoluteValue.toString(36)
-    }
-
-    override suspend fun get(prompt: Prompt, tools: List<ToolDescriptor>): List<Message.Response>? {
-        val key = cacheKey(prompt, tools)
-        val entry = cache[key] ?: return null
+    override suspend fun get(request: Request): List<Message.Response>? {
+        val entry = cache[request.asCacheKey] ?: return null
 
         // Update last accessed time
         entry.accessed = Clock.System.now()
@@ -59,8 +48,8 @@ public class InMemoryPromptCache(private val maxEntries: Int?) : PromptCache {
         return entry.response
     }
 
-    override suspend fun put(prompt: Prompt, tools: List<ToolDescriptor>, response: List<Message.Response>) {
-        val key = cacheKey(prompt, tools)
+    override suspend fun put(request: Request, response: List<Message.Response>) {
+        val key = request.asCacheKey
 
         // Enforce size limit if specified
         if (maxEntries != null && cache.size >= maxEntries && !cache.containsKey(key)) {

--- a/prompt/prompt-cache/prompt-cache-model/src/commonMain/kotlin/ai/koog/prompt/cache/model/PromptCache.kt
+++ b/prompt/prompt-cache/prompt-cache-model/src/commonMain/kotlin/ai/koog/prompt/cache/model/PromptCache.kt
@@ -13,68 +13,9 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlin.math.absoluteValue
 
-internal val defaultJson = Json {
+private val defaultJson = Json {
     ignoreUnknownKeys = true
     allowStructuredMapKeys = true
-}
-
-/**
- * Represents a request to be cached, consisting of a prompt and optional tools.
- * This class is used by PromptCache implementations to store and retrieve cached responses.
- *
- * @property prompt The prompt to be cached
- * @property toolJsons Json representations of the tools
- */
-@Serializable
-public class Request private constructor (
-    public val prompt: Prompt,
-    public val toolJsons: List<JsonObject> = emptyList()
-) {
-    /**
-     * A unique identifier for the cache entry derived from the request's prompt and tools.
-     * This value is used by caching mechanisms to store and retrieve cached responses.
-     */
-    public val asCacheKey: String
-        get() {
-            // Create a new prompt with timestamps removed from all messages
-            val messagesWithoutMetaInfo = prompt.messages.map { message ->
-                when (message) {
-                    is Message.User -> message.copy(metaInfo = RequestMetaInfo.empty())
-                    is Message.System -> message.copy(metaInfo = RequestMetaInfo.empty())
-                    is Message.Assistant -> message.copy(metaInfo = ResponseMetaInfo.empty())
-                    is Message.Tool.Call -> message.copy(metaInfo = ResponseMetaInfo.empty())
-                    is Message.Tool.Result -> message.copy(metaInfo = RequestMetaInfo.empty())
-                }
-            }
-
-            val requestWithoutMetaInfo = Request(Prompt(messagesWithoutMetaInfo, prompt.id, prompt.params), toolJsons)
-
-            return defaultJson.encodeToString(requestWithoutMetaInfo).hashCode().absoluteValue.toString(36)
-        }
-
-    /**
-     * Companion object for the Request class, providing factory functions and utility methods.
-     */
-    public companion object {
-        /**
-         * Creates a new [Request] instance with the provided prompt and a list of tools.
-         *
-         * @param prompt The [Prompt] object containing the messages, ID, and parameters to construct the request.
-         * @param tools A list of [ToolDescriptor] objects to be included in the request. Each tool is converted to a JSON representation.
-         * @return A new [Request] instance initialized with the given prompt and tool data.
-         */
-        public fun create(prompt: Prompt, tools: List<ToolDescriptor>): Request =
-            Request(prompt, tools.map { toolToJsonObject(it) })
-
-        /**
-         * Convert a ToolDescriptor to a JsonObject representation.
-         * This is a simplified version that just captures the tool name and description for caching purposes.
-         */
-        private fun toolToJsonObject(tool: ToolDescriptor): JsonObject = buildJsonObject {
-            put("name", JsonPrimitive(tool.name))
-            put("description", JsonPrimitive(tool.description))
-        }
-    }
 }
 
 /**
@@ -188,6 +129,65 @@ public interface PromptCache {
     }
 
     /**
+     * Represents a request to be cached, consisting of a prompt and optional tools.
+     * This class is used by PromptCache implementations to store and retrieve cached responses.
+     *
+     * @property prompt The prompt to be cached
+     * @property toolJsons Json representations of the tools
+     */
+    @Serializable
+    public class Request private constructor (
+        public val prompt: Prompt,
+        public val toolJsons: List<JsonObject> = emptyList()
+    ) {
+        /**
+         * A unique identifier for the cache entry derived from the request's prompt and tools.
+         * This value is used by caching mechanisms to store and retrieve cached responses.
+         */
+        public val asCacheKey: String
+            get() {
+                // Create a new prompt with timestamps removed from all messages
+                val messagesWithoutMetaInfo = prompt.messages.map { message ->
+                    when (message) {
+                        is Message.User -> message.copy(metaInfo = RequestMetaInfo.Empty)
+                        is Message.System -> message.copy(metaInfo = RequestMetaInfo.Empty)
+                        is Message.Assistant -> message.copy(metaInfo = ResponseMetaInfo.Empty)
+                        is Message.Tool.Call -> message.copy(metaInfo = ResponseMetaInfo.Empty)
+                        is Message.Tool.Result -> message.copy(metaInfo = RequestMetaInfo.Empty)
+                    }
+                }
+
+                val requestWithoutMetaInfo = Request(Prompt(messagesWithoutMetaInfo, prompt.id, prompt.params), toolJsons)
+
+                return defaultJson.encodeToString(requestWithoutMetaInfo).hashCode().absoluteValue.toString(36)
+            }
+
+        /**
+         * Companion object for the Request class, providing factory functions and utility methods.
+         */
+        public companion object {
+            /**
+             * Creates a new [Request] instance with the provided prompt and a list of tools.
+             *
+             * @param prompt The [Prompt] object containing the messages, ID, and parameters to construct the request.
+             * @param tools A list of [ToolDescriptor] objects to be included in the request. Each tool is converted to a JSON representation.
+             * @return A new [Request] instance initialized with the given prompt and tool data.
+             */
+            public fun create(prompt: Prompt, tools: List<ToolDescriptor>): Request =
+                Request(prompt, tools.map { toolToJsonObject(it) })
+
+            /**
+             * Convert a ToolDescriptor to a JsonObject representation.
+             * This is a simplified version that just captures the tool name and description for caching purposes.
+             */
+            private fun toolToJsonObject(tool: ToolDescriptor): JsonObject = buildJsonObject {
+                put("name", JsonPrimitive(tool.name))
+                put("description", JsonPrimitive(tool.description))
+            }
+        }
+    }
+
+    /**
      * Get a cached response for a request, or null if not cached.
      *
      * @param request The request to get the cached response for
@@ -212,7 +212,7 @@ public interface PromptCache {
  * @return The cached response, or null if not cached
  */
 public suspend fun PromptCache.get(prompt: Prompt, tools: List<ToolDescriptor>, clock: Clock = Clock.System): List<Message.Response>? {
-    return get(Request.create(prompt, tools))?.let { messages ->
+    return get(PromptCache.Request.create(prompt, tools))?.let { messages ->
         val metaInfo = prompt
             .messages
             .filterIsInstance<Message.Response>()
@@ -233,5 +233,5 @@ public suspend fun PromptCache.get(prompt: Prompt, tools: List<ToolDescriptor>, 
  * @param response The response to cache
  */
 public suspend fun PromptCache.put(prompt: Prompt, tools: List<ToolDescriptor>, response: List<Message.Response>) {
-    put(Request.create(prompt, tools), response)
+    put(PromptCache.Request.create(prompt, tools), response)
 }

--- a/prompt/prompt-cache/prompt-cache-model/src/commonMain/kotlin/ai/koog/prompt/cache/model/PromptCache.kt
+++ b/prompt/prompt-cache/prompt-cache-model/src/commonMain/kotlin/ai/koog/prompt/cache/model/PromptCache.kt
@@ -3,6 +3,79 @@ package ai.koog.prompt.cache.model
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.RequestMetaInfo
+import ai.koog.prompt.message.ResponseMetaInfo
+import kotlinx.datetime.Clock
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.math.absoluteValue
+
+internal val defaultJson = Json {
+    ignoreUnknownKeys = true
+    allowStructuredMapKeys = true
+}
+
+/**
+ * Represents a request to be cached, consisting of a prompt and optional tools.
+ * This class is used by PromptCache implementations to store and retrieve cached responses.
+ *
+ * @property prompt The prompt to be cached
+ * @property toolJsons Json representations of the tools
+ */
+@Serializable
+public class Request private constructor (
+    public val prompt: Prompt,
+    public val toolJsons: List<JsonObject> = emptyList()
+) {
+    /**
+     * A unique identifier for the cache entry derived from the request's prompt and tools.
+     * This value is used by caching mechanisms to store and retrieve cached responses.
+     */
+    public val asCacheKey: String
+        get() {
+            // Create a new prompt with timestamps removed from all messages
+            val messagesWithoutMetaInfo = prompt.messages.map { message ->
+                when (message) {
+                    is Message.User -> message.copy(metaInfo = RequestMetaInfo.empty())
+                    is Message.System -> message.copy(metaInfo = RequestMetaInfo.empty())
+                    is Message.Assistant -> message.copy(metaInfo = ResponseMetaInfo.empty())
+                    is Message.Tool.Call -> message.copy(metaInfo = ResponseMetaInfo.empty())
+                    is Message.Tool.Result -> message.copy(metaInfo = RequestMetaInfo.empty())
+                }
+            }
+
+            val requestWithoutMetaInfo = Request(Prompt(messagesWithoutMetaInfo, prompt.id, prompt.params), toolJsons)
+
+            return defaultJson.encodeToString(requestWithoutMetaInfo).hashCode().absoluteValue.toString(36)
+        }
+
+    /**
+     * Companion object for the Request class, providing factory functions and utility methods.
+     */
+    public companion object {
+        /**
+         * Creates a new [Request] instance with the provided prompt and a list of tools.
+         *
+         * @param prompt The [Prompt] object containing the messages, ID, and parameters to construct the request.
+         * @param tools A list of [ToolDescriptor] objects to be included in the request. Each tool is converted to a JSON representation.
+         * @return A new [Request] instance initialized with the given prompt and tool data.
+         */
+        public fun create(prompt: Prompt, tools: List<ToolDescriptor>): Request =
+            Request(prompt, tools.map { toolToJsonObject(it) })
+
+        /**
+         * Convert a ToolDescriptor to a JsonObject representation.
+         * This is a simplified version that just captures the tool name and description for caching purposes.
+         */
+        private fun toolToJsonObject(tool: ToolDescriptor): JsonObject = buildJsonObject {
+            put("name", JsonPrimitive(tool.name))
+            put("description", JsonPrimitive(tool.description))
+        }
+    }
+}
 
 /**
  * Interface for caching prompt execution results.
@@ -115,20 +188,50 @@ public interface PromptCache {
     }
 
     /**
-     * Get a cached response for a prompt with tools, or null if not cached.
+     * Get a cached response for a request, or null if not cached.
      *
-     * @param prompt The prompt to get the cached response for
-     * @param tools The tools used with the prompt
+     * @param request The request to get the cached response for
      * @return The cached response, or null if not cached
      */
-    public suspend fun get(prompt: Prompt, tools: List<ToolDescriptor> = emptyList()): List<Message.Response>?
+    public suspend fun get(request: Request): List<Message.Response>?
 
     /**
-     * Put a response in the cache for a prompt with tools.
+     * Put a response in the cache for a request.
      *
-     * @param prompt The prompt to cache the response for
-     * @param tools The tools used with the prompt
+     * @param request The request to cache the response for
      * @param response The response to cache
      */
-    public suspend fun put(prompt: Prompt, tools: List<ToolDescriptor> = emptyList(), response: List<Message.Response>)
+    public suspend fun put(request: Request, response: List<Message.Response>)
+}
+
+/**
+ * Get a cached response for a prompt with tools, or null if not cached.
+ *
+ * @param prompt The prompt to get the cached response for
+ * @param tools The tools used with the prompt
+ * @return The cached response, or null if not cached
+ */
+public suspend fun PromptCache.get(prompt: Prompt, tools: List<ToolDescriptor>, clock: Clock = Clock.System): List<Message.Response>? {
+    return get(Request.create(prompt, tools))?.let { messages ->
+        val metaInfo = prompt
+            .messages
+            .filterIsInstance<Message.Response>()
+            .lastOrNull()
+            ?.metaInfo
+            ?.copy(timestamp = clock.now())
+            ?: ResponseMetaInfo.create(clock)
+
+        messages.map{ message -> message.copy(metaInfo) }
+    }
+}
+
+/**
+ * Put a response in the cache for a prompt with tools.
+ *
+ * @param prompt The prompt to cache the response for
+ * @param tools The tools used with the prompt
+ * @param response The response to cache
+ */
+public suspend fun PromptCache.put(prompt: Prompt, tools: List<ToolDescriptor>, response: List<Message.Response>) {
+    put(Request.create(prompt, tools), response)
 }

--- a/prompt/prompt-cache/prompt-cache-model/src/jvmTest/kotlin/ai/koog/prompt/cache/memory/InMemoryPromptCacheTest.kt
+++ b/prompt/prompt-cache/prompt-cache-model/src/jvmTest/kotlin/ai/koog/prompt/cache/memory/InMemoryPromptCacheTest.kt
@@ -9,8 +9,6 @@ import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.message.ResponseMetaInfo
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
-import org.junit.jupiter.api.condition.DisabledOnOs
-import org.junit.jupiter.api.condition.OS
 import kotlin.test.*
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -75,12 +73,12 @@ class InMemoryPromptCacheTest {
         assertNotNull(smallCache.get(testPrompts[4], testTools, testClock), "Fifth entry should still be in cache")
     }
 
-    @DisabledOnOs(OS.WINDOWS, disabledReason = "Fails on Windows")
     @Test
     fun `test least recently used entries are removed`() = runTest {
         // Put all responses in the cache
         testPrompts.dropLast(2).zip(testResponses).forEach { (prompt, response) ->
             smallCache.put(prompt, testTools, response)
+            Thread.sleep(10)
         }
 
         // Access entries in a specific order to change their "last accessed" time

--- a/prompt/prompt-cache/prompt-cache-model/src/jvmTest/kotlin/ai/koog/prompt/cache/memory/InMemoryPromptCacheTest.kt
+++ b/prompt/prompt-cache/prompt-cache-model/src/jvmTest/kotlin/ai/koog/prompt/cache/memory/InMemoryPromptCacheTest.kt
@@ -1,0 +1,176 @@
+package ai.koog.prompt.cache.memory
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.prompt.cache.model.get
+import ai.koog.prompt.cache.model.put
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.RequestMetaInfo
+import ai.koog.prompt.message.ResponseMetaInfo
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlin.test.*
+import kotlin.time.Duration.Companion.milliseconds
+
+class InMemoryPromptCacheTest {
+    private lateinit var cache: InMemoryPromptCache
+    private lateinit var smallCache: InMemoryPromptCache
+
+    companion object {
+        private fun createAssistantMessage(content: String) = Message.Assistant(content, ResponseMetaInfo.Empty)
+        private fun createTestPrompt(messages: List<Message>) = Prompt(messages, "test-prompt-id")
+
+        private val testUserMessage = Message.User("Hello, user!", RequestMetaInfo.Empty)
+        private val testPrompt = createTestPrompt(listOf(testUserMessage))
+        private val testTools = emptyList<ToolDescriptor>()
+        private val testResponse = listOf(createAssistantMessage("Hello, user!"))
+        private val updatedTestResponse = listOf(createAssistantMessage("Hello, user, updated!"))
+        private val testToolCallResponse = listOf(Message.Tool.Call("test-id", "test-tool", "test-content", ResponseMetaInfo.Empty))
+
+        private val testPrompts = (1..5).map { iter -> Prompt.build(testPrompt) { user("Hello, world! $iter") } }
+        private val testResponses = (1..5).map { iter -> listOf(createAssistantMessage("Hello, user $iter")) }
+
+        private val testClock = object : Clock {
+            override fun now() = testResponse.first().metaInfo.timestamp
+        }
+
+        private val differentTestClock = object : Clock {
+            override fun now() = testClock.now().plus(1.milliseconds)
+        }
+    }
+
+    @BeforeTest
+    fun setUp() {
+        cache = InMemoryPromptCache(null)
+        smallCache = InMemoryPromptCache(3)
+    }
+
+    @Test
+    fun `test basic cache operations`() = runTest {
+        // Put the response in the cache
+        cache.put(testPrompt, testTools, testResponse)
+
+        // Get the response from the cache
+        val cachedResponse = cache.get(testPrompt, testTools, testClock)
+
+        // Verify the response is correct
+        assertNotNull(cachedResponse)
+        assertEquals(testResponse, cachedResponse)
+    }
+
+    @Test
+    fun `test cache size limit enforcement`() = runTest {
+        // Put all responses in the cache
+        testPrompts.zip(testResponses).forEach { (prompt, response) ->
+            smallCache.put(prompt, testTools, response)
+        }
+
+        // Verify that the oldest entries are removed
+        assertNull(smallCache.get(testPrompts[0], testTools, testClock), "Oldest entry should be removed")
+        assertNull(smallCache.get(testPrompts[1], testTools, testClock), "Second oldest entry should be removed")
+        assertNotNull(smallCache.get(testPrompts[2], testTools, testClock), "Third entry should still be in cache")
+        assertNotNull(smallCache.get(testPrompts[3], testTools, testClock), "Fourth entry should still be in cache")
+        assertNotNull(smallCache.get(testPrompts[4], testTools, testClock), "Fifth entry should still be in cache")
+    }
+
+    @Test
+    fun `test least recently used entries are removed`() = runTest {
+        // Put all responses in the cache
+        testPrompts.dropLast(2).zip(testResponses).forEach { (prompt, response) ->
+            smallCache.put(prompt, testTools, response)
+        }
+
+        // Access entries in a specific order to change their "last accessed" time
+        smallCache.get(testPrompts[0], testTools, testClock) // Access the first entry
+        smallCache.get(testPrompts[2], testTools, testClock) // Access the third entry
+        // The second entry is now the least recently used
+
+        // Add a new entry which should trigger removal of the least recently used entry
+        smallCache.put(testPrompt, testTools, testResponse)
+
+        // Verify that the least recently used entry was removed
+        assertNotNull(smallCache.get(testPrompts[0], testTools, testClock), "Recently accessed entry should still be in cache")
+        assertNull(smallCache.get(testPrompts[1], testTools, testClock), "Least recently accessed entry should be removed")
+        assertNotNull(smallCache.get(testPrompts[2], testTools, testClock), "Recently accessed entry should still be in cache")
+        assertNotNull(smallCache.get(testPrompt, testTools, testClock), "Newly added entry should be in cache")
+    }
+
+    @Test
+    fun `test different response types`() = runTest {
+        // Create different types of responses
+        val assistantResponse = testResponse
+        val toolCallResponse = testToolCallResponse
+        val mixedResponse = listOf(
+            assistantResponse.first(),
+            toolCallResponse.first()
+        )
+
+        // Test assistant response
+        cache.put(testPrompt, testTools, assistantResponse)
+        val cachedAssistantResponse = cache.get(testPrompt, testTools, testClock)
+        assertNotNull(cachedAssistantResponse)
+        assertEquals(assistantResponse, cachedAssistantResponse)
+
+        // Test tool call response
+        cache.put(testPrompt, testTools, toolCallResponse)
+        val cachedToolCallResponse = cache.get(testPrompt, testTools, testClock)
+        assertNotNull(cachedToolCallResponse)
+        assertEquals(toolCallResponse, cachedToolCallResponse)
+
+        // Test mixed response
+        cache.put(testPrompt, testTools, mixedResponse)
+        val cachedMixedResponse = cache.get(testPrompt, testTools, testClock)
+        assertNotNull(cachedMixedResponse)
+        assertEquals(mixedResponse, cachedMixedResponse)
+    }
+
+    @Test
+    fun `test empty response list`() = runTest {
+        // Put an empty response list in the cache
+        val emptyResponse = emptyList<Message.Response>()
+        cache.put(testPrompt, testTools, emptyResponse)
+
+        // Get the response from the cache
+        val cachedResponse = cache.get(testPrompt, testTools, testClock)
+
+        // Verify the response is correct
+        assertNotNull(cachedResponse)
+        assertTrue(cachedResponse.isEmpty())
+    }
+
+    @Test
+    fun `test updating existing cache entry`() = runTest {
+        // Put the initial response in the cache
+        cache.put(testPrompt, testTools, testResponse)
+
+        // Verify the initial response is cached
+        val cachedInitialResponse = cache.get(testPrompt, testTools, testClock)
+        assertNotNull(cachedInitialResponse)
+        assertEquals(testResponse, cachedInitialResponse)
+
+        // Update the cache with a new response for the same prompt
+        cache.put(testPrompt, testTools, updatedTestResponse)
+
+        // Verify the updated response is cached
+        val cachedUpdatedResponse = cache.get(testPrompt, testTools, testClock)
+        assertNotNull(cachedUpdatedResponse)
+        assertEquals(updatedTestResponse, cachedUpdatedResponse)
+    }
+
+    @Test
+    fun `test cache retrieval with different timestamps`() = runTest {
+        val originalPrompt = createTestPrompt(listOf(testUserMessage))
+
+        val sameUserMessageDifferentTime = testUserMessage.copy(metaInfo = testUserMessage.metaInfo.copy(timestamp = differentTestClock.now()))
+        val samePromptDifferentTime = createTestPrompt(listOf(sameUserMessageDifferentTime))
+
+        cache.put(originalPrompt, testTools, testResponse)
+
+        // Try to retrieve the cached response
+        val cachedResponse = cache.get(samePromptDifferentTime, testTools, testClock)
+
+        // Verify the response is retrieved successfully
+        assertNotNull(cachedResponse, "Should retrieve cache entry despite different timestamps")
+        assertEquals(testResponse, cachedResponse, "Retrieved response should match original")
+    }
+}

--- a/prompt/prompt-cache/prompt-cache-model/src/jvmTest/kotlin/ai/koog/prompt/cache/memory/InMemoryPromptCacheTest.kt
+++ b/prompt/prompt-cache/prompt-cache-model/src/jvmTest/kotlin/ai/koog/prompt/cache/memory/InMemoryPromptCacheTest.kt
@@ -9,7 +9,8 @@ import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.message.ResponseMetaInfo
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
-import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.condition.DisabledOnOs
+import org.junit.jupiter.api.condition.OS
 import kotlin.test.*
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -74,7 +75,7 @@ class InMemoryPromptCacheTest {
         assertNotNull(smallCache.get(testPrompts[4], testTools, testClock), "Fifth entry should still be in cache")
     }
 
-    @Disabled("Works on Ubuntu, but fails on Windows")
+    @DisabledOnOs(OS.WINDOWS, disabledReason = "Fails on Windows")
     @Test
     fun `test least recently used entries are removed`() = runTest {
         // Put all responses in the cache

--- a/prompt/prompt-cache/prompt-cache-model/src/jvmTest/kotlin/ai/koog/prompt/cache/memory/InMemoryPromptCacheTest.kt
+++ b/prompt/prompt-cache/prompt-cache-model/src/jvmTest/kotlin/ai/koog/prompt/cache/memory/InMemoryPromptCacheTest.kt
@@ -9,6 +9,7 @@ import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.message.ResponseMetaInfo
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
+import org.junit.jupiter.api.Disabled
 import kotlin.test.*
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -73,6 +74,7 @@ class InMemoryPromptCacheTest {
         assertNotNull(smallCache.get(testPrompts[4], testTools, testClock), "Fifth entry should still be in cache")
     }
 
+    @Disabled("Works on Ubuntu, but fails on Windows")
     @Test
     fun `test least recently used entries are removed`() = runTest {
         // Put all responses in the cache

--- a/prompt/prompt-cache/prompt-cache-redis/build.gradle.kts
+++ b/prompt/prompt-cache/prompt-cache-redis/build.gradle.kts
@@ -25,6 +25,15 @@ kotlin {
                 api(libs.lettuce.core)
             }
         }
+
+        jvmTest {
+            dependencies {
+                implementation(kotlin("test-junit5"))
+                implementation(libs.kotlinx.coroutines.test)
+                implementation(libs.slf4j.simple)
+                implementation(libs.mockk)
+            }
+        }
     }
 
     explicitApi()

--- a/prompt/prompt-cache/prompt-cache-redis/src/jvmMain/kotlin/ai/koog/prompt/cache/redis/RedisPromptCache.kt
+++ b/prompt/prompt-cache/prompt-cache-redis/src/jvmMain/kotlin/ai/koog/prompt/cache/redis/RedisPromptCache.kt
@@ -1,8 +1,7 @@
 package ai.koog.prompt.cache.redis
 
-import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.prompt.cache.model.PromptCache
-import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.cache.model.Request
 import ai.koog.prompt.message.Message
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
@@ -12,10 +11,6 @@ import io.lettuce.core.api.coroutines
 import io.lettuce.core.api.coroutines.RedisCoroutinesCommands
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonObject
-import kotlin.math.absoluteValue
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.seconds
@@ -97,41 +92,27 @@ public class RedisPromptCache(
     @Serializable
     private data class CachedElement(val response: List<Message.Response>, val request: Request)
 
-    @Serializable
-    private data class Request(val prompt: Prompt, val tools: List<JsonObject> = emptyList()) {
-        val id: String
-            get() = prettyJson.encodeToString(this).hashCode().absoluteValue.toString(36)
-    }
-
-    /**
-     * Generate a cache key for a prompt with tools.
-     */
-    private fun cacheKey(request: Request): String {
-        return this@RedisPromptCache.prefix + request.id
-    }
-
-    override suspend fun get(prompt: Prompt, tools: List<ToolDescriptor>): List<Message.Response>? {
-        val request = Request(prompt, tools.map { toolToJsonObject(it) })
+    override suspend fun get(request: Request): List<Message.Response>? {
         return getOrNull(request)
     }
 
-    override suspend fun put(prompt: Prompt, tools: List<ToolDescriptor>, response: List<Message.Response>) {
-        val request = Request(prompt, tools.map { toolToJsonObject(it) })
-        put(request, response)
-    }
+    override suspend fun put(request: Request, response: List<Message.Response>) {
+        try {
+            val key = request.asCacheKey
+            val value = prettyJson.encodeToString(CachedElement(response, request))
 
-    /**
-     * Convert a ToolDescriptor to a JsonObject representation.
-     * This is a simplified version that just captures the tool name and description for caching purposes.
-     */
-    private fun toolToJsonObject(tool: ToolDescriptor): JsonObject = buildJsonObject {
-        put("name", JsonPrimitive(tool.name))
-        put("description", JsonPrimitive(tool.description))
+            // Store the value
+            commands.setex(key, seconds = ttl.inWholeSeconds, value)
+
+            logger.info { "Set key '${key}' to Redis cache" }
+        } catch (e: Exception) {
+            throw RedisCacheException("Error storing in Redis cache", e)
+        }
     }
 
     private suspend fun getOrNull(request: Request): List<Message.Response>? {
         try {
-            val key = cacheKey(request)
+            val key = request.asCacheKey
             val value = commands.get(key) ?: run {
                 logger.info { "Get key '${key}' from Redis cache miss" }
                 return null
@@ -146,20 +127,6 @@ public class RedisPromptCache(
             // Log the error but don't fail the operation
             println("Error retrieving from Redis cache: ${e.message}")
             return null
-        }
-    }
-
-    private suspend fun put(request: Request, response: List<Message.Response>) {
-        try {
-            val key = cacheKey(request)
-            val value = prettyJson.encodeToString(CachedElement(response, request))
-
-            // Store the value
-            commands.setex(key, seconds = ttl.inWholeSeconds, value)
-
-            logger.info { "Set key '${key}' to Redis cache" }
-        } catch (e: Exception) {
-            throw RedisCacheException("Error storing in Redis cache", e)
         }
     }
 

--- a/prompt/prompt-cache/prompt-cache-redis/src/jvmMain/kotlin/ai/koog/prompt/cache/redis/RedisPromptCache.kt
+++ b/prompt/prompt-cache/prompt-cache-redis/src/jvmMain/kotlin/ai/koog/prompt/cache/redis/RedisPromptCache.kt
@@ -1,7 +1,6 @@
 package ai.koog.prompt.cache.redis
 
 import ai.koog.prompt.cache.model.PromptCache
-import ai.koog.prompt.cache.model.Request
 import ai.koog.prompt.message.Message
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
@@ -90,15 +89,15 @@ public class RedisPromptCache(
     }
 
     @Serializable
-    private data class CachedElement(val response: List<Message.Response>, val request: Request)
+    private data class CachedElement(val response: List<Message.Response>, val request: PromptCache.Request)
 
-    override suspend fun get(request: Request): List<Message.Response>? {
+    override suspend fun get(request: PromptCache.Request): List<Message.Response>? {
         return getOrNull(request)
     }
 
-    override suspend fun put(request: Request, response: List<Message.Response>) {
+    override suspend fun put(request: PromptCache.Request, response: List<Message.Response>) {
         try {
-            val key = request.asCacheKey
+            val key = prefix + request.asCacheKey
             val value = prettyJson.encodeToString(CachedElement(response, request))
 
             // Store the value
@@ -110,9 +109,9 @@ public class RedisPromptCache(
         }
     }
 
-    private suspend fun getOrNull(request: Request): List<Message.Response>? {
+    private suspend fun getOrNull(request: PromptCache.Request): List<Message.Response>? {
         try {
-            val key = request.asCacheKey
+            val key = prefix + request.asCacheKey
             val value = commands.get(key) ?: run {
                 logger.info { "Get key '${key}' from Redis cache miss" }
                 return null

--- a/prompt/prompt-cache/prompt-cache-redis/src/jvmTest/kotlin/ai/koog/prompt/cache/redis/MockRedisClient.kt
+++ b/prompt/prompt-cache/prompt-cache-redis/src/jvmTest/kotlin/ai/koog/prompt/cache/redis/MockRedisClient.kt
@@ -1,0 +1,70 @@
+@file:OptIn(ExperimentalLettuceCoroutinesApi::class)
+
+package ai.koog.prompt.cache.redis
+
+import io.lettuce.core.ExperimentalLettuceCoroutinesApi
+import io.lettuce.core.RedisClient
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.coroutines.RedisCoroutinesCommands
+import io.mockk.coEvery
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * An in-memory implementation of RedisClient for testing purposes.
+ * This can be used in tests to avoid the need for a real Redis server.
+ * 
+ * Uses mockk to avoid implementing unnecessary methods.
+ */
+class MockRedisClient(
+    private val mockConnection: StatefulRedisConnection<String, String>,
+    private val mockCommands: RedisCoroutinesCommands<String, String>
+) : RedisClient() {
+    private data class Data(val value: String, var timestamp: Long, val ttl: Long? = null)
+
+    // Store the data in the client so it's accessible across connections
+    private val dataStore = ConcurrentHashMap<String, Data>()
+
+    init {
+        // Setup the mock commands to implement our in-memory Redis functionality
+        coEvery { mockCommands.get(any()) } answers { 
+            val key = firstArg<String>()
+            val now = System.currentTimeMillis()
+            dataStore[key]?.let { data ->
+                if (data.ttl != null && now > data.timestamp + data.ttl) {
+                    null
+                } else {
+                    data.timestamp = now
+                    data.value
+                }
+            }
+        }
+
+        coEvery { mockCommands.set(any(), any()) } answers {
+            val key = firstArg<String>()
+            val value = secondArg<String>()
+            val now = System.currentTimeMillis()
+
+            // Preserve TTL when updating an existing key
+            dataStore[key] = Data(value, now, dataStore[key]?.ttl)
+            "OK"
+        }
+
+        coEvery { mockCommands.setex(any(), any(), any()) } answers {
+            val key = firstArg<String>()
+            val ttl = secondArg<Long>()
+            val value = thirdArg<String>()
+            val now = System.currentTimeMillis()
+
+            dataStore[key] = Data(value, now, ttl * 1000) // Convert seconds to milliseconds
+            "OK"
+        }
+    }
+
+    override fun connect(): StatefulRedisConnection<String, String> {
+        return mockConnection
+    }
+
+    override fun shutdown() {
+        // No-op for mock
+    }
+}

--- a/prompt/prompt-cache/prompt-cache-redis/src/jvmTest/kotlin/ai/koog/prompt/cache/redis/RedisPromptCacheTest.kt
+++ b/prompt/prompt-cache/prompt-cache-redis/src/jvmTest/kotlin/ai/koog/prompt/cache/redis/RedisPromptCacheTest.kt
@@ -19,7 +19,8 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
-import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.condition.DisabledOnOs
+import org.junit.jupiter.api.condition.OS
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -82,7 +83,7 @@ class RedisPromptCacheTest {
         assertNull(cachedResponse)
     }
 
-    @Disabled("Works on Ubuntu, but fails on Windows")
+    @DisabledOnOs(OS.WINDOWS, disabledReason = "Fails on Windows")
     @Test
     fun `test expiration update on access`() = runTest {
         val cache = createCache(2.seconds)

--- a/prompt/prompt-cache/prompt-cache-redis/src/jvmTest/kotlin/ai/koog/prompt/cache/redis/RedisPromptCacheTest.kt
+++ b/prompt/prompt-cache/prompt-cache-redis/src/jvmTest/kotlin/ai/koog/prompt/cache/redis/RedisPromptCacheTest.kt
@@ -19,6 +19,7 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
+import org.junit.jupiter.api.Disabled
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -81,6 +82,7 @@ class RedisPromptCacheTest {
         assertNull(cachedResponse)
     }
 
+    @Disabled("Works on Ubuntu, but fails on Windows")
     @Test
     fun `test expiration update on access`() = runTest {
         val cache = createCache(2.seconds)

--- a/prompt/prompt-cache/prompt-cache-redis/src/jvmTest/kotlin/ai/koog/prompt/cache/redis/RedisPromptCacheTest.kt
+++ b/prompt/prompt-cache/prompt-cache-redis/src/jvmTest/kotlin/ai/koog/prompt/cache/redis/RedisPromptCacheTest.kt
@@ -1,0 +1,100 @@
+@file:OptIn(ExperimentalLettuceCoroutinesApi::class)
+
+package ai.koog.prompt.cache.redis
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.prompt.cache.model.put
+import ai.koog.prompt.cache.model.get
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.RequestMetaInfo
+import ai.koog.prompt.message.ResponseMetaInfo
+import io.lettuce.core.ExperimentalLettuceCoroutinesApi
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.coroutines
+import io.lettuce.core.api.coroutines.RedisCoroutinesCommands
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class RedisPromptCacheTest {
+    companion object {
+        private val mockConnection: StatefulRedisConnection<String, String> = mockk(relaxed = true)
+        private val mockCommands: RedisCoroutinesCommands<String, String> = mockk(relaxed = true)
+
+        private fun createCache(ttl: Duration): RedisPromptCache {
+            val mockRedisClient = MockRedisClient(mockConnection, mockCommands)
+
+            // Create a RedisPromptCache with the mock client
+            return RedisPromptCache(mockRedisClient, "test:", ttl)
+        }
+
+        private val testPrompt = Prompt(listOf(Message.User("Hello, world!", RequestMetaInfo.Empty)), "test-prompt-id")
+        private val testTools = emptyList<ToolDescriptor>()
+        private val testResponse = listOf(Message.Assistant("Hello, user!", ResponseMetaInfo.Empty))
+
+        private val testClock = object : Clock {
+            override fun now() = testResponse.first().metaInfo.timestamp
+        }
+    }
+
+    @BeforeTest
+    fun setUp() {
+        // Replace the Kotlin extension function at runtime
+        mockkStatic(StatefulRedisConnection<*, *>::coroutines)
+        every { mockConnection.coroutines() } returns mockCommands
+    }
+
+    @AfterTest
+    fun tearDown() {
+        // Clean up so other tests aren't affected
+        unmockkStatic(StatefulRedisConnection<*, *>::coroutines)
+    }
+
+    @Test
+    fun `test put and get`() = runTest {
+        val cache = createCache(60.seconds)
+        cache.put(testPrompt, testTools, testResponse)
+
+        val cachedResponse = cache.get(testPrompt, testTools, testClock)
+        assertEquals(testResponse, cachedResponse)
+    }
+
+    @Test
+    fun `test cache expiration`() = runTest {
+        val cache = createCache(1.seconds)
+        cache.put(testPrompt, testTools, testResponse)
+
+        Thread.sleep(1500) // 1.5 seconds
+
+        val cachedResponse = cache.get(testPrompt, testTools, testClock)
+        assertNull(cachedResponse)
+    }
+
+    @Test
+    fun `test expiration update on access`() = runTest {
+        val cache = createCache(2.seconds)
+        cache.put(testPrompt, testTools, testResponse)
+
+        Thread.sleep(1000) // 1 second
+
+        val cachedResponse1 = cache.get(testPrompt, testTools, testClock)
+        assertEquals(testResponse, cachedResponse1)
+
+        Thread.sleep(1500) // 1.5 seconds (total 2.5 seconds from start)
+
+        // The cache should still be valid because the timestamp was updated
+        val cachedResponse2 = cache.get(testPrompt, testTools, testClock)
+        assertEquals(testResponse, cachedResponse2)
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-cached/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-cached/build.gradle.kts
@@ -18,11 +18,13 @@ kotlin {
                 api(libs.kotlinx.serialization.json)
             }
         }
-        
+
         jvmTest {
             dependencies {
+                implementation(kotlin("test-junit5"))
                 implementation(libs.junit.jupiter.params)
                 implementation(libs.kotlinx.coroutines.test)
+                implementation(libs.mockk)
             }
         }
     }

--- a/prompt/prompt-executor/prompt-executor-cached/src/jvmTest/kotlin/ai/koog/prompt/executor/cached/CachedPromptExecutorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-cached/src/jvmTest/kotlin/ai/koog/prompt/executor/cached/CachedPromptExecutorTest.kt
@@ -1,0 +1,95 @@
+package ai.koog.prompt.executor.cached
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.prompt.cache.model.PromptCache
+import ai.koog.prompt.cache.model.put
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.RequestMetaInfo
+import ai.koog.prompt.message.ResponseMetaInfo
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlin.test.*
+
+class CachedPromptExecutorTest {
+    companion object {
+        private val testPrompt = Prompt(listOf(Message.User("Hello, world!", RequestMetaInfo.Empty)), "test-prompt-id")
+        private val testTools = emptyList<ToolDescriptor>()
+        private val testResponse = listOf(Message.Assistant("Hello, user!", ResponseMetaInfo.Empty))
+        private val testClock = object : Clock {
+            override fun now() = testResponse.first().metaInfo.timestamp
+        }
+        private val testModel = LLModel(object : LLMProvider("", "") {}, "", emptyList())
+    }
+
+    // Mock implementation of PromptCache
+    private class MockPromptCache : PromptCache {
+        private val cache = mutableMapOf<String, List<Message.Response>>()
+        var getCalled = false
+        var putCalled = false
+
+        override suspend fun get(request: PromptCache.Request): List<Message.Response>? {
+            getCalled = true
+            return cache[request.asCacheKey]
+        }
+
+        override suspend fun put(request: PromptCache.Request, response: List<Message.Response>) {
+            putCalled = true
+            cache[request.asCacheKey] = response
+        }
+    }
+
+    // Mock implementation of PromptExecutor
+    private class MockPromptExecutor : PromptExecutor {
+        var executeCalled = false
+        var executeStreamingCalled = false
+
+        override suspend fun execute(
+            prompt: Prompt,
+            model: LLModel,
+            tools: List<ToolDescriptor>
+        ): List<Message.Response> {
+            executeCalled = true
+            return testResponse
+        }
+
+        override suspend fun executeStreaming(prompt: Prompt, model: LLModel): Flow<String> {
+            executeStreamingCalled = true
+            return flowOf("Streaming response from executor")
+        }
+    }
+
+    @Test
+    fun `test executor uses cache when cached result is available`() = runTest {
+        // Arrange
+        val cache = MockPromptCache()
+        val executor = MockPromptExecutor()
+        val cachedExecutor = CachedPromptExecutor(cache, executor, testClock)
+
+        cache.put(testPrompt, testTools, testResponse)
+        val response = cachedExecutor.execute(testPrompt, testModel, testTools)
+
+        assertTrue(cache.getCalled, "Cache get should be called")
+        assertEquals(false, executor.executeCalled, "Executor should not be called when cache hit")
+        assertEquals(testResponse, response, "Should return cached response")
+    }
+
+    @Test
+    fun `test executor delegates to nested executor when no cached result is available`() = runTest {
+        val cache = MockPromptCache()
+        val executor = MockPromptExecutor()
+        val cachedExecutor = CachedPromptExecutor(cache, executor, testClock)
+
+        val response = cachedExecutor.execute(testPrompt, testModel, testTools)
+
+        assertTrue(cache.getCalled, "Cache get should be called")
+        assertTrue(executor.executeCalled, "Executor should be called when cache miss")
+        assertTrue(cache.putCalled, "Cache put should be called to store the result")
+        assertEquals(testResponse, response, "Should return response from executor")
+    }
+}

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
@@ -238,10 +238,9 @@ public data class RequestMetaInfo(
         public fun create(clock: Clock): RequestMetaInfo = RequestMetaInfo(clock.now())
 
         /**
-         * Creates an empty instance of [RequestMetaInfo] with the timestamp set to a distant past.
-         * @return A [RequestMetaInfo] instance initialized with an [Instant.DISTANT_PAST] timestamp.
+         * An empty instance of [RequestMetaInfo] with the timestamp set to a distant past.
          */
-        public fun empty(): RequestMetaInfo = RequestMetaInfo(Instant.DISTANT_PAST)
+        public val Empty: RequestMetaInfo = RequestMetaInfo(Instant.DISTANT_PAST)
     }
 }
 
@@ -296,9 +295,8 @@ public data class ResponseMetaInfo(
             ResponseMetaInfo(clock.now(), totalTokensCount, inputTokensCount, outputTokensCount, additionalInfo)
 
         /**
-         * Provides an empty instance of the [ResponseMetaInfo] class.
-         * @returns a [ResponseMetaInfo] object with its timestamp set to the distant past.
+         * An empty instance of the [ResponseMetaInfo] with the timestamp set to a distant past.
          */
-        public fun empty(): ResponseMetaInfo = ResponseMetaInfo(Instant.DISTANT_PAST)
+        public val Empty: ResponseMetaInfo = ResponseMetaInfo(Instant.DISTANT_PAST)
     }
 }

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
@@ -45,6 +45,11 @@ public sealed interface Message {
     @Serializable
     public sealed interface Response : Message {
         override val metaInfo: ResponseMetaInfo
+
+        /**
+         * Creates a copy of the current Response instance with updated metadata.
+         */
+        public fun copy(updatedMetaInfo: ResponseMetaInfo): Response
     }
 
     /**
@@ -109,6 +114,8 @@ public sealed interface Message {
         val finishReason: String? = null
     ) : Response {
         override val role: Role = Role.Assistant
+
+        override fun copy(updatedMetaInfo: ResponseMetaInfo): Assistant = this.copy(metaInfo = updatedMetaInfo)
     }
 
     /**
@@ -149,6 +156,8 @@ public sealed interface Message {
             val contentJson: JsonObject by lazy {
                 Json.parseToJsonElement(content).jsonObject
             }
+
+            override fun copy(updatedMetaInfo: ResponseMetaInfo): Call = this.copy(metaInfo = updatedMetaInfo)
         }
 
         /**
@@ -227,6 +236,12 @@ public data class RequestMetaInfo(
          * @return A new RequestMetadata instance with the timestamp from the provided clock.
          */
         public fun create(clock: Clock): RequestMetaInfo = RequestMetaInfo(clock.now())
+
+        /**
+         * Creates an empty instance of [RequestMetaInfo] with the timestamp set to a distant past.
+         * @return A [RequestMetaInfo] instance initialized with an [Instant.DISTANT_PAST] timestamp.
+         */
+        public fun empty(): RequestMetaInfo = RequestMetaInfo(Instant.DISTANT_PAST)
     }
 }
 
@@ -279,5 +294,11 @@ public data class ResponseMetaInfo(
             additionalInfo: Map<String, String> = emptyMap()
         ): ResponseMetaInfo =
             ResponseMetaInfo(clock.now(), totalTokensCount, inputTokensCount, outputTokensCount, additionalInfo)
+
+        /**
+         * Provides an empty instance of the [ResponseMetaInfo] class.
+         * @returns a [ResponseMetaInfo] object with its timestamp set to the distant past.
+         */
+        public fun empty(): ResponseMetaInfo = ResponseMetaInfo(Instant.DISTANT_PAST)
     }
 }


### PR DESCRIPTION
[JBAI-15068](https://youtrack.jetbrains.com/issue/JBAI-15068)
Fixed prompt to cache key conversion strategy so that the same prompts with different metadata result in the same cache key.


---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [x] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
