### PR TITLE
:recycle: Extract file metadata interface

### DIFF
--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileMetadata.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileMetadata.kt
@@ -10,13 +10,11 @@ import kotlinx.serialization.Serializable
  * @property hidden A flag indicating whether the file or directory is hidden.
  * @property content The type of content stored in the file.
  */
-@Serializable
-public data class FileMetadata(
-    @SerialName("content_type")
-    val type: FileType,
-    val hidden: Boolean,
-    val content: FileContent,
-) {
+public interface FileMetadata {
+    public val type: FileType
+    public val hidden: Boolean
+    public val content: FileContent
+
     /**
      * Represents the type of a file in the context of file metadata.
      */
@@ -82,3 +80,18 @@ public data class FileMetadata(
         Inapplicable("inapplicable");
     }
 }
+
+/**
+ * Implementation of the FileMetadata interface.
+ *
+ * @property type The type of the file, indicating whether it is a file or a directory.
+ * @property hidden A flag indicating whether the file or directory is hidden.
+ * @property content The type of content stored in the file.
+ */
+@Serializable
+public data class FileMetadataImpl(
+    @SerialName("content_type")
+    override val type: FileMetadata.FileType,
+    override val hidden: Boolean,
+    override val content: FileMetadata.FileContent,
+) : FileMetadata

--- a/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
+++ b/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
@@ -117,9 +117,9 @@ public object JVMFileSystemProvider {
          */
         override suspend fun metadata(path: Path): FileMetadata? {
             return if (path.isRegularFile()) {
-                FileMetadata(FileType.File, path.isHidden(), path.contentType())
+                FileMetadataImpl(FileType.File, path.isHidden(), path.contentType())
             } else if (path.isDirectory()) {
-                FileMetadata(FileType.Directory, path.isHidden(), path.contentType())
+                FileMetadataImpl(FileType.Directory, path.isHidden(), path.contentType())
             } else {
                 null
             }

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -169,14 +169,14 @@ class JVMFileSystemProviderTest : KoogTestBase() {
 
     @Test
     fun `test metadata file`() = runBlocking {
-        val metadata = FileMetadata(FileMetadata.FileType.File, hidden = false, content = FileMetadata.FileContent.Text)
+        val metadata = FileMetadataImpl(FileMetadata.FileType.File, hidden = false, content = FileMetadata.FileContent.Text)
         val testMetadata = select.metadata(file1)
         assertEquals(metadata, testMetadata)
     }
 
     @Test
     fun `test metadata dir`() = runBlocking {
-        val metadata = FileMetadata(
+        val metadata = FileMetadataImpl(
             FileMetadata.FileType.Directory,
             hidden = false,
             content = FileMetadata.FileContent.Inapplicable
@@ -781,7 +781,7 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     @Test
     fun `test ReadOnly metadata`() = runBlocking {
         val metadata =
-            FileMetadata(FileMetadata.FileType.File, hidden = false, content = FileMetadata.FileContent.Text)
+            FileMetadataImpl(FileMetadata.FileType.File, hidden = false, content = FileMetadata.FileContent.Text)
         val testMetadata = readOnly.metadata(file1)
         assertEquals(metadata, testMetadata)
     }
@@ -902,7 +902,7 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     @Test
     fun `test ReadWrite metadata`() = runBlocking {
         val metadata =
-            FileMetadata(FileMetadata.FileType.File, hidden = false, content = FileMetadata.FileContent.Text)
+            FileMetadataImpl(FileMetadata.FileType.File, hidden = false, content = FileMetadata.FileContent.Text)
         val testMetadata = readWrite.metadata(file1)
         assertEquals(metadata, testMetadata)
     }


### PR DESCRIPTION
I propose to extract an interface from the FileMetadata class to enable re-implementing FileSystemProvider including it's internals and not being forced to re-use FileMetadata as provided by Koog, because it is being returned by the metadata method.


---

#### Type of the change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation fix
- [ ] Tests improvement

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
