### PR TITLE
Returned llama3.2:latest as default LLAMA_3_2 model

### DIFF
--- a/prompt/prompt-llm/src/commonMain/kotlin/ai/koog/prompt/llm/OllamaModels.kt
+++ b/prompt/prompt-llm/src/commonMain/kotlin/ai/koog/prompt/llm/OllamaModels.kt
@@ -95,7 +95,7 @@ public object OllamaModels {
         )
 
         /**
-         * Represents the LLAMA version 3.2 model provided by Meta.
+         * Represents the latest LLAMA version 3.2 model provided by Meta.
          *
          * This variable defines an instance of the `LLModel` class with the Ollama provider, a unique identifier "llama3.2",
          * and a set of capabilities. The supported capabilities include:
@@ -106,7 +106,16 @@ public object OllamaModels {
          * LLAMA 3.2 is designed to support these specified features, enabling developers to utilize the model for tasks
          * that require dynamic behavior adjustments, schema adherence, and tool-based interactions.
          */
-        public val LLAMA_3_2: LLModel = LLAMA_3_2_3B
+        public val LLAMA_3_2: LLModel = LLModel(
+            provider = LLMProvider.Ollama,
+            id = "llama3.2:latest",
+            capabilities = listOf(
+                LLMCapability.Temperature,
+                LLMCapability.Schema.JSON.Simple,
+                LLMCapability.Tools
+            ),
+            contextLength = 131_072,
+        )
 
         /**
          * Represents the LLAMA version 4 model provided by Meta.


### PR DESCRIPTION
I returned `llama3.2:latest` tag to `LLAMA_3_2` model, because it turns out if you have `llama3.2:latest` installed and trying to run `llama3.2:3b` it's failing with exception about missing `llama3.2:3b`.
We even experienced it in the tests.
So in order to avoid such confusing behaviour - `LLAMA_3_2` is now `llama3.2:latest`


---

#### Type of the change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation fix
- [ ] Tests improvement

#### Checklist for all pull requests
- [ ] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [ ] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
