### PR TITLE
Add tests for invalid ToolDescriptor validation

### DIFF
--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/ToolSchemaExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/ToolSchemaExecutorIntegrationTest.kt
@@ -25,6 +25,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 import kotlin.test.assertEquals
@@ -51,55 +52,38 @@ class ToolSchemaExecutorIntegrationTest {
         }
 
         @JvmStatic
-        fun invalidToolDescriptors(): Stream<ToolDescriptor> {
+        fun invalidToolDescriptors(): Stream<Arguments> {
             return Stream.of(
-                // Empty tool name
-                ToolDescriptor(
-                    name = "",
-                    description = "Tool with empty name"
-                ),
-                // Whitespace-only properties
-                ToolDescriptor(
-                    name = "   ",
-                    description = "\t\n",
-                    requiredParameters = listOf(
-                        ToolParameterDescriptor(
-                            name = " ",
-                            description = "  \t  ",
-                            type = ToolParameterType.String
+                Arguments.of(
+                    ToolDescriptor(
+                        name = "",
+                        description = "Tool with empty name",
+                        requiredParameters = listOf(
+                            ToolParameterDescriptor("param", "A parameter", ToolParameterType.String)
                         )
-                    )
+                    ),
+                    "Invalid 'tools[0].function.name': empty string. Expected a string with minimum length 1, but got an empty string instead."
                 ),
                 // Todo uncomment when KG-185 is fixed
-                /*
-                // Empty tool description
-                ToolDescriptor(
-                    name = "valid_tool_name",
-                    description = ""
-                ),
-                // Empty parameter name
-                ToolDescriptor(
-                    name = "valid_tool",
-                    description = "Tool with empty parameter name",
-                    requiredParameters = listOf(
-                        ToolParameterDescriptor(
-                            name = "",
-                            description = "Parameter with empty name",
-                            type = ToolParameterType.String
+                /*Arguments.of(
+                    ToolDescriptor(
+                        name = "test_tool",
+                        description = "",
+                        requiredParameters = listOf(
+                            ToolParameterDescriptor("param", "A parameter", ToolParameterType.String)
                         )
-                    )
+                    ),
+                    "Invalid 'tools[0].function.description': empty string. Expected a string with minimum length 1, but got an empty string instead."
                 ),
-                // Empty parameter description
-                ToolDescriptor(
-                    name = "valid_tool",
-                    description = "Tool with empty parameter description",
-                    requiredParameters = listOf(
-                        ToolParameterDescriptor(
-                            name = "validParam",
-                            description = "",
-                            type = ToolParameterType.String
+                Arguments.of(
+                    ToolDescriptor(
+                        name = "param_name_test",
+                        description = "Tool to test parameter name validation",
+                        requiredParameters = listOf(
+                            ToolParameterDescriptor("", "Parameter with empty name", ToolParameterType.String)
                         )
-                    )
+                    ),
+                    "Invalid 'tools[0].function.requiredParameters[0]': empty string. Expected a string with minimum length 1, but got an empty string instead."
                 )*/
             )
         }
@@ -169,15 +153,20 @@ class ToolSchemaExecutorIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("invalidToolDescriptors")
-    fun integration_testInvalidToolDescriptorShouldFail(invalidToolDescriptor: ToolDescriptor) =
+    fun integration_testInvalidToolDescriptorShouldFail(invalidToolDescriptor: ToolDescriptor, message: String) =
         runTest(timeout = 300.seconds) {
             val prompt = prompt("test-invalid-tool", params = LLMParams(toolChoice = ToolChoice.Required)) {
                 system("You are a helpful assistant with access to tools.")
                 user("Hi.")
             }
 
-            assertFailsWith<Exception> {
+            val exception = assertFailsWith<Exception> {
                 client.execute(prompt, model, listOf(invalidToolDescriptor))
             }
+
+            assumeTrue(
+                exception.message?.contains(message) == true,
+                "Expected exception message to contain '$message', but got '${exception.message}'"
+            )
         }
 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/ToolSchemaExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/ToolSchemaExecutorIntegrationTest.kt
@@ -1,5 +1,8 @@
 package ai.koog.integration.tests
 
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolParameterDescriptor
+import ai.koog.agents.core.tools.ToolParameterType
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.core.tools.annotations.Tool
 import ai.koog.agents.core.tools.reflect.ToolSet
@@ -11,6 +14,7 @@ import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
 import ai.koog.prompt.executor.clients.google.GoogleLLMClient
 import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
@@ -23,9 +27,10 @@ import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.seconds
 
 class ToolSchemaExecutorIntegrationTest {
@@ -44,7 +49,64 @@ class ToolSchemaExecutorIntegrationTest {
         fun googleModels(): Stream<LLModel> {
             return Models.googleModels()
         }
+
+        @JvmStatic
+        fun invalidToolDescriptors(): Stream<ToolDescriptor> {
+            return Stream.of(
+                // Empty tool name
+                ToolDescriptor(
+                    name = "",
+                    description = "Tool with empty name"
+                ),
+                // Whitespace-only properties
+                ToolDescriptor(
+                    name = "   ",
+                    description = "\t\n",
+                    requiredParameters = listOf(
+                        ToolParameterDescriptor(
+                            name = " ",
+                            description = "  \t  ",
+                            type = ToolParameterType.String
+                        )
+                    )
+                ),
+                // Todo uncomment when KG-185 is fixed
+                /*
+                // Empty tool description
+                ToolDescriptor(
+                    name = "valid_tool_name",
+                    description = ""
+                ),
+                // Empty parameter name
+                ToolDescriptor(
+                    name = "valid_tool",
+                    description = "Tool with empty parameter name",
+                    requiredParameters = listOf(
+                        ToolParameterDescriptor(
+                            name = "",
+                            description = "Parameter with empty name",
+                            type = ToolParameterType.String
+                        )
+                    )
+                ),
+                // Empty parameter description
+                ToolDescriptor(
+                    name = "valid_tool",
+                    description = "Tool with empty parameter description",
+                    requiredParameters = listOf(
+                        ToolParameterDescriptor(
+                            name = "validParam",
+                            description = "",
+                            type = ToolParameterType.String
+                        )
+                    )
+                )*/
+            )
+        }
     }
+
+    val model = OpenAIModels.Chat.GPT4o
+    val client = OpenAILLMClient(TestUtils.readTestOpenAIKeyFromEnv())
 
     class FileTools : ToolSet {
 
@@ -104,4 +166,18 @@ class ToolSchemaExecutorIntegrationTest {
             assertEquals("Hello, World!", fileOperation.content)
         }
     }
+
+    @ParameterizedTest
+    @MethodSource("invalidToolDescriptors")
+    fun integration_testInvalidToolDescriptorShouldFail(invalidToolDescriptor: ToolDescriptor) =
+        runTest(timeout = 300.seconds) {
+            val prompt = prompt("test-invalid-tool", params = LLMParams(toolChoice = ToolChoice.Required)) {
+                system("You are a helpful assistant with access to tools.")
+                user("Hi.")
+            }
+
+            assertFailsWith<Exception> {
+                client.execute(prompt, model, listOf(invalidToolDescriptor))
+            }
+        }
 }


### PR DESCRIPTION
Cover the cases that weren't yet checked. Found a bug, see https://youtrack.jetbrains.com/issue/KG-185/No-validation-for-an-empty-description-or-tool-parameter-name-on-execution

---

#### Type of the change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation fix
- [x] Tests improvement

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
