### PR TITLE
AWS Bedrock tests + serialization/deserialization tests for Bedrock providers

### DIFF
--- a/.github/workflows/heavy-tests.yml
+++ b/.github/workflows/heavy-tests.yml
@@ -46,6 +46,8 @@ jobs:
           OPEN_AI_API_TEST_KEY: ${{ secrets.OPEN_AI_API_TEST_KEY }}
           GEMINI_API_TEST_KEY: ${{ secrets.GEMINI_API_TEST_KEY }}
           OPEN_ROUTER_API_TEST_KEY: ${{ vars.OPEN_ROUTER_API_TEST_KEY }}
+          AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         run: ./gradlew jvmIntegrationTest --continue
 
       - name: Collect reports

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,7 +90,8 @@ subprojects {
                 "OPEN_AI_API_TEST_KEY" to System.getenv("OPEN_AI_API_TEST_KEY"),
                 "GEMINI_API_TEST_KEY" to System.getenv("GEMINI_API_TEST_KEY"),
                 "OPEN_ROUTER_API_TEST_KEY" to System.getenv("OPEN_ROUTER_API_TEST_KEY"),
-                "OLLAMA_IMAGE_URL" to System.getenv("OLLAMA_IMAGE_URL"),
+                "AWS_SECRET_KEY" to System.getenv("AWS_SECRET_KEY"),
+                "AWS_ACCESS_KEY_ID" to System.getenv("AWS_ACCESS_KEY_ID"),
             )
         )
     }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SingleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SingleLLMPromptExecutorIntegrationTest.kt
@@ -1,27 +1,31 @@
 package ai.koog.integration.tests
 
-import ai.koog.integration.tests.utils.MediaTestScenarios
-import ai.koog.integration.tests.utils.MediaTestUtils
-import ai.koog.integration.tests.utils.Models
-import ai.koog.integration.tests.utils.TestUtils
-import ai.koog.integration.tests.utils.TestUtils.readTestAnthropicKeyFromEnv
-import ai.koog.integration.tests.utils.TestUtils.readTestOpenAIKeyFromEnv
-import ai.koog.integration.tests.utils.TestUtils.readTestOpenRouterKeyFromEnv
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
+import ai.koog.integration.tests.utils.MediaTestScenarios
+import ai.koog.integration.tests.utils.MediaTestScenarios.AudioTestScenario
 import ai.koog.integration.tests.utils.MediaTestScenarios.ImageTestScenario
 import ai.koog.integration.tests.utils.MediaTestScenarios.MarkdownTestScenario
 import ai.koog.integration.tests.utils.MediaTestScenarios.TextTestScenario
-import ai.koog.integration.tests.utils.MediaTestScenarios.AudioTestScenario
+import ai.koog.integration.tests.utils.MediaTestUtils
 import ai.koog.integration.tests.utils.MediaTestUtils.checkExecutorMediaResponse
 import ai.koog.integration.tests.utils.MediaTestUtils.checkResponseBasic
+import ai.koog.integration.tests.utils.Models
 import ai.koog.integration.tests.utils.RetryUtils.withRetry
+import ai.koog.integration.tests.utils.TestUtils
+import ai.koog.integration.tests.utils.TestUtils.readAwsAccessKeyIdFromEnv
+import ai.koog.integration.tests.utils.TestUtils.readAwsSecretAccessKeyFromEnv
+import ai.koog.integration.tests.utils.TestUtils.readTestAnthropicKeyFromEnv
 import ai.koog.integration.tests.utils.TestUtils.readTestGoogleAIKeyFromEnv
+import ai.koog.integration.tests.utils.TestUtils.readTestOpenAIKeyFromEnv
+import ai.koog.integration.tests.utils.TestUtils.readTestOpenRouterKeyFromEnv
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
+import ai.koog.prompt.executor.clients.bedrock.BedrockClientSettings
+import ai.koog.prompt.executor.clients.bedrock.BedrockLLMClient
 import ai.koog.prompt.executor.clients.google.GoogleLLMClient
 import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
@@ -38,7 +42,6 @@ import ai.koog.prompt.message.Message
 import ai.koog.prompt.params.LLMParams.ToolChoice
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
-import kotlinx.io.files.Path as KtPath
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.BeforeAll
@@ -55,6 +58,7 @@ import kotlin.io.path.writeBytes
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.io.files.Path as KtPath
 
 class SingleLLMPromptExecutorIntegrationTest {
     companion object {
@@ -73,16 +77,25 @@ class SingleLLMPromptExecutorIntegrationTest {
             val openAIClientInstance = OpenAILLMClient(readTestOpenAIKeyFromEnv())
             val anthropicClientInstance = AnthropicLLMClient(readTestAnthropicKeyFromEnv())
             val googleClientInstance = GoogleLLMClient(readTestGoogleAIKeyFromEnv())
+            val bedrockClientInstance = BedrockLLMClient(
+                readAwsAccessKeyIdFromEnv(),
+                readAwsSecretAccessKeyFromEnv(),
+                BedrockClientSettings()
+            )
             val openRouterClientInstance = OpenRouterLLMClient(readTestOpenRouterKeyFromEnv())
 
             return Stream.concat(
                 Stream.concat(
-                    Models.openAIModels().map { model -> Arguments.of(model, openAIClientInstance) },
-                    Models.anthropicModels().map { model -> Arguments.of(model, anthropicClientInstance) }
+                    Stream.concat(
+                        Models.openAIModels().map { model -> Arguments.of(model, openAIClientInstance) },
+                        Models.anthropicModels().map { model -> Arguments.of(model, anthropicClientInstance) }
+                    ),
+                    Stream.concat(
+                        Models.googleModels().map { model -> Arguments.of(model, googleClientInstance) },
+                        Models.bedrockModels().map { model -> Arguments.of(model, bedrockClientInstance) }
+                    ),
                 ),
-                Models.googleModels().map { model -> Arguments.of(model, googleClientInstance) }
-                // Will enable when there're models that support tool calls
-                /*Models.openRouterModels().map { model -> Arguments.of(model, openRouterClientInstance) }*/
+                Models.openRouterModels().map { model -> Arguments.of(model, openRouterClientInstance) }
             )
         }
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SingleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SingleLLMPromptExecutorIntegrationTest.kt
@@ -31,6 +31,7 @@ import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.clients.openrouter.OpenRouterLLMClient
 import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
+import ai.koog.prompt.executor.llms.all.simpleBedrockExecutor
 import ai.koog.prompt.executor.model.PromptExecutorExt.execute
 import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLMProvider
@@ -45,6 +46,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -77,26 +79,35 @@ class SingleLLMPromptExecutorIntegrationTest {
             val openAIClientInstance = OpenAILLMClient(readTestOpenAIKeyFromEnv())
             val anthropicClientInstance = AnthropicLLMClient(readTestAnthropicKeyFromEnv())
             val googleClientInstance = GoogleLLMClient(readTestGoogleAIKeyFromEnv())
-            val bedrockClientInstance = BedrockLLMClient(
+            /*val bedrockClientInstance = BedrockLLMClient(
                 readAwsAccessKeyIdFromEnv(),
                 readAwsSecretAccessKeyFromEnv(),
                 BedrockClientSettings()
-            )
+            )*/
             val openRouterClientInstance = OpenRouterLLMClient(readTestOpenRouterKeyFromEnv())
 
             return Stream.concat(
                 Stream.concat(
-                    Stream.concat(
-                        Models.openAIModels().map { model -> Arguments.of(model, openAIClientInstance) },
-                        Models.anthropicModels().map { model -> Arguments.of(model, anthropicClientInstance) }
-                    ),
-                    Stream.concat(
-                        Models.googleModels().map { model -> Arguments.of(model, googleClientInstance) },
-                        Models.bedrockModels().map { model -> Arguments.of(model, bedrockClientInstance) }
-                    ),
+                    Models.openAIModels().map { model -> Arguments.of(model, openAIClientInstance) },
+                    Models.anthropicModels().map { model -> Arguments.of(model, anthropicClientInstance) }
                 ),
-                Models.openRouterModels().map { model -> Arguments.of(model, openRouterClientInstance) }
+                Stream.concat(
+                    Models.googleModels().map { model -> Arguments.of(model, googleClientInstance) },
+                    Models.openRouterModels().map { model -> Arguments.of(model, openRouterClientInstance) }
+                ),
             )
+            // Models.bedrockModels().map { model -> Arguments.of(model, bedrockClientInstance) }
+        }
+
+        @JvmStatic
+        fun bedrockCombinations(): Stream<Arguments> {
+            val bedrockClientInstance = BedrockLLMClient(
+                readAwsAccessKeyIdFromEnv(),
+                readAwsSecretAccessKeyFromEnv(),
+                BedrockClientSettings(),
+            )
+
+            return Models.bedrockModels().map { model -> Arguments.of(model, bedrockClientInstance) }
         }
 
         @JvmStatic
@@ -1022,6 +1033,46 @@ class SingleLLMPromptExecutorIntegrationTest {
                         response.content.contains("logo", ignoreCase = true),
                 "Response should mention the image content"
             )
+        }
+    }
+
+    /**
+     * Tests the simpleBedrockExecutor function with different Bedrock models.
+     *
+     * Some models may require an inference profile instead of on-demand throughput.
+     * The test may fail if the AWS account doesn't have access to the specified models.
+     */
+    @Disabled("Until we get a list of supported Bedrock models")
+    @ParameterizedTest
+    @MethodSource("bedrockCombinations")
+    fun integration_testSimpleBedrockExecutor(model: LLModel) = runTest(timeout = 300.seconds) {
+        val executor = simpleBedrockExecutor(
+            readAwsAccessKeyIdFromEnv(),
+            readAwsSecretAccessKeyFromEnv()
+        )
+
+        val prompt = Prompt.build("test-simple-bedrock-executor") {
+            system("You are a helpful assistant.")
+            user("What is the capital of France?")
+        }
+
+        withRetry(times = 3, testName = "integration_testSimpleBedrockExecutor[${model.id}]") {
+            val response = executor.execute(prompt, model, emptyList())
+
+            assertNotNull(response, "Response should not be null")
+            assertTrue(response.isNotEmpty(), "Response should not be empty")
+            assertTrue(response.first() is Message.Assistant, "Response should be an Assistant message")
+
+            val message = response.first() as Message.Assistant
+
+            assertTrue(
+                message.content.contains("Paris", ignoreCase = true),
+                "Response should contain 'Paris'"
+            )
+
+            assertNotNull(message.metaInfo.inputTokensCount, "Input tokens count should not be null")
+            assertNotNull(message.metaInfo.outputTokensCount, "Output tokens count should not be null")
+            assertNotNull(message.metaInfo.totalTokensCount, "Total tokens count should not be null")
         }
     }
 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
@@ -72,35 +72,14 @@ object Models {
         )
     }
 
+    // listing not all profiles but one from each LLM provider
     @JvmStatic
     fun bedrockModels(): Stream<LLModel> {
         return Stream.of(
             BedrockModels.AI21JambaMini,
-            BedrockModels.AI21JambaLarge,
-            BedrockModels.AmazonNovaPro,
             BedrockModels.AmazonNovaLite,
-            BedrockModels.AmazonNovaMicro,
-            BedrockModels.AmazonNovaPremier,
-            BedrockModels.AnthropicClaude2,
-            BedrockModels.AnthropicClaude21,
             BedrockModels.AnthropicClaude35Haiku,
-            BedrockModels.AnthropicClaude35SonnetV2,
-            BedrockModels.AnthropicClaude3Haiku,
-            BedrockModels.AnthropicClaude3Opus,
-            BedrockModels.AnthropicClaude3Sonnet,
-            BedrockModels.AnthropicClaude4Opus,
-            BedrockModels.AnthropicClaude4Sonnet,
-            BedrockModels.AnthropicClaudeInstant,
-            BedrockModels.MetaLlama3_0_70BInstruct,
             BedrockModels.MetaLlama3_1_8BInstruct,
-            BedrockModels.MetaLlama3_1_70BInstruct,
-            BedrockModels.MetaLlama3_0_8BInstruct,
-            BedrockModels.MetaLlama3_1_405BInstruct,
-            BedrockModels.MetaLlama3_2_11BInstruct,
-            BedrockModels.MetaLlama3_2_1BInstruct,
-            BedrockModels.MetaLlama3_2_3BInstruct,
-            BedrockModels.MetaLlama3_2_90BInstruct,
-            BedrockModels.MetaLlama3_3_70BInstruct,
         )
     }
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
@@ -4,6 +4,7 @@ import ai.koog.integration.tests.utils.TestUtils.readTestAnthropicKeyFromEnv
 import ai.koog.integration.tests.utils.TestUtils.readTestOpenAIKeyFromEnv
 import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
 import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
+import ai.koog.prompt.executor.clients.bedrock.BedrockModels
 import ai.koog.prompt.executor.clients.google.GoogleModels
 import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
@@ -68,6 +69,38 @@ object Models {
             GoogleModels.Gemini1_5Flash8B001,
             GoogleModels.Gemini1_5Flash8BLatest,
             GoogleModels.Gemini2_5FlashPreview0417,
+        )
+    }
+
+    @JvmStatic
+    fun bedrockModels(): Stream<LLModel> {
+        return Stream.of(
+            BedrockModels.AI21JambaMini,
+            BedrockModels.AI21JambaLarge,
+            BedrockModels.AmazonNovaPro,
+            BedrockModels.AmazonNovaLite,
+            BedrockModels.AmazonNovaMicro,
+            BedrockModels.AmazonNovaPremier,
+            BedrockModels.AnthropicClaude2,
+            BedrockModels.AnthropicClaude21,
+            BedrockModels.AnthropicClaude35Haiku,
+            BedrockModels.AnthropicClaude35SonnetV2,
+            BedrockModels.AnthropicClaude3Haiku,
+            BedrockModels.AnthropicClaude3Opus,
+            BedrockModels.AnthropicClaude3Sonnet,
+            BedrockModels.AnthropicClaude4Opus,
+            BedrockModels.AnthropicClaude4Sonnet,
+            BedrockModels.AnthropicClaudeInstant,
+            BedrockModels.MetaLlama3_0_70BInstruct,
+            BedrockModels.MetaLlama3_1_8BInstruct,
+            BedrockModels.MetaLlama3_1_70BInstruct,
+            BedrockModels.MetaLlama3_0_8BInstruct,
+            BedrockModels.MetaLlama3_1_405BInstruct,
+            BedrockModels.MetaLlama3_2_11BInstruct,
+            BedrockModels.MetaLlama3_2_1BInstruct,
+            BedrockModels.MetaLlama3_2_3BInstruct,
+            BedrockModels.MetaLlama3_2_90BInstruct,
+            BedrockModels.MetaLlama3_3_70BInstruct,
         )
     }
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/TestUtils.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/TestUtils.kt
@@ -26,6 +26,16 @@ object TestUtils {
             ?: error("ERROR: environment variable `OPEN_ROUTER_API_TEST_KEY` is not set")
     }
 
+    fun readAwsAccessKeyIdFromEnv(): String {
+        return System.getenv("AWS_ACCESS_KEY_ID")
+            ?: error("ERROR: environment variable `AWS_ACCESS_KEY_ID` is not set")
+    }
+
+    fun readAwsSecretAccessKeyFromEnv(): String {
+        return System.getenv("AWS_SECRET_KEY")
+            ?: error("ERROR: environment variable `AWS_SECRET_KEY` is not set")
+    }
+
     @Serializable
     enum class CalculatorOperation {
         ADD, SUBTRACT, MULTIPLY, DIVIDE

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/build.gradle.kts
@@ -45,6 +45,7 @@ kotlin {
         jvmTest {
             dependencies {
                 implementation(kotlin("test-junit5"))
+                implementation(libs.junit.jupiter.params)
             }
         }
     }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/BedrockToolSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/BedrockToolSerializationTest.kt
@@ -5,251 +5,221 @@ import ai.koog.agents.core.tools.ToolParameterType
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import kotlin.test.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class BedrockToolSerializationTest {
-    private val namePropertyName = "name"
-    private val namePropertyDesc = "User name"
-    private val objectParamName = "user"
-    private val objectParamDesc = "User information"
+    companion object {
+        @JvmStatic
+        fun toolParameterTestCases(): Stream<Arguments> {
+            val stringParamDesc = "Search query"
+            val intParamDesc = "Number of results"
+            val floatParamDesc = "Temperature value"
+            val boolParamDesc = "Feature toggle"
+            val enumValues = listOf("json", "xml", "text")
+            val listParamDesc = "List of users"
+            val listIntParamDesc = "List of IDs"
+            val objectParamDesc = "User information"
+            val namePropertyName = "name"
+            val namePropertyDesc = "User name"
+            val agePropertyName = "age"
+            val agePropertyDesc = "User age"
+            val streetPropertyName = "street"
+            val streetPropertyDesc = "Street address"
+            val cityPropertyName = "city"
+            val cityPropertyDesc = "City name"
+            val addressPropertyName = "address"
+            val addressPropertyDesc = "User address"
 
-    @Test
-    fun `test buildToolParameterSchema with String parameter`() {
-        val stringParamDesc = "Search query"
+            return Stream.of(
+                // String 
+                Arguments.of(
+                    ToolParameterDescriptor(
+                        name = "query",
+                        description = stringParamDesc,
+                        type = ToolParameterType.String
+                    ),
+                    mapOf(
+                        "description" to stringParamDesc,
+                        "type" to "string"
+                    )
+                ),
 
-        val param = ToolParameterDescriptor(
-            name = "query",
-            description = stringParamDesc,
-            type = ToolParameterType.String
-        )
+                // Integer 
+                Arguments.of(
+                    ToolParameterDescriptor(
+                        name = "count",
+                        description = intParamDesc,
+                        type = ToolParameterType.Integer
+                    ),
+                    mapOf(
+                        "description" to intParamDesc,
+                        "type" to "integer"
+                    )
+                ),
 
-        val schema = BedrockToolSerialization.buildToolParameterSchema(param)
+                // Float 
+                Arguments.of(
+                    ToolParameterDescriptor(
+                        name = "temperature",
+                        description = floatParamDesc,
+                        type = ToolParameterType.Float
+                    ),
+                    mapOf(
+                        "description" to floatParamDesc,
+                        "type" to "number"
+                    )
+                ),
 
-        assertNotNull(schema)
-        assertEquals(stringParamDesc, schema["description"]?.jsonPrimitive?.content)
-        assertEquals("string", schema["type"]?.jsonPrimitive?.content)
-    }
+                // Boolean 
+                Arguments.of(
+                    ToolParameterDescriptor(
+                        name = "enabled",
+                        description = boolParamDesc,
+                        type = ToolParameterType.Boolean
+                    ),
+                    mapOf(
+                        "description" to boolParamDesc,
+                        "type" to "boolean"
+                    )
+                ),
 
-    @Test
-    fun `test buildToolParameterSchema with Integer parameter`() {
-        val paramDesc = "Number of results"
+                // Enum 
+                Arguments.of(
+                    ToolParameterDescriptor(
+                        name = "format",
+                        description = "Output format",
+                        type = ToolParameterType.Enum(enumValues.toTypedArray())
+                    ),
+                    mapOf(
+                        "description" to "Output format",
+                        "type" to "string",
+                        "enum" to enumValues
+                    )
+                ),
 
-        val param = ToolParameterDescriptor(
-            name = "count",
-            description = paramDesc,
-            type = ToolParameterType.Integer
-        )
+                // List of String
+                Arguments.of(
+                    ToolParameterDescriptor(
+                        name = "user",
+                        description = listParamDesc,
+                        type = ToolParameterType.List(ToolParameterType.String)
+                    ),
+                    mapOf(
+                        "description" to listParamDesc,
+                        "type" to "array",
+                        "items" to mapOf("type" to "string")
+                    )
+                ),
 
-        val schema = BedrockToolSerialization.buildToolParameterSchema(param)
+                // List of Integer 
+                Arguments.of(
+                    ToolParameterDescriptor(
+                        name = "List",
+                        description = listIntParamDesc,
+                        type = ToolParameterType.List(ToolParameterType.Integer)
+                    ),
+                    mapOf(
+                        "description" to listIntParamDesc,
+                        "type" to "array",
+                        "items" to mapOf("type" to "integer")
+                    )
+                ),
 
-        assertNotNull(schema)
-        assertEquals(paramDesc, schema["description"]?.jsonPrimitive?.content)
-        assertEquals("integer", schema["type"]?.jsonPrimitive?.content)
-    }
+                // Object
+                Arguments.of(
+                    {
+                        val objectType = ToolParameterType.Object(
+                            properties = listOf(
+                                ToolParameterDescriptor(namePropertyName, namePropertyDesc, ToolParameterType.String),
+                                ToolParameterDescriptor(agePropertyName, agePropertyDesc, ToolParameterType.Integer)
+                            )
+                        )
 
-    @Test
-    fun `test buildToolParameterSchema with Float parameter`() {
-        val paramDesc = "Temperature value"
+                        ToolParameterDescriptor(
+                            name = "user",
+                            description = objectParamDesc,
+                            type = objectType
+                        )
+                    }(),
+                    mapOf(
+                        "description" to objectParamDesc,
+                        "type" to "object"
+                    )
+                ),
 
-        val param = ToolParameterDescriptor(
-            name = "temperature",
-            description = paramDesc,
-            type = ToolParameterType.Float
-        )
+                // Nested Object
+                Arguments.of(
+                    {
+                        val addressType = ToolParameterType.Object(
+                            properties = listOf(
+                                ToolParameterDescriptor(
+                                    streetPropertyName,
+                                    streetPropertyDesc,
+                                    ToolParameterType.String
+                                ),
+                                ToolParameterDescriptor(cityPropertyName, cityPropertyDesc, ToolParameterType.String)
+                            )
+                        )
 
-        val schema = BedrockToolSerialization.buildToolParameterSchema(param)
+                        val userType = ToolParameterType.Object(
+                            properties = listOf(
+                                ToolParameterDescriptor(namePropertyName, namePropertyDesc, ToolParameterType.String),
+                                ToolParameterDescriptor(addressPropertyName, addressPropertyDesc, addressType)
+                            )
+                        )
 
-        assertNotNull(schema)
-        assertEquals(paramDesc, schema["description"]?.jsonPrimitive?.content)
-        assertEquals("number", schema["type"]?.jsonPrimitive?.content)
-    }
-
-    @Test
-    fun `test buildToolParameterSchema with Boolean parameter`() {
-        val paramDesc = "Feature toggle"
-
-        val param = ToolParameterDescriptor(
-            name = "enabled",
-            description = paramDesc,
-            type = ToolParameterType.Boolean
-        )
-
-        val schema = BedrockToolSerialization.buildToolParameterSchema(param)
-
-        assertNotNull(schema)
-        assertEquals(paramDesc, schema["description"]?.jsonPrimitive?.content)
-        assertEquals("boolean", schema["type"]?.jsonPrimitive?.content)
-    }
-
-    @Test
-    fun `test buildToolParameterSchema with Enum parameter`() {
-        val paramDesc = "Output format"
-
-        val param = ToolParameterDescriptor(
-            name = "format",
-            description = paramDesc,
-            type = ToolParameterType.Enum(arrayOf("json", "xml", "text"))
-        )
-
-        val schema = BedrockToolSerialization.buildToolParameterSchema(param)
-
-        assertNotNull(schema)
-        assertEquals(paramDesc, schema["description"]?.jsonPrimitive?.content)
-        assertEquals("string", schema["type"]?.jsonPrimitive?.content)
-
-        val enumValues = schema["enum"]?.jsonArray
-        assertNotNull(enumValues)
-        assertEquals(3, enumValues.size)
-
-        assertTrue(enumValues.any { it.toString().contains("json") })
-        assertTrue(enumValues.any { it.toString().contains("xml") })
-        assertTrue(enumValues.any { it.toString().contains("text") })
-    }
-
-    @Test
-    fun `test buildToolParameterSchema with List parameter`() {
-        val paramDesc = "List of users"
-
-        val param = ToolParameterDescriptor(
-            name = "user",
-            description = paramDesc,
-            type = ToolParameterType.List(ToolParameterType.String)
-        )
-
-        val schema = BedrockToolSerialization.buildToolParameterSchema(param)
-
-        assertNotNull(schema)
-        assertEquals(paramDesc, schema["description"]?.jsonPrimitive?.content)
-        assertEquals("array", schema["type"]?.jsonPrimitive?.content)
-
-        val items = schema["items"]?.jsonObject
-        assertNotNull(items)
-        assertEquals("string", items["type"]?.jsonPrimitive?.content)
-    }
-
-    @Test
-    fun `test buildToolParameterSchema with List of Integer parameter`() {
-        val paramDesc = "List of IDs"
-
-        val param = ToolParameterDescriptor(
-            name = "List",
-            description = paramDesc,
-            type = ToolParameterType.List(ToolParameterType.Integer)
-        )
-
-        val schema = BedrockToolSerialization.buildToolParameterSchema(param)
-
-        assertNotNull(schema)
-        assertEquals(paramDesc, schema["description"]?.jsonPrimitive?.content)
-        assertEquals("array", schema["type"]?.jsonPrimitive?.content)
-
-        val items = schema["items"]?.jsonObject
-        assertNotNull(items)
-        assertEquals("integer", items["type"]?.jsonPrimitive?.content)
-    }
-
-    @Test
-    fun `test buildToolParameterSchema with Object parameter`() {
-        val namePropertyName = "name"
-        val namePropertyDesc = "User name"
-        val agePropertyName = "age"
-        val agePropertyDesc = "User age"
-
-        val objectType = ToolParameterType.Object(
-            properties = listOf(
-                ToolParameterDescriptor(namePropertyName, namePropertyDesc, ToolParameterType.String),
-                ToolParameterDescriptor(agePropertyName, agePropertyDesc, ToolParameterType.Integer)
+                        ToolParameterDescriptor(
+                            name = "user",
+                            description = objectParamDesc,
+                            type = userType
+                        )
+                    }(),
+                    mapOf(
+                        "description" to objectParamDesc,
+                        "type" to "object"
+                    )
+                )
             )
-        )
-
-        val param = ToolParameterDescriptor(
-            name = objectParamName,
-            description = objectParamDesc,
-            type = objectType
-        )
-
-        val schema = BedrockToolSerialization.buildToolParameterSchema(param)
-
-        assertNotNull(schema)
-        assertEquals(objectParamDesc, schema["description"]?.jsonPrimitive?.content)
-        assertEquals("object", schema["type"]?.jsonPrimitive?.content)
-
-        val properties = schema["properties"]?.jsonObject
-        assertNotNull(properties)
-
-        val nameProperty = properties[namePropertyName]?.jsonObject
-        assertNotNull(nameProperty)
-        assertEquals(namePropertyDesc, nameProperty["description"]?.jsonPrimitive?.content)
-        assertEquals("string", nameProperty["type"]?.jsonPrimitive?.content)
-
-        val ageProperty = properties[agePropertyName]?.jsonObject
-        assertNotNull(ageProperty)
-        assertEquals(agePropertyDesc, ageProperty["description"]?.jsonPrimitive?.content)
-        assertEquals("integer", ageProperty["type"]?.jsonPrimitive?.content)
+        }
     }
 
-    @Test
-    fun `test buildToolParameterSchema with nested Object parameter`() {
-        val streetPropertyName = "street"
-        val streetPropertyDesc = "Street address"
-        val cityPropertyName = "city"
-        val cityPropertyDesc = "City name"
-        val addressPropertyName = "address"
-        val addressPropertyDesc = "User address"
-
-        val addressType = ToolParameterType.Object(
-            properties = listOf(
-                ToolParameterDescriptor(streetPropertyName, streetPropertyDesc, ToolParameterType.String),
-                ToolParameterDescriptor(cityPropertyName, cityPropertyDesc, ToolParameterType.String)
-            )
-        )
-
-        val userType = ToolParameterType.Object(
-            properties = listOf(
-                ToolParameterDescriptor(namePropertyName, namePropertyDesc, ToolParameterType.String),
-                ToolParameterDescriptor(addressPropertyName, addressPropertyDesc, addressType)
-            )
-        )
-
-        val param = ToolParameterDescriptor(
-            name = objectParamName,
-            description = objectParamDesc,
-            type = userType
-        )
-
+    @ParameterizedTest
+    @MethodSource("toolParameterTestCases")
+    fun testBuildToolParameterSchema(
+        param: ToolParameterDescriptor,
+        expectedValues: Map<String, Any>
+    ) {
         val schema = BedrockToolSerialization.buildToolParameterSchema(param)
 
         assertNotNull(schema)
-        assertEquals(objectParamDesc, schema["description"]?.jsonPrimitive?.content)
-        assertEquals("object", schema["type"]?.jsonPrimitive?.content)
 
-        val properties = schema["properties"]?.jsonObject
-        assertNotNull(properties)
+        expectedValues.forEach { (key, value) ->
+            when (key) {
+                "description" -> assertEquals(value as String, schema["description"]?.jsonPrimitive?.content)
+                "type" -> assertEquals(value as String, schema["type"]?.jsonPrimitive?.content)
+                "enum" -> {
+                    val enumValues = schema["enum"]?.jsonArray
+                    assertNotNull(enumValues)
+                    assertEquals((value as List<*>).size, enumValues.size)
+                    value.forEach { enumValue ->
+                        assertTrue(enumValues.any { it.toString().contains(enumValue.toString()) })
+                    }
+                }
 
-        val nameProperty = properties[namePropertyName]?.jsonObject
-        assertNotNull(nameProperty)
-        assertEquals(namePropertyDesc, nameProperty["description"]?.jsonPrimitive?.content)
-        assertEquals("string", nameProperty["type"]?.jsonPrimitive?.content)
-
-        val addressProperty = properties[addressPropertyName]?.jsonObject
-        assertNotNull(addressProperty)
-        assertEquals(addressPropertyDesc, addressProperty["description"]?.jsonPrimitive?.content)
-        assertEquals("object", addressProperty["type"]?.jsonPrimitive?.content)
-
-        val addressProperties = addressProperty["properties"]?.jsonObject
-        assertNotNull(addressProperties)
-
-        val streetProperty = addressProperties[streetPropertyName]?.jsonObject
-        assertNotNull(streetProperty)
-        assertEquals(streetPropertyDesc, streetProperty["description"]?.jsonPrimitive?.content)
-        assertEquals("string", streetProperty["type"]?.jsonPrimitive?.content)
-
-        val cityProperty = addressProperties[cityPropertyName]?.jsonObject
-        assertNotNull(cityProperty)
-        assertEquals(cityPropertyDesc, cityProperty["description"]?.jsonPrimitive?.content)
-        assertEquals("string", cityProperty["type"]?.jsonPrimitive?.content)
+                "items" -> {
+                    val items = schema["items"]?.jsonObject
+                    assertNotNull(items)
+                    (value as Map<*, *>).forEach { (itemKey, itemValue) ->
+                        assertEquals(itemValue, items[itemKey.toString()]?.jsonPrimitive?.content)
+                    }
+                }
+            }
+        }
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/BedrockToolSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/BedrockToolSerializationTest.kt
@@ -1,0 +1,255 @@
+package ai.koog.prompt.executor.clients.bedrock.modelfamilies
+
+import ai.koog.agents.core.tools.ToolParameterDescriptor
+import ai.koog.agents.core.tools.ToolParameterType
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class BedrockToolSerializationTest {
+    private val namePropertyName = "name"
+    private val namePropertyDesc = "User name"
+    private val objectParamName = "user"
+    private val objectParamDesc = "User information"
+
+    @Test
+    fun `test buildToolParameterSchema with String parameter`() {
+        val stringParamDesc = "Search query"
+
+        val param = ToolParameterDescriptor(
+            name = "query",
+            description = stringParamDesc,
+            type = ToolParameterType.String
+        )
+
+        val schema = BedrockToolSerialization.buildToolParameterSchema(param)
+
+        assertNotNull(schema)
+        assertEquals(stringParamDesc, schema["description"]?.jsonPrimitive?.content)
+        assertEquals("string", schema["type"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `test buildToolParameterSchema with Integer parameter`() {
+        val paramDesc = "Number of results"
+
+        val param = ToolParameterDescriptor(
+            name = "count",
+            description = paramDesc,
+            type = ToolParameterType.Integer
+        )
+
+        val schema = BedrockToolSerialization.buildToolParameterSchema(param)
+
+        assertNotNull(schema)
+        assertEquals(paramDesc, schema["description"]?.jsonPrimitive?.content)
+        assertEquals("integer", schema["type"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `test buildToolParameterSchema with Float parameter`() {
+        val paramDesc = "Temperature value"
+
+        val param = ToolParameterDescriptor(
+            name = "temperature",
+            description = paramDesc,
+            type = ToolParameterType.Float
+        )
+
+        val schema = BedrockToolSerialization.buildToolParameterSchema(param)
+
+        assertNotNull(schema)
+        assertEquals(paramDesc, schema["description"]?.jsonPrimitive?.content)
+        assertEquals("number", schema["type"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `test buildToolParameterSchema with Boolean parameter`() {
+        val paramDesc = "Feature toggle"
+
+        val param = ToolParameterDescriptor(
+            name = "enabled",
+            description = paramDesc,
+            type = ToolParameterType.Boolean
+        )
+
+        val schema = BedrockToolSerialization.buildToolParameterSchema(param)
+
+        assertNotNull(schema)
+        assertEquals(paramDesc, schema["description"]?.jsonPrimitive?.content)
+        assertEquals("boolean", schema["type"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `test buildToolParameterSchema with Enum parameter`() {
+        val paramDesc = "Output format"
+
+        val param = ToolParameterDescriptor(
+            name = "format",
+            description = paramDesc,
+            type = ToolParameterType.Enum(arrayOf("json", "xml", "text"))
+        )
+
+        val schema = BedrockToolSerialization.buildToolParameterSchema(param)
+
+        assertNotNull(schema)
+        assertEquals(paramDesc, schema["description"]?.jsonPrimitive?.content)
+        assertEquals("string", schema["type"]?.jsonPrimitive?.content)
+
+        val enumValues = schema["enum"]?.jsonArray
+        assertNotNull(enumValues)
+        assertEquals(3, enumValues.size)
+
+        assertTrue(enumValues.any { it.toString().contains("json") })
+        assertTrue(enumValues.any { it.toString().contains("xml") })
+        assertTrue(enumValues.any { it.toString().contains("text") })
+    }
+
+    @Test
+    fun `test buildToolParameterSchema with List parameter`() {
+        val paramDesc = "List of users"
+
+        val param = ToolParameterDescriptor(
+            name = "user",
+            description = paramDesc,
+            type = ToolParameterType.List(ToolParameterType.String)
+        )
+
+        val schema = BedrockToolSerialization.buildToolParameterSchema(param)
+
+        assertNotNull(schema)
+        assertEquals(paramDesc, schema["description"]?.jsonPrimitive?.content)
+        assertEquals("array", schema["type"]?.jsonPrimitive?.content)
+
+        val items = schema["items"]?.jsonObject
+        assertNotNull(items)
+        assertEquals("string", items["type"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `test buildToolParameterSchema with List of Integer parameter`() {
+        val paramDesc = "List of IDs"
+
+        val param = ToolParameterDescriptor(
+            name = "List",
+            description = paramDesc,
+            type = ToolParameterType.List(ToolParameterType.Integer)
+        )
+
+        val schema = BedrockToolSerialization.buildToolParameterSchema(param)
+
+        assertNotNull(schema)
+        assertEquals(paramDesc, schema["description"]?.jsonPrimitive?.content)
+        assertEquals("array", schema["type"]?.jsonPrimitive?.content)
+
+        val items = schema["items"]?.jsonObject
+        assertNotNull(items)
+        assertEquals("integer", items["type"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `test buildToolParameterSchema with Object parameter`() {
+        val namePropertyName = "name"
+        val namePropertyDesc = "User name"
+        val agePropertyName = "age"
+        val agePropertyDesc = "User age"
+
+        val objectType = ToolParameterType.Object(
+            properties = listOf(
+                ToolParameterDescriptor(namePropertyName, namePropertyDesc, ToolParameterType.String),
+                ToolParameterDescriptor(agePropertyName, agePropertyDesc, ToolParameterType.Integer)
+            )
+        )
+
+        val param = ToolParameterDescriptor(
+            name = objectParamName,
+            description = objectParamDesc,
+            type = objectType
+        )
+
+        val schema = BedrockToolSerialization.buildToolParameterSchema(param)
+
+        assertNotNull(schema)
+        assertEquals(objectParamDesc, schema["description"]?.jsonPrimitive?.content)
+        assertEquals("object", schema["type"]?.jsonPrimitive?.content)
+
+        val properties = schema["properties"]?.jsonObject
+        assertNotNull(properties)
+
+        val nameProperty = properties[namePropertyName]?.jsonObject
+        assertNotNull(nameProperty)
+        assertEquals(namePropertyDesc, nameProperty["description"]?.jsonPrimitive?.content)
+        assertEquals("string", nameProperty["type"]?.jsonPrimitive?.content)
+
+        val ageProperty = properties[agePropertyName]?.jsonObject
+        assertNotNull(ageProperty)
+        assertEquals(agePropertyDesc, ageProperty["description"]?.jsonPrimitive?.content)
+        assertEquals("integer", ageProperty["type"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `test buildToolParameterSchema with nested Object parameter`() {
+        val streetPropertyName = "street"
+        val streetPropertyDesc = "Street address"
+        val cityPropertyName = "city"
+        val cityPropertyDesc = "City name"
+        val addressPropertyName = "address"
+        val addressPropertyDesc = "User address"
+
+        val addressType = ToolParameterType.Object(
+            properties = listOf(
+                ToolParameterDescriptor(streetPropertyName, streetPropertyDesc, ToolParameterType.String),
+                ToolParameterDescriptor(cityPropertyName, cityPropertyDesc, ToolParameterType.String)
+            )
+        )
+
+        val userType = ToolParameterType.Object(
+            properties = listOf(
+                ToolParameterDescriptor(namePropertyName, namePropertyDesc, ToolParameterType.String),
+                ToolParameterDescriptor(addressPropertyName, addressPropertyDesc, addressType)
+            )
+        )
+
+        val param = ToolParameterDescriptor(
+            name = objectParamName,
+            description = objectParamDesc,
+            type = userType
+        )
+
+        val schema = BedrockToolSerialization.buildToolParameterSchema(param)
+
+        assertNotNull(schema)
+        assertEquals(objectParamDesc, schema["description"]?.jsonPrimitive?.content)
+        assertEquals("object", schema["type"]?.jsonPrimitive?.content)
+
+        val properties = schema["properties"]?.jsonObject
+        assertNotNull(properties)
+
+        val nameProperty = properties[namePropertyName]?.jsonObject
+        assertNotNull(nameProperty)
+        assertEquals(namePropertyDesc, nameProperty["description"]?.jsonPrimitive?.content)
+        assertEquals("string", nameProperty["type"]?.jsonPrimitive?.content)
+
+        val addressProperty = properties[addressPropertyName]?.jsonObject
+        assertNotNull(addressProperty)
+        assertEquals(addressPropertyDesc, addressProperty["description"]?.jsonPrimitive?.content)
+        assertEquals("object", addressProperty["type"]?.jsonPrimitive?.content)
+
+        val addressProperties = addressProperty["properties"]?.jsonObject
+        assertNotNull(addressProperties)
+
+        val streetProperty = addressProperties[streetPropertyName]?.jsonObject
+        assertNotNull(streetProperty)
+        assertEquals(streetPropertyDesc, streetProperty["description"]?.jsonPrimitive?.content)
+        assertEquals("string", streetProperty["type"]?.jsonPrimitive?.content)
+
+        val cityProperty = addressProperties[cityPropertyName]?.jsonObject
+        assertNotNull(cityProperty)
+        assertEquals(cityPropertyDesc, cityProperty["description"]?.jsonPrimitive?.content)
+        assertEquals("string", cityProperty["type"]?.jsonPrimitive?.content)
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/BedrockAI21JambaSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/BedrockAI21JambaSerializationTest.kt
@@ -27,7 +27,7 @@ class BedrockAI21JambaSerializationTest {
     private val toolName = "get_weather"
 
     @Test
-    fun `test createJambaRequest with basic prompt`() {
+    fun `createJambaRequest with basic prompt`() {
         val temperature = 0.7
 
         val prompt = Prompt.build("test", params = LLMParams(temperature = temperature)) {
@@ -52,7 +52,7 @@ class BedrockAI21JambaSerializationTest {
     }
 
     @Test
-    fun `test createJambaRequest with conversation history`() {
+    fun `createJambaRequest with conversation history`() {
         val userNewMessage = "Hello, who are you?"
         val assistantMessage = "I'm an AI assistant. How can I help you today?"
 
@@ -83,7 +83,7 @@ class BedrockAI21JambaSerializationTest {
     }
 
     @Test
-    fun `test createJambaRequest with tools`() {
+    fun `createJambaRequest with tools`() {
         val description = "Get current weather for a city"
 
         val tools = listOf(
@@ -121,7 +121,7 @@ class BedrockAI21JambaSerializationTest {
     }
 
     @Test
-    fun `test createJambaRequest default temperature`() {
+    fun `createJambaRequest default temperature`() {
         val prompt = Prompt.build("test") {
             user("Tell me a story.")
         }
@@ -131,7 +131,7 @@ class BedrockAI21JambaSerializationTest {
     }
 
     @Test
-    fun `test createJambaRequest respects model temperature capability`() {
+    fun `createJambaRequest respects model temperature capability`() {
         val temperature = 0.3
 
         val promptWithTemperature = Prompt.build("test", params = LLMParams(temperature = temperature)) {
@@ -156,7 +156,7 @@ class BedrockAI21JambaSerializationTest {
     }
 
     @Test
-    fun `test parseJambaResponse with text content`() {
+    fun `parseJambaResponse with text content`() {
         val responseContent = "Paris is the capital of France"
         val responseJson = """
             {
@@ -196,7 +196,7 @@ class BedrockAI21JambaSerializationTest {
     }
 
     @Test
-    fun `test parseJambaResponse with tool call content`() {
+    fun `parseJambaResponse with tool call content`() {
         val callId = "call_01234567"
         // language=json
         val responseJson = """
@@ -246,7 +246,7 @@ class BedrockAI21JambaSerializationTest {
     }
 
     @Test
-    fun `test parseJambaResponse with both text and tool calls`() {
+    fun `parseJambaResponse with both text and tool calls`() {
         val message = "I'll check the weather for you."
         val callId = "call_01234567"
 
@@ -299,7 +299,7 @@ class BedrockAI21JambaSerializationTest {
     }
 
     @Test
-    fun `test parseJambaStreamChunk`() {
+    fun testParseJambaStreamChunk() {
         val chunkJson = """
             {
                 "id": "resp_01234567",
@@ -319,7 +319,7 @@ class BedrockAI21JambaSerializationTest {
     }
 
     @Test
-    fun `test parseJambaStreamChunk with empty content`() {
+    fun `parseJambaStreamChunk with empty content`() {
         val chunkJson = """
             {
                 "id": "resp_01234567",
@@ -339,7 +339,7 @@ class BedrockAI21JambaSerializationTest {
     }
 
     @Test
-    fun `test parseJambaStreamChunk with null content`() {
+    fun `parseJambaStreamChunk with null content`() {
         val chunkJson = """
             {
                 "id": "resp_01234567",

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/BedrockAI21JambaSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/BedrockAI21JambaSerializationTest.kt
@@ -198,6 +198,7 @@ class BedrockAI21JambaSerializationTest {
     @Test
     fun `test parseJambaResponse with tool call content`() {
         val callId = "call_01234567"
+        // language=json
         val responseJson = """
             {
                 "id": "resp_01234567",

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/BedrockAI21JambaSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/BedrockAI21JambaSerializationTest.kt
@@ -1,0 +1,358 @@
+package ai.koog.prompt.executor.clients.bedrock.modelfamilies.ai21
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolParameterDescriptor
+import ai.koog.agents.core.tools.ToolParameterType
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.executor.clients.bedrock.BedrockModels
+import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.params.LLMParams
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.jsonObject
+import kotlin.test.*
+
+class BedrockAI21JambaSerializationTest {
+
+    private val mockClock = object : Clock {
+        override fun now(): Instant = Clock.System.now()
+    }
+
+    private val model = BedrockModels.AI21JambaMini
+    private val systemMessage = "You are a helpful assistant."
+    private val userMessage = "Tell me about Paris."
+    private val toolName = "get_weather"
+
+    @Test
+    fun `test createJambaRequest with basic prompt`() {
+        val temperature = 0.7
+
+        val prompt = Prompt.build("test", params = LLMParams(temperature = temperature)) {
+            system(systemMessage)
+            user(userMessage)
+        }
+
+        val request = BedrockAI21JambaSerialization.createJambaRequest(prompt, model, emptyList())
+
+        assertNotNull(request)
+        assertEquals(model.id, request.model)
+        assertEquals(4096, request.maxTokens)
+        assertEquals(temperature, request.temperature)
+
+        assertEquals(2, request.messages.size)
+
+        assertEquals("system", request.messages[0].role)
+        assertEquals(systemMessage, request.messages[0].content)
+
+        assertEquals("user", request.messages[1].role)
+        assertEquals(userMessage, request.messages[1].content)
+    }
+
+    @Test
+    fun `test createJambaRequest with conversation history`() {
+        val userNewMessage = "Hello, who are you?"
+        val assistantMessage = "I'm an AI assistant. How can I help you today?"
+
+        val prompt = Prompt.build("test") {
+            system(systemMessage)
+            user(userNewMessage)
+            assistant(assistantMessage)
+            user(userMessage)
+        }
+
+        val request = BedrockAI21JambaSerialization.createJambaRequest(prompt, model, emptyList())
+
+        assertNotNull(request)
+
+        assertEquals(4, request.messages.size)
+
+        assertEquals("system", request.messages[0].role)
+        assertEquals(systemMessage, request.messages[0].content)
+
+        assertEquals("user", request.messages[1].role)
+        assertEquals(userNewMessage, request.messages[1].content)
+
+        assertEquals("assistant", request.messages[2].role)
+        assertEquals(assistantMessage, request.messages[2].content)
+
+        assertEquals("user", request.messages[3].role)
+        assertEquals(userMessage, request.messages[3].content)
+    }
+
+    @Test
+    fun `test createJambaRequest with tools`() {
+        val description = "Get current weather for a city"
+
+        val tools = listOf(
+            ToolDescriptor(
+                name = toolName,
+                description = description,
+                requiredParameters = listOf(
+                    ToolParameterDescriptor("city", "The city name", ToolParameterType.String)
+                ),
+                optionalParameters = listOf(
+                    ToolParameterDescriptor("units", "Temperature units", ToolParameterType.String)
+                )
+            )
+        )
+
+        val prompt = Prompt.build("test") {
+            user("What's the weather in Paris?")
+        }
+
+        val request = BedrockAI21JambaSerialization.createJambaRequest(prompt, model, tools)
+
+        assertNotNull(request)
+
+        assertNotNull(request.tools)
+        assertEquals(1, request.tools.size)
+        assertEquals(toolName, request.tools[0].function.name)
+        assertEquals(description, request.tools[0].function.description)
+
+        val parameters = request.tools[0].function.parameters
+        assertNotNull(parameters)
+        assertTrue(
+            parameters.jsonObject.toString().contains("city"),
+            "Required parameter \"city\" not found"
+        )
+    }
+
+    @Test
+    fun `test createJambaRequest default temperature`() {
+        val prompt = Prompt.build("test") {
+            user("Tell me a story.")
+        }
+
+        val request = BedrockAI21JambaSerialization.createJambaRequest(prompt, model, emptyList())
+        assertEquals(null, request.temperature)
+    }
+
+    @Test
+    fun `test createJambaRequest respects model temperature capability`() {
+        val temperature = 0.3
+
+        val promptWithTemperature = Prompt.build("test", params = LLMParams(temperature = temperature)) {
+            user("Tell me a story.")
+        }
+
+        val request = BedrockAI21JambaSerialization.createJambaRequest(promptWithTemperature, model, emptyList())
+        assertEquals(temperature, request.temperature)
+
+        val modelWithoutTemperature = LLModel(
+            provider = LLMProvider.Bedrock,
+            id = "test-model",
+            capabilities = listOf(LLMCapability.Completion) // No temperature capability
+        )
+
+        val requestWithoutTemp = BedrockAI21JambaSerialization.createJambaRequest(
+            promptWithTemperature,
+            modelWithoutTemperature,
+            emptyList()
+        )
+        assertEquals(null, requestWithoutTemp.temperature)
+    }
+
+    @Test
+    fun `test parseJambaResponse with text content`() {
+        val responseContent = "Paris is the capital of France"
+        val responseJson = """
+            {
+                "id": "resp_01234567",
+                "model": "ai21.jamba-1-5-large-v1:0",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "$responseContent and one of the most visited cities in the world."
+                        },
+                        "finish_reason": "stop"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 25,
+                    "completion_tokens": 20,
+                    "total_tokens": 45
+                }
+            }
+        """.trimIndent()
+
+        val messages = BedrockAI21JambaSerialization.parseJambaResponse(responseJson, mockClock)
+
+        assertNotNull(messages)
+        assertEquals(1, messages.size)
+
+        val message = messages.first()
+        assertTrue(message is Message.Assistant)
+        assertContains(message.content, responseContent)
+        assertEquals("stop", message.finishReason)
+
+        assertEquals(25, message.metaInfo.inputTokensCount)
+        assertEquals(20, message.metaInfo.outputTokensCount)
+        assertEquals(45, message.metaInfo.totalTokensCount)
+    }
+
+    @Test
+    fun `test parseJambaResponse with tool call content`() {
+        val callId = "call_01234567"
+        val responseJson = """
+            {
+                "id": "resp_01234567",
+                "model": "ai21.jamba-1-5-large-v1:0",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "tool_calls": [
+                                {
+                                    "id": "$callId",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "$toolName",
+                                        "arguments": "{\"city\":\"Paris\",\"units\":\"celsius\"}"
+                                    }
+                                }
+                            ]
+                        },
+                        "finish_reason": "tool_calls"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 25,
+                    "completion_tokens": 15,
+                    "total_tokens": 40
+                }
+            }
+        """.trimIndent()
+
+        val messages = BedrockAI21JambaSerialization.parseJambaResponse(responseJson, mockClock)
+
+        assertNotNull(messages)
+        assertEquals(1, messages.size)
+
+        val message = messages.first()
+        assertTrue(message is Message.Tool.Call)
+        assertEquals(callId, message.id)
+        assertEquals(toolName, message.tool)
+
+        assertEquals(25, message.metaInfo.inputTokensCount)
+        assertEquals(15, message.metaInfo.outputTokensCount)
+        assertEquals(40, message.metaInfo.totalTokensCount)
+    }
+
+    @Test
+    fun `test parseJambaResponse with both text and tool calls`() {
+        val message = "I'll check the weather for you."
+        val callId = "call_01234567"
+
+        val responseJson = """
+            {
+                "id": "resp_01234567",
+                "model": "ai21.jamba-1-5-large-v1:0",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "$message",
+                            "tool_calls": [
+                                {
+                                    "id": "$callId",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "$toolName",
+                                        "arguments": "{\"city\":\"Paris\"}"
+                                    }
+                                }
+                            ]
+                        },
+                        "finish_reason": "tool_calls"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 25,
+                    "completion_tokens": 30,
+                    "total_tokens": 55
+                }
+            }
+        """.trimIndent()
+
+        val messages = BedrockAI21JambaSerialization.parseJambaResponse(responseJson, mockClock)
+
+        assertNotNull(messages)
+        assertEquals(2, messages.size)
+
+        val textMessage = messages[0]
+        assertTrue(textMessage is Message.Assistant)
+        assertEquals(message, textMessage.content)
+
+        val toolMessage = messages[1]
+        assertTrue(toolMessage is Message.Tool.Call)
+        assertEquals(callId, toolMessage.id)
+        assertEquals(toolName, toolMessage.tool)
+    }
+
+    @Test
+    fun `test parseJambaStreamChunk`() {
+        val chunkJson = """
+            {
+                "id": "resp_01234567",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "content": "Paris is "
+                        }
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val content = BedrockAI21JambaSerialization.parseJambaStreamChunk(chunkJson)
+        assertEquals("Paris is ", content)
+    }
+
+    @Test
+    fun `test parseJambaStreamChunk with empty content`() {
+        val chunkJson = """
+            {
+                "id": "resp_01234567",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "content": ""
+                        }
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val content = BedrockAI21JambaSerialization.parseJambaStreamChunk(chunkJson)
+        assertEquals("", content)
+    }
+
+    @Test
+    fun `test parseJambaStreamChunk with null content`() {
+        val chunkJson = """
+            {
+                "id": "resp_01234567",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "content": null
+                        }
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val content = BedrockAI21JambaSerialization.parseJambaStreamChunk(chunkJson)
+        assertEquals("", content)
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/BedrockAI21JambaSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/BedrockAI21JambaSerializationTest.kt
@@ -250,6 +250,7 @@ class BedrockAI21JambaSerializationTest {
         val message = "I'll check the weather for you."
         val callId = "call_01234567"
 
+        // language=json
         val responseJson = """
             {
                 "id": "resp_01234567",

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/JambaDataModelsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/JambaDataModelsTest.kt
@@ -172,7 +172,7 @@ class JambaDataModelsTest {
     }
 
     @Test
-    fun `test JambaMessage deserialization with tool calls`() {
+    fun `JambaMessage deserialization with tool calls`() {
         val jsonString = """
             {
                 "role": "assistant",

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/JambaDataModelsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/JambaDataModelsTest.kt
@@ -17,7 +17,7 @@ class JambaDataModelsTest {
     }
 
     @Test
-    fun `test JambaRequest serialization`() {
+    fun `JambaRequest serialization`() {
         val request = JambaRequest(
             model = "ai21.jamba-1-5-large-v1:0",
             messages = listOf(
@@ -44,7 +44,7 @@ class JambaDataModelsTest {
     }
 
     @Test
-    fun `test JambaRequest serialization with null fields`() {
+    fun `JambaRequest serialization with null fields`() {
         val request = JambaRequest(
             model = "ai21.jamba-1-5-large-v1:0",
             messages = listOf(
@@ -64,7 +64,7 @@ class JambaDataModelsTest {
     }
 
     @Test
-    fun `test JambaRequest deserialization`() {
+    fun `JambaRequest deserialization`() {
         val jsonString = """
             {
                 "model": "ai21.jamba-1-5-large-v1:0",
@@ -90,7 +90,7 @@ class JambaDataModelsTest {
     }
 
     @Test
-    fun `test JambaRequest deserialization with missing fields`() {
+    fun `JambaRequest deserialization with missing fields`() {
         val jsonString = """
             {
                 "model": "ai21.jamba-1-5-large-v1:0",
@@ -114,7 +114,7 @@ class JambaDataModelsTest {
     }
 
     @Test
-    fun `test JambaMessage serialization`() {
+    fun `JambaMessage serialization`() {
         val message = JambaMessage(
             role = "user",
             content = "Tell me about Paris"
@@ -128,7 +128,7 @@ class JambaDataModelsTest {
     }
 
     @Test
-    fun `test JambaMessage serialization with tool calls`() {
+    fun `JambaMessage serialization with tool calls`() {
         val message = JambaMessage(
             role = "assistant",
             content = null,
@@ -155,7 +155,7 @@ class JambaDataModelsTest {
     }
 
     @Test
-    fun `test JambaMessage deserialization`() {
+    fun `JambaMessage deserialization`() {
         val jsonString = """
             {
                 "role": "user",
@@ -202,7 +202,7 @@ class JambaDataModelsTest {
     }
 
     @Test
-    fun `test JambaTool serialization`() {
+    fun `JambaTool serialization`() {
         val tool = JambaTool(
             function = JambaFunction(
                 name = "get_weather",
@@ -236,7 +236,7 @@ class JambaDataModelsTest {
     }
 
     @Test
-    fun `test JambaResponse serialization`() {
+    fun `JambaResponse serialization`() {
         val response = JambaResponse(
             id = "resp_01234567",
             model = "ai21.jamba-1-5-large-v1:0",
@@ -275,7 +275,7 @@ class JambaDataModelsTest {
     }
 
     @Test
-    fun `test JambaResponse deserialization`() {
+    fun `JambaResponse deserialization`() {
         val jsonString = """
             {
                 "id": "resp_01234567",
@@ -314,7 +314,7 @@ class JambaDataModelsTest {
     }
 
     @Test
-    fun `test JambaStreamResponse serialization`() {
+    fun `JambaStreamResponse serialization`() {
         val streamResponse = JambaStreamResponse(
             id = "resp_01234567",
             choices = listOf(
@@ -338,7 +338,7 @@ class JambaDataModelsTest {
     }
 
     @Test
-    fun `test JambaStreamResponse deserialization`() {
+    fun `JambaStreamResponse deserialization`() {
         val jsonString = """
             {
                 "id": "resp_01234567",

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/JambaDataModelsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/JambaDataModelsTest.kt
@@ -1,0 +1,363 @@
+package ai.koog.prompt.executor.clients.bedrock.modelfamilies.ai21
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class JambaDataModelsTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        explicitNulls = false
+    }
+
+    @Test
+    fun `test JambaRequest serialization`() {
+        val request = JambaRequest(
+            model = "ai21.jamba-1-5-large-v1:0",
+            messages = listOf(
+                JambaMessage(role = "user", content = "Tell me about Paris")
+            ),
+            maxTokens = 1000,
+            temperature = 0.7
+        )
+
+        val serialized = json.encodeToString(JambaRequest.serializer(), request)
+
+        assertNotNull(serialized)
+        assert(serialized.contains("\"model\"")) { "Serialized JSON should contain 'model' field: $serialized" }
+        assert(serialized.contains("\"ai21.jamba-1-5-large-v1:0\"")) { "Serialized JSON should contain the model ID: $serialized" }
+        assert(serialized.contains("\"messages\"")) { "Serialized JSON should contain 'messages' field: $serialized" }
+        assert(serialized.contains("\"role\"")) { "Serialized JSON should contain 'role' field: $serialized" }
+        assert(serialized.contains("\"user\"")) { "Serialized JSON should contain 'user' role: $serialized" }
+        assert(serialized.contains("\"content\"")) { "Serialized JSON should contain 'content' field: $serialized" }
+        assert(serialized.contains("\"Tell me about Paris\"")) { "Serialized JSON should contain the message content: $serialized" }
+        assert(serialized.contains("\"max_tokens\"")) { "Serialized JSON should contain 'max_tokens' field: $serialized" }
+        assert(serialized.contains("1000")) { "Serialized JSON should contain the maxTokens value: $serialized" }
+        assert(serialized.contains("\"temperature\"")) { "Serialized JSON should contain 'temperature' field: $serialized" }
+        assert(serialized.contains("0.7")) { "Serialized JSON should contain the temperature value: $serialized" }
+    }
+
+    @Test
+    fun `test JambaRequest serialization with null fields`() {
+        val request = JambaRequest(
+            model = "ai21.jamba-1-5-large-v1:0",
+            messages = listOf(
+                JambaMessage(role = "user", content = "Tell me about Paris")
+            ),
+            maxTokens = null,
+            temperature = null
+        )
+
+        val serialized = json.encodeToString(JambaRequest.serializer(), request)
+
+        assertNotNull(serialized)
+        assert(serialized.contains("\"model\"")) { "Serialized JSON should contain 'model' field: $serialized" }
+        assert(serialized.contains("\"messages\"")) { "Serialized JSON should contain 'messages' field: $serialized" }
+        assert(!serialized.contains("\"max_tokens\"")) { "Serialized JSON should not contain 'max_tokens' field when it's null: $serialized" }
+        assert(!serialized.contains("\"temperature\"")) { "Serialized JSON should not contain 'temperature' field when it's null: $serialized" }
+    }
+
+    @Test
+    fun `test JambaRequest deserialization`() {
+        val jsonString = """
+            {
+                "model": "ai21.jamba-1-5-large-v1:0",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "Tell me about Paris"
+                    }
+                ],
+                "max_tokens": 1000,
+                "temperature": 0.7
+            }
+        """.trimIndent()
+
+        val request = json.decodeFromString(JambaRequest.serializer(), jsonString)
+
+        assertEquals("ai21.jamba-1-5-large-v1:0", request.model)
+        assertEquals(1, request.messages.size)
+        assertEquals("user", request.messages[0].role)
+        assertEquals("Tell me about Paris", request.messages[0].content)
+        assertEquals(1000, request.maxTokens)
+        assertEquals(0.7, request.temperature)
+    }
+
+    @Test
+    fun `test JambaRequest deserialization with missing fields`() {
+        val jsonString = """
+            {
+                "model": "ai21.jamba-1-5-large-v1:0",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "Tell me about Paris"
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val request = json.decodeFromString(JambaRequest.serializer(), jsonString)
+
+        assertEquals("ai21.jamba-1-5-large-v1:0", request.model)
+        assertEquals(1, request.messages.size)
+        assertEquals("user", request.messages[0].role)
+        assertEquals("Tell me about Paris", request.messages[0].content)
+        assertNull(request.maxTokens)
+        assertNull(request.temperature)
+    }
+
+    @Test
+    fun `test JambaMessage serialization`() {
+        val message = JambaMessage(
+            role = "user",
+            content = "Tell me about Paris"
+        )
+
+        val serialized = json.encodeToString(JambaMessage.serializer(), message)
+
+        assertNotNull(serialized)
+        assert(serialized.contains("\"role\":\"user\""))
+        assert(serialized.contains("\"content\":\"Tell me about Paris\""))
+    }
+
+    @Test
+    fun `test JambaMessage serialization with tool calls`() {
+        val message = JambaMessage(
+            role = "assistant",
+            content = null,
+            toolCalls = listOf(
+                JambaToolCall(
+                    id = "call_01234567",
+                    function = JambaFunctionCall(
+                        name = "get_weather",
+                        arguments = "{\"city\":\"Paris\"}"
+                    )
+                )
+            )
+        )
+
+        val serialized = json.encodeToString(JambaMessage.serializer(), message)
+
+        assertNotNull(serialized)
+        assert(serialized.contains("\"role\":\"assistant\""))
+        assert(serialized.contains("\"tool_calls\""))
+        assert(serialized.contains("\"id\":\"call_01234567\""))
+        assert(serialized.contains("\"function\""))
+        assert(serialized.contains("\"name\":\"get_weather\""))
+        assert(serialized.contains("\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\""))
+    }
+
+    @Test
+    fun `test JambaMessage deserialization`() {
+        val jsonString = """
+            {
+                "role": "user",
+                "content": "Tell me about Paris"
+            }
+        """.trimIndent()
+
+        val message = json.decodeFromString(JambaMessage.serializer(), jsonString)
+
+        assertEquals("user", message.role)
+        assertEquals("Tell me about Paris", message.content)
+        assertNull(message.toolCalls)
+        assertNull(message.toolCallId)
+    }
+
+    @Test
+    fun `test JambaMessage deserialization with tool calls`() {
+        val jsonString = """
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_01234567",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": "{\"city\":\"Paris\"}"
+                        }
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val message = json.decodeFromString(JambaMessage.serializer(), jsonString)
+
+        assertEquals("assistant", message.role)
+        assertNull(message.content)
+        assertNotNull(message.toolCalls)
+        assertEquals(1, message.toolCalls.size)
+        assertEquals("call_01234567", message.toolCalls[0].id)
+        assertEquals("function", message.toolCalls[0].type)
+        assertEquals("get_weather", message.toolCalls[0].function.name)
+        assertEquals("{\"city\":\"Paris\"}", message.toolCalls[0].function.arguments)
+    }
+
+    @Test
+    fun `test JambaTool serialization`() {
+        val tool = JambaTool(
+            function = JambaFunction(
+                name = "get_weather",
+                description = "Get current weather for a city",
+                parameters = buildJsonObject {
+                    put("type", "object")
+                    put("properties", buildJsonObject {
+                        put("city", buildJsonObject {
+                            put("type", "string")
+                            put("description", "The city name")
+                        })
+                    })
+                    put("required", buildJsonObject {
+                        put("0", "city")
+                    })
+                }
+            )
+        )
+
+        val serialized = json.encodeToString(JambaTool.serializer(), tool)
+        println("Serialized JambaTool: $serialized")
+
+        assertNotNull(serialized)
+        assert(serialized.contains("\"function\""))
+        assert(serialized.contains("\"name\":\"get_weather\""))
+        assert(serialized.contains("\"description\":\"Get current weather for a city\""))
+        assert(serialized.contains("\"parameters\""))
+        assert(serialized.contains("\"properties\""))
+        assert(serialized.contains("\"city\""))
+        assert(serialized.contains("\"required\""))
+    }
+
+    @Test
+    fun `test JambaResponse serialization`() {
+        val response = JambaResponse(
+            id = "resp_01234567",
+            model = "ai21.jamba-1-5-large-v1:0",
+            choices = listOf(
+                JambaChoice(
+                    index = 0,
+                    message = JambaMessage(
+                        role = "assistant",
+                        content = "Paris is the capital of France."
+                    ),
+                    finishReason = "stop"
+                )
+            ),
+            usage = JambaUsage(
+                promptTokens = 10,
+                completionTokens = 15,
+                totalTokens = 25
+            )
+        )
+
+        val serialized = json.encodeToString(JambaResponse.serializer(), response)
+
+        assertNotNull(serialized)
+        assert(serialized.contains("\"id\":\"resp_01234567\""))
+        assert(serialized.contains("\"model\":\"ai21.jamba-1-5-large-v1:0\""))
+        assert(serialized.contains("\"choices\""))
+        assert(serialized.contains("\"index\":0"))
+        assert(serialized.contains("\"message\""))
+        assert(serialized.contains("\"role\":\"assistant\""))
+        assert(serialized.contains("\"content\":\"Paris is the capital of France.\""))
+        assert(serialized.contains("\"finish_reason\":\"stop\""))
+        assert(serialized.contains("\"usage\""))
+        assert(serialized.contains("\"prompt_tokens\":10"))
+        assert(serialized.contains("\"completion_tokens\":15"))
+        assert(serialized.contains("\"total_tokens\":25"))
+    }
+
+    @Test
+    fun `test JambaResponse deserialization`() {
+        val jsonString = """
+            {
+                "id": "resp_01234567",
+                "model": "ai21.jamba-1-5-large-v1:0",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "Paris is the capital of France."
+                        },
+                        "finish_reason": "stop"
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 15,
+                    "total_tokens": 25
+                }
+            }
+        """.trimIndent()
+
+        val response = json.decodeFromString(JambaResponse.serializer(), jsonString)
+
+        assertEquals("resp_01234567", response.id)
+        assertEquals("ai21.jamba-1-5-large-v1:0", response.model)
+        assertEquals(1, response.choices.size)
+        assertEquals(0, response.choices[0].index)
+        assertEquals("assistant", response.choices[0].message.role)
+        assertEquals("Paris is the capital of France.", response.choices[0].message.content)
+        assertEquals("stop", response.choices[0].finishReason)
+        assertNotNull(response.usage)
+        assertEquals(10, response.usage.promptTokens)
+        assertEquals(15, response.usage.completionTokens)
+        assertEquals(25, response.usage.totalTokens)
+    }
+
+    @Test
+    fun `test JambaStreamResponse serialization`() {
+        val streamResponse = JambaStreamResponse(
+            id = "resp_01234567",
+            choices = listOf(
+                JambaStreamChoice(
+                    index = 0,
+                    delta = JambaStreamDelta(
+                        content = "Paris is "
+                    )
+                )
+            )
+        )
+
+        val serialized = json.encodeToString(JambaStreamResponse.serializer(), streamResponse)
+
+        assertNotNull(serialized)
+        assert(serialized.contains("\"id\":\"resp_01234567\""))
+        assert(serialized.contains("\"choices\""))
+        assert(serialized.contains("\"index\":0"))
+        assert(serialized.contains("\"delta\""))
+        assert(serialized.contains("\"content\":\"Paris is \""))
+    }
+
+    @Test
+    fun `test JambaStreamResponse deserialization`() {
+        val jsonString = """
+            {
+                "id": "resp_01234567",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "content": "Paris is "
+                        }
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val streamResponse = json.decodeFromString(JambaStreamResponse.serializer(), jsonString)
+
+        assertEquals("resp_01234567", streamResponse.id)
+        assertEquals(1, streamResponse.choices.size)
+        assertEquals(0, streamResponse.choices[0].index)
+        assertEquals("Paris is ", streamResponse.choices[0].delta.content)
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/amazon/BedrockAmazonNovaSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/amazon/BedrockAmazonNovaSerializationTest.kt
@@ -24,7 +24,7 @@ class BedrockAmazonNovaSerializationTest {
     private val assistantMessage = "I'm an AI assistant. How can I help you today?"
 
     @Test
-    fun `test createNovaRequest with system and user messages`() {
+    fun `createNovaRequest with system and user messages`() {
         val temperature = 0.7
 
         val prompt = Prompt.build("test", params = LLMParams(temperature = temperature)) {
@@ -51,7 +51,7 @@ class BedrockAmazonNovaSerializationTest {
     }
 
     @Test
-    fun `test createNovaRequest with conversation history`() {
+    fun `createNovaRequest with conversation history`() {
         val prompt = Prompt.build("test") {
             system(systemMessage)
             user(userNewMessage)
@@ -80,7 +80,7 @@ class BedrockAmazonNovaSerializationTest {
     }
 
     @Test
-    fun `test createNovaRequest respects model temperature capability`() {
+    fun `createNovaRequest respects model temperature capability`() {
         val temperature = 0.3
 
         val promptWithTemperature = Prompt.build("test", params = LLMParams(temperature = temperature)) {
@@ -104,7 +104,7 @@ class BedrockAmazonNovaSerializationTest {
     }
 
     @Test
-    fun `test parseNovaResponse`() {
+    fun testParseNovaResponse() {
         val responseContent = "Paris is the capital of France and one of the most visited cities in the world."
         val responseJson = """
             {
@@ -143,7 +143,7 @@ class BedrockAmazonNovaSerializationTest {
     }
 
     @Test
-    fun `test parseNovaResponse with missing usage`() {
+    fun `parseNovaResponse with missing usage`() {
         val responseContent = "Paris is the capital of France."
         val responseJson = """
             {
@@ -176,7 +176,7 @@ class BedrockAmazonNovaSerializationTest {
     }
 
     @Test
-    fun `test parseNovaStreamChunk`() {
+    fun testParseNovaStreamChunk() {
         val chunkContent = "Paris is "
         val chunkJson = """
             {
@@ -193,7 +193,7 @@ class BedrockAmazonNovaSerializationTest {
     }
 
     @Test
-    fun `test parseNovaStreamChunk with empty text`() {
+    fun `parseNovaStreamChunk with empty text`() {
         val chunkJson = """
             {
                 "contentBlockDelta": {
@@ -209,7 +209,7 @@ class BedrockAmazonNovaSerializationTest {
     }
 
     @Test
-    fun `test parseNovaStreamChunk with null text`() {
+    fun `parseNovaStreamChunk with null text`() {
         val chunkJson = """
             {
                 "contentBlockDelta": {
@@ -225,7 +225,7 @@ class BedrockAmazonNovaSerializationTest {
     }
 
     @Test
-    fun `test parseNovaStreamChunk with message stop`() {
+    fun `parseNovaStreamChunk with message stop`() {
         val chunkJson = """
             {
                 "messageStop": {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/amazon/BedrockAmazonNovaSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/amazon/BedrockAmazonNovaSerializationTest.kt
@@ -1,0 +1,245 @@
+package ai.koog.prompt.executor.clients.bedrock.modelfamilies.amazon
+
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.executor.clients.bedrock.BedrockModels
+import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.params.LLMParams
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.test.*
+
+class BedrockAmazonNovaSerializationTest {
+
+    private val mockClock = object : Clock {
+        override fun now(): Instant = Clock.System.now()
+    }
+
+    private val model = BedrockModels.AmazonNovaPro
+    private val systemMessage = "You are a helpful assistant."
+    private val userMessage = "Tell me about Paris."
+    private val userNewMessage = "Hello, who are you?"
+    private val assistantMessage = "I'm an AI assistant. How can I help you today?"
+
+    @Test
+    fun `test createNovaRequest with system and user messages`() {
+        val temperature = 0.7
+
+        val prompt = Prompt.build("test", params = LLMParams(temperature = temperature)) {
+            system(systemMessage)
+            user(userMessage)
+        }
+
+        val request = BedrockAmazonNovaSerialization.createNovaRequest(prompt, model)
+
+        assertNotNull(request)
+
+        assertNotNull(request.system)
+        assertEquals(1, request.system.size)
+        assertEquals(systemMessage, request.system[0].text)
+
+        assertEquals(1, request.messages.size)
+        assertEquals("user", request.messages[0].role)
+        assertEquals(1, request.messages[0].content.size)
+        assertEquals(userMessage, request.messages[0].content[0].text)
+
+        assertNotNull(request.inferenceConfig)
+        assertEquals(4096, request.inferenceConfig.maxTokens)
+        assertEquals(temperature, request.inferenceConfig.temperature)
+    }
+
+    @Test
+    fun `test createNovaRequest with conversation history`() {
+        val prompt = Prompt.build("test") {
+            system(systemMessage)
+            user(userNewMessage)
+            assistant(assistantMessage)
+            user(userMessage)
+        }
+
+        val request = BedrockAmazonNovaSerialization.createNovaRequest(prompt, model)
+
+        assertNotNull(request)
+
+        assertNotNull(request.system)
+        assertEquals(1, request.system.size)
+        assertEquals(systemMessage, request.system[0].text)
+
+        assertEquals(3, request.messages.size)
+
+        assertEquals("user", request.messages[0].role)
+        assertEquals(userNewMessage, request.messages[0].content[0].text)
+
+        assertEquals("assistant", request.messages[1].role)
+        assertEquals(assistantMessage, request.messages[1].content[0].text)
+
+        assertEquals("user", request.messages[2].role)
+        assertEquals(userMessage, request.messages[2].content[0].text)
+    }
+
+    @Test
+    fun `test createNovaRequest respects model temperature capability`() {
+        val temperature = 0.3
+
+        val promptWithTemperature = Prompt.build("test", params = LLMParams(temperature = temperature)) {
+            user("Tell me a story.")
+        }
+
+        val request = BedrockAmazonNovaSerialization.createNovaRequest(promptWithTemperature, model)
+        assertEquals(temperature, request.inferenceConfig?.temperature)
+
+        val modelWithoutTemperature = LLModel(
+            provider = LLMProvider.Bedrock,
+            id = "test-model",
+            capabilities = listOf(LLMCapability.Completion) // No temperature capability
+        )
+
+        val requestWithoutTemp = BedrockAmazonNovaSerialization.createNovaRequest(
+            promptWithTemperature,
+            modelWithoutTemperature,
+        )
+        assertEquals(null, requestWithoutTemp.inferenceConfig?.temperature)
+    }
+
+    @Test
+    fun `test parseNovaResponse`() {
+        val responseContent = "Paris is the capital of France and one of the most visited cities in the world."
+        val responseJson = """
+            {
+                "output": {
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "text": "$responseContent"
+                            }
+                        ]
+                    }
+                },
+                "usage": {
+                    "inputTokens": 25,
+                    "outputTokens": 20,
+                    "totalTokens": 45
+                },
+                "stopReason": "stop"
+            }
+        """.trimIndent()
+
+        val messages = BedrockAmazonNovaSerialization.parseNovaResponse(responseJson, mockClock)
+
+        assertNotNull(messages)
+        assertEquals(1, messages.size)
+
+        val message = messages.first()
+        assertTrue(message is Message.Assistant)
+        assertContains(message.content, responseContent)
+
+        // Check token counts - Note: Nova only provides outputTokens in the metaInfo
+        assertEquals(20, message.metaInfo.outputTokensCount)
+        assertEquals(null, message.metaInfo.inputTokensCount)
+        assertEquals(null, message.metaInfo.totalTokensCount)
+    }
+
+    @Test
+    fun `test parseNovaResponse with missing usage`() {
+        val responseContent = "Paris is the capital of France."
+        val responseJson = """
+            {
+                "output": {
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "text": "$responseContent"
+                            }
+                        ]
+                    }
+                },
+                "stopReason": "stop"
+            }
+        """.trimIndent()
+
+        val messages = BedrockAmazonNovaSerialization.parseNovaResponse(responseJson, mockClock)
+
+        assertNotNull(messages)
+        assertEquals(1, messages.size)
+
+        val message = messages.first()
+        assertTrue(message is Message.Assistant)
+        assertEquals(responseContent, message.content)
+
+        assertEquals(null, message.metaInfo.inputTokensCount)
+        assertEquals(null, message.metaInfo.outputTokensCount)
+        assertEquals(null, message.metaInfo.totalTokensCount)
+    }
+
+    @Test
+    fun `test parseNovaStreamChunk`() {
+        val chunkContent = "Paris is "
+        val chunkJson = """
+            {
+                "contentBlockDelta": {
+                    "delta": {
+                        "text": "$chunkContent"
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val content = BedrockAmazonNovaSerialization.parseNovaStreamChunk(chunkJson)
+        assertEquals(chunkContent, content)
+    }
+
+    @Test
+    fun `test parseNovaStreamChunk with empty text`() {
+        val chunkJson = """
+            {
+                "contentBlockDelta": {
+                    "delta": {
+                        "text": ""
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val content = BedrockAmazonNovaSerialization.parseNovaStreamChunk(chunkJson)
+        assertEquals("", content)
+    }
+
+    @Test
+    fun `test parseNovaStreamChunk with null text`() {
+        val chunkJson = """
+            {
+                "contentBlockDelta": {
+                    "delta": {
+                        "text": null
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val content = BedrockAmazonNovaSerialization.parseNovaStreamChunk(chunkJson)
+        assertEquals("", content)
+    }
+
+    @Test
+    fun `test parseNovaStreamChunk with message stop`() {
+        val chunkJson = """
+            {
+                "messageStop": {
+                    "stopReason": "stop"
+                },
+                "metadata": {
+                    "usage": {
+                        "outputTokens": 20
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val content = BedrockAmazonNovaSerialization.parseNovaStreamChunk(chunkJson)
+        assertEquals("", content)
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/amazon/NovaDataModelsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/amazon/NovaDataModelsTest.kt
@@ -15,7 +15,7 @@ class NovaDataModelsTest {
     }
 
     @Test
-    fun `test NovaRequest serialization`() {
+    fun `NovaRequest serialization`() {
         val request = NovaRequest(
             messages = listOf(
                 NovaMessage(
@@ -51,7 +51,7 @@ class NovaDataModelsTest {
     }
 
     @Test
-    fun `test NovaRequest serialization with null fields`() {
+    fun `NovaRequest serialization with null fields`() {
         val request = NovaRequest(
             messages = listOf(
                 NovaMessage(
@@ -72,7 +72,7 @@ class NovaDataModelsTest {
     }
 
     @Test
-    fun `test NovaRequest deserialization`() {
+    fun `NovaRequest deserialization`() {
         val jsonString = """
             {
                 "messages": [
@@ -112,7 +112,7 @@ class NovaDataModelsTest {
     }
 
     @Test
-    fun `test NovaRequest deserialization with missing fields`() {
+    fun `NovaRequest deserialization with missing fields`() {
         val jsonString = """
             {
                 "messages": [
@@ -139,7 +139,7 @@ class NovaDataModelsTest {
     }
 
     @Test
-    fun `test NovaMessage serialization`() {
+    fun `NovaMessage serialization`() {
         val message = NovaMessage(
             role = "user",
             content = listOf(NovaContent(text = "Tell me about Paris"))
@@ -154,7 +154,7 @@ class NovaDataModelsTest {
     }
 
     @Test
-    fun `test NovaMessage deserialization`() {
+    fun `NovaMessage deserialization`() {
         val jsonString = """
             {
                 "role": "user",
@@ -174,7 +174,7 @@ class NovaDataModelsTest {
     }
 
     @Test
-    fun `test NovaInferenceConfig serialization`() {
+    fun `NovaInferenceConfig serialization`() {
         val config = NovaInferenceConfig(
             temperature = 0.7,
             topP = 0.9,
@@ -192,7 +192,7 @@ class NovaDataModelsTest {
     }
 
     @Test
-    fun `test NovaInferenceConfig serialization with null fields`() {
+    fun `NovaInferenceConfig serialization with null fields`() {
         val config = NovaInferenceConfig(
             temperature = null,
             topP = null,
@@ -210,7 +210,7 @@ class NovaDataModelsTest {
     }
 
     @Test
-    fun `test NovaInferenceConfig deserialization`() {
+    fun `NovaInferenceConfig deserialization`() {
         val jsonString = """
             {
                 "temperature": 0.7,
@@ -229,7 +229,7 @@ class NovaDataModelsTest {
     }
 
     @Test
-    fun `test NovaResponse serialization`() {
+    fun `NovaResponse serialization`() {
         val response = NovaResponse(
             output = NovaOutput(
                 message = NovaMessage(
@@ -261,7 +261,7 @@ class NovaDataModelsTest {
     }
 
     @Test
-    fun `test NovaResponse deserialization`() {
+    fun `NovaResponse deserialization`() {
         val jsonString = """
             {
                 "output": {
@@ -296,7 +296,7 @@ class NovaDataModelsTest {
     }
 
     @Test
-    fun `test NovaStreamChunk serialization`() {
+    fun `NovaStreamChunk serialization`() {
         val chunk = NovaStreamChunk(
             contentBlockDelta = NovaContentBlockDelta(
                 delta = NovaContentDelta(text = "Paris is ")
@@ -312,7 +312,7 @@ class NovaDataModelsTest {
     }
 
     @Test
-    fun `test NovaStreamChunk serialization with message stop`() {
+    fun `NovaStreamChunk serialization with message stop`() {
         val chunk = NovaStreamChunk(
             messageStop = NovaMessageStop(stopReason = "stop"),
             metadata = NovaStreamMetadata(
@@ -331,7 +331,7 @@ class NovaDataModelsTest {
     }
 
     @Test
-    fun `test NovaStreamChunk deserialization`() {
+    fun `NovaStreamChunk deserialization`() {
         val jsonString = """
             {
                 "contentBlockDelta": {
@@ -351,7 +351,7 @@ class NovaDataModelsTest {
     }
 
     @Test
-    fun `test NovaStreamChunk deserialization with message stop`() {
+    fun `NovaStreamChunk deserialization with message stop`() {
         val jsonString = """
             {
                 "messageStop": {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/amazon/NovaDataModelsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/amazon/NovaDataModelsTest.kt
@@ -1,0 +1,377 @@
+package ai.koog.prompt.executor.clients.bedrock.modelfamilies.amazon
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class NovaDataModelsTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        explicitNulls = false
+    }
+
+    @Test
+    fun `test NovaRequest serialization`() {
+        val request = NovaRequest(
+            messages = listOf(
+                NovaMessage(
+                    role = "user",
+                    content = listOf(NovaContent(text = "Tell me about Paris"))
+                )
+            ),
+            inferenceConfig = NovaInferenceConfig(
+                temperature = 0.7,
+                maxTokens = 1000
+            ),
+            system = listOf(
+                NovaSystemMessage(text = "You are a helpful assistant.")
+            )
+        )
+
+        val serialized = json.encodeToString(NovaRequest.serializer(), request)
+
+        assertNotNull(serialized)
+        assert(serialized.contains("\"messages\"")) { "Serialized JSON should contain 'messages' field: $serialized" }
+        assert(serialized.contains("\"role\"")) { "Serialized JSON should contain 'role' field: $serialized" }
+        assert(serialized.contains("\"user\"")) { "Serialized JSON should contain 'user' role: $serialized" }
+        assert(serialized.contains("\"content\"")) { "Serialized JSON should contain 'content' field: $serialized" }
+        assert(serialized.contains("\"text\"")) { "Serialized JSON should contain 'text' field: $serialized" }
+        assert(serialized.contains("\"Tell me about Paris\"")) { "Serialized JSON should contain the message text: $serialized" }
+        assert(serialized.contains("\"inferenceConfig\"")) { "Serialized JSON should contain 'inferenceConfig' field: $serialized" }
+        assert(serialized.contains("\"temperature\"")) { "Serialized JSON should contain 'temperature' field: $serialized" }
+        assert(serialized.contains("0.7")) { "Serialized JSON should contain the temperature value: $serialized" }
+        assert(serialized.contains("\"maxTokens\"")) { "Serialized JSON should contain 'maxTokens' field: $serialized" }
+        assert(serialized.contains("1000")) { "Serialized JSON should contain the maxTokens value: $serialized" }
+        assert(serialized.contains("\"system\"")) { "Serialized JSON should contain 'system' field: $serialized" }
+        assert(serialized.contains("\"You are a helpful assistant.\"")) { "Serialized JSON should contain the system message: $serialized" }
+    }
+
+    @Test
+    fun `test NovaRequest serialization with null fields`() {
+        val request = NovaRequest(
+            messages = listOf(
+                NovaMessage(
+                    role = "user",
+                    content = listOf(NovaContent(text = "Tell me about Paris"))
+                )
+            ),
+            inferenceConfig = null,
+            system = null
+        )
+
+        val serialized = json.encodeToString(NovaRequest.serializer(), request)
+
+        assertNotNull(serialized)
+        assert(serialized.contains("\"messages\"")) { "Serialized JSON should contain 'messages' field: $serialized" }
+        assert(!serialized.contains("\"inferenceConfig\"")) { "Serialized JSON should not contain 'inferenceConfig' field when it's null: $serialized" }
+        assert(!serialized.contains("\"system\"")) { "Serialized JSON should not contain 'system' field when it's null: $serialized" }
+    }
+
+    @Test
+    fun `test NovaRequest deserialization`() {
+        val jsonString = """
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "text": "Tell me about Paris"
+                            }
+                        ]
+                    }
+                ],
+                "inferenceConfig": {
+                    "temperature": 0.7,
+                    "maxTokens": 1000
+                },
+                "system": [
+                    {
+                        "text": "You are a helpful assistant."
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val request = json.decodeFromString(NovaRequest.serializer(), jsonString)
+
+        assertEquals(1, request.messages.size)
+        assertEquals("user", request.messages[0].role)
+        assertEquals(1, request.messages[0].content.size)
+        assertEquals("Tell me about Paris", request.messages[0].content[0].text)
+        assertNotNull(request.inferenceConfig)
+        assertEquals(0.7, request.inferenceConfig.temperature)
+        assertEquals(1000, request.inferenceConfig.maxTokens)
+        assertNotNull(request.system)
+        assertEquals(1, request.system.size)
+        assertEquals("You are a helpful assistant.", request.system[0].text)
+    }
+
+    @Test
+    fun `test NovaRequest deserialization with missing fields`() {
+        val jsonString = """
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "text": "Tell me about Paris"
+                            }
+                        ]
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val request = json.decodeFromString(NovaRequest.serializer(), jsonString)
+
+        assertEquals(1, request.messages.size)
+        assertEquals("user", request.messages[0].role)
+        assertEquals(1, request.messages[0].content.size)
+        assertEquals("Tell me about Paris", request.messages[0].content[0].text)
+        assertNull(request.inferenceConfig)
+        assertNull(request.system)
+    }
+
+    @Test
+    fun `test NovaMessage serialization`() {
+        val message = NovaMessage(
+            role = "user",
+            content = listOf(NovaContent(text = "Tell me about Paris"))
+        )
+
+        val serialized = json.encodeToString(NovaMessage.serializer(), message)
+
+        assertNotNull(serialized)
+        assert(serialized.contains("\"role\":\"user\""))
+        assert(serialized.contains("\"content\""))
+        assert(serialized.contains("\"text\":\"Tell me about Paris\""))
+    }
+
+    @Test
+    fun `test NovaMessage deserialization`() {
+        val jsonString = """
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "text": "Tell me about Paris"
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        val message = json.decodeFromString(NovaMessage.serializer(), jsonString)
+
+        assertEquals("user", message.role)
+        assertEquals(1, message.content.size)
+        assertEquals("Tell me about Paris", message.content[0].text)
+    }
+
+    @Test
+    fun `test NovaInferenceConfig serialization`() {
+        val config = NovaInferenceConfig(
+            temperature = 0.7,
+            topP = 0.9,
+            topK = 50,
+            maxTokens = 1000
+        )
+
+        val serialized = json.encodeToString(NovaInferenceConfig.serializer(), config)
+
+        assertNotNull(serialized)
+        assert(serialized.contains("\"temperature\":0.7"))
+        assert(serialized.contains("\"topP\":0.9"))
+        assert(serialized.contains("\"topK\":50"))
+        assert(serialized.contains("\"maxTokens\":1000"))
+    }
+
+    @Test
+    fun `test NovaInferenceConfig serialization with null fields`() {
+        val config = NovaInferenceConfig(
+            temperature = null,
+            topP = null,
+            topK = null,
+            maxTokens = null
+        )
+
+        val serialized = json.encodeToString(NovaInferenceConfig.serializer(), config)
+
+        assertNotNull(serialized)
+        assert(!serialized.contains("\"temperature\""))
+        assert(!serialized.contains("\"topP\""))
+        assert(!serialized.contains("\"topK\""))
+        assert(!serialized.contains("\"maxTokens\""))
+    }
+
+    @Test
+    fun `test NovaInferenceConfig deserialization`() {
+        val jsonString = """
+            {
+                "temperature": 0.7,
+                "topP": 0.9,
+                "topK": 50,
+                "maxTokens": 1000
+            }
+        """.trimIndent()
+
+        val config = json.decodeFromString(NovaInferenceConfig.serializer(), jsonString)
+
+        assertEquals(0.7, config.temperature)
+        assertEquals(0.9, config.topP)
+        assertEquals(50, config.topK)
+        assertEquals(1000, config.maxTokens)
+    }
+
+    @Test
+    fun `test NovaResponse serialization`() {
+        val response = NovaResponse(
+            output = NovaOutput(
+                message = NovaMessage(
+                    role = "assistant",
+                    content = listOf(NovaContent(text = "Paris is the capital of France."))
+                )
+            ),
+            usage = NovaUsage(
+                inputTokens = 10,
+                outputTokens = 15,
+                totalTokens = 25
+            ),
+            stopReason = "stop"
+        )
+
+        val serialized = json.encodeToString(NovaResponse.serializer(), response)
+
+        assertNotNull(serialized)
+        assert(serialized.contains("\"output\""))
+        assert(serialized.contains("\"message\""))
+        assert(serialized.contains("\"role\":\"assistant\""))
+        assert(serialized.contains("\"content\""))
+        assert(serialized.contains("\"text\":\"Paris is the capital of France.\""))
+        assert(serialized.contains("\"usage\""))
+        assert(serialized.contains("\"inputTokens\":10"))
+        assert(serialized.contains("\"outputTokens\":15"))
+        assert(serialized.contains("\"totalTokens\":25"))
+        assert(serialized.contains("\"stopReason\":\"stop\""))
+    }
+
+    @Test
+    fun `test NovaResponse deserialization`() {
+        val jsonString = """
+            {
+                "output": {
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "text": "Paris is the capital of France."
+                            }
+                        ]
+                    }
+                },
+                "usage": {
+                    "inputTokens": 10,
+                    "outputTokens": 15,
+                    "totalTokens": 25
+                },
+                "stopReason": "stop"
+            }
+        """.trimIndent()
+
+        val response = json.decodeFromString(NovaResponse.serializer(), jsonString)
+
+        assertEquals("assistant", response.output.message.role)
+        assertEquals(1, response.output.message.content.size)
+        assertEquals("Paris is the capital of France.", response.output.message.content[0].text)
+        assertNotNull(response.usage)
+        assertEquals(10, response.usage.inputTokens)
+        assertEquals(15, response.usage.outputTokens)
+        assertEquals(25, response.usage.totalTokens)
+        assertEquals("stop", response.stopReason)
+    }
+
+    @Test
+    fun `test NovaStreamChunk serialization`() {
+        val chunk = NovaStreamChunk(
+            contentBlockDelta = NovaContentBlockDelta(
+                delta = NovaContentDelta(text = "Paris is ")
+            )
+        )
+
+        val serialized = json.encodeToString(NovaStreamChunk.serializer(), chunk)
+
+        assertNotNull(serialized)
+        assert(serialized.contains("\"contentBlockDelta\""))
+        assert(serialized.contains("\"delta\""))
+        assert(serialized.contains("\"text\":\"Paris is \""))
+    }
+
+    @Test
+    fun `test NovaStreamChunk serialization with message stop`() {
+        val chunk = NovaStreamChunk(
+            messageStop = NovaMessageStop(stopReason = "stop"),
+            metadata = NovaStreamMetadata(
+                usage = NovaUsage(outputTokens = 20)
+            )
+        )
+
+        val serialized = json.encodeToString(NovaStreamChunk.serializer(), chunk)
+
+        assertNotNull(serialized)
+        assert(serialized.contains("\"messageStop\""))
+        assert(serialized.contains("\"stopReason\":\"stop\""))
+        assert(serialized.contains("\"metadata\""))
+        assert(serialized.contains("\"usage\""))
+        assert(serialized.contains("\"outputTokens\":20"))
+    }
+
+    @Test
+    fun `test NovaStreamChunk deserialization`() {
+        val jsonString = """
+            {
+                "contentBlockDelta": {
+                    "delta": {
+                        "text": "Paris is "
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val chunk = json.decodeFromString(NovaStreamChunk.serializer(), jsonString)
+
+        assertNotNull(chunk.contentBlockDelta)
+        assertEquals("Paris is ", chunk.contentBlockDelta.delta.text)
+        assertNull(chunk.messageStop)
+        assertNull(chunk.metadata)
+    }
+
+    @Test
+    fun `test NovaStreamChunk deserialization with message stop`() {
+        val jsonString = """
+            {
+                "messageStop": {
+                    "stopReason": "stop"
+                },
+                "metadata": {
+                    "usage": {
+                        "outputTokens": 20
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val chunk = json.decodeFromString(NovaStreamChunk.serializer(), jsonString)
+
+        assertNull(chunk.contentBlockDelta)
+        assertNotNull(chunk.messageStop)
+        assertEquals("stop", chunk.messageStop.stopReason)
+        assertNotNull(chunk.metadata)
+        assertNotNull(chunk.metadata.usage)
+        assertEquals(20, chunk.metadata.usage.outputTokens)
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/anthropic/BedrockAnthropicClaudeSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/anthropic/BedrockAnthropicClaudeSerializationTest.kt
@@ -31,7 +31,7 @@ class BedrockAnthropicClaudeSerializationTest {
     private val toolId = "toolu_01234567"
 
     @Test
-    fun `test createAnthropicRequest with basic prompt`() {
+    fun `createAnthropicRequest with basic prompt`() {
         val temperature = 0.7
 
         val prompt = Prompt.build("test", params = LLMParams(temperature = temperature)) {
@@ -58,7 +58,7 @@ class BedrockAnthropicClaudeSerializationTest {
     }
 
     @Test
-    fun `test createAnthropicRequest with conversation history`() {
+    fun `createAnthropicRequest with conversation history`() {
         val prompt = Prompt.build("test") {
             system(systemMessage)
             user(userNewMessage)
@@ -86,7 +86,7 @@ class BedrockAnthropicClaudeSerializationTest {
     }
 
     @Test
-    fun `test createAnthropicRequest with tools`() {
+    fun `createAnthropicRequest with tools`() {
         val tools = listOf(
             ToolDescriptor(
                 name = toolName,
@@ -126,7 +126,7 @@ class BedrockAnthropicClaudeSerializationTest {
     }
 
     @Test
-    fun `test createAnthropicRequest with different tool choices`() {
+    fun `createAnthropicRequest with different tool choices`() {
         val tools = listOf(
             ToolDescriptor(
                 name = toolName,
@@ -164,7 +164,7 @@ class BedrockAnthropicClaudeSerializationTest {
     }
 
     @Test
-    fun `test parseAnthropicResponse with text content`() {
+    fun `parseAnthropicResponse with text content`() {
         val stopReason = "end_turn"
         val responseJson = """
             {
@@ -204,7 +204,7 @@ class BedrockAnthropicClaudeSerializationTest {
     }
 
     @Test
-    fun `test parseAnthropicResponse with tool use content`() {
+    fun `parseAnthropicResponse with tool use content`() {
         val responseJson = """
             {
                 "id": "msg_01234567",
@@ -248,7 +248,7 @@ class BedrockAnthropicClaudeSerializationTest {
     }
 
     @Test
-    fun `test parseAnthropicResponse with multiple content blocks`() {
+    fun `parseAnthropicResponse with multiple content blocks`() {
         val message = "I'll check the weather for you."
 
         val responseJson = """
@@ -295,7 +295,7 @@ class BedrockAnthropicClaudeSerializationTest {
     }
 
     @Test
-    fun `test parseAnthropicStreamChunk with content_block_delta`() {
+    fun `parseAnthropicStreamChunk with content_block_delta`() {
         val chunkJson = """
             {
                 "type": "content_block_delta",
@@ -312,7 +312,7 @@ class BedrockAnthropicClaudeSerializationTest {
     }
 
     @Test
-    fun `test parseAnthropicStreamChunk with message_delta`() {
+    fun `parseAnthropicStreamChunk with message_delta`() {
         val chunkJson = """
             {
                 "type": "message_delta",
@@ -340,7 +340,7 @@ class BedrockAnthropicClaudeSerializationTest {
     }
 
     @Test
-    fun `test parseAnthropicStreamChunk with message_start`() {
+    fun `parseAnthropicStreamChunk with message_start`() {
         val chunkJson = """
             {
                 "type": "message_start",
@@ -363,7 +363,7 @@ class BedrockAnthropicClaudeSerializationTest {
     }
 
     @Test
-    fun `test parseAnthropicStreamChunk with message_stop`() {
+    fun `parseAnthropicStreamChunk with message_stop`() {
         val chunkJson = """
             {
                 "type": "message_stop",

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/anthropic/BedrockAnthropicClaudeSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/anthropic/BedrockAnthropicClaudeSerializationTest.kt
@@ -1,0 +1,393 @@
+package ai.koog.prompt.executor.clients.bedrock.modelfamilies.anthropic
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolParameterDescriptor
+import ai.koog.agents.core.tools.ToolParameterType
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.executor.clients.anthropic.AnthropicContent
+import ai.koog.prompt.executor.clients.anthropic.AnthropicToolChoice
+import ai.koog.prompt.executor.clients.bedrock.BedrockModels
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.params.LLMParams
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.jsonObject
+import kotlin.test.*
+
+class BedrockAnthropicClaudeSerializationTest {
+
+    private val mockClock = object : Clock {
+        override fun now(): Instant = Clock.System.now()
+    }
+
+    private val model = BedrockModels.AnthropicClaude3Sonnet
+    private val systemMessage = "You are a helpful assistant."
+    private val userMessage = "Tell me about Paris."
+    private val userMessageQuestion = "What's the weather in Paris?"
+    private val userNewMessage = "Hello, who are you?"
+    private val assistantMessage = "I'm Claude, an AI assistant created by Anthropic. How can I help you today?"
+    private val toolName = "get_weather"
+    private val toolDescription = "Get current weather for a city"
+    private val toolId = "toolu_01234567"
+
+    @Test
+    fun `test createAnthropicRequest with basic prompt`() {
+        val temperature = 0.7
+
+        val prompt = Prompt.build("test", params = LLMParams(temperature = temperature)) {
+            system(systemMessage)
+            user(userMessage)
+        }
+
+        val request = BedrockAnthropicClaudeSerialization.createAnthropicRequest(prompt, model, emptyList())
+
+        assertNotNull(request)
+        assertEquals(model.id, request.model)
+        assertEquals(4096, request.maxTokens)
+        assertEquals(temperature, request.temperature)
+
+        assertNotNull(request.system)
+        assertEquals(1, request.system?.size)
+        assertEquals(systemMessage, request.system?.first()?.text)
+
+        assertEquals(1, request.messages.size)
+        assertEquals("user", request.messages[0].role)
+        assertEquals(1, request.messages[0].content.size)
+        assertTrue(request.messages[0].content[0] is AnthropicContent.Text)
+        assertEquals(userMessage, (request.messages[0].content[0] as AnthropicContent.Text).text)
+    }
+
+    @Test
+    fun `test createAnthropicRequest with conversation history`() {
+        val prompt = Prompt.build("test") {
+            system(systemMessage)
+            user(userNewMessage)
+            assistant(assistantMessage)
+            user(userMessage)
+        }
+
+        val request = BedrockAnthropicClaudeSerialization.createAnthropicRequest(prompt, model, emptyList())
+
+        assertNotNull(request)
+
+        assertEquals(3, request.messages.size)
+
+        assertEquals("user", request.messages[0].role)
+        assertEquals("Hello, who are you?", (request.messages[0].content[0] as AnthropicContent.Text).text)
+
+        assertEquals("assistant", request.messages[1].role)
+        assertEquals(
+            "I'm Claude, an AI assistant created by Anthropic. How can I help you today?",
+            (request.messages[1].content[0] as AnthropicContent.Text).text
+        )
+
+        assertEquals("user", request.messages[2].role)
+        assertEquals("Tell me about Paris.", (request.messages[2].content[0] as AnthropicContent.Text).text)
+    }
+
+    @Test
+    fun `test createAnthropicRequest with tools`() {
+        val tools = listOf(
+            ToolDescriptor(
+                name = toolName,
+                description = toolDescription,
+                requiredParameters = listOf(
+                    ToolParameterDescriptor("city", "The city name", ToolParameterType.String)
+                ),
+                optionalParameters = listOf(
+                    ToolParameterDescriptor("units", "Temperature units", ToolParameterType.String)
+                )
+            )
+        )
+
+        val prompt = Prompt.build("test", params = LLMParams(toolChoice = LLMParams.ToolChoice.Auto)) {
+            user(userMessageQuestion)
+        }
+
+        val request = BedrockAnthropicClaudeSerialization.createAnthropicRequest(prompt, model, tools)
+
+        assertNotNull(request)
+
+        assertNotNull(request.tools)
+        assertEquals(1, request.tools?.size)
+        assertEquals(toolName, request.tools?.get(0)?.name)
+        assertEquals(toolDescription, request.tools?.get(0)?.description)
+
+        val schema = request.tools?.get(0)?.inputSchema
+        assertNotNull(schema)
+
+        assertEquals(listOf("city"), schema.required)
+
+        val properties = schema.properties.jsonObject
+        assertNotNull(properties["city"])
+        assertNotNull(properties["units"])
+
+        assertEquals(AnthropicToolChoice.Auto, request.toolChoice)
+    }
+
+    @Test
+    fun `test createAnthropicRequest with different tool choices`() {
+        val tools = listOf(
+            ToolDescriptor(
+                name = toolName,
+                description = toolDescription,
+                requiredParameters = listOf(
+                    ToolParameterDescriptor("city", "The city name", ToolParameterType.String)
+                )
+            )
+        )
+
+        val promptAuto = Prompt.build("test", params = LLMParams(toolChoice = LLMParams.ToolChoice.Auto)) {
+            user(userMessageQuestion)
+        }
+        val requestAuto = BedrockAnthropicClaudeSerialization.createAnthropicRequest(promptAuto, model, tools)
+        assertEquals(AnthropicToolChoice.Auto, requestAuto.toolChoice)
+
+        val promptNone = Prompt.build("test", params = LLMParams(toolChoice = LLMParams.ToolChoice.None)) {
+            user(userMessageQuestion)
+        }
+        val requestNone = BedrockAnthropicClaudeSerialization.createAnthropicRequest(promptNone, model, tools)
+        assertEquals(AnthropicToolChoice.None, requestNone.toolChoice)
+
+        val promptRequired = Prompt.build("test", params = LLMParams(toolChoice = LLMParams.ToolChoice.Required)) {
+            user(userMessageQuestion)
+        }
+        val requestRequired = BedrockAnthropicClaudeSerialization.createAnthropicRequest(promptRequired, model, tools)
+        assertEquals(AnthropicToolChoice.Any, requestRequired.toolChoice)
+
+        val promptNamed = Prompt.build("test", params = LLMParams(toolChoice = LLMParams.ToolChoice.Named(toolName))) {
+            user(userMessageQuestion)
+        }
+        val requestNamed = BedrockAnthropicClaudeSerialization.createAnthropicRequest(promptNamed, model, tools)
+        assertTrue(requestNamed.toolChoice is AnthropicToolChoice.Tool)
+        assertEquals(toolName, (requestNamed.toolChoice as AnthropicToolChoice.Tool).name)
+    }
+
+    @Test
+    fun `test parseAnthropicResponse with text content`() {
+        val stopReason = "end_turn"
+        val responseJson = """
+            {
+                "id": "msg_01234567",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Paris is the capital of France and one of the most visited cities in the world."
+                    }
+                ],
+                "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+                "stopReason": "$stopReason",
+                "usage": {
+                    "inputTokens": 25,
+                    "outputTokens": 20
+                }
+            }
+        """.trimIndent()
+
+        val messages = BedrockAnthropicClaudeSerialization.parseAnthropicResponse(responseJson, mockClock)
+
+        assertNotNull(messages)
+        assertEquals(1, messages.size)
+
+        val message = messages.first()
+        assertTrue(message is Message.Assistant)
+        assertContains(message.content, "Paris is the capital of France")
+
+        val assistant = message
+        assertEquals(stopReason, assistant.finishReason)
+
+        assertEquals(25, message.metaInfo.inputTokensCount)
+        assertEquals(20, message.metaInfo.outputTokensCount)
+        assertEquals(45, message.metaInfo.totalTokensCount)
+    }
+
+    @Test
+    fun `test parseAnthropicResponse with tool use content`() {
+        val responseJson = """
+            {
+                "id": "msg_01234567",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "$toolId",
+                        "name": "$toolName",
+                        "input": {
+                            "city": "Paris",
+                            "units": "celsius"
+                        }
+                    }
+                ],
+                "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+                "stopReason": "tool_use",
+                "usage": {
+                    "inputTokens": 25,
+                    "outputTokens": 15
+                }
+            }
+        """.trimIndent()
+
+        val messages = BedrockAnthropicClaudeSerialization.parseAnthropicResponse(responseJson, mockClock)
+
+        assertNotNull(messages)
+        assertEquals(1, messages.size)
+
+        val message = messages.first()
+        assertTrue(message is Message.Tool.Call)
+        assertEquals(toolId, message.id)
+        assertEquals(toolName, message.tool)
+        assertContains(message.content, "Paris")
+        assertContains(message.content, "celsius")
+
+        assertEquals(25, message.metaInfo.inputTokensCount)
+        assertEquals(15, message.metaInfo.outputTokensCount)
+        assertEquals(40, message.metaInfo.totalTokensCount)
+    }
+
+    @Test
+    fun `test parseAnthropicResponse with multiple content blocks`() {
+        val message = "I'll check the weather for you."
+
+        val responseJson = """
+            {
+                "id": "msg_01234567",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "$message"
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "$toolId",
+                        "name": "$toolName",
+                        "input": {
+                            "city": "Paris"
+                        }
+                    }
+                ],
+                "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+                "stopReason": "tool_use",
+                "usage": {
+                    "inputTokens": 25,
+                    "outputTokens": 30
+                }
+            }
+        """.trimIndent()
+
+        val messages = BedrockAnthropicClaudeSerialization.parseAnthropicResponse(responseJson, mockClock)
+
+        assertNotNull(messages)
+        assertEquals(2, messages.size)
+
+        val textMessage = messages[0]
+        assertTrue(textMessage is Message.Assistant)
+        assertEquals(message, textMessage.content)
+
+        val toolMessage = messages[1]
+        assertTrue(toolMessage is Message.Tool.Call)
+        assertEquals(toolId, toolMessage.id)
+        assertEquals(toolName, toolMessage.tool)
+    }
+
+    @Test
+    fun `test parseAnthropicStreamChunk with content_block_delta`() {
+        val chunkJson = """
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {
+                    "type": "text_delta",
+                    "text": "Paris is "
+                }
+            }
+        """.trimIndent()
+
+        val content = BedrockAnthropicClaudeSerialization.parseAnthropicStreamChunk(chunkJson)
+        assertEquals("Paris is ", content)
+    }
+
+    @Test
+    fun `test parseAnthropicStreamChunk with message_delta`() {
+        val chunkJson = """
+            {
+                "type": "message_delta",
+                "delta": {
+                    "type": "text_delta",
+                    "stopReason": "end_turn"
+                },
+                "message": {
+                    "id": "msg_01234567",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "the capital of France."
+                        }
+                    ],
+                    "model": "anthropic.claude-3-sonnet-20240229-v1:0"
+                }
+            }
+        """.trimIndent()
+
+        val content = BedrockAnthropicClaudeSerialization.parseAnthropicStreamChunk(chunkJson)
+        assertEquals("the capital of France.", content)
+    }
+
+    @Test
+    fun `test parseAnthropicStreamChunk with message_start`() {
+        val chunkJson = """
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_01234567",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                    "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+                    "usage": {
+                        "inputTokens": 25,
+                        "outputTokens": 0
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val content = BedrockAnthropicClaudeSerialization.parseAnthropicStreamChunk(chunkJson)
+        assertEquals("", content)
+    }
+
+    @Test
+    fun `test parseAnthropicStreamChunk with message_stop`() {
+        val chunkJson = """
+            {
+                "type": "message_stop",
+                "message": {
+                    "id": "msg_01234567",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Paris is the capital of France."
+                        }
+                    ],
+                    "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+                    "stopReason": "end_turn",
+                    "usage": {
+                        "inputTokens": 25,
+                        "outputTokens": 20
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val content = BedrockAnthropicClaudeSerialization.parseAnthropicStreamChunk(chunkJson)
+        assertEquals("", content)
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/meta/BedrockMetaLlamaSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/meta/BedrockMetaLlamaSerializationTest.kt
@@ -1,0 +1,177 @@
+package ai.koog.prompt.executor.clients.bedrock.modelfamilies.meta
+
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.executor.clients.bedrock.BedrockModels
+import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.params.LLMParams
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.test.*
+
+class BedrockMetaLlamaSerializationTest {
+
+    private val mockClock = object : Clock {
+        override fun now(): Instant = Clock.System.now()
+    }
+
+    private val model = BedrockModels.MetaLlama3_0_8BInstruct
+    private val systemMessage = "You are a helpful assistant."
+    private val userMessage = "Tell me about Paris."
+    private val userNewMessage = "Hello, who are you?"
+    private val assistantMessage = "I'm an AI assistant based on the Llama model. How can I help you today?"
+
+    @Test
+    fun `test createLlamaRequest with system and user messages`() {
+        val temperature = 0.7
+
+        val prompt = Prompt.build("test", params = LLMParams(temperature = temperature)) {
+            system(systemMessage)
+            user(userMessage)
+        }
+
+        val request = BedrockMetaLlamaSerialization.createLlamaRequest(prompt, model)
+
+        assertNotNull(request)
+        assertEquals(2048, request.maxGenLen)
+        assertEquals(temperature, request.temperature)
+
+        val expectedSystemPart = "<|begin_of_text|><|start_header_id|>system<|end_header_id|>"
+        val expectedUserPart = "<|start_header_id|>user<|end_header_id|>"
+        val expectedAssistantStart = "<|start_header_id|>assistant<|end_header_id|>"
+
+        assertContains(request.prompt, expectedSystemPart)
+        assertContains(request.prompt, systemMessage)
+        assertContains(request.prompt, expectedUserPart)
+        assertContains(request.prompt, userMessage)
+        assertContains(request.prompt, expectedAssistantStart)
+    }
+
+    @Test
+    fun `test createLlamaRequest with conversation history`() {
+        val prompt = Prompt.build("test") {
+            system(systemMessage)
+            user(userNewMessage)
+            assistant(assistantMessage)
+            user("Tell me about machine learning.")
+        }
+
+        val request = BedrockMetaLlamaSerialization.createLlamaRequest(prompt, model)
+
+        assertNotNull(request)
+
+        assertContains(request.prompt, systemMessage)
+        assertContains(request.prompt, userNewMessage)
+        assertContains(request.prompt, assistantMessage)
+        assertContains(request.prompt, "Tell me about machine learning.")
+    }
+
+    @Test
+    fun `test createLlamaRequest respects model temperature capability`() {
+        val temperature = 0.3
+        val promptWithTemperature = Prompt.build("test", params = LLMParams(temperature = temperature)) {
+            user("Tell me a story.")
+        }
+
+        val request = BedrockMetaLlamaSerialization.createLlamaRequest(promptWithTemperature, model)
+        assertEquals(temperature, request.temperature)
+
+        val modelWithoutTemperature = LLModel(
+            provider = LLMProvider.Bedrock,
+            id = "test-model",
+            capabilities = listOf(LLMCapability.Completion) // No temperature capability
+        )
+
+        val requestWithoutTemp =
+            BedrockMetaLlamaSerialization.createLlamaRequest(promptWithTemperature, modelWithoutTemperature)
+        assertEquals(null, requestWithoutTemp.temperature)
+    }
+
+    @Test
+    fun `test parseLlamaResponse`() {
+        val responseJson = """
+            {
+                "generation": "Machine learning is a subset of artificial intelligence that focuses on developing systems that learn from data.",
+                "prompt_token_count": 15,
+                "generation_token_count": 20,
+                "stop_reason": "stop"
+            }
+        """.trimIndent()
+
+        val messages = BedrockMetaLlamaSerialization.parseLlamaResponse(responseJson, mockClock)
+
+        assertNotNull(messages)
+        assertEquals(1, messages.size)
+
+        val message = messages.first()
+        assertTrue(message is Message.Assistant)
+        assertContains(message.content, "Machine learning is a subset of artificial intelligence")
+        assertEquals("stop", message.finishReason)
+
+        assertEquals(15, message.metaInfo.inputTokensCount)
+        assertEquals(20, message.metaInfo.outputTokensCount)
+        assertEquals(35, message.metaInfo.totalTokensCount)
+    }
+
+    @Test
+    fun `test parseLlamaResponse with missing token counts`() {
+        val responseJson = """
+            {
+                "generation": "This is a test response.",
+                "stop_reason": "length"
+            }
+        """.trimIndent()
+
+        val messages = BedrockMetaLlamaSerialization.parseLlamaResponse(responseJson, mockClock)
+
+        assertNotNull(messages)
+        assertEquals(1, messages.size)
+
+        val message = messages.first()
+        assertTrue(message is Message.Assistant)
+        assertEquals("This is a test response.", message.content)
+        assertEquals("length", message.finishReason)
+
+        assertEquals(null, message.metaInfo.inputTokensCount)
+        assertEquals(null, message.metaInfo.outputTokensCount)
+        assertEquals(null, message.metaInfo.totalTokensCount)
+    }
+
+    @Test
+    fun `test parseLlamaStreamChunk`() {
+        val chunkJson = """
+            {
+                "generation": "Hello, "
+            }
+        """.trimIndent()
+
+        val content = BedrockMetaLlamaSerialization.parseLlamaStreamChunk(chunkJson)
+        assertEquals("Hello, ", content)
+    }
+
+    @Test
+    fun `test parseLlamaStreamChunk with empty generation`() {
+        val chunkJson = """
+            {
+                "generation": ""
+            }
+        """.trimIndent()
+
+        val content = BedrockMetaLlamaSerialization.parseLlamaStreamChunk(chunkJson)
+        assertEquals("", content)
+    }
+
+    @Test
+    fun `test parseLlamaStreamChunk with null generation`() {
+        val chunkJson = """
+            {
+                "generation": null
+            }
+        """.trimIndent()
+
+        val content = BedrockMetaLlamaSerialization.parseLlamaStreamChunk(chunkJson)
+        assertEquals("", content)
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/meta/BedrockMetaLlamaSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/meta/BedrockMetaLlamaSerializationTest.kt
@@ -24,7 +24,7 @@ class BedrockMetaLlamaSerializationTest {
     private val assistantMessage = "I'm an AI assistant based on the Llama model. How can I help you today?"
 
     @Test
-    fun `test createLlamaRequest with system and user messages`() {
+    fun `createLlamaRequest with system and user messages`() {
         val temperature = 0.7
 
         val prompt = Prompt.build("test", params = LLMParams(temperature = temperature)) {
@@ -50,7 +50,7 @@ class BedrockMetaLlamaSerializationTest {
     }
 
     @Test
-    fun `test createLlamaRequest with conversation history`() {
+    fun `createLlamaRequest with conversation history`() {
         val prompt = Prompt.build("test") {
             system(systemMessage)
             user(userNewMessage)
@@ -69,7 +69,7 @@ class BedrockMetaLlamaSerializationTest {
     }
 
     @Test
-    fun `test createLlamaRequest respects model temperature capability`() {
+    fun `createLlamaRequest respects model temperature capability`() {
         val temperature = 0.3
         val promptWithTemperature = Prompt.build("test", params = LLMParams(temperature = temperature)) {
             user("Tell me a story.")
@@ -90,7 +90,7 @@ class BedrockMetaLlamaSerializationTest {
     }
 
     @Test
-    fun `test parseLlamaResponse`() {
+    fun testParseLlamaResponse() {
         val responseJson = """
             {
                 "generation": "Machine learning is a subset of artificial intelligence that focuses on developing systems that learn from data.",
@@ -116,7 +116,7 @@ class BedrockMetaLlamaSerializationTest {
     }
 
     @Test
-    fun `test parseLlamaResponse with missing token counts`() {
+    fun `parseLlamaResponse with missing token counts`() {
         val responseJson = """
             {
                 "generation": "This is a test response.",
@@ -140,7 +140,7 @@ class BedrockMetaLlamaSerializationTest {
     }
 
     @Test
-    fun `test parseLlamaStreamChunk`() {
+    fun testParseLlamaStreamChunk() {
         val chunkJson = """
             {
                 "generation": "Hello, "
@@ -152,7 +152,7 @@ class BedrockMetaLlamaSerializationTest {
     }
 
     @Test
-    fun `test parseLlamaStreamChunk with empty generation`() {
+    fun `parseLlamaStreamChunk with empty generation`() {
         val chunkJson = """
             {
                 "generation": ""
@@ -164,7 +164,7 @@ class BedrockMetaLlamaSerializationTest {
     }
 
     @Test
-    fun `test parseLlamaStreamChunk with null generation`() {
+    fun `parseLlamaStreamChunk with null generation`() {
         val chunkJson = """
             {
                 "generation": null

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/meta/LlamaDataModelsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/meta/LlamaDataModelsTest.kt
@@ -15,7 +15,7 @@ class LlamaDataModelsTest {
     }
 
     @Test
-    fun `test LlamaRequest serialization`() {
+    fun `LlamaRequest serialization`() {
         val request = LlamaRequest(
             prompt = "Tell me about Paris",
             maxGenLen = 1000, // Non-default value
@@ -34,7 +34,7 @@ class LlamaDataModelsTest {
     }
 
     @Test
-    fun `test LlamaRequest serialization with null temperature`() {
+    fun `LlamaRequest serialization with null temperature`() {
         val request = LlamaRequest(
             prompt = "Tell me about Paris",
             maxGenLen = 1000, // Non-default value
@@ -52,7 +52,7 @@ class LlamaDataModelsTest {
     }
 
     @Test
-    fun `test LlamaRequest deserialization`() {
+    fun `LlamaRequest deserialization`() {
         val jsonString = """
             {
                 "prompt": "Tell me about Paris",
@@ -69,7 +69,7 @@ class LlamaDataModelsTest {
     }
 
     @Test
-    fun `test LlamaRequest deserialization with missing fields`() {
+    fun `LlamaRequest deserialization with missing fields`() {
         val jsonString = """
             {
                 "prompt": "Tell me about Paris"
@@ -84,7 +84,7 @@ class LlamaDataModelsTest {
     }
 
     @Test
-    fun `test LlamaResponse serialization`() {
+    fun `LlamaResponse serialization`() {
         val response = LlamaResponse(
             generation = "Paris is the capital of France.",
             promptTokenCount = 10,
@@ -102,7 +102,7 @@ class LlamaDataModelsTest {
     }
 
     @Test
-    fun `test LlamaResponse serialization with null fields`() {
+    fun `LlamaResponse serialization with null fields`() {
         val response = LlamaResponse(
             generation = "Paris is the capital of France.",
             promptTokenCount = null,
@@ -120,7 +120,7 @@ class LlamaDataModelsTest {
     }
 
     @Test
-    fun `test LlamaResponse deserialization`() {
+    fun `LlamaResponse deserialization`() {
         val jsonString = """
             {
                 "generation": "Paris is the capital of France.",
@@ -139,7 +139,7 @@ class LlamaDataModelsTest {
     }
 
     @Test
-    fun `test LlamaResponse deserialization with missing fields`() {
+    fun `LlamaResponse deserialization with missing fields`() {
         val jsonString = """
             {
                 "generation": "Paris is the capital of France."
@@ -155,7 +155,7 @@ class LlamaDataModelsTest {
     }
 
     @Test
-    fun `test LlamaStreamChunk serialization`() {
+    fun `LlamaStreamChunk serialization`() {
         val chunk = LlamaStreamChunk(
             generation = "Hello, "
         )
@@ -167,7 +167,7 @@ class LlamaDataModelsTest {
     }
 
     @Test
-    fun `test LlamaStreamChunk serialization with null generation`() {
+    fun `LlamaStreamChunk serialization with null generation`() {
         val chunk = LlamaStreamChunk(
             generation = null
         )
@@ -179,7 +179,7 @@ class LlamaDataModelsTest {
     }
 
     @Test
-    fun `test LlamaStreamChunk deserialization`() {
+    fun `LlamaStreamChunk deserialization`() {
         val jsonString = """
             {
                 "generation": "Hello, "
@@ -192,7 +192,7 @@ class LlamaDataModelsTest {
     }
 
     @Test
-    fun `test LlamaStreamChunk deserialization with null generation`() {
+    fun `LlamaStreamChunk deserialization with null generation`() {
         val jsonString = """
             {
                 "generation": null
@@ -205,7 +205,7 @@ class LlamaDataModelsTest {
     }
 
     @Test
-    fun `test LlamaStreamChunk deserialization with missing generation`() {
+    fun `LlamaStreamChunk deserialization with missing generation`() {
         val jsonString = """
             {
             }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/meta/LlamaDataModelsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/meta/LlamaDataModelsTest.kt
@@ -1,0 +1,218 @@
+package ai.koog.prompt.executor.clients.bedrock.modelfamilies.meta
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class LlamaDataModelsTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        explicitNulls = false
+    }
+
+    @Test
+    fun `test LlamaRequest serialization`() {
+        val request = LlamaRequest(
+            prompt = "Tell me about Paris",
+            maxGenLen = 1000, // Non-default value
+            temperature = 0.7
+        )
+
+        val serialized = json.encodeToString(LlamaRequest.serializer(), request)
+
+        assertNotNull(serialized)
+        assert(serialized.contains("\"prompt\"")) { "Serialized JSON should contain 'prompt' field: $serialized" }
+        assert(serialized.contains("\"Tell me about Paris\"")) { "Serialized JSON should contain the prompt text: $serialized" }
+        assert(serialized.contains("\"max_gen_len\"")) { "Serialized JSON should contain 'max_gen_len' field: $serialized" }
+        assert(serialized.contains("1000")) { "Serialized JSON should contain the maxGenLen value: $serialized" }
+        assert(serialized.contains("\"temperature\"")) { "Serialized JSON should contain 'temperature' field: $serialized" }
+        assert(serialized.contains("0.7")) { "Serialized JSON should contain the temperature value: $serialized" }
+    }
+
+    @Test
+    fun `test LlamaRequest serialization with null temperature`() {
+        val request = LlamaRequest(
+            prompt = "Tell me about Paris",
+            maxGenLen = 1000, // Non-default value
+            temperature = null
+        )
+
+        val serialized = json.encodeToString(LlamaRequest.serializer(), request)
+
+        assertNotNull(serialized)
+        assert(serialized.contains("\"prompt\"")) { "Serialized JSON should contain 'prompt' field: $serialized" }
+        assert(serialized.contains("\"Tell me about Paris\"")) { "Serialized JSON should contain the prompt text: $serialized" }
+        assert(serialized.contains("\"max_gen_len\"")) { "Serialized JSON should contain 'max_gen_len' field: $serialized" }
+        assert(serialized.contains("1000")) { "Serialized JSON should contain the maxGenLen value: $serialized" }
+        assert(!serialized.contains("\"temperature\"")) { "Serialized JSON should not contain 'temperature' field when it's null: $serialized" }
+    }
+
+    @Test
+    fun `test LlamaRequest deserialization`() {
+        val jsonString = """
+            {
+                "prompt": "Tell me about Paris",
+                "max_gen_len": 2048,
+                "temperature": 0.7
+            }
+        """.trimIndent()
+
+        val request = json.decodeFromString(LlamaRequest.serializer(), jsonString)
+
+        assertEquals("Tell me about Paris", request.prompt)
+        assertEquals(2048, request.maxGenLen)
+        assertEquals(0.7, request.temperature)
+    }
+
+    @Test
+    fun `test LlamaRequest deserialization with missing fields`() {
+        val jsonString = """
+            {
+                "prompt": "Tell me about Paris"
+            }
+        """.trimIndent()
+
+        val request = json.decodeFromString(LlamaRequest.serializer(), jsonString)
+
+        assertEquals("Tell me about Paris", request.prompt)
+        assertEquals(2048, request.maxGenLen) // Default value
+        assertNull(request.temperature) // Default value
+    }
+
+    @Test
+    fun `test LlamaResponse serialization`() {
+        val response = LlamaResponse(
+            generation = "Paris is the capital of France.",
+            promptTokenCount = 10,
+            generationTokenCount = 15,
+            stopReason = "stop"
+        )
+
+        val serialized = json.encodeToString(LlamaResponse.serializer(), response)
+
+        assertNotNull(serialized)
+        assert(serialized.contains("\"generation\":\"Paris is the capital of France.\""))
+        assert(serialized.contains("\"prompt_token_count\":10"))
+        assert(serialized.contains("\"generation_token_count\":15"))
+        assert(serialized.contains("\"stop_reason\":\"stop\""))
+    }
+
+    @Test
+    fun `test LlamaResponse serialization with null fields`() {
+        val response = LlamaResponse(
+            generation = "Paris is the capital of France.",
+            promptTokenCount = null,
+            generationTokenCount = null,
+            stopReason = null
+        )
+
+        val serialized = json.encodeToString(LlamaResponse.serializer(), response)
+
+        assertNotNull(serialized)
+        assert(serialized.contains("\"generation\":\"Paris is the capital of France.\""))
+        assert(!serialized.contains("\"prompt_token_count\":"))
+        assert(!serialized.contains("\"generation_token_count\":"))
+        assert(!serialized.contains("\"stop_reason\":"))
+    }
+
+    @Test
+    fun `test LlamaResponse deserialization`() {
+        val jsonString = """
+            {
+                "generation": "Paris is the capital of France.",
+                "prompt_token_count": 10,
+                "generation_token_count": 15,
+                "stop_reason": "stop"
+            }
+        """.trimIndent()
+
+        val response = json.decodeFromString(LlamaResponse.serializer(), jsonString)
+
+        assertEquals("Paris is the capital of France.", response.generation)
+        assertEquals(10, response.promptTokenCount)
+        assertEquals(15, response.generationTokenCount)
+        assertEquals("stop", response.stopReason)
+    }
+
+    @Test
+    fun `test LlamaResponse deserialization with missing fields`() {
+        val jsonString = """
+            {
+                "generation": "Paris is the capital of France."
+            }
+        """.trimIndent()
+
+        val response = json.decodeFromString(LlamaResponse.serializer(), jsonString)
+
+        assertEquals("Paris is the capital of France.", response.generation)
+        assertNull(response.promptTokenCount)
+        assertNull(response.generationTokenCount)
+        assertNull(response.stopReason)
+    }
+
+    @Test
+    fun `test LlamaStreamChunk serialization`() {
+        val chunk = LlamaStreamChunk(
+            generation = "Hello, "
+        )
+
+        val serialized = json.encodeToString(LlamaStreamChunk.serializer(), chunk)
+
+        assertNotNull(serialized)
+        assert(serialized.contains("\"generation\":\"Hello, \""))
+    }
+
+    @Test
+    fun `test LlamaStreamChunk serialization with null generation`() {
+        val chunk = LlamaStreamChunk(
+            generation = null
+        )
+
+        val serialized = json.encodeToString(LlamaStreamChunk.serializer(), chunk)
+
+        assertNotNull(serialized)
+        assert(!serialized.contains("\"generation\":"))
+    }
+
+    @Test
+    fun `test LlamaStreamChunk deserialization`() {
+        val jsonString = """
+            {
+                "generation": "Hello, "
+            }
+        """.trimIndent()
+
+        val chunk = json.decodeFromString(LlamaStreamChunk.serializer(), jsonString)
+
+        assertEquals("Hello, ", chunk.generation)
+    }
+
+    @Test
+    fun `test LlamaStreamChunk deserialization with null generation`() {
+        val jsonString = """
+            {
+                "generation": null
+            }
+        """.trimIndent()
+
+        val chunk = json.decodeFromString(LlamaStreamChunk.serializer(), jsonString)
+
+        assertNull(chunk.generation)
+    }
+
+    @Test
+    fun `test LlamaStreamChunk deserialization with missing generation`() {
+        val jsonString = """
+            {
+            }
+        """.trimIndent()
+
+        val chunk = json.decodeFromString(LlamaStreamChunk.serializer(), jsonString)
+
+        assertNull(chunk.generation)
+    }
+}


### PR DESCRIPTION
1. Added tests for serialization and deserialization of requests to Bedrock from different sub-providers;
2. Added `AWS_SECRET_KEY` and `AWS_ACCESS_KEY_ID` env variables to the environment variables of integration tests' run;
3. Add a test for `simpleBedrockExecutor`.

---

#### Type of the change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation fix
- [x] New tests 

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
