### PR TITLE
Openapi response fix - make "id" field optional

### DIFF
--- a/agents/agents-features/agents-features-memory/src/jvmTest/kotlin/ai/koog/agents/memory/providers/LocalFileMemoryProviderTest.kt
+++ b/agents/agents-features/agents-features-memory/src/jvmTest/kotlin/ai/koog/agents/memory/providers/LocalFileMemoryProviderTest.kt
@@ -36,7 +36,7 @@ class LocalFileMemoryProviderTest {
     fun testDifferentMemoryScopes(@TempDir tempDir: Path) = runTest {
         val fs = JVMFileSystemProvider.ReadWrite
         val storage = createTestStorage(fs)
-        val config = LocalMemoryConfig(tempDir.toString())
+        val config = LocalMemoryConfig("memory-storage")
         val provider = LocalFileMemoryProvider(config, storage, fs, tempDir)
 
         val subject = UserSubject
@@ -90,7 +90,7 @@ class LocalFileMemoryProviderTest {
     fun testFactOperations(@TempDir tempDir: Path) = runTest {
         val fs = JVMFileSystemProvider.ReadWrite
         val storage = createTestStorage(fs)
-        val config = LocalMemoryConfig(tempDir.toString())
+        val config = LocalMemoryConfig("memory-storage")
         val provider = LocalFileMemoryProvider(config, storage, fs, tempDir)
 
         val subject = UserSubject

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/DataModel.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/DataModel.kt
@@ -119,7 +119,7 @@ internal data class OpenAIToolFunction(
 
 @Serializable
 internal data class OpenAIResponse(
-    val id: String,
+    val id: String? = null,
     @SerialName("object") val objectType: String,
     val created: Long,
     val model: String,

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -138,6 +138,7 @@ public object FileSystemProvider {
          * @param path The path to read.
          * @return The file content as a byte array.
          * @throws IllegalArgumentException if the path doesn't exist or isn't a regular file.
+         * @throws IOException if an I/O error occurs during reading.
          */
         public suspend fun read(path: Path): ByteArray
 
@@ -158,6 +159,7 @@ public object FileSystemProvider {
          * @param path The path to examine.
          * @return The file size in bytes.
          * @throws IllegalArgumentException if the path doesn't exist or isn't a regular file.
+         * @throws IOException if an I/O error occurs while determining the file size.
          */
         public suspend fun size(path: Path): Long
     }
@@ -177,6 +179,7 @@ public object FileSystemProvider {
      * This interface focuses on write operations and complements the read operations
      * provided by other interfaces.
      */
+    @Deprecated("For internal use only.")
     public interface Write<Path> : Serialization<Path> {
         /**
          * Creates a new file or directory inside [parent] with specified [name] and [type].
@@ -184,13 +187,9 @@ public object FileSystemProvider {
          *
          * @param parent The parent directory path.
          * @param name The name of the new file or directory.
-         *        On Windows platforms, reserved names like "CON",
-         *        "PRN", "AUX", "NUL", "COM1"-"COM9", "LPT1"-"LPT9" are not allowed.
          * @param type The type (file or directory) to create.
-         * @throws FileAlreadyExistsException if a file or directory with [name] already exists in [parent].
-         * @throws InvalidPathException if [name] is invalid (e.g., contains reserved characters).
-         *         Some implementations may throw a more general IllegalArgumentException or IOException instead.
-         * @throws IOException if any other I/O error occurs.
+         * @throws IOException or its inheritor if a file or directory with [name] already exists in [parent],
+         *         or [name] is invalid (e.g., contains reserved characters), or if any other I/O error occurs.
          */
         public suspend fun create(parent: Path, name: String, type: FileMetadata.FileType)
 
@@ -201,8 +200,8 @@ public object FileSystemProvider {
          *
          * @param source The source path to move from.
          * @param target The target path to move to.
-         * @throws FileAlreadyExistsException if [source] already exists in [target].
-         * @throws IOException if the source path doesn't exist, isn't a file or directory, or any I/O error occurs.
+         * @throws IOException or its inheritor if the source path doesn't exist, isn't a file or directory,
+         *         or [target] already exists, or any I/O error occurs.
          */
         public suspend fun move(source: Path, target: Path)
 
@@ -219,10 +218,10 @@ public object FileSystemProvider {
         public suspend fun write(path: Path, content: ByteArray)
 
         /**
-         * Creates a Sink for writing to a file.
+         * Creates a [Sink] for writing to a file.
          * If the file doesn't exist, it will be created.
          * If the parent directories don't exist, they will be created.
-         * The returned Sink is buffered.
+         * The returned [Sink] is buffered.
          *
          * @param path The path where Sink will be created.
          * @param append Append to existing content (true) or overwrite (false). Default is false (overwrite).
@@ -237,8 +236,7 @@ public object FileSystemProvider {
          *
          * @param parent The parent directory containing the item to delete.
          * @param name The name of the item to delete.
-         * @throws NoSuchFileException if the file or directory doesn't exist.
-         * @throws IOException if a file or directory can't be deleted for any other reason.
+         * @throws IOException or its inheritor if the file or directory doesn't exist or can't be deleted for any other reason.
          */
         public suspend fun delete(parent: Path, name: String)
     }

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -24,11 +24,11 @@ public object FileSystemProvider {
         public fun toAbsolutePathString(path: Path): String
 
         /**
-         * Creates a [Path] object from an absolute path string.
-         * If a relative path is provided, it will be resolved against the current working directory.
+         * Creates a [Path] object from a path string.
+         * If a relative path is provided, it will remain relative.
          *
-         * @param path The absolute path string to convert. Can also accept a relative path.
-         * @return A path object representing the absolute path.
+         * @param path The path string to convert. Can be absolute or relative.
+         * @return A path object representing the given path.
          */
         public fun fromAbsoluteString(path: String): Path
 

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -4,25 +4,16 @@ import kotlinx.io.Sink
 import kotlinx.io.Source
 
 /**
- * Provides interfaces for interacting with a filesystem.
- *
- * Contains nested interfaces for path serialization, file operations,
- * and content reading/writing.
+ * Provides [ReadOnly] and [ReadWrite] interfaces
+ * for interacting with a filesystem through file operations and content reading/writing.
  */
 public object FileSystemProvider {
 
     /**
      * Handles serialization and deserialization of file paths.
      */
+    @Deprecated("For internal use only.")
     public interface Serialization<Path> {
-        /**
-         * Converts a [path] to its string representation.
-         *
-         * @param path The path to convert.
-         * @return String representation of the path.
-         */
-        @Deprecated("Use toAbsolutePathString instead", ReplaceWith("toAbsolutePathString(path)"))
-        public fun toPathString(path: Path): String
 
         /**
          * Converts a [path] to its absolute path string representation.
@@ -53,21 +44,19 @@ public object FileSystemProvider {
 
         /**
          * Gets the name component of a [path].
-         * This is a suspending function as it may require filesystem access.
          *
          * @param path The path to examine.
          * @return The name of the file or directory.
          */
-        public suspend fun name(path: Path): String
+        public fun name(path: Path): String
 
         /**
          * Gets the file extension from a [path].
-         * This is a suspending function as it may require filesystem access.
          *
          * @param path The path to examine.
          * @return The file extension or empty string if none exists.
          */
-        public suspend fun extension(path: Path): String
+        public fun extension(path: Path): String
     }
 
     /**
@@ -80,19 +69,18 @@ public object FileSystemProvider {
          * Retrieves metadata for a file or directory using a [path].
          *
          * @param path The path to examine.
-         * @return FileMetadata object or null if the path doesn't exist or isn't a regular file or directory.
-         * @throws IOException if file/directory access fails.
+         * @return [FileMetadata] object or null if the path doesn't exist or isn't a regular file or directory.
          */
         public suspend fun metadata(path: Path): FileMetadata?
 
         /**
-         * Lists contents of a directory using a [path].
+         * Lists contents of a directory using a [directory].
          *
-         * @param path The directory path to list.
-         * @return List of paths contained in the directory, or empty list if the path doesn't exist, isn't a directory, or an error occurs.
-         * @throws IOException if directory access fails.
+         * @param directory The directory path to list.
+         * @return List of paths contained in the directory.
+         * @throws IllegalArgumentException if passed argument is not a directory, or it doesn't exist.
          */
-        public suspend fun list(path: Path): List<Path>
+        public suspend fun list(directory: Path): List<Path>
 
         /**
          * Gets the parent path of a given [path].
@@ -100,20 +88,8 @@ public object FileSystemProvider {
          *
          * @param path The path to examine.
          * @return The parent path or null if no parent exists.
-         * @throws IOException if directory access fails.
          */
-        public suspend fun parent(path: Path): Path?
-
-        /**
-         * Computes the relative path from a [root] to a target [path].
-         *
-         * @param root The root path.
-         * @param path The target path.
-         * @return The relative path as a string, or null if not relativizable.
-         * @throws IllegalArgumentException if either path is invalid.
-         */
-        @Deprecated("Use relativize instead", ReplaceWith("relativize(root, path)"))
-        public suspend fun relative(root: Path, path: Path): String? = relativize(root, path)
+        public fun parent(path: Path): Path?
 
         /**
          * Computes the relative path from a [root] to a target [path].
@@ -122,16 +98,14 @@ public object FileSystemProvider {
          * @param root The root path.
          * @param path The target path.
          * @return The relative path as a string, or null if the paths cannot be relativized (e.g., they have no common prefix).
-         * @throws IllegalArgumentException if either path is invalid.
          */
-        public suspend fun relativize(root: Path, path: Path): String?
+        public fun relativize(root: Path, path: Path): String?
 
         /**
          * Checks if a [path] exists in the filesystem.
          *
          * @param path The path to check.
          * @return true if the path exists, false otherwise.
-         * @throws IOException if file/directory access fails.
          */
         public suspend fun exists(path: Path): Boolean
     }
@@ -157,8 +131,7 @@ public object FileSystemProvider {
          *
          * @param path The path to read from.
          * @return A Source object for reading.
-         * @throws NoSuchFileException if the path doesn't exist.
-         * @throws IllegalArgumentException if the path isn't a regular file.
+         * @throws IllegalArgumentException if the path isn't a regular file, or it doesn't exist.
          */
         public suspend fun source(path: Path): Source
 
@@ -208,9 +181,7 @@ public object FileSystemProvider {
          *
          * @param source The source path to move from.
          * @param target The target path to move to.
-         * @throws IOException if the source path doesn't exist, isn't a file or directory, or if an error occurs during move operation.
-         * @throws NoSuchFileException if the path doesn't exist.
-         * @throws AccessDeniedException if there are not enough permissions to perform operation.
+         * @throws IOException if the source path doesn't exist, isn't a file or directory, or any IO error occurs.
          */
         public suspend fun move(source: Path, target: Path)
 
@@ -234,7 +205,6 @@ public object FileSystemProvider {
          * @param path The path where Sink will be created.
          * @param append Append to existing content (true) or overwrite (false). Default is false (overwrite).
          * @return A Sink object for writing.
-         * @throws IOException if an IO error occurs during sink creation.
          */
         public suspend fun sink(path: Path, append: Boolean = false): Sink
 
@@ -245,8 +215,6 @@ public object FileSystemProvider {
          *
          * @param parent The parent directory containing the item to delete.
          * @param name The name of the item to delete.
-         * @throws AccessDeniedException if there are not enough permissions to perform operation.
-         * @throws IOException if an error occurs during deletion (e.g., file is locked).
          */
         public suspend fun delete(parent: Path, name: String)
     }

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -34,12 +34,11 @@ public object FileSystemProvider {
 
         /**
          * Resolves a [path] string against a [base] path.
-         * If [path] is the root path, it's resolved with [fromAbsoluteString].
          *
          * @param base The base path for resolution.
          * @param path The path string to resolve.
          * @return The resolved path object.
-         * @throws IllegalArgumentException if [path] is an absolute path, except for the root path.
+         * @throws IllegalArgumentException if [path] is an absolute path.
          */
         public fun fromRelativeString(base: Path, path: String): Path
 

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -177,13 +177,16 @@ public object FileSystemProvider {
      * Provides a read-only interface that combines the functionalities of [FileSystemProvider.Serialization], [FileSystemProvider.Select],
      * and [FileSystemProvider.Read].
      *
-     * It provides operations for path serialization,
-     * structure navigation, and content reading in a read-only manner.
+     * It provides operations for path serialization, structure navigation, and content reading
+     * in a read-only manner without modifying the filesystem.
      */
     public interface ReadOnly<Path> : Serialization<Path>, Select<Path>, Read<Path> {}
 
     /**
      * Provides operations for creating, moving, writing, and deleting files or directories.
+     *
+     * This interface focuses on write operations and complements the read operations
+     * provided by other interfaces.
      */
     public interface Write<Path> : Serialization<Path> {
         /**
@@ -237,18 +240,22 @@ public object FileSystemProvider {
 
         /**
          * Deletes a file or directory from [parent] using [name].
-         * If the item is a directory, it will be deleted recursively.
-         * It doesn't throw any errors if a file/directory doesn't exist.
+         * If the item is a directory, it will be deleted recursively with all its contents.
+         * This operation is idempotent - it doesn't throw any errors if a file/directory doesn't exist.
          *
          * @param parent The parent directory containing the item to delete.
          * @param name The name of the item to delete.
          * @throws AccessDeniedException if there are not enough permissions to perform operation.
+         * @throws IOException if an error occurs during deletion (e.g., file is locked).
          */
         public suspend fun delete(parent: Path, name: String)
     }
 
     /**
      * Provides a read-write interface that combines the functionalities of [FileSystemProvider.ReadOnly] and [FileSystemProvider.Write] for full filesystem access.
+     *
+     * This is the most comprehensive interface, offering complete filesystem operations
+     * including reading, writing, and path manipulation.
      */
     public interface ReadWrite<Path> : ReadOnly<Path>, Write<Path>
 }

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -17,7 +17,6 @@ public object FileSystemProvider {
 
         /**
          * Converts a [path] to its absolute path string representation.
-         * The path is normalized before being converted.
          *
          * @param path The path to convert.
          * @return Absolute path as a string.
@@ -35,12 +34,11 @@ public object FileSystemProvider {
 
         /**
          * Resolves a [path] string against a [base] path.
-         * The resulting path is normalized.
-         * If [path] is the root path (system separator), returns the root of [base].
+         * If [path] is the root path, it's resolved with [fromAbsoluteString].
          *
          * @param base The base path for resolution.
          * @param path The path string to resolve.
-         * @return The normalized resolved path object.
+         * @return The resolved path object.
          * @throws IllegalArgumentException if [path] is an absolute path, except for the root path.
          */
         public fun fromRelativeString(base: Path, path: String): Path
@@ -86,8 +84,9 @@ public object FileSystemProvider {
          *
          * @param directory The directory path to list.
          * @return List of paths contained in the directory, sorted by name.
-         *         Returns an empty list if an error occurs or the directory is empty.
+         *         Returns an empty list if the directory is empty.
          * @throws IllegalArgumentException if [directory] is not a directory or doesn't exist.
+         * @throws IOException if an I/O error occurs during listing.
          */
         public suspend fun list(directory: Path): List<Path>
 
@@ -103,11 +102,10 @@ public object FileSystemProvider {
         /**
          * Computes the relative path from a [root] to a target [path].
          * It doesn't check if the paths actually exist in the filesystem.
-         * The returned path is normalized.
          *
          * @param root The root path.
          * @param path The target path.
-         * @return The normalized relative path as a string, or null if the paths cannot be relativized (e.g., they have no common prefix).
+         * @return The relative path as a string, or null if the paths cannot be relativized (e.g., they have no common prefix).
          */
         public fun relativize(root: Path, path: Path): String?
 

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -209,6 +209,7 @@ public object FileSystemProvider {
         /**
          * Writes content to a file.
          * If the file doesn't exist, it will be created.
+         * If the file exists, its content will be overwritten.
          * Parent directories will be created if they don't exist.
          *
          * @param path The path to write to.

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -17,6 +17,7 @@ public object FileSystemProvider {
 
         /**
          * Converts a [path] to its absolute path string representation.
+         * The path is normalized before being converted.
          *
          * @param path The path to convert.
          * @return Absolute path as a string.
@@ -35,27 +36,31 @@ public object FileSystemProvider {
 
         /**
          * Resolves a [path] string against a [base] path.
+         * The resulting path is normalized.
+         * If [path] is the root path (system separator), returns the root of [base].
          *
          * @param base The base path for resolution.
          * @param path The path string to resolve.
-         * @return The resolved path object.
+         * @return The normalized resolved path object.
          * @throws IllegalArgumentException if [path] is an absolute path, except for the root path.
          */
         public fun fromRelativeString(base: Path, path: String): Path
 
         /**
          * Gets the name component of a [path].
+         * This method works with the path structure and doesn't check if the path actually exists in the filesystem.
          *
          * @param path The path to examine.
-         * @return The name of the file or directory.
+         * @return The name of the file or directory, or an empty string if the path has no name component.
          */
         public fun name(path: Path): String
 
         /**
          * Gets the extension of a [path].
+         * This method works with the path structure and doesn't check if the path actually exists in the filesystem.
          *
          * @param path The path to examine.
-         * @return The extension of [path] or empty string if [path] doesn't exist.
+         * @return The extension of [path] or empty string if [path] doesn't have an extension.
          */
         public fun extension(path: Path): String
     }
@@ -99,10 +104,11 @@ public object FileSystemProvider {
         /**
          * Computes the relative path from a [root] to a target [path].
          * It doesn't check if the paths actually exist in the filesystem.
+         * The returned path is normalized.
          *
          * @param root The root path.
          * @param path The target path.
-         * @return The relative path as a string, or null if the paths cannot be relativized (e.g., they have no common prefix).
+         * @return The normalized relative path as a string, or null if the paths cannot be relativized (e.g., they have no common prefix).
          */
         public fun relativize(root: Path, path: Path): String?
 
@@ -132,11 +138,13 @@ public object FileSystemProvider {
 
         /**
          * Creates a Source for reading from a file at the specified [path].
+         * The returned Source is buffered.
          *
          * @param path The path to read from.
-         * @return A Source object for reading.
+         * @return A buffered Source object for reading.
          * @throws NoSuchFileException if the path doesn't exist.
          * @throws IllegalArgumentException if the path isn't a regular file.
+         * @throws IOException if an I/O error occurs during source creation.
          */
         public suspend fun source(path: Path): Source
 
@@ -172,11 +180,14 @@ public object FileSystemProvider {
          *
          * @param parent The parent directory path.
          * @param name The name of the new file or directory.
+         *        On Windows platforms, reserved names like "CON",
+         *        "PRN", "AUX", "NUL", "COM1"-"COM9", "LPT1"-"LPT9" are not allowed.
          * @param type The type (file or directory) to create.
          * @throws FileAlreadyExistsException if the file with [name] already exists in [parent].
          *         It can also be NoSuchFileException.
          * @throws InvalidPathException if [name] is invalid (e.g., contains reserved characters).
          *         Optional specific exception, some implementations may throw more general IllegalArgumentException or IOException.
+         * @throws IOException if the name is a reserved name on Windows platforms.
          */
         public suspend fun create(parent: Path, name: String, type: FileMetadata.FileType)
 
@@ -199,6 +210,7 @@ public object FileSystemProvider {
          *
          * @param path The path to write to.
          * @param content The content to write as a byte array.
+         * @throws IOException if an I/O error occurs during writing.
          */
         public suspend fun write(path: Path, content: ByteArray)
 
@@ -206,10 +218,12 @@ public object FileSystemProvider {
          * Creates a Sink for writing to a file.
          * If the file doesn't exist, it will be created.
          * If the parent directories don't exist, they will be created.
+         * The returned Sink is buffered.
          *
          * @param path The path where Sink will be created.
          * @param append Append to existing content (true) or overwrite (false). Default is false (overwrite).
-         * @return A Sink object for writing.
+         * @return A buffered Sink object for writing.
+         * @throws IOException if an I/O error occurs during sink creation.
          */
         public suspend fun sink(path: Path, append: Boolean = false): Sink
 

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -128,7 +128,7 @@ public object FileSystemProvider {
          *
          * @param path The path to read.
          * @return The file content as a byte array.
-         * @throws IllegalArgumentException if the path isn't a regular file, or it doesn't exist.
+         * @throws IllegalArgumentException if the path doesn't exist or isn't a regular file.
          */
         public suspend fun read(path: Path): ByteArray
 
@@ -149,7 +149,7 @@ public object FileSystemProvider {
          *
          * @param path The path to examine.
          * @return The file size in bytes.
-         * @throws IllegalArgumentException if the path isn't a regular file, or it doesn't exist.
+         * @throws IllegalArgumentException if the path doesn't exist or isn't a regular file.
          */
         public suspend fun size(path: Path): Long
     }
@@ -179,11 +179,10 @@ public object FileSystemProvider {
          *        On Windows platforms, reserved names like "CON",
          *        "PRN", "AUX", "NUL", "COM1"-"COM9", "LPT1"-"LPT9" are not allowed.
          * @param type The type (file or directory) to create.
-         * @throws FileAlreadyExistsException if the file with [name] already exists in [parent].
-         *         It can also be NoSuchFileException.
+         * @throws FileAlreadyExistsException if a file or directory with [name] already exists in [parent].
          * @throws InvalidPathException if [name] is invalid (e.g., contains reserved characters).
-         *         Optional specific exception, some implementations may throw more general IllegalArgumentException or IOException.
-         * @throws IOException if the name is a reserved name on Windows platforms.
+         *         Some implementations may throw a more general IllegalArgumentException or IOException instead.
+         * @throws IOException if the name is a reserved name on Windows platforms or any other I/O error occurs.
          */
         public suspend fun create(parent: Path, name: String, type: FileMetadata.FileType)
 
@@ -206,7 +205,7 @@ public object FileSystemProvider {
          *
          * @param path The path to write to.
          * @param content The content to write as a byte array.
-         * @throws IOException if an I/O error occurs during writing.
+         * @throws IOException if the path is a directory or any other I/O error occurs during writing.
          */
         public suspend fun write(path: Path, content: ByteArray)
 
@@ -219,7 +218,7 @@ public object FileSystemProvider {
          * @param path The path where Sink will be created.
          * @param append Append to existing content (true) or overwrite (false). Default is false (overwrite).
          * @return A buffered Sink object for writing.
-         * @throws IOException if an I/O error occurs during sink creation.
+         * @throws IOException if the path is a directory or any other I/O error occurs during sink creation.
          */
         public suspend fun sink(path: Path, append: Boolean = false): Sink
 
@@ -229,9 +228,8 @@ public object FileSystemProvider {
          *
          * @param parent The parent directory containing the item to delete.
          * @param name The name of the item to delete.
-         * @throws IOException if a file or directory can't be deleted for any reason.
-         *         More specific exceptions can be used to handle each specific case separately
-         *         (e.g., NoSuchFileException when the file / directory doesn't exist).
+         * @throws NoSuchFileException if the file or directory doesn't exist.
+         * @throws IOException if a file or directory can't be deleted for any other reason.
          */
         public suspend fun delete(parent: Path, name: String)
     }

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -25,7 +25,7 @@ public object FileSystemProvider {
 
         /**
          * Creates a [Path] object from an absolute path string.
-         * If a relative path is provided, it will be resolved against the current working directory.
+         * If a relative path is provided, it will remain relative.
          *
          * @param path The absolute path string to convert. Can also accept a relative path.
          * @return A path object representing the absolute path.

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -29,6 +29,7 @@ public object FileSystemProvider {
          *
          * @param path The absolute path string to convert. Can also accept a relative path.
          * @return A path object representing the absolute path.
+         * @throws IllegalArgumentException if the resolved path is not absolute.
          */
         public fun fromAbsoluteString(path: String): Path
 
@@ -37,8 +38,8 @@ public object FileSystemProvider {
          *
          * @param base The base path for resolution.
          * @param path The path string to resolve.
-         *             If this is an absolute path, the [base] path is ignored and the absolute path is returned directly.
          * @return The resolved path object.
+         * @throws IllegalArgumentException if [path] is an absolute path, except for the root path.
          */
         public fun fromRelativeString(base: Path, path: String): Path
 
@@ -51,10 +52,10 @@ public object FileSystemProvider {
         public fun name(path: Path): String
 
         /**
-         * Gets the file extension from a [path].
+         * Gets the extension of a [path].
          *
          * @param path The path to examine.
-         * @return The file extension or empty string if none exists.
+         * @return The extension of [path] or empty string if [path] doesn't exist.
          */
         public fun extension(path: Path): String
     }
@@ -64,6 +65,7 @@ public object FileSystemProvider {
      *
      * @param Path The type representing file paths in the implementation.
      */
+    @Deprecated("For internal use only.")
     public interface Select<Path> : Serialization<Path> {
         /**
          * Retrieves metadata for a file or directory using a [path].
@@ -75,10 +77,13 @@ public object FileSystemProvider {
 
         /**
          * Lists contents of a [directory].
+         * Children are sorted by name.
+         * The listing is not recursive.
          *
          * @param directory The directory path to list.
-         * @return List of paths contained in the directory.
+         * @return List of paths contained in the directory, sorted by name.
          *         Returns an empty list if an error occurs or the directory is empty.
+         * @throws IllegalArgumentException if [directory] is not a directory or doesn't exist.
          */
         public suspend fun list(directory: Path): List<Path>
 

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -130,6 +130,7 @@ public object FileSystemProvider {
      *
      * @param Path The type representing file paths in the implementation.
      */
+    @Deprecated("For internal use only.")
     public interface Read<Path> : Serialization<Path> {
         /**
          * Reads the content of a file at the specified [path].
@@ -146,8 +147,7 @@ public object FileSystemProvider {
          *
          * @param path The path to read from.
          * @return A buffered Source object for reading.
-         * @throws NoSuchFileException if the path doesn't exist.
-         * @throws IllegalArgumentException if the path isn't a regular file.
+         * @throws IllegalArgumentException if the path doesn't exist or isn't a regular file.
          * @throws IOException if an I/O error occurs during source creation.
          */
         public suspend fun source(path: Path): Source
@@ -202,7 +202,7 @@ public object FileSystemProvider {
          * @param source The source path to move from.
          * @param target The target path to move to.
          * @throws FileAlreadyExistsException if [source] already exists in [target].
-         * @throws IOException if the source path doesn't exist, isn't a file or directory, or any IO error occurs.
+         * @throws IOException if the source path doesn't exist, isn't a file or directory, or any I/O error occurs.
          */
         public suspend fun move(source: Path, target: Path)
 

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -24,11 +24,11 @@ public object FileSystemProvider {
         public fun toAbsolutePathString(path: Path): String
 
         /**
-         * Creates a [Path] object from a path string.
-         * If a relative path is provided, it will remain relative.
+         * Creates a [Path] object from an absolute path string.
+         * If a relative path is provided, it will be resolved against the current working directory.
          *
-         * @param path The path string to convert. Can be absolute or relative.
-         * @return A path object representing the given path.
+         * @param path The absolute path string to convert. Can also accept a relative path.
+         * @return A path object representing the absolute path.
          */
         public fun fromAbsoluteString(path: String): Path
 

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -37,7 +37,7 @@ public object FileSystemProvider {
          *
          * @param base The base path for resolution.
          * @param path The path string to resolve.
-         * If this is an absolute path, the [base] path is ignored and the absolute path is returned directly.
+         *             If this is an absolute path, the [base] path is ignored and the absolute path is returned directly.
          * @return The resolved path object.
          */
         public fun fromRelativeString(base: Path, path: String): Path
@@ -74,11 +74,11 @@ public object FileSystemProvider {
         public suspend fun metadata(path: Path): FileMetadata?
 
         /**
-         * Lists contents of a directory using a [directory].
+         * Lists contents of a [directory].
          *
          * @param directory The directory path to list.
          * @return List of paths contained in the directory.
-         * @throws IllegalArgumentException if passed argument is not a directory, or it doesn't exist.
+         *         Returns an empty list if an error occurs or the directory is empty.
          */
         public suspend fun list(directory: Path): List<Path>
 
@@ -121,8 +121,7 @@ public object FileSystemProvider {
          *
          * @param path The path to read.
          * @return The file content as a byte array.
-         * @throws NoSuchFileException if the path doesn't exist.
-         * @throws IllegalArgumentException if the path isn't a regular file.
+         * @throws IllegalArgumentException if the path isn't a regular file, or it doesn't exist.
          */
         public suspend fun read(path: Path): ByteArray
 
@@ -131,7 +130,8 @@ public object FileSystemProvider {
          *
          * @param path The path to read from.
          * @return A Source object for reading.
-         * @throws IllegalArgumentException if the path isn't a regular file, or it doesn't exist.
+         * @throws NoSuchFileException if the path doesn't exist.
+         * @throws IllegalArgumentException if the path isn't a regular file.
          */
         public suspend fun source(path: Path): Source
 
@@ -140,8 +140,7 @@ public object FileSystemProvider {
          *
          * @param path The path to examine.
          * @return The file size in bytes.
-         * @throws NoSuchFileException if the path doesn't exist.
-         * @throws IllegalArgumentException if the path isn't a regular file.
+         * @throws IllegalArgumentException if the path isn't a regular file, or it doesn't exist.
          */
         public suspend fun size(path: Path): Long
     }
@@ -169,8 +168,10 @@ public object FileSystemProvider {
          * @param parent The parent directory path.
          * @param name The name of the new file or directory.
          * @param type The type (file or directory) to create.
-         * @throws IOException if the name is invalid (e.g., contains reserved characters) or an error occurs during creation.
-         * @throws AccessDeniedException if there are not enough permissions to perform operation.
+         * @throws FileAlreadyExistsException if the file with [name] already exists in [parent].
+         *         It can also be NoSuchFileException.
+         * @throws InvalidPathException if [name] is invalid (e.g., contains reserved characters).
+         *         Optional specific exception, some implementations may throw more general IllegalArgumentException or IOException.
          */
         public suspend fun create(parent: Path, name: String, type: FileMetadata.FileType)
 
@@ -181,6 +182,7 @@ public object FileSystemProvider {
          *
          * @param source The source path to move from.
          * @param target The target path to move to.
+         * @throws FileAlreadyExistsException if [source] already exists in [target].
          * @throws IOException if the source path doesn't exist, isn't a file or directory, or any IO error occurs.
          */
         public suspend fun move(source: Path, target: Path)
@@ -192,8 +194,6 @@ public object FileSystemProvider {
          *
          * @param path The path to write to.
          * @param content The content to write as a byte array.
-         * @throws IOException if an IO error occurs during writing.
-         * @throws AccessDeniedException if there are not enough permissions to perform operation.
          */
         public suspend fun write(path: Path, content: ByteArray)
 
@@ -211,10 +211,11 @@ public object FileSystemProvider {
         /**
          * Deletes a file or directory from [parent] using [name].
          * If the item is a directory, it will be deleted recursively with all its contents.
-         * This operation is idempotent - it doesn't throw any errors if a file/directory doesn't exist.
          *
          * @param parent The parent directory containing the item to delete.
          * @param name The name of the item to delete.
+         * @throws NoSuchFileException if a file or directory doesn't exist.
+         *         Optional specific exception, some implementations may throw more general IOException.
          */
         public suspend fun delete(parent: Path, name: String)
     }

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -26,9 +26,8 @@ public object FileSystemProvider {
 
         /**
          * Creates a [Path] object from an absolute path string.
-         * If a relative path is provided, it will remain relative.
          *
-         * @param path The absolute path string to convert. Can also accept a relative path.
+         * @param path The absolute path string to convert.
          * @return A path object representing the absolute path.
          * @throws IllegalArgumentException if the resolved path is not absolute.
          */
@@ -233,8 +232,9 @@ public object FileSystemProvider {
          *
          * @param parent The parent directory containing the item to delete.
          * @param name The name of the item to delete.
-         * @throws NoSuchFileException if a file or directory doesn't exist.
          * @throws IOException if a file or directory can't be deleted for any reason.
+         *         More specific exceptions can be used to handle each specific case separately
+         *         (e.g., NoSuchFileException when the file / directory doesn't exist).
          */
         public suspend fun delete(parent: Path, name: String)
     }

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -57,7 +57,6 @@ public object FileSystemProvider {
          *
          * @param path The path to examine.
          * @return The name of the file or directory.
-         * @throws IllegalArgumentException if the path is invalid.
          */
         public suspend fun name(path: Path): String
 
@@ -67,7 +66,6 @@ public object FileSystemProvider {
          *
          * @param path The path to examine.
          * @return The file extension or empty string if none exists.
-         * @throws IllegalArgumentException if the path is invalid.
          */
         public suspend fun extension(path: Path): String
     }
@@ -84,7 +82,6 @@ public object FileSystemProvider {
          * @param path The path to examine.
          * @return FileMetadata object or null if the path doesn't exist or isn't a regular file or directory.
          * @throws IOException if file/directory access fails.
-         * @throws IllegalArgumentException if the path is invalid.
          */
         public suspend fun metadata(path: Path): FileMetadata?
 
@@ -94,7 +91,6 @@ public object FileSystemProvider {
          * @param path The directory path to list.
          * @return List of paths contained in the directory, or empty list if the path doesn't exist, isn't a directory, or an error occurs.
          * @throws IOException if directory access fails.
-         * @throws IllegalArgumentException if the path is invalid.
          */
         public suspend fun list(path: Path): List<Path>
 
@@ -105,7 +101,6 @@ public object FileSystemProvider {
          * @param path The path to examine.
          * @return The parent path or null if no parent exists.
          * @throws IOException if directory access fails.
-         * @throws IllegalArgumentException if the path is invalid.
          */
         public suspend fun parent(path: Path): Path?
 
@@ -137,7 +132,6 @@ public object FileSystemProvider {
          * @param path The path to check.
          * @return true if the path exists, false otherwise.
          * @throws IOException if file/directory access fails.
-         * @throws IllegalArgumentException if the path is invalid.
          */
         public suspend fun exists(path: Path): Boolean
     }

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -238,10 +238,11 @@ public object FileSystemProvider {
         /**
          * Deletes a file or directory from [parent] using [name].
          * If the item is a directory, it will be deleted recursively.
-         * It doesn't throw any error if a file/directory doesn't exist.
+         * It doesn't throw any errors if a file/directory doesn't exist.
          *
          * @param parent The parent directory containing the item to delete.
          * @param name The name of the item to delete.
+         * @throws AccessDeniedException if there are not enough permissions to perform operation.
          */
         public suspend fun delete(parent: Path, name: String)
     }

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -190,7 +190,7 @@ public object FileSystemProvider {
          * @throws FileAlreadyExistsException if a file or directory with [name] already exists in [parent].
          * @throws InvalidPathException if [name] is invalid (e.g., contains reserved characters).
          *         Some implementations may throw a more general IllegalArgumentException or IOException instead.
-         * @throws IOException if the name is a reserved name on Windows platforms or any other I/O error occurs.
+         * @throws IOException if any other I/O error occurs.
          */
         public suspend fun create(parent: Path, name: String, type: FileMetadata.FileType)
 

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -234,7 +234,7 @@ public object FileSystemProvider {
          * @param parent The parent directory containing the item to delete.
          * @param name The name of the item to delete.
          * @throws NoSuchFileException if a file or directory doesn't exist.
-         *         Optional specific exception, some implementations may throw more general IOException.
+         * @throws IOException if a file or directory can't be deleted for any reason.
          */
         public suspend fun delete(parent: Path, name: String)
     }

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -148,7 +148,7 @@ public object FileSystemProvider {
          *
          * @param path The path to read from.
          * @return A buffered Source object for reading.
-         * @throws IllegalArgumentException if the path doesn't exist or isn't a regular file.
+         * @throws IllegalArgumentException if [path] doesn't exist or isn't a regular file.
          * @throws IOException if an I/O error occurs during source creation.
          */
         public suspend fun source(path: Path): Source

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -4,240 +4,256 @@ import kotlinx.io.Sink
 import kotlinx.io.Source
 
 /**
- * Provides a broad set of functionalities for interacting with a filesystem or a similar hierarchy of data.
- * This object contains nested interfaces for serialization, reading, writing, and managing file or directory paths.
+ * Provides interfaces for interacting with a filesystem.
+ *
+ * Contains nested interfaces for path serialization, file operations,
+ * and content reading/writing.
  */
 public object FileSystemProvider {
 
     /**
-     * Interface defining methods for serializing and deserializing file paths and handling related metadata.
-     * This is a generic interface that operates with paths of a specified type.
+     * Handles serialization and deserialization of file paths.
      */
     public interface Serialization<Path> {
         /**
-         * Converts the given path to a string representation of the file path.
+         * Converts a [path] to its string representation.
          *
-         * @param path The path to convert into a string.
-         * @return A string representation of the supplied path.
-         * @deprecated Use toAbsolutePathString instead for generating string representations of absolute paths.
+         * @param path The path to convert.
+         * @return String representation of the path.
          */
         @Deprecated("Use toAbsolutePathString instead", ReplaceWith("toAbsolutePathString(path)"))
         public fun toPathString(path: Path): String
+
         /**
-         * Converts a given Path object into its absolute path representation as a string.
+         * Converts a [path] to its absolute path string representation.
          *
-         * @param path The Path object to be converted into an absolute path string.
-         * @return The absolute path string representation of the provided Path object.
+         * @param path The path to convert.
+         * @return Absolute path as a string.
          */
         public fun toAbsolutePathString(path: Path): String
+
         /**
-         * Converts a string representation of an absolute file path into a Path object.
+         * Creates a [Path] object from an absolute path string.
+         * If a relative path is provided, it will be resolved against the current working directory.
          *
-         * @param path The absolute path as a string.
-         * @return A Path object representing the absolute path.
+         * @param path The absolute path string to convert. Can also accept a relative path.
+         * @return A path object representing the absolute path.
          */
         public fun fromAbsoluteString(path: String): Path
+
         /**
-         * Converts a relative path string to a `Path` object by resolving it against a base path.
+         * Resolves a [path] string against a [base] path.
          *
-         * @param base The base `Path` against which the relative path will be resolved.
-         * @param path The relative path in string form to be resolved.
-         * @return A `Path` object representing the resolved path.
+         * @param base The base path for resolution.
+         * @param path The path string to resolve.
+         * If this is an absolute path, the [base] path is ignored and the absolute path is returned directly.
+         * @return The resolved path object.
          */
         public fun fromRelativeString(base: Path, path: String): Path
 
         /**
-         * Retrieves the name of the file or directory represented by the given path.
+         * Gets the name component of a [path].
+         * This is a suspending function as it may require filesystem access.
          *
-         * @param path The path representing a file or directory whose name is to be retrieved.
-         * @return The name of the file or directory as a string.
+         * @param path The path to examine.
+         * @return The name of the file or directory.
+         * @throws IllegalArgumentException if the path is invalid.
          */
         public suspend fun name(path: Path): String
+
         /**
-         * Retrieves the file extension from the specified path.
+         * Gets the file extension from a [path].
+         * This is a suspending function as it may require filesystem access.
          *
-         * @param path The file path from which to extract the extension.
-         * @return The file extension as a string, or an empty string if the path does not have an extension.
+         * @param path The path to examine.
+         * @return The file extension or empty string if none exists.
+         * @throws IllegalArgumentException if the path is invalid.
          */
         public suspend fun extension(path: Path): String
     }
 
     /**
-     * Represents an interface for handling file and directory operations within a filesystem context.
-     * Extends the `Serialization` interface to support path serialization and deserialization.
+     * Provides operations for examining filesystem structure.
      *
-     * @param Path The type representing the file or directory path.
+     * @param Path The type representing file paths in the implementation.
      */
     public interface Select<Path> : Serialization<Path> {
         /**
-         * Retrieves the metadata associated with the specified file or directory.
+         * Retrieves metadata for a file or directory using a [path].
          *
-         * @param path The path to the file or directory whose metadata is being retrieved.
-         * @return The metadata of the specified file or directory as a [ai.koog.agents.memory.providers.FileMetadata] object,
-         * or null if the metadata could not be retrieved or the path does not exist.
+         * @param path The path to examine.
+         * @return FileMetadata object or null if the path doesn't exist or isn't a regular file or directory.
+         * @throws IOException if file/directory access fails.
+         * @throws IllegalArgumentException if the path is invalid.
          */
         public suspend fun metadata(path: Path): FileMetadata?
+
         /**
-         * Lists all the paths under a specified directory or file path.
+         * Lists contents of a directory using a [path].
          *
-         * This method retrieves a list of paths that are either contained within a directory
-         * or represent the current path, depending on the type of the given `path`.
-         *
-         * @param path The path for which to list associated paths. If the path is a directory,
-         *             it retrieves paths contained within it. If it is a file, it returns the file itself.
-         * @return A list of paths under the given directory or file path.
+         * @param path The directory path to list.
+         * @return List of paths contained in the directory, or empty list if the path doesn't exist, isn't a directory, or an error occurs.
+         * @throws IOException if directory access fails.
+         * @throws IllegalArgumentException if the path is invalid.
          */
         public suspend fun list(path: Path): List<Path>
+
         /**
-         * Retrieves the parent directory/path of the given path.
+         * Gets the parent path of a given [path].
+         * This method works with the path structure and doesn't check if the path actually exists in the filesystem.
          *
-         * @param path The path for which the parent directory is to be determined.
-         * @return The parent path of the given path, or null if the path has no parent.
+         * @param path The path to examine.
+         * @return The parent path or null if no parent exists.
+         * @throws IOException if directory access fails.
+         * @throws IllegalArgumentException if the path is invalid.
          */
         public suspend fun parent(path: Path): Path?
+
         /**
-         * Computes the relative path from a given root path to the specified path.
+         * Computes the relative path from a [root] to a target [path].
          *
-         * @param root The root directory path from which the relative path is calculated.
-         * @param path The target path to calculate the relative path to.
-         * @return The relative path as a string, or null if the paths cannot be relativized.
+         * @param root The root path.
+         * @param path The target path.
+         * @return The relative path as a string, or null if not relativizable.
+         * @throws IllegalArgumentException if either path is invalid.
          */
         @Deprecated("Use relativize instead", ReplaceWith("relativize(root, path)"))
         public suspend fun relative(root: Path, path: Path): String? = relativize(root, path)
+
         /**
-         * Relativizes the given path `path` based on the specified `root` path.
-         * This function calculates the relative path from the `root` to the `path`.
+         * Computes the relative path from a [root] to a target [path].
+         * It doesn't check if the paths actually exist in the filesystem.
          *
-         * @param root The base path against which the relative path should be computed.
-         * @param path The target path to compute its relation to the root.
-         * @return A string representing the relative path from the root to the path, or null if the paths cannot be relativized.
+         * @param root The root path.
+         * @param path The target path.
+         * @return The relative path as a string, or null if the paths cannot be relativized (e.g., they have no common prefix).
+         * @throws IllegalArgumentException if either path is invalid.
          */
         public suspend fun relativize(root: Path, path: Path): String?
+
         /**
-         * Checks if a given path exists in the file system.
+         * Checks if a [path] exists in the filesystem.
          *
-         * @param path The path to be checked for existence.
-         * @return `true` if the path exists, `false` otherwise.
+         * @param path The path to check.
+         * @return true if the path exists, false otherwise.
+         * @throws IOException if file/directory access fails.
+         * @throws IllegalArgumentException if the path is invalid.
          */
         public suspend fun exists(path: Path): Boolean
     }
 
     /**
-     * An interface that defines the operations for reading file or content-related data.
-     * Extends the [Serialization] interface to provide additional methods for reading byte data,
-     * retrieving data sources, and determining the size of given paths.
+     * Provides operations for reading file content.
      *
-     * @param Path The type that represents the file or directory path.
+     * @param Path The type representing file paths in the implementation.
      */
     public interface Read<Path> : Serialization<Path> {
         /**
-         * Reads the content of the file at the specified path.
+         * Reads the content of a file at the specified [path].
          *
-         * @param path The path of the file to read.
-         * @return The content of the file as a ByteArray.
+         * @param path The path to read.
+         * @return The file content as a byte array.
+         * @throws NoSuchFileException if the path doesn't exist.
+         * @throws IllegalArgumentException if the path isn't a regular file.
          */
         public suspend fun read(path: Path): ByteArray
+
         /**
-         * Provides access to a data source represented by the given path.
+         * Creates a Source for reading from a file at the specified [path].
          *
-         * @param path The path to the source from which data should be accessed.
-         * @return A Source object associated with the specified path.
+         * @param path The path to read from.
+         * @return A Source object for reading.
+         * @throws NoSuchFileException if the path doesn't exist.
+         * @throws IllegalArgumentException if the path isn't a regular file.
          */
         public suspend fun source(path: Path): Source
+
         /**
-         * Retrieves the size of the file or directory at the specified path.
+         * Gets the size of a file in bytes.
          *
-         * @param path The path of the file or directory whose size is to be determined.
-         * @return The size of the file or directory in bytes. For directories, this may
-         * represent the cumulative size of its contents, depending on the implementation.
+         * @param path The path to examine.
+         * @return The file size in bytes.
+         * @throws NoSuchFileException if the path doesn't exist.
+         * @throws IllegalArgumentException if the path isn't a regular file.
          */
         public suspend fun size(path: Path): Long
     }
 
     /**
-     * Defines a read-only interface that combines the functionalities of serialization, file selection,
-     * and file reading in a file system or comparable data structure.
+     * Provides a read-only interface that combines the functionalities of [FileSystemProvider.Serialization], [FileSystemProvider.Select],
+     * and [FileSystemProvider.Read].
      *
-     * @param Path Represents the type of the path used to reference files or directories.
-     *
-     * This interface inherits methods from the following:
-     * - `Serialization`: Serialization and deserialization of file paths into string representations.
-     * - `Select`: Operations to fetch metadata, list contents, navigate parent directories, and check existence.
-     * - `Read`: Functionality to read file content, access file content as a source, and determine file size.
-     *
-     * Implementers of this interface are expected to provide implementations for all functionality
-     * associated with serialization, selection, and reading, ensuring a complete read-only perspective
-     * of the file system or equivalent storage mechanisms.
-     *
-     * This interface is useful in scenarios where modification operations are either undesired or disallowed,
-     * offering controlled access to an underlying file or directory structure.
+     * It provides operations for path serialization,
+     * structure navigation, and content reading in a read-only manner.
      */
-    public interface ReadOnly<Path>: Serialization<Path>, Select<Path>, Read<Path>  {}
+    public interface ReadOnly<Path> : Serialization<Path>, Select<Path>, Read<Path> {}
 
     /**
-     * Provides functionalities for creating, moving, writing, and deleting files or directories
-     * while maintaining a serialization context.
-     *
-     * This interface is designed to interact with a file system hierarchy in a structured way,
-     * allowing operations to manage file content and metadata effectively.
-     *
-     * @param Path A type representing a file system location.
+     * Provides operations for creating, moving, writing, and deleting files or directories.
      */
     public interface Write<Path> : Serialization<Path> {
         /**
-         * Creates a new file or directory within a specified parent directory.
+         * Creates a new file or directory inside [parent] with specified [name] and [type].
+         * Parent directories will be created if they don't exist.
          *
-         * @param parent The path of the parent directory where the item will be created.
-         * @param name The name of the new file or directory to be created.
-         * @param type The type of the item to create, either a file or a directory, as defined by [ai.koog.agents.memory.providers.FileMetadata.FileType].
+         * @param parent The parent directory path.
+         * @param name The name of the new file or directory.
+         * @param type The type (file or directory) to create.
+         * @throws IOException if the name is invalid (e.g., contains reserved characters) or an error occurs during creation.
+         * @throws AccessDeniedException if there are not enough permissions to perform operation.
          */
         public suspend fun create(parent: Path, name: String, type: FileMetadata.FileType)
+
         /**
-         * Moves a file or directory from the source path to the target path.
+         * Moves a file or directory from [source] to [target].
+         * If the source is a directory, all its contents are moved recursively.
+         * Parent directories of the target will be created if they don't exist.
          *
-         * @param source The path of the file or directory to be moved.
-         * @param target The destination path where the file or directory will be moved.
+         * @param source The source path to move from.
+         * @param target The target path to move to.
+         * @throws IOException if the source path doesn't exist, isn't a file or directory, or if an error occurs during move operation.
+         * @throws NoSuchFileException if the path doesn't exist.
+         * @throws AccessDeniedException if there are not enough permissions to perform operation.
          */
         public suspend fun move(source: Path, target: Path)
+
         /**
-         * Writes the specified content to the given path.
+         * Writes content to a file.
+         * If the file doesn't exist, it will be created.
+         * Parent directories will be created if they don't exist.
          *
-         * @param path The file system path where the content should be written.
-         * @param content The data to be written as a byte array.
+         * @param path The path to write to.
+         * @param content The content to write as a byte array.
+         * @throws IOException if an IO error occurs during writing.
+         * @throws AccessDeniedException if there are not enough permissions to perform operation.
          */
         public suspend fun write(path: Path, content: ByteArray)
+
         /**
-         * Creates and returns a Sink for the given path.
-         * The Sink can be used to write data to the file or directory represented by the specified path.
+         * Creates a Sink for writing to a file.
+         * If the file doesn't exist, it will be created.
+         * If the parent directories don't exist, they will be created.
          *
-         * @param path The path where the sink will be created, representing the file or directory target.
-         * @param append A boolean indicating whether to append to the file if it exists.
-         *               Defaults to false, meaning the file will be overwritten if it exists.
-         * @return A Sink instance for writing to the specified path.
+         * @param path The path where Sink will be created.
+         * @param append Append to existing content (true) or overwrite (false). Default is false (overwrite).
+         * @return A Sink object for writing.
+         * @throws IOException if an IO error occurs during sink creation.
          */
         public suspend fun sink(path: Path, append: Boolean = false): Sink
+
         /**
-         * Deletes a child file or directory with the specified name from the parent directory.
+         * Deletes a file or directory from [parent] using [name].
+         * If the item is a directory, it will be deleted recursively.
+         * It doesn't throw any error if a file/directory doesn't exist.
          *
-         * @param parent The path to the parent directory from which the file or directory should be deleted.
-         * @param name The name of the file or directory to be deleted.
+         * @param parent The parent directory containing the item to delete.
+         * @param name The name of the item to delete.
          */
         public suspend fun delete(parent: Path, name: String)
     }
 
     /**
-     * Represents a combined interface for read and write operations on a given pathway or resource.
-     *
-     * This interface extends both the [ReadOnly] and [Write] interfaces, allowing full control
-     * over interacting with resources associated with a specific `Path`. This includes retrieval,
-     * modification, and creation operations. Suitable for cases where both read and write capabilities
-     * are required, without compromising the ability to manage the underlying resource effectively.
-     *
-     * The `ReadWrite` interface inherits the contract of the following:
-     * - [ReadOnly]: Provides read-only access, including serialization, selection, and data retrieval operations.
-     * - [Write]: Enables data creation, modification, and deletion, supporting essential write-related functionality.
-     *
-     * @param Path The type of the resource pathway or identifier handled by this interface.
+     * Provides a read-write interface that combines the functionalities of [FileSystemProvider.ReadOnly] and [FileSystemProvider.Write] for full filesystem access.
      */
     public interface ReadWrite<Path> : ReadOnly<Path>, Write<Path>
 }

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -17,6 +17,8 @@ public object FileSystemProvider {
 
         /**
          * Converts a [path] to its absolute path string representation.
+         * This method works with the path structure
+         * and doesn't check if the path actually exists in the filesystem.
          *
          * @param path The path to convert.
          * @return Absolute path as a string.
@@ -25,15 +27,19 @@ public object FileSystemProvider {
 
         /**
          * Creates a [Path] object from an absolute path string.
+         * This method works with the path structure
+         * and doesn't check if the path actually exists in the filesystem.
          *
          * @param path The absolute path string to convert.
          * @return A path object representing the absolute path.
-         * @throws IllegalArgumentException if the resolved path is not absolute.
+         * @throws IllegalArgumentException if [path] is not absolute.
          */
         public fun fromAbsoluteString(path: String): Path
 
         /**
          * Resolves a [path] string against a [base] path.
+         * This method works with the path structure
+         * and doesn't check if the path actually exists in the filesystem.
          *
          * @param base The base path for resolution.
          * @param path The path string to resolve.
@@ -44,7 +50,8 @@ public object FileSystemProvider {
 
         /**
          * Gets the name component of a [path].
-         * This method works with the path structure and doesn't check if the path actually exists in the filesystem.
+         * This method works with the path structure
+         * and doesn't check if the path actually exists in the filesystem.
          *
          * @param path The path to examine.
          * @return The name of the file or directory, or an empty string if the path has no name component.
@@ -53,7 +60,8 @@ public object FileSystemProvider {
 
         /**
          * Gets the extension of a [path].
-         * This method works with the path structure and doesn't check if the path actually exists in the filesystem.
+         * This method works with the path structure
+         * and doesn't check if the path actually exists in the filesystem.
          *
          * @param path The path to examine.
          * @return The extension of [path] or empty string if [path] doesn't have an extension.

--- a/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
+++ b/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
@@ -41,15 +41,8 @@ public object JVMFileSystemProvider {
          * @param path The absolute file path as a string.
          * @return The normalized Path representation of the given string.
          */
-        override fun fromAbsoluteString(path: String): Path {
-            val adjustedPath = toSystemDependentName(path)
-            val pathObj = Path.of(adjustedPath)
-            return if (pathObj.isAbsolute) {
-                pathObj.normalize()
-            } else {
-                Path.of("").toAbsolutePath().resolve(pathObj).normalize()
-            }
-        }
+        override fun fromAbsoluteString(path: String): Path = Path.of(toSystemDependentName(path)).normalize()
+
         /**
          * Converts a relative string representation of a path into a normalized Path object
          * based on the provided base Path.

--- a/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
+++ b/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
@@ -35,13 +35,19 @@ public object JVMFileSystemProvider {
          * @return the absolute path string representation of the given [path]
          */
         override fun toAbsolutePathString(path: Path): String = path.normalize().absolutePathString()
+
         /**
          * Converts the given absolute file path string to a normalized Path object.
          *
          * @param path The absolute file path as a string.
          * @return The normalized Path representation of the given string.
+         * @throws IllegalArgumentException if the resolved path is not absolute.
          */
-        override fun fromAbsoluteString(path: String): Path = Path.of(toSystemDependentName(path)).normalize()
+        override fun fromAbsoluteString(path: String): Path {
+            val resolvedPath = Path.of(toSystemDependentName(path)).normalize()
+            require(resolvedPath.isAbsolute) { "Resolved path must be absolute" }
+            return resolvedPath
+        }
 
         /**
          * Converts a relative string representation of a path into a normalized Path object
@@ -50,8 +56,17 @@ public object JVMFileSystemProvider {
          * @param base The base path against which the relative path will be resolved.
          * @param path The relative path as a string to be resolved.
          * @return A normalized Path object representing the resolved path.
+         * @throws IllegalArgumentException if the path is absolute, except for the root path.
          */
-        override fun fromRelativeString(base: Path, path: String): Path = base.resolve(path).normalize()
+        override fun fromRelativeString(base: Path, path: String): Path {
+            if (path == FileSystems.getDefault().separator) {
+                return base.root ?: base.absolute().root
+            }
+
+            val resolvedPath = Path.of(path)
+            require(!resolvedPath.isAbsolute) { "Path must be relative, but was absolute: $path" }
+            return base.resolve(path).normalize()
+        }
 
         /**
          * Retrieves the name of the given file path.
@@ -60,11 +75,12 @@ public object JVMFileSystemProvider {
          * @return the name of the file or directory represented by the provided path
          */
         override fun name(path: Path): String = path.name
+
         /**
-         * Retrieves the file extension of the specified path.
+         * Retrieves the extension of the specified path.
          *
-         * @param path the path from which to extract the file extension.
-         * @return the file extension as a string.
+         * @param path the path from which to extract the extension.
+         * @return the extension of [path] as a string.
          */
         override fun extension(path: Path): String = path.extension
 
@@ -116,15 +132,21 @@ public object JVMFileSystemProvider {
 
         /**
          * Retrieves a sorted list of paths within the specified directory.
+         * The listing is not recursive.
          *
          * @param directory The directory path whose contents are to be listed.
          * @return A list of paths within the specified directory, sorted by name.
          *         Returns an empty list if an error occurs or the directory is empty.
+         * @throws IllegalArgumentException if [directory] is not a directory or doesn't exist.
          */
-        override suspend fun list(directory: Path): List<Path> = runCatching {
-            Files.list(directory).use {
-            it.sorted { a, b -> a.name.compareTo(b.name) }.toList()
-        }}.getOrElse { emptyList() }
+        override suspend fun list(directory: Path): List<Path> {
+            require(directory.exists()) { "Path must exist" }
+            require(directory.isDirectory()) { "Path must be a directory" }
+
+            return Files.list(directory).use {
+                it.sorted { a, b -> a.name.compareTo(b.name) }.toList()
+            }
+        }
 
         /**
          * Retrieves the parent directory of the specified path, if it exists.
@@ -172,13 +194,17 @@ public object JVMFileSystemProvider {
 
             return withContext(Dispatchers.IO) { path.readBytes() }
         }
+
         /**
          * Opens a source to read from the specified file path.
          *
          * @param path The file path from which the source will be opened.
          * @return A buffered source for reading from the file.
          */
-        override suspend fun source(path: Path): Source = withContext(Dispatchers.IO) { SystemFileSystem.source(path = kotlinx.io.files.Path(path.pathString)).buffered() }
+        override suspend fun source(path: Path): Source = withContext(Dispatchers.IO) {
+            SystemFileSystem.source(path = kotlinx.io.files.Path(path.pathString)).buffered()
+        }
+
         /**
          * Returns the size of the regular file at the specified path.
          *
@@ -204,7 +230,7 @@ public object JVMFileSystemProvider {
      * It provides operations for path serialization, structure navigation, and
      * content reading in a read-only manner.
      */
-    public object ReadOnly: FileSystemProvider.ReadOnly<Path>,
+    public object ReadOnly : FileSystemProvider.ReadOnly<Path>,
         FileSystemProvider.Select<Path> by Select,
         FileSystemProvider.Read<Path> by Read {
 
@@ -223,6 +249,7 @@ public object JVMFileSystemProvider {
          * @return A normalized Path object corresponding to the given absolute string.
          */
         override fun fromAbsoluteString(path: String): Path = Serialization.fromAbsoluteString(path)
+
         /**
          * Resolves a given relative path string against a base path and returns the normalized path.
          *
@@ -239,6 +266,7 @@ public object JVMFileSystemProvider {
          * @return the name of the provided path as a String.
          */
         override fun name(path: Path): String = Serialization.name(path)
+
         /**
          * Retrieves the file extension from the specified path using the serialization logic.
          *
@@ -256,7 +284,7 @@ public object JVMFileSystemProvider {
      * read-only and write capabilities. By delegating to `ReadOnly` and `Write` objects, it provides
      * comprehensive file system operations including reading, writing, serialization, and path manipulation.
      */
-    public object ReadWrite: FileSystemProvider.ReadWrite<Path>,
+    public object ReadWrite : FileSystemProvider.ReadWrite<Path>,
         FileSystemProvider.ReadOnly<Path> by ReadOnly,
         FileSystemProvider.Write<Path> by Write {
 
@@ -267,6 +295,7 @@ public object JVMFileSystemProvider {
          * @return the absolute path as a string
          */
         override fun toAbsolutePathString(path: Path): String = Serialization.toAbsolutePathString(path)
+
         /**
          * Converts an absolute string path into a normalized Path object suitable for the current file system.
          *
@@ -274,6 +303,7 @@ public object JVMFileSystemProvider {
          * @return A Path object representing the input absolute string, normalized for the current file system.
          */
         override fun fromAbsoluteString(path: String): Path = Serialization.fromAbsoluteString(path)
+
         /**
          * Resolves a relative path string against a given base path and normalizes the resulting path.
          *
@@ -282,6 +312,7 @@ public object JVMFileSystemProvider {
          * @return The resolved and normalized path as a `Path` object.
          */
         override fun fromRelativeString(base: Path, path: String): Path = Serialization.fromRelativeString(base, path)
+
         /**
          * Retrieves the name of the file or directory represented by the specified path.
          *
@@ -289,6 +320,7 @@ public object JVMFileSystemProvider {
          * @return the name of the file or directory as a string
          */
         override fun name(path: Path): String = Serialization.name(path)
+
         /**
          * Gets the extension of the file represented by the given path.
          *

--- a/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
+++ b/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
@@ -13,8 +13,8 @@ import java.nio.ByteBuffer
 import java.nio.charset.Charset
 import java.nio.file.FileSystems
 import java.nio.file.Files
+import java.nio.file.NoSuchFileException
 import java.nio.file.Path
-import kotlin.io.NoSuchFileException
 import kotlin.io.path.*
 import kotlin.use
 

--- a/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
+++ b/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
@@ -41,7 +41,15 @@ public object JVMFileSystemProvider {
          * @param path The absolute file path as a string.
          * @return The normalized Path representation of the given string.
          */
-        override fun fromAbsoluteString(path: String): Path = Path.of(toSystemDependentName(path)).normalize()
+        override fun fromAbsoluteString(path: String): Path {
+            val adjustedPath = toSystemDependentName(path)
+            val pathObj = Path.of(adjustedPath)
+            return if (pathObj.isAbsolute) {
+                pathObj.normalize()
+            } else {
+                Path.of("").toAbsolutePath().resolve(pathObj).normalize()
+            }
+        }
         /**
          * Converts a relative string representation of a path into a normalized Path object
          * based on the provided base Path.

--- a/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
+++ b/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
@@ -11,10 +11,7 @@ import kotlinx.io.files.SystemFileSystem
 import java.io.IOException
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
-import java.nio.file.FileSystems
-import java.nio.file.Files
-import java.nio.file.NoSuchFileException
-import java.nio.file.Path
+import java.nio.file.*
 import kotlin.io.path.*
 import kotlin.use
 
@@ -135,13 +132,18 @@ public object JVMFileSystemProvider {
          * @return A list of paths within the specified directory, sorted by name.
          *         Returns an empty list if an error occurs or the directory is empty.
          * @throws IllegalArgumentException if [directory] is not a directory or doesn't exist.
+         * @throws IOException if an I/O error occurs during listing.
          */
         override suspend fun list(directory: Path): List<Path> {
             require(directory.exists()) { "Path must exist" }
             require(directory.isDirectory()) { "Path must be a directory" }
 
-            return Files.list(directory).use {
-                it.sorted { a, b -> a.name.compareTo(b.name) }.toList()
+            return try {
+                Files.list(directory).use {
+                    it.sorted { a, b -> a.name.compareTo(b.name) }.toList()
+                }
+            } catch (e: IOException) {
+                throw IOException("Failed to list directory: $directory", e)
             }
         }
 
@@ -184,6 +186,7 @@ public object JVMFileSystemProvider {
          * @param path the path of the file to read, which must be a regular file and must exist.
          * @return a ByteArray containing the contents of the file.
          * @throws IllegalArgumentException if the specified path is not a regular file or does not exist.
+         * @throws IOException if an I/O error occurs during reading.
          */
         override suspend fun read(path: Path): ByteArray {
             require(path.exists()) { "Path must exist" }
@@ -197,8 +200,12 @@ public object JVMFileSystemProvider {
          *
          * @param path The file path from which the source will be opened.
          * @return A buffered source for reading from the file.
+         * @throws IllegalArgumentException if [path] doesn't exist or isn't a regular file.
+         * @throws IOException if an I/O error occurs during source creation.
          */
         override suspend fun source(path: Path): Source = withContext(Dispatchers.IO) {
+            require(path.exists()) { "Path must exist" }
+            require(path.isRegularFile()) { "Path must be a regular file" }
             SystemFileSystem.source(path = kotlinx.io.files.Path(path.pathString)).buffered()
         }
 
@@ -208,8 +215,8 @@ public object JVMFileSystemProvider {
          * @param path the path to the file whose size is to be obtained.
          * Must be a regular file and exist.
          * @return the size of the file in bytes.
-         * @throws IllegalArgumentException if the provided path is not a regular file.
-         * @throws IllegalArgumentException if the provided path does not exist.
+         * @throws IllegalArgumentException if [path] doesn't exist or isn't a regular file.
+         * @throws IOException if an I/O error occurs while determining the file size.
          */
         override suspend fun size(path: Path): Long {
             require(path.exists()) { "Path must exist" }
@@ -417,10 +424,17 @@ public object JVMFileSystemProvider {
          *
          * @param source The source path of the file or directory to be moved.
          * @param target The target path where the file or directory should be moved.
-         * @throws IOException If the source path is neither a file nor a directory, or if any IO error occurs.
+         * @throws IOException f the source path is neither a file nor a directory, or if any IO error occurs.
+         * @throws FileAlreadyExistsException if [target] already exists.
+         * @throws IllegalArgumentException if [source] doesn't exist.
          */
         override suspend fun move(source: Path, target: Path) {
             withContext(Dispatchers.IO) {
+                if (target.exists()) {
+                    throw FileAlreadyExistsException("Target path already exists: $target")
+                }
+                require(source.exists()) { "Source path does not exist" }
+
                 if (source.isDirectory()) {
                     target.createDirectories()
                     Files.list(source).use { stream ->
@@ -431,6 +445,7 @@ public object JVMFileSystemProvider {
                     }
                     source.deleteExisting()
                 } else if (source.isRegularFile()) {
+                    target.createParentDirectories()
                     source.moveTo(target)
                 } else {
                     throw IOException("Source path is neither a file nor a directory: $source")

--- a/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
+++ b/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
@@ -28,15 +28,6 @@ public object JVMFileSystemProvider {
      */
     public object Serialization : FileSystemProvider.Serialization<Path> {
         /**
-         * Converts the given [Path] to a normalized string representation.
-         * This function is deprecated and should be replaced by the `toAbsolutePathString` method.
-         *
-         * @param path the [Path] to be converted to a string
-         * @return the string representation of the normalized [Path]
-         */
-        @Deprecated("Use toAbsolutePathString instead", replaceWith = ReplaceWith("toAbsolutePathString(path)"))
-        override fun toPathString(path: Path): String = path.normalize().pathString
-        /**
          * Converts the given [path] to its absolute path representation as a string.
          * The path is normalized before being converted.
          *
@@ -67,14 +58,14 @@ public object JVMFileSystemProvider {
          * @param path the file path from which to extract the name
          * @return the name of the file or directory represented by the provided path
          */
-        override suspend fun name(path: Path): String = path.name
+        override fun name(path: Path): String = path.name
         /**
          * Retrieves the file extension of the specified path.
          *
          * @param path the path from which to extract the file extension.
          * @return the file extension as a string.
          */
-        override suspend fun extension(path: Path): String = path.extension
+        override fun extension(path: Path): String = path.extension
 
         /**
          * Converts a given file path to a system-dependent format by replacing universal separators
@@ -125,11 +116,12 @@ public object JVMFileSystemProvider {
         /**
          * Retrieves a sorted list of paths within the specified directory.
          *
-         * @param path The directory path whose contents are to be listed.
+         * @param directory The directory path whose contents are to be listed.
          * @return A list of paths within the specified directory, sorted by name.
          *         Returns an empty list if an error occurs or the directory is empty.
          */
-        override suspend fun list(path: Path): List<Path> = runCatching { Files.list(path).use {
+        override suspend fun list(directory: Path): List<Path> = runCatching {
+            Files.list(directory).use {
             it.sorted { a, b -> a.name.compareTo(b.name) }.toList()
         }}.getOrElse { emptyList() }
 
@@ -139,18 +131,7 @@ public object JVMFileSystemProvider {
          * @param path the path for which to retrieve the parent directory
          * @return the parent path if it exists, or null if the path does not have a parent
          */
-        override suspend fun parent(path: Path): Path? = path.parent
-
-        /**
-         * Computes the relative path from the specified root to the given path.
-         *
-         * @param root The root path to which the relative computation is performed.
-         * @param path The path for which the relative computation is performed.
-         * @return The relative path as a string, or null if the relative computation is not possible.
-         */
-        @Deprecated("Use relativize instead", replaceWith = ReplaceWith("relativize(root, path)"))
-        override suspend fun relative(root: Path, path: Path): String? =
-            path.relativeToOrNull(root)?.normalize()?.pathString
+        override fun parent(path: Path): Path? = path.parent
 
         /**
          * Computes the relative path from the given root to the specified path.
@@ -159,7 +140,7 @@ public object JVMFileSystemProvider {
          * @param path the path for which the relative path needs to be determined.
          * @return the relative path from the root to the given path as a normalized string, or null if the paths have no common prefix.
          */
-        override suspend fun relativize(root: Path, path: Path): String? {
+        override fun relativize(root: Path, path: Path): String? {
             return path.relativeToOrNull(root)?.normalize()?.pathString
         }
 
@@ -227,15 +208,6 @@ public object JVMFileSystemProvider {
         FileSystemProvider.Read<Path> by Read {
 
         /**
-         * Converts the specified [path] to its string representation.
-         *
-         * @param path the file system path to convert to a string.
-         * @return the string representation of the specified path.
-         * @deprecated Use toAbsolutePathString instead.
-         */
-        @Deprecated("Use toAbsolutePathString instead", replaceWith = ReplaceWith("toAbsolutePathString(path)"))
-        override fun toPathString(path: Path): String = Serialization.toPathString(path)
-        /**
          * Converts the given Path to its absolute path string representation.
          *
          * @param path the path to be converted to an absolute path string
@@ -265,14 +237,14 @@ public object JVMFileSystemProvider {
          * @param path the Path object from which the name will be extracted.
          * @return the name of the provided path as a String.
          */
-        override suspend fun name(path: Path): String = Serialization.name(path)
+        override fun name(path: Path): String = Serialization.name(path)
         /**
          * Retrieves the file extension from the specified path using the serialization logic.
          *
          * @param path The path from which to extract the file extension.
          * @return The file extension as a string.
          */
-        override suspend fun extension(path: Path): String = Serialization.extension(path)
+        override fun extension(path: Path): String = Serialization.extension(path)
 
     }
 
@@ -287,15 +259,6 @@ public object JVMFileSystemProvider {
         FileSystemProvider.ReadOnly<Path> by ReadOnly,
         FileSystemProvider.Write<Path> by Write {
 
-        /**
-         * Converts the given [path] to its string representation.
-         * The method is deprecated and it is recommended to use `toAbsolutePathString` instead.
-         *
-         * @param path the path to be converted to a string.
-         * @return the string representation of the provided path.
-         */
-        @Deprecated("Use toAbsolutePathString instead", replaceWith = ReplaceWith("toAbsolutePathString(path)"))
-        override fun toPathString(path: Path): String = Serialization.toPathString(path)
         /**
          * Converts the specified [path] to its absolute path represented as a string.
          *
@@ -324,14 +287,14 @@ public object JVMFileSystemProvider {
          * @param path the path from which the name should be extracted
          * @return the name of the file or directory as a string
          */
-        override suspend fun name(path: Path): String = Serialization.name(path)
+        override fun name(path: Path): String = Serialization.name(path)
         /**
          * Gets the extension of the file represented by the given path.
          *
          * @param path The path of the file whose extension is to be determined.
          * @return The file extension as a string.
          */
-        override suspend fun extension(path: Path): String = Serialization.extension(path)
+        override fun extension(path: Path): String = Serialization.extension(path)
     }
 
     /**

--- a/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
+++ b/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
@@ -57,14 +57,9 @@ public object JVMFileSystemProvider {
          * @param base The base path against which the relative path will be resolved.
          * @param path The relative path as a string to be resolved.
          * @return A normalized Path object representing the resolved path.
-         * @throws IllegalArgumentException if the path is absolute, except for the root path.
+         * @throws IllegalArgumentException if [path] is absolute.
          */
         override fun fromRelativeString(base: Path, path: String): Path {
-            if (path == FileSystems.getDefault().separator) {
-                val rootPath = (base.root ?: base.absolute().root).toString()
-                return fromAbsoluteString(rootPath)
-            }
-
             val resolvedPath = Path.of(path)
             require(!resolvedPath.isAbsolute) { "Path must be relative, but was absolute: $path" }
             return base.resolve(path).normalize()

--- a/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
+++ b/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
@@ -174,8 +174,8 @@ public object JVMFileSystemProvider {
          * @throws IllegalArgumentException if the specified path is not a regular file or does not exist.
          */
         override suspend fun read(path: Path): ByteArray {
-            require(path.isRegularFile()) { "Path must be a regular file" }
             require(path.exists()) { "Path must exist" }
+            require(path.isRegularFile()) { "Path must be a regular file" }
 
             return withContext(Dispatchers.IO) { path.readBytes() }
         }
@@ -196,8 +196,8 @@ public object JVMFileSystemProvider {
          * @throws IllegalArgumentException if the provided path does not exist.
          */
         override suspend fun size(path: Path): Long {
-            require(path.isRegularFile()) { "Path must be a regular file" }
             require(path.exists()) { "Path must exist" }
+            require(path.isRegularFile()) { "Path must be a regular file" }
             return withContext(Dispatchers.IO) { path.fileSize() }
         }
     }

--- a/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
+++ b/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
@@ -61,7 +61,8 @@ public object JVMFileSystemProvider {
          */
         override fun fromRelativeString(base: Path, path: String): Path {
             if (path == FileSystems.getDefault().separator) {
-                return base.root ?: base.absolute().root
+                val rootPath = (base.root ?: base.absolute().root).toString()
+                return fromAbsoluteString(rootPath)
             }
 
             val resolvedPath = Path.of(path)

--- a/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
+++ b/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
@@ -14,6 +14,7 @@ import java.nio.charset.Charset
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.NoSuchFileException
 import kotlin.io.path.*
 import kotlin.use
 
@@ -447,6 +448,7 @@ public object JVMFileSystemProvider {
          *
          * @param parent The parent path in which the file or directory resides.
          * @param name The name of the file or directory to be deleted.
+         * @throws NoSuchFileException if a file or directory doesn't exist.
          */
         @OptIn(ExperimentalPathApi::class)
         override suspend fun delete(parent: Path, name: String) {

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -6,16 +6,16 @@ import kotlinx.io.writeString
 import org.jetbrains.annotations.TestOnly
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.condition.EnabledOnOs
 import org.junit.jupiter.api.condition.OS
 import java.io.File
+import java.io.FileNotFoundException
 import java.io.IOException
-import java.nio.file.FileSystems
-import java.nio.file.Files
-import java.nio.file.InvalidPathException
-import java.nio.file.Path
+import java.nio.file.*
 import kotlin.io.path.*
 import kotlin.test.assertContentEquals
+import kotlin.test.assertNull
 
 class JVMFileSystemProviderTest : KoogTestBase() {
     private val serialization = JVMFileSystemProvider.Serialization
@@ -95,7 +95,7 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     fun `test from relative string with absolute path`() {
         val absolutePath = file1.absolute().pathString
         val fileFromPath = serialization.fromRelativeString(src3, absolutePath)
-        
+
         // If the path is absolute, the base path should be ignored
         val expectedPath = serialization.fromAbsoluteString(absolutePath)
         assertEquals(expectedPath, fileFromPath)
@@ -173,6 +173,12 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     }
 
     @Test
+    fun `test parent with non-existing path`() = runBlocking {
+        val testParent = select.parent(Path.of("non-existing-path"))
+        assertNull(testParent)
+    }
+
+    @Test
     fun `test relative`() = runBlocking {
         val target = resource1
         val targetParent = src1
@@ -181,20 +187,17 @@ class JVMFileSystemProviderTest : KoogTestBase() {
         val testPath = select.relativize(targetParent, target)
         assertEquals(expectedRelativePath, testPath)
     }
+
+    @Test
+    fun `test relative with no common prefix`() = runBlocking {
+        val target = src1
+        val targetParent = Path.of("non-existing-path")
+        val testPath = select.relativize(targetParent, target)
+        assertNull(testPath)
+    }
     //endregion
 
     //region FileSystemProvider.Read
-    @Test
-    fun `test read throws IOException when file doesn't exist`() {
-        val testFile = dirEmpty.resolve("non-existing-file.txt")
-
-        assertThrows(IllegalArgumentException::class.java) {
-            runBlocking {
-                read.read(testFile)
-            }
-        }
-    }
-
     @Test
     fun `test extension`() = runBlocking {
         val testExtension = select.extension(file1)
@@ -258,14 +261,14 @@ class JVMFileSystemProviderTest : KoogTestBase() {
 
     @Test
     fun `test read dir`() {
-        assertThrows(Exception::class.java) {
+        assertThrows(IllegalArgumentException::class.java) {
             runBlocking { read.read(dir2) }
         }
     }
 
     @Test
     fun `test read not exist`() {
-        assertThrows(Exception::class.java) {
+        assertThrows(IllegalArgumentException::class.java) {
             runBlocking { read.read(Path.of(file1.pathString + "fake")) }
         }
     }
@@ -309,6 +312,17 @@ class JVMFileSystemProviderTest : KoogTestBase() {
         }
         assertEquals(testCode, actualContent)
     }
+
+    @Test
+    fun `test source method read non-existing file`() {
+        assertThrows<FileNotFoundException>() {
+            runBlocking {
+                read.source(Path.of(file1.pathString + "fake")).use { source ->
+                    source.readString()
+                }
+            }
+        }
+    }
     //endregion
 
     //region JVMFileSystemProvider.Write
@@ -323,6 +337,28 @@ class JVMFileSystemProviderTest : KoogTestBase() {
             }
         }
     }
+
+    @Test
+    fun `test move throws FileAlreadyExistsException when target file already exists`() {
+        val sourcePath = dirEmpty.resolve("source-file.txt").apply {
+            createFile()
+            writeText("source content")
+        }
+        val targetPath = dirEmpty.resolve("target-file.txt").apply {
+            createFile()
+            writeText("target content")
+        }
+
+        assertTrue(sourcePath.exists())
+        assertTrue(targetPath.exists())
+
+        assertThrows(FileAlreadyExistsException::class.java) {
+            runBlocking {
+                write.move(sourcePath, targetPath)
+            }
+        }
+    }
+
 
     @Test
     fun `test create file`() {
@@ -343,7 +379,7 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     fun `test create already existing file`() {
         val parent = dir1.parent
         val fileName = "newFile.txt"
-        assertThrows(IOException::class.java) {
+        assertThrows(FileAlreadyExistsException::class.java) {
             runBlocking {
                 write.create(parent, fileName, FileMetadata.FileType.File)
                 write.create(parent, fileName, FileMetadata.FileType.File)
@@ -356,7 +392,7 @@ class JVMFileSystemProviderTest : KoogTestBase() {
         val dirPath = dirEmpty
         assertEmpty(dirPath.listDirectoryEntries())
         val fileName = "Dir" + String(byteArrayOf(0))
-        assertThrows(Exception::class.java) {
+        assertThrows(InvalidPathException::class.java) {
             runBlocking { write.create(dirEmpty, fileName, FileMetadata.FileType.File) }
         }
         assertEmpty(dirPath.listDirectoryEntries())
@@ -535,6 +571,27 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     }
 
     @Test
+    fun `test sink to non-existing directory and file`() = runBlocking {
+        val dirPath = dirEmpty
+        val nonExistingDir = dirPath.resolve("non-existing-dir")
+        val fileName = "newFile.txt"
+        val filePath = nonExistingDir.resolve(fileName)
+
+        assertFalse(nonExistingDir.exists())
+        assertFalse(filePath.exists())
+
+        val testContent = "Test content for non-existing file"
+        write.sink(filePath, false).use { sink ->
+            sink.writeString(testContent)
+            sink.flush()
+        }
+
+        assertTrue(nonExistingDir.exists())
+        assertTrue(filePath.exists())
+        assertEquals(testContent, filePath.readText())
+    }
+
+    @Test
     fun `test write to a file with sink with not-append mode`() = runBlocking {
         val dirPath = dirEmpty
 
@@ -632,7 +689,8 @@ class JVMFileSystemProviderTest : KoogTestBase() {
 
     @Test
     fun `test ReadOnly metadata`() = runBlocking {
-        val metadata = FileMetadata(FileMetadata.FileType.File, hidden = false, content = FileMetadata.FileContent.Text)
+        val metadata =
+            FileMetadata(FileMetadata.FileType.File, hidden = false, content = FileMetadata.FileContent.Text)
         val testMetadata = readOnly.metadata(file1)
         assertEquals(metadata, testMetadata)
     }
@@ -722,7 +780,8 @@ class JVMFileSystemProviderTest : KoogTestBase() {
 
     @Test
     fun `test ReadWrite metadata`() = runBlocking {
-        val metadata = FileMetadata(FileMetadata.FileType.File, hidden = false, content = FileMetadata.FileContent.Text)
+        val metadata =
+            FileMetadata(FileMetadata.FileType.File, hidden = false, content = FileMetadata.FileContent.Text)
         val testMetadata = readWrite.metadata(file1)
         assertEquals(metadata, testMetadata)
     }
@@ -812,6 +871,24 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     }
 
     @Test
+    fun `test ReadWrite write to non-existing directory`() = runBlocking {
+        val dirPath = dirEmpty
+        val nonExistingDir = dirPath.resolve("non-existing-dir")
+        val fileName = "newFile.txt"
+        val filePath = nonExistingDir.resolve(fileName)
+
+        assertFalse(nonExistingDir.exists())
+        assertFalse(filePath.exists())
+
+        val testContent = "Test content for non-existing file"
+        readWrite.write(filePath, testContent.toByteArray())
+
+        assertTrue(nonExistingDir.exists())
+        assertTrue(filePath.exists())
+        assertEquals(testContent, filePath.readText())
+    }
+
+    @Test
     fun `test ReadWrite sink`() = runBlocking {
         val dirPath = dirEmpty
         val fileName = "newFileReadWriteSink.txt"
@@ -869,6 +946,18 @@ class JVMFileSystemProviderTest : KoogTestBase() {
 
         assertFalse(filePath.exists())
     }
+
+    @Test
+    fun `test ReadWrite delete with non-existing file`() {
+        val dirPath = dirEmpty
+        val fileName = dirPath.resolve("non-existing.txt").fileName.toString()
+        assertThrows(NoSuchFileException::class.java) {
+            runBlocking {
+                readWrite.delete(dirPath, fileName)
+            }
+        }
+    }
+
     //endregion
 
     @TestOnly

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -85,8 +85,9 @@ class JVMFileSystemProviderTest : KoogTestBase() {
 
     @Test
     fun `test from relative string to root`() {
-        val rootPath = serialization.fromRelativeString(file3, FileSystems.getDefault().separator)
-        assertEquals(getRoot(file3), rootPath)
+        assertThrows(IllegalArgumentException::class.java) {
+            serialization.fromRelativeString(file3, FileSystems.getDefault().separator)
+        }
     }
 
     @Test
@@ -691,8 +692,9 @@ class JVMFileSystemProviderTest : KoogTestBase() {
 
     @Test
     fun `test ReadOnly fromRelativeString to root`() {
-        val rootPath = readOnly.fromRelativeString(file3, FileSystems.getDefault().separator)
-        assertEquals(getRoot(file3), rootPath)
+        assertThrows(IllegalArgumentException::class.java) {
+            readOnly.fromRelativeString(file3, FileSystems.getDefault().separator)
+        }
     }
 
     @Test
@@ -788,8 +790,9 @@ class JVMFileSystemProviderTest : KoogTestBase() {
 
     @Test
     fun `test ReadWrite fromRelativeString to root`() {
-        val rootPath = readWrite.fromRelativeString(file3, FileSystems.getDefault().separator)
-        assertEquals(getRoot(file3), rootPath)
+        assertThrows(IllegalArgumentException::class.java) {
+            readWrite.fromRelativeString(file3, FileSystems.getDefault().separator)
+        }
     }
 
     @Test

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -84,7 +84,7 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     }
 
     @Test
-    fun `test from relative string to root`() {
+    fun `test from relative string with absolute path`() {
         val absolutePath = file1.absolute().pathString
         assertThrows(IllegalArgumentException::class.java) {
             serialization.fromRelativeString(file3, absolutePath)
@@ -692,7 +692,7 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     }
 
     @Test
-    fun `test ReadOnly fromRelativeString to root`() {
+    fun `test ReadOnly fromRelativeString with absolute path`() {
         val absolutePath = file1.absolute().pathString
         assertThrows(IllegalArgumentException::class.java) {
             readOnly.fromRelativeString(file3, absolutePath)
@@ -791,7 +791,7 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     }
 
     @Test
-    fun `test ReadWrite fromRelativeString to root`() {
+    fun `test ReadWrite fromRelativeString with absolute path`() {
         val absolutePath = file1.absolute().pathString
         assertThrows(IllegalArgumentException::class.java) {
             readWrite.fromRelativeString(file3, absolutePath)

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -58,7 +58,7 @@ class JVMFileSystemProviderTest : KoogTestBase() {
         val relativePathString = "relative/test/path"
         val resolvedPath = serialization.fromAbsoluteString(relativePathString)
 
-        val normalizedPath = resolvedPath.toString().normalizeForAssertion()
+        val normalizedPath = resolvedPath.toString().replace("\\", "/")
         assertEquals(relativePathString, normalizedPath)
     }
 

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -83,6 +83,7 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     //endregion
 
     //region JVMFileSystemProvider.Select
+
     @Test
     fun `test list dir sorted`() = runBlocking {
         val testList = select.list(resources)
@@ -163,6 +164,17 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     //endregion
 
     //region FileSystemProvider.Read
+    @Test
+    fun `test read throws IOException when file doesn't exist`() {
+        val testFile = dirEmpty.resolve("non-existing-file.txt")
+
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking {
+                read.read(testFile)
+            }
+        }
+    }
+
     @Test
     fun `test extension`() = runBlocking {
         val testExtension = select.extension(file1)
@@ -280,6 +292,18 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     //endregion
 
     //region JVMFileSystemProvider.Write
+    @Test
+    fun `test move throws IOException when source file doesn't exist`() {
+        val sourcePath = dirEmpty.resolve("non-existing-file.txt")
+        val targetPath = dirEmpty.resolve("target-path")
+
+        assertThrows(IOException::class.java) {
+            runBlocking {
+                write.move(sourcePath, targetPath)
+            }
+        }
+    }
+
     @Test
     fun `test create file`() {
         runBlocking {

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -58,7 +58,8 @@ class JVMFileSystemProviderTest : KoogTestBase() {
         val relativePathString = "relative/test/path"
         val resolvedPath = serialization.fromAbsoluteString(relativePathString)
 
-        assertEquals(relativePathString, resolvedPath.toString())
+        val normalizedPath = resolvedPath.toString().normalizeForAssertion()
+        assertEquals(relativePathString, normalizedPath)
     }
 
     @Test

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -360,6 +360,24 @@ class JVMFileSystemProviderTest : KoogTestBase() {
 
     //region JVMFileSystemProvider.Write
     @Test
+    fun `test write method overwrites existing file content`() = runBlocking {
+        val dirPath = dirEmpty
+        val fileName = "fileToOverwrite.txt"
+        val filePath = Path.of(dirPath.pathString + FileSystems.getDefault().separator + fileName)
+
+        val initialContent = "Initial content"
+        filePath.writeText(initialContent)
+        assertEquals(initialContent, filePath.readText())
+
+        val newContent = "New content"
+        write.write(filePath, newContent.toByteArray())
+
+        val actualContent = filePath.readText()
+        assertEquals(newContent, actualContent)
+        assertFalse(actualContent.contains(initialContent), "File contents should be overwritten")
+    }
+
+    @Test
     fun `test move throws IOException when source file doesn't exist`() {
         val sourcePath = dirEmpty.resolve("non-existing-file.txt")
         val targetPath = dirEmpty.resolve("target-path")
@@ -900,7 +918,7 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     }
 
     @Test
-    fun `test ReadWrite write`() = runBlocking {
+    fun `ReadWrite should create missing file when needed`() = runBlocking {
         val dirPath = dirEmpty
         val fileName = "newFileReadWrite.txt"
         val tempFilePath = Path.of(dirPath.pathString + FileSystems.getDefault().separator + fileName)

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.condition.EnabledOnOs
 import org.junit.jupiter.api.condition.OS
 import java.io.File
-import java.io.FileNotFoundException
 import java.io.IOException
 import java.nio.file.*
 import kotlin.io.path.*
@@ -348,9 +347,20 @@ class JVMFileSystemProviderTest : KoogTestBase() {
 
     @Test
     fun `test source method read non-existing file`() {
-        assertThrows<FileNotFoundException>() {
+        assertThrows<IllegalArgumentException>() {
             runBlocking {
                 read.source(Path.of(file1.pathString + "fake")).use { source ->
+                    source.readString()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `test source method read directory`() {
+        assertThrows<IllegalArgumentException>() {
+            runBlocking {
+                read.source(dir2).use { source ->
                     source.readString()
                 }
             }
@@ -382,7 +392,7 @@ class JVMFileSystemProviderTest : KoogTestBase() {
         val sourcePath = dirEmpty.resolve("non-existing-file.txt")
         val targetPath = dirEmpty.resolve("target-path")
 
-        assertThrows(IOException::class.java) {
+        assertThrows(IllegalArgumentException::class.java) {
             runBlocking {
                 write.move(sourcePath, targetPath)
             }
@@ -659,7 +669,7 @@ class JVMFileSystemProviderTest : KoogTestBase() {
         }
 
         val actualContent = tempFilePath.readText()
-        
+
         assertAll(
             {
                 assertEquals(
@@ -820,6 +830,28 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     }
 
     @Test
+    fun `test ReadOnly source with non-existing file`() {
+        assertThrows<IllegalArgumentException>() {
+            runBlocking {
+                readOnly.source(Path.of(file1.pathString + "fake")).use { source ->
+                    source.readString()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `test ReadOnly source with directory`() {
+        assertThrows<IllegalArgumentException>() {
+            runBlocking {
+                readOnly.source(dir2).use { source ->
+                    source.readString()
+                }
+            }
+        }
+    }
+
+    @Test
     fun `test ReadOnly size`() = runBlocking {
         val size = readOnly.size(file1)
         assertTrue(size > 0) { "Expected size more than a zero, but was $size" }
@@ -916,6 +948,28 @@ class JVMFileSystemProviderTest : KoogTestBase() {
             source.readString()
         }
         assertEquals(testCode, actualContent)
+    }
+
+    @Test
+    fun `test ReadWrite source with non-existing file`() {
+        assertThrows<IllegalArgumentException>() {
+            runBlocking {
+                readWrite.source(Path.of(file1.pathString + "fake")).use { source ->
+                    source.readString()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `test ReadWrite source with directory`() {
+        assertThrows<IllegalArgumentException>() {
+            runBlocking {
+                readWrite.source(dir2).use { source ->
+                    source.readString()
+                }
+            }
+        }
     }
 
     @Test

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -55,19 +55,11 @@ class JVMFileSystemProviderTest : KoogTestBase() {
 
     @Test
     fun `test relative path from absolute string`() {
-        // Create a relative path string (without leading slash)
         val relativePathString = "relative/test/path"
-
-        // Call fromAbsoluteString with the relative path
         val resolvedPath = serialization.fromAbsoluteString(relativePathString)
-
-        // Get the expected path by resolving against the current working directory
         val expectedPath = Path.of("").toAbsolutePath().resolve(relativePathString).normalize()
 
-        // Verify that the method returns a Path object resolved against the current working directory
         assertEquals(expectedPath, resolvedPath)
-
-        // Verify that the path is now absolute (resolved against current working directory)
         assertTrue(resolvedPath.isAbsolute)
     }
 
@@ -97,6 +89,16 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     fun `test from relative string to root`() {
         val rootPath = serialization.fromRelativeString(file3, FileSystems.getDefault().separator)
         assertEquals(getRoot(file3), rootPath)
+    }
+
+    @Test
+    fun `test from relative string with absolute path`() {
+        val absolutePath = file1.absolute().pathString
+        val fileFromPath = serialization.fromRelativeString(src3, absolutePath)
+        
+        // If the path is absolute, the base path should be ignored
+        val expectedPath = serialization.fromAbsoluteString(absolutePath)
+        assertEquals(expectedPath, fileFromPath)
     }
     //endregion
 

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -48,9 +48,17 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     }
 
     @Test
-    fun `test fake path from absolute string`() {
-        val filePathString = file1.absolute().pathString + "fake"
-        assertNotNull(serialization.fromAbsoluteString(filePathString))
+    fun `test fromAbsoluteString with non-existent path`() {
+        val nonExistentPath = file1.absolute().pathString + "non_existent"
+        val result = serialization.fromAbsoluteString(nonExistentPath).toString()
+        assertEquals(nonExistentPath, result)
+    }
+
+    @Test
+    fun `test toAbsolutePathString with non-existent path`() {
+        val nonExistentPath = Path.of(file1.absolute().pathString + "non_existent")
+        val result = serialization.toAbsolutePathString(nonExistentPath)
+        assertEquals(nonExistentPath.toString(), result)
     }
 
     @Test
@@ -99,6 +107,15 @@ class JVMFileSystemProviderTest : KoogTestBase() {
             serialization.fromRelativeString(src3, absolutePath)
         }
     }
+
+    @Test
+    fun `test fromRelativeString with non-existent path`() {
+        val nonExistentRelativePath = "non_existent_folder/non_existent_file.txt"
+        val result = serialization.fromRelativeString(src1, nonExistentRelativePath)
+        assertTrue(result.pathString.contains("non_existent_folder"))
+        assertTrue(result.pathString.contains("non_existent_file.txt"))
+    }
+
     //endregion
 
     //region JVMFileSystemProvider.Select

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -870,7 +870,7 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     }
 
     @Test
-    fun `test ReadWrite write to non-existing directory`() = runBlocking {
+    fun `ReadWrite should create missing directory when needed`() = runBlocking {
         val dirPath = dirEmpty
         val nonExistingDir = dirPath.resolve("non-existing-dir")
         val fileName = "newFile.txt"

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -690,6 +690,12 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     }
 
     @Test
+    fun `test ReadOnly fromRelativeString to root`() {
+        val rootPath = readOnly.fromRelativeString(file3, FileSystems.getDefault().separator)
+        assertEquals(getRoot(file3), rootPath)
+    }
+
+    @Test
     fun `test ReadOnly name`() = runBlocking {
         val testName = readOnly.name(file1)
         assertEquals("TestGenerator.kt", testName)
@@ -778,6 +784,12 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     fun `test ReadWrite fromRelativeString`() {
         val fileFullPath = readWrite.fromRelativeString(src1, file1.name)
         assertEquals(file1, fileFullPath)
+    }
+
+    @Test
+    fun `test ReadWrite fromRelativeString to root`() {
+        val rootPath = readWrite.fromRelativeString(file3, FileSystems.getDefault().separator)
+        assertEquals(getRoot(file3), rootPath)
     }
 
     @Test

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -57,10 +57,8 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     fun `test relative path from absolute string`() {
         val relativePathString = "relative/test/path"
         val resolvedPath = serialization.fromAbsoluteString(relativePathString)
-        val expectedPath = Path.of("").toAbsolutePath().resolve(relativePathString).normalize()
 
-        assertEquals(expectedPath, resolvedPath)
-        assertTrue(resolvedPath.isAbsolute)
+        assertEquals(relativePathString, resolvedPath.toString())
     }
 
     @Test

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -965,11 +965,16 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     fun `test ReadWrite delete with non-existing file`() {
         val dirPath = dirEmpty
         val fileName = dirPath.resolve("non-existing.txt").fileName.toString()
-        assertThrows(NoSuchFileException::class.java) {
+        val exception = assertThrows(NoSuchFileException::class.java) {
             runBlocking {
                 readWrite.delete(dirPath, fileName)
             }
         }
+        val expectedPath = dirPath.resolve(fileName).toString()
+        assertTrue(
+            exception.message?.contains(expectedPath) == true,
+            "Exception message should contain the file path: $expectedPath, but was: ${exception.message}"
+        )
     }
 
     //endregion

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -85,8 +85,9 @@ class JVMFileSystemProviderTest : KoogTestBase() {
 
     @Test
     fun `test from relative string to root`() {
+        val absolutePath = file1.absolute().pathString
         assertThrows(IllegalArgumentException::class.java) {
-            serialization.fromRelativeString(file3, FileSystems.getDefault().separator)
+            serialization.fromRelativeString(file3, absolutePath)
         }
     }
 
@@ -692,8 +693,9 @@ class JVMFileSystemProviderTest : KoogTestBase() {
 
     @Test
     fun `test ReadOnly fromRelativeString to root`() {
+        val absolutePath = file1.absolute().pathString
         assertThrows(IllegalArgumentException::class.java) {
-            readOnly.fromRelativeString(file3, FileSystems.getDefault().separator)
+            readOnly.fromRelativeString(file3, absolutePath)
         }
     }
 
@@ -790,8 +792,9 @@ class JVMFileSystemProviderTest : KoogTestBase() {
 
     @Test
     fun `test ReadWrite fromRelativeString to root`() {
+        val absolutePath = file1.absolute().pathString
         assertThrows(IllegalArgumentException::class.java) {
-            readWrite.fromRelativeString(file3, FileSystems.getDefault().separator)
+            readWrite.fromRelativeString(file3, absolutePath)
         }
     }
 

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -61,14 +61,14 @@ class JVMFileSystemProviderTest : KoogTestBase() {
         // Call fromAbsoluteString with the relative path
         val resolvedPath = serialization.fromAbsoluteString(relativePathString)
 
-        // Get the expected path by using Path.of directly
-        val expectedPath = Path.of(relativePathString).normalize()
-        
-        // Verify that the method returns a Path object with the relative path
+        // Get the expected path by resolving against the current working directory
+        val expectedPath = Path.of("").toAbsolutePath().resolve(relativePathString).normalize()
+
+        // Verify that the method returns a Path object resolved against the current working directory
         assertEquals(expectedPath, resolvedPath)
 
-        // Verify that the path is still relative (not absolute)
-        assertFalse(resolvedPath.isAbsolute)
+        // Verify that the path is now absolute (resolved against current working directory)
+        assertTrue(resolvedPath.isAbsolute)
     }
 
     @Test

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -54,12 +54,11 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     }
 
     @Test
-    fun `test relative path from absolute string`() {
+    fun `test fromAbsoluteString throws exception when resolved path is not absolute`() {
         val relativePathString = "relative/test/path"
-        val resolvedPath = serialization.fromAbsoluteString(relativePathString)
-
-        val normalizedPath = resolvedPath.toString().replace("\\", "/")
-        assertEquals(relativePathString, normalizedPath)
+        assertThrows(IllegalArgumentException::class.java) {
+            serialization.fromAbsoluteString(relativePathString)
+        }
     }
 
     @Test
@@ -91,13 +90,12 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     }
 
     @Test
-    fun `test from relative string with absolute path`() {
+    fun `test from relative string with absolute path throws exception`() {
         val absolutePath = file1.absolute().pathString
-        val fileFromPath = serialization.fromRelativeString(src3, absolutePath)
 
-        // If the path is absolute, the base path should be ignored
-        val expectedPath = serialization.fromAbsoluteString(absolutePath)
-        assertEquals(expectedPath, fileFromPath)
+        assertThrows(IllegalArgumentException::class.java) {
+            serialization.fromRelativeString(src3, absolutePath)
+        }
     }
     //endregion
 
@@ -117,21 +115,38 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     }
 
     @Test
-    fun `test list fake dir`() = runBlocking {
-        val testList = select.list(Path.of(dir1.pathString + "fake"))
-        assertEquals(emptyList<Path>(), testList)
+    fun `test list is not recursive`() = runBlocking {
+        // dir1 contains src1, which contains resources and file1
+        // We should only get src1 when listing dir1, not the nested contents
+        val testList = select.list(dir1)
+        assertEquals(listOf(src1), testList)
     }
 
     @Test
-    fun `test list text file`() = runBlocking {
-        val testList = select.list(file1.absolute())
-        assertEquals(emptyList<Path>(), testList)
+    fun `test list fake dir`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking {
+                select.list(Path.of(dir1.pathString + "fake"))
+            }
+        }
     }
 
     @Test
-    fun `test list zip`() = runBlocking {
-        val testList = select.list(zip1.absolute())
-        assertEquals(emptyList<Path>(), testList)
+    fun `test list text file`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking {
+                select.list(file1.absolute())
+            }
+        }
+    }
+
+    @Test
+    fun `test list zip`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking {
+                select.list(zip1.absolute())
+            }
+        }
     }
 
     @Test

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -643,56 +643,78 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     }
 
     @Test
-    fun `test write to a file with sink with not-append mode`() = runBlocking {
-        val dirPath = dirEmpty
-
+    fun `test write to a file with sink with overwrite mode`() = runBlocking {
         val fileName = "newFile.txt"
-        val tempFilePath = Path.of(dirPath.pathString + FileSystems.getDefault().separator + fileName)
-        tempFilePath.writeText("Hello")
+        val tempFilePath = Path.of(dirEmpty.pathString + FileSystems.getDefault().separator + fileName)
+        val initialContent = "Hello"
+        tempFilePath.writeText(initialContent)
 
         assertTrue(tempFilePath.exists())
-        assertEquals("Hello", tempFilePath.readText())
+        assertEquals(initialContent, tempFilePath.readText())
 
-        val testMessage = " world"
+        val newContent = " world"
         write.sink(tempFilePath, false).use { sink ->
-            sink.writeString(testMessage)
+            sink.writeString(newContent)
             sink.flush()
         }
 
-        val actualLines = tempFilePath.readLines()
-        val expectedLines = listOf(testMessage)
-
+        val actualContent = tempFilePath.readText()
+        
         assertAll(
-            { assertEquals(1, actualLines.size) { "Expected 1 line, but was ${actualLines.size}" } },
-            { assertContentEquals(expectedLines, actualLines) }
+            {
+                assertEquals(
+                    newContent,
+                    actualContent
+                ) { "Expected content to be overwritten with '$newContent', but was '$actualContent'" }
+            },
+            {
+                assertFalse(
+                    actualContent.contains(initialContent),
+                    "File should not contain the initial content when in overwrite mode"
+                )
+            }
         )
     }
 
     @Test
     fun `test write to a file with sink with append mode`() = runBlocking {
-        val dirPath = dirEmpty
-
         val fileName = "newFile.txt"
-        val tempFilePath = Path.of(dirPath.pathString + FileSystems.getDefault().separator + fileName)
+        val tempFilePath = Path.of(dirEmpty.pathString + FileSystems.getDefault().separator + fileName)
 
-        val testMessageHello = "Hello"
-        tempFilePath.writeText(testMessageHello)
+        val initialContent = "Hello"
+        tempFilePath.writeText(initialContent)
 
         assertTrue(tempFilePath.exists())
-        assertEquals(testMessageHello, tempFilePath.readText())
+        assertEquals(initialContent, tempFilePath.readText())
 
-        val testMessageWorld = " world"
+        val additionalContent = " world"
         write.sink(tempFilePath, true).use { sink ->
-            sink.writeString(testMessageWorld)
+            sink.writeString(additionalContent)
             sink.flush()
         }
 
-        val actualLines = tempFilePath.readLines()
-        val expectedLines = listOf(testMessageHello + testMessageWorld)
+        val expectedCombinedContent = initialContent + additionalContent
+        val actualContent = tempFilePath.readText()
 
         assertAll(
-            { assertEquals(1, actualLines.size) { "Expected 1 line, but was ${actualLines.size}" } },
-            { assertContentEquals(expectedLines, actualLines) }
+            {
+                assertEquals(
+                    expectedCombinedContent,
+                    actualContent
+                ) { "Expected content to be '$expectedCombinedContent', but was '$actualContent'" }
+            },
+            {
+                assertTrue(
+                    actualContent.startsWith(initialContent),
+                    "File should start with the initial content when in append mode"
+                )
+            },
+            {
+                assertTrue(
+                    actualContent.endsWith(additionalContent),
+                    "File should end with the additional content when in append mode"
+                )
+            }
         )
     }
 

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -54,6 +54,24 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     }
 
     @Test
+    fun `test relative path from absolute string`() {
+        // Create a relative path string (without leading slash)
+        val relativePathString = "relative/test/path"
+
+        // Call fromAbsoluteString with the relative path
+        val resolvedPath = serialization.fromAbsoluteString(relativePathString)
+
+        // Get the expected path by using Path.of directly
+        val expectedPath = Path.of(relativePathString).normalize()
+        
+        // Verify that the method returns a Path object with the relative path
+        assertEquals(expectedPath, resolvedPath)
+
+        // Verify that the path is still relative (not absolute)
+        assertFalse(resolvedPath.isAbsolute)
+    }
+
+    @Test
     fun `test to path string`() {
         val filePathString = file1.absolute().pathString
 

--- a/rag/vector-storage/src/commonTest/kotlin/ai/koog/rag/vector/mocks/MockDocumentProviders.kt
+++ b/rag/vector-storage/src/commonTest/kotlin/ai/koog/rag/vector/mocks/MockDocumentProviders.kt
@@ -45,31 +45,29 @@ class MockDocumentProvider(val mockFileSystem: MockFileSystem) : DocumentProvide
 }
 
 class MockFileSystemProvicer(val mockFileSystem: MockFileSystem) : FileSystemProvider.ReadWrite<String> {
-    override fun toPathString(path: String): String = path
-
     override fun toAbsolutePathString(path: String): String = path
 
     override fun fromAbsoluteString(path: String): String = path
 
     override fun fromRelativeString(base: String, path: String): String = "$base/$path"
 
-    override suspend fun name(path: String): String = path.substringAfterLast('/')
+    override fun name(path: String): String = path.substringAfterLast('/')
 
-    override suspend fun extension(path: String): String = path.substringAfterLast('.')
+    override fun extension(path: String): String = path.substringAfterLast('.')
 
     override suspend fun metadata(path: String): FileMetadata? = null
 
-    override suspend fun list(path: String): List<String> {
+    override suspend fun list(directory: String): List<String> {
         return mockFileSystem.documents
             .filter { (docPath, entry) ->
-                docPath.startsWith(path.removeSuffix("/")) && entry is MockDocument
+                docPath.startsWith(directory.removeSuffix("/")) && entry is MockDocument
             }
             .keys.toList()
     }
 
-    override suspend fun parent(path: String): String? = path.substringBeforeLast('/', "").ifEmpty { null }
+    override fun parent(path: String): String? = path.substringBeforeLast('/', "").ifEmpty { null }
 
-    override suspend fun relativize(root: String, path: String): String? =
+    override fun relativize(root: String, path: String): String? =
         if (path.startsWith(root)) path.removePrefix(root) else null
 
     override suspend fun exists(path: String): Boolean = path in mockFileSystem.documents


### PR DESCRIPTION
Some models compatible with the OpenAI API (e.g., GigaChat) do not return an id in their responses, which cause deserialization exception.