### PR TITLE
Openapi response fix - make `id` field optional

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/DataModel.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/DataModel.kt
@@ -120,7 +120,7 @@ internal data class OpenAIToolFunction(
 
 @Serializable
 internal data class OpenAIResponse(
-    val id: String,
+    val id: String? = null,
     @SerialName("object") val objectType: String,
     val created: Long,
     val model: String,


### PR DESCRIPTION
Some models compatible with the OpenAI API (e.g., GigaChat) do not return an id in their responses, which cause deserialization exception.