### PR TITLE
Introduce Retry logic for LLM clients

### DIFF
--- a/docs/docs/prompt-api.md
+++ b/docs/docs/prompt-api.md
@@ -308,7 +308,6 @@ fun main() {
 -->
 ```kotlin
 val config = RetryConfig(
-    enableStreamingRetry = true,  // Enable stream retry
     maxAttempts = 3
 )
 
@@ -317,7 +316,7 @@ val stream = client.executeStreaming(prompt, OpenAIModels.Chat.GPT4o)
 ```
 <!--- KNIT example-prompt-api-09.kt -->
 
-> **Note**: Stream retry restarts from the beginning. Already emitted chunks cannot be replayed.
+> **Note**: Streaming retry only applies to connection failures before the first token is received. Once streaming begins, errors are passed through to preserve content integrity.
 
 ### Timeout Configuration
 

--- a/docs/docs/prompt-api.md
+++ b/docs/docs/prompt-api.md
@@ -1,6 +1,19 @@
 # Prompt API
 
-The Prompt API lets you create well-structured prompts with Kotlin DSL, execute them against different LLM providers, and process responses in different formats.
+The Prompt API provides a comprehensive toolkit for interacting with Large Language Models (LLMs) in production applications. It offers:
+
+- **Kotlin DSL** for creating structured prompts with type safety
+- **Multi-provider support** for OpenAI, Anthropic, Google, and other LLM providers
+- **Production features** like retry logic, error handling, and timeout configuration
+- **Multimodal capabilities** for working with text, images, audio, and documents
+
+## Architecture Overview
+
+The Prompt API consists of three main layers:
+
+1. **LLM Clients** - Low-level interfaces to specific providers (OpenAI, Anthropic, etc.)
+2. **Decorators** - Optional wrappers that add functionality like retry logic
+3. **Prompt Executors** - High-level abstractions that manage client lifecycle and simplify usage
 
 ## Create a prompt
 
@@ -122,6 +135,276 @@ fun main() {
 ```
 <!--- KNIT example-prompt-api-04.kt -->
 
+## Retry functionality
+
+When working with LLM providers, you may encounter transient errors like rate limits or temporary service unavailability. The `RetryingLLMClient` decorator adds automatic retry logic to any LLM client.
+
+### Basic usage
+
+Wrap any existing client with retry capability:
+
+<!--- INCLUDE
+import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import ai.koog.prompt.executor.clients.retry.RetryingLLMClient
+import ai.koog.prompt.dsl.prompt
+import kotlinx.coroutines.runBlocking
+
+fun main() {
+    runBlocking {
+        val apiKey = System.getenv("OPENAI_API_KEY")
+        val prompt = prompt("test") {
+            user("Hello")
+        }
+-->
+<!--- SUFFIX
+    }
+}
+-->
+```kotlin
+// Wrap any client with retry capability
+val client = OpenAILLMClient(apiKey)
+val resilientClient = RetryingLLMClient(client)
+
+// Now all operations will automatically retry on transient errors
+val response = resilientClient.execute(prompt, OpenAIModels.Chat.GPT4o)
+```
+<!--- KNIT example-prompt-api-05.kt -->
+
+#### Configuring Retry Behavior
+
+Koog provides several predefined retry configurations:
+
+| Configuration | Max Attempts | Initial Delay | Max Delay | Use Case |
+|--------------|-------------|---------------|-----------|----------|
+| `DISABLED` | 1 (no retry) | - | - | Development/testing |
+| `CONSERVATIVE` | 3 | 2s | 30s | Normal production use |
+| `AGGRESSIVE` | 5 | 500ms | 20s | Critical operations |
+| `PRODUCTION` | 3 | 1s | 20s | Recommended default |
+
+Use them directly or create custom configurations:
+
+<!--- INCLUDE
+import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+import ai.koog.prompt.executor.clients.retry.RetryConfig
+import ai.koog.prompt.executor.clients.retry.RetryingLLMClient
+import kotlin.time.Duration.Companion.seconds
+
+val apiKey = System.getenv("OPENAI_API_KEY")
+val client = OpenAILLMClient(apiKey)
+-->
+```kotlin
+// Use predefined configuration
+val conservativeClient = RetryingLLMClient(
+    delegate = client,
+    config = RetryConfig.CONSERVATIVE
+)
+
+// Or create custom configuration
+val customClient = RetryingLLMClient(
+    delegate = client,
+    config = RetryConfig(
+        maxAttempts = 5,
+        initialDelay = 1.seconds,
+        maxDelay = 30.seconds,
+        backoffMultiplier = 2.0,
+        jitterFactor = 0.2
+    )
+)
+```
+<!--- KNIT example-prompt-api-06.kt -->
+
+#### Retryable Error Patterns
+
+By default, the retry mechanism recognizes common transient errors:
+
+- **HTTP Status Codes**: 429 (Rate Limit), 500, 502, 503, 504
+- **Error Keywords**: "rate limit", "timeout", "connection reset", "overloaded"
+
+You can define custom patterns for your specific needs:
+
+<!--- INCLUDE
+import ai.koog.prompt.executor.clients.retry.RetryConfig
+import ai.koog.prompt.executor.clients.retry.RetryablePattern
+-->
+```kotlin
+val config = RetryConfig(
+    retryablePatterns = listOf(
+        RetryablePattern.Status(429),           // Specific status code
+        RetryablePattern.Keyword("quota"),      // Keyword in error message
+        RetryablePattern.Regex(Regex("ERR_\\d+")), // Custom regex pattern
+        RetryablePattern.Custom { error ->      // Custom logic
+            error.contains("temporary") && error.length > 20
+        }
+    )
+)
+```
+<!--- KNIT example-prompt-api-07.kt -->
+
+#### Retry with Prompt Executors
+
+When using prompt executors, wrap the underlying client before creating the executor:
+
+<!--- INCLUDE
+import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
+import ai.koog.prompt.executor.clients.bedrock.BedrockLLMClient
+import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+import ai.koog.prompt.executor.clients.retry.RetryConfig
+import ai.koog.prompt.executor.clients.retry.RetryingLLMClient
+import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
+import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
+import ai.koog.prompt.llm.LLMProvider
+
+-->
+```kotlin
+// Single provider executor with retry
+val resilientClient = RetryingLLMClient(
+    OpenAILLMClient(System.getenv("OPENAI_API_KEY")),
+    RetryConfig.PRODUCTION
+)
+val executor = SingleLLMPromptExecutor(resilientClient)
+
+// Multi-provider executor with flexible client configuration
+val multiExecutor = MultiLLMPromptExecutor(
+    LLMProvider.OpenAI to RetryingLLMClient(
+        OpenAILLMClient(System.getenv("OPENAI_API_KEY")),
+        RetryConfig.CONSERVATIVE
+    ),
+    LLMProvider.Anthropic to RetryingLLMClient(
+        AnthropicLLMClient(System.getenv("ANTHROPIC_API_KEY")),
+        RetryConfig.AGGRESSIVE  
+    ),
+    // Bedrock client already has AWS SDK retry built-in
+    LLMProvider.Bedrock to BedrockLLMClient(
+        awsAccessKeyId = System.getenv("AWS_ACCESS_KEY_ID"),
+        awsSecretAccessKey = System.getenv("AWS_SECRET_ACCESS_KEY"),
+        awsSessionToken = System.getenv("AWS_SESSION_TOKEN"),
+    ))
+```
+<!--- KNIT example-prompt-api-08.kt -->
+
+#### Streaming with Retry
+
+Streaming operations can optionally be retried (disabled by default):
+
+<!--- INCLUDE
+import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import ai.koog.prompt.executor.clients.retry.RetryConfig
+import ai.koog.prompt.executor.clients.retry.RetryingLLMClient
+import ai.koog.prompt.dsl.prompt
+import kotlinx.coroutines.runBlocking
+
+fun main() {
+    runBlocking {
+        val baseClient = OpenAILLMClient(System.getenv("OPENAI_API_KEY"))
+        val prompt = prompt("test") {
+            user("Generate a story")
+        }
+-->
+<!--- SUFFIX
+    }
+}
+-->
+```kotlin
+val config = RetryConfig(
+    enableStreamingRetry = true,  // Enable stream retry
+    maxAttempts = 3
+)
+
+val client = RetryingLLMClient(baseClient, config)
+val stream = client.executeStreaming(prompt, OpenAIModels.Chat.GPT4o)
+```
+<!--- KNIT example-prompt-api-09.kt -->
+
+> **Note**: Stream retry restarts from the beginning. Already emitted chunks cannot be replayed.
+
+### Timeout Configuration
+
+All LLM clients support timeout configuration to prevent hanging requests:
+
+<!--- INCLUDE
+import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
+import ai.koog.prompt.executor.clients.openai.OpenAIClientSettings
+import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+
+val apiKey = System.getenv("OPENAI_API_KEY")
+-->
+```kotlin
+val client = OpenAILLMClient(
+    apiKey = apiKey,
+    settings = OpenAIClientSettings(
+        timeoutConfig = ConnectionTimeoutConfig(
+            connectTimeoutMillis = 5000,    // 5 seconds to establish connection
+            requestTimeoutMillis = 60000    // 60 seconds for the entire request
+        )
+    )
+)
+```
+<!--- KNIT example-prompt-api-10.kt -->
+
+### Error Handling Best Practices
+
+When working with LLMs in production:
+
+1. **Always wrap operations in try-catch blocks** to handle unexpected errors
+2. **Log errors with context** for debugging
+3. **Implement fallback strategies** for critical operations
+4. **Monitor retry patterns** to identify systemic issues
+
+Example of comprehensive error handling:
+
+<!--- INCLUDE
+import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import ai.koog.prompt.executor.clients.retry.RetryingLLMClient
+import ai.koog.prompt.dsl.prompt
+import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
+
+fun main() {
+    runBlocking {
+        val logger = LoggerFactory.getLogger("Example")
+        val resilientClient = RetryingLLMClient(
+            OpenAILLMClient(System.getenv("OPENAI_API_KEY"))
+        )
+        val prompt = prompt("test") { user("Hello") }
+        val model = OpenAIModels.Chat.GPT4o
+        
+        fun processResponse(response: Any) { /* ... */ }
+        fun scheduleRetryLater() { /* ... */ }
+        fun notifyAdministrator() { /* ... */ }
+        fun useDefaultResponse() { /* ... */ }
+-->
+<!--- SUFFIX
+    }
+}
+-->
+```kotlin
+try {
+    val response = resilientClient.execute(prompt, model)
+    processResponse(response)
+} catch (e: Exception) {
+    logger.error("LLM operation failed", e)
+    
+    when {
+        e.message?.contains("rate limit") == true -> {
+            // Handle rate limiting specifically
+            scheduleRetryLater()
+        }
+        e.message?.contains("invalid api key") == true -> {
+            // Handle authentication errors
+            notifyAdministrator()
+        }
+        else -> {
+            // Fall back to alternative solution
+            useDefaultResponse()
+        }
+    }
+}
+```
+<!--- KNIT example-prompt-api-11.kt -->
+
 ## Multimodal inputs
 
 In addition to providing text messages within prompts, Koog also lets you send images, audio, video, and files to LLMs along with `user` messages. As with standard text-only prompts, you also add media to the prompt using the DSL structure for prompt construction.
@@ -144,7 +427,7 @@ val prompt = prompt("multimodal_input") {
     }
 }
 ```
-<!--- KNIT example-prompt-api-05.kt -->
+<!--- KNIT example-prompt-api-12.kt -->
 
 ### Textual prompt content
 
@@ -169,7 +452,7 @@ user(
     )
 )
 ```
-<!--- KNIT example-prompt-api-06.kt -->
+<!--- KNIT example-prompt-api-13.kt -->
 
 ### File attachments
 
@@ -198,7 +481,7 @@ user(
     )
 )
 ```
-<!--- KNIT example-prompt-api-07.kt -->
+<!--- KNIT example-prompt-api-14.kt -->
 
 The `attachments` parameter takes a list of file inputs, where each item is an instance of one of the following classes:
 
@@ -275,14 +558,18 @@ val prompt = prompt("mixed_content") {
     }
 }
 ```
-<!--- KNIT example-prompt-api-08.kt -->
+<!--- KNIT example-prompt-api-15.kt -->
 
-## Prompt executors
+## Prompt Executors
 
-Prompt executors provide a higher-level way to work with LLMs, handling the details of client creation and management.
+While LLM clients provide direct access to providers, **Prompt Executors** offer a higher-level abstraction that simplifies common use cases and handles client lifecycle management. They're ideal when you want to:
 
-You can use a prompt executor to manage and run prompts.
-You can choose a prompt executor based on the LLM provider you plan to use or create a custom prompt executor using one of the available LLM clients.
+- Quickly prototype without managing client configuration
+- Work with multiple providers through a unified interface  
+- Simplify dependency injection in larger applications
+- Abstract away provider-specific details
+
+### Executor Types
 
 The Koog framework provides several prompt executors:
 
@@ -310,7 +597,7 @@ const val apiToken = "YOUR_API_TOKEN"
 // Create an OpenAI executor
 val promptExecutor = simpleOpenAIExecutor(apiToken)
 ```
-<!--- KNIT example-prompt-api-09.kt -->
+<!--- KNIT example-prompt-api-16.kt -->
 
 2. Execute the prompt with a specific LLM:
 <!--- INCLUDE
@@ -334,7 +621,7 @@ val response = promptExecutor.execute(
     model = OpenAIModels.Chat.GPT4o
 )
 ```
-<!--- KNIT example-prompt-api-10.kt -->
+<!--- KNIT example-prompt-api-17.kt -->
 
 ### Create a multi-provider executor
 
@@ -351,7 +638,7 @@ val openAIClient = OpenAILLMClient(System.getenv("OPENAI_KEY"))
 val anthropicClient = AnthropicLLMClient(System.getenv("ANTHROPIC_KEY"))
 val googleClient = GoogleLLMClient(System.getenv("GOOGLE_KEY"))
 ```
-<!--- KNIT example-prompt-api-11.kt -->
+<!--- KNIT example-prompt-api-18.kt -->
 
 2. Pass the configured clients to the `DefaultMultiLLMPromptExecutor` class constructor to create a prompt executor with multiple LLM providers:
 <!--- INCLUDE
@@ -363,7 +650,7 @@ import ai.koog.prompt.executor.llms.all.DefaultMultiLLMPromptExecutor
 ```kotlin
 val multiExecutor = DefaultMultiLLMPromptExecutor(openAIClient, anthropicClient, googleClient)
 ```
-<!--- KNIT example-prompt-api-12.kt -->
+<!--- KNIT example-prompt-api-19.kt -->
 
 3. Execute the prompt with a specific LLM:
 <!--- INCLUDE
@@ -387,5 +674,5 @@ val response = multiExecutor.execute(
     model = OpenAIModels.Chat.GPT4o
 )
 ```
-<!--- KNIT example-prompt-api-13.kt -->
+<!--- KNIT example-prompt-api-20.kt -->
 

--- a/docs/docs/prompt-api.md
+++ b/docs/docs/prompt-api.md
@@ -601,8 +601,8 @@ val promptExecutor = simpleOpenAIExecutor(apiToken)
 
 2. Execute the prompt with a specific LLM:
 <!--- INCLUDE
-import ai.koog.agents.example.examplePromptApi08.prompt
-import ai.koog.agents.example.examplePromptApi09.promptExecutor
+import ai.koog.agents.example.examplePromptApi12.prompt
+import ai.koog.agents.example.examplePromptApi16.promptExecutor
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.model.PromptExecutorExt.execute
 import kotlinx.coroutines.runBlocking
@@ -642,9 +642,9 @@ val googleClient = GoogleLLMClient(System.getenv("GOOGLE_KEY"))
 
 2. Pass the configured clients to the `DefaultMultiLLMPromptExecutor` class constructor to create a prompt executor with multiple LLM providers:
 <!--- INCLUDE
-import ai.koog.agents.example.examplePromptApi11.anthropicClient
-import ai.koog.agents.example.examplePromptApi11.googleClient
-import ai.koog.agents.example.examplePromptApi11.openAIClient
+import ai.koog.agents.example.examplePromptApi18.anthropicClient
+import ai.koog.agents.example.examplePromptApi18.googleClient
+import ai.koog.agents.example.examplePromptApi18.openAIClient
 import ai.koog.prompt.executor.llms.all.DefaultMultiLLMPromptExecutor
 -->
 ```kotlin
@@ -654,8 +654,8 @@ val multiExecutor = DefaultMultiLLMPromptExecutor(openAIClient, anthropicClient,
 
 3. Execute the prompt with a specific LLM:
 <!--- INCLUDE
-import ai.koog.agents.example.examplePromptApi08.prompt
-import ai.koog.agents.example.examplePromptApi12.multiExecutor
+import ai.koog.agents.example.examplePromptApi12.prompt
+import ai.koog.agents.example.examplePromptApi19.multiExecutor
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.model.PromptExecutorExt.execute
 import kotlinx.coroutines.runBlocking

--- a/prompt/prompt-executor/Module.md
+++ b/prompt/prompt-executor/Module.md
@@ -8,7 +8,7 @@ The prompt-executor module provides a unified interface for executing prompts ag
 
 - **prompt-executor-model**: Core interfaces and models for executing prompts against language models
 - **prompt-executor-cached**: Caching implementation for prompt execution
-- **prompt-executor-clients**: Client implementations for various LLM providers (OpenAI, Anthropic, OpenRouter)
+- **prompt-executor-clients**: Client implementations for various LLM providers and a retry logic decorator
 - **prompt-executor-llms**: Implementations of PromptExecutor for executing prompts with LLMs
 - **prompt-executor-llms-all**: Unified access to multiple LLM providers for prompt execution
 - **prompt-executor-ollama**: Client implementation for executing prompts using Ollama, a local LLM service

--- a/prompt/prompt-executor/prompt-executor-clients/Module.md
+++ b/prompt/prompt-executor/prompt-executor-clients/Module.md
@@ -1,21 +1,28 @@
 # Module prompt:prompt-executor:prompt-executor-clients
 
-A collection of client implementations for executing prompts using various LLM providers.
+A collection of client implementations for executing prompts using various LLM providers and retry logic features.
 
 ### Overview
 
 This module provides client implementations for different LLM providers, allowing you to execute prompts using various
-models with support for multimodal content including images, audio, video, and documents. The module includes the
-following sub-modules:
+models with support for multimodal content including images, audio, video, and documents. The module includes 
+**production-ready retry logic** through the `RetryingLLMClient` decorator, which adds automatic error handling and
+resilience to any client implementation.
 
-1. **prompt-executor-anthropic-client**: Client implementation for Anthropic's Claude models with image and document
-   support
+The module consists of:
+
+**Core Functionality:**
+- **LLMClient interface**: Base interface for all LLM client implementations
+- **RetryingLLMClient**: Decorator that adds retry logic with configurable policies
+- **RetryConfig**: Flexible retry configuration with predefined settings for different use cases
+
+**Provider-Specific Sub-modules:**
+1. **prompt-executor-anthropic-client**: Client implementation for Anthropic's Claude models with image and document support
 2. **prompt-executor-openai-client**: Client implementation for OpenAI's GPT models with image and audio capabilities
-3. **prompt-executor-google-client**: Client implementation for Google Gemini models with comprehensive multimodal
-   support (audio, image, video, documents)
-4. **prompt-executor-openrouter-client**: Client implementation for OpenRouter's API with image, audio, and document
-   support
-5. **prompt-executor-ollama-client**: Client implementation for local Ollama models
+3. **prompt-executor-google-client**: Client implementation for Google Gemini models with comprehensive multimodal support
+4. **prompt-executor-openrouter-client**: Client implementation for OpenRouter's API with image, audio, and document support
+5. **prompt-executor-bedrock-client**: Client implementation for AWS Bedrock with support for multiple model providers (JVM only)
+6. **prompt-executor-ollama-client**: Client implementation for local Ollama models
 
 Each client handles authentication, request formatting, response parsing, and media content encoding specific to its
 respective API requirements.
@@ -93,6 +100,33 @@ val response = client.execute(
 
 println(response)
 ```
+
+### Retry Logic
+
+Wrap any client with `RetryingLLMClient` to add automatic retry capabilities:
+
+```kotlin
+import ai.koog.prompt.executor.clients.retry.RetryingLLMClient
+import ai.koog.prompt.executor.clients.retry.RetryConfig
+
+val baseClient = OpenAILLMClient(apiKey = System.getenv("OPENAI_API_KEY"))
+val resilientClient = RetryingLLMClient(
+    delegate = baseClient,
+    config = RetryConfig.PRODUCTION  // Or CONSERVATIVE, AGGRESSIVE, DISABLED
+)
+
+val response = resilientClient.execute(prompt, model)
+
+resilientClient.executeStreaming(prompt, model).collect { chunk ->
+    print(chunk)
+}
+```
+
+**Retry Configurations:**
+- `RetryConfig.PRODUCTION` - Recommended for production (3 attempts, balanced delays)
+- `RetryConfig.CONSERVATIVE` - Fewer retries, longer delays (3 attempts, 2s initial delay)
+- `RetryConfig.AGGRESSIVE` - More retries, shorter delays (5 attempts, 500ms initial delay)
+- `RetryConfig.DISABLED` - No retries (1 attempt)
 
 ### Multimodal Content Support
 

--- a/prompt/prompt-executor/prompt-executor-clients/Module.md
+++ b/prompt/prompt-executor/prompt-executor-clients/Module.md
@@ -106,9 +106,6 @@ println(response)
 Wrap any client with `RetryingLLMClient` to add automatic retry capabilities:
 
 ```kotlin
-import ai.koog.prompt.executor.clients.retry.RetryingLLMClient
-import ai.koog.prompt.executor.clients.retry.RetryConfig
-
 val baseClient = OpenAILLMClient(apiKey = System.getenv("OPENAI_API_KEY"))
 val resilientClient = RetryingLLMClient(
     delegate = baseClient,

--- a/prompt/prompt-executor/prompt-executor-clients/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/build.gradle.kts
@@ -22,6 +22,12 @@ kotlin {
                 api(kotlin("reflect"))
             }
         }
+        commonTest {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(libs.kotlinx.coroutines.test)
+            }
+        }
     }
 
     explicitApi()

--- a/prompt/prompt-executor/prompt-executor-clients/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/build.gradle.kts
@@ -28,6 +28,12 @@ kotlin {
                 implementation(libs.kotlinx.coroutines.test)
             }
         }
+        jvmTest {
+            dependencies {
+                implementation(kotlin("test-junit5"))
+                implementation(libs.slf4j.simple)
+            }
+        }
     }
 
     explicitApi()

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfig.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfig.kt
@@ -13,7 +13,6 @@ import kotlin.time.Duration.Companion.seconds
  * @property backoffMultiplier Multiplier for exponential backoff
  * @property jitterFactor Random jitter factor (0.0 to 1.0)
  * @property retryablePatterns Patterns to identify retryable errors
- * @property enableStreamingRetry Whether to retry streaming operations
  * @property retryAfterExtractor Optional extractor for retry-after hints
  */
 public data class RetryConfig(
@@ -23,13 +22,13 @@ public data class RetryConfig(
     val backoffMultiplier: Double = 2.0,
     val jitterFactor: Double = 0.1,
     val retryablePatterns: List<RetryablePattern> = DEFAULT_PATTERNS,
-    val enableStreamingRetry: Boolean = false,
     val retryAfterExtractor: RetryAfterExtractor? = DefaultRetryAfterExtractor
 ) {
     init {
         require(maxAttempts >= 1) { "maxAttempts must be at least 1" }
         require(backoffMultiplier >= 1.0) { "backoffMultiplier must be at least 1.0" }
         require(jitterFactor in 0.0..1.0) { "jitterFactor must be between 0.0 and 1.0" }
+        require(initialDelay <= maxDelay) { "initialDelay ($initialDelay) must not be greater than maxDelay ($maxDelay)" }
     }
 
     public companion object {
@@ -49,12 +48,14 @@ public data class RetryConfig(
             RetryablePattern.Keyword("rate limit"),
             RetryablePattern.Keyword("too many requests"),
             RetryablePattern.Keyword("overloaded"),
-            RetryablePattern.Keyword("timeout"),
-            RetryablePattern.Keyword("timed out"),
-            RetryablePattern.Keyword("connection reset"),
+            RetryablePattern.Keyword("request timeout"),
+            RetryablePattern.Keyword("connection timeout"),
+            RetryablePattern.Keyword("read timeout"),
+            RetryablePattern.Keyword("write timeout"),
+            RetryablePattern.Keyword("connection reset by peer"),
             RetryablePattern.Keyword("connection refused"),
-            RetryablePattern.Keyword("EOF"),
-            RetryablePattern.Keyword("temporarily unavailable")
+            RetryablePattern.Keyword("temporarily unavailable"),
+            RetryablePattern.Keyword("service unavailable")
         )
 
         /**

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfig.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfig.kt
@@ -1,0 +1,168 @@
+package ai.koog.prompt.executor.clients.retry
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Configuration for retry behavior in LLM client operations.
+ *
+ * @property maxAttempts Maximum number of attempts (including initial)
+ * @property initialDelay Initial delay before first retry
+ * @property maxDelay Maximum delay between retries
+ * @property backoffMultiplier Multiplier for exponential backoff
+ * @property jitterFactor Random jitter factor (0.0 to 1.0)
+ * @property retryablePatterns Patterns to identify retryable errors
+ * @property enableStreamingRetry Whether to retry streaming operations
+ * @property retryAfterExtractor Optional extractor for retry-after hints
+ */
+public data class RetryConfig(
+    val maxAttempts: Int = 3,
+    val initialDelay: Duration = 1.seconds,
+    val maxDelay: Duration = 30.seconds,
+    val backoffMultiplier: Double = 2.0,
+    val jitterFactor: Double = 0.1,
+    val retryablePatterns: List<RetryablePattern> = DEFAULT_PATTERNS,
+    val enableStreamingRetry: Boolean = false,
+    val retryAfterExtractor: RetryAfterExtractor? = DefaultRetryAfterExtractor
+) {
+    init {
+        require(maxAttempts >= 1) { "maxAttempts must be at least 1" }
+        require(backoffMultiplier >= 1.0) { "backoffMultiplier must be at least 1.0" }
+        require(jitterFactor in 0.0..1.0) { "jitterFactor must be between 0.0 and 1.0" }
+    }
+
+    public companion object {
+        /**
+         * Default retry patterns that work across all providers.
+         */
+        public val DEFAULT_PATTERNS: List<RetryablePattern> = listOf(
+            // HTTP status codes
+            RetryablePattern.Status(429), // Rate limit
+            RetryablePattern.Status(500), // Internal server error
+            RetryablePattern.Status(502), // Bad gateway
+            RetryablePattern.Status(503), // Service unavailable
+            RetryablePattern.Status(504), // Gateway timeout
+            RetryablePattern.Status(529), // Anthropic overloaded
+
+            // Error keywords
+            RetryablePattern.Keyword("rate limit"),
+            RetryablePattern.Keyword("too many requests"),
+            RetryablePattern.Keyword("overloaded"),
+            RetryablePattern.Keyword("timeout"),
+            RetryablePattern.Keyword("timed out"),
+            RetryablePattern.Keyword("connection reset"),
+            RetryablePattern.Keyword("connection refused"),
+            RetryablePattern.Keyword("EOF"),
+            RetryablePattern.Keyword("temporarily unavailable")
+        )
+
+        /**
+         * Conservative configuration - fewer retries, longer delays.
+         */
+        public val CONSERVATIVE: RetryConfig = RetryConfig(
+            maxAttempts = 3,
+            initialDelay = 2.seconds,
+            maxDelay = 30.seconds
+        )
+
+        /**
+         * Aggressive configuration - more retries, shorter delays.
+         */
+        public val AGGRESSIVE: RetryConfig = RetryConfig(
+            maxAttempts = 5,
+            initialDelay = 500.milliseconds,
+            maxDelay = 20.seconds,
+            backoffMultiplier = 1.5
+        )
+
+        /**
+         * Production configuration - balanced for production use.
+         */
+        public val PRODUCTION: RetryConfig = RetryConfig(
+            maxAttempts = 3,
+            initialDelay = 1.seconds,
+            maxDelay = 20.seconds,
+            backoffMultiplier = 2.0,
+            jitterFactor = 0.2
+        )
+
+        /**
+         * No retry - effectively disables retry logic.
+         */
+        public val DISABLED: RetryConfig = RetryConfig(maxAttempts = 1)
+    }
+}
+
+/**
+ * Pattern for identifying retryable errors.
+ */
+public sealed class RetryablePattern {
+    public abstract fun matches(message: String): Boolean
+
+    /**
+     * Matches HTTP status codes in error messages.
+     */
+    public data class Status(val code: Int) : RetryablePattern() {
+        private val patterns = listOf(
+            Regex("\\b$code\\b"),
+            Regex("status:?\\s*$code"),
+            Regex("error:?\\s*$code", RegexOption.IGNORE_CASE)
+        )
+
+        override fun matches(message: String): Boolean =
+            patterns.any { it.containsMatchIn(message) }
+    }
+
+    /**
+     * Matches keywords in error messages.
+     */
+    public data class Keyword(val keyword: String) : RetryablePattern() {
+        override fun matches(message: String): Boolean =
+            keyword.lowercase() in message.lowercase()
+    }
+
+    /**
+     * Matches using a custom regex.
+     */
+    public data class Regex(val pattern: kotlin.text.Regex) : RetryablePattern() {
+        override fun matches(message: String): Boolean =
+            pattern.containsMatchIn(message)
+    }
+
+    /**
+     * Custom matching logic.
+     */
+    public class Custom(private val matcher: (String) -> Boolean) : RetryablePattern() {
+        override fun matches(message: String): Boolean = matcher(message)
+    }
+}
+
+/**
+ * Extracts retry-after hints from error messages.
+ */
+public fun interface RetryAfterExtractor {
+    public fun extract(message: String): Duration?
+}
+
+/**
+ * Default implementation that extracts common retry-after patterns.
+ */
+public object DefaultRetryAfterExtractor : RetryAfterExtractor {
+    private val patterns = listOf(
+        Regex("retry\\s+after\\s+(\\d+)\\s+second", RegexOption.IGNORE_CASE),
+        Regex("retry-after:\\s*(\\d+)", RegexOption.IGNORE_CASE),
+        Regex("wait\\s+(\\d+)\\s+second", RegexOption.IGNORE_CASE)
+    )
+
+    override fun extract(message: String): Duration? {
+        for (pattern in patterns) {
+            pattern.find(message)?.let { match ->
+                match.groupValues.getOrNull(1)?.toLongOrNull()?.let { seconds ->
+                    return seconds.seconds
+                }
+            }
+        }
+        return null
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClient.kt
@@ -1,0 +1,192 @@
+package ai.koog.prompt.executor.clients.retry
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.prompt.dsl.ModerationResult
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.executor.clients.LLMClient
+import ai.koog.prompt.executor.model.LLMChoice
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.Message
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
+import kotlin.random.Random
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * A decorator that adds retry capabilities to any LLMClient implementation.
+ *
+ * This is a pure decorator - it has no knowledge of specific providers or implementations.
+ * It simply wraps any LLMClient and retries operations based on configurable policies.
+ *
+ * Example usage:
+ * ```kotlin
+ * val client = AnthropicLLMClient(apiKey)
+ * val retryingClient = RetryingLLMClient(client, RetryConfig.CONSERVATIVE)
+ * ```
+ *
+ * @param delegate The LLMClient to wrap with retry logic
+ * @param config Configuration for retry behavior
+ */
+public class RetryingLLMClient(
+    private val delegate: LLMClient,
+    private val config: RetryConfig = RetryConfig()
+) : LLMClient {
+
+    private companion object {
+        private val logger = KotlinLogging.logger { }
+    }
+
+    override suspend fun execute(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>
+    ): List<Message.Response> = withRetry("execute") {
+        delegate.execute(prompt, model, tools)
+    }
+
+    override fun executeStreaming(
+        prompt: Prompt,
+        model: LLModel
+    ): Flow<String> {
+        if (!config.enableStreamingRetry) {
+            // Simple passthrough if streaming retry is disabled
+            return delegate.executeStreaming(prompt, model)
+        }
+
+        // Streaming retry with reconnection support
+        return flow {
+            var attempt = 0
+            var lastError: Throwable? = null
+
+            while (attempt < config.maxAttempts) {
+                try {
+                    delegate.executeStreaming(prompt, model)
+                        .catch { error ->
+                            if (shouldRetry(error) && attempt < config.maxAttempts - 1) {
+                                throw StreamRetrySignal(error)
+                            } else {
+                                throw error
+                            }
+                        }
+                        .collect { chunk ->
+                            emit(chunk)
+                        }
+                    return@flow // Success
+                } catch (e: StreamRetrySignal) {
+                    lastError = e.cause
+                    attempt++
+
+                    if (attempt < config.maxAttempts) {
+                        val delay = calculateDelay(attempt - 1)
+                        logger.warn {
+                            "Stream interrupted (attempt $attempt/${config.maxAttempts}). " +
+                                "Retrying in ${delay.inWholeMilliseconds}ms. Error: ${e.cause.message}"
+                        }
+                        delay(delay)
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    if (!shouldRetry(e)) throw e
+
+                    lastError = e
+                    attempt++
+
+                    if (attempt >= config.maxAttempts) throw e
+
+                    val delay = calculateDelay(attempt - 1)
+                    logger.warn {
+                        "Stream failed (attempt $attempt/${config.maxAttempts}). " +
+                            "Retrying in ${delay.inWholeMilliseconds}ms"
+                    }
+                    delay(delay)
+                }
+            }
+
+            throw lastError ?: IllegalStateException("Stream retry exhausted")
+        }
+    }
+
+    override suspend fun executeMultipleChoices(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>
+    ): List<LLMChoice> = withRetry("executeMultipleChoices") {
+        delegate.executeMultipleChoices(prompt, model, tools)
+    }
+
+    override suspend fun moderate(
+        prompt: Prompt,
+        model: LLModel
+    ): ModerationResult = withRetry("moderate") {
+        delegate.moderate(prompt, model)
+    }
+
+    private suspend fun <T> withRetry(
+        operation: String,
+        block: suspend () -> T
+    ): T {
+        var lastException: Throwable? = null
+
+        repeat(config.maxAttempts) { attempt ->
+            try {
+                return block()
+            } catch (e: CancellationException) {
+                throw e // Never retry cancellations
+            } catch (e: Throwable) {
+                lastException = e
+
+                if (!shouldRetry(e) || attempt >= config.maxAttempts - 1) {
+                    throw e
+                }
+
+                val delay = calculateDelay(attempt, e)
+                logger.warn {
+                    "$operation failed (attempt ${attempt + 1}/${config.maxAttempts}). " +
+                        "Retrying in ${delay.inWholeMilliseconds}ms. Error: ${e.message}"
+                }
+                delay(delay)
+            }
+        }
+
+        throw lastException!!
+    }
+
+    private fun shouldRetry(error: Throwable): Boolean {
+        val message = error.message ?: return false
+
+        // Check if error matches any retry pattern
+        return config.retryablePatterns.any { pattern ->
+            pattern.matches(message)
+        }
+    }
+
+    private fun calculateDelay(attempt: Int, error: Throwable? = null): Duration {
+        // Check for retry-after hint in error message
+        error?.message?.let { message ->
+            config.retryAfterExtractor?.extract(message)?.let { retryAfter ->
+                return retryAfter
+            }
+        }
+
+        // Exponential backoff with jitter
+        var exponentialMs = config.initialDelay.inWholeMilliseconds.toDouble()
+        repeat(attempt) {
+            exponentialMs *= config.backoffMultiplier
+        }
+        val boundedMs = minOf(exponentialMs, config.maxDelay.inWholeMilliseconds.toDouble())
+
+        // Add jitter
+        val jitter = Random.nextDouble(1.0 - config.jitterFactor, 1.0 + config.jitterFactor)
+        val finalMs = (boundedMs * jitter).toLong()
+
+        return finalMs.milliseconds
+    }
+
+    private class StreamRetrySignal(override val cause: Throwable) : Exception(cause)
+}

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClient.kt
@@ -70,7 +70,7 @@ public class RetryingLLMClient(
                     if (firstTokenReceived) {
                         throw e
                     }
-                    
+
                     if (!shouldRetry(e) || attempt >= config.maxAttempts - 1) {
                         throw e
                     }
@@ -161,5 +161,4 @@ public class RetryingLLMClient(
 
         return finalMs.milliseconds
     }
-
 }

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClient.kt
@@ -11,7 +11,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import kotlin.random.Random
 import kotlin.time.Duration
@@ -49,66 +48,41 @@ public class RetryingLLMClient(
         delegate.execute(prompt, model, tools)
     }
 
+    // Streaming retry: Only retries connection failures before the first token is received.
+    // Once streaming starts, errors are passed through to avoid content duplication.
     override fun executeStreaming(
         prompt: Prompt,
         model: LLModel
     ): Flow<String> {
-        if (!config.enableStreamingRetry) {
-            // Simple passthrough if streaming retry is disabled
-            return delegate.executeStreaming(prompt, model)
-        }
-
-        // Streaming retry with reconnection support
         return flow {
-            var attempt = 0
-            var lastError: Throwable? = null
-
-            while (attempt < config.maxAttempts) {
+            repeat(config.maxAttempts) { attempt ->
+                var firstTokenReceived = false
                 try {
-                    delegate.executeStreaming(prompt, model)
-                        .catch { error ->
-                            if (shouldRetry(error) && attempt < config.maxAttempts - 1) {
-                                throw StreamRetrySignal(error)
-                            } else {
-                                throw error
-                            }
-                        }
-                        .collect { chunk ->
-                            emit(chunk)
-                        }
-                    return@flow // Success
-                } catch (e: StreamRetrySignal) {
-                    lastError = e.cause
-                    attempt++
-
-                    if (attempt < config.maxAttempts) {
-                        val delay = calculateDelay(attempt - 1)
-                        logger.warn {
-                            "Stream interrupted (attempt $attempt/${config.maxAttempts}). " +
-                                "Retrying in ${delay.inWholeMilliseconds}ms. Error: ${e.cause.message}"
-                        }
-                        delay(delay)
+                    delegate.executeStreaming(prompt, model).collect { chunk ->
+                        firstTokenReceived = true
+                        emit(chunk)
                     }
+                    return@flow
                 } catch (e: CancellationException) {
-                    throw e
+                    throw e // Never retry cancellations
                 } catch (e: Throwable) {
-                    if (!shouldRetry(e)) throw e
+                    // If we already received tokens, don't retry - pass error through
+                    if (firstTokenReceived) {
+                        throw e
+                    }
+                    
+                    if (!shouldRetry(e) || attempt >= config.maxAttempts - 1) {
+                        throw e
+                    }
 
-                    lastError = e
-                    attempt++
-
-                    if (attempt >= config.maxAttempts) throw e
-
-                    val delay = calculateDelay(attempt - 1)
+                    val delay = calculateDelay(attempt, e)
                     logger.warn {
-                        "Stream failed (attempt $attempt/${config.maxAttempts}). " +
-                            "Retrying in ${delay.inWholeMilliseconds}ms"
+                        "Stream connection failed before first token (attempt ${attempt + 1}/${config.maxAttempts}). " +
+                            "Retrying in ${delay.inWholeMilliseconds}ms. Error: ${e.message}"
                     }
                     delay(delay)
                 }
             }
-
-            throw lastError ?: IllegalStateException("Stream retry exhausted")
         }
     }
 
@@ -181,12 +155,11 @@ public class RetryingLLMClient(
         }
         val boundedMs = minOf(exponentialMs, config.maxDelay.inWholeMilliseconds.toDouble())
 
-        // Add jitter
-        val jitter = Random.nextDouble(1.0 - config.jitterFactor, 1.0 + config.jitterFactor)
-        val finalMs = (boundedMs * jitter).toLong()
+        // Add jitter (only increases delay, never decreases)
+        val jitterMs = Random.nextDouble(0.0, boundedMs * config.jitterFactor)
+        val finalMs = (boundedMs + jitterMs).toLong()
 
         return finalMs.milliseconds
     }
 
-    private class StreamRetrySignal(override val cause: Throwable) : Exception(cause)
 }

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfigTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfigTest.kt
@@ -1,0 +1,217 @@
+package ai.koog.prompt.executor.clients.retry
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class RetryConfigTest {
+
+    @Test
+    fun `should create config with default values`() {
+        val config = RetryConfig()
+
+        assertEquals(3, config.maxAttempts)
+        assertEquals(1.seconds, config.initialDelay)
+        assertEquals(30.seconds, config.maxDelay)
+        assertEquals(2.0, config.backoffMultiplier)
+        assertEquals(0.1, config.jitterFactor)
+        assertFalse(config.enableStreamingRetry)
+        assertNotNull(config.retryAfterExtractor)
+        assertTrue(config.retryablePatterns.isNotEmpty())
+    }
+
+    @Test
+    fun `should validate maxAttempts`() {
+        assertFailsWith<IllegalArgumentException> {
+            RetryConfig(maxAttempts = 0)
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            RetryConfig(maxAttempts = -1)
+        }
+
+        // Should not throw
+        RetryConfig(maxAttempts = 1)
+        RetryConfig(maxAttempts = 100)
+    }
+
+    @Test
+    fun `should validate backoffMultiplier`() {
+        assertFailsWith<IllegalArgumentException> {
+            RetryConfig(backoffMultiplier = 0.5)
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            RetryConfig(backoffMultiplier = -1.0)
+        }
+
+        // Should not throw
+        RetryConfig(backoffMultiplier = 1.0)
+        RetryConfig(backoffMultiplier = 10.0)
+    }
+
+    @Test
+    fun `should validate jitterFactor`() {
+        assertFailsWith<IllegalArgumentException> {
+            RetryConfig(jitterFactor = -0.1)
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            RetryConfig(jitterFactor = 1.1)
+        }
+
+        // Should not throw
+        RetryConfig(jitterFactor = 0.0)
+        RetryConfig(jitterFactor = 0.5)
+        RetryConfig(jitterFactor = 1.0)
+    }
+
+    @Test
+    fun `CONSERVATIVE config should have expected values`() {
+        val config = RetryConfig.CONSERVATIVE
+
+        assertEquals(3, config.maxAttempts)
+        assertEquals(2.seconds, config.initialDelay)
+        assertEquals(30.seconds, config.maxDelay)
+    }
+
+    @Test
+    fun `AGGRESSIVE config should have expected values`() {
+        val config = RetryConfig.AGGRESSIVE
+
+        assertEquals(5, config.maxAttempts)
+        assertEquals(500.milliseconds, config.initialDelay)
+        assertEquals(20.seconds, config.maxDelay)
+        assertEquals(1.5, config.backoffMultiplier)
+    }
+
+    @Test
+    fun `DISABLED config should have maxAttempts of 1`() {
+        val config = RetryConfig.DISABLED
+
+        assertEquals(1, config.maxAttempts)
+    }
+
+    @Test
+    fun `default patterns should include common error codes`() {
+        val patterns = RetryConfig.DEFAULT_PATTERNS
+
+        // Check for important status codes
+        assertTrue(patterns.any { it is RetryablePattern.Status && it.code == 429 })
+        assertTrue(patterns.any { it is RetryablePattern.Status && it.code == 500 })
+        assertTrue(patterns.any { it is RetryablePattern.Status && it.code == 503 })
+
+        // Check for important keywords
+        assertTrue(patterns.any { it is RetryablePattern.Keyword && it.keyword == "rate limit" })
+        assertTrue(patterns.any { it is RetryablePattern.Keyword && it.keyword == "timeout" })
+    }
+}
+
+class RetryablePatternTest {
+
+    @Test
+    fun `Status pattern should match various formats`() {
+        val pattern = RetryablePattern.Status(429)
+
+        // Should match
+        assertTrue(pattern.matches("Error 429"))
+        assertTrue(pattern.matches("status: 429"))
+        assertTrue(pattern.matches("status:429"))
+        assertTrue(pattern.matches("HTTP 429 Too Many Requests"))
+        assertTrue(pattern.matches("Error from API: 429"))
+
+        // Should not match
+        assertFalse(pattern.matches("Error 430"))
+        assertFalse(pattern.matches("Error 42"))
+        assertFalse(pattern.matches("429a"))
+        assertFalse(pattern.matches("No status code here"))
+    }
+
+    @Test
+    fun `Keyword pattern should be case insensitive`() {
+        val pattern = RetryablePattern.Keyword("Rate Limit")
+
+        // Should match
+        assertTrue(pattern.matches("rate limit exceeded"))
+        assertTrue(pattern.matches("RATE LIMIT"))
+        assertTrue(pattern.matches("Rate Limit"))
+        assertTrue(pattern.matches("You've hit the rate limit"))
+
+        // Should not match
+        assertFalse(pattern.matches("ratelimit"))
+        assertFalse(pattern.matches("rate-limit"))
+        assertFalse(pattern.matches("No matching text here"))
+    }
+
+    @Test
+    fun `Regex pattern should match custom patterns`() {
+        val pattern = RetryablePattern.Regex(Regex("CUSTOM_ERROR_\\d{3}"))
+
+        // Should match
+        assertTrue(pattern.matches("CUSTOM_ERROR_123"))
+        assertTrue(pattern.matches("Got CUSTOM_ERROR_456 from service"))
+
+        // Should not match (regex requires exactly 3 digits)
+        assertFalse(pattern.matches("CUSTOM_ERROR_12"))
+        assertFalse(pattern.matches("CUSTOM_ERROR_A123"))
+        assertFalse(pattern.matches("CUSTOM_ERROR"))
+    }
+
+    @Test
+    fun `Custom pattern should use provided matcher`() {
+        val pattern = RetryablePattern.Custom { message ->
+            message.contains("special") && message.length > 10
+        }
+
+        // Should match
+        assertTrue(pattern.matches("This is a special error"))
+
+        // Should not match
+        assertFalse(pattern.matches("special")) // Too short
+        assertFalse(pattern.matches("This is a normal error")) // No "special"
+    }
+}
+
+class RetryAfterExtractorTest {
+
+    @Test
+    fun `should extract retry after in seconds`() {
+        val extractor = DefaultRetryAfterExtractor
+
+        assertEquals(5.seconds, extractor.extract("Retry after 5 seconds"))
+        assertEquals(10.seconds, extractor.extract("retry-after: 10"))
+        assertEquals(30.seconds, extractor.extract("Please retry after 30 seconds"))
+        assertEquals(60.seconds, extractor.extract("Wait 60 seconds"))
+    }
+
+    @Test
+    fun `should handle various formats`() {
+        val extractor = DefaultRetryAfterExtractor
+
+        assertEquals(5.seconds, extractor.extract("RETRY AFTER 5 SECONDS"))
+        assertEquals(10.seconds, extractor.extract("Retry-After: 10"))
+        assertEquals(15.seconds, extractor.extract("retry after 15 seconds"))
+    }
+
+    @Test
+    fun `should return null when no retry-after found`() {
+        val extractor = DefaultRetryAfterExtractor
+
+        assertNull(extractor.extract("No retry information here"))
+        assertNull(extractor.extract("Error 429 Too Many Requests"))
+        assertNull(extractor.extract(""))
+    }
+
+    @Test
+    fun `should extract first match when multiple present`() {
+        val extractor = DefaultRetryAfterExtractor
+
+        assertEquals(5.seconds, extractor.extract("Retry after 5 seconds, or wait 10 seconds"))
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfigTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfigTest.kt
@@ -21,7 +21,6 @@ class RetryConfigTest {
         assertEquals(30.seconds, config.maxDelay)
         assertEquals(2.0, config.backoffMultiplier)
         assertEquals(0.1, config.jitterFactor)
-        assertFalse(config.enableStreamingRetry)
         assertNotNull(config.retryAfterExtractor)
         assertTrue(config.retryablePatterns.isNotEmpty())
     }
@@ -73,6 +72,27 @@ class RetryConfigTest {
     }
 
     @Test
+    fun `should validate initialDelay not greater than maxDelay`() {
+        assertFailsWith<IllegalArgumentException> {
+            RetryConfig(
+                initialDelay = 60.seconds,
+                maxDelay = 30.seconds
+            )
+        }
+
+        // Should not throw
+        RetryConfig(
+            initialDelay = 30.seconds,
+            maxDelay = 60.seconds
+        )
+        RetryConfig(
+            initialDelay = 30.seconds,
+            maxDelay = 30.seconds
+        )
+    }
+
+
+    @Test
     fun `CONSERVATIVE config should have expected values`() {
         val config = RetryConfig.CONSERVATIVE
 
@@ -109,7 +129,7 @@ class RetryConfigTest {
 
         // Check for important keywords
         assertTrue(patterns.any { it is RetryablePattern.Keyword && it.keyword == "rate limit" })
-        assertTrue(patterns.any { it is RetryablePattern.Keyword && it.keyword == "timeout" })
+        assertTrue(patterns.any { it is RetryablePattern.Keyword && it.keyword == "request timeout" })
     }
 }
 

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfigTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfigTest.kt
@@ -91,7 +91,6 @@ class RetryConfigTest {
         )
     }
 
-
     @Test
     fun `CONSERVATIVE config should have expected values`() {
         val config = RetryConfig.CONSERVATIVE

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClientTest.kt
@@ -1,0 +1,409 @@
+package ai.koog.prompt.executor.clients.retry
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.prompt.dsl.ModerationResult
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.clients.LLMClient
+import ai.koog.prompt.executor.model.LLMChoice
+import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.ResponseMetaInfo
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.time.Duration.Companion.milliseconds
+
+class RetryingLLMClientTest {
+
+    private val testModel = LLModel(
+        provider = LLMProvider.OpenAI,
+        id = "test-model",
+        capabilities = listOf(LLMCapability.Completion),
+        contextLength = 4096
+    )
+
+    private val testPrompt = prompt("test-prompt") {
+        system("Test system message")
+        user("Test user message")
+    }
+
+    private val testMetaInfo = ResponseMetaInfo.create(Clock.System)
+
+    private val testResponse = listOf(
+        Message.Assistant(
+            content = "Test response",
+            metaInfo = testMetaInfo
+        )
+    )
+
+    @Test
+    fun testSucceedOnFirstAttempt() = runTest {
+        val mockClient = MockLLMClient(
+            executeResponse = testResponse
+        )
+
+        val retryingClient = RetryingLLMClient(mockClient)
+
+        val result = retryingClient.execute(testPrompt, testModel, emptyList())
+
+        assertEquals(testResponse, result)
+        assertEquals(1, mockClient.executeCalls)
+    }
+
+    @Test
+    fun testRetryOnRateLimitError() = runTest {
+        val mockClient = MockLLMClient(
+            executeResponse = testResponse,
+            failuresBeforeSuccess = 2,
+            failureMessage = "Error from API: 429 Too Many Requests"
+        )
+
+        val retryingClient = RetryingLLMClient(
+            mockClient,
+            RetryConfig(
+                maxAttempts = 3,
+                initialDelay = 10.milliseconds // Fast for testing
+            )
+        )
+
+        val result = retryingClient.execute(testPrompt, testModel, emptyList())
+
+        assertEquals(testResponse, result)
+        assertEquals(3, mockClient.executeCalls) // 2 failures + 1 success
+    }
+
+    @Test
+    fun testRetryOnServiceUnavailable() = runTest {
+        val mockClient = MockLLMClient(
+            executeResponse = testResponse,
+            failuresBeforeSuccess = 1,
+            failureMessage = "Error: 503 Service Unavailable"
+        )
+
+        val retryingClient = RetryingLLMClient(
+            mockClient,
+            RetryConfig(
+                maxAttempts = 2,
+                initialDelay = 10.milliseconds
+            )
+        )
+
+        val result = retryingClient.execute(testPrompt, testModel, emptyList())
+
+        assertEquals(testResponse, result)
+        assertEquals(2, mockClient.executeCalls)
+    }
+
+    @Test
+    fun testRetryOnTimeout() = runTest {
+        val mockClient = MockLLMClient(
+            executeResponse = testResponse,
+            failuresBeforeSuccess = 1,
+            failureMessage = "Connection timeout"
+        )
+
+        val retryingClient = RetryingLLMClient(
+            mockClient,
+            RetryConfig(
+                maxAttempts = 2,
+                initialDelay = 10.milliseconds
+            )
+        )
+
+        val result = retryingClient.execute(testPrompt, testModel, emptyList())
+
+        assertEquals(testResponse, result)
+        assertEquals(2, mockClient.executeCalls)
+    }
+
+    @Test
+    fun testNoRetryOnClientError() = runTest {
+        val mockClient = MockLLMClient(
+            executeResponse = testResponse,
+            failuresBeforeSuccess = 1,
+            failureMessage = "Error: 400 Bad Request"
+        )
+
+        val retryingClient = RetryingLLMClient(
+            mockClient,
+            RetryConfig(maxAttempts = 3)
+        )
+
+        assertFailsWith<RuntimeException> {
+            retryingClient.execute(testPrompt, testModel, emptyList())
+        }
+
+        assertEquals(1, mockClient.executeCalls) // No retry
+    }
+
+    @Test
+    fun testThrowAfterMaxAttempts() = runTest {
+        val mockClient = MockLLMClient(
+            executeResponse = testResponse,
+            failuresBeforeSuccess = 5, // Will always fail
+            failureMessage = "Error: 503"
+        )
+
+        val retryingClient = RetryingLLMClient(
+            mockClient,
+            RetryConfig(
+                maxAttempts = 3,
+                initialDelay = 10.milliseconds
+            )
+        )
+
+        val exception = assertFailsWith<RuntimeException> {
+            retryingClient.execute(testPrompt, testModel, emptyList())
+        }
+
+        assertEquals(exception.message?.contains("503"), true)
+        assertEquals(3, mockClient.executeCalls)
+    }
+
+    @Test
+    fun testCustomRetryPatterns() = runTest {
+        val mockClient = MockLLMClient(
+            executeResponse = testResponse,
+            failuresBeforeSuccess = 1,
+            failureMessage = "CUSTOM_ERROR_123"
+        )
+
+        val retryingClient = RetryingLLMClient(
+            mockClient,
+            RetryConfig(
+                maxAttempts = 2,
+                initialDelay = 10.milliseconds,
+                retryablePatterns = listOf(
+                    RetryablePattern.Regex(Regex("CUSTOM_ERROR_\\d+"))
+                )
+            )
+        )
+
+        val result = retryingClient.execute(testPrompt, testModel, emptyList())
+
+        assertEquals(testResponse, result)
+        assertEquals(2, mockClient.executeCalls)
+    }
+
+    @Test
+    fun testNoRetryOnCancellation() = runTest {
+        val mockClient = MockLLMClient(
+            executeResponse = testResponse,
+            throwCancellation = true
+        )
+
+        val retryingClient = RetryingLLMClient(
+            mockClient,
+            RetryConfig(maxAttempts = 3)
+        )
+
+        assertFailsWith<CancellationException> {
+            retryingClient.execute(testPrompt, testModel, emptyList())
+        }
+
+        assertEquals(1, mockClient.executeCalls) // No retry on cancellation
+    }
+
+    @Test
+    fun testDisabledRetryConfig() = runTest {
+        val mockClient = MockLLMClient(
+            executeResponse = testResponse,
+            failuresBeforeSuccess = 1,
+            failureMessage = "Error: 503"
+        )
+
+        val retryingClient = RetryingLLMClient(
+            mockClient,
+            RetryConfig.DISABLED
+        )
+
+        assertFailsWith<RuntimeException> {
+            retryingClient.execute(testPrompt, testModel, emptyList())
+        }
+
+        assertEquals(1, mockClient.executeCalls) // No retry with DISABLED config
+    }
+
+    @Test
+    fun testStreamingWithoutRetry() = runTest {
+        val mockClient = MockLLMClient(
+            streamResponse = flowOf("chunk1", "chunk2", "chunk3")
+        )
+
+        val retryingClient = RetryingLLMClient(
+            mockClient,
+            RetryConfig(enableStreamingRetry = false)
+        )
+
+        val result = retryingClient.executeStreaming(testPrompt, testModel).toList()
+
+        assertEquals(listOf("chunk1", "chunk2", "chunk3"), result)
+        assertEquals(1, mockClient.streamCalls)
+    }
+
+    @Test
+    fun testStreamingWithRetry() = runTest {
+        val mockClient = MockLLMClient(
+            streamResponse = flowOf("chunk1", "chunk2"),
+            streamFailuresBeforeSuccess = 1,
+            failureMessage = "Error: 503"
+        )
+
+        val retryingClient = RetryingLLMClient(
+            mockClient,
+            RetryConfig(
+                maxAttempts = 2,
+                initialDelay = 10.milliseconds,
+                enableStreamingRetry = true
+            )
+        )
+
+        val result = retryingClient.executeStreaming(testPrompt, testModel).toList()
+
+        assertEquals(listOf("chunk1", "chunk2"), result)
+        assertEquals(2, mockClient.streamCalls)
+    }
+
+    @Test
+    fun testRetryMultipleChoices() = runTest {
+        val choices = listOf(
+            listOf(Message.Assistant("Choice 1", testMetaInfo)),
+            listOf(Message.Assistant("Choice 2", testMetaInfo))
+        )
+
+        val mockClient = MockLLMClient(
+            multipleChoicesResponse = choices,
+            failuresBeforeSuccess = 1,
+            failureMessage = "Error: 429"
+        )
+
+        val retryingClient = RetryingLLMClient(
+            mockClient,
+            RetryConfig(
+                maxAttempts = 2,
+                initialDelay = 10.milliseconds
+            )
+        )
+
+        val result = retryingClient.executeMultipleChoices(testPrompt, testModel, emptyList())
+
+        assertEquals(choices, result)
+        assertEquals(2, mockClient.multipleChoicesCalls)
+    }
+
+    @Test
+    fun testRetryModerate() = runTest {
+        val moderationResult = ModerationResult(
+            isHarmful = false,
+            categories = emptyMap()
+        )
+
+        val mockClient = MockLLMClient(
+            moderateResponse = moderationResult,
+            failuresBeforeSuccess = 1,
+            failureMessage = "Error: 503"
+        )
+
+        val retryingClient = RetryingLLMClient(
+            mockClient,
+            RetryConfig(
+                maxAttempts = 2,
+                initialDelay = 10.milliseconds
+            )
+        )
+
+        val result = retryingClient.moderate(testPrompt, testModel)
+
+        assertEquals(moderationResult, result)
+        assertEquals(2, mockClient.moderateCalls)
+    }
+
+    // Mock LLMClient for testing
+    private class MockLLMClient(
+        private val executeResponse: List<Message.Response> = emptyList(),
+        private val streamResponse: Flow<String> = flowOf(),
+        private val multipleChoicesResponse: List<LLMChoice> = emptyList(),
+        private val moderateResponse: ModerationResult = ModerationResult(false, emptyMap()),
+        private var failuresBeforeSuccess: Int = 0,
+        private var streamFailuresBeforeSuccess: Int = 0,
+        private val failureMessage: String = "Mock failure",
+        private val throwCancellation: Boolean = false
+    ) : LLMClient {
+
+        var executeCalls = 0
+        var streamCalls = 0
+        var multipleChoicesCalls = 0
+        var moderateCalls = 0
+
+        private var executeFailures = 0
+        private var streamFailures = 0
+        private var multipleChoicesFailures = 0
+        private var moderateFailures = 0
+
+        override suspend fun execute(
+            prompt: Prompt,
+            model: LLModel,
+            tools: List<ToolDescriptor>
+        ): List<Message.Response> {
+            executeCalls++
+
+            if (throwCancellation) {
+                throw CancellationException("Cancelled")
+            }
+
+            if (executeFailures < failuresBeforeSuccess) {
+                executeFailures++
+                throw RuntimeException(failureMessage)
+            }
+
+            return executeResponse
+        }
+
+        override fun executeStreaming(prompt: Prompt, model: LLModel): Flow<String> = flow {
+            streamCalls++
+
+            if (streamFailures < streamFailuresBeforeSuccess) {
+                streamFailures++
+                throw RuntimeException(failureMessage)
+            }
+
+            streamResponse.collect { emit(it) }
+        }
+
+        override suspend fun executeMultipleChoices(
+            prompt: Prompt,
+            model: LLModel,
+            tools: List<ToolDescriptor>
+        ): List<LLMChoice> {
+            multipleChoicesCalls++
+
+            if (multipleChoicesFailures < failuresBeforeSuccess) {
+                multipleChoicesFailures++
+                throw RuntimeException(failureMessage)
+            }
+
+            return multipleChoicesResponse
+        }
+
+        override suspend fun moderate(prompt: Prompt, model: LLModel): ModerationResult {
+            moderateCalls++
+
+            if (moderateFailures < failuresBeforeSuccess) {
+                moderateFailures++
+                throw RuntimeException(failureMessage)
+            }
+
+            return moderateResponse
+        }
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClientTest.kt
@@ -235,19 +235,22 @@ class RetryingLLMClientTest {
     }
 
     @Test
-    fun testStreamingWithoutRetry() = runTest {
+    fun testStreamingSucceedOnFirstAttempt() = runTest {
         val mockClient = MockLLMClient(
-            streamResponse = flowOf("chunk1", "chunk2", "chunk3")
+            streamResponse = flowOf("chunk1", "chunk2"),
+            streamFailuresBeforeSuccess = 0
         )
 
         val retryingClient = RetryingLLMClient(
             mockClient,
-            RetryConfig(enableStreamingRetry = false)
+            RetryConfig(
+                maxAttempts = 2
+            )
         )
 
         val result = retryingClient.executeStreaming(testPrompt, testModel).toList()
 
-        assertEquals(listOf("chunk1", "chunk2", "chunk3"), result)
+        assertEquals(listOf("chunk1", "chunk2"), result)
         assertEquals(1, mockClient.streamCalls)
     }
 
@@ -264,7 +267,6 @@ class RetryingLLMClientTest {
             RetryConfig(
                 maxAttempts = 2,
                 initialDelay = 10.milliseconds,
-                enableStreamingRetry = true
             )
         )
 
@@ -272,6 +274,32 @@ class RetryingLLMClientTest {
 
         assertEquals(listOf("chunk1", "chunk2"), result)
         assertEquals(2, mockClient.streamCalls)
+    }
+
+    @Test
+    fun testStreamingNoRetryAfterFirstToken() = runTest {
+        // Mock that emits one token then fails
+        val mockClient = MockLLMClient(
+            streamResponse = flow {
+                emit("first-token")
+                throw RuntimeException("Connection lost after first token")
+            }
+        )
+
+        val retryingClient = RetryingLLMClient(
+            mockClient,
+            RetryConfig(
+                maxAttempts = 3,
+            )
+        )
+
+        // Should not retry because we already received a token
+        val exception = assertFailsWith<RuntimeException> {
+            retryingClient.executeStreaming(testPrompt, testModel).toList()
+        }
+        
+        assertEquals("Connection lost after first token", exception.message)
+        assertEquals(1, mockClient.streamCalls) // No retry
     }
 
     @Test

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClientTest.kt
@@ -297,7 +297,7 @@ class RetryingLLMClientTest {
         val exception = assertFailsWith<RuntimeException> {
             retryingClient.executeStreaming(testPrompt, testModel).toList()
         }
-        
+
         assertEquals("Connection lost after first token", exception.message)
         assertEquals(1, mockClient.streamCalls) // No retry
     }


### PR DESCRIPTION
Real world agent usage is facing multiple provider connectivity issues: timeouts, rate limits (especially during parallel agents execution), network and backend issues. To make agents more resilient, retry logic possibility should be added. This change introduces an LLM clients decorator supporting configurable retry logic. 

Issue: https://youtrack.jetbrains.com/issue/KG-235/Introduce-Retry-logic-for-LLM-clients

---

#### Type of the change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation fix
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist for all pull requests
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [x] Docs have been added / updated
