### PR TITLE
Fix open telemetry parallel nodes support

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentNode.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentNode.kt
@@ -123,9 +123,9 @@ public abstract class AIAgentNodeBase<Input, Output> internal constructor() {
  * @property execute A suspending function that defines the execution logic for the node. It
  * processes the provided input within the given execution context and produces an output.
  */
-internal class AIAgentNode<Input, Output> internal constructor(
+public open class AIAgentNode<Input, Output> internal constructor(
     override val name: String,
-    val execute: suspend AIAgentContextBase.(input: Input) -> Output
+    public val execute: suspend AIAgentContextBase.(input: Input) -> Output
 ) : AIAgentNodeBase<Input, Output>() {
 
     @InternalAgentsApi
@@ -151,25 +151,14 @@ internal class AIAgentNode<Input, Output> internal constructor(
  * execution flow in multi-subgraph setups.
  *
  * @param Input The type of input data this node processes and produces as output.
+ * @param subgraphName The name of the related subgraph
  */
-public class StartNode<Input> internal constructor() : AIAgentNodeBase<Input, Input>() {
-    /**
-     * The name of the subgraph associated with the AI agent's starting node.
-     *
-     * This property serves as an identifier or label for the subgraph, helping to distinguish
-     * and reference specific AI workflows or strategies. It can be null if no subgraph
-     * name has been assigned.
-     *
-     * Internal changes to this property are restricted to ensure controlled modification, as the setter
-     * is marked internal. Its value may influence how the AI agent node generates its unique name.
-     */
-    public var subgraphName: String? = null
-        internal set
-
-    override val name: String get() = subgraphName?.let { "__start__$it" } ?: "__start__"
-
-    override suspend fun execute(context: AIAgentContextBase, input: Input): Input = input
-}
+public class StartNode<Input> internal constructor(
+    subgraphName: String? = null
+) : AIAgentNode<Input, Input>(
+    name = subgraphName?.let { "__start__$it" } ?: "__start__",
+    execute = { input -> input }
+)
 
 /**
  * Represents a specialized node within an AI agent strategy graph that marks the endpoint of a subgraph.
@@ -184,25 +173,15 @@ public class StartNode<Input> internal constructor() : AIAgentNodeBase<Input, In
  * execution flow in multi-subgraph setups.
  *
  * @param Output The type of data this node processes and produces.
+ * @param subgraphName The name of the related subgraph
  */
-public class FinishNode<Output> internal constructor() : AIAgentNodeBase<Output, Output>() {
-    /**
-     * Stores the name of the subgraph associated with the node.
-     *
-     * This variable is used to identify or tag subgraphs in AI agent strategies.
-     * If `subgraphName` is set, it will be integrated into the node's identity or behavior,
-     * such as forming a unique name for the node.
-     *
-     * This property is mutable within the internal scope, but read-only from external scopes.
-     */
-    public var subgraphName: String? = null
-        internal set
-
-    override val name: String = subgraphName?.let { "__finish__$it" } ?: "__finish__"
-
+public class FinishNode<Output> internal constructor(
+    subgraphName: String? = null
+) : AIAgentNode<Output, Output>(
+    name = subgraphName?.let { "__finish__$it" } ?: "__finish__",
+    execute = { input -> input }
+) {
     override fun addEdge(edge: AIAgentEdge<Output, *>) {
         throw IllegalStateException("FinishSubgraphNode cannot have outgoing edges")
     }
-
-    override suspend fun execute(context: AIAgentContextBase, input: Output): Output = input
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentNode.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentNode.kt
@@ -85,7 +85,6 @@ public abstract class AIAgentNodeBase<Input, Output> internal constructor() {
      * @suppress
      */
     @Suppress("UNCHECKED_CAST")
-    @InternalAgentsApi
     public suspend fun resolveEdgeUnsafe(context: AIAgentContextBase, nodeOutput: Any?): ResolvedEdge? =
         resolveEdge(context, nodeOutput as Output)
 
@@ -108,7 +107,6 @@ public abstract class AIAgentNodeBase<Input, Output> internal constructor() {
      * @return The result of the execution, which may be of any type depending on the implementation.
      */
     @Suppress("UNCHECKED_CAST")
-    @InternalAgentsApi
     public suspend fun executeUnsafe(context: AIAgentContextBase, input: Any?): Any? =
         execute(context, input as Input)
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentNode.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentNode.kt
@@ -109,15 +109,8 @@ public abstract class AIAgentNodeBase<Input, Output> internal constructor() {
      */
     @Suppress("UNCHECKED_CAST")
     @InternalAgentsApi
-    public suspend fun executeUnsafe(context: AIAgentContextBase, input: Any?): Any? {
-        return withContext(NodeInfoContextElement(nodeName = name)) {
-            context.pipeline.onBeforeNode(context = context, node = this@AIAgentNodeBase, input = input)
-            val output = execute(context, input as Input)
-            context.pipeline.onAfterNode(context = context, node = this@AIAgentNodeBase, input = input, output = output)
-
-            return@withContext output
-        }
-    }
+    public suspend fun executeUnsafe(context: AIAgentContextBase, input: Any?): Any? =
+        execute(context, input as Input)
 }
 
 /**
@@ -134,7 +127,16 @@ internal class AIAgentNode<Input, Output> internal constructor(
     override val name: String,
     val execute: suspend AIAgentContextBase.(input: Input) -> Output
 ) : AIAgentNodeBase<Input, Output>() {
-    override suspend fun execute(context: AIAgentContextBase, input: Input): Output = context.execute(input)
+
+    @InternalAgentsApi
+    override suspend fun execute(context: AIAgentContextBase, input: Input): Output {
+        return withContext(NodeInfoContextElement(nodeName = name)) {
+            context.pipeline.onBeforeNode(context = context, node = this@AIAgentNode, input = input)
+            val nodeOutput = context.execute(input)
+            context.pipeline.onAfterNode(context = context, node = this@AIAgentNode, input = input, output = nodeOutput)
+            return@withContext nodeOutput
+        }
+    }
 }
 
 /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentSubgraph.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentSubgraph.kt
@@ -3,7 +3,6 @@ package ai.koog.agents.core.agent.entity
 import ai.koog.agents.core.agent.AIAgentMaxNumberOfIterationsReachedException
 import ai.koog.agents.core.agent.AIAgentStuckInTheNodeException
 import ai.koog.agents.core.agent.context.AIAgentContextBase
-import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.dsl.extension.replaceHistoryWithTLDR
 import ai.koog.agents.core.prompt.Prompts.selectRelevantTools
 import ai.koog.agents.core.tools.ToolDescriptor
@@ -84,7 +83,6 @@ public open class AIAgentSubgraph<Input, Output>(
      * @param input The input object representing the data to be processed by the AI agent.
      * @return The output of the AI agent execution, generated after processing the input.
      */
-    @OptIn(InternalAgentsApi::class)
     override suspend fun execute(context: AIAgentContextBase, input: Input): Output {
         val newTools = selectTools(context)
 
@@ -99,7 +97,7 @@ public open class AIAgentSubgraph<Input, Output>(
             )
         }
 
-        // Execute the subgraph with inner context and get the result and updated prompt.
+        // Execute the subgraph with an inner context and get the result and updated prompt.
         val result = executeWithInnerContext(innerContext, input)
 
         // Restore original LLM params on the new prompt.
@@ -111,7 +109,6 @@ public open class AIAgentSubgraph<Input, Output>(
         return result
     }
 
-    @OptIn(InternalAgentsApi::class)
     private suspend fun executeWithInnerContext(context: AIAgentContextBase, initialInput: Input): Output {
         logger.info { formatLog(context, "Executing subgraph $name") }
         var currentNode: AIAgentNodeBase<*, *> = start

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentSubgraph.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentSubgraph.kt
@@ -38,7 +38,8 @@ public open class AIAgentSubgraph<Input, Output>(
     private val llmParams: LLMParams? = null,
 ) : AIAgentNodeBase<Input, Output>() {
     private companion object {
-        private val logger = KotlinLogging.logger("ai.koog.agents.core.agent.entity.${AIAgentSubgraph::class.simpleName}")
+        private val logger =
+            KotlinLogging.logger("ai.koog.agents.core.agent.entity.${AIAgentSubgraph::class.simpleName}")
     }
 
     @Serializable
@@ -46,6 +47,35 @@ public open class AIAgentSubgraph<Input, Output>(
         @property:LLMDescription("List of selected tools for the given subtask")
         val tools: List<String>
     )
+
+    private suspend fun selectTools(context: AIAgentContextBase) = when (toolSelectionStrategy) {
+        is ToolSelectionStrategy.ALL -> context.llm.tools
+        is ToolSelectionStrategy.NONE -> emptyList()
+        is ToolSelectionStrategy.Tools -> toolSelectionStrategy.tools
+        is ToolSelectionStrategy.AutoSelectForTask -> context.llm.writeSession {
+            val initialPrompt = prompt
+
+            replaceHistoryWithTLDR()
+
+            updatePrompt {
+                user {
+                    selectRelevantTools(tools, toolSelectionStrategy.subtaskDescription)
+                }
+            }
+
+            val selectedTools = this.requestLLMStructured(
+                structure = JsonStructuredData.createJsonStructure<SelectedTools>(
+                    schemaFormat = JsonSchemaGenerator.SchemaFormat.JsonSchema,
+                    examples = listOf(SelectedTools(listOf()), SelectedTools(tools.map { it.name }.take(3))),
+                ),
+                retries = toolSelectionStrategy.maxRetries,
+            ).getOrThrow()
+
+            prompt = initialPrompt
+
+            tools.filter { it.name in selectedTools.structure.tools.toSet() }
+        }
+    }
 
     /**
      * Executes the desired operation based on the input and the provided context.
@@ -57,39 +87,9 @@ public open class AIAgentSubgraph<Input, Output>(
      */
     @OptIn(InternalAgentsApi::class)
     override suspend fun execute(context: AIAgentContextBase, input: Input): Output {
-        val newTools = when (toolSelectionStrategy) {
-            ToolSelectionStrategy.ALL -> context.llm.tools
+        val newTools = selectTools(context)
 
-            ToolSelectionStrategy.NONE -> emptyList()
-
-            is ToolSelectionStrategy.Tools -> toolSelectionStrategy.tools
-
-            is ToolSelectionStrategy.AutoSelectForTask -> context.llm.writeSession {
-                val initialPrompt = prompt
-
-                replaceHistoryWithTLDR()
-
-                updatePrompt {
-                    user {
-                        selectRelevantTools(tools, toolSelectionStrategy.subtaskDescription)
-                    }
-                }
-
-                val selectedTools = this.requestLLMStructured(
-                    structure = JsonStructuredData.createJsonStructure<SelectedTools>(
-                        schemaFormat = JsonSchemaGenerator.SchemaFormat.JsonSchema,
-                        examples = listOf(SelectedTools(listOf()), SelectedTools(tools.map { it.name }.take(3))),
-                    ),
-                    retries = toolSelectionStrategy.maxRetries,
-                ).getOrThrow()
-
-                prompt = initialPrompt
-
-                tools.filter { it.name in selectedTools.structure.tools.toSet() }
-            }
-        }
-
-        // Copy inner context with new tools, model and LLM params
+        // Copy inner context with new tools, model and LLM params.
         val innerContext = with(context) {
             copy(
                 llm = llm.copy(
@@ -100,21 +100,20 @@ public open class AIAgentSubgraph<Input, Output>(
             )
         }
 
-        /*
-         Execute subgraph with inner context and get result and updated prompt.
-         Restore original LLM params on the new prompt.
-        */
-        val result = doExecute(innerContext, input)
-        val newPrompt = innerContext.llm.readSession { prompt.copy(params = context.llm.prompt.params) }
+        // Execute the subgraph with inner context and get the result and updated prompt.
+        val result = executeWithInnerContext(innerContext, input)
 
-        // Update outer context with new prompt
+        // Restore original LLM params on the new prompt.
+        val newPrompt = innerContext.llm.readSession {
+            prompt.copy(params = context.llm.prompt.params)
+        }
         context.llm.writeSession { prompt = newPrompt }
 
         return result
     }
 
     @OptIn(InternalAgentsApi::class)
-    protected suspend fun doExecute(context: AIAgentContextBase, initialInput: Input): Output {
+    private suspend fun executeWithInnerContext(context: AIAgentContextBase, initialInput: Input): Output {
         logger.info { formatLog(context, "Executing subgraph $name") }
         var currentNode: AIAgentNodeBase<*, *> = start
         var currentInput: Any? = initialInput

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentSubgraph.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentSubgraph.kt
@@ -38,8 +38,7 @@ public open class AIAgentSubgraph<Input, Output>(
     private val llmParams: LLMParams? = null,
 ) : AIAgentNodeBase<Input, Output>() {
     private companion object {
-        private val logger =
-            KotlinLogging.logger("ai.koog.agents.core.agent.entity.${AIAgentSubgraph::class.simpleName}")
+        private val logger = KotlinLogging.logger { }
     }
 
     @Serializable

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/builder/AIAgentNodeBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/builder/AIAgentNodeBuilder.kt
@@ -3,7 +3,6 @@ package ai.koog.agents.core.dsl.builder
 import ai.koog.agents.core.agent.context.AIAgentContextBase
 import ai.koog.agents.core.agent.entity.AIAgentNode
 import ai.koog.agents.core.agent.entity.AIAgentNodeBase
-import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.utils.Some
 import kotlin.reflect.KProperty
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/builder/AIAgentNodeBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/builder/AIAgentNodeBuilder.kt
@@ -3,6 +3,7 @@ package ai.koog.agents.core.dsl.builder
 import ai.koog.agents.core.agent.context.AIAgentContextBase
 import ai.koog.agents.core.agent.entity.AIAgentNode
 import ai.koog.agents.core.agent.entity.AIAgentNodeBase
+import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.utils.Some
 import kotlin.reflect.KProperty
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/builder/AIAgentSubgraphBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/builder/AIAgentSubgraphBuilder.kt
@@ -176,8 +176,8 @@ public class AIAgentSubgraphBuilder<Input, Output>(
     private val llmParams: LLMParams?,
 ) : AIAgentSubgraphBuilderBase<Input, Output>(),
     BaseBuilder<AIAgentSubgraphDelegate<Input, Output>> {
-    override val nodeStart: StartNode<Input> = StartNode()
-    override val nodeFinish: FinishNode<Output> = FinishNode()
+    override val nodeStart: StartNode<Input> = StartNode(name)
+    override val nodeFinish: FinishNode<Output> = FinishNode(name)
 
     override fun build(): AIAgentSubgraphDelegate<Input, Output> {
         require(isFinishReachable(nodeStart)) {
@@ -234,8 +234,8 @@ public open class AIAgentSubgraphDelegate<Input, Output> internal constructor(
 
             subgraph = AIAgentSubgraph<Input, Output>(
                 name = nameOfSubgraph,
-                start = nodeStart.apply { subgraphName = nameOfSubgraph },
-                finish = nodeFinish.apply { subgraphName = nameOfSubgraph },
+                start = nodeStart,
+                finish = nodeFinish,
                 toolSelectionStrategy = toolSelectionStrategy,
                 llmModel = llmModel,
                 llmParams = llmParams,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/builder/AIAgentSubgraphBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/builder/AIAgentSubgraphBuilder.kt
@@ -186,7 +186,6 @@ public class AIAgentSubgraphBuilder<Input, Output>(
 
         return AIAgentSubgraphDelegate(name, nodeStart, nodeFinish, toolSelectionStrategy, llmModel, llmParams)
     }
-
 }
 
 /**
@@ -229,7 +228,7 @@ public open class AIAgentSubgraphDelegate<Input, Output> internal constructor(
      */
     public operator fun getValue(thisRef: Any?, property: KProperty<*>): AIAgentSubgraph<Input, Output> {
         if (subgraph == null) {
-            // if name is explicitly defined, use it, otherwise use property name as node name
+            // if the name is explicitly defined, use it, otherwise use the property name as node name
             val nameOfSubgraph = this@AIAgentSubgraphDelegate.name ?: property.name
 
             subgraph = AIAgentSubgraph<Input, Output>(

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
@@ -784,10 +784,6 @@ class OpenTelemetryTest {
             assertTrue(collectedSpans.isNotEmpty(), "Spans should be created during agent execution")
 
             agent.close()
-
-            // Print all collected spans for debugging
-            logger.debug { "All collected spans: ${collectedSpans.map { it.name }}" }
-
             // Check each span
             // We expect spans for:
             // 1. Agent creation
@@ -801,82 +797,48 @@ class OpenTelemetryTest {
             val nodeSpanNames = collectedSpans.map { it.name }
                 .filter { it.startsWith("node.") }
                 .sorted()
-            
+
             logger.debug { "Node span names: $nodeSpanNames" }
-            
+
             // Print all node spans with their attributes for debugging
             collectedSpans.filter { it.name.startsWith("node.") }.forEach { span ->
                 val attributes = span.attributes.asMap().asSequence().associate { it.key.key to it.value }
                 logger.debug { "Node span: ${span.name}, attributes: $attributes" }
             }
-            
+
             // Check if we have the expected number of node spans (5 nodes)
-            assertEquals(5, nodeSpanNames.size, "Expected 5 node spans but found ${nodeSpanNames.size}")
-            
+            assertEquals(6, nodeSpanNames.size, "Expected 6 node spans but found ${nodeSpanNames.size}")
+
             // Check for each specific node span
             assertTrue(nodeSpanNames.any { it.contains("nodeFirstJoke") }, "First joke node span should be created")
             assertTrue(nodeSpanNames.any { it.contains("nodeSecondJoke") }, "Second joke node span should be created")
             assertTrue(nodeSpanNames.any { it.contains("nodeThirdJoke") }, "Third joke node span should be created")
-            assertTrue(nodeSpanNames.any { it.contains("nodeSelectBestJoke") }, "Select best joke node span should be created")
-            assertTrue(nodeSpanNames.any { it.contains("nodeGenerateJokes") }, "Generate jokes node span should be created")
-            
-            // Create expected spans structure
-            val expectedSpans = listOf(
-                mapOf(
-                    "agent.$agentId" to mapOf(
-                        "attributes" to mapOf(
-                            "gen_ai.operation.name" to "create_agent",
-                            "gen_ai.system" to model.provider.id,
-                            "gen_ai.agent.id" to agentId,
-                            "gen_ai.request.model" to model.id
-                        ),
-                        "events" to emptyMap()
-                    )
-                ),
-                
-                mapOf(
-                    "run.${mockExporter.lastRunId}" to mapOf(
-                        "attributes" to mapOf(
-                            "gen_ai.operation.name" to "invoke_agent",
-                            "koog.agent.strategy.name" to "test-strategy",
-                            "gen_ai.system" to model.provider.id,
-                            "gen_ai.agent.id" to agentId,
-                            "gen_ai.conversation.id" to mockExporter.lastRunId
-                        ),
-                        "events" to emptyMap()
-                    )
-                )
+            assertTrue(
+                nodeSpanNames.any { it.contains("nodeSelectBestJoke") },
+                "Select best joke node span should be created"
             )
-            
-            // Span count already verified above
-            
-            // Verify run span attributes
-            val runSpan = collectedSpans.find { it.name == "run.${mockExporter.lastRunId}" }
-            assertNotNull(runSpan, "Run span should be created")
-            
-            val runSpanAttributes = runSpan.attributes.asMap().asSequence().associate {
-                it.key.key to it.value
-            }
-            
-            assertEquals("invoke_agent", runSpanAttributes["gen_ai.operation.name"], "Run span should have operation name 'invoke_agent'")
-            assertEquals("test-strategy", runSpanAttributes["koog.agent.strategy.name"], "Run span should have strategy name 'test-strategy'")
-            assertEquals(agentId, runSpanAttributes["gen_ai.agent.id"], "Run span should have agent ID '$agentId'")
-            
+            assertTrue(
+                nodeSpanNames.any { it.contains("nodeGenerateJokes") },
+                "Generate jokes node span should be created"
+            )
+
             // Verify parallel node spans have the correct conversation ID
-            val parallelNodeSpans = collectedSpans.filter { 
-                it.name.startsWith("node.") && 
-                (it.name.contains("nodeFirstJoke") || it.name.contains("nodeSecondJoke") || it.name.contains("nodeThirdJoke")) 
+            val parallelNodeSpans = collectedSpans.filter {
+                it.name.startsWith("node.") &&
+                        (it.name.contains("nodeFirstJoke") || it.name.contains("nodeSecondJoke") || it.name.contains("nodeThirdJoke"))
             }
-            
+
             assertEquals(3, parallelNodeSpans.size, "Should have 3 parallel node spans")
-            
+
             parallelNodeSpans.forEach { span ->
                 val spanAttributes = span.attributes.asMap().asSequence().associate {
                     it.key.key to it.value
                 }
-                
-                assertEquals(mockExporter.lastRunId, spanAttributes["gen_ai.conversation.id"], 
-                    "Parallel node span ${span.name} should have conversation ID '${mockExporter.lastRunId}'")
+
+                assertEquals(
+                    mockExporter.lastRunId, spanAttributes["gen_ai.conversation.id"],
+                    "Parallel node span ${span.name} should have conversation ID '${mockExporter.lastRunId}'"
+                )
             }
         }
     }
@@ -931,8 +893,16 @@ class OpenTelemetryTest {
     }
 
     private fun assertSpanNames(expectedSpanNames: List<String>, actualSpanNames: List<String>) {
-        assertEquals(expectedSpanNames.size, actualSpanNames.size, "Expected collection of spans should be the same size")
-        assertContentEquals(expectedSpanNames, actualSpanNames, "Expected collection of spans should be the same as actual")
+        assertEquals(
+            expectedSpanNames.size,
+            actualSpanNames.size,
+            "Expected collection of spans should be the same size"
+        )
+        assertContentEquals(
+            expectedSpanNames,
+            actualSpanNames,
+            "Expected collection of spans should be the same as actual"
+        )
     }
 
     /**
@@ -957,7 +927,10 @@ class OpenTelemetryTest {
             logger.debug { "Asserting event (name: $actualEventName) for the Span (name: $spanName)" }
 
             val expectedEventAttributes = expectedEvents[actualEventName]
-            assertNotNull(expectedEventAttributes, "Event (name: $actualEventName) not found in expected events for span (name: $spanName)")
+            assertNotNull(
+                expectedEventAttributes,
+                "Event (name: $actualEventName) not found in expected events for span (name: $spanName)"
+            )
 
             assertAttributes(spanName, expectedEventAttributes, actualEventAttributes)
         }
@@ -985,8 +958,15 @@ class OpenTelemetryTest {
             logger.debug { "Find expected attribute (name: $actualArgName) for the Span (name: $spanName)" }
             val expectedArgValue = expectedAttributes[actualArgName]
 
-            assertNotNull(expectedArgValue, "Attribute (name: $actualArgName) not found in expected attributes for span (name: $spanName)")
-            assertEquals(expectedArgValue, actualArgValue, "Attribute values should be the same for the span (name: $spanName)()")
+            assertNotNull(
+                expectedArgValue,
+                "Attribute (name: $actualArgName) not found in expected attributes for span (name: $spanName)"
+            )
+            assertEquals(
+                expectedArgValue,
+                actualArgValue,
+                "Attribute values should be the same for the span (name: $spanName)()"
+            )
         }
     }
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
@@ -742,10 +742,7 @@ class OpenTelemetryTest {
                 // Define a node to run joke generation in parallel
                 val nodeGenerateJokes by parallel(
                     nodeFirstJoke, nodeSecondJoke, nodeThirdJoke
-                )
-
-                // Define a node to select the best joke
-                val nodeSelectBestJoke by merge<String, String> {
+                ) {
                     selectByIndex { jokes ->
                         // Always select the first joke for testing purposes
                         0
@@ -753,8 +750,7 @@ class OpenTelemetryTest {
                 }
 
                 edge(nodeStart forwardTo nodeGenerateJokes)
-                edge(nodeGenerateJokes forwardTo nodeSelectBestJoke)
-                edge(nodeSelectBestJoke forwardTo nodeFinish)
+                edge(nodeGenerateJokes forwardTo nodeFinish)
             }
 
             val mockResponse = "Why do programmers prefer dark mode? Because light attracts bugs!"
@@ -807,16 +803,12 @@ class OpenTelemetryTest {
             }
 
             // Check if we have the expected number of node spans (5 nodes)
-            assertEquals(6, nodeSpanNames.size, "Expected 6 node spans but found ${nodeSpanNames.size}")
+            assertEquals(5, nodeSpanNames.size, "Expected 6 node spans but found ${nodeSpanNames.size}")
 
             // Check for each specific node span
             assertTrue(nodeSpanNames.any { it.contains("nodeFirstJoke") }, "First joke node span should be created")
             assertTrue(nodeSpanNames.any { it.contains("nodeSecondJoke") }, "Second joke node span should be created")
             assertTrue(nodeSpanNames.any { it.contains("nodeThirdJoke") }, "Third joke node span should be created")
-            assertTrue(
-                nodeSpanNames.any { it.contains("nodeSelectBestJoke") },
-                "Select best joke node span should be created"
-            )
             assertTrue(
                 nodeSpanNames.any { it.contains("nodeGenerateJokes") },
                 "Generate jokes node span should be created"

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
@@ -715,6 +715,172 @@ class OpenTelemetryTest {
         }
     }
 
+    @Test
+    fun `test spans are created for agent with parallel nodes execution`() = runBlocking {
+        MockSpanExporter().use { mockExporter ->
+
+            val userPrompt = "What's the best joke about programming?"
+            val agentId = "test-agent-id"
+            val promptId = "test-prompt-id"
+            val testClock = Clock.System
+            val model = OpenAIModels.Chat.GPT4o
+            val temperature = 0.4
+
+            val strategy = strategy("test-strategy") {
+                val nodeFirstJoke by node<String, String> { topic ->
+                    "First joke about $topic: Why do programmers prefer dark mode? Because light attracts bugs!"
+                }
+
+                val nodeSecondJoke by node<String, String> { topic ->
+                    "Second joke about $topic: Why do Java developers wear glasses? Because they don't C#!"
+                }
+
+                val nodeThirdJoke by node<String, String> { topic ->
+                    "Third joke about $topic: A SQL query walks into a bar, walks up to two tables and asks, 'Can I join you?'"
+                }
+
+                // Define a node to run joke generation in parallel
+                val nodeGenerateJokes by parallel(
+                    nodeFirstJoke, nodeSecondJoke, nodeThirdJoke
+                )
+
+                // Define a node to select the best joke
+                val nodeSelectBestJoke by merge<String, String> {
+                    selectByIndex { jokes ->
+                        // Always select the first joke for testing purposes
+                        0
+                    }
+                }
+
+                edge(nodeStart forwardTo nodeGenerateJokes)
+                edge(nodeGenerateJokes forwardTo nodeSelectBestJoke)
+                edge(nodeSelectBestJoke forwardTo nodeFinish)
+            }
+
+            val mockResponse = "Why do programmers prefer dark mode? Because light attracts bugs!"
+
+            val mockExecutor = getMockExecutor(clock = testClock) {
+                mockLLMAnswer(mockResponse) onRequestEquals userPrompt
+            }
+
+            val agent = createAgent(
+                agentId = agentId,
+                strategy = strategy,
+                promptId = promptId,
+                promptExecutor = mockExecutor,
+                model = model,
+                clock = testClock,
+                temperature = temperature
+            ) {
+                install(OpenTelemetry) {
+                    addSpanExporter(mockExporter)
+                    setVerbose(true)
+                }
+            }
+
+            agent.run(userPrompt)
+
+            val collectedSpans = mockExporter.collectedSpans
+            assertTrue(collectedSpans.isNotEmpty(), "Spans should be created during agent execution")
+
+            agent.close()
+
+            // Print all collected spans for debugging
+            logger.debug { "All collected spans: ${collectedSpans.map { it.name }}" }
+
+            // Check each span
+            // We expect spans for:
+            // 1. Agent creation
+            // 2. Agent run
+            // 3. Start node
+            // 4. Each parallel node (3 nodes)
+            // 5. Merge node
+            // 6. Finish node
+
+            // Verify that we have spans for all parallel nodes
+            val nodeSpanNames = collectedSpans.map { it.name }
+                .filter { it.startsWith("node.") }
+                .sorted()
+            
+            logger.debug { "Node span names: $nodeSpanNames" }
+            
+            // Print all node spans with their attributes for debugging
+            collectedSpans.filter { it.name.startsWith("node.") }.forEach { span ->
+                val attributes = span.attributes.asMap().asSequence().associate { it.key.key to it.value }
+                logger.debug { "Node span: ${span.name}, attributes: $attributes" }
+            }
+            
+            // Check if we have the expected number of node spans (5 nodes)
+            assertEquals(5, nodeSpanNames.size, "Expected 5 node spans but found ${nodeSpanNames.size}")
+            
+            // Check for each specific node span
+            assertTrue(nodeSpanNames.any { it.contains("nodeFirstJoke") }, "First joke node span should be created")
+            assertTrue(nodeSpanNames.any { it.contains("nodeSecondJoke") }, "Second joke node span should be created")
+            assertTrue(nodeSpanNames.any { it.contains("nodeThirdJoke") }, "Third joke node span should be created")
+            assertTrue(nodeSpanNames.any { it.contains("nodeSelectBestJoke") }, "Select best joke node span should be created")
+            assertTrue(nodeSpanNames.any { it.contains("nodeGenerateJokes") }, "Generate jokes node span should be created")
+            
+            // Create expected spans structure
+            val expectedSpans = listOf(
+                mapOf(
+                    "agent.$agentId" to mapOf(
+                        "attributes" to mapOf(
+                            "gen_ai.operation.name" to "create_agent",
+                            "gen_ai.system" to model.provider.id,
+                            "gen_ai.agent.id" to agentId,
+                            "gen_ai.request.model" to model.id
+                        ),
+                        "events" to emptyMap()
+                    )
+                ),
+                
+                mapOf(
+                    "run.${mockExporter.lastRunId}" to mapOf(
+                        "attributes" to mapOf(
+                            "gen_ai.operation.name" to "invoke_agent",
+                            "koog.agent.strategy.name" to "test-strategy",
+                            "gen_ai.system" to model.provider.id,
+                            "gen_ai.agent.id" to agentId,
+                            "gen_ai.conversation.id" to mockExporter.lastRunId
+                        ),
+                        "events" to emptyMap()
+                    )
+                )
+            )
+            
+            // Span count already verified above
+            
+            // Verify run span attributes
+            val runSpan = collectedSpans.find { it.name == "run.${mockExporter.lastRunId}" }
+            assertNotNull(runSpan, "Run span should be created")
+            
+            val runSpanAttributes = runSpan.attributes.asMap().asSequence().associate {
+                it.key.key to it.value
+            }
+            
+            assertEquals("invoke_agent", runSpanAttributes["gen_ai.operation.name"], "Run span should have operation name 'invoke_agent'")
+            assertEquals("test-strategy", runSpanAttributes["koog.agent.strategy.name"], "Run span should have strategy name 'test-strategy'")
+            assertEquals(agentId, runSpanAttributes["gen_ai.agent.id"], "Run span should have agent ID '$agentId'")
+            
+            // Verify parallel node spans have the correct conversation ID
+            val parallelNodeSpans = collectedSpans.filter { 
+                it.name.startsWith("node.") && 
+                (it.name.contains("nodeFirstJoke") || it.name.contains("nodeSecondJoke") || it.name.contains("nodeThirdJoke")) 
+            }
+            
+            assertEquals(3, parallelNodeSpans.size, "Should have 3 parallel node spans")
+            
+            parallelNodeSpans.forEach { span ->
+                val spanAttributes = span.attributes.asMap().asSequence().associate {
+                    it.key.key to it.value
+                }
+                
+                assertEquals(mockExporter.lastRunId, spanAttributes["gen_ai.conversation.id"], 
+                    "Parallel node span ${span.name} should have conversation ID '${mockExporter.lastRunId}'")
+            }
+        }
+    }
+
     //region Private Methods
 
     /**

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/feature/TestingFeature.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/feature/TestingFeature.kt
@@ -6,7 +6,6 @@ import ai.koog.agents.core.agent.config.AIAgentConfigBase
 import ai.koog.agents.core.agent.context.AIAgentContextBase
 import ai.koog.agents.core.agent.context.AIAgentLLMContext
 import ai.koog.agents.core.agent.entity.*
-import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.environment.AIAgentEnvironment
 import ai.koog.agents.core.environment.ReceivedToolResult
 import ai.koog.agents.core.feature.AIAgentFeature
@@ -1013,7 +1012,6 @@ public class Testing {
                     )
                 }
 
-                @OptIn(InternalAgentsApi::class)
                 config.assertEquals(
                     assertion.expectedOutput,
                     fromNode.executeUnsafe(
@@ -1025,7 +1023,6 @@ public class Testing {
                 )
             }
 
-            @OptIn(InternalAgentsApi::class)
             // Verify edges using DFS
             for (assertion in graphAssertions.edgeAssertions) {
                 val fromNode = assertion.node.resolve(graph)
@@ -1045,7 +1042,6 @@ public class Testing {
                 )
             }
 
-            @OptIn(InternalAgentsApi::class)
             // Verify edges using DFS
             for (assertion in graphAssertions.unconditionalEdgeAssertions) {
                 val fromNode = assertion.node.resolve(graph)

--- a/examples/src/main/kotlin/ai/koog/agents/example/parallelexecution/BestJokeAgent.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/parallelexecution/BestJokeAgent.kt
@@ -6,6 +6,7 @@ import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.example.ApiKeyService
+import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
 import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
@@ -14,6 +15,7 @@ import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.structure.json.JsonStructuredData
+import io.opentelemetry.exporter.logging.LoggingSpanExporter
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 
@@ -138,7 +140,10 @@ fun main(args: Array<String>) = runBlocking {
             LLMProvider.Anthropic to AnthropicLLMClient(ApiKeyService.anthropicApiKey),
         ), strategy = strategy, agentConfig = agentConfig, toolRegistry = ToolRegistry.EMPTY
     ) {
-
+        install(OpenTelemetry) {
+            // Add a console logger for local debugging
+            addSpanExporter(LoggingSpanExporter.create())
+        }
     }
 
     val topic = "programming"


### PR DESCRIPTION
Before the name duplication exception was thrown from, because parallel nodes call not `executeUnsafe` but `execute`, skipping adding naming for the open telemetry


---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix

#### Checklist for all pull requests
- [ ] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [ ] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
