### PR TITLE
Add default value for `totalTokens` field in OpenAIUsage class

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/DataModel.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/DataModel.kt
@@ -139,7 +139,7 @@ internal data class OpenAIChoice(
 internal data class OpenAIUsage(
     val promptTokens: Int? = null,
     val completionTokens: Int? = null,
-    val totalTokens: Int
+    val totalTokens: Int? = promptTokens?.let { prompt -> completionTokens?.let { prompt + it } }
 )
 
 @Serializable


### PR DESCRIPTION
Fix for missing `totalTokens` in some OpenAI API compartible responses (e.g., qwen).
