### PR TITLE
KG-135. Fix verbose flag behavior for event body fields in Open Telemetry

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/AssistantMessageEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/AssistantMessageEvent.kt
@@ -7,7 +7,7 @@ import ai.koog.prompt.message.Message
 
 internal data class AssistantMessageEvent(
     private val provider: LLMProvider,
-    private val message: Message,
+    private val message: Message.Response,
     override val verbose: Boolean = false
 ) : GenAIAgentEvent {
 
@@ -22,23 +22,20 @@ internal data class AssistantMessageEvent(
             add(EventBodyFields.Role(role = message.role))
         }
 
+
         when (message) {
             is Message.Assistant -> {
-                add(EventBodyFields.Content(content = message.content))
+                if (verbose) {
+                    add(EventBodyFields.Content(content = message.content))
+                }
             }
 
             is Message.Tool.Call -> {
-                add(EventBodyFields.ToolCalls(tools = listOf(message)))
+                if (verbose) {
+                    add(EventBodyFields.ToolCalls(tools = listOf(message)))
+                }
             }
-
-            is Message.Tool.Result -> {
-                add(EventBodyFields.ToolCalls(tools = listOf(message)))
-            }
-
-            else -> error(
-                "Expected message types: ${Message.Tool.Call::class.simpleName}, " +
-                    "${Message.Tool.Result::class.simpleName}, but received: ${message::class.simpleName}"
-            )
         }
     }
+
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEvent.kt
@@ -18,20 +18,26 @@ internal class ChoiceEvent(
     }
 
     override val bodyFields: List<EventBodyField> = buildList {
+        add(EventBodyFields.Index(0))
+
         when (message) {
             is Message.Assistant -> {
-                add(EventBodyFields.Index(0))
                 message.finishReason?.let { reason ->
                     add(EventBodyFields.FinishReason(reason))
                 }
-                add(EventBodyFields.Message(
-                    role = message.role.takeIf { role -> role != Message.Role.Assistant },
-                    content = message.content
-                ))
+
+                if (verbose) {
+                    add(EventBodyFields.Message(
+                        role = message.role.takeIf { role -> role != Message.Role.Assistant },
+                        content = message.content
+                    ))
+                }
             }
+
             is Message.Tool.Call -> {
-                add(EventBodyFields.Index(0))
-                add(EventBodyFields.ToolCalls(tools = listOf(message)))
+                if (verbose) {
+                    add(EventBodyFields.ToolCalls(tools = listOf(message)))
+                }
             }
         }
     }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/GenAIAgentEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/GenAIAgentEvent.kt
@@ -28,10 +28,6 @@ internal interface GenAIAgentEvent {
             "Unable to convert Event Body Fields into Attribute because no body fields found"
         }
 
-        check(verbose) {
-            "Unable to convert Event Body Fields into Attribute because 'verbose' is set to 'false'"
-        }
-
         val value = bodyFields.joinToString(separator = ",", prefix = "{", postfix = "}") { bodyField ->
             "\"${bodyField.key}\":${bodyField.valueString}"
         }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ModerationResponseEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ModerationResponseEvent.kt
@@ -13,14 +13,20 @@ internal class ModerationResponseEvent(
     override val verbose: Boolean = false,
 ) : GenAIAgentEvent {
 
-    override val name: String = "moderation.result"
-
-    override val bodyFields: List<EventBodyField> = buildList {
-        add(EventBodyFields.Role(role = Message.Role.Assistant))
-        add(EventBodyFields.Content(content = Json.encodeToString(ModerationResult.serializer(), moderationResult)))
+    companion object {
+        private val json = Json { allowStructuredMapKeys = true }
     }
+
+    override val name: String = "moderation.result"
 
     override val attributes: List<Attribute> = buildList {
         add(CommonAttributes.System(provider))
+    }
+
+    override val bodyFields: List<EventBodyField> = buildList {
+        add(EventBodyFields.Role(role = Message.Role.Assistant))
+        if (verbose) {
+            add(EventBodyFields.Content(content = json.encodeToString(ModerationResult.serializer(), moderationResult)))
+        }
     }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/SystemMessageEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/SystemMessageEvent.kt
@@ -18,11 +18,12 @@ internal data class SystemMessageEvent(
     }
 
     override val bodyFields: List<EventBodyField> = buildList {
-
-        add(EventBodyFields.Content(content = message.content))
-
         if (message.role != Message.Role.System) {
             add(EventBodyFields.Role(role = message.role))
+        }
+
+        if (verbose) {
+            add(EventBodyFields.Content(content = message.content))
         }
     }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ToolMessageEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ToolMessageEvent.kt
@@ -20,7 +20,9 @@ internal class ToolMessageEvent(
 
     override val bodyFields: List<EventBodyField> = buildList {
         // Content
-        add(EventBodyFields.Content(content = toolResult.toStringDefault()))
+        if (verbose) {
+            add(EventBodyFields.Content(content = toolResult.toStringDefault()))
+        }
 
         // Id
         toolCallId?.let { id ->

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/UserMessageEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/UserMessageEvent.kt
@@ -19,10 +19,12 @@ internal data class UserMessageEvent(
 
     override val bodyFields: List<EventBodyField> = buildList {
 
-        add(EventBodyFields.Content(content = message.content))
-
         if (message.role != Message.Role.User) {
             add(EventBodyFields.Role(role = message.role))
+        }
+
+        if (verbose) {
+            add(EventBodyFields.Content(content = message.content))
         }
     }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/GenAIAgentSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/GenAIAgentSpan.kt
@@ -52,7 +52,7 @@ internal abstract class GenAIAgentSpan(
             // Pass body fields as attributes until an API is updated.
             val attributes = buildList {
                 addAll(event.attributes)
-                if (event.bodyFields.isNotEmpty() && event.verbose) {
+                if (event.bodyFields.isNotEmpty()) {
                     add(event.bodyFieldsAsAttribute())
                 }
             }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/AssistantMessageEventTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/AssistantMessageEventTest.kt
@@ -1,0 +1,156 @@
+package ai.koog.agents.features.opentelemetry.event
+
+import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
+import ai.koog.agents.features.opentelemetry.mock.MockLLMProvider
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.ResponseMetaInfo
+import kotlinx.datetime.Clock
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AssistantMessageEventTest {
+
+    //region Attributes
+
+    @Test
+    fun `test assistant message attributes verbose false`() {
+
+        val expectedContent = "Test message"
+        val expectedMessage = createTestAssistantMessage(expectedContent)
+        val llmProvider = MockLLMProvider()
+
+        val assistantMessageEvent = AssistantMessageEvent(
+            provider = llmProvider,
+            message = expectedMessage,
+            verbose = false,
+        )
+
+        val expectedAttributes = listOf(
+            CommonAttributes.System(llmProvider)
+        )
+
+        assertEquals(expectedAttributes.size, assistantMessageEvent.attributes.size)
+        assertContentEquals(expectedAttributes, assistantMessageEvent.attributes)
+    }
+
+    @Test
+    fun `test assistant message attributes verbose true`() {
+
+        val expectedContent = "Test message"
+        val expectedMessage = createTestAssistantMessage(expectedContent)
+        val llmProvider = MockLLMProvider()
+
+        val assistantMessageEvent = AssistantMessageEvent(
+            provider = llmProvider,
+            message = expectedMessage,
+            verbose = false,
+        )
+
+        val expectedAttributes = listOf(
+            CommonAttributes.System(llmProvider)
+        )
+
+        assertEquals(expectedAttributes.size, assistantMessageEvent.attributes.size)
+        assertContentEquals(expectedAttributes, assistantMessageEvent.attributes)
+    }
+
+
+    //endregion Attributes
+
+    //region Body Fields
+
+    @Test
+    fun `test assistant message with verbose false`() {
+
+        val expectedContent = "Test message"
+        val expectedMessage = createTestAssistantMessage(expectedContent)
+
+        val assistantMessageEvent = AssistantMessageEvent(
+            provider = MockLLMProvider(),
+            message = expectedMessage,
+            verbose = false,
+        )
+
+        assertTrue(
+            assistantMessageEvent.bodyFields.isEmpty(),
+            "No content message should be added with verbose set to 'false'"
+        )
+    }
+
+    @Test
+    fun `test tool call message verbose false`() {
+
+        val expectedContent = "Test message"
+        val expectedMessage = createTestToolCallMessage("test-id", "test-tool", expectedContent)
+
+        val assistantMessageEvent = AssistantMessageEvent(
+            provider = MockLLMProvider(),
+            message = expectedMessage,
+            verbose = false,
+        )
+
+        val expectedBodyFields = listOf(
+            EventBodyFields.Role(role = Message.Role.Tool)
+        )
+
+        assertEquals(expectedBodyFields.size, assistantMessageEvent.bodyFields.size)
+        assertContentEquals(expectedBodyFields, assistantMessageEvent.bodyFields)
+    }
+
+    @Test
+    fun `test assistant message verbose true`() {
+
+        val expectedContent = "Test message"
+        val expectedMessage = createTestAssistantMessage(expectedContent)
+
+        val assistantMessageEvent = AssistantMessageEvent(
+            provider = MockLLMProvider(),
+            message = expectedMessage,
+            verbose = true,
+        )
+
+        val expectedBodyFields = listOf(
+            EventBodyFields.Content(content = expectedContent)
+        )
+
+        assertEquals(expectedBodyFields.size, assistantMessageEvent.bodyFields.size)
+        assertContentEquals(expectedBodyFields, assistantMessageEvent.bodyFields)
+    }
+
+    @Test
+    fun `test tool call message verbose true`() {
+
+        val expectedContent = "Test message"
+        val expectedMessage = createTestToolCallMessage("test-id", "test-tool", expectedContent)
+
+        val assistantMessageEvent = AssistantMessageEvent(
+            provider = MockLLMProvider(),
+            message = expectedMessage,
+            verbose = true,
+        )
+
+        val expectedBodyFields = listOf(
+            EventBodyFields.Role(role = Message.Role.Tool),
+            EventBodyFields.ToolCalls(tools = listOf(expectedMessage))
+        )
+
+        assertEquals(expectedBodyFields.size, assistantMessageEvent.bodyFields.size)
+        assertContentEquals(expectedBodyFields, assistantMessageEvent.bodyFields)
+    }
+
+    //endregion Body Fields
+
+    //region Private Methods
+
+    private fun createTestAssistantMessage(content: String): Message.Response = Message.Assistant(
+        content = content, metaInfo = ResponseMetaInfo(Clock.System.now())
+    )
+
+    private fun createTestToolCallMessage(id: String, tool: String, content: String): Message.Tool.Call = Message.Tool.Call(
+        id = id, tool = tool, content = content, metaInfo = ResponseMetaInfo(Clock.System.now())
+    )
+
+    //endregion Private Methods
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEventTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEventTest.kt
@@ -1,0 +1,183 @@
+package ai.koog.agents.features.opentelemetry.event
+
+import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
+import ai.koog.agents.features.opentelemetry.mock.MockLLMProvider
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.ResponseMetaInfo
+import kotlinx.datetime.Clock
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class ChoiceEventTest {
+
+    //region Attributes
+
+    @Test
+    fun `test choice attributes verbose false`() {
+
+        val expectedContent = "Test message"
+        val expectedMessage = createTestAssistantMessage(expectedContent)
+        val llmProvider = MockLLMProvider()
+
+        val choiceEvent = ChoiceEvent(
+            provider = llmProvider,
+            message = expectedMessage,
+            verbose = false,
+        )
+
+        val expectedAttributes = listOf(
+            CommonAttributes.System(llmProvider)
+        )
+
+        assertEquals(expectedAttributes.size, choiceEvent.attributes.size)
+        assertContentEquals(expectedAttributes, choiceEvent.attributes)
+    }
+
+    @Test
+    fun `test choice attributes verbose true`() {
+
+        val expectedContent = "Test message"
+        val expectedMessage = createTestAssistantMessage(expectedContent)
+        val llmProvider = MockLLMProvider()
+
+        val choiceEvent = ChoiceEvent(
+            provider = llmProvider,
+            message = expectedMessage,
+            verbose = true,
+        )
+
+        val expectedAttributes = listOf(
+            CommonAttributes.System(llmProvider)
+        )
+
+        assertEquals(expectedAttributes.size, choiceEvent.attributes.size)
+        assertContentEquals(expectedAttributes, choiceEvent.attributes)
+    }
+
+    //endregion Attributes
+
+    //region Body Fields
+
+    @Test
+    fun `test assistant message with verbose false`() {
+
+        val expectedContent = "Test message"
+        val expectedMessage = createTestAssistantMessage(expectedContent)
+
+        val choiceEvent = ChoiceEvent(
+            provider = MockLLMProvider(),
+            message = expectedMessage,
+            verbose = false,
+        )
+
+        val expectedBodyFields = listOf(
+            EventBodyFields.Index(0)
+        )
+
+        assertEquals(expectedBodyFields.size, choiceEvent.bodyFields.size)
+        assertContentEquals(expectedBodyFields, choiceEvent.bodyFields)
+    }
+
+    @Test
+    fun `test assistant message with finish reason verbose false`() {
+
+        val expectedContent = "Test message"
+        val expectedMessage = createTestAssistantMessage(expectedContent, "stop")
+
+        val choiceEvent = ChoiceEvent(
+            provider = MockLLMProvider(),
+            message = expectedMessage,
+            verbose = false,
+        )
+
+        val expectedBodyFields = listOf(
+            EventBodyFields.Index(0),
+            EventBodyFields.FinishReason("stop")
+        )
+
+        assertEquals(expectedBodyFields.size, choiceEvent.bodyFields.size)
+        assertContentEquals(expectedBodyFields, choiceEvent.bodyFields)
+    }
+
+    @Test
+    fun `test tool call message verbose false`() {
+
+        val expectedContent = "Test message"
+        val expectedMessage = createTestToolCallMessage("test-id", "test-tool", expectedContent)
+
+        val choiceEvent = ChoiceEvent(
+            provider = MockLLMProvider(),
+            message = expectedMessage,
+            verbose = false,
+        )
+
+        val expectedBodyFields = listOf(
+            EventBodyFields.Index(0)
+        )
+
+        assertEquals(expectedBodyFields.size, choiceEvent.bodyFields.size)
+        assertContentEquals(expectedBodyFields, choiceEvent.bodyFields)
+    }
+
+    @Test
+    fun `test assistant message verbose true`() {
+
+        val expectedContent = "Test message"
+        val expectedMessage = createTestAssistantMessage(expectedContent)
+
+        val choiceEvent = ChoiceEvent(
+            provider = MockLLMProvider(),
+            message = expectedMessage,
+            verbose = true,
+        )
+
+        val expectedBodyFields = listOf(
+            EventBodyFields.Index(0),
+            EventBodyFields.Message(
+                role = null,
+                content = expectedContent
+            )
+        )
+
+        assertEquals(expectedBodyFields.size, choiceEvent.bodyFields.size)
+        assertContentEquals(expectedBodyFields, choiceEvent.bodyFields)
+    }
+
+    @Test
+    fun `test tool call message verbose true`() {
+
+        val expectedContent = "Test message"
+        val expectedMessage = createTestToolCallMessage("test-id", "test-tool", expectedContent)
+
+        val choiceEvent = ChoiceEvent(
+            provider = MockLLMProvider(),
+            message = expectedMessage,
+            verbose = true,
+        )
+
+        val expectedBodyFields = listOf(
+            EventBodyFields.Index(0),
+            EventBodyFields.ToolCalls(tools = listOf(expectedMessage))
+        )
+
+        assertEquals(expectedBodyFields.size, choiceEvent.bodyFields.size)
+        assertContentEquals(expectedBodyFields, choiceEvent.bodyFields)
+    }
+
+    //endregion Body Fields
+
+    //region Private Methods
+
+    private fun createTestAssistantMessage(content: String, finishReason: String? = null): Message.Assistant = Message.Assistant(
+        content = content, 
+        metaInfo = ResponseMetaInfo(Clock.System.now()),
+        finishReason = finishReason
+    )
+
+    private fun createTestToolCallMessage(id: String, tool: String, content: String): Message.Tool.Call = Message.Tool.Call(
+        id = id, tool = tool, content = content, metaInfo = ResponseMetaInfo(Clock.System.now())
+    )
+
+    //endregion Private Methods
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/EventBodyFieldTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/EventBodyFieldTest.kt
@@ -193,7 +193,7 @@ class EventBodyFieldTest {
     
     @Test
     fun `test toAttribute throws exception when bodyFields is empty`() {
-        val field = MockGenAIAgentEvent(bodyFields = emptyList(), verbose = true)
+        val field = MockGenAIAgentEvent(fields = emptyList(), verbose = true)
 
         val exception = assertFailsWith<IllegalStateException> {
             field.bodyFieldsAsAttribute()
@@ -206,18 +206,27 @@ class EventBodyFieldTest {
     }
     
     @Test
-    fun `test toAttribute throws exception when verbose is false`() {
+    fun `test toAttribute filter body fields when verbose is false`() {
         val bodyField = MockEventBodyField("testKey", "testValue")
-        val field = MockGenAIAgentEvent(bodyFields = listOf(bodyField), verbose = false)
+        val bodyFieldContent = MockEventBodyField("testContent", "testContentValue")
+        val field = MockGenAIAgentEvent(fields = listOf(bodyField, bodyFieldContent), verbose = false)
 
-        val exception = assertFailsWith<IllegalStateException> {
-            field.bodyFieldsAsAttribute()
-        }
+        val actualAttribute = field.bodyFieldsAsAttribute()
 
-        assertEquals(
-            "Unable to convert Event Body Fields into Attribute because 'verbose' is set to 'false'",
-            exception.message
-        )
+        assertEquals("body", actualAttribute.key)
+        assertEquals("{\"testKey\":\"testValue\"}", actualAttribute.value)
+    }
+
+    @Test
+    fun `test toAttribute does not filter body fields when verbose is true`() {
+        val bodyField = MockEventBodyField("testKey", "testValue")
+        val bodyFieldContent = MockEventBodyField("testContent", "testContentValue")
+        val field = MockGenAIAgentEvent(fields = listOf(bodyField, bodyFieldContent), verbose = true)
+
+        val actualAttribute = field.bodyFieldsAsAttribute()
+
+        assertEquals("body", actualAttribute.key)
+        assertEquals("{\"testKey\":\"testValue\",\"testContent\":\"testContentValue\"}", actualAttribute.value)
     }
 
     //region Private Methods
@@ -231,7 +240,7 @@ class EventBodyFieldTest {
         expectedVerbose: Boolean
     ) {
         val bodyField = MockEventBodyField(key, value)
-        val field = MockGenAIAgentEvent(bodyFields = listOf(bodyField), verbose = verbose)
+        val field = MockGenAIAgentEvent(fields = listOf(bodyField), verbose = verbose)
         val actualAttribute = field.bodyFieldsAsAttribute()
 
         assertEquals(expectedKey, actualAttribute.key)

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/ModerationResponseEventTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/ModerationResponseEventTest.kt
@@ -1,0 +1,112 @@
+package ai.koog.agents.features.opentelemetry.event
+
+import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
+import ai.koog.agents.features.opentelemetry.mock.MockLLMProvider
+import ai.koog.prompt.dsl.ModerationCategory
+import ai.koog.prompt.dsl.ModerationCategoryResult
+import ai.koog.prompt.dsl.ModerationResult
+import ai.koog.prompt.message.Message
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class ModerationResponseEventTest {
+
+    //region Attributes
+
+    @Test
+    fun `test moderation response attributes verbose false`() {
+        val moderationResult = createTestModerationResult()
+        val llmProvider = MockLLMProvider()
+
+        val moderationResponseEvent = ModerationResponseEvent(
+            provider = llmProvider,
+            moderationResult = moderationResult,
+            verbose = false,
+        )
+
+        val expectedAttributes = listOf(
+            CommonAttributes.System(llmProvider)
+        )
+
+        assertEquals(expectedAttributes.size, moderationResponseEvent.attributes.size)
+        assertContentEquals(expectedAttributes, moderationResponseEvent.attributes)
+    }
+
+    @Test
+    fun `test moderation response attributes verbose true`() {
+        val moderationResult = createTestModerationResult()
+        val llmProvider = MockLLMProvider()
+
+        val moderationResponseEvent = ModerationResponseEvent(
+            provider = llmProvider,
+            moderationResult = moderationResult,
+            verbose = true,
+        )
+
+        val expectedAttributes = listOf(
+            CommonAttributes.System(llmProvider)
+        )
+
+        assertEquals(expectedAttributes.size, moderationResponseEvent.attributes.size)
+        assertContentEquals(expectedAttributes, moderationResponseEvent.attributes)
+    }
+
+    //endregion Attributes
+
+    //region Body Fields
+
+    @Test
+    fun `test moderation response body fields verbose false`() {
+        val moderationResult = createTestModerationResult()
+
+        val moderationResponseEvent = ModerationResponseEvent(
+            provider = MockLLMProvider(),
+            moderationResult = moderationResult,
+            verbose = false,
+        )
+
+        val expectedBodyFields = listOf(
+            EventBodyFields.Role(role = Message.Role.Assistant)
+        )
+
+        assertEquals(expectedBodyFields.size, moderationResponseEvent.bodyFields.size)
+        assertContentEquals(expectedBodyFields, moderationResponseEvent.bodyFields)
+    }
+
+    @Test
+    fun `test moderation response body fields verbose true`() {
+        val moderationResult = createTestModerationResult()
+
+        val moderationResponseEvent = ModerationResponseEvent(
+            provider = MockLLMProvider(),
+            moderationResult = moderationResult,
+            verbose = true,
+        )
+
+        val json = Json { allowStructuredMapKeys = true }
+
+        val expectedBodyFields = listOf(
+            EventBodyFields.Role(role = Message.Role.Assistant),
+            EventBodyFields.Content(content = json.encodeToString(ModerationResult.serializer(), moderationResult))
+        )
+
+        assertEquals(expectedBodyFields.size, moderationResponseEvent.bodyFields.size)
+        assertContentEquals(expectedBodyFields, moderationResponseEvent.bodyFields)
+    }
+
+    //endregion Body Fields
+
+    //region Private Methods
+
+    private fun createTestModerationResult(): ModerationResult {
+        val categories = mapOf(
+            ModerationCategory.Harassment to ModerationCategoryResult(detected = false, confidenceScore = 0.1),
+            ModerationCategory.Hate to ModerationCategoryResult(detected = false, confidenceScore = 0.05)
+        )
+        return ModerationResult(isHarmful = false, categories = categories)
+    }
+
+    //endregion Private Methods
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/SystemMessageEventTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/SystemMessageEventTest.kt
@@ -1,0 +1,106 @@
+package ai.koog.agents.features.opentelemetry.event
+
+import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
+import ai.koog.agents.features.opentelemetry.mock.MockLLMProvider
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.RequestMetaInfo
+import kotlinx.datetime.Clock
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class SystemMessageEventTest {
+
+    //region Attributes
+
+    @Test
+    fun `test system message attributes verbose false`() {
+        val expectedContent = "Test message"
+        val expectedMessage = createTestSystemMessage(expectedContent)
+        val llmProvider = MockLLMProvider()
+
+        val systemMessageEvent = SystemMessageEvent(
+            provider = llmProvider,
+            message = expectedMessage,
+            verbose = false,
+        )
+
+        val expectedAttributes = listOf(
+            CommonAttributes.System(llmProvider)
+        )
+
+        assertEquals(expectedAttributes.size, systemMessageEvent.attributes.size)
+        assertContentEquals(expectedAttributes, systemMessageEvent.attributes)
+    }
+
+    @Test
+    fun `test system message attributes verbose true`() {
+        val expectedContent = "Test message"
+        val expectedMessage = createTestSystemMessage(expectedContent)
+        val llmProvider = MockLLMProvider()
+
+        val systemMessageEvent = SystemMessageEvent(
+            provider = llmProvider,
+            message = expectedMessage,
+            verbose = true,
+        )
+
+        val expectedAttributes = listOf(
+            CommonAttributes.System(llmProvider)
+        )
+
+        assertEquals(expectedAttributes.size, systemMessageEvent.attributes.size)
+        assertContentEquals(expectedAttributes, systemMessageEvent.attributes)
+    }
+
+    //endregion Attributes
+
+    //region Body Fields
+
+    @Test
+    fun `test system message body fields verbose false`() {
+        val expectedContent = "Test message"
+        val expectedMessage = createTestSystemMessage(expectedContent)
+
+        val systemMessageEvent = SystemMessageEvent(
+            provider = MockLLMProvider(),
+            message = expectedMessage,
+            verbose = false,
+        )
+
+        val expectedBodyFields = emptyList<EventBodyField>()
+
+        assertEquals(expectedBodyFields.size, systemMessageEvent.bodyFields.size)
+        assertContentEquals(expectedBodyFields, systemMessageEvent.bodyFields)
+    }
+
+    @Test
+    fun `test system message body fields verbose true`() {
+        val expectedContent = "Test message"
+        val expectedMessage = createTestSystemMessage(expectedContent)
+
+        val systemMessageEvent = SystemMessageEvent(
+            provider = MockLLMProvider(),
+            message = expectedMessage,
+            verbose = true,
+        )
+
+        val expectedBodyFields = listOf(
+            EventBodyFields.Content(content = expectedContent)
+        )
+
+        assertEquals(expectedBodyFields.size, systemMessageEvent.bodyFields.size)
+        assertContentEquals(expectedBodyFields, systemMessageEvent.bodyFields)
+    }
+
+    //endregion Body Fields
+
+    //region Private Methods
+
+    private fun createTestSystemMessage(content: String): Message.System = Message.System(
+        content = content, 
+        metaInfo = RequestMetaInfo(Clock.System.now())
+    )
+
+    //endregion Private Methods
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/ToolMessageEventTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/ToolMessageEventTest.kt
@@ -1,0 +1,148 @@
+package ai.koog.agents.features.opentelemetry.event
+
+import ai.koog.agents.core.tools.ToolResult
+import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
+import ai.koog.agents.features.opentelemetry.mock.MockLLMProvider
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class ToolMessageEventTest {
+
+    //region Attributes
+
+    @Test
+    fun `test tool message attributes verbose false`() {
+        val toolCallId = "test-id"
+        val toolResult = createTestToolResult("Test result")
+        val llmProvider = MockLLMProvider()
+
+        val toolMessageEvent = ToolMessageEvent(
+            provider = llmProvider,
+            toolCallId = toolCallId,
+            toolResult = toolResult,
+            verbose = false,
+        )
+
+        val expectedAttributes = listOf(
+            CommonAttributes.System(llmProvider)
+        )
+
+        assertEquals(expectedAttributes.size, toolMessageEvent.attributes.size)
+        assertContentEquals(expectedAttributes, toolMessageEvent.attributes)
+    }
+
+    @Test
+    fun `test tool message attributes verbose true`() {
+        val toolCallId = "test-id"
+        val toolResult = createTestToolResult("Test result")
+        val llmProvider = MockLLMProvider()
+
+        val toolMessageEvent = ToolMessageEvent(
+            provider = llmProvider,
+            toolCallId = toolCallId,
+            toolResult = toolResult,
+            verbose = true,
+        )
+
+        val expectedAttributes = listOf(
+            CommonAttributes.System(llmProvider)
+        )
+
+        assertEquals(expectedAttributes.size, toolMessageEvent.attributes.size)
+        assertContentEquals(expectedAttributes, toolMessageEvent.attributes)
+    }
+
+    //endregion Attributes
+
+    //region Body Fields
+
+    @Test
+    fun `test tool message body fields with id verbose false`() {
+        val toolCallId = "test-id"
+        val toolResult = createTestToolResult("Test result")
+
+        val toolMessageEvent = ToolMessageEvent(
+            provider = MockLLMProvider(),
+            toolCallId = toolCallId,
+            toolResult = toolResult,
+            verbose = false,
+        )
+
+        val expectedBodyFields = listOf(
+            EventBodyFields.Id(id = toolCallId)
+        )
+
+        assertEquals(expectedBodyFields.size, toolMessageEvent.bodyFields.size)
+        assertContentEquals(expectedBodyFields, toolMessageEvent.bodyFields)
+    }
+
+    @Test
+    fun `test tool message body fields without id verbose false`() {
+        val toolCallId = null
+        val toolResult = createTestToolResult("Test result")
+
+        val toolMessageEvent = ToolMessageEvent(
+            provider = MockLLMProvider(),
+            toolCallId = toolCallId,
+            toolResult = toolResult,
+            verbose = false,
+        )
+
+        val expectedBodyFields = emptyList<EventBodyField>()
+
+        assertEquals(expectedBodyFields.size, toolMessageEvent.bodyFields.size)
+        assertContentEquals(expectedBodyFields, toolMessageEvent.bodyFields)
+    }
+
+    @Test
+    fun `test tool message body fields with id verbose true`() {
+        val toolCallId = "test-id"
+        val toolResult = createTestToolResult("Test result")
+
+        val toolMessageEvent = ToolMessageEvent(
+            provider = MockLLMProvider(),
+            toolCallId = toolCallId,
+            toolResult = toolResult,
+            verbose = true,
+        )
+
+        val expectedBodyFields = listOf(
+            EventBodyFields.Content(content = toolResult.toStringDefault()),
+            EventBodyFields.Id(id = toolCallId)
+        )
+
+        assertEquals(expectedBodyFields.size, toolMessageEvent.bodyFields.size)
+        assertContentEquals(expectedBodyFields, toolMessageEvent.bodyFields)
+    }
+
+    @Test
+    fun `test tool message body fields without id verbose true`() {
+        val toolCallId = null
+        val toolResult = createTestToolResult("Test result")
+
+        val toolMessageEvent = ToolMessageEvent(
+            provider = MockLLMProvider(),
+            toolCallId = toolCallId,
+            toolResult = toolResult,
+            verbose = true,
+        )
+
+        val expectedBodyFields = listOf(
+            EventBodyFields.Content(content = toolResult.toStringDefault())
+        )
+
+        assertEquals(expectedBodyFields.size, toolMessageEvent.bodyFields.size)
+        assertContentEquals(expectedBodyFields, toolMessageEvent.bodyFields)
+    }
+
+    //endregion Body Fields
+
+    //region Private Methods
+
+    private fun createTestToolResult(content: String): ToolResult = object : ToolResult {
+        override fun toStringDefault(): String = content
+    }
+
+    //endregion Private Methods
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/UserMessageEventTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/UserMessageEventTest.kt
@@ -1,0 +1,104 @@
+package ai.koog.agents.features.opentelemetry.event
+
+import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
+import ai.koog.agents.features.opentelemetry.mock.MockLLMProvider
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.RequestMetaInfo
+import kotlinx.datetime.Clock
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class UserMessageEventTest {
+
+    //region Attributes
+
+    @Test
+    fun `test user message attributes verbose false`() {
+        val expectedContent = "Test message"
+        val expectedMessage = createTestUserMessage(expectedContent)
+        val llmProvider = MockLLMProvider()
+
+        val userMessageEvent = UserMessageEvent(
+            provider = llmProvider,
+            message = expectedMessage,
+            verbose = false,
+        )
+
+        val expectedAttributes = listOf(
+            CommonAttributes.System(llmProvider)
+        )
+
+        assertEquals(expectedAttributes.size, userMessageEvent.attributes.size)
+        assertContentEquals(expectedAttributes, userMessageEvent.attributes)
+    }
+
+    @Test
+    fun `test user message attributes verbose true`() {
+        val expectedContent = "Test message"
+        val expectedMessage = createTestUserMessage(expectedContent)
+        val llmProvider = MockLLMProvider()
+
+        val userMessageEvent = UserMessageEvent(
+            provider = llmProvider,
+            message = expectedMessage,
+            verbose = true,
+        )
+
+        val expectedAttributes = listOf(
+            CommonAttributes.System(llmProvider)
+        )
+
+        assertEquals(expectedAttributes.size, userMessageEvent.attributes.size)
+        assertContentEquals(expectedAttributes, userMessageEvent.attributes)
+    }
+
+    //endregion Attributes
+
+    //region Body Fields
+
+    @Test
+    fun `test user message body fields verbose false`() {
+        val expectedContent = "Test message"
+        val expectedMessage = createTestUserMessage(expectedContent)
+
+        val userMessageEvent = UserMessageEvent(
+            provider = MockLLMProvider(),
+            message = expectedMessage,
+            verbose = false,
+        )
+
+        assertTrue(userMessageEvent.bodyFields.isEmpty())
+    }
+
+    @Test
+    fun `test user message body fields verbose true`() {
+        val expectedContent = "Test message"
+        val expectedMessage = createTestUserMessage(expectedContent)
+
+        val userMessageEvent = UserMessageEvent(
+            provider = MockLLMProvider(),
+            message = expectedMessage,
+            verbose = true,
+        )
+
+        val expectedBodyFields = listOf(
+            EventBodyFields.Content(content = expectedContent)
+        )
+
+        assertEquals(expectedBodyFields.size, userMessageEvent.bodyFields.size)
+        assertContentEquals(expectedBodyFields, userMessageEvent.bodyFields)
+    }
+
+    //endregion Body Fields
+
+    //region Private Methods
+
+    private fun createTestUserMessage(content: String): Message.User = Message.User(
+        content = content, 
+        metaInfo = RequestMetaInfo(Clock.System.now())
+    )
+
+    //endregion Private Methods
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/mock/MockGenAIAgentEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/mock/MockGenAIAgentEvent.kt
@@ -7,6 +7,17 @@ import ai.koog.agents.features.opentelemetry.event.GenAIAgentEvent
 internal data class MockGenAIAgentEvent(
     override val name: String = "test_event",
     override val attributes: List<Attribute> = listOf(),
-    override val bodyFields: List<EventBodyField> = listOf(),
+    private val fields: List<EventBodyField> = emptyList(),
     override val verbose: Boolean = false
-) : GenAIAgentEvent
+) : GenAIAgentEvent {
+
+
+    override val bodyFields: List<EventBodyField> = buildList {
+        fields.forEach { field ->
+            if (!verbose && field.key.contains("content", ignoreCase = true)) {
+                return@forEach
+            }
+            add(field)
+        }
+    }
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/mock/MockLLMProvider.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/mock/MockLLMProvider.kt
@@ -1,0 +1,8 @@
+package ai.koog.agents.features.opentelemetry.mock
+
+import ai.koog.prompt.llm.LLMProvider
+
+class MockLLMProvider : LLMProvider(
+    "test-provider-id",
+    "test-provider-name",
+)

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/ModerationAPI.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/ModerationAPI.kt
@@ -193,7 +193,6 @@ public data class ModerationCategoryResult(
 /**
  * Represents the result of a content moderation request.
  *
- * @property model The model used to generate the moderation results.
  * @property isHarmful Whether the content is classified as harmful (i.e. any of the categories are flagged).
  * @property categories A map of ModerationCategory objects to [ModerationCategoryResult] values indicating whether
  *  each category is flagged with metainformation about assessment.


### PR DESCRIPTION
- Body fields should not be fully filtered when verbose is sert to false. It rather should hide the sensitive content. Updated the logic to filter content from Open Telemetry events;
- Add tests to verify the verbose flag for each event and for agent run;
- Fix issue with serializing Moderation Response event for Open Telemetry.

---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [x] Documentation fix
- [x] Tests improvement

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [x] Docs have been added / updated
