### PR TITLE
Rename `fromAbsoluteString` to `fromAbsolutePathString`

### DIFF
--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FileSystemProvider.kt
@@ -32,7 +32,7 @@ public object FileSystemProvider {
          * @return A path object representing the absolute path.
          * @throws IllegalArgumentException if [path] is not absolute.
          */
-        public fun fromAbsoluteString(path: String): Path
+        public fun fromAbsolutePathString(path: String): Path
 
         /**
          * Resolves a [path] string against a [base] path.

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FilteredFileSystemProvider.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/FilteredFileSystemProvider.kt
@@ -82,7 +82,7 @@ internal open class FilteredReadOnly<P>(
 
     override fun toAbsolutePathString(path: P): String = fs.toAbsolutePathString(path)
 
-    override fun fromAbsoluteString(path: String): P = fs.fromAbsoluteString(path)
+    override fun fromAbsolutePathString(path: String): P = fs.fromAbsolutePathString(path)
 
     override fun fromRelativeString(base: P, path: String): P = fs.fromRelativeString(base, path)
 

--- a/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
+++ b/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
@@ -67,7 +67,7 @@ public object JVMFileSystemProvider {
          * @return The normalized Path representation of the given string.
          * @throws IllegalArgumentException if the resolved path is not absolute.
          */
-        override fun fromAbsoluteString(path: String): Path {
+        override fun fromAbsolutePathString(path: String): Path {
             val resolvedPath = Path.of(toSystemDependentName(path)).normalize()
             require(resolvedPath.isAbsolute) { "Resolved path must be absolute" }
             return resolvedPath

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFileSystemProviderTest.kt
@@ -41,7 +41,7 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     @Test
     fun `test fromAbsoluteString with non-existent path`() {
         val nonExistentPath = file1.absolute().pathString + "non_existent"
-        val result = readOnly.fromAbsoluteString(nonExistentPath).toString()
+        val result = readOnly.fromAbsolutePathString(nonExistentPath).toString()
         assertEquals(nonExistentPath, result)
     }
 
@@ -149,7 +149,7 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     @Test
     fun `test ReadOnly fromAbsoluteString`() {
         val filePathString = file1.absolute().pathString
-        val fileFromPath = readOnly.fromAbsoluteString(filePathString)
+        val fileFromPath = readOnly.fromAbsolutePathString(filePathString)
         assertEquals(file1, fileFromPath)
     }
 
@@ -260,14 +260,14 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     @Test
     fun `test ReadOnly path windows delimiters`() {
         val filePathString = file1.absolute().pathString.replace("/", "\\")
-        val fileFromString = readOnly.fromAbsoluteString(filePathString)
+        val fileFromString = readOnly.fromAbsolutePathString(filePathString)
         assertEquals(file1, fileFromString)
     }
 
     @Test
     fun `test ReadOnly path unix delimiters`() {
         val filePathString = file1.absolute().pathString.replace("\\", "/")
-        val fileFromString = readOnly.fromAbsoluteString(filePathString)
+        val fileFromString = readOnly.fromAbsolutePathString(filePathString)
         assertEquals(file1, fileFromString)
     }
 
@@ -282,7 +282,7 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     fun `test ReadOnly fromAbsoluteString throws exception when resolved path is not absolute`() {
         val relativePathString = "relative/test/path"
         assertThrows(IllegalArgumentException::class.java) {
-            readOnly.fromAbsoluteString(relativePathString)
+            readOnly.fromAbsolutePathString(relativePathString)
         }
     }
 
@@ -303,7 +303,7 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     @Test
     fun `test ReadOnly path starting with slash windows`() {
         val filePathString = "\\" + file1.absolute().pathString.replace("/", "\\")
-        val fileFromString = readOnly.fromAbsoluteString(filePathString)
+        val fileFromString = readOnly.fromAbsolutePathString(filePathString)
         assertEquals(file1, fileFromString)
     }
 
@@ -403,7 +403,7 @@ class JVMFileSystemProviderTest : KoogTestBase() {
     @Test
     fun `test ReadWrite fromAbsoluteString`() {
         val filePathString = file1.absolute().pathString
-        val fileFromPath = readWrite.fromAbsoluteString(filePathString)
+        val fileFromPath = readWrite.fromAbsolutePathString(filePathString)
         assertEquals(file1, fileFromPath)
     }
 

--- a/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFilteredFileSystemProviderTest.kt
+++ b/rag/rag-base/src/jvmTest/kotlin/ai/koog/rag/base/files/JVMFilteredFileSystemProviderTest.kt
@@ -91,7 +91,7 @@ class JVMFilteredFileSystemProviderTest : KoogTestBase() {
     fun `test select does not throw`() {
         assertNotNull(fsReadOnly.parent(src2))
         assertNotNull(fsReadOnly.fromRelativeString(src2, assertNotNull(fsReadOnly.relativize(src2, file2))))
-        assertNotNull(fsReadOnly.fromAbsoluteString(assertNotNull(fsReadOnly.toAbsolutePathString(file2))))
+        assertNotNull(fsReadOnly.fromAbsolutePathString(assertNotNull(fsReadOnly.toAbsolutePathString(file2))))
         assertNotNull(fsReadOnly.name(src2))
         assertNotNull(fsReadOnly.extension(file2))
     }

--- a/rag/vector-storage/src/commonTest/kotlin/ai/koog/rag/vector/mocks/MockDocumentProviders.kt
+++ b/rag/vector-storage/src/commonTest/kotlin/ai/koog/rag/vector/mocks/MockDocumentProviders.kt
@@ -45,7 +45,7 @@ class MockDocumentProvider(val mockFileSystem: MockFileSystem) : DocumentProvide
 class MockFileSystemProvider(val mockFileSystem: MockFileSystem) : FileSystemProvider.ReadWrite<String> {
     override fun toAbsolutePathString(path: String): String = path
 
-    override fun fromAbsoluteString(path: String): String = path
+    override fun fromAbsolutePathString(path: String): String = path
 
     override fun fromRelativeString(base: String, path: String): String = "$base/$path"
 


### PR DESCRIPTION
To make it in sync with `toAbsolutePathString`

---

#### Type of the change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation fix
- [ ] Tests improvement
- [X] Refactoring

#### Checklist for all pull requests
- [ ] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [X] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
