### PR TITLE
KG-175. Add input.value and output.value attributes for ExecuteToolSpan

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/SpanAttributes.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/SpanAttributes.kt
@@ -283,5 +283,17 @@ internal object SpanAttributes {
             override val key: String = super.key.concatKey("name")
             override val value: String = name
         }
+
+        // Custom tool attribute with tool arguments used for tool calls
+        data class InputValue(private val input: String) : Attribute {
+            override val key: String = "input.value"
+            override val value: Any = input
+        }
+
+        // Custom tool attribute with tool execution results used for tool calls
+        data class OutputValue(private val output: String) : Attribute {
+            override val key: String = "output.value"
+            override val value: Any = output
+        }
     }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
@@ -345,7 +345,8 @@ public class OpenTelemetry {
 
                 val executeToolSpan = ExecuteToolSpan(
                     parent = nodeExecuteSpan,
-                    tool = eventContext.tool
+                    tool = eventContext.tool,
+                    toolArgs = eventContext.toolArgs,
                 )
 
                 spanProcessor.startSpan(executeToolSpan)
@@ -368,7 +369,16 @@ public class OpenTelemetry {
                 )
 
                 // End the ExecuteToolSpan span
-                spanProcessor.endSpan(executeToolSpanId)
+                val finishAttributes = buildList {
+                    eventContext.result?.toStringDefault()?.let { result ->
+                        add(SpanAttributes.Tool.OutputValue(result))
+                    }
+                }
+
+                spanProcessor.endSpan(
+                    spanId = executeToolSpanId,
+                    attributes = finishAttributes
+                )
             }
 
             pipeline.interceptToolCallFailure(interceptContext) { eventContext ->

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/ExecuteToolSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/ExecuteToolSpan.kt
@@ -1,6 +1,8 @@
 package ai.koog.agents.features.opentelemetry.span
 
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
+import ai.koog.agents.core.tools.ToolResult
 import ai.koog.agents.features.opentelemetry.attribute.Attribute
 import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
 import io.opentelemetry.api.trace.SpanKind
@@ -11,6 +13,7 @@ import io.opentelemetry.api.trace.SpanKind
 internal class ExecuteToolSpan(
     parent: NodeExecuteSpan,
     private val tool: Tool<*, *>,
+    private val toolArgs: ToolArgs
 ) : GenAIAgentSpan(parent) {
 
     companion object {
@@ -26,7 +29,7 @@ internal class ExecuteToolSpan(
     override val kind: SpanKind = SpanKind.INTERNAL
 
     /**
-     * Add the necessary attributes for the Execute Tool Span according to the Open Telemetry Semantic Convention:
+     * Add the necessary attributes for the Execute Tool Span, according to the Open Telemetry Semantic Convention:
      * https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#execute-tool-span
      *
      * Attribute description:
@@ -41,5 +44,11 @@ internal class ExecuteToolSpan(
 
         // gen_ai.tool.name
         add(SpanAttributes.Tool.Name(name = tool.name))
+
+        // Tool arguments
+        @Suppress("UNCHECKED_CAST")
+        (tool as? Tool<ToolArgs, ToolResult>)?.let { tool ->
+            add(SpanAttributes.Tool.InputValue(tool.encodeArgsToString(toolArgs)))
+        }
     }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
@@ -478,7 +478,7 @@ class OpenTelemetryTest {
 
             val mockExecutor = getMockExecutor(clock = testClock) {
                 mockLLMToolCall(TestGetWeatherTool, TestGetWeatherTool.Args("Paris")) onRequestEquals userPrompt
-                mockLLMAnswer(mockResponse) onRequestContains "rainy, 57°F"
+                mockLLMAnswer(mockResponse) onRequestContains TestGetWeatherTool.RESULT
             }
 
             val agent = createAgent(
@@ -581,6 +581,8 @@ class OpenTelemetryTest {
                 mapOf(
                     "tool.Get whether" to mapOf(
                         "attributes" to mapOf(
+                            "output.value" to TestGetWeatherTool.RESULT,
+                            "input.value" to "{\"location\":\"Paris\"}",
                             "gen_ai.tool.description" to "The test tool to get a whether based on provided location.",
                             "gen_ai.tool.name" to "Get whether",
                         ),
@@ -764,6 +766,8 @@ class OpenTelemetryTest {
                 mapOf(
                     "tool.Get whether" to mapOf(
                         "attributes" to mapOf(
+                            "output.value" to TestGetWeatherTool.RESULT,
+                            "input.value" to "{\"location\":\"Paris\"}",
                             "gen_ai.tool.description" to "The test tool to get a whether based on provided location.",
                             "gen_ai.tool.name" to "Get whether",
                         ),


### PR DESCRIPTION
Add `input.value` and `output.value` attributes for `ExecuteToolSpan` span in OpenTelemetry support

---

#### Type of the change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation fix
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
