### PR TITLE
Add tool arguments for gen_ai.choice and gen_ai.assistant.message events (#462)

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/AssistantMessageEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/AssistantMessageEvent.kt
@@ -4,10 +4,12 @@ import ai.koog.agents.features.opentelemetry.attribute.Attribute
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.message.Message
+import kotlinx.serialization.json.JsonObject
 
-internal data class AssistantMessageEvent(
-    private val provider: LLMProvider,
+internal class AssistantMessageEvent(
+    provider: LLMProvider,
     private val message: Message.Response,
+    private val arguments: JsonObject? = null,
     override val verbose: Boolean = false
 ) : GenAIAgentEvent {
 
@@ -26,6 +28,7 @@ internal data class AssistantMessageEvent(
             is Message.Assistant -> {
                 if (verbose) {
                     add(EventBodyFields.Content(content = message.content))
+                    arguments?.let { add(EventBodyFields.Arguments(it)) }
                 }
             }
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEvent.kt
@@ -4,10 +4,12 @@ import ai.koog.agents.features.opentelemetry.attribute.Attribute
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.message.Message
+import kotlinx.serialization.json.JsonObject
 
 internal class ChoiceEvent(
     provider: LLMProvider,
     private val message: Message.Response,
+    private val arguments: JsonObject? = null,
     override val verbose: Boolean = false,
 ) : GenAIAgentEvent {
 
@@ -33,6 +35,8 @@ internal class ChoiceEvent(
                             content = message.content
                         )
                     )
+
+                    arguments?.let { add(EventBodyFields.Arguments(it)) }
                 }
             }
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/EventBodyFields.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/EventBodyFields.kt
@@ -1,5 +1,7 @@
 package ai.koog.agents.features.opentelemetry.event
 
+import kotlinx.serialization.json.JsonObject
+
 internal object EventBodyFields {
 
     data class ToolCalls(
@@ -23,6 +25,11 @@ internal object EventBodyFields {
             }
     }
 
+    data class Arguments(private val arguments: JsonObject) : EventBodyField() {
+        override val key: String = "arguments"
+        override val value: String = arguments.toString()
+    }
+
     data class Content(private val content: String) : EventBodyField() {
         override val key: String = "content"
         override val value: String = content
@@ -43,8 +50,11 @@ internal object EventBodyFields {
         override val value: String = reason
     }
 
-    data class Message(private val role: ai.koog.prompt.message.Message.Role?, private val content: String) :
-        EventBodyField() {
+    data class Message(
+        private val role: ai.koog.prompt.message.Message.Role?,
+        private val content: String
+    ) : EventBodyField() {
+
         override val key: String = "message"
         override val value: Map<String, String> = buildMap {
             role?.let { role -> put("role", role.name.lowercase()) }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/SystemMessageEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/SystemMessageEvent.kt
@@ -5,8 +5,8 @@ import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.message.Message
 
-internal data class SystemMessageEvent(
-    private val provider: LLMProvider,
+internal class SystemMessageEvent(
+    provider: LLMProvider,
     private val message: Message.System,
     override val verbose: Boolean = false
 ) : GenAIAgentEvent {

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ToolMessageEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ToolMessageEvent.kt
@@ -5,7 +5,7 @@ import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
 import ai.koog.prompt.llm.LLMProvider
 
 internal class ToolMessageEvent(
-    private val provider: LLMProvider,
+    provider: LLMProvider,
     private val toolCallId: String?,
     private val content: String,
     override val verbose: Boolean = false

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/UserMessageEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/UserMessageEvent.kt
@@ -5,8 +5,8 @@ import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.message.Message
 
-internal data class UserMessageEvent(
-    private val provider: LLMProvider,
+internal class UserMessageEvent(
+    provider: LLMProvider,
     private val message: Message.User,
     override val verbose: Boolean = false
 ) : GenAIAgentEvent {

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
@@ -305,7 +305,9 @@ public class OpenTelemetry {
                     eventContext.responses.map { message ->
                         when (message) {
                             is Message.Assistant -> add(AssistantMessageEvent(provider, message, verbose = config.isVerbose))
-                            is Message.Tool.Call -> add(ChoiceEvent(provider, message, verbose = config.isVerbose))
+                            is Message.Tool.Call -> add(
+                                ChoiceEvent(provider, message, arguments = message.contentJson, verbose = config.isVerbose)
+                            )
                         }
                     }
 


### PR DESCRIPTION
Add a tool arguments to Open Telemetry event and updated test (#462)

---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix
- [ ] Tests improvement

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
