### PR TITLE
fix: add function calling for gemini-2.5-flash

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleModels.kt
@@ -124,7 +124,7 @@ public object GoogleModels : LLModelDefinitions {
     public val Gemini2_5Flash: LLModel = LLModel(
         provider = LLMProvider.Google,
         id = "gemini-2.5-flash",
-        capabilities = multimodalCapabilities,
+        capabilities = fullCapabilities,
         contextLength = 1_048_576,
         maxOutputTokens = 65_536,
     )


### PR DESCRIPTION
bug - Koog presents the error "Model gemini-2.5-flash does not support tools" when using tools with gemini-2.5-flash
fix - update gemini-2.5-flash to support all capabilities 


---

#### Type of the change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation fix
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist for all pull requests
- [X] The pull request has a description of the proposed change
- [X] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [X] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
