### PR TITLE
Add javadoc publication for jvm-only standalone modules

### DIFF
--- a/buildSrc/src/main/kotlin/ai.kotlin.jvm.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/ai.kotlin.jvm.publish.gradle.kts
@@ -11,10 +11,16 @@ java {
     withSourcesJar()
 }
 
+val javadocJar by tasks.registering(Jar::class) {
+    archiveClassifier.set("javadoc")
+    from(tasks.javadoc)
+}
+
 publishing {
     publications {
         create<MavenPublication>("maven") {
             from(components["java"])
+            artifact(javadocJar)
         }
     }
 }

--- a/buildSrc/src/main/kotlin/ai/koog/gradle/publish/maven/Publishing.kt
+++ b/buildSrc/src/main/kotlin/ai/koog/gradle/publish/maven/Publishing.kt
@@ -11,7 +11,7 @@ import java.net.URL
 object Publishing {
     fun Project.publishToMaven() {
         publishTo({
-//            it.graziePublic(project)
+            it.graziePublic(project)
             it.artifactsMaven(project)
         }) {
             it.publications(

--- a/buildSrc/src/main/kotlin/ai/koog/gradle/publish/maven/Publishing.kt
+++ b/buildSrc/src/main/kotlin/ai/koog/gradle/publish/maven/Publishing.kt
@@ -11,7 +11,7 @@ import java.net.URL
 object Publishing {
     fun Project.publishToMaven() {
         publishTo({
-            it.graziePublic(project)
+//            it.graziePublic(project)
             it.artifactsMaven(project)
         }) {
             it.publications(


### PR DESCRIPTION
Add javadoc publication for jvm-only standalone modules

---

#### Type of the change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation fix
- [ ] Tests improvement

#### Checklist for all pull requests
- [ ] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [ ] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
