### PR TITLE
Add RetryExtension and OllamaTestFixtureExtension to OllamaAgentIntegrationTest

### DIFF
--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OllamaAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OllamaAgentIntegrationTest.kt
@@ -13,17 +13,21 @@ import ai.koog.integration.tests.tools.AnswerVerificationTool
 import ai.koog.integration.tests.tools.GenericParameterTool
 import ai.koog.integration.tests.tools.GeographyQueryTool
 import ai.koog.integration.tests.utils.annotations.Retry
+import ai.koog.integration.tests.utils.annotations.RetryExtension
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.OllamaModels
 import ai.koog.prompt.params.LLMParams
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
+@ExtendWith(OllamaTestFixtureExtension::class)
+@ExtendWith(RetryExtension::class)
 class OllamaAgentIntegrationTest {
     companion object {
         @field:InjectOllamaTestFixture


### PR DESCRIPTION
Fix the failing OllamaAgentIntegrationTest by adding necessary extensions via the `@ExtendWith` annotation.

---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
