### PR TITLE
Adjust OpenTelemetry attributes to reflect the real agent operation when viewed in Langfuse or Weave

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/build.gradle.kts
+++ b/agents/agents-features/agents-features-opentelemetry/build.gradle.kts
@@ -44,6 +44,7 @@ kotlin {
         jvmTest {
             dependencies {
                 implementation(kotlin("test-junit5"))
+                implementation(libs.opentelemetry.sdk.testing)
                 implementation(project(":agents:agents-test"))
             }
         }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/CommonAttributes.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/CommonAttributes.kt
@@ -20,6 +20,18 @@ internal object CommonAttributes {
             override val key: String = super.key.concatKey("type")
             override val value: String = type
         }
+
+        // error.message
+        data class Message(private val message: String) : Error {
+            override val key: String = super.key.concatKey("message")
+            override val value: String = message
+        }
+
+        // error.stacktrace
+        data class Stacktrace(private val stacktrace: String) : Error {
+            override val key: String = super.key.concatKey("stacktrace")
+            override val value: String = stacktrace
+        }
     }
 
     // server

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ExceptionEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ExceptionEvent.kt
@@ -1,0 +1,20 @@
+package ai.koog.agents.features.opentelemetry.event
+
+import ai.koog.agents.features.opentelemetry.attribute.Attribute
+import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
+
+internal class ExceptionEvent(
+    private val throwable: Throwable,
+    override val verbose: Boolean = false,
+) : GenAIAgentEvent {
+
+    override val name: String = super.name.concatName("exception")
+
+    override val attributes: List<Attribute> = buildList {
+        add(CommonAttributes.Error.Type(throwable.cause.toString()))
+        add(CommonAttributes.Error.Message(throwable.message.toString()))
+        add(CommonAttributes.Error.Stacktrace(throwable.stackTraceToString()))
+    }
+
+    override val bodyFields: List<EventBodyField> = emptyList()
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
@@ -114,10 +114,13 @@ public class OpenTelemetry {
             pipeline.interceptAgentRunError(interceptContext) { eventContext ->
                 logger.debug { "Execute OpenTelemetry agent run error handler" }
 
+                val errorStatus = SpanEndStatus(code = StatusCode.ERROR, description = eventContext.throwable.message)
+
                 // Make sure all spans inside InvokeAgentSpan are finished
                 spanProcessor.endUnfinishedInvokeAgentSpans(
                     agentId = eventContext.agentId,
-                    runId = eventContext.runId
+                    runId = eventContext.runId,
+                    errorStatus
                 )
 
                 // Finish current InvokeAgentSpan
@@ -133,7 +136,7 @@ public class OpenTelemetry {
                 spanProcessor.endSpan(
                     spanId = invokeAgentSpanId,
                     attributes = finishAttributes,
-                    spanEndStatus = SpanEndStatus(code = StatusCode.ERROR, description = eventContext.throwable.message)
+                    spanEndStatus = errorStatus
                 )
             }
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/SpanProcessor.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/SpanProcessor.kt
@@ -99,7 +99,7 @@ internal class SpanProcessor(private val tracer: Tracer) {
             ?: error("Span with id <$id> is not of expected type. Expected: <${T::class.simpleName}>, actual: <${span::class.simpleName}>")
     }
 
-    fun endUnfinishedSpans(filter: (spanId: String) -> Boolean = { true }) {
+    fun endUnfinishedSpans(filter: (spanId: String) -> Boolean = { true }, spanEndStatus: SpanEndStatus? = null) {
         _spans.keys
             .filter { spanId ->
                 val isRequireFinish = filter(spanId)
@@ -110,16 +110,16 @@ internal class SpanProcessor(private val tracer: Tracer) {
                 endSpan(
                     spanId = spanId,
                     attributes = emptyList(),
-                    spanEndStatus = SpanEndStatus(StatusCode.UNSET)
+                    spanEndStatus = spanEndStatus ?: SpanEndStatus(StatusCode.UNSET)
                 )
             }
     }
 
-    fun endUnfinishedInvokeAgentSpans(agentId: String, runId: String) {
+    fun endUnfinishedInvokeAgentSpans(agentId: String, runId: String, spanEndStatus: SpanEndStatus? = null) {
         val agentRunSpanId = InvokeAgentSpan.createId(agentId, runId)
         val agentSpanId = CreateAgentSpan.createId(agentId)
 
-        endUnfinishedSpans(filter = { id -> id != agentSpanId && id != agentRunSpanId })
+        endUnfinishedSpans(filter = { id -> id != agentSpanId && id != agentRunSpanId }, spanEndStatus)
     }
 
     //region Private Methods

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/langfuse/TracingTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/langfuse/TracingTest.kt
@@ -1,0 +1,259 @@
+package ai.koog.agents.features.opentelemetry.langfuse
+
+import ai.koog.agents.core.agent.entity.AIAgentStrategy
+import ai.koog.agents.core.dsl.builder.forwardTo
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.core.dsl.extension.nodeLLMRequest
+import ai.koog.agents.core.dsl.extension.nodeUpdatePrompt
+import ai.koog.agents.core.dsl.extension.onAssistantMessage
+import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.createAgent
+import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
+import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.agents.testing.tools.mockLLMAnswer
+import ai.koog.agents.utils.use
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.resources.Resource
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor
+import io.opentelemetry.sdk.trace.export.SpanExporter
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Clock
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.lang.System
+import java.time.Duration
+import java.util.*
+import java.util.concurrent.TimeUnit
+import kotlin.test.AfterTest
+import kotlin.test.assertTrue
+
+/**
+ * Test assumes manual traces inspection using Langfuse.
+ *
+ * TODO: convert to general OTEL test with InMemorySpanExporter
+ */
+class TracingTest {
+    val inMemorySpanExporter: InMemorySpanExporter = InMemorySpanExporter.create()
+
+    @AfterTest
+    fun cleanSpans() {
+        inMemorySpanExporter.reset()
+    }
+
+    @Test
+    fun testSingleLLMCall() = runBlocking {
+        val strategy = strategy("single-llm-call-strategy") {
+            val llmRequest by nodeLLMRequest("llm-call")
+
+            edge(nodeStart forwardTo llmRequest)
+            edge(llmRequest forwardTo nodeFinish onAssistantMessage { true })
+        }
+
+        runAgentWithStrategy(strategy)
+
+        val spans = inMemorySpanExporter.finishedSpanItems
+
+        assertTrue { spans.filter { it.name.startsWith("run.") }.size == 1 }
+        assertTrue { spans.filter { it.name == "node.__start__" }.size == 1 }
+        assertTrue { spans.filter { it.name == "node.llm-call" }.size == 1 }
+        assertTrue { spans.filter { it.name == "llm.test-prompt-id" }.size == 1 }
+
+        val runNode = spans.first { it.name.startsWith("run.") }
+        val startNode = spans.first { it.name == "node.__start__" }
+        val llmNode = spans.first { it.name == "node.llm-call" }
+        val llmGeneration = spans.first { it.name == "llm.test-prompt-id" }
+
+        assertTrue { runNode.spanId == startNode.parentSpanId }
+        assertTrue { runNode.spanId == llmNode.parentSpanId }
+        assertTrue { llmNode.spanId == llmGeneration.parentSpanId }
+    }
+
+    @Test
+    fun testSubsequentLLMCalls() = runBlocking {
+        val strategy = strategy("tracing-test-strategy") {
+            val setPrompt by nodeUpdatePrompt("Set prompt") {
+                system("System 1")
+                user("User 1")
+            }
+            val updatePrompt by nodeUpdatePrompt("Update prompt") {
+                system("System 2")
+                user("User 2")
+            }
+
+            val llmRequest0 by nodeLLMRequest("LLM Request 1", allowToolCalls = false)
+            val llmRequest1 by nodeLLMRequest("LLM Request 2", allowToolCalls = false)
+
+            edge(nodeStart forwardTo setPrompt)
+            edge(setPrompt forwardTo llmRequest0)
+            edge(llmRequest0 forwardTo updatePrompt transformed { input -> })
+            edge(updatePrompt forwardTo llmRequest1 transformed { input -> "" })
+            edge(llmRequest1 forwardTo nodeFinish transformed { input -> input.content })
+        }
+
+        runAgentWithStrategy(strategy)
+    }
+
+    private suspend fun runAgentWithStrategy(strategy: AIAgentStrategy<String, String>) {
+        val userPrompt = "User prompt message"
+        val agentId = "test-agent-id"
+        val promptId = "test-prompt-id"
+        val testClock = Clock.System
+        val model = OpenAIModels.Chat.GPT4o
+        val temperature = 0.4
+
+        val mockResponse = "The weather in Paris is rainy and overcast, with temperatures around 57°F"
+
+        val mockExecutor = getMockExecutor(clock = testClock) {
+            mockLLMAnswer(mockResponse) onRequestEquals userPrompt
+        }
+
+        val agent = createAgent(
+            agentId = agentId,
+            strategy = strategy,
+            promptId = promptId,
+            promptExecutor = mockExecutor,
+            model = model,
+            clock = testClock,
+            temperature = temperature
+        ) {
+            install(OpenTelemetry) {
+                addSpanExporter(
+                    createLangfuseSpanExporter(
+                        System.getenv()["LANGFUSE_HOST"]
+                            ?: throw IllegalArgumentException("LANGFUSE_PUBLIC_KEY is not set"),
+                        System.getenv()["LANGFUSE_PUBLIC_KEY"]
+                            ?: throw IllegalArgumentException("LANGFUSE_PUBLIC_KEY is not set"),
+                        System.getenv()["LANGFUSE_SECRET_KEY"]
+                            ?: throw IllegalArgumentException("LANGFUSE_SECRET_KEY is not set"),
+                    )
+                )
+                addSpanExporter(
+                    createWeaveSpanExporter(
+                        "https://trace.wandb.ai",
+                        System.getenv()["WEAVE_ENTITY"] ?: throw IllegalArgumentException("WEAVE_ENTITY is not set"),
+                        System.getenv()["WEAVE_PROJECT_NAME"] ?: "koog-tracing",
+                        System.getenv()["WEAVE_API_KEY"] ?: throw IllegalArgumentException("WEAVE_API_KEY is not set")
+                    )
+                )
+                addSpanExporter(inMemorySpanExporter)
+            }
+        }
+
+        agent.use {
+            it.run(userPrompt)
+        }
+    }
+}
+
+fun createLangfuseSpanExporter(
+    langfuseUrl: String,
+    langfusePublicKey: String,
+    langfuseSecretKey: String,
+): SpanExporter {
+    val credentials = "$langfusePublicKey:$langfuseSecretKey"
+    val auth = Base64.getEncoder().encodeToString(credentials.toByteArray(Charsets.UTF_8))
+
+    return OtlpHttpSpanExporter.builder()
+        .setTimeout(30, TimeUnit.SECONDS)
+        .setEndpoint("$langfuseUrl/api/public/otel/v1/traces")
+        .addHeader("Authorization", "Basic $auth")
+        .build()
+}
+
+private fun createWeaveSpanExporter(
+    weaveOtelUrl: String,
+    entity: String,
+    projectName: String,
+    apiKey: String,
+): SpanExporter {
+    val auth = Base64.getEncoder().encodeToString("api:$apiKey".toByteArray(Charsets.UTF_8))
+
+    return OtlpHttpSpanExporter.builder()
+        .setTimeout(30, TimeUnit.SECONDS)
+        .setEndpoint("$weaveOtelUrl/otel/v1/traces")
+        .addHeader("project_id", "$entity/$projectName")
+        .addHeader("Authorization", "Basic $auth")
+        .build()
+}
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class BaseOpenTelemetryTracingTest {
+    internal lateinit var tracerProvider: SdkTracerProvider
+    internal lateinit var spanExporter: InMemorySpanExporter
+    internal lateinit var tracer: Tracer
+
+    @BeforeAll
+    fun setupTelemetry() {
+        val tracing = initOpenTelemetry()
+
+        tracerProvider = tracing.tracerProvider
+        spanExporter = tracing.spanExporter as InMemorySpanExporter
+        tracer = GlobalOpenTelemetry.getTracer("koog.tracer")
+    }
+
+    @AfterTest
+    fun cleanSpans() {
+        spanExporter.reset()
+    }
+
+    @AfterAll
+    fun shutdownTelemetry() {
+        tracerProvider.apply {
+            forceFlush().join(1, TimeUnit.SECONDS)
+            shutdown().join(1, TimeUnit.SECONDS)
+        }
+    }
+
+    fun analyzeSpans(): List<SpanData> {
+        tracerProvider.forceFlush().join(30, TimeUnit.SECONDS)
+        return spanExporter.finishedSpanItems.mapNotNull { it }
+    }
+}
+
+fun initOpenTelemetry(): Tracing {
+    val resource = Resource.getDefault()
+        .merge(
+            Resource.create(
+                Attributes.of(AttributeKey.stringKey("service.name"), "ai-development-kit")
+            )
+        )
+
+    val spanExporter = InMemorySpanExporter.create()
+    val batchProcessor = BatchSpanProcessor.builder(spanExporter)
+        .setScheduleDelay(Duration.ofMillis(100))
+        .setMaxExportBatchSize(512)
+        .setMaxQueueSize(2048)
+        .build()
+
+
+    val tracerProvider = SdkTracerProvider.builder()
+        .setResource(resource)
+        .addSpanProcessor(batchProcessor)
+        .build()
+
+    val openTelemetry = OpenTelemetrySdk.builder()
+        .setTracerProvider(tracerProvider)
+        .buildAndRegisterGlobal()
+
+    val sdk = openTelemetry
+    Runtime.getRuntime().addShutdownHook(Thread {
+        sdk.sdkTracerProvider.shutdown()
+    })
+
+    return Tracing(tracerProvider, spanExporter)
+}
+
+data class Tracing(
+    val tracerProvider: SdkTracerProvider,
+    val spanExporter: SpanExporter
+)

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/langfuse/TracingTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/langfuse/TracingTest.kt
@@ -246,10 +246,9 @@ class TracingTest {
         assertTrue(spans.any { it.name == "node.Error Node" }, "Expected error node to be present")
 
         val errorNode = spans.first { it.name == "node.Error Node" }
+        val errorCode = errorNode.status.statusCode.toString()
 
-        assertTrue("Expected error status when no exception events are present") {
-            errorNode.status.statusCode.toString() == "ERROR"
-        }
+        assertTrue(errorCode == "ERROR", "Expected ERROR status code, instead: $errorCode")
     }
 
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/langfuse/TracingTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/langfuse/TracingTest.kt
@@ -249,19 +249,25 @@ class TracingTest {
         val errorNode = spans.first { it.name == "node.Error Node" }
         val errorNodeErrorCode = errorNode.status.statusCode.toString()
         val errorNodeErrorMessage = errorNode.status.description
+        val errorNodeEvents = errorNode.events
 
         assertTrue(
             errorNodeErrorCode == "ERROR",
             "On error node expected ERROR status code, instead: $errorNodeErrorCode"
         )
         assertEquals("Test error in node", errorNodeErrorMessage)
+        assertTrue(errorNodeEvents.isNotEmpty(), "Expected non empty events for node that throws an exception")
+        assertEquals(errorNodeEvents.first().name, "gen_ai.exception")
 
         val runNode = spans.first { it.name.startsWith("run.") }
         val runNodeErrorCode = runNode.status.statusCode.toString()
         val runNodeErrorMessage = runNode.status.description
+        val runNodeEvents = runNode.events
 
         assertTrue(runNodeErrorCode == "ERROR", "On run node expected ERROR status code, instead: $runNodeErrorCode")
         assertEquals("Test error in node", runNodeErrorMessage)
+        assertTrue(runNodeEvents.isNotEmpty(), "Expected non empty events for run node")
+        assertEquals(runNodeEvents.first().name, "gen_ai.exception")
     }
 
     @Test
@@ -292,28 +298,36 @@ class TracingTest {
         // all nodes: error, proxy and run are marked with ERROR
         val errorNode = spans.first { it.name == "node.Error Node" }
         val errorNodeErrorCode = errorNode.status.statusCode.toString()
+        val errorNodeErrorMessage = errorNode.status.description
+        val errorNodeEvents = errorNode.events
 
         assertTrue(
             errorNodeErrorCode == "ERROR",
             "On error node expected ERROR status code, instead: $errorNodeErrorCode"
         )
+        assertEquals("Test error in node", errorNodeErrorMessage)
+        assertTrue(errorNodeEvents.isNotEmpty(), "Expected non empty events for error node")
 
         val proxyNode = spans.first { it.name == "node.Proxy Node" }
         val proxyNodeErrorCode = proxyNode.status.statusCode.toString()
         val proxyNodeErrorMessage = proxyNode.status.description
+        val proxyNodeEvents = proxyNode.events
 
         assertTrue(
             proxyNodeErrorCode == "ERROR",
             "On proxy node expected ERROR status code, instead: $proxyNodeErrorCode"
         )
         assertEquals("Test error in node", proxyNodeErrorMessage)
+        assertTrue(proxyNodeEvents.isNotEmpty(), "Expected non empty events for proxy node")
 
         val runNode = spans.first { it.name.startsWith("run.") }
         val runNodeErrorCode = runNode.status.statusCode.toString()
         val runNodeErrorMessage = runNode.status.description
+        val runNodeEvents = runNode.events
 
         assertTrue(runNodeErrorCode == "ERROR", "On run node expected ERROR status code, instead: $runNodeErrorCode")
         assertEquals("Test error in node", runNodeErrorMessage)
+        assertTrue(runNodeEvents.isNotEmpty(), "Expected non empty events for run node")
     }
 
     /**

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/mock/MockToolGetWeather.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/mock/MockToolGetWeather.kt
@@ -23,6 +23,9 @@ internal object TestGetWeatherTool : SimpleTool<TestGetWeatherTool.Args>() {
     )
 
     override suspend fun doExecute(args: Args): String {
-        return "rainy, 57°F"
+        return when (args.location) {
+            "London" -> "cloudy, 62°F"
+            else -> "rainy, 57°F"
+        }
     }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/span/SpanProcessorTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/span/SpanProcessorTest.kt
@@ -190,7 +190,7 @@ class SpanProcessorTest {
         assertFalse(span3.isEnded)
 
         // End spans that match the filter (only span1)
-        spanProcessor.endUnfinishedSpans { id -> id == span1Id }
+        spanProcessor.endUnfinishedSpans({ id -> id == span1Id })
 
         // Verify span1 is ended, span2 was already ended, span3 is still not ended
         assertTrue(span1.isStarted)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,7 @@ opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk" }
 opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp" }
 opentelemetry-exporter-logging = { module = "io.opentelemetry:opentelemetry-exporter-logging" }
 aws-sdk-kotlin-bedrockruntime = { module = "aws.sdk.kotlin:bedrockruntime", version.ref = "aws-sdk-kotlin" }
+opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testing" }
 
 # Spring
 spring-boot-bom = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot" }


### PR DESCRIPTION
Adopting OTEL support to Langfuse and W&B Weave traces visualization.

[Semantic conventions for generative AI systems](https://opentelemetry.io/docs/specs/semconv/gen-ai/) are currently in draft, so not all attributes are supported on collectors side and some additional attributes may be required.

The goal of this change is to adjust trace attributes so traces/spans reflects the real agent operation when viewed in Langfuse and Weave.

---

#### Type of the change
- [x] New feature
- [x] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [ ] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [ ] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
