### PR TITLE
Validate retryCount in RetrySubgraphResult and add unit tests for retry logic

### DIFF
--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/SubgraphWithRetry.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/SubgraphWithRetry.kt
@@ -18,7 +18,11 @@ public data class RetrySubgraphResult<Output>(
     val output: Output,
     val success: Boolean,
     val retryCount: Int,
-)
+) {
+    init {
+        require(retryCount > 0) { "retryCount must be greater than 0" }
+    }
+}
 
 /**
  * Creates a subgraph with retry mechanism, allowing a specified action subgraph to be retried multiple

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/SubgraphWithRetryTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/SubgraphWithRetryTest.kt
@@ -1,0 +1,424 @@
+package ai.koog.agents.ext.agent
+
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.features.eventHandler.feature.EventHandler
+import ai.koog.agents.testing.tools.DummyTool
+import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.llm.OllamaModels
+import kotlinx.coroutines.test.runTest
+import kotlin.test.*
+
+private const val MAX_AGENT_ITERATIONS = 20
+private const val SUCCESS = "success"
+private fun getBasicResult(
+    output: String? = "test output",
+    success: Boolean = true,
+    retryCount: Int = 2,
+) =
+    RetrySubgraphResult(
+        output = output,
+        success = success,
+        retryCount = retryCount,
+    )
+
+class SubgraphWithRetryTest {
+
+    @Test
+    fun testRetrySubgraphResult() = runTest {
+        val result = getBasicResult()
+
+        assertEquals("test output", result.output)
+        assertTrue(result.success)
+        assertEquals(2, result.retryCount)
+    }
+
+    @Test
+    fun testRetrySubgraphResultNullOutput() = runTest {
+        val result = getBasicResult(null)
+
+        assertEquals(null, result.output)
+        assertTrue(result.success)
+        assertEquals(2, result.retryCount)
+    }
+
+    @Test
+    fun testRetrySubgraphResultZeroRetries() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            getBasicResult(retryCount = 0)
+        }
+    }
+
+    @Test
+    fun testRetrySubgraphResultCopy() = runTest {
+        val result = getBasicResult()
+
+        val copiedResult = result.copy()
+
+        assertEquals(result.output, copiedResult.output)
+        assertEquals(result.success, copiedResult.success)
+        assertEquals(result.retryCount, copiedResult.retryCount)
+    }
+
+    @Test
+    fun testRetrySubgraphResultCopyWithChanges() = runTest {
+        val result = getBasicResult()
+
+        val copiedResult = result.copy(success = false)
+
+        assertEquals(result.output, copiedResult.output)
+        assertNotEquals(result.success, copiedResult.success)
+        assertFalse(copiedResult.success)
+        assertEquals(result.retryCount, copiedResult.retryCount)
+    }
+
+    @Test
+    fun testRetrySubgraphResultCopyZeroRetries() = runTest {
+        val result = getBasicResult()
+
+        assertFailsWith<IllegalArgumentException> {
+            result.copy(retryCount = 0)
+        }
+    }
+
+    @Test
+    fun testSubgraphWithRetrySuccessFirstTry() = runTest {
+        val results = mutableListOf<Any?>()
+
+        val testStrategy = strategy("test-strategy") {
+            val retrySubgraph by subgraphWithRetry(
+                condition = { it == SUCCESS },
+                maxRetries = 3,
+                name = "test-retry",
+            ) {
+                val processNode by node<String, String> { input ->
+                    SUCCESS
+                }
+
+                nodeStart then processNode then nodeFinish
+            }
+
+            nodeStart then retrySubgraph then nodeFinish
+        }
+
+        val agentConfig = AIAgentConfig(
+            prompt = prompt("test-agent") {},
+            model = OllamaModels.Meta.LLAMA_3_2,
+            maxAgentIterations = MAX_AGENT_ITERATIONS,
+        )
+
+        val agent = AIAgent(
+            promptExecutor = getMockExecutor {},
+            strategy = testStrategy,
+            agentConfig = agentConfig,
+            toolRegistry = ToolRegistry {
+                tool(DummyTool())
+            },
+        ) {
+            install(EventHandler) {
+                onAgentFinished { eventContext -> results += eventContext.result }
+            }
+        }
+
+        agent.run("test input")
+
+        assertEquals(1, results.size)
+        val result = results.first() as RetrySubgraphResult<*>
+        assertEquals(SUCCESS, result.output)
+        assertTrue(result.success)
+        assertEquals(1, result.retryCount)
+    }
+
+    @Test
+    fun testSubgraphWithRetrySuccessAfterRetries() = runTest {
+        val results = mutableListOf<Any?>()
+        val attemptCount = mutableListOf<Int>()
+        val maxAttempts = 3
+
+        val testStrategy = strategy("test-strategy") {
+            val retrySubgraph by subgraphWithRetry(
+                condition = { it == SUCCESS },
+                maxRetries = maxAttempts,
+                name = "test-retry",
+            ) {
+                val processNode by node<String, String> { input ->
+                    val currentAttempt = attemptCount.size + 1
+                    attemptCount.add(currentAttempt)
+
+                    if (currentAttempt < maxAttempts) {
+                        "failure"
+                    } else {
+                        SUCCESS
+                    }
+                }
+
+                nodeStart then processNode then nodeFinish
+            }
+
+            nodeStart then retrySubgraph then nodeFinish
+        }
+
+        val agentConfig = AIAgentConfig(
+            prompt = prompt("test-agent") {},
+            model = OllamaModels.Meta.LLAMA_3_2,
+            maxAgentIterations = MAX_AGENT_ITERATIONS,
+        )
+
+        val agent = AIAgent(
+            promptExecutor = getMockExecutor {},
+            strategy = testStrategy,
+            agentConfig = agentConfig,
+            toolRegistry = ToolRegistry {
+                tool(DummyTool())
+            },
+        ) {
+            install(EventHandler) {
+                onAgentFinished { eventContext -> results += eventContext.result }
+            }
+        }
+
+        agent.run("test input")
+
+        assertEquals(1, results.size)
+        val result = results.first() as RetrySubgraphResult<*>
+        assertEquals(SUCCESS, result.output)
+        assertTrue(result.success)
+        assertEquals(maxAttempts, result.retryCount)
+        assertEquals(maxAttempts, attemptCount.size)
+    }
+
+    @Test
+    fun testSubgraphWithRetryMaxRetriesReached() = runTest {
+        val results = mutableListOf<Any?>()
+        val attemptCount = mutableListOf<Int>()
+        val maxAttempts = 3
+
+        val testStrategy = strategy("test-strategy") {
+            val retrySubgraph by subgraphWithRetry(
+                condition = { it == SUCCESS },
+                maxRetries = maxAttempts,
+                name = "test-retry",
+            ) {
+                val processNode by node<String, String> { input ->
+                    val currentAttempt = attemptCount.size + 1
+                    attemptCount.add(currentAttempt)
+                    "failure"
+                }
+
+                nodeStart then processNode then nodeFinish
+            }
+
+            nodeStart then retrySubgraph then nodeFinish
+        }
+
+        val agentConfig = AIAgentConfig(
+            prompt = prompt("test-agent") {},
+            model = OllamaModels.Meta.LLAMA_3_2,
+            maxAgentIterations = MAX_AGENT_ITERATIONS,
+        )
+
+        val agent = AIAgent(
+            promptExecutor = getMockExecutor {},
+            strategy = testStrategy,
+            agentConfig = agentConfig,
+            toolRegistry = ToolRegistry {
+                tool(DummyTool())
+            },
+        ) {
+            install(EventHandler) {
+                onAgentFinished { eventContext -> results += eventContext.result }
+            }
+        }
+
+        agent.run("test input")
+
+        assertEquals(1, results.size)
+        val result = results.first() as RetrySubgraphResult<*>
+        assertEquals(maxAttempts, result.retryCount)
+        assertEquals(maxAttempts, attemptCount.size)
+        assertFalse(result.success)
+    }
+
+    @Test
+    fun testSubgraphWithRetryZeroMaxRetries() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            strategy<String, String>("test-strategy") {
+                subgraphWithRetry(
+                    condition = { it == SUCCESS },
+                    maxRetries = 0,
+                    name = "test-retry",
+                ) {
+                    val processNode by node<String, String> { input -> input }
+                    nodeStart then processNode then nodeFinish
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testSubgraphWithRetrySimpleSuccess() = runTest {
+        val results = mutableListOf<Any?>()
+
+        val testStrategy = strategy("test-strategy") {
+            val retrySubgraph by subgraphWithRetrySimple(
+                condition = { it == SUCCESS },
+                maxRetries = 3,
+                name = "test-retry-simple",
+            ) {
+                val processNode by node<String, String> { input ->
+                    SUCCESS
+                }
+
+                nodeStart then processNode then nodeFinish
+            }
+
+            nodeStart then retrySubgraph then nodeFinish
+        }
+
+        val agentConfig = AIAgentConfig(
+            prompt = prompt("test-agent") {},
+            model = OllamaModels.Meta.LLAMA_3_2,
+            maxAgentIterations = MAX_AGENT_ITERATIONS,
+        )
+
+        val agent = AIAgent(
+            promptExecutor = getMockExecutor {},
+            strategy = testStrategy,
+            agentConfig = agentConfig,
+            toolRegistry = ToolRegistry {
+                tool(DummyTool())
+            },
+        ) {
+            install(EventHandler) {
+                onAgentFinished { eventContext -> results += eventContext.result }
+            }
+        }
+
+        agent.run("test input")
+
+        assertEquals(1, results.size)
+        assertEquals(SUCCESS, results.first())
+    }
+
+    @Test
+    fun testSubgraphWithRetrySimpleFailureStrict() = runTest {
+        val results = mutableListOf<Any?>()
+        val attemptCount = mutableListOf<Int>()
+        val maxAttempts = 3
+
+        val testStrategy = strategy("test-strategy") {
+            val retrySubgraph by subgraphWithRetrySimple(
+                condition = { it == SUCCESS },
+                maxRetries = maxAttempts,
+                strict = true,
+                name = "test-retry-simple",
+            ) {
+                val processNode by node<String, String> { input ->
+                    val currentAttempt = attemptCount.size + 1
+                    attemptCount.add(currentAttempt)
+                    "failure"
+                }
+
+                nodeStart then processNode then nodeFinish
+            }
+
+            nodeStart then retrySubgraph then nodeFinish
+        }
+
+        val agentConfig = AIAgentConfig(
+            prompt = prompt("test-agent") {},
+            model = OllamaModels.Meta.LLAMA_3_2,
+            maxAgentIterations = MAX_AGENT_ITERATIONS,
+        )
+
+        val agent = AIAgent(
+            promptExecutor = getMockExecutor {},
+            strategy = testStrategy,
+            agentConfig = agentConfig,
+            toolRegistry = ToolRegistry {
+                tool(DummyTool())
+            },
+        ) {
+            install(EventHandler) {
+                onAgentFinished { eventContext -> results += eventContext.result }
+            }
+        }
+
+        assertFailsWith<IllegalStateException> {
+            agent.run("test input")
+        }
+
+        assertEquals(maxAttempts, attemptCount.size)
+    }
+
+    @Test
+    fun testSubgraphWithRetrySimpleFailureNonStrict() = runTest {
+        val results = mutableListOf<Any?>()
+        val attemptCount = mutableListOf<Int>()
+        val maxAttempts = 3
+
+        val testStrategy = strategy("test-strategy") {
+            val retrySubgraph by subgraphWithRetrySimple(
+                condition = { it == SUCCESS },
+                maxRetries = maxAttempts,
+                strict = false,
+                name = "test-retry-simple",
+            ) {
+                val processNode by node<String, String> { input ->
+                    val currentAttempt = attemptCount.size + 1
+                    attemptCount.add(currentAttempt)
+                    "failure"
+                }
+
+                nodeStart then processNode then nodeFinish
+            }
+
+            nodeStart then retrySubgraph then nodeFinish
+        }
+
+        val agentConfig = AIAgentConfig(
+            prompt = prompt("test-agent") {},
+            model = OllamaModels.Meta.LLAMA_3_2,
+            maxAgentIterations = MAX_AGENT_ITERATIONS,
+        )
+
+        val agent = AIAgent(
+            promptExecutor = getMockExecutor {},
+            strategy = testStrategy,
+            agentConfig = agentConfig,
+            toolRegistry = ToolRegistry {
+                tool(DummyTool())
+            },
+        ) {
+            install(EventHandler) {
+                onAgentFinished { eventContext -> results += eventContext.result }
+            }
+        }
+
+        agent.run("test input")
+
+        assertEquals(1, results.size)
+        assertEquals("failure", results.first())
+        assertEquals(maxAttempts, attemptCount.size)
+    }
+
+    @Test
+    fun testSubgraphWithRetrySimpleZeroMaxRetries() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            strategy<String, String>("test-strategy") {
+                subgraphWithRetrySimple(
+                    condition = { it == SUCCESS },
+                    maxRetries = 0,
+                    strict = false,
+                    name = "test-retry-simple",
+                ) {
+                    val processNode by node<String, String> { input -> input }
+                    nodeStart then processNode then nodeFinish
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
1. Add a validation for retryCount in RetrySubgraphResult;
2. Add tests for RetrySubgraphResult, subgraphWithRetry, and subgraphWithRetrySimple.

---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix
- [x] New tests

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
