### PR TITLE
Fix memory retrieval documentation to reflect actual API behavior

### DIFF
--- a/agents/agents-features/agents-features-memory/README.md
+++ b/agents/agents-features/agents-features-memory/README.md
@@ -149,16 +149,17 @@ memoryProvider.save(
 ### Step 3: Retrieve the Fact
 ```kotlin
 // Get the stored information
-try {
-    val greeting = memoryProvider.load(
-        concept = Concept("greeting", "User's name", FactType.SINGLE),
-        subject = MemorySubjects.User
-    )
-    println("Retrieved: $greeting")
-} catch (e: MemoryNotFoundException) {
+val greetingFacts = memoryProvider.load(
+    concept = Concept("greeting", "User's name", FactType.SINGLE),
+    subject = MemorySubject.User
+)
+
+if (greetingFacts.isEmpty()) {
     println("Information not found. First time here?")
-} catch (e: Exception) {
-    println("Error accessing memory: ${e.message}")
+} else {
+    // For single facts, typically you'd access the first (and only) element
+    val greeting = (greetingFacts.first() as SingleFact).value
+    println("Retrieved: $greeting")
 }
 ```
 


### PR DESCRIPTION
This PR corrects the documentation example for retrieving facts from memory storage. The example was incorrectly showing exception handling for `MemoryNotFoundException`, but the [actual implementation](https://github.com/JetBrains/koog/blob/362ea10b5254ba782e6663a236fa56db5e11f17e/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/providers/LocalFileMemoryProvider.kt#L237-L241) returns an empty list when no facts are found.

- Updated Step 3 in the "Getting Started" section to check for empty list instead of using try-catch
- Added example of how to properly handle both empty and non-empty results
- Clarified that single facts should access the first element when the list is not empty

The previous documentation was misleading developers to expect an exception when no facts are found, which could lead to:
- Unnecessary try-catch blocks in user code
- Confusion when the expected exception is never thrown
- Incorrect error handling patterns

---

#### Type of the change
- [ ] New feature
- [ ] Bug fix
- [x] Documentation fix
- [ ] Tests improvement

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added **[N/A]**
- [x] All new and existing tests passed **[N/A]**

##### Additional steps for pull requests adding a new feature **[N/A]**
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
