### PR TITLE
Remove deprecated tests and error constants leading to FN tests

### DIFF
--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/MultipleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/MultipleLLMPromptExecutorIntegrationTest.kt
@@ -213,37 +213,6 @@ class MultipleLLMPromptExecutorIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("openAIModels", "anthropicModels", "googleModels")
-    fun integration_testCodeGeneration(model: LLModel) = runTest(timeout = 300.seconds) {
-        Models.assumeAvailable(model.provider)
-        assumeTrue(model.capabilities.contains(LLMCapability.Tools))
-
-        val prompt = prompt("test-code") {
-            system("You are a helpful coding assistant.")
-            user(
-                "Write a simple Kotlin function to calculate the factorial of a number. " +
-                    "Make sure the name of the function starts with 'factorial'. ONLY generate CODE, no explanations or other texts. " +
-                    "The function MUST have a return statement."
-            )
-        }
-
-        withRetry(times = 3, testName = "integration_testCodeGeneration[${model.id}]") {
-            val response = executor.execute(prompt, model, emptyList())
-
-            assertNotNull(response, "Response should not be null")
-            assertTrue(response.isNotEmpty(), "Response should not be empty")
-            assertTrue(response.first() is Message.Assistant, "Response should be an Assistant message")
-
-            val content = (response.first() as Message.Assistant).content
-            assertTrue(
-                content.contains("fun factorial"),
-                "Response should contain a factorial function. Response: $response. Content: $content"
-            )
-            assertTrue(content.contains("return"), "Response should contain a return statement")
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("openAIModels", "anthropicModels", "googleModels")
     fun integration_testToolsWithRequiredParams(model: LLModel) = runTest(timeout = 300.seconds) {
         Models.assumeAvailable(model.provider)
         assumeTrue(model.capabilities.contains(LLMCapability.Tools), "Model $model does not support tools")

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SingleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/SingleLLMPromptExecutorIntegrationTest.kt
@@ -192,37 +192,6 @@ class SingleLLMPromptExecutorIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("modelClientCombinations")
-    fun integration_testCodeGeneration(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
-        Models.assumeAvailable(model.provider)
-        val executor = SingleLLMPromptExecutor(client)
-
-        val prompt = Prompt.build("test-code") {
-            system("You are a helpful coding assistant.")
-            user(
-                "Write a simple Kotlin function to calculate the factorial of a number. Make sure the name of the function starts with 'factorial'."
-            )
-        }
-
-        var response: List<Message>
-
-        withRetry(times = 3, testName = "integration_testCodeGeneration[${model.id}]") {
-            response = executor.execute(prompt, model, emptyList())
-
-            assertNotNull(response, "Response should not be null")
-            assertTrue(response.isNotEmpty(), "Response should not be empty")
-            assertTrue(response.first() is Message.Assistant, "Response should be an Assistant message")
-
-            val content = (response.first() as Message.Assistant).content
-            assertTrue(
-                content.contains("fun factorial"),
-                "Response should contain a factorial function. Response: $response. Content: $content"
-            )
-            assertTrue(content.contains("return"), "Response should contain a return statement")
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("modelClientCombinations")
     fun integration_testToolsWithRequiredParams(model: LLModel, client: LLMClient) = runTest(timeout = 300.seconds) {
         Models.assumeAvailable(model.provider)
         assumeTrue(model.capabilities.contains(LLMCapability.Tools), "Model $model does not support tools")

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/RetryUtils.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/RetryUtils.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Assumptions
 * so I had to add this workaround to skip/retry tests with @ParametrizedTest annotation.
 * */
 object RetryUtils {
-    private const val GOOGLE_API_ERROR = "Field 'parts' is required for type with serial name"
     private const val GOOGLE_429_ERROR = "Error from GoogleAI API: 429 Too Many Requests"
     private const val GOOGLE_500_ERROR = "Error from GoogleAI API: 500 Internal Server Error"
     private const val GOOGLE_503_ERROR = "Error from GoogleAI API: 503 Service Unavailable"
@@ -20,7 +19,6 @@ object RetryUtils {
 
     private fun isThirdPartyError(e: Throwable): Boolean {
         val errorMessages = listOf(
-            GOOGLE_API_ERROR,
             GOOGLE_429_ERROR,
             GOOGLE_500_ERROR,
             GOOGLE_503_ERROR,


### PR DESCRIPTION
I tried to reproduce the #561 and failed.

So I checked the tests and found out that we ignore the mentioned problem. So I deleted this error wrap (and got rid of a couple of tests which aren't much different from `integration_testExecute()`).

Let's observe now how tests will behave and whether they will catch the mentioned problem.

---

#### Type of the change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation fix
- [x] Tests improvement
- [ ] Refactoring

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
