### PR TITLE
Extract content metadata into a separate method

### DIFF
--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileMetadata.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileMetadata.kt
@@ -8,14 +8,12 @@ import kotlinx.serialization.Serializable
  *
  * @property type The type of the file, indicating whether it is a file or a directory.
  * @property hidden A flag indicating whether the file or directory is hidden.
- * @property content The type of content stored in the file.
  */
 @Serializable
 public data class FileMetadata(
     @SerialName("content_type")
     val type: FileType,
     val hidden: Boolean,
-    val content: FileContent,
 ) {
     /**
      * Represents the type of a file in the context of file metadata.
@@ -60,7 +58,7 @@ public data class FileMetadata(
      *
      * @property display A string representation of the content type.
      */
-    public enum class FileContent(public val display: String) {
+    public enum class FileContentType(public val display: String) {
         /**
          * Represents textual file content.
          * Associated with the string display value "text".
@@ -73,15 +71,6 @@ public data class FileMetadata(
          * This value is used to denote that the content of a file is binary data, as opposed to plain text or other types.
          * It provides a display string ("binary") to identify this content type.
          */
-        Binary("binary"),
-
-        /**
-         * Represents a file content type that is not applicable or relevant.
-         * Typically used in scenarios where the file content type does not
-         * conform to valid or expected classifications.
-         *
-         * This enumeration is part of the `FileContent` enum.
-         */
-        Inapplicable("inapplicable")
+        Binary("binary")
     }
 }

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -76,6 +76,16 @@ public object FileSystemProvider {
         public suspend fun metadata(path: Path): FileMetadata?
 
         /**
+         * Detects the type of content stored in a file using a [path].
+         *
+         * @param path The path to a file whose content type is to be detected.
+         * @return [FileMetadata.FileContentType.Text] for text files, [FileMetadata.FileContentType.Binary] for binary files.
+         * @throws IllegalArgumentException if the path doesn't exist or isn't a regular file.
+         * @throws IOException if an I/O error occurs while detecting the file content type.
+         */
+        public suspend fun getFileContentType(path: Path): FileMetadata.FileContentType
+
+        /**
          * Lists contents of a [directory].
          * Children are sorted by name.
          * The listing is not recursive.

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FilteredFileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FilteredFileSystemProvider.kt
@@ -63,6 +63,11 @@ internal open class FilteredReadOnly<P>(
         }
     }
 
+    override suspend fun getFileContentType(path: P): FileMetadata.FileContentType {
+        requireAllowed(path)
+        return fs.getFileContentType(path)
+    }
+
     override suspend fun exists(path: P): Boolean {
         return if (filter.show(path, fs)) {
             fs.exists(path)

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -181,8 +181,7 @@ class JVMFileSystemProviderTest : KoogTestBase() {
 
     @Test
     fun `test ReadOnly metadata`() = runBlocking {
-        val metadata =
-            FileMetadata(FileMetadata.FileType.File, hidden = false, content = FileMetadata.FileContent.Text)
+        val metadata = FileMetadata(FileMetadata.FileType.File, hidden = false)
         val testMetadata = readOnly.metadata(file1)
         assertEquals(metadata, testMetadata)
     }
@@ -344,11 +343,36 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     }
 
     @Test
-    fun `test ReadOnly metadata dir`() = runBlocking {
+    fun `test metadata file`() = runBlocking {
+        val expectedMetadata = FileMetadata(FileMetadata.FileType.File, hidden = false)
+        val actualMetadata = readOnly.metadata(file1)
+        assertEquals(expectedMetadata, actualMetadata)
+    }
+
+    @Test
+    fun `test getFileContentType with Text type`() = runBlocking {
+        val contentType = readOnly.getFileContentType(file1)
+        assertEquals(FileMetadata.FileContentType.Text, contentType)
+    }
+
+    @Test
+    fun `test getFileContentType with directory throws IllegalArgumentException`() {
+        assertThrows<IllegalArgumentException> {
+            runBlocking { readOnly.getFileContentType(dirEmpty) }
+        }
+    }
+
+    @Test
+    fun `test getFileContentType with Binary type`() = runBlocking {
+        val contentType = readOnly.getFileContentType(zip1)
+        assertEquals(FileMetadata.FileContentType.Binary, contentType)
+    }
+
+    @Test
+    fun `test metadata dir`() = runBlocking {
         val metadata = FileMetadata(
             FileMetadata.FileType.Directory,
             hidden = false,
-            content = FileMetadata.FileContent.Inapplicable
         )
         val testMetadata = readOnly.metadata(dir1)
         assertEquals(metadata, testMetadata)
@@ -411,10 +435,9 @@ class JVMFileSystemProviderTest : KoogTestBase() {
 
     @Test
     fun `test ReadWrite metadata`() = runBlocking {
-        val metadata =
-            FileMetadata(FileMetadata.FileType.File, hidden = false, content = FileMetadata.FileContent.Text)
+        val expectedMetadata = FileMetadata(FileMetadata.FileType.File, hidden = false)
         val testMetadata = readWrite.metadata(file1)
-        assertEquals(metadata, testMetadata)
+        assertEquals(expectedMetadata, testMetadata)
     }
 
     @Test

--- a/rag/vector-storage/src/commonTest/kotlin/ai/koog/rag/vector/FileDocumentEmbeddingStorageTest.kt
+++ b/rag/vector-storage/src/commonTest/kotlin/ai/koog/rag/vector/FileDocumentEmbeddingStorageTest.kt
@@ -4,7 +4,7 @@ import ai.koog.embeddings.base.Vector
 import ai.koog.rag.vector.mocks.MockDocument
 import ai.koog.rag.vector.mocks.MockDocumentProvider
 import ai.koog.rag.vector.mocks.MockFileSystem
-import ai.koog.rag.vector.mocks.MockFileSystemProvicer
+import ai.koog.rag.vector.mocks.MockFileSystemProvider
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -36,7 +36,7 @@ class FileDocumentEmbeddingStorageTest {
     private suspend fun createTestStorage(): FileDocumentEmbeddingStorage<MockDocument, String> {
         val mockFileSystem = MockFileSystem()
         val mockDocumentProvider = MockDocumentProvider(mockFileSystem)
-        val mockFileSystemProvicer = MockFileSystemProvicer(mockFileSystem)
+        val mockFileSystemProvicer = MockFileSystemProvider(mockFileSystem)
         val mockEmbedder = MockDocumentEmbedder()
 
         return FileDocumentEmbeddingStorage(mockEmbedder, mockDocumentProvider, mockFileSystemProvicer, "test-root")

--- a/rag/vector-storage/src/commonTest/kotlin/ai/koog/rag/vector/FileVectorStorageTest.kt
+++ b/rag/vector-storage/src/commonTest/kotlin/ai/koog/rag/vector/FileVectorStorageTest.kt
@@ -4,7 +4,7 @@ import ai.koog.embeddings.base.Vector
 import ai.koog.rag.vector.mocks.MockDocument
 import ai.koog.rag.vector.mocks.MockDocumentProvider
 import ai.koog.rag.vector.mocks.MockFileSystem
-import ai.koog.rag.vector.mocks.MockFileSystemProvicer
+import ai.koog.rag.vector.mocks.MockFileSystemProvider
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -17,7 +17,7 @@ class FileVectorStorageTest {
     private fun createTestStorage(): FileVectorStorage<MockDocument, String> {
         val mockFileSystem = MockFileSystem()
         val mockDocumentProvider = MockDocumentProvider(mockFileSystem)
-        val mockFileSystemProvider = MockFileSystemProvicer(mockFileSystem)
+        val mockFileSystemProvider = MockFileSystemProvider(mockFileSystem)
 
         val storage = FileVectorStorage(mockDocumentProvider, mockFileSystemProvider, "test-root")
         return storage

--- a/rag/vector-storage/src/commonTest/kotlin/ai/koog/rag/vector/TextFileDocumentEmbeddingStorageTest.kt
+++ b/rag/vector-storage/src/commonTest/kotlin/ai/koog/rag/vector/TextFileDocumentEmbeddingStorageTest.kt
@@ -5,7 +5,7 @@ import ai.koog.embeddings.base.Vector
 import ai.koog.rag.vector.mocks.MockDocument
 import ai.koog.rag.vector.mocks.MockDocumentProvider
 import ai.koog.rag.vector.mocks.MockFileSystem
-import ai.koog.rag.vector.mocks.MockFileSystemProvicer
+import ai.koog.rag.vector.mocks.MockFileSystemProvider
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -33,7 +33,7 @@ class TextFileDocumentEmbeddingStorageTest {
     private suspend fun createTestStorage(): TextFileDocumentEmbeddingStorage<MockDocument, String> {
         val mockFileSystem = MockFileSystem()
         val mockDocumentProvider = MockDocumentProvider(mockFileSystem)
-        val mockFileSystemProvicer = MockFileSystemProvicer(mockFileSystem)
+        val mockFileSystemProvicer = MockFileSystemProvider(mockFileSystem)
         val mockEmbedder = MockEmbedder()
 
         return TextFileDocumentEmbeddingStorage(mockEmbedder, mockDocumentProvider, mockFileSystemProvicer, "test-root")

--- a/rag/vector-storage/src/commonTest/kotlin/ai/koog/rag/vector/mocks/MockDocumentProviders.kt
+++ b/rag/vector-storage/src/commonTest/kotlin/ai/koog/rag/vector/mocks/MockDocumentProviders.kt
@@ -42,7 +42,7 @@ class MockDocumentProvider(val mockFileSystem: MockFileSystem) : DocumentProvide
     }
 }
 
-class MockFileSystemProvicer(val mockFileSystem: MockFileSystem) : FileSystemProvider.ReadWrite<String> {
+class MockFileSystemProvider(val mockFileSystem: MockFileSystem) : FileSystemProvider.ReadWrite<String> {
     override fun toAbsolutePathString(path: String): String = path
 
     override fun fromAbsoluteString(path: String): String = path
@@ -69,6 +69,13 @@ class MockFileSystemProvicer(val mockFileSystem: MockFileSystem) : FileSystemPro
         if (path.startsWith(root)) path.removePrefix(root) else null
 
     override suspend fun exists(path: String): Boolean = path in mockFileSystem.documents
+
+    override suspend fun getFileContentType(path: String): FileMetadata.FileContentType =
+        when (mockFileSystem.documents[path]) {
+            is MockDocument -> FileMetadata.FileContentType.Text
+            is MockDirectory -> throw IllegalArgumentException("Path must be a regular file")
+            else -> throw IllegalArgumentException("Path must exist and be a regular file")
+        }
 
     override suspend fun read(path: String): ByteArray =
         mockFileSystem.documents[path]?.let { it as? MockDocument }?.content?.encodeToByteArray()


### PR DESCRIPTION
1. Extracted `content` into a separate method to make `metadata` and `isFile/isDirectory` faster.
2. Renamed `FileContent` to `FileContentType` to better reflect its purpose.
3. Covered the new method with tests.
4. Fixed typo in `MockFileSystemProvider` name.

~~**QUESTION 1** Please take a look at `getFileContentType` in `FilteredFileSystemProvider` and in~~ ~~`FileSystemProvider`. Should we make the return type nullable and use the same check as for `metadata`?~~
~~```~~
~~return if (filter.show(path, fs)) {~~
~~    fs.getFileContentType(path)~~
~~} else {~~
~~    null~~
~~}~~
~~```~~
~~Now it uses `requireAllowed(path)`.~~

~~**QUESTION 2** Should I just get rid of `Path.contentType()` and inline its logic in `getFileContentType` since it's~~ ~~the~~ only place where it's used and move `isFileHeadTextBased` to `Select`?~~
~~UPD: done in the latest commit to allow easy revert.~~

---

#### Type of the change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation fix
- [x] Tests improvement

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
