### PR TITLE
fix configuration error on agents-feature-opentelemetry

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/build.gradle.kts
+++ b/agents/agents-features/agents-features-opentelemetry/build.gradle.kts
@@ -61,10 +61,15 @@ val generateProductProperties = tasks.register("generateProductProperties") {
     outputs.file(propertiesFile)
 
     doLast {
+        val version = inputs.properties["version"] as String
+        val group = inputs.properties["group"] as String
+
         propertiesFile.asFile.parentFile.mkdirs()
         propertiesFile.asFile.writeText("""
             version=$rootProjectVersion
             name=$rootProjectGroup
+            version=$version
+            name=$group
         """.trimIndent())
     }
 }


### PR DESCRIPTION
fix some error in my private KMP project errors:

```text
Configuration cache problems found in this build.

1 problem was found storing the configuration cache.
- Task `:koog:agents:agents-features:agents-features-opentelemetry:generateProductProperties` of type `org.gradle.api.DefaultTask`: cannot serialize Gradle script object references as these are not supported with the configuration cache.
  See https://docs.gradle.org/8.14/userguide/configuration_cache.html#config_cache:requirements:disallowed_types

See the complete report at file:///Users/886kagg/IdeaProjects/xxxx/build/reports/configuration-cache/47lwgowjrml0l5x76kzuififw/6ptgmhw8aou4m2ixyqugxynq5/configuration-cache-report.html
```

check the source code:

```kotlin
doLast {
        propertiesFile.asFile.parentFile.mkdirs()
        propertiesFile.asFile.writeText("""
            version=$rootProjectVersion
            name=$rootProjectGroup
        """.trimIndent())
    }
```

> Gradle model types (e.g., Gradle, Settings, Project, SourceSet, Configuration) are often used to pass task inputs that should instead be explicitly declared.
> 
> For example, instead of referencing a Project to retrieve project.version at execution time, declare the project version as a Property<String> input. Similarly, instead of referencing a SourceSet for source files or classpath resolution, declare these as a FileCollection input.
> [https://docs.gradle.org/8.14/userguide/configuration_cache.html#gradle_model_types](https://docs.gradle.org/8.14/userguide/configuration_cache.html#gradle_model_types)

so i change it

---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix
- [ ] Tests improvement

#### Checklist for all pull requests
- [ ] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed