### PR TITLE
KG-172. Add all messages to the inference span for Open Telemetry

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ToolMessageEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ToolMessageEvent.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.features.opentelemetry.event
 
-import ai.koog.agents.core.tools.ToolResult
 import ai.koog.agents.features.opentelemetry.attribute.Attribute
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
 import ai.koog.prompt.llm.LLMProvider
@@ -8,7 +7,7 @@ import ai.koog.prompt.llm.LLMProvider
 internal class ToolMessageEvent(
     private val provider: LLMProvider,
     private val toolCallId: String?,
-    private val toolResult: ToolResult,
+    private val content: String,
     override val verbose: Boolean = false
 ) : GenAIAgentEvent {
 
@@ -21,7 +20,7 @@ internal class ToolMessageEvent(
     override val bodyFields: List<EventBodyField> = buildList {
         // Content
         if (verbose) {
-            add(EventBodyFields.Content(content = toolResult.toStringDefault()))
+            add(EventBodyFields.Content(content = content))
         }
 
         // Id

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/GenAIAgentSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/GenAIAgentSpan.kt
@@ -41,9 +41,19 @@ internal abstract class GenAIAgentSpan(
 
     abstract val attributes: List<Attribute>
 
+    val events: Set<GenAIAgentEvent>
+        get() = _events
+
+    private val _events: MutableSet<GenAIAgentEvent> = mutableSetOf()
+
     fun addEvents(events: List<GenAIAgentEvent>) {
         events.forEach { event ->
             logger.debug { "Adding event '${event.name}' to span '$spanId'" }
+
+            if (_events.contains(event)) {
+                logger.warn { "Event '${event.name}' already added to span '$spanId'" }
+                return@forEach
+            }
 
             // The 'opentelemetry-java' SDK does not have support for event body fields at the moment.
             // Pass body fields as attributes until an API is updated.
@@ -56,5 +66,6 @@ internal abstract class GenAIAgentSpan(
 
             span.addEvent(event.name, attributes.toSdkAttributes())
         }
+        _events.addAll(events)
     }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestAPI.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestAPI.kt
@@ -30,9 +30,9 @@ internal object OpenTelemetryTestAPI {
     ): AIAgent<String, String> {
         val agentConfig = AIAgentConfig(
             prompt = prompt(promptId ?: "Test prompt", clock = clock, params = LLMParams(temperature = temperature)) {
-                system(systemPrompt ?: "Test system message")
-                user(userPrompt ?: "Test user message")
-                assistant(assistantPrompt ?: "Test assistant response")
+                systemPrompt?.let { system(systemPrompt) }
+                userPrompt?.let { user(userPrompt) }
+                assistantPrompt?.let { assistant(assistantPrompt) }
             },
             model = model ?: OpenAIModels.Chat.GPT4o,
             maxAgentIterations = 10,

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/ToolMessageEventTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/ToolMessageEventTest.kt
@@ -20,7 +20,7 @@ class ToolMessageEventTest {
         val toolMessageEvent = ToolMessageEvent(
             provider = llmProvider,
             toolCallId = toolCallId,
-            toolResult = toolResult,
+            content = toolResult.toStringDefault(),
             verbose = false,
         )
 
@@ -41,7 +41,7 @@ class ToolMessageEventTest {
         val toolMessageEvent = ToolMessageEvent(
             provider = llmProvider,
             toolCallId = toolCallId,
-            toolResult = toolResult,
+            content = toolResult.toStringDefault(),
             verbose = true,
         )
 
@@ -65,7 +65,7 @@ class ToolMessageEventTest {
         val toolMessageEvent = ToolMessageEvent(
             provider = MockLLMProvider(),
             toolCallId = toolCallId,
-            toolResult = toolResult,
+            content = toolResult.toStringDefault(),
             verbose = false,
         )
 
@@ -85,7 +85,7 @@ class ToolMessageEventTest {
         val toolMessageEvent = ToolMessageEvent(
             provider = MockLLMProvider(),
             toolCallId = toolCallId,
-            toolResult = toolResult,
+            content = toolResult.toStringDefault(),
             verbose = false,
         )
 
@@ -103,7 +103,7 @@ class ToolMessageEventTest {
         val toolMessageEvent = ToolMessageEvent(
             provider = MockLLMProvider(),
             toolCallId = toolCallId,
-            toolResult = toolResult,
+            content = toolResult.toStringDefault(),
             verbose = true,
         )
 
@@ -124,7 +124,7 @@ class ToolMessageEventTest {
         val toolMessageEvent = ToolMessageEvent(
             provider = MockLLMProvider(),
             toolCallId = toolCallId,
-            toolResult = toolResult,
+            content = toolResult.toStringDefault(),
             verbose = true,
         )
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/mock/MockToolGetWeather.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/mock/MockToolGetWeather.kt
@@ -9,6 +9,9 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 
 internal object TestGetWeatherTool : SimpleTool<TestGetWeatherTool.Args>() {
+
+    const val RESULT: String = "rainy, 57°F"
+
     @Serializable
     data class Args(val location: String) : ToolArgs
 
@@ -27,6 +30,6 @@ internal object TestGetWeatherTool : SimpleTool<TestGetWeatherTool.Args>() {
     )
 
     override suspend fun doExecute(args: Args): String {
-        return "rainy, 57°F"
+        return RESULT
     }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/span/GenAIAgentSpanTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/span/GenAIAgentSpanTest.kt
@@ -1,5 +1,6 @@
 package ai.koog.agents.features.opentelemetry.span
 
+import ai.koog.agents.features.opentelemetry.event.EventBodyFields
 import ai.koog.agents.features.opentelemetry.mock.MockAttribute
 import ai.koog.agents.features.opentelemetry.mock.MockGenAIAgentEvent
 import ai.koog.agents.features.opentelemetry.mock.MockGenAIAgentSpan
@@ -119,8 +120,48 @@ class GenAIAgentSpanTest {
 
         span.addEvents(events)
 
-        // Since we can't directly verify the events were added (MockSpan doesn't track them),
-        // we're just verifying the method doesn't throw exceptions
-        assertTrue(true, "addEvents completed without exceptions")
+        // Verify events were added to the internal events set
+        assertEquals(2, span.events.size)
+        assertTrue(span.events.contains(events[0]))
+        assertTrue(span.events.contains(events[1]))
+    }
+
+    @Test
+    fun `addEvents should handle duplicate events`() {
+        val span = MockGenAIAgentSpan("test.span")
+        val mockSpan = MockSpan()
+        span.span = mockSpan
+
+        val event = MockGenAIAgentEvent(
+            name = "duplicate-event",
+            attributes = listOf(MockAttribute("key", "value"))
+        )
+
+        // Add the same event twice
+        span.addEvents(listOf(event))
+        span.addEvents(listOf(event))
+
+        // Verify the event was added only once
+        assertEquals(1, span.events.size)
+        assertTrue(span.events.contains(event))
+    }
+
+    @Test
+    fun `addEvents should handle events with body fields`() {
+        val span = MockGenAIAgentSpan("test.span")
+        val mockSpan = MockSpan()
+        span.span = mockSpan
+
+        val event = MockGenAIAgentEvent(
+            name = "event-with-body-fields",
+            attributes = listOf(MockAttribute("key", "value")),
+            fields = listOf(EventBodyFields.Content("test content"))
+        )
+
+        span.addEvents(listOf(event))
+
+        // Verify the event was added
+        assertEquals(1, span.events.size)
+        assertTrue(span.events.contains(event))
     }
 }


### PR DESCRIPTION
Add a list of all messages when creating an inference span

---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix
- [ ] Tests improvement

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [x] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
