### PR TITLE
Ignore license check for koog-spring-boot-starter module to avoid false positive on spring-boot-web

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -70,5 +70,8 @@ exclude:
       - docs
       - examples
       - integration-tests
+  - name: CheckDependencyLicenses
+    paths:
+      - koog-spring-boot-starter
 # Enable quick fixes for found issues
 fixesStrategy: apply


### PR DESCRIPTION
Currently Qodana detects a transitive dependency license coming from spring-boot-web (which is Apache 2.0) as proprietary. 
This fix disables the check on this module


---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix
- [ ] Tests improvement

#### Checklist for all pull requests
- [ ] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [ ] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
