### PR TITLE
Fix for urls generated from AzureOpenAIClientSettings

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/azure/Azure.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/azure/Azure.kt
@@ -18,7 +18,7 @@ public fun AzureOpenAIClientSettings(
     version: AzureOpenAIServiceVersion,
     timeoutConfig: ConnectionTimeoutConfig = ConnectionTimeoutConfig(),
 ): OpenAIClientSettings = AzureOpenAIClientSettings(
-    baseUrl = "https://$resourceName.openai.azure.com/openai/deployments/$deploymentName",
+    baseUrl = "https://$resourceName.openai.azure.com/openai/deployments/$deploymentName/",
     version = version,
     timeoutConfig = timeoutConfig,
 )
@@ -41,6 +41,6 @@ public fun AzureOpenAIClientSettings(
 ): OpenAIClientSettings = OpenAIClientSettings(
     baseUrl = baseUrl,
     timeoutConfig = timeoutConfig,
-    chatCompletionsPath = "/chat/completions?api-version=${version.value}",
-    embeddingsPath = "/embeddings?api-version=${version.value}",
+    chatCompletionsPath = "chat/completions?api-version=${version.value}",
+    embeddingsPath = "embeddings?api-version=${version.value}",
 )


### PR DESCRIPTION
mergeUrls function function from ktor.DefaultRequest is wrongly merging path segment if `chatCompletionsPath` and `
embeddingsPath` start with slash symbol.

And base url should also end with slash, so last part will not be dropped.


---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix
- [ ] Tests improvement

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
