### PR TITLE
Fix duplicated tool names in AIAgentSubgraphExt

### DIFF
--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
@@ -143,7 +143,7 @@ public object ProvideVerifiedSubgraphResult : ProvideSubgraphResult<VerifiedSubg
  * - Execution logic that returns the input `StringSubgraphResult` as output without transformation.
  *
  * Features:
- * - The `descriptor` describes the tool as "finish_task_execution" and requires a parameter named "result"
+ * - The `descriptor` describes the tool as "finish_task_execution_result" and requires a parameter named "result"
  *   representing the task result.
  * - The `execute` method processes the input argument and returns the result.
  */
@@ -151,7 +151,7 @@ public object ProvideStringSubgraphResult : ProvideSubgraphResult<StringSubgraph
     override val argsSerializer: KSerializer<StringSubgraphResult> = StringSubgraphResult.serializer()
 
     override val descriptor: ToolDescriptor = ToolDescriptor(
-        name = "finish_task_execution",
+        name = "finish_task_execution_result",
         description = "Please call this tool after you are sure that the task is completed. Verify if the task was completed correctly and provide additional information if there are problems.",
         requiredParameters = listOf(
             ToolParameterDescriptor(

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
@@ -109,7 +109,7 @@ public object ProvideVerifiedSubgraphResult : ProvideSubgraphResult<VerifiedSubg
     override val argsSerializer: KSerializer<VerifiedSubgraphResult> = VerifiedSubgraphResult.serializer()
 
     override val descriptor: ToolDescriptor = ToolDescriptor(
-        name = "finish_task_execution",
+        name = "finish_task_execution_verified",
         description = "Please call this tool after you are sure that the task is completed. Verify if the task was completed correctly and provide additional information if there are problems.",
         requiredParameters = listOf(
             ToolParameterDescriptor(
@@ -143,7 +143,7 @@ public object ProvideVerifiedSubgraphResult : ProvideSubgraphResult<VerifiedSubg
  * - Execution logic that returns the input `StringSubgraphResult` as output without transformation.
  *
  * Features:
- * - The `descriptor` describes the tool as "finish_task_execution_result" and requires a parameter named "result"
+ * - The `descriptor` describes the tool as "finish_task_execution_string" and requires a parameter named "result"
  *   representing the task result.
  * - The `execute` method processes the input argument and returns the result.
  */
@@ -151,7 +151,7 @@ public object ProvideStringSubgraphResult : ProvideSubgraphResult<StringSubgraph
     override val argsSerializer: KSerializer<StringSubgraphResult> = StringSubgraphResult.serializer()
 
     override val descriptor: ToolDescriptor = ToolDescriptor(
-        name = "finish_task_execution_result",
+        name = "finish_task_execution_string",
         description = "Please call this tool after you are sure that the task is completed. Verify if the task was completed correctly and provide additional information if there are problems.",
         requiredParameters = listOf(
             ToolParameterDescriptor(


### PR DESCRIPTION
Update the descriptor name to `finish_task_execution_result` in AIAgentSubgraphExt to avoid name collision.

---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix
- [ ] Tests improvement

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [x] Docs have been added / updated
