### PR TITLE
:sparkles: Add LLMClientWithRetry.kt

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/LLMClientWithRetry.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/LLMClientWithRetry.kt
@@ -1,0 +1,80 @@
+package ai.koog.prompt.executor.clients
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.prompt.dsl.ModerationResult
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.Message
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlin.random.Random
+
+
+/**
+ * A wrapper for LLMClient that adds retry logic for connection errors and rate limiting.
+ */
+public class LLMClientWithRetry(
+    private val delegate: LLMClient,
+    private val maxRetries: Int = 5,
+    private val initialDelayMs: Long = 1000,
+    private val retryableErrorMatchers: List<RetryableErrorMatcher> = defaultRetryableErrorMatchers,
+) : LLMClient {
+    private companion object {
+        private val logger = KotlinLogging.logger { }
+        
+        val defaultRetryableErrorMatchers = listOf(
+            createRetryableErrorMatcher("ai.koog.agents.core.exception.UnexpectedServerException"),
+            createRetryableErrorMatcher("java.io.EOFException", "Failed to parse HTTP response: the server prematurely closed the connection"),
+            createRetryableErrorMatcher("java.lang.IllegalStateException", "Error from Anthropic API: 529")
+        )
+    }
+    
+    private fun calculateBackoffDelayMs(retryCount: Int): Long {
+        val baseDelayMs = initialDelayMs * (1L shl retryCount)
+        val jitterFactor = 0.5 + Random.nextDouble()
+        return (baseDelayMs * jitterFactor).toLong()
+    }
+    
+    private suspend fun waitForRetryOrRethrow(e: Throwable, retryCount: Int) {
+        if(retryCount < maxRetries) {
+            val delayMillis = calculateBackoffDelayMs(retryCount)
+            logger.warn {
+                "Server side error detected. Retrying (${retryCount}/$maxRetries) after ${delayMillis}ms delay..."
+            }
+            delay(delayMillis)
+        } else {
+            logger.error(e) { "Failed to execute LLM request after $maxRetries retries" }
+            throw RuntimeException(
+                "LLM provider Server side error after $maxRetries retries: ${e.message}",
+                e
+            )
+        }
+    }
+
+    public override suspend fun execute(prompt: Prompt, model: LLModel, tools: List<ToolDescriptor>): List<Message.Response> {
+        var retryCount = 0
+
+        while (true) {
+            try {
+                return delegate.execute(prompt, model, tools)
+            } catch (e: Throwable) {
+                val shouldRetry = retryableErrorMatchers.any { it.matches(e) }
+                if (!shouldRetry) {
+                    throw e
+                }
+                
+                retryCount += 1
+                waitForRetryOrRethrow(e, retryCount)
+            }
+        }
+    }
+
+    public override fun executeStreaming(prompt: Prompt, model: LLModel): Flow<String> {
+        return delegate.executeStreaming(prompt, model)
+    }
+
+    public override suspend fun moderate(prompt: Prompt, model: LLModel): ModerationResult {
+        return delegate.moderate(prompt, model)
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/RetryableErrorMatcher.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/RetryableErrorMatcher.kt
@@ -1,0 +1,26 @@
+package ai.koog.prompt.executor.clients
+
+/**
+ * Platform-independent interface for matching errors that should be retried.
+ */
+public interface RetryableErrorMatcher {
+    /**
+     * Checks if the given throwable matches the pattern for retryable errors.
+     *
+     * @param throwable The throwable to check
+     * @return true if the throwable matches the pattern, false otherwise
+     */
+    public fun matches(throwable: Throwable): Boolean
+}
+
+/**
+ * Creates a RetryableErrorMatcher for the specified exception type and optional message pattern.
+ *
+ * @param exceptionType The fully qualified name of the exception class
+ * @param messagePattern Optional substring that must be present in the exception message to match
+ * @return A RetryableErrorMatcher that matches the specified criteria
+ */
+public expect fun createRetryableErrorMatcher(
+    exceptionType: String,
+    messagePattern: String? = null
+): RetryableErrorMatcher

--- a/prompt/prompt-executor/prompt-executor-clients/src/jsMain/kotlin/ai/koog/prompt/executor/clients/RetryableErrorMatcherJs.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/jsMain/kotlin/ai/koog/prompt/executor/clients/RetryableErrorMatcherJs.kt
@@ -1,0 +1,26 @@
+package ai.koog.prompt.executor.clients
+
+/**
+ * JS implementation of RetryableErrorMatcher.
+ */
+public actual fun createRetryableErrorMatcher(
+    exceptionType: String,
+    messagePattern: String?
+): RetryableErrorMatcher = JsRetryableErrorMatcher(exceptionType, messagePattern)
+
+private class JsRetryableErrorMatcher(
+    private val exceptionType: String,
+    private val messagePattern: String?
+) : RetryableErrorMatcher {
+    override fun matches(throwable: Throwable): Boolean {
+        // In JS, we can't use Java reflection, so we'll do a simple check based on the class name
+        val throwableClassName = throwable::class.simpleName ?: ""
+        val expectedClassName = exceptionType.substringAfterLast('.')
+        
+        if (throwableClassName != expectedClassName) {
+            return false
+        }
+        
+        return messagePattern == null || (throwable.message ?: "").contains(messagePattern)
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/RetryableErrorMatcherJvm.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/RetryableErrorMatcherJvm.kt
@@ -1,0 +1,31 @@
+package ai.koog.prompt.executor.clients
+
+/**
+ * JVM implementation of RetryableErrorMatcher that uses Java reflection.
+ */
+public actual fun createRetryableErrorMatcher(
+    exceptionType: String,
+    messagePattern: String?
+): RetryableErrorMatcher = JvmRetryableErrorMatcher(exceptionType, messagePattern)
+
+private class JvmRetryableErrorMatcher(
+    private val exceptionType: String,
+    private val messagePattern: String?
+) : RetryableErrorMatcher {
+    private val exceptionClass: Class<out Throwable> by lazy {
+        try {
+            @Suppress("UNCHECKED_CAST")
+            Class.forName(exceptionType) as Class<out Throwable>
+        } catch (e: ClassNotFoundException) {
+            throw IllegalArgumentException("Exception class not found: $exceptionType", e)
+        }
+    }
+
+    override fun matches(throwable: Throwable): Boolean {
+        if (!exceptionClass.isInstance(throwable)) {
+            return false
+        }
+        
+        return messagePattern == null || (throwable.message ?: "").contains(messagePattern)
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/src/wasmJsMain/kotlin/ai/koog/prompt/executor/clients/RetryableErrorMatcherWasmJs.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/wasmJsMain/kotlin/ai/koog/prompt/executor/clients/RetryableErrorMatcherWasmJs.kt
@@ -1,0 +1,26 @@
+package ai.koog.prompt.executor.clients
+
+/**
+ * WASM-JS implementation of RetryableErrorMatcher.
+ */
+public actual fun createRetryableErrorMatcher(
+    exceptionType: String,
+    messagePattern: String?
+): RetryableErrorMatcher = WasmJsRetryableErrorMatcher(exceptionType, messagePattern)
+
+private class WasmJsRetryableErrorMatcher(
+    private val exceptionType: String,
+    private val messagePattern: String?
+) : RetryableErrorMatcher {
+    override fun matches(throwable: Throwable): Boolean {
+        // In WASM-JS, we can't use Java reflection, so we'll do a simple check based on the class name
+        val throwableClassName = throwable::class.simpleName ?: ""
+        val expectedClassName = exceptionType.substringAfterLast('.')
+        
+        if (throwableClassName != expectedClassName) {
+            return false
+        }
+        
+        return messagePattern == null || (throwable.message ?: "").contains(messagePattern)
+    }
+}


### PR DESCRIPTION
Add an LLMClientWithRetry wrapper that allows to catch and retry server side errors, while letting client side errors pass through


---

#### Type of the change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation fix
- [ ] Tests improvement

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
