### PR TITLE
KG-218. Fix attributes for Inference and Tool spans

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/SpanAttributes.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/SpanAttributes.kt
@@ -1,5 +1,6 @@
 package ai.koog.agents.features.opentelemetry.attribute
 
+import ai.koog.agents.utils.HiddenString
 import ai.koog.prompt.llm.LLModel
 
 /**
@@ -287,13 +288,13 @@ internal object SpanAttributes {
         // Custom tool attribute with tool arguments used for tool calls
         data class InputValue(private val input: String) : Attribute {
             override val key: String = "input.value"
-            override val value: Any = input
+            override val value: HiddenString = HiddenString(input)
         }
 
         // Custom tool attribute with tool execution results used for tool calls
         data class OutputValue(private val output: String) : Attribute {
             override val key: String = "output.value"
-            override val value: Any = output
+            override val value: HiddenString = HiddenString(output)
         }
     }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/AssistantMessageEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/AssistantMessageEvent.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.features.opentelemetry.event
 
-import ai.koog.agents.features.opentelemetry.attribute.Attribute
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.message.Message
@@ -10,25 +9,26 @@ internal class AssistantMessageEvent(
     provider: LLMProvider,
     private val message: Message.Response,
     private val arguments: JsonObject? = null,
-) : GenAIAgentEvent {
+) : GenAIAgentEvent() {
 
-    override val name: String = super.name.concatName("assistant.message")
+    init {
+        // Attributes
+        addAttribute(CommonAttributes.System(provider))
 
-    override val attributes: List<Attribute> = buildList {
-        add(CommonAttributes.System(provider))
-    }
+        // Body Fields
+        addBodyField(EventBodyFields.Role(role = message.role))
 
-    override val bodyFields: List<EventBodyField> = buildList {
-        add(EventBodyFields.Role(role = message.role))
         when (message) {
             is Message.Assistant -> {
-                add(EventBodyFields.Content(content = message.content))
-                arguments?.let { add(EventBodyFields.Arguments(it)) }
+                addBodyField(EventBodyFields.Content(content = message.content))
+                arguments?.let { addBodyField(EventBodyFields.Arguments(it)) }
             }
 
             is Message.Tool.Call -> {
-                add(EventBodyFields.ToolCalls(tools = listOf(message)))
+                addBodyField(EventBodyFields.ToolCalls(tools = listOf(message)))
             }
         }
     }
+
+    override val name: String = super.name.concatName("assistant.message")
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/AssistantMessageEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/AssistantMessageEvent.kt
@@ -19,10 +19,7 @@ internal class AssistantMessageEvent(
     }
 
     override val bodyFields: List<EventBodyField> = buildList {
-        if (message.role != Message.Role.Assistant) {
-            add(EventBodyFields.Role(role = message.role))
-        }
-
+        add(EventBodyFields.Role(role = message.role))
         when (message) {
             is Message.Assistant -> {
                 add(EventBodyFields.Content(content = message.content))

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEvent.kt
@@ -30,7 +30,7 @@ internal class ChoiceEvent(
 
                 add(
                     EventBodyFields.Message(
-                        role = message.role.takeIf { role -> role != Message.Role.Assistant },
+                        role = message.role,
                         content = message.content
                     )
                 )

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEvent.kt
@@ -1,6 +1,7 @@
 package ai.koog.agents.features.opentelemetry.event
 
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
+import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.message.Message
 import kotlinx.serialization.json.JsonObject
@@ -38,6 +39,7 @@ internal class ChoiceEvent(
             is Message.Tool.Call -> {
                 addBodyField(EventBodyFields.Role(role = message.role))
                 addBodyField(EventBodyFields.ToolCalls(tools = listOf(message)))
+                addBodyField(EventBodyFields.FinishReason(SpanAttributes.Response.FinishReasonType.ToolCalls.id))
             }
         }
     }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEvent.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.features.opentelemetry.event
 
-import ai.koog.agents.features.opentelemetry.attribute.Attribute
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.message.Message
@@ -11,36 +10,37 @@ internal class ChoiceEvent(
     private val message: Message.Response,
     private val arguments: JsonObject? = null,
     val index: Int,
-) : GenAIAgentEvent {
+) : GenAIAgentEvent() {
 
-    override val name: String = super.name.concatName("choice")
+    init {
+        // Attributes
+        addAttribute(CommonAttributes.System(provider))
 
-    override val attributes: List<Attribute> = buildList {
-        add(CommonAttributes.System(provider))
-    }
-
-    override val bodyFields: List<EventBodyField> = buildList {
-        add(EventBodyFields.Index(index))
+        // Body Fields
+        addBodyField(EventBodyFields.Index(index))
 
         when (message) {
             is Message.Assistant -> {
                 message.finishReason?.let { reason ->
-                    add(EventBodyFields.FinishReason(reason))
+                    addBodyField(EventBodyFields.FinishReason(reason))
                 }
 
-                add(
+                addBodyField(
                     EventBodyFields.Message(
                         role = message.role,
                         content = message.content
                     )
                 )
 
-                arguments?.let { add(EventBodyFields.Arguments(it)) }
+                arguments?.let { addBodyField(EventBodyFields.Arguments(it)) }
             }
 
             is Message.Tool.Call -> {
-                add(EventBodyFields.ToolCalls(tools = listOf(message)))
+                addBodyField(EventBodyFields.Role(role = message.role))
+                addBodyField(EventBodyFields.ToolCalls(tools = listOf(message)))
             }
         }
     }
+
+    override val name: String = super.name.concatName("choice")
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/EventBodyField.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/EventBodyField.kt
@@ -18,18 +18,18 @@ internal abstract class EventBodyField {
     abstract val value: Any
 
     fun valueString(verbose: Boolean): String {
-        return convertValueToString(key, value, verbose)
+        return convertValueToString(value, verbose)
     }
 
     //region Private Methods
 
-    private fun convertValueToString(key: Any, value: Any, verbose: Boolean): String {
+    private fun convertValueToString(value: Any, verbose: Boolean): String {
         return when (value) {
             is HiddenString -> {
                 if (verbose) {
-                    convertValueToString(key, value.value, true)
+                    convertValueToString(value.value, true)
                 } else {
-                    convertValueToString(key, value.toString(), false)
+                    convertValueToString(value.toString(), false)
                 }
             }
             is CharSequence, is Char -> {
@@ -42,7 +42,7 @@ internal abstract class EventBodyField {
             }
             is List<*> -> {
                 value.filterNotNull().joinToString(separator = ",", prefix = "[", postfix = "]") { item ->
-                    convertValueToString(key, item, verbose)
+                    convertValueToString(item, verbose)
                 }
             }
 
@@ -50,7 +50,7 @@ internal abstract class EventBodyField {
                 value.entries
                     .filter { it.key != null && it.value != null }
                     .joinToString(separator = ",", prefix = "{", postfix = "}") { (key, value) ->
-                        "\"$key\":${convertValueToString(key!!, value!!, verbose)}"
+                        "\"$key\":${convertValueToString(value!!, verbose)}"
                     }
             }
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/EventBodyFields.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/EventBodyFields.kt
@@ -52,15 +52,15 @@ internal object EventBodyFields {
     }
 
     data class Message(
-        private val role: ai.koog.prompt.message.Message.Role?,
+        private val role: ai.koog.prompt.message.Message.Role,
         private val content: String
     ) : EventBodyField() {
 
         override val key: String = "message"
-        override val value: Map<String, Any> = buildMap {
-            role?.let { role -> put("role", role.name.lowercase()) }
-            put("content", HiddenString(content))
-        }
+        override val value: Map<String, Any> = mapOf(
+            "role" to role.name.lowercase(),
+            "content" to HiddenString(content)
+        )
     }
 
     data class Id(private val id: String) : EventBodyField() {

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/GenAIAgentEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/GenAIAgentEvent.kt
@@ -1,14 +1,22 @@
 package ai.koog.agents.features.opentelemetry.event
 
 import ai.koog.agents.features.opentelemetry.attribute.Attribute
-import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
 
-internal interface GenAIAgentEvent {
+internal abstract class GenAIAgentEvent {
 
-    val name: String
+    open val name: String
         get() = "gen_ai"
 
+    private val _attributes: MutableList<Attribute> = mutableListOf()
+
+    private val _bodyFields: MutableList<EventBodyField> = mutableListOf()
+
+    /**
+     * Provides a list of attributes associated with this event. These attributes are typically
+     * used to provide metadata or additional contextual information.
+     */
     val attributes: List<Attribute>
+        get() = _attributes
 
     /**
      * The body field for the event.
@@ -18,18 +26,23 @@ internal interface GenAIAgentEvent {
      *       Fields are merged with attributes when creating the event.
      */
     val bodyFields: List<EventBodyField>
+        get() = _bodyFields
+
+    fun addAttribute(attribute: Attribute) {
+        _attributes.add(attribute)
+    }
+
+    fun addAttributes(attributes: List<Attribute>) {
+        _attributes.addAll(attributes)
+    }
+
+    fun addBodyField(eventField: EventBodyField) {
+        _bodyFields.add(eventField)
+    }
+
+    fun removeBodyField(eventField: EventBodyField): Boolean {
+        return _bodyFields.remove(eventField)
+    }
 
     fun String.concatName(other: String): String = "$this.$other"
-
-    fun bodyFieldsAsAttribute(verbose: Boolean): Attribute {
-        check(bodyFields.isNotEmpty()) {
-            "Unable to convert Event Body Fields into Attribute because no body fields found"
-        }
-
-        val value = bodyFields.joinToString(separator = ",", prefix = "{", postfix = "}") { bodyField ->
-            "\"${bodyField.key}\":${bodyField.valueString(verbose)}"
-        }
-
-        return CustomAttribute("body", value)
-    }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ModerationResponseEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ModerationResponseEvent.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.features.opentelemetry.event
 
-import ai.koog.agents.features.opentelemetry.attribute.Attribute
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
 import ai.koog.prompt.dsl.ModerationResult
 import ai.koog.prompt.llm.LLMProvider
@@ -10,20 +9,20 @@ import kotlinx.serialization.json.Json
 internal class ModerationResponseEvent(
     provider: LLMProvider,
     private val moderationResult: ModerationResult
-) : GenAIAgentEvent {
+) : GenAIAgentEvent() {
 
     companion object {
         private val json = Json { allowStructuredMapKeys = true }
     }
 
+    init {
+        // Attributes
+        addAttribute(CommonAttributes.System(provider))
+
+        // Body Fields
+        addBodyField(EventBodyFields.Role(role = Message.Role.Assistant))
+        addBodyField(EventBodyFields.Content(content = json.encodeToString(ModerationResult.serializer(), moderationResult)))
+    }
+
     override val name: String = "moderation.result"
-
-    override val attributes: List<Attribute> = buildList {
-        add(CommonAttributes.System(provider))
-    }
-
-    override val bodyFields: List<EventBodyField> = buildList {
-        add(EventBodyFields.Role(role = Message.Role.Assistant))
-        add(EventBodyFields.Content(content = json.encodeToString(ModerationResult.serializer(), moderationResult)))
-    }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/SystemMessageEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/SystemMessageEvent.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.features.opentelemetry.event
 
-import ai.koog.agents.features.opentelemetry.attribute.Attribute
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.message.Message
@@ -8,16 +7,16 @@ import ai.koog.prompt.message.Message
 internal class SystemMessageEvent(
     provider: LLMProvider,
     private val message: Message.System
-) : GenAIAgentEvent {
+) : GenAIAgentEvent() {
+
+    init {
+        // Attributes
+        addAttribute(CommonAttributes.System(provider))
+
+        // Body Fields
+        addBodyField(EventBodyFields.Role(role = message.role))
+        addBodyField(EventBodyFields.Content(content = message.content))
+    }
 
     override val name: String = super.name.concatName("system.message")
-
-    override val attributes: List<Attribute> = buildList {
-        add(CommonAttributes.System(provider))
-    }
-
-    override val bodyFields: List<EventBodyField> = buildList {
-        add(EventBodyFields.Role(role = message.role))
-        add(EventBodyFields.Content(content = message.content))
-    }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/SystemMessageEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/SystemMessageEvent.kt
@@ -17,10 +17,7 @@ internal class SystemMessageEvent(
     }
 
     override val bodyFields: List<EventBodyField> = buildList {
-        if (message.role != Message.Role.System) {
-            add(EventBodyFields.Role(role = message.role))
-        }
-
+        add(EventBodyFields.Role(role = message.role))
         add(EventBodyFields.Content(content = message.content))
     }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ToolMessageEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ToolMessageEvent.kt
@@ -3,6 +3,7 @@ package ai.koog.agents.features.opentelemetry.event
 import ai.koog.agents.features.opentelemetry.attribute.Attribute
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
 import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.message.Message
 
 internal class ToolMessageEvent(
     provider: LLMProvider,
@@ -17,6 +18,9 @@ internal class ToolMessageEvent(
     }
 
     override val bodyFields: List<EventBodyField> = buildList {
+        // Role (conditional).
+        add(EventBodyFields.Role(role = Message.Role.Tool))
+
         // Content
         add(EventBodyFields.Content(content = content))
 
@@ -24,8 +28,5 @@ internal class ToolMessageEvent(
         toolCallId?.let { id ->
             add(EventBodyFields.Id(id = id))
         }
-
-        // Role (conditional).
-        // Do not add Role as a tool result guarantee the response has a Tool role.
     }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ToolMessageEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ToolMessageEvent.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.features.opentelemetry.event
 
-import ai.koog.agents.features.opentelemetry.attribute.Attribute
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.message.Message
@@ -9,24 +8,19 @@ internal class ToolMessageEvent(
     provider: LLMProvider,
     private val toolCallId: String?,
     private val content: String,
-) : GenAIAgentEvent {
+) : GenAIAgentEvent() {
 
-    override val name: String = super.name.concatName("tool.message")
+    init {
+        // Attributes
+        addAttribute(CommonAttributes.System(provider))
 
-    override val attributes: List<Attribute> = buildList {
-        add(CommonAttributes.System(provider))
-    }
-
-    override val bodyFields: List<EventBodyField> = buildList {
-        // Role (conditional).
-        add(EventBodyFields.Role(role = Message.Role.Tool))
-
-        // Content
-        add(EventBodyFields.Content(content = content))
-
-        // Id
+        // Body Fields
+        addBodyField(EventBodyFields.Role(role = Message.Role.Tool))
+        addBodyField(EventBodyFields.Content(content = content))
         toolCallId?.let { id ->
-            add(EventBodyFields.Id(id = id))
+            addBodyField(EventBodyFields.Id(id = id))
         }
     }
+
+    override val name: String = super.name.concatName("tool.message")
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/UserMessageEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/UserMessageEvent.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.features.opentelemetry.event
 
-import ai.koog.agents.features.opentelemetry.attribute.Attribute
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.message.Message
@@ -8,16 +7,16 @@ import ai.koog.prompt.message.Message
 internal class UserMessageEvent(
     provider: LLMProvider,
     private val message: Message.User
-) : GenAIAgentEvent {
+) : GenAIAgentEvent() {
+
+    init {
+        // Attributes
+        addAttribute(CommonAttributes.System(provider))
+
+        // Body Fields
+        addBodyField(EventBodyFields.Role(role = message.role))
+        addBodyField(EventBodyFields.Content(content = message.content))
+    }
 
     override val name: String = super.name.concatName("user.message")
-
-    override val attributes: List<Attribute> = buildList {
-        add(CommonAttributes.System(provider))
-    }
-
-    override val bodyFields: List<EventBodyField> = buildList {
-        add(EventBodyFields.Role(role = message.role))
-        add(EventBodyFields.Content(content = message.content))
-    }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/UserMessageEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/UserMessageEvent.kt
@@ -17,11 +17,7 @@ internal class UserMessageEvent(
     }
 
     override val bodyFields: List<EventBodyField> = buildList {
-
-        if (message.role != Message.Role.User) {
-            add(EventBodyFields.Role(role = message.role))
-        }
-
+        add(EventBodyFields.Role(role = message.role))
         add(EventBodyFields.Content(content = message.content))
     }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/extension/EventBodyFieldExt.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/extension/EventBodyFieldExt.kt
@@ -1,0 +1,12 @@
+package ai.koog.agents.features.opentelemetry.extension
+
+import ai.koog.agents.features.opentelemetry.attribute.Attribute
+import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
+import ai.koog.agents.features.opentelemetry.event.EventBodyField
+
+internal fun EventBodyField.toCustomAttribute(
+    attributeCreator: ((EventBodyField) -> Attribute)? = null
+): Attribute {
+    return attributeCreator?.invoke(this)
+        ?: CustomAttribute(key, value)
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/extension/GenAIAgentEventExt.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/extension/GenAIAgentEventExt.kt
@@ -1,22 +1,63 @@
 package ai.koog.agents.features.opentelemetry.extension
 
-import ai.koog.agents.features.opentelemetry.attribute.Attribute
 import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
-import ai.koog.agents.features.opentelemetry.event.EventBodyField
 import ai.koog.agents.features.opentelemetry.event.GenAIAgentEvent
 import ai.koog.agents.features.opentelemetry.span.GenAIAgentSpan
 
-internal fun GenAIAgentEvent.toSpanAttributes(span: GenAIAgentSpan) {
-    // Convert event attributes to Span Attributes
-    attributes.forEach { attribute -> span.addAttribute(attribute) }
+/**
+ * Converts the attributes and body fields of a GenAIAgentEvent into span attributes
+ * and adds them to the specified {@link GenAIAgentSpan}.
+ *
+ * @param span The span to which the converted attributes will be added.
+ */
+internal fun GenAIAgentEvent.toSpanAttributes(
+    span: GenAIAgentSpan
+) {
+    // 1. Convert all event body fields into attributes
+    this.bodyFieldsToAttributes()
 
-    // Convert Body Fields to Span Attributes
-    bodyFields.forEach { bodyField ->
-        val attribute = bodyField.toGenAIAttribute()
-        span.addAttribute(attribute)
-    }
+    // 2. Convert all event attributes into the span attributes
+    attributes.forEach { attribute -> span.addAttribute(attribute) }
 }
 
-internal fun EventBodyField.toGenAIAttribute(): Attribute {
-    return CustomAttribute(key, value)
+/**
+ * Converts the body fields of the event into attributes and adds them to the event.
+ * Each body field is transformed into a custom attribute representation using the
+ * `toCustomAttribute` method, and the result is added as an attribute to the event.
+ */
+internal fun GenAIAgentEvent.bodyFieldsToAttributes() {
+    val bodyFieldsToProcess = bodyFields.toList()
+
+    // Convert each Body Field into an event attribute
+    bodyFieldsToProcess.forEach { bodyField ->
+        val attribute = bodyField.toCustomAttribute()
+        this.addAttribute(attribute)
+    }
+
+    // Clean all converted body fields
+    bodyFieldsToProcess.forEach { bodyField -> removeBodyField(bodyField) }
+}
+
+/**
+ * Converts the `bodyFields` of the event into a single JSON-like string representation and adds it
+ * as a custom "body" attribute to the event's attribute list.
+ *
+ * If the `bodyFields` list is empty, the method does nothing.
+ */
+internal fun GenAIAgentEvent.bodyFieldsToBodyAttribute(verbose: Boolean) {
+    if (bodyFields.isEmpty()) {
+        return
+    }
+
+    val bodyFieldsToProcess = bodyFields.toList()
+
+    val value = bodyFieldsToProcess.joinToString(separator = ",", prefix = "{", postfix = "}") { bodyField ->
+        "\"${bodyField.key}\":${bodyField.valueString(verbose)}"
+    }
+
+    // Add a new 'body' attribute for the event
+    addAttribute(CustomAttribute("body", value))
+
+    // Clean all converted body fields
+    bodyFieldsToProcess.forEach { bodyField -> this.removeBodyField(bodyField) }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/extension/GenAIAgentEventExt.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/extension/GenAIAgentEventExt.kt
@@ -3,6 +3,7 @@ package ai.koog.agents.features.opentelemetry.extension
 import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
 import ai.koog.agents.features.opentelemetry.event.GenAIAgentEvent
 import ai.koog.agents.features.opentelemetry.span.GenAIAgentSpan
+import ai.koog.agents.utils.HiddenString
 
 /**
  * Converts the attributes and body fields of a GenAIAgentEvent into span attributes
@@ -11,10 +12,11 @@ import ai.koog.agents.features.opentelemetry.span.GenAIAgentSpan
  * @param span The span to which the converted attributes will be added.
  */
 internal fun GenAIAgentEvent.toSpanAttributes(
-    span: GenAIAgentSpan
+    span: GenAIAgentSpan,
+    verbose: Boolean
 ) {
     // 1. Convert all event body fields into attributes
-    this.bodyFieldsToAttributes()
+    this.bodyFieldsToAttributes(verbose)
 
     // 2. Convert all event attributes into the span attributes
     attributes.forEach { attribute -> span.addAttribute(attribute) }
@@ -25,12 +27,47 @@ internal fun GenAIAgentEvent.toSpanAttributes(
  * Each body field is transformed into a custom attribute representation using the
  * `toCustomAttribute` method, and the result is added as an attribute to the event.
  */
-internal fun GenAIAgentEvent.bodyFieldsToAttributes() {
+internal fun GenAIAgentEvent.bodyFieldsToAttributes(verbose: Boolean) {
     val bodyFieldsToProcess = bodyFields.toList()
 
     // Convert each Body Field into an event attribute
     bodyFieldsToProcess.forEach { bodyField ->
-        val attribute = bodyField.toCustomAttribute()
+        val attribute = bodyField.toCustomAttribute { field ->
+            val value = field.value
+            val valueToProcess = when (value) {
+                is HiddenString, is CharSequence, is Char, is Boolean, is Long, is Int, is Float, is Double -> {
+                    // SDK Primitives
+                    field.value
+                }
+                is List<*> -> {
+                    // SDK Array Primitives
+                    val isSdkArrayPrimitive = value.all { v ->
+                        v is HiddenString ||
+                            v is CharSequence ||
+                            v is Char ||
+                            v is Boolean ||
+                            v is Long ||
+                            v is Int ||
+                            v is Float ||
+                            v is Double
+                    }
+
+                    // Add value as is if SDK supports this type and [String] type for the rest
+                    if (isSdkArrayPrimitive) {
+                        field.value
+                    } else {
+                        field.valueString(verbose)
+                    }
+                }
+                else -> {
+                    field.valueString(verbose)
+                }
+            }
+
+            // Custom attribute
+            CustomAttribute(field.key, valueToProcess)
+        }
+
         this.addAttribute(attribute)
     }
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/extension/SpanExt.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/extension/SpanExt.kt
@@ -27,9 +27,10 @@ internal fun Span.setEvents(events: List<GenAIAgentEvent>, verbose: Boolean) {
         // The 'opentelemetry-java' SDK does not have support for event body fields at the moment.
         // Pass body fields as attributes until an API is updated.
         val attributes = buildList {
-            // Collect all body fields into a single attribute with the 'body' key and JSON string structure as a value.
-            // Can be updated to [bodyFieldsToAttributes] to collect body fields as event attributes.
-            event.bodyFieldsToBodyAttribute(verbose)
+            // Collect all body fields into separate attributes.
+            // Please use [bodyFieldsToBodyAttribute] method to collect body fields into a single attribute
+            // with the 'body' key and JSON string structure as a value.
+            event.bodyFieldsToAttributes(verbose)
             addAll(event.attributes)
         }
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
@@ -277,8 +277,9 @@ public class OpenTelemetry {
                 // Add events to the InferenceSpan after the span is created
                 val eventsFromMessages = eventContext.prompt.messages.mapNotNull { message ->
                     when (message) {
-                        is Message.User -> UserMessageEvent(provider, message)
                         is Message.System -> SystemMessageEvent(provider, message)
+                        is Message.User -> UserMessageEvent(provider, message)
+                        is Message.Assistant -> AssistantMessageEvent(provider, message)
                         is Message.Tool.Result -> {
                             ToolMessageEvent(
                                 provider = provider,
@@ -319,11 +320,13 @@ public class OpenTelemetry {
 
                 // Add events to the InferenceSpan before finishing the span
                 val eventsToAdd = buildList {
-                    eventContext.responses.map { message ->
+                    eventContext.responses.mapIndexed { index, message ->
                         when (message) {
-                            is Message.Assistant -> add(AssistantMessageEvent(provider, message))
+                            is Message.Assistant -> add(
+                                AssistantMessageEvent(provider, message)
+                            )
                             is Message.Tool.Call -> add(
-                                ChoiceEvent(provider, message, arguments = message.contentJson, index = 0)
+                                ChoiceEvent(provider, message, arguments = message.contentJson, index = index)
                             )
                         }
                     }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
@@ -338,6 +338,22 @@ public class OpenTelemetry {
 
                 inferenceSpan.addEvents(eventsToAdd)
 
+                // Add attributes to InferenceSpan
+
+                // Finish Reasons Attribute
+                eventContext.responses.lastOrNull()?.let { message ->
+                    val finishReasonsAttribute = when (message) {
+                        is Message.Assistant -> {
+                            SpanAttributes.Response.FinishReasons(reasons = listOf(SpanAttributes.Response.FinishReasonType.Stop))
+                        }
+                        is Message.Tool.Call -> {
+                            SpanAttributes.Response.FinishReasons(reasons = listOf(SpanAttributes.Response.FinishReasonType.ToolCalls))
+                        }
+                    }
+
+                    inferenceSpan.addAttribute(finishReasonsAttribute)
+                }
+
                 // Stop InferenceSpan
                 spanAdapter?.onBeforeSpanFinished(inferenceSpan)
                 spanProcessor.endSpan(inferenceSpan)

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/Utils.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/Utils.kt
@@ -1,0 +1,51 @@
+package ai.koog.agents.features.opentelemetry.integration
+
+import ai.koog.agents.features.opentelemetry.attribute.Attribute
+import ai.koog.agents.features.opentelemetry.event.EventBodyField
+import ai.koog.agents.features.opentelemetry.event.GenAIAgentEvent
+import ai.koog.agents.features.opentelemetry.span.GenAIAgentSpan
+
+/**
+ * Transfers specific body fields of an event to custom attributes in the span
+ * and subsequently removes these fields from the event's body.
+ *
+ * @param TBodyField The type of event body field to be processed, which must be a subclass of EventBodyField.
+ * @param event The event containing body fields to be processed.
+ * @param attributeCreate A function that transforms a body field of type TBodyField into an Attribute.
+ */
+internal inline fun <reified TBodyField : EventBodyField> GenAIAgentSpan.bodyFieldsToCustomAttribute(
+    event: GenAIAgentEvent,
+    attributeCreate: (TBodyField) -> Attribute
+) {
+    val span = this
+    val eventBodyFields = event.bodyFields.filterIsInstance<TBodyField>().toList()
+
+    eventBodyFields.forEach { bodyField ->
+        val attributeFromEvent = attributeCreate(bodyField)
+        span.addAttribute(attributeFromEvent)
+    }
+
+    eventBodyFields.forEach { bodyField -> event.removeBodyField(bodyField) }
+}
+
+/**
+ * Replaces specific body fields in a GenAI agent event by executing a specified action and
+ * then removing them from the event.
+ *
+ * @param TBodyField The type of body fields to be replaced, extending EventBodyField.
+ * @param event The GenAI agent event whose body fields are being processed.
+ * @param processBodyFieldAction A lambda function defining the action to be performed on each matching
+ *                                body field within the context of the span.
+ */
+internal inline fun <reified TBodyField> GenAIAgentSpan.replaceBodyFields(
+    event: GenAIAgentEvent,
+    processBodyFieldAction: GenAIAgentSpan.(TBodyField) -> Unit
+) where TBodyField : EventBodyField {
+    val eventBodyFields = event.bodyFields.filterIsInstance<TBodyField>().toList()
+
+    eventBodyFields.forEach { bodyField ->
+        processBodyFieldAction(bodyField)
+    }
+
+    eventBodyFields.forEach { bodyField -> event.removeBodyField(bodyField) }
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/Langfuse.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/Langfuse.kt
@@ -11,10 +11,14 @@ import kotlin.time.Duration.Companion.seconds
 /**
  * Configure an OpenTelemetry span exporter that sends data to [Langfuse](https://langfuse.com/).
  *
- * @param langfuseUrl the base URL of the Langfuse instance. If not set is retrieved from `LANGFUSE_HOST` environment variable. Defaults to [https://cloud.langfuse.com](https://cloud.langfuse.com).
+ * @param langfuseUrl the base URL of the Langfuse instance.
+ *        If not set is retrieved from `LANGFUSE_HOST` environment variable.
+ *        Defaults to [https://cloud.langfuse.com](https://cloud.langfuse.com).
  * @param langfusePublicKey if not set is retrieved from `LANGFUSE_PUBLIC_KEY` environment variable.
  * @param langfuseSecretKey if not set is retrieved from `LANGFUSE_SECRET_KEY` environment variable.
- * @param timeout OpenTelemetry SpanExporter timeout. See [io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder.setTimeout].
+ * @param timeout OpenTelemetry SpanExporter timeout.
+ *        See [io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder.setTimeout].
+ * @param verbose flag to enable verbose logging for the Langfuse span adapter. Defaults to 'false'.
  *
  * @see <a href="https://langfuse.com/docs/get-started#create-new-project-in-langfuse">How to create a new project in Langfuse</a>
  * @see <a href="https://langfuse.com/faq/all/where-are-langfuse-api-keys">How to set up API keys in Langfuse</a>
@@ -25,6 +29,7 @@ public fun OpenTelemetryConfig.addLangfuseExporter(
     langfusePublicKey: String? = null,
     langfuseSecretKey: String? = null,
     timeout: Duration = 10.seconds,
+    verbose: Boolean = false,
 ) {
     val url = langfuseUrl ?: System.getenv()["LANGFUSE_HOST"] ?: "https://cloud.langfuse.com"
 
@@ -46,7 +51,7 @@ public fun OpenTelemetryConfig.addLangfuseExporter(
             .build()
     )
 
-    addSpanAdapter(LangfuseSpanAdapter)
+    addSpanAdapter(LangfuseSpanAdapter(verbose))
 }
 
-private val logger = KotlinLogging.logger {}
+private val logger = KotlinLogging.logger { }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapter.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapter.kt
@@ -76,6 +76,10 @@ internal class LangfuseSpanAdapter(private val verbose: Boolean) : SpanAdapter()
                                 CustomAttribute("gen_ai.completion.$index.content", toolCalls.valueString(verbose))
                             }
 
+                            span.bodyFieldsToCustomAttribute<EventBodyFields.FinishReason>(event) { finishReason ->
+                                CustomAttribute("gen_ai.completion.$index.finish_reason", finishReason.value)
+                            }
+
                             // Delete event from the span
                             span.removeEvent(event)
                         }
@@ -84,7 +88,7 @@ internal class LangfuseSpanAdapter(private val verbose: Boolean) : SpanAdapter()
                             // Convert event data fields into the span attributes
                             span.bodyFieldsToCustomAttribute<EventBodyFields.Role>(event) { role ->
                                 // Langfuse expects to have an assistant message for correct displaying the responses from LLM.
-                                // Set role explicitly to Assistant (even for LLM Tool Calls response).
+                                // Set a role explicitly to Assistant (even for LLM Tool Calls response).
                                 CustomAttribute("gen_ai.completion.$index.${role.key}", Message.Role.Assistant.name.lowercase())
                             }
 
@@ -94,6 +98,10 @@ internal class LangfuseSpanAdapter(private val verbose: Boolean) : SpanAdapter()
 
                             span.bodyFieldsToCustomAttribute<EventBodyFields.ToolCalls>(event) { toolCalls ->
                                 CustomAttribute("gen_ai.completion.$index.content", toolCalls.valueString(verbose))
+                            }
+
+                            span.bodyFieldsToCustomAttribute<EventBodyFields.FinishReason>(event) { finishReason ->
+                                CustomAttribute("gen_ai.completion.$index.finish_reason", finishReason.value)
                             }
 
                             // Delete event from the span

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapter.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapter.kt
@@ -1,62 +1,107 @@
 package ai.koog.agents.features.opentelemetry.integration.langfuse
 
-import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
 import ai.koog.agents.features.opentelemetry.event.AssistantMessageEvent
 import ai.koog.agents.features.opentelemetry.event.ChoiceEvent
 import ai.koog.agents.features.opentelemetry.event.EventBodyFields
+import ai.koog.agents.features.opentelemetry.event.SystemMessageEvent
+import ai.koog.agents.features.opentelemetry.event.ToolMessageEvent
 import ai.koog.agents.features.opentelemetry.event.UserMessageEvent
-import ai.koog.agents.features.opentelemetry.extension.eventBodyFieldToAttribute
 import ai.koog.agents.features.opentelemetry.integration.SpanAdapter
+import ai.koog.agents.features.opentelemetry.integration.bodyFieldsToCustomAttribute
 import ai.koog.agents.features.opentelemetry.span.GenAIAgentSpan
 import ai.koog.agents.features.opentelemetry.span.InferenceSpan
+import ai.koog.prompt.message.Message
 
-@OptIn(InternalAgentsApi::class)
-internal object LangfuseSpanAdapter : SpanAdapter() {
+/**
+ * Internal adapter class for enhancing and modifying spans related to GenAI agent processing.
+ * This class processes specific types of GenAIAgentSpan instances, particularly those
+ * of type `InferenceSpan`, to transform and manage associated events and attributes
+ * both before the span starts and before it finishes.
+ *
+ * The class operates on specific event types contained within the span and converts
+ * their data into custom attributes. Additionally, it ensures that the converted events
+ * are removed from the span's event list after conversion.
+ */
+internal class LangfuseSpanAdapter(private val verbose: Boolean) : SpanAdapter() {
 
-    override fun onBeforeSpanFinished(span: GenAIAgentSpan) {
+    override fun onBeforeSpanStarted(span: GenAIAgentSpan) {
         when (span) {
-            is InferenceSpan -> span.prepareSpanAttributes()
-        }
-    }
+            is InferenceSpan -> {
+                val eventsToProcess = span.events.toList()
 
-    //region Private Methods
+                // Each event - convert into the span attribute
+                eventsToProcess.forEachIndexed { index, event ->
+                    when (event) {
+                        is SystemMessageEvent,
+                        is UserMessageEvent,
+                        is AssistantMessageEvent,
+                        is ToolMessageEvent -> {
+                            // Convert event data fields into the span attributes
+                            span.bodyFieldsToCustomAttribute<EventBodyFields.Role>(event) { role ->
+                                CustomAttribute("gen_ai.prompt.$index.${role.key}", role.value)
+                            }
 
-    private fun InferenceSpan.prepareSpanAttributes() {
-        this.events.forEach { event ->
-            when (event) {
-                is AssistantMessageEvent -> {
-                    this.eventBodyFieldToAttribute<EventBodyFields.Role>(event) { role ->
-                        CustomAttribute("gen_ai.completion.${role.key}", role.value)
-                    }
+                            span.bodyFieldsToCustomAttribute<EventBodyFields.Content>(event) { content ->
+                                CustomAttribute("gen_ai.prompt.$index.${content.key}", content.value)
+                            }
 
-                    this.eventBodyFieldToAttribute<EventBodyFields.Content>(event) { content ->
-                        CustomAttribute("gen_ai.completion.content", content.value)
-                    }
-                }
-
-                is ChoiceEvent -> {
-                    val index = event.index
-
-                    this.eventBodyFieldToAttribute<EventBodyFields.Role>(event) { role ->
-                        CustomAttribute("gen_ai.$index.${role.key}", role.value)
-                    }
-
-                    this.eventBodyFieldToAttribute<EventBodyFields.Content>(event) { content ->
-                        CustomAttribute("gen_ai.completion.$index.content", content.value)
+                            // Delete event from the span
+                            span.removeEvent(event)
+                        }
                     }
                 }
-
-                is UserMessageEvent -> {
-                    this.eventBodyFieldToAttribute<EventBodyFields.Content>(event) { content ->
-                        CustomAttribute("gen_ai.completion.content", content.value)
-                    }
-                }
-
-                else -> { }
             }
         }
     }
 
-    //endregion Private Methods
+    override fun onBeforeSpanFinished(span: GenAIAgentSpan) {
+        when (span) {
+            is InferenceSpan -> {
+                val eventsToProcess = span.events.toList()
+
+                eventsToProcess.forEachIndexed { index, event ->
+                    when (event) {
+                        is AssistantMessageEvent -> {
+                            // Convert event data fields into the span attributes
+                            span.bodyFieldsToCustomAttribute<EventBodyFields.Role>(event) { role ->
+                                CustomAttribute("gen_ai.completion.$index.${role.key}", role.value)
+                            }
+
+                            span.bodyFieldsToCustomAttribute<EventBodyFields.Content>(event) { content ->
+                                CustomAttribute("gen_ai.completion.$index.${content.key}", content.value)
+                            }
+
+                            span.bodyFieldsToCustomAttribute<EventBodyFields.ToolCalls>(event) { toolCalls ->
+                                CustomAttribute("gen_ai.completion.$index.content", toolCalls.valueString(verbose))
+                            }
+
+                            // Delete event from the span
+                            span.removeEvent(event)
+                        }
+
+                        is ChoiceEvent -> {
+                            // Convert event data fields into the span attributes
+                            span.bodyFieldsToCustomAttribute<EventBodyFields.Role>(event) { role ->
+                                // Langfuse expects to have an assistant message for correct displaying the responses from LLM.
+                                // Set role explicitly to Assistant (even for LLM Tool Calls response).
+                                CustomAttribute("gen_ai.completion.$index.${role.key}", Message.Role.Assistant.name.lowercase())
+                            }
+
+                            span.bodyFieldsToCustomAttribute<EventBodyFields.Content>(event) { content ->
+                                CustomAttribute("gen_ai.completion.$index.${content.key}", content.value)
+                            }
+
+                            span.bodyFieldsToCustomAttribute<EventBodyFields.ToolCalls>(event) { toolCalls ->
+                                CustomAttribute("gen_ai.completion.$index.content", toolCalls.valueString(verbose))
+                            }
+
+                            // Delete event from the span
+                            span.removeEvent(event)
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/weave/Weave.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/weave/Weave.kt
@@ -11,12 +11,19 @@ import kotlin.time.Duration.Companion.seconds
 /**
  * Configure an OpenTelemetry span exporter that sends data to [W&B Weave](https://wandb.ai/site/weave/).
  *
- * @param weaveOtelBaseUrl the URL of the Weave OpenTelemetry endpoint. If not set is retrieved from `WEAVE_URL` environment variable. Defaults to [https://trace.wandb.ai](https://trace.wandb.ai).
- * @param weaveEntity can be found by visiting your W&B dashboard at [https://wandb.ai/home](https://wandb.ai/home) and checking the *Teams* field in the left sidebar.
- * If not set is retrieved from `WEAVE_ENTITY` environment variable.
- * @param weaveProjectName name of your Weave project. If not set is retrieved from `WEAVE_PROJECT_NAME` environment variable.
- * @param weaveApiKey can be created on the [https://wandb.ai/authorize](https://wandb.ai/authorize) page. If not set is retrieved from `WEAVE_API_KEY` environment variable.
- * @param timeout OpenTelemetry SpanExporter timeout. See [io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder.setTimeout].
+ * @param weaveOtelBaseUrl the URL of the Weave OpenTelemetry endpoint.
+ *        If not set is retrieved from `WEAVE_URL` environment variable.
+ *        Defaults to [https://trace.wandb.ai](https://trace.wandb.ai).
+ * @param weaveEntity can be found by visiting your W&B dashboard at [https://wandb.ai/home](https://wandb.ai/home) and
+ *        checking the *Teams* field in the left sidebar.
+ *        If not set is retrieved from `WEAVE_ENTITY` environment variable.
+ * @param weaveProjectName name of your Weave project.
+ *        If not set is retrieved from `WEAVE_PROJECT_NAME` environment variable.
+ * @param weaveApiKey can be created on the [https://wandb.ai/authorize](https://wandb.ai/authorize) page.
+ *        If not set is retrieved from `WEAVE_API_KEY` environment variable.
+ * @param timeout OpenTelemetry SpanExporter timeout.
+ *        See [io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder.setTimeout].
+ * @param verbose flag to enable verbose logging for the Weave span adapter. Defaults to 'false'.
  *
  * @see <a href="https://weave-docs.wandb.ai/guides/tracking/otel/">Weave OpenTelemetry Docs</a>
  */
@@ -26,6 +33,7 @@ public fun OpenTelemetryConfig.addWeaveExporter(
     weaveProjectName: String? = null,
     weaveApiKey: String? = null,
     timeout: Duration = 10.seconds,
+    verbose: Boolean = false,
 ) {
     val url = weaveOtelBaseUrl ?: System.getenv()["WEAVE_URL"] ?: "https://trace.wandb.ai"
 
@@ -46,7 +54,7 @@ public fun OpenTelemetryConfig.addWeaveExporter(
             .build()
     )
 
-    addSpanAdapter(WeaveSpanAdapter)
+    addSpanAdapter(WeaveSpanAdapter(verbose))
 }
 
 private val logger = KotlinLogging.logger { }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/weave/WeaveSpanAdapter.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/weave/WeaveSpanAdapter.kt
@@ -1,62 +1,109 @@
 package ai.koog.agents.features.opentelemetry.integration.weave
 
-import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
 import ai.koog.agents.features.opentelemetry.event.AssistantMessageEvent
 import ai.koog.agents.features.opentelemetry.event.ChoiceEvent
 import ai.koog.agents.features.opentelemetry.event.EventBodyFields
+import ai.koog.agents.features.opentelemetry.event.SystemMessageEvent
+import ai.koog.agents.features.opentelemetry.event.ToolMessageEvent
 import ai.koog.agents.features.opentelemetry.event.UserMessageEvent
-import ai.koog.agents.features.opentelemetry.extension.eventBodyFieldToAttribute
 import ai.koog.agents.features.opentelemetry.integration.SpanAdapter
+import ai.koog.agents.features.opentelemetry.integration.bodyFieldsToCustomAttribute
 import ai.koog.agents.features.opentelemetry.span.GenAIAgentSpan
 import ai.koog.agents.features.opentelemetry.span.InferenceSpan
+import ai.koog.prompt.message.Message
 
-@OptIn(InternalAgentsApi::class)
-internal object WeaveSpanAdapter : SpanAdapter() {
+/**
+ * WeaveSpanAdapter is a specialized implementation of [SpanAdapter] designed to process and transform
+ * spans related to Generative AI agent events. It provides customized handling for specific types of
+ * events, converting their data fields into span attributes and removing processed events.
+ *
+ * This adapter specifically handles spans of type [InferenceSpan] and processes events such as
+ * [SystemMessageEvent], [UserMessageEvent], [AssistantMessageEvent], and [ToolMessageEvent].
+ * Events are converted into custom span attributes for better traceability and observability.
+ *
+ * @param verbose A flag to control the verbosity of the processing.
+ *        When set to true, additional details may be added to span attributes during processing.
+ */
+internal class WeaveSpanAdapter(private val verbose: Boolean) : SpanAdapter() {
 
-    override fun onBeforeSpanFinished(span: GenAIAgentSpan) {
+    override fun onBeforeSpanStarted(span: GenAIAgentSpan) {
         when (span) {
-            is InferenceSpan -> span.prepareSpanAttributes()
-        }
-    }
+            is InferenceSpan -> {
+                val eventsToProcess = span.events.toList()
 
-    //region Private Methods
+                // Each event - convert into the span attribute
+                eventsToProcess.forEachIndexed { index, event ->
+                    when (event) {
+                        is SystemMessageEvent,
+                        is UserMessageEvent,
+                        is AssistantMessageEvent,
+                        is ToolMessageEvent -> {
+                            // Convert event data fields into the span attributes
+                            span.bodyFieldsToCustomAttribute<EventBodyFields.Role>(event) { role ->
+                                CustomAttribute("gen_ai.prompt.$index.${role.key}", role.value)
+                            }
 
-    private fun InferenceSpan.prepareSpanAttributes() {
-        this.events.forEach { event ->
-            when (event) {
-                is AssistantMessageEvent -> {
-                    this.eventBodyFieldToAttribute<EventBodyFields.Role>(event) { role ->
-                        CustomAttribute("gen_ai.completion.${role.key}", role.value)
-                    }
+                            span.bodyFieldsToCustomAttribute<EventBodyFields.Content>(event) { content ->
+                                CustomAttribute("gen_ai.prompt.$index.${content.key}", content.value)
+                            }
 
-                    this.eventBodyFieldToAttribute<EventBodyFields.Content>(event) { content ->
-                        CustomAttribute("gen_ai.completion.content", content.value)
-                    }
-                }
-
-                is ChoiceEvent -> {
-                    val index = event.index
-
-                    this.eventBodyFieldToAttribute<EventBodyFields.Role>(event) { role ->
-                        CustomAttribute("gen_ai.$index.${role.key}", role.value)
-                    }
-
-                    this.eventBodyFieldToAttribute<EventBodyFields.Content>(event) { content ->
-                        CustomAttribute("gen_ai.completion.$index.content", content.value)
+                            // Delete event from the span
+                            span.removeEvent(event)
+                        }
                     }
                 }
-
-                is UserMessageEvent -> {
-                    this.eventBodyFieldToAttribute<EventBodyFields.Content>(event) { content ->
-                        CustomAttribute("gen_ai.completion.content", content.value)
-                    }
-                }
-
-                else -> { }
             }
         }
     }
 
-    //endregion Private Methods
+    override fun onBeforeSpanFinished(span: GenAIAgentSpan) {
+        when (span) {
+            is InferenceSpan -> {
+                val eventsToProcess = span.events.toList()
+
+                eventsToProcess.forEachIndexed { index, event ->
+                    when (event) {
+                        is AssistantMessageEvent -> {
+                            // Convert event data fields into the span attributes
+                            span.bodyFieldsToCustomAttribute<EventBodyFields.Role>(event) { role ->
+                                CustomAttribute("gen_ai.completion.$index.${role.key}", role.value)
+                            }
+
+                            span.bodyFieldsToCustomAttribute<EventBodyFields.Content>(event) { content ->
+                                CustomAttribute("gen_ai.completion.$index.${content.key}", content.value)
+                            }
+
+                            span.bodyFieldsToCustomAttribute<EventBodyFields.ToolCalls>(event) { toolCalls ->
+                                CustomAttribute("gen_ai.completion.$index.content", toolCalls.valueString(verbose))
+                            }
+
+                            // Delete event from the span
+                            span.removeEvent(event)
+                        }
+
+                        is ChoiceEvent -> {
+                            // Convert event data fields into the span attributes
+                            span.bodyFieldsToCustomAttribute<EventBodyFields.Role>(event) { role ->
+                                // Weave expects to have an assistant message for correct displaying the responses from LLM.
+                                // Set role explicitly to Assistant (even for LLM Tool Calls response).
+                                CustomAttribute("gen_ai.completion.$index.${role.key}", Message.Role.Assistant.name.lowercase())
+                            }
+
+                            span.bodyFieldsToCustomAttribute<EventBodyFields.Content>(event) { content ->
+                                CustomAttribute("gen_ai.completion.$index.${content.key}", content.value)
+                            }
+
+                            span.bodyFieldsToCustomAttribute<EventBodyFields.ToolCalls>(event) { toolCalls ->
+                                CustomAttribute("gen_ai.completion.$index.content", toolCalls.valueString(verbose))
+                            }
+
+                            // Delete event from the span
+                            span.removeEvent(event)
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/weave/WeaveSpanAdapter.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/weave/WeaveSpanAdapter.kt
@@ -78,6 +78,11 @@ internal class WeaveSpanAdapter(private val verbose: Boolean) : SpanAdapter() {
                                 CustomAttribute("gen_ai.completion.$index.content", toolCalls.valueString(verbose))
                             }
 
+                            // Finish Reason
+                            span.bodyFieldsToCustomAttribute<EventBodyFields.FinishReason>(event) { finishReason ->
+                                CustomAttribute("gen_ai.completion.$index.finish_reason", finishReason.value)
+                            }
+
                             // Delete event from the span
                             span.removeEvent(event)
                         }
@@ -86,7 +91,7 @@ internal class WeaveSpanAdapter(private val verbose: Boolean) : SpanAdapter() {
                             // Convert event data fields into the span attributes
                             span.bodyFieldsToCustomAttribute<EventBodyFields.Role>(event) { role ->
                                 // Weave expects to have an assistant message for correct displaying the responses from LLM.
-                                // Set role explicitly to Assistant (even for LLM Tool Calls response).
+                                // Set a role explicitly to Assistant (even for LLM Tool Calls response).
                                 CustomAttribute("gen_ai.completion.$index.${role.key}", Message.Role.Assistant.name.lowercase())
                             }
 
@@ -96,6 +101,10 @@ internal class WeaveSpanAdapter(private val verbose: Boolean) : SpanAdapter() {
 
                             span.bodyFieldsToCustomAttribute<EventBodyFields.ToolCalls>(event) { toolCalls ->
                                 CustomAttribute("gen_ai.completion.$index.content", toolCalls.valueString(verbose))
+                            }
+
+                            span.bodyFieldsToCustomAttribute<EventBodyFields.FinishReason>(event) { finishReason ->
+                                CustomAttribute("gen_ai.completion.$index.finish_reason", finishReason.value)
                             }
 
                             // Delete event from the span

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/GenAIAgentSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/GenAIAgentSpan.kt
@@ -65,14 +65,14 @@ internal abstract class GenAIAgentSpan(
 
     private val _attributes = mutableListOf<Attribute>()
 
+    private val _events = mutableListOf<GenAIAgentEvent>()
+
     /**
      * Provides a list of attributes associated with the span.
      * These attributes contain metadata and additional information about the span.
      */
     val attributes: List<Attribute>
         get() = _attributes
-
-    private val _events = mutableListOf<GenAIAgentEvent>()
 
     /**
      * Provides access to the list of events associated with this span.
@@ -87,10 +87,6 @@ internal abstract class GenAIAgentSpan(
 
     fun addAttributes(attributes: List<Attribute>) {
         _attributes.addAll(attributes)
-    }
-
-    fun removeAttribute(attribute: Attribute): Boolean {
-        return _attributes.remove(attribute)
     }
 
     fun addEvent(event: GenAIAgentEvent) {

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestAPI.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestAPI.kt
@@ -56,7 +56,15 @@ internal object OpenTelemetryTestAPI {
 
         expected.forEach { (key, value) ->
             assertTrue(actual.containsKey(key), "$message - Key '$key' should exist in actual map")
-            assertEquals(value, actual[key], "$message - Value for key '$key' should match")
+
+            val actualValue = actual[key]
+            assertEquals(
+                value,
+                actualValue,
+                "$message - Value for key '$key' should match. " +
+                    "Expected: <$value: ${value?.javaClass?.simpleName}>, " +
+                    "Actual: <$actualValue: ${actualValue?.javaClass?.simpleName}>."
+            )
         }
     }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/attribute/SpanAttributesTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/attribute/SpanAttributesTest.kt
@@ -1,0 +1,283 @@
+package ai.koog.agents.features.opentelemetry.attribute
+
+import ai.koog.agents.features.opentelemetry.mock.MockLLMProvider
+import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLModel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SpanAttributesTest {
+
+    //region Tool
+
+    @Test
+    fun `test input value empty string`() {
+        val actualAttribute = SpanAttributes.Tool.InputValue("")
+        assertEquals("input.value", actualAttribute.key)
+        assertEquals("", actualAttribute.value.toString())
+    }
+
+    @Test
+    fun `test input value string hidden by default`() {
+        val inputValue = "sensitive user input"
+        val actualAttribute = SpanAttributes.Tool.InputValue(inputValue)
+
+        assertEquals("input.value", actualAttribute.key)
+        assertEquals("HIDDEN:non-empty", actualAttribute.value.toString())
+        assertEquals(inputValue, actualAttribute.value.value)
+    }
+
+    @Test
+    fun `test output value empty string`() {
+        val actualAttribute = SpanAttributes.Tool.OutputValue("")
+        assertEquals("output.value", actualAttribute.key)
+        assertEquals("", actualAttribute.value.toString())
+    }
+
+    @Test
+    fun `test output value string hidden by default`() {
+        val outputValue = "sensitive tool output"
+        val actualAttribute = SpanAttributes.Tool.OutputValue(outputValue)
+
+        assertEquals("output.value", actualAttribute.key)
+        assertEquals("HIDDEN:non-empty", actualAttribute.value.toString())
+        assertEquals(outputValue, actualAttribute.value.value)
+    }
+
+    @Test
+    fun `test tool call id attribute`() {
+        val attribute = SpanAttributes.Tool.Call.Id("call-123")
+        assertEquals("gen_ai.tool.call.id", attribute.key)
+        assertEquals("call-123", attribute.value)
+    }
+
+    @Test
+    fun `test tool name attribute`() {
+        val attribute = SpanAttributes.Tool.Name("search")
+        assertEquals("gen_ai.tool.name", attribute.key)
+        assertEquals("search", attribute.value)
+    }
+
+    @Test
+    fun `test tool description attribute`() {
+        val attribute = SpanAttributes.Tool.Description("Performs web search")
+        assertEquals("gen_ai.tool.description", attribute.key)
+        assertEquals("Performs web search", attribute.value)
+    }
+
+    //endregion Tool
+
+    //region Agent
+
+    @Test
+    fun `test agent id attribute`() {
+        val idAttribute = SpanAttributes.Agent.Id("test-agent")
+        assertEquals("gen_ai.agent.id", idAttribute.key)
+        assertEquals("test-agent", idAttribute.value)
+    }
+
+    @Test
+    fun `test agent name attribute`() {
+        val nameAttribute = SpanAttributes.Agent.Name("Test Agent")
+        assertEquals("gen_ai.agent.name", nameAttribute.key)
+        assertEquals("Test Agent", nameAttribute.value)
+    }
+
+    @Test
+    fun `test agent description attributes`() {
+        val descriptionAttribute = SpanAttributes.Agent.Description("This is a test agent")
+        assertEquals("gen_ai.agent.description", descriptionAttribute.key)
+        assertEquals("This is a test agent", descriptionAttribute.value)
+    }
+
+    //endregion Agent
+
+    //region Conversation
+
+    @Test
+    fun `test conversation id attribute`() {
+        val conversationAttribute = SpanAttributes.Conversation.Id("conversation-id")
+        assertEquals("gen_ai.conversation.id", conversationAttribute.key)
+        assertEquals("conversation-id", conversationAttribute.value)
+    }
+
+    //endregion Conversation
+
+    //region Data Source
+
+    @Test
+    fun `test data source id attribute`() {
+        val dataSourceAttribute = SpanAttributes.DataSource.Id("data-source-id")
+        assertEquals("gen_ai.data_source.id", dataSourceAttribute.key)
+        assertEquals("data-source-id", dataSourceAttribute.value)
+    }
+
+    //endregion Data Source
+
+    //region Operation
+
+    @Test
+    fun `test operation name chat attribute`() {
+        val attribute = SpanAttributes.Operation.Name(SpanAttributes.Operation.OperationNameType.CHAT)
+        assertEquals("gen_ai.operation.name", attribute.key)
+        assertEquals("chat", attribute.value)
+    }
+
+    @Test
+    fun `test operation name execute tool attribute`() {
+        val attribute = SpanAttributes.Operation.Name(SpanAttributes.Operation.OperationNameType.EXECUTE_TOOL)
+        assertEquals("gen_ai.operation.name", attribute.key)
+        assertEquals("execute_tool", attribute.value)
+    }
+
+    @Test
+    fun `test operation name generate content attribute`() {
+        val attribute = SpanAttributes.Operation.Name(SpanAttributes.Operation.OperationNameType.GENERATE_CONTENT)
+        assertEquals("gen_ai.operation.name", attribute.key)
+        assertEquals("generate_content", attribute.value)
+    }
+
+    //endregion Operation
+
+    //region Output
+
+    @Test
+    fun `test output type text attribute`() {
+        val attribute = SpanAttributes.Output.Type(SpanAttributes.Output.OutputType.TEXT)
+        assertEquals("gen_ai.output.type", attribute.key)
+        assertEquals("text", attribute.value)
+    }
+
+    @Test
+    fun `test output type json attribute`() {
+        val attribute = SpanAttributes.Output.Type(SpanAttributes.Output.OutputType.JSON)
+        assertEquals("gen_ai.output.type", attribute.key)
+        assertEquals("json", attribute.value)
+    }
+
+    @Test
+    fun `test output type image attribute`() {
+        val attribute = SpanAttributes.Output.Type(SpanAttributes.Output.OutputType.IMAGE)
+        assertEquals("gen_ai.output.type", attribute.key)
+        assertEquals("image", attribute.value)
+    }
+
+    //endregion Output
+
+    //region Request
+
+    @Test
+    fun `test request choice count attribute`() {
+        val attribute = SpanAttributes.Request.Choice.Count(3)
+        assertEquals("gen_ai.request.choice.count", attribute.key)
+        assertEquals(3, attribute.value)
+    }
+
+    @Test
+    fun `test request model attribute`() {
+        val model = LLModel(MockLLMProvider(), "gpt-4o", listOf(LLMCapability.Completion), 8192, 4096)
+        val attribute = SpanAttributes.Request.Model(model)
+        assertEquals("gen_ai.request.model", attribute.key)
+        assertEquals("gpt-4o", attribute.value)
+    }
+
+    @Test
+    fun `test request seed attribute`() {
+        val attribute = SpanAttributes.Request.Seed(42)
+        assertEquals("gen_ai.request.seed", attribute.key)
+        assertEquals(42, attribute.value)
+    }
+
+    @Test
+    fun `test request frequency penalty attribute`() {
+        val attribute = SpanAttributes.Request.FrequencyPenalty(0.25)
+        assertEquals("gen_ai.request.frequency_penalty", attribute.key)
+        assertEquals(0.25, attribute.value)
+    }
+
+    @Test
+    fun `test request max tokens attribute`() {
+        val attribute = SpanAttributes.Request.MaxTokens(1024)
+        assertEquals("gen_ai.request.max_tokens", attribute.key)
+        assertEquals(1024, attribute.value)
+    }
+
+    @Test
+    fun `test request presence penalty attribute`() {
+        val attribute = SpanAttributes.Request.PresencePenalty(0.75)
+        assertEquals("gen_ai.request.presence_penalty", attribute.key)
+        assertEquals(0.75, attribute.value)
+    }
+
+    @Test
+    fun `test request stop sequences attribute`() {
+        val stops = listOf("END", "STOP")
+        val attribute = SpanAttributes.Request.StopSequences(stops)
+        assertEquals("gen_ai.request.stop_sequences", attribute.key)
+        assertEquals(stops, attribute.value)
+    }
+
+    @Test
+    fun `test request temperature attribute`() {
+        val attribute = SpanAttributes.Request.Temperature(0.8)
+        assertEquals("gen_ai.request.temperature", attribute.key)
+        assertEquals(0.8, attribute.value)
+    }
+
+    @Test
+    fun `test request top_p attribute`() {
+        val attribute = SpanAttributes.Request.TopP(0.9)
+        assertEquals("gen_ai.request.top_p", attribute.key)
+        assertEquals(0.9, attribute.value)
+    }
+
+    //endregion Request
+
+    //region Response
+
+    @Test
+    fun `test response finish reasons attribute`() {
+        val reasons = listOf(
+            SpanAttributes.Response.FinishReasonType.Stop,
+            SpanAttributes.Response.FinishReasonType.Custom("custom-reason"),
+        )
+        val attribute = SpanAttributes.Response.FinishReasons(reasons)
+        assertEquals("gen_ai.response.finish_reasons", attribute.key)
+        assertEquals(listOf("stop", "custom-reason"), attribute.value)
+    }
+
+    @Test
+    fun `test response id attribute`() {
+        val attribute = SpanAttributes.Response.Id("resp-001")
+        assertEquals("gen_ai.response.id", attribute.key)
+        assertEquals("resp-001", attribute.value)
+    }
+
+    @Test
+    fun `test response model attribute`() {
+        val model = LLModel(MockLLMProvider(), "gemini-1.5-pro", emptyList(), 32768)
+        val attribute = SpanAttributes.Response.Model(model)
+        assertEquals("gen_ai.response.model", attribute.key)
+        assertEquals("gemini-1.5-pro", attribute.value)
+    }
+
+    //endregion Response
+
+    //region Usage
+
+    @Test
+    fun `test usage input tokens attribute`() {
+        val attribute = SpanAttributes.Usage.InputTokens(123)
+        assertEquals("gen_ai.usage.input_tokens", attribute.key)
+        assertEquals(123, attribute.value)
+    }
+
+    @Test
+    fun `test usage output tokens attribute`() {
+        val attribute = SpanAttributes.Usage.OutputTokens(456)
+        assertEquals("gen_ai.usage.output_tokens", attribute.key)
+        assertEquals(456, attribute.value)
+    }
+
+    //endregion Usage
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/AssistantMessageEventTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/AssistantMessageEventTest.kt
@@ -17,8 +17,7 @@ class AssistantMessageEventTest {
 
     @Test
     fun `test assistant message attributes`() {
-        val expectedContent = "Test message"
-        val expectedMessage = createTestAssistantMessage(expectedContent)
+        val expectedMessage = createTestAssistantMessage("Test message")
         val llmProvider = MockLLMProvider()
 
         val assistantMessageEvent = AssistantMessageEvent(
@@ -40,8 +39,7 @@ class AssistantMessageEventTest {
 
     @Test
     fun `test tool call message`() {
-        val expectedContent = "Test message"
-        val expectedMessage = createTestToolCallMessage("test-id", "test-tool", expectedContent)
+        val expectedMessage = createTestToolCallMessage("test-id", "test-tool", "Test message")
 
         val assistantMessageEvent = AssistantMessageEvent(
             provider = MockLLMProvider(),
@@ -59,8 +57,7 @@ class AssistantMessageEventTest {
 
     @Test
     fun `test assistant message`() {
-        val expectedContent = "Test message"
-        val expectedMessage = createTestAssistantMessage(expectedContent)
+        val expectedMessage = createTestAssistantMessage("Test message")
 
         val assistantMessageEvent = AssistantMessageEvent(
             provider = MockLLMProvider(),
@@ -68,7 +65,8 @@ class AssistantMessageEventTest {
         )
 
         val expectedBodyFields = listOf(
-            EventBodyFields.Content(content = expectedContent)
+            EventBodyFields.Role(role = expectedMessage.role),
+            EventBodyFields.Content(content = expectedMessage.content)
         )
 
         assertEquals(expectedBodyFields.size, assistantMessageEvent.bodyFields.size)
@@ -81,8 +79,7 @@ class AssistantMessageEventTest {
 
     @Test
     fun `test assistant message with arguments`() {
-        val expectedContent = "Test message"
-        val expectedMessage = createTestAssistantMessage(expectedContent)
+        val expectedMessage = createTestAssistantMessage("Test message")
         val args = buildJsonObject {
             put("string", "value")
             put("integer", 42)
@@ -95,7 +92,8 @@ class AssistantMessageEventTest {
         )
 
         val expectedBodyFields = listOf(
-            EventBodyFields.Content(content = expectedContent),
+            EventBodyFields.Role(role = expectedMessage.role),
+            EventBodyFields.Content(content = expectedMessage.content),
             EventBodyFields.Arguments(args)
         )
 
@@ -105,8 +103,7 @@ class AssistantMessageEventTest {
 
     @Test
     fun `test tool call message ignores arguments`() {
-        val expectedContent = "Test message"
-        val expectedMessage = createTestToolCallMessage("test-id", "test-tool", expectedContent)
+        val expectedMessage = createTestToolCallMessage("test-id", "test-tool", "Test message")
         val args = buildJsonObject { put("ignored", true) }
 
         val assistantMessageEvent = AssistantMessageEvent(

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEventTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEventTest.kt
@@ -53,7 +53,7 @@ class ChoiceEventTest {
         val expectedBodyFields = listOf(
             EventBodyFields.Index(0),
             EventBodyFields.FinishReason("stop"),
-            EventBodyFields.Message(null, expectedMessage.content)
+            EventBodyFields.Message(expectedMessage.role, expectedMessage.content)
         )
 
         assertEquals(expectedBodyFields.size, choiceEvent.bodyFields.size)
@@ -94,8 +94,8 @@ class ChoiceEventTest {
         val expectedBodyFields = listOf(
             EventBodyFields.Index(0),
             EventBodyFields.Message(
-                role = null,
-                content = expectedContent
+                role = expectedMessage.role,
+                content = expectedMessage.content
             )
         )
 
@@ -125,10 +125,7 @@ class ChoiceEventTest {
 
         val expectedBodyFields = listOf(
             EventBodyFields.Index(0),
-            EventBodyFields.Message(
-                role = null,
-                content = expectedContent
-            ),
+            EventBodyFields.Message(expectedMessage.role, expectedMessage.content),
             EventBodyFields.Arguments(args)
         )
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEventTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEventTest.kt
@@ -73,6 +73,7 @@ class ChoiceEventTest {
 
         val expectedBodyFields = listOf(
             EventBodyFields.Index(0),
+            EventBodyFields.Role(role = Message.Role.Tool),
             EventBodyFields.ToolCalls(tools = listOf(expectedMessage))
         )
 
@@ -148,6 +149,7 @@ class ChoiceEventTest {
 
         val expectedBodyFields = listOf(
             EventBodyFields.Index(0),
+            EventBodyFields.Role(role = Message.Role.Tool),
             EventBodyFields.ToolCalls(tools = listOf(expectedMessage))
         )
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEventTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEventTest.kt
@@ -1,6 +1,7 @@
 package ai.koog.agents.features.opentelemetry.event
 
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
+import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
 import ai.koog.agents.features.opentelemetry.mock.MockLLMProvider
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
@@ -74,7 +75,8 @@ class ChoiceEventTest {
         val expectedBodyFields = listOf(
             EventBodyFields.Index(0),
             EventBodyFields.Role(role = Message.Role.Tool),
-            EventBodyFields.ToolCalls(tools = listOf(expectedMessage))
+            EventBodyFields.ToolCalls(tools = listOf(expectedMessage)),
+            EventBodyFields.FinishReason(reason = SpanAttributes.Response.FinishReasonType.ToolCalls.id)
         )
 
         assertEquals(expectedBodyFields.size, choiceEvent.bodyFields.size)
@@ -150,7 +152,8 @@ class ChoiceEventTest {
         val expectedBodyFields = listOf(
             EventBodyFields.Index(0),
             EventBodyFields.Role(role = Message.Role.Tool),
-            EventBodyFields.ToolCalls(tools = listOf(expectedMessage))
+            EventBodyFields.ToolCalls(tools = listOf(expectedMessage)),
+            EventBodyFields.FinishReason(reason = SpanAttributes.Response.FinishReasonType.ToolCalls.id)
         )
 
         assertEquals(expectedBodyFields.size, choiceEvent.bodyFields.size)

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/GenAIAgentEventTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/GenAIAgentEventTest.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.features.opentelemetry.event
 
-import ai.koog.agents.features.opentelemetry.attribute.Attribute
 import ai.koog.agents.features.opentelemetry.mock.MockAttribute
 import ai.koog.agents.features.opentelemetry.mock.MockGenAIAgentEvent
 import org.junit.jupiter.api.Test
@@ -10,11 +9,7 @@ class GenAIAgentEventTest {
 
     @Test
     fun `default name should be gen_ai`() {
-        val event = object : GenAIAgentEvent {
-            override val attributes: List<Attribute> = emptyList()
-            override val bodyFields: List<EventBodyField> = emptyList()
-        }
-
+        val event = object : GenAIAgentEvent() { }
         assertEquals("gen_ai", event.name)
     }
 
@@ -34,7 +29,8 @@ class GenAIAgentEventTest {
             MockAttribute("key3", true)
         )
 
-        val event = MockGenAIAgentEvent(attributes = attributes)
+        val event = MockGenAIAgentEvent()
+        event.addAttributes(attributes)
 
         assertEquals(attributes, event.attributes)
         assertEquals(3, event.attributes.size)

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/SystemMessageEventTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/SystemMessageEventTest.kt
@@ -38,8 +38,7 @@ class SystemMessageEventTest {
 
     @Test
     fun `test system message body fields`() {
-        val expectedContent = "Test message"
-        val expectedMessage = createTestSystemMessage(expectedContent)
+        val expectedMessage = createTestSystemMessage("Test message")
 
         val systemMessageEvent = SystemMessageEvent(
             provider = MockLLMProvider(),
@@ -47,7 +46,8 @@ class SystemMessageEventTest {
         )
 
         val expectedBodyFields = listOf(
-            EventBodyFields.Content(content = expectedContent)
+            EventBodyFields.Role(role = expectedMessage.role),
+            EventBodyFields.Content(content = expectedMessage.content),
         )
 
         assertEquals(expectedBodyFields.size, systemMessageEvent.bodyFields.size)

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/ToolMessageEventTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/ToolMessageEventTest.kt
@@ -3,6 +3,7 @@ package ai.koog.agents.features.opentelemetry.event
 import ai.koog.agents.core.tools.ToolResult
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
 import ai.koog.agents.features.opentelemetry.mock.MockLLMProvider
+import ai.koog.prompt.message.Message
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -47,6 +48,7 @@ class ToolMessageEventTest {
         )
 
         val expectedBodyFields = listOf(
+            EventBodyFields.Role(role = Message.Role.Tool),
             EventBodyFields.Content(content = toolResult.toStringDefault()),
             EventBodyFields.Id(id = toolCallId)
         )
@@ -67,6 +69,7 @@ class ToolMessageEventTest {
         )
 
         val expectedBodyFields = listOf(
+            EventBodyFields.Role(role = Message.Role.Tool),
             EventBodyFields.Content(content = toolResult.toStringDefault())
         )
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/UserMessageEventTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/UserMessageEventTest.kt
@@ -38,8 +38,7 @@ class UserMessageEventTest {
 
     @Test
     fun `test user message body fields`() {
-        val expectedContent = "Test message"
-        val expectedMessage = createTestUserMessage(expectedContent)
+        val expectedMessage = createTestUserMessage("Test message")
 
         val userMessageEvent = UserMessageEvent(
             provider = MockLLMProvider(),
@@ -47,7 +46,8 @@ class UserMessageEventTest {
         )
 
         val expectedBodyFields = listOf(
-            EventBodyFields.Content(content = expectedContent)
+            EventBodyFields.Role(role = expectedMessage.role),
+            EventBodyFields.Content(content = expectedMessage.content),
         )
 
         assertEquals(expectedBodyFields.size, userMessageEvent.bodyFields.size)

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/extension/EventBodyFieldExtTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/extension/EventBodyFieldExtTest.kt
@@ -1,0 +1,32 @@
+package ai.koog.agents.features.opentelemetry.extension
+
+import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
+import ai.koog.agents.features.opentelemetry.event.EventBodyField
+import ai.koog.agents.features.opentelemetry.mock.MockEventBodyField
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EventBodyFieldExtTest {
+
+    @Test
+    fun `toCustomAttribute returns CustomAttribute when creator is not specified`() {
+        val field: EventBodyField = MockEventBodyField("key", 42)
+
+        val attribute = field.toCustomAttribute()
+
+        assertEquals("key", attribute.key)
+        assertEquals(42, attribute.value)
+    }
+
+    @Test
+    fun `toCustomAttribute uses provided attribute creator parameter`() {
+        val bodyField: EventBodyField = MockEventBodyField("key", "value")
+
+        val attribute = bodyField.toCustomAttribute { field ->
+            CustomAttribute("custom.${field.key}", "custom.${field.value}")
+        }
+
+        assertEquals("custom.key", attribute.key)
+        assertEquals("custom.value", attribute.value)
+    }
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/extension/GenAIAgentEventExtTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/extension/GenAIAgentEventExtTest.kt
@@ -1,0 +1,87 @@
+package ai.koog.agents.features.opentelemetry.extension
+
+import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
+import ai.koog.agents.features.opentelemetry.mock.MockEventBodyField
+import ai.koog.agents.features.opentelemetry.mock.MockGenAIAgentEvent
+import ai.koog.agents.features.opentelemetry.mock.MockGenAIAgentSpan
+import ai.koog.agents.features.opentelemetry.mock.MockSpan
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class GenAIAgentEventExtTest {
+
+    @Test
+    fun `bodyFieldsToAttributes converts body fields to attributes and clears fields`() {
+        val bodyFieldString = MockEventBodyField("keyString", "valueString")
+        val bodyFieldList = MockEventBodyField("keyList", listOf(1, 2, 3))
+
+        val event = MockGenAIAgentEvent(fields = listOf(bodyFieldString, bodyFieldList))
+        assertEquals(0, event.attributes.size)
+        assertEquals(2, event.bodyFields.size)
+
+        event.bodyFieldsToAttributes(verbose = true)
+
+        // Verify that all fields are converted to attributes, and fields are cleared
+        assertEquals(0, event.bodyFields.size)
+        assertEquals(2, event.attributes.size)
+
+        val expectedAttributes = listOf(
+            CustomAttribute("keyString", "valueString"),
+            CustomAttribute("keyList", listOf(1, 2, 3))
+        )
+
+        assertContentEquals(expectedAttributes, event.attributes)
+    }
+
+    @Test
+    fun `toSpanAttributes adds converted attributes to span`() {
+        val bodyFieldMap = MockEventBodyField("bodyFieldMap", mapOf("test-key" to "test-value"))
+        val event = MockGenAIAgentEvent(fields = listOf(bodyFieldMap))
+        val span = MockGenAIAgentSpan(spanId = "test-span-id")
+
+        val mockSpan = MockSpan()
+        span.span = mockSpan
+
+        event.toSpanAttributes(span = span, verbose = false)
+
+        val expectedAttributes = listOf(CustomAttribute("bodyFieldMap", "{\"test-key\":\"test-value\"}"))
+
+        assertEquals(expectedAttributes.size, span.attributes.size)
+        assertContentEquals(expectedAttributes, span.attributes)
+        assertEquals(0, event.bodyFields.size)
+    }
+
+    @Test
+    fun `bodyFieldsToBodyAttribute adds single body attribute and clears fields`() {
+        val bodyFieldBoolean = MockEventBodyField("keyBoolean", true)
+        val bodyFieldInt = MockEventBodyField("keyInt", 1)
+        val event = MockGenAIAgentEvent(fields = listOf(bodyFieldBoolean, bodyFieldInt))
+
+        event.bodyFieldsToBodyAttribute(verbose = true)
+
+        val expectedAttributes = listOf(
+            CustomAttribute("body", "{\"keyBoolean\":true,\"keyInt\":1}")
+        )
+
+        assertEquals(expectedAttributes.size, event.attributes.size)
+        assertContentEquals(expectedAttributes, event.attributes)
+        assertEquals(0, event.bodyFields.size)
+    }
+
+    @Test
+    fun `bodyFieldsToBodyAttribute with mixed types`() {
+        val field = MockEventBodyField("mixed", listOf("string", 1))
+        val event = MockGenAIAgentEvent(fields = listOf(field))
+
+        event.bodyFieldsToAttributes(verbose = true)
+
+        val expected = listOf(
+            CustomAttribute("mixed", listOf("string", 1))
+        )
+
+        assertEquals(0, event.bodyFields.size)
+        assertEquals(expected.size, event.attributes.size)
+        assertContentEquals(expected, event.attributes)
+    }
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/extension/SpanExtTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/extension/SpanExtTest.kt
@@ -1,0 +1,76 @@
+package ai.koog.agents.features.opentelemetry.extension
+
+import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.assertMapsEqual
+import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
+import ai.koog.agents.features.opentelemetry.mock.MockEventBodyField
+import ai.koog.agents.features.opentelemetry.mock.MockGenAIAgentEvent
+import ai.koog.agents.features.opentelemetry.mock.MockSpan
+import ai.koog.agents.features.opentelemetry.span.SpanEndStatus
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.StatusCode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SpanExtTest {
+
+    @Test
+    fun `setSpanStatus sets OK by default`() {
+        val span = MockSpan()
+        span.setSpanStatus()
+        assertEquals(StatusCode.OK, span.status)
+        assertEquals("", span.statusDescription)
+    }
+
+    @Test
+    fun `setSpanStatus sets provided code and description`() {
+        val span = MockSpan()
+        span.setSpanStatus(SpanEndStatus(StatusCode.ERROR, "test description"))
+        assertEquals(StatusCode.ERROR, span.status)
+        assertEquals("test description", span.statusDescription)
+    }
+
+    @Test
+    fun `setAttributes on Span writes all attributes`() {
+        val span = MockSpan()
+        val attributes = listOf(
+            CustomAttribute("keyString", "valueString"),
+            CustomAttribute("keyInt", 1),
+            CustomAttribute("keyBoolean", true),
+        )
+
+        span.setAttributes(attributes, verbose = true)
+
+        val actualAttributes = span.collectedAttributes
+        val expectedAttributes = mapOf(
+            AttributeKey.stringKey("keyString") to "valueString",
+            AttributeKey.longKey("keyInt") to 1L,
+            AttributeKey.booleanKey("keyBoolean") to true
+        )
+
+        assertEquals(expectedAttributes.size, actualAttributes.size)
+        assertMapsEqual(expectedAttributes, actualAttributes)
+    }
+
+    @Test
+    fun `setEvents converts body fields to attributes and adds events`() {
+        val span = MockSpan()
+        val event = MockGenAIAgentEvent().apply {
+            addAttribute(CustomAttribute("keyString", "valueString"))
+            addBodyField(MockEventBodyField("keyInt", 1))
+        }
+
+        span.setEvents(listOf(event), verbose = true)
+
+        val actualEvents = span.collectedEvents
+        assertEquals(1, actualEvents.size)
+
+        val actualEventAttributes = actualEvents.values.first().asMap()
+        val expectedEvents = mapOf(
+            AttributeKey.stringKey("keyString") to "valueString",
+            AttributeKey.longKey("keyInt") to 1L,
+        )
+
+        assertEquals(expectedEvents.size, actualEventAttributes.size)
+        assertMapsEqual(expectedEvents, actualEventAttributes)
+    }
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
@@ -828,8 +828,8 @@ class OpenTelemetryTest {
                 mapOf(
                     "tool.Get whether" to mapOf(
                         "attributes" to mapOf(
-                            "output.value" to TestGetWeatherTool.RESULT,
-                            "input.value" to "{\"location\":\"Paris\"}",
+                            "output.value" to HiddenString.HIDDEN_STRING_PLACEHOLDER,
+                            "input.value" to HiddenString.HIDDEN_STRING_PLACEHOLDER,
                             "gen_ai.tool.description" to "The test tool to get a whether based on provided location.",
                             "gen_ai.tool.name" to "Get whether",
                         ),

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
@@ -231,22 +231,22 @@ class OpenTelemetryTest {
                         "events" to mapOf(
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${userPrompt}\"}"
+                                "body" to "{\"role\":\"user\",\"content\":\"${userPrompt}\"}"
                             )
                         ),
 
                         "events" to mapOf(
                             "gen_ai.system.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${systemPrompt}\"}"
+                                "body" to "{\"role\":\"system\",\"content\":\"${systemPrompt}\"}"
                             ),
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${userPrompt}\"}"
+                                "body" to "{\"role\":\"user\",\"content\":\"${userPrompt}\"}"
                             ),
                             "gen_ai.assistant.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${mockResponse}\"}"
+                                "body" to "{\"role\":\"assistant\",\"content\":\"${mockResponse}\"}"
                             )
                         )
                     )
@@ -382,15 +382,15 @@ class OpenTelemetryTest {
                         "events" to mapOf(
                             "gen_ai.system.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${systemPrompt}\"}"
+                                "body" to "{\"role\":\"system\",\"content\":\"${systemPrompt}\"}"
                             ),
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${userPrompt1}\"}"
+                                "body" to "{\"role\":\"user\",\"content\":\"${userPrompt1}\"}"
                             ),
                             "gen_ai.assistant.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${mockResponse1}\"}"
+                                "body" to "{\"role\":\"assistant\",\"content\":\"${mockResponse1}\"}"
                             )
                         )
                     )
@@ -452,15 +452,15 @@ class OpenTelemetryTest {
                         "events" to mapOf(
                             "gen_ai.system.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${systemPrompt}\"}"
+                                "body" to "{\"role\":\"system\",\"content\":\"${systemPrompt}\"}"
                             ),
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${userPrompt0}\"}"
+                                "body" to "{\"role\":\"user\",\"content\":\"${userPrompt0}\"}"
                             ),
                             "gen_ai.assistant.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${mockResponse0}\"}"
+                                "body" to "{\"role\":\"assistant\",\"content\":\"${mockResponse0}\"}"
                             )
                         )
                     )
@@ -597,19 +597,19 @@ class OpenTelemetryTest {
                         "events" to mapOf(
                             "gen_ai.system.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${systemPrompt}\"}"
+                                "body" to "{\"role\":\"system\",\"content\":\"${systemPrompt}\"}"
                             ),
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${userPrompt}\"}"
+                                "body" to "{\"role\":\"user\",\"content\":\"${userPrompt}\"}"
                             ),
                             "gen_ai.tool.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${TestGetWeatherTool.RESULT}\"}"
+                                "body" to "{\"role\":\"tool\",\"content\":\"${TestGetWeatherTool.RESULT}\"}"
                             ),
                             "gen_ai.assistant.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${mockResponse}\"}"
+                                "body" to "{\"role\":\"assistant\",\"content\":\"${mockResponse}\"}"
                             ),
                         )
                     )
@@ -655,11 +655,11 @@ class OpenTelemetryTest {
                         "events" to mapOf(
                             "gen_ai.system.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${systemPrompt}\"}"
+                                "body" to "{\"role\":\"system\",\"content\":\"${systemPrompt}\"}"
                             ),
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${userPrompt}\"}"
+                                "body" to "{\"role\":\"user\",\"content\":\"${userPrompt}\"}"
                             ),
                             "gen_ai.choice" to mapOf(
                                 "gen_ai.system" to model.provider.id,
@@ -799,19 +799,19 @@ class OpenTelemetryTest {
                         "events" to mapOf(
                             "gen_ai.system.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"}"
+                                "body" to "{\"role\":\"system\",\"content\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"}"
                             ),
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"}"
+                                "body" to "{\"role\":\"user\",\"content\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"}"
                             ),
                             "gen_ai.tool.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"}"
+                                "body" to "{\"role\":\"tool\",\"content\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"}"
                             ),
                             "gen_ai.assistant.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"}"
+                                "body" to "{\"role\":\"assistant\",\"content\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"}"
                             ),
                         )
                     )
@@ -857,11 +857,11 @@ class OpenTelemetryTest {
                         "events" to mapOf(
                             "gen_ai.system.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"}"
+                                "body" to "{\"role\":\"system\",\"content\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"}"
                             ),
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"content\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"}"
+                                "body" to "{\"role\":\"user\",\"content\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"}"
                             ),
                             "gen_ai.choice" to mapOf(
                                 "gen_ai.system" to model.provider.id,

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
@@ -514,7 +514,7 @@ class OpenTelemetryTest {
 
             val mockExecutor = getMockExecutor(clock = testClock) {
                 mockLLMToolCall(TestGetWeatherTool, TestGetWeatherTool.Args("Paris")) onRequestEquals userPrompt
-                mockLLMAnswer(mockResponse) onRequestContains TestGetWeatherTool.RESULT
+                mockLLMAnswer(mockResponse) onRequestContains TestGetWeatherTool.DEFAULT_PARIS_RESULT
             }
 
             val agent = createAgent(
@@ -605,7 +605,7 @@ class OpenTelemetryTest {
                             ),
                             "gen_ai.tool.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"tool\",\"content\":\"${TestGetWeatherTool.RESULT}\"}"
+                                "body" to "{\"role\":\"tool\",\"content\":\"${TestGetWeatherTool.DEFAULT_PARIS_RESULT}\"}"
                             ),
                             "gen_ai.assistant.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
@@ -626,7 +626,7 @@ class OpenTelemetryTest {
                 mapOf(
                     "tool.Get whether" to mapOf(
                         "attributes" to mapOf(
-                            "output.value" to TestGetWeatherTool.RESULT,
+                            "output.value" to TestGetWeatherTool.DEFAULT_PARIS_RESULT,
                             "input.value" to "{\"location\":\"Paris\"}",
                             "gen_ai.tool.description" to "The test tool to get a whether based on provided location.",
                             "gen_ai.tool.name" to "Get whether",
@@ -663,7 +663,7 @@ class OpenTelemetryTest {
                             ),
                             "gen_ai.choice" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"index\":0,\"tool_calls\":[{\"function\":{\"name\":\"${TestGetWeatherTool.name}\",\"arguments\":\"${TestGetWeatherTool.encodeArgsToString(TestGetWeatherTool.Args("Paris"))}\"},\"id\":\"\",\"type\":\"function\"}]}"
+                                "body" to "{\"index\":0,\"role\":\"tool\",\"tool_calls\":[{\"function\":{\"name\":\"${TestGetWeatherTool.name}\",\"arguments\":\"${TestGetWeatherTool.encodeArgsToString(TestGetWeatherTool.Args("Paris"))}\"},\"id\":\"\",\"type\":\"function\"}]}"
                             ),
                         )
                     )
@@ -865,7 +865,7 @@ class OpenTelemetryTest {
                             ),
                             "gen_ai.choice" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"index\":0,\"tool_calls\":[{\"function\":{\"name\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\",\"arguments\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"},\"id\":\"\",\"type\":\"function\"}]}"
+                                "body" to "{\"index\":0,\"role\":\"tool\",\"tool_calls\":[{\"function\":{\"name\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\",\"arguments\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"},\"id\":\"\",\"type\":\"function\"}]}"
                             ),
                         )
                     )

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
@@ -231,22 +231,26 @@ class OpenTelemetryTest {
                         "events" to mapOf(
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"user\",\"content\":\"${userPrompt}\"}"
+                                "role" to "user",
+                                "content" to userPrompt
                             )
                         ),
 
                         "events" to mapOf(
                             "gen_ai.system.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"system\",\"content\":\"${systemPrompt}\"}"
+                                "role" to "system",
+                                "content" to systemPrompt,
                             ),
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"user\",\"content\":\"${userPrompt}\"}"
+                                "role" to "user",
+                                "content" to userPrompt,
                             ),
                             "gen_ai.assistant.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"assistant\",\"content\":\"${mockResponse}\"}"
+                                "role" to "assistant",
+                                "content" to mockResponse,
                             )
                         )
                     )
@@ -382,15 +386,18 @@ class OpenTelemetryTest {
                         "events" to mapOf(
                             "gen_ai.system.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"system\",\"content\":\"${systemPrompt}\"}"
+                                "role" to "system",
+                                "content" to systemPrompt,
                             ),
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"user\",\"content\":\"${userPrompt1}\"}"
+                                "role" to "user",
+                                "content" to userPrompt1,
                             ),
                             "gen_ai.assistant.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"assistant\",\"content\":\"${mockResponse1}\"}"
+                                "role" to "assistant",
+                                "content" to mockResponse1,
                             )
                         )
                     )
@@ -452,15 +459,18 @@ class OpenTelemetryTest {
                         "events" to mapOf(
                             "gen_ai.system.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"system\",\"content\":\"${systemPrompt}\"}"
+                                "role" to "system",
+                                "content" to systemPrompt,
                             ),
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"user\",\"content\":\"${userPrompt0}\"}"
+                                "role" to "user",
+                                "content" to userPrompt0,
                             ),
                             "gen_ai.assistant.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"assistant\",\"content\":\"${mockResponse0}\"}"
+                                "role" to "assistant",
+                                "content" to mockResponse0,
                             )
                         )
                     )
@@ -597,19 +607,23 @@ class OpenTelemetryTest {
                         "events" to mapOf(
                             "gen_ai.system.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"system\",\"content\":\"${systemPrompt}\"}"
+                                "role" to "system",
+                                "content" to systemPrompt,
                             ),
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"user\",\"content\":\"${userPrompt}\"}"
+                                "role" to "user",
+                                "content" to userPrompt,
                             ),
                             "gen_ai.tool.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"tool\",\"content\":\"${TestGetWeatherTool.DEFAULT_PARIS_RESULT}\"}"
+                                "role" to "tool",
+                                "content" to TestGetWeatherTool.DEFAULT_PARIS_RESULT,
                             ),
                             "gen_ai.assistant.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"assistant\",\"content\":\"${mockResponse}\"}"
+                                "role" to "assistant",
+                                "content" to mockResponse,
                             ),
                         )
                     )
@@ -655,15 +669,19 @@ class OpenTelemetryTest {
                         "events" to mapOf(
                             "gen_ai.system.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"system\",\"content\":\"${systemPrompt}\"}"
+                                "role" to "system",
+                                "content" to systemPrompt,
                             ),
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"user\",\"content\":\"${userPrompt}\"}"
+                                "role" to "user",
+                                "content" to userPrompt,
                             ),
                             "gen_ai.choice" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"index\":0,\"role\":\"tool\",\"tool_calls\":[{\"function\":{\"name\":\"${TestGetWeatherTool.name}\",\"arguments\":\"${TestGetWeatherTool.encodeArgsToString(TestGetWeatherTool.Args("Paris"))}\"},\"id\":\"\",\"type\":\"function\"}]}"
+                                "index" to 0L,
+                                "role" to "tool",
+                                "tool_calls" to "[{\"function\":{\"name\":\"${TestGetWeatherTool.name}\",\"arguments\":\"${TestGetWeatherTool.encodeArgsToString(TestGetWeatherTool.Args("Paris"))}\"},\"id\":\"\",\"type\":\"function\"}]"
                             ),
                         )
                     )
@@ -799,19 +817,23 @@ class OpenTelemetryTest {
                         "events" to mapOf(
                             "gen_ai.system.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"system\",\"content\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"}"
+                                "role" to "system",
+                                "content" to HiddenString.HIDDEN_STRING_PLACEHOLDER,
                             ),
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"user\",\"content\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"}"
+                                "role" to "user",
+                                "content" to HiddenString.HIDDEN_STRING_PLACEHOLDER,
                             ),
                             "gen_ai.tool.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"tool\",\"content\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"}"
+                                "role" to "tool",
+                                "content" to HiddenString.HIDDEN_STRING_PLACEHOLDER,
                             ),
                             "gen_ai.assistant.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"assistant\",\"content\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"}"
+                                "role" to "assistant",
+                                "content" to HiddenString.HIDDEN_STRING_PLACEHOLDER,
                             ),
                         )
                     )
@@ -857,15 +879,19 @@ class OpenTelemetryTest {
                         "events" to mapOf(
                             "gen_ai.system.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"system\",\"content\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"}"
+                                "role" to "system",
+                                "content" to HiddenString.HIDDEN_STRING_PLACEHOLDER,
                             ),
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"role\":\"user\",\"content\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"}"
+                                "role" to "user",
+                                "content" to HiddenString.HIDDEN_STRING_PLACEHOLDER,
                             ),
                             "gen_ai.choice" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "body" to "{\"index\":0,\"role\":\"tool\",\"tool_calls\":[{\"function\":{\"name\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\",\"arguments\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"},\"id\":\"\",\"type\":\"function\"}]}"
+                                "index" to 0L,
+                                "role" to "tool",
+                                "tool_calls" to "[{\"function\":{\"name\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\",\"arguments\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"},\"id\":\"\",\"type\":\"function\"}]"
                             ),
                         )
                     )

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
@@ -22,6 +22,7 @@ import ai.koog.agents.testing.tools.mockLLMAnswer
 import ai.koog.agents.utils.HiddenString
 import ai.koog.agents.utils.use
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import ai.koog.prompt.message.Message
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.trace.SdkTracerProvider
@@ -227,11 +228,12 @@ class OpenTelemetryTest {
                             "gen_ai.conversation.id" to mockExporter.lastRunId,
                             "gen_ai.request.temperature" to temperature,
                             "gen_ai.request.model" to model.id,
+                            "gen_ai.response.finish_reasons" to listOf(FinishReasonType.Stop.id)
                         ),
                         "events" to mapOf(
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "user",
+                                "role" to Message.Role.User.name.lowercase(),
                                 "content" to userPrompt
                             )
                         ),
@@ -239,17 +241,17 @@ class OpenTelemetryTest {
                         "events" to mapOf(
                             "gen_ai.system.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "system",
+                                "role" to Message.Role.System.name.lowercase(),
                                 "content" to systemPrompt,
                             ),
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "user",
+                                "role" to Message.Role.User.name.lowercase(),
                                 "content" to userPrompt,
                             ),
                             "gen_ai.assistant.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "assistant",
+                                "role" to Message.Role.Assistant.name.lowercase(),
                                 "content" to mockResponse,
                             )
                         )
@@ -382,21 +384,22 @@ class OpenTelemetryTest {
                             "gen_ai.conversation.id" to mockExporter.runIds[1],
                             "gen_ai.request.temperature" to temperature,
                             "gen_ai.request.model" to model.id,
+                            "gen_ai.response.finish_reasons" to listOf(FinishReasonType.Stop.id),
                         ),
                         "events" to mapOf(
                             "gen_ai.system.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "system",
+                                "role" to Message.Role.System.name.lowercase(),
                                 "content" to systemPrompt,
                             ),
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "user",
+                                "role" to Message.Role.User.name.lowercase(),
                                 "content" to userPrompt1,
                             ),
                             "gen_ai.assistant.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "assistant",
+                                "role" to Message.Role.Assistant.name.lowercase(),
                                 "content" to mockResponse1,
                             )
                         )
@@ -455,21 +458,22 @@ class OpenTelemetryTest {
                             "gen_ai.conversation.id" to mockExporter.runIds[0],
                             "gen_ai.request.temperature" to temperature,
                             "gen_ai.request.model" to model.id,
+                            "gen_ai.response.finish_reasons" to listOf(FinishReasonType.Stop.id),
                         ),
                         "events" to mapOf(
                             "gen_ai.system.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "system",
+                                "role" to Message.Role.System.name.lowercase(),
                                 "content" to systemPrompt,
                             ),
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "user",
+                                "role" to Message.Role.User.name.lowercase(),
                                 "content" to userPrompt0,
                             ),
                             "gen_ai.assistant.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "assistant",
+                                "role" to Message.Role.Assistant.name.lowercase(),
                                 "content" to mockResponse0,
                             )
                         )
@@ -603,26 +607,27 @@ class OpenTelemetryTest {
                             "gen_ai.conversation.id" to mockExporter.lastRunId,
                             "gen_ai.operation.name" to "chat",
                             "gen_ai.request.temperature" to temperature,
+                            "gen_ai.response.finish_reasons" to listOf(FinishReasonType.Stop.id),
                         ),
                         "events" to mapOf(
                             "gen_ai.system.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "system",
+                                "role" to Message.Role.System.name.lowercase(),
                                 "content" to systemPrompt,
                             ),
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "user",
+                                "role" to Message.Role.User.name.lowercase(),
                                 "content" to userPrompt,
                             ),
                             "gen_ai.tool.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "tool",
+                                "role" to Message.Role.Tool.name.lowercase(),
                                 "content" to TestGetWeatherTool.DEFAULT_PARIS_RESULT,
                             ),
                             "gen_ai.assistant.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "assistant",
+                                "role" to Message.Role.Assistant.name.lowercase(),
                                 "content" to mockResponse,
                             ),
                         )
@@ -665,23 +670,25 @@ class OpenTelemetryTest {
                             "gen_ai.conversation.id" to mockExporter.lastRunId,
                             "gen_ai.operation.name" to "chat",
                             "gen_ai.request.temperature" to temperature,
+                            "gen_ai.response.finish_reasons" to listOf(FinishReasonType.ToolCalls.id),
                         ),
                         "events" to mapOf(
                             "gen_ai.system.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "system",
+                                "role" to Message.Role.System.name.lowercase(),
                                 "content" to systemPrompt,
                             ),
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "user",
+                                "role" to Message.Role.User.name.lowercase(),
                                 "content" to userPrompt,
                             ),
                             "gen_ai.choice" to mapOf(
                                 "gen_ai.system" to model.provider.id,
                                 "index" to 0L,
-                                "role" to "tool",
-                                "tool_calls" to "[{\"function\":{\"name\":\"${TestGetWeatherTool.name}\",\"arguments\":\"${TestGetWeatherTool.encodeArgsToString(TestGetWeatherTool.Args("Paris"))}\"},\"id\":\"\",\"type\":\"function\"}]"
+                                "role" to Message.Role.Tool.name.lowercase(),
+                                "tool_calls" to "[{\"function\":{\"name\":\"${TestGetWeatherTool.name}\",\"arguments\":\"${TestGetWeatherTool.encodeArgsToString(TestGetWeatherTool.Args("Paris"))}\"},\"id\":\"\",\"type\":\"function\"}]",
+                                "finish_reason" to FinishReasonType.ToolCalls.id,
                             ),
                         )
                     )
@@ -813,26 +820,27 @@ class OpenTelemetryTest {
                             "gen_ai.conversation.id" to mockExporter.lastRunId,
                             "gen_ai.operation.name" to "chat",
                             "gen_ai.request.temperature" to temperature,
+                            "gen_ai.response.finish_reasons" to listOf(FinishReasonType.Stop.id),
                         ),
                         "events" to mapOf(
                             "gen_ai.system.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "system",
+                                "role" to Message.Role.System.name.lowercase(),
                                 "content" to HiddenString.HIDDEN_STRING_PLACEHOLDER,
                             ),
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "user",
+                                "role" to Message.Role.User.name.lowercase(),
                                 "content" to HiddenString.HIDDEN_STRING_PLACEHOLDER,
                             ),
                             "gen_ai.tool.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "tool",
+                                "role" to Message.Role.Tool.name.lowercase(),
                                 "content" to HiddenString.HIDDEN_STRING_PLACEHOLDER,
                             ),
                             "gen_ai.assistant.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "assistant",
+                                "role" to Message.Role.Assistant.name.lowercase(),
                                 "content" to HiddenString.HIDDEN_STRING_PLACEHOLDER,
                             ),
                         )
@@ -875,23 +883,25 @@ class OpenTelemetryTest {
                             "gen_ai.conversation.id" to mockExporter.lastRunId,
                             "gen_ai.operation.name" to "chat",
                             "gen_ai.request.temperature" to temperature,
+                            "gen_ai.response.finish_reasons" to listOf(FinishReasonType.ToolCalls.id),
                         ),
                         "events" to mapOf(
                             "gen_ai.system.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "system",
+                                "role" to Message.Role.System.name.lowercase(),
                                 "content" to HiddenString.HIDDEN_STRING_PLACEHOLDER,
                             ),
                             "gen_ai.user.message" to mapOf(
                                 "gen_ai.system" to model.provider.id,
-                                "role" to "user",
+                                "role" to Message.Role.User.name.lowercase(),
                                 "content" to HiddenString.HIDDEN_STRING_PLACEHOLDER,
                             ),
                             "gen_ai.choice" to mapOf(
                                 "gen_ai.system" to model.provider.id,
                                 "index" to 0L,
-                                "role" to "tool",
-                                "tool_calls" to "[{\"function\":{\"name\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\",\"arguments\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"},\"id\":\"\",\"type\":\"function\"}]"
+                                "role" to Message.Role.Tool.name.lowercase(),
+                                "tool_calls" to "[{\"function\":{\"name\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\",\"arguments\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"},\"id\":\"\",\"type\":\"function\"}]",
+                                "finish_reason" to FinishReasonType.ToolCalls.id,
                             ),
                         )
                     )

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/TraceStructureTestBase.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/TraceStructureTestBase.kt
@@ -1,0 +1,384 @@
+package ai.koog.agents.features.opentelemetry.integration
+
+import ai.koog.agents.core.agent.entity.AIAgentStrategy
+import ai.koog.agents.core.dsl.builder.forwardTo
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.core.dsl.extension.nodeExecuteTool
+import ai.koog.agents.core.dsl.extension.nodeLLMRequest
+import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResult
+import ai.koog.agents.core.dsl.extension.onAssistantMessage
+import ai.koog.agents.core.dsl.extension.onToolCall
+import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI
+import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.assertMapsEqual
+import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
+import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryConfig
+import ai.koog.agents.features.opentelemetry.mock.MockSpanExporter
+import ai.koog.agents.features.opentelemetry.mock.TestGetWeatherTool
+import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.agents.testing.tools.mockLLMAnswer
+import ai.koog.agents.utils.use
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.Message
+import io.opentelemetry.sdk.trace.export.SpanExporter
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Clock
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+abstract class TraceStructureTestBase(private val openTelemetryConfigurator: OpenTelemetryConfig.() -> Unit) {
+
+    @Test
+    fun testSingleLLMCall() = runBlocking {
+        MockSpanExporter().use { mockSpanExporter ->
+
+            val strategy = strategy("single-llm-call-strategy") {
+                val llmRequest by nodeLLMRequest("llm-call")
+
+                edge(nodeStart forwardTo llmRequest)
+                edge(llmRequest forwardTo nodeFinish onAssistantMessage { true })
+            }
+
+            val model = OpenAIModels.Chat.GPT4o
+            val temperature = 0.4
+            val systemPrompt = "You are the application that predicts weather"
+            val userPrompt = "What's the weather in Paris?"
+            val mockResponse = "The weather in Paris is rainy and overcast, with temperatures around 57°F"
+
+            val promptExecutor = getMockExecutor {
+                mockLLMAnswer(mockResponse) onRequestEquals userPrompt
+            }
+
+            runAgentWithStrategy(
+                strategy = strategy,
+                promptExecutor = promptExecutor,
+                systemPrompt = systemPrompt,
+                userPrompt = userPrompt,
+                model = model,
+                temperature = temperature,
+                spanExporter = mockSpanExporter,
+            )
+
+            val actualSpans = mockSpanExporter.collectedSpans
+
+            assertTrue { actualSpans.filter { it.name.startsWith("run.") }.size == 1 }
+            assertTrue { actualSpans.filter { it.name == "node.__start__" }.size == 1 }
+            assertTrue { actualSpans.filter { it.name == "node.llm-call" }.size == 1 }
+            assertTrue { actualSpans.filter { it.name == "llm.test-prompt-id" }.size == 1 }
+
+            val runNode = actualSpans.first { it.name.startsWith("run.") }
+            val startNode = actualSpans.first { it.name == "node.__start__" }
+            val llmNode = actualSpans.first { it.name == "node.llm-call" }
+            val llmGeneration = actualSpans.first { it.name == "llm.test-prompt-id" }
+
+            assertTrue { runNode.spanId == startNode.parentSpanId }
+            assertTrue { runNode.spanId == llmNode.parentSpanId }
+            assertTrue { llmNode.spanId == llmGeneration.parentSpanId }
+
+            val actualSpanAttributes = llmGeneration.attributes.asMap()
+                .map { (key, value) -> key.key to value }
+                .toMap()
+
+            // Assert expected LLM Call Span (IntentSpan) attributes for Langfuse/Weave
+
+            val expectedAttributes = mapOf(
+                // General attributes
+                "gen_ai.system" to model.provider.id,
+                "gen_ai.conversation.id" to mockSpanExporter.lastRunId,
+                "gen_ai.operation.name" to "chat",
+                "gen_ai.request.model" to model.id,
+                "gen_ai.request.temperature" to 0.4,
+
+                // Langfuse/Weave specific attributes
+                "gen_ai.prompt.0.role" to "system",
+                "gen_ai.prompt.0.content" to systemPrompt,
+                "gen_ai.prompt.1.role" to "user",
+                "gen_ai.prompt.1.content" to userPrompt,
+                "gen_ai.completion.0.role" to "assistant",
+                "gen_ai.completion.0.content" to mockResponse,
+            )
+
+            assertEquals(expectedAttributes.size, actualSpanAttributes.size)
+            assertMapsEqual(expectedAttributes, actualSpanAttributes)
+        }
+    }
+
+    @Test
+    fun testLLMCallToolCallLLMCall() = runBlocking {
+        MockSpanExporter().use { mockSpanExporter ->
+            val strategy = strategy("llm-tool-llm-strategy") {
+                val llmRequest by nodeLLMRequest("LLM Request", allowToolCalls = true)
+                val executeTool by nodeExecuteTool("Execute Tool")
+                val sendToolResult by nodeLLMSendToolResult("Send Tool Result")
+
+                edge(nodeStart forwardTo llmRequest)
+                edge(llmRequest forwardTo executeTool onToolCall { true })
+                edge(executeTool forwardTo sendToolResult)
+                edge(sendToolResult forwardTo nodeFinish onAssistantMessage { true })
+            }
+
+            val model = OpenAIModels.Chat.GPT4o
+            val temperature = 0.4
+            val systemPrompt = "You are the application that predicts weather"
+            val userPrompt = "What's the weather in Paris?"
+            val toolCallArgs = TestGetWeatherTool.Args("Paris")
+            val toolResponse = TestGetWeatherTool.DEFAULT_PARIS_RESULT
+            val finalResponse = "The weather in Paris is rainy and overcast, with temperatures around 57°F"
+
+            val mockExecutor = getMockExecutor {
+                mockLLMToolCall(TestGetWeatherTool, toolCallArgs) onRequestEquals userPrompt
+                mockLLMAnswer(finalResponse) onRequestContains toolResponse
+            }
+
+            val toolRegistry = ToolRegistry {
+                tool(TestGetWeatherTool)
+            }
+
+            runAgentWithStrategy(
+                strategy = strategy,
+                promptExecutor = mockExecutor,
+                toolRegistry = toolRegistry,
+                systemPrompt = systemPrompt,
+                userPrompt = userPrompt,
+                model = model,
+                temperature = temperature,
+                spanExporter = mockSpanExporter
+            )
+
+            val actualSpans = mockSpanExporter.collectedSpans
+
+            assertTrue { actualSpans.filter { it.name == "tool.Get whether" }.size == 1 }
+
+            val runNode = actualSpans.first { it.name.startsWith("run.") }
+            val startNode = actualSpans.first { it.name == "node.__start__" }
+            val llmRequestNode = actualSpans.first { it.name == "node.LLM Request" }
+            val executeToolNode = actualSpans.first { it.name == "node.Execute Tool" }
+            val sendToolResultNode = actualSpans.first { it.name == "node.Send Tool Result" }
+            val toolCallSpan = actualSpans.first { it.name == "tool.Get whether" }
+            val llmSpans = actualSpans.filter { it.name == "llm.test-prompt-id" }
+
+            // All nodes should have runNode as parent
+            assertTrue { runNode.spanId == startNode.parentSpanId }
+            assertTrue { runNode.spanId == llmRequestNode.parentSpanId }
+            assertTrue { runNode.spanId == executeToolNode.parentSpanId }
+            assertTrue { runNode.spanId == sendToolResultNode.parentSpanId }
+
+            // Check LLM Call span with the initial call and tool call request
+            val actualInitialLLMCallSpan = llmSpans.firstOrNull { it.parentSpanId == llmRequestNode.spanId }
+            assertNotNull(actualInitialLLMCallSpan)
+
+            val actualInitialLLMCallSpanAttributes =
+                actualInitialLLMCallSpan.attributes.asMap().map { (key, value) -> key.key to value }.toMap()
+
+            val expectedInitialLLMCallSpansAttributes = mapOf(
+                "gen_ai.system" to model.provider.id,
+                "gen_ai.conversation.id" to mockSpanExporter.lastRunId,
+                "gen_ai.operation.name" to "chat",
+                "gen_ai.request.temperature" to temperature,
+                "gen_ai.request.model" to model.id,
+
+                "gen_ai.prompt.0.role" to Message.Role.System.name.lowercase(),
+                "gen_ai.prompt.0.content" to systemPrompt,
+                "gen_ai.prompt.1.role" to Message.Role.User.name.lowercase(),
+                "gen_ai.prompt.1.content" to userPrompt,
+                "gen_ai.completion.0.role" to Message.Role.Assistant.name.lowercase(),
+                "gen_ai.completion.0.content" to "[{\"function\":{\"name\":\"${TestGetWeatherTool.name}\",\"arguments\":\"{\"location\":\"Paris\"}\"},\"id\":\"\",\"type\":\"function\"}]",
+            )
+
+            assertEquals(expectedInitialLLMCallSpansAttributes.size, actualInitialLLMCallSpanAttributes.size)
+            assertMapsEqual(expectedInitialLLMCallSpansAttributes, actualInitialLLMCallSpanAttributes)
+
+            // Check LLM Call span with the final LLM response after the tool is executed
+            val actualFinalLLMCallSpan = llmSpans.firstOrNull { it.parentSpanId == sendToolResultNode.spanId }
+            assertNotNull(actualFinalLLMCallSpan)
+
+            val actualFinalLLMCallSpanAttributes =
+                actualFinalLLMCallSpan.attributes.asMap().map { (key, value) -> key.key to value }.toMap()
+
+            val expectedFinalLLMCallSpansAttributes = mapOf(
+                "gen_ai.system" to model.provider.id,
+                "gen_ai.conversation.id" to mockSpanExporter.lastRunId,
+                "gen_ai.operation.name" to "chat",
+                "gen_ai.request.temperature" to temperature,
+                "gen_ai.request.model" to model.id,
+
+                "gen_ai.prompt.0.role" to Message.Role.System.name.lowercase(),
+                "gen_ai.prompt.0.content" to systemPrompt,
+                "gen_ai.prompt.1.role" to Message.Role.User.name.lowercase(),
+                "gen_ai.prompt.1.content" to userPrompt,
+                "gen_ai.prompt.2.role" to Message.Role.Tool.name.lowercase(),
+                "gen_ai.prompt.2.content" to TestGetWeatherTool.DEFAULT_PARIS_RESULT,
+                "gen_ai.completion.0.role" to Message.Role.Assistant.name.lowercase(),
+                "gen_ai.completion.0.content" to finalResponse,
+            )
+
+            assertEquals(expectedFinalLLMCallSpansAttributes.size, actualFinalLLMCallSpanAttributes.size)
+            assertMapsEqual(expectedFinalLLMCallSpansAttributes, actualFinalLLMCallSpanAttributes)
+
+            // Tool span should have executed tool node as parent
+            assertTrue { executeToolNode.spanId == toolCallSpan.parentSpanId }
+            val actualToolCallSpanAttributes =
+                toolCallSpan.attributes.asMap().map { (key, value) -> key.key to value }.toMap()
+
+            val expectedToolCallSpanAttributes = mapOf(
+                "gen_ai.tool.name" to TestGetWeatherTool.name,
+                "gen_ai.tool.description" to TestGetWeatherTool.descriptor.description,
+                "input.value" to "{\"location\":\"Paris\"}",
+                "output.value" to TestGetWeatherTool.DEFAULT_PARIS_RESULT,
+            )
+
+            assertEquals(expectedToolCallSpanAttributes.size, actualToolCallSpanAttributes.size)
+            assertMapsEqual(expectedToolCallSpanAttributes, actualToolCallSpanAttributes)
+        }
+    }
+
+    @Test
+    fun testMultipleToolCalls() = runBlocking {
+        MockSpanExporter().use { mockSpanExporter ->
+            val strategy = strategy("multiple-tool-calls-strategy") {
+                val llmRequest by nodeLLMRequest("Initial LLM Request", allowToolCalls = true)
+                val executeTool1 by nodeExecuteTool("Execute Tool 1")
+                val sendToolResult1 by nodeLLMSendToolResult("Send Tool Result 1")
+                val executeTool2 by nodeExecuteTool("Execute Tool 2")
+                val sendToolResult2 by nodeLLMSendToolResult("Send Tool Result 2")
+
+                edge(nodeStart forwardTo llmRequest)
+                edge(llmRequest forwardTo executeTool1 onToolCall { true })
+                edge(executeTool1 forwardTo sendToolResult1)
+                edge(sendToolResult1 forwardTo executeTool2 onToolCall { true })
+                edge(executeTool2 forwardTo sendToolResult2)
+                edge(sendToolResult2 forwardTo nodeFinish transformed { input -> input.content })
+            }
+
+            val model = OpenAIModels.Chat.GPT4o
+            val temperature = 0.4
+
+            val systemPrompt = "You are the application that predicts weather"
+            val userPrompt = "What's the weather in Paris and London?"
+
+            val toolCallArgs1 = TestGetWeatherTool.Args("Paris")
+            val toolResponse1 = TestGetWeatherTool.DEFAULT_PARIS_RESULT
+
+            val toolCallArgs2 = TestGetWeatherTool.Args("London")
+            val toolResponse2 = TestGetWeatherTool.DEFAULT_LONDON_RESULT
+
+            val finalResponse = "The weather in Paris is rainy (57°F) and in London it's cloudy (62°F)"
+
+            val mockExecutor = getMockExecutor {
+                mockLLMToolCall(TestGetWeatherTool, toolCallArgs1) onRequestEquals userPrompt
+                mockLLMToolCall(TestGetWeatherTool, toolCallArgs2) onRequestContains toolResponse1
+                mockLLMAnswer(finalResponse) onRequestContains toolResponse2
+            }
+
+            val toolRegistry = ToolRegistry {
+                tool(TestGetWeatherTool)
+            }
+
+            runAgentWithStrategy(
+                strategy = strategy,
+                promptExecutor = mockExecutor,
+                toolRegistry = toolRegistry,
+                systemPrompt = systemPrompt,
+                userPrompt = userPrompt,
+                model = model,
+                temperature = temperature,
+                spanExporter = mockSpanExporter
+            )
+
+            val actualSpans = mockSpanExporter.collectedSpans
+
+            // Execute Tool 1 Spans
+            val executeTool1NodeSpan = actualSpans.first { it.name == "node.Execute Tool 1" }
+            val executeTool1Span = actualSpans.firstOrNull { spanData ->
+                spanData.name == "tool.${TestGetWeatherTool.name}" &&
+                    spanData.parentSpanId == executeTool1NodeSpan.spanId
+            }
+
+            assertNotNull(executeTool1Span)
+
+            // Execute Tool 2 Spans
+            val executeTool2NodeSpan = actualSpans.first { it.name == "node.Execute Tool 2" }
+            val executeTool2Span = actualSpans.firstOrNull { spanData ->
+                spanData.name == "tool.${TestGetWeatherTool.name}" &&
+                    spanData.spanId != executeTool2NodeSpan.spanId
+            }
+
+            assertNotNull(executeTool2Span)
+
+            // Assert Execute Tool 1 Span
+            val actualExecuteTool1SpanAttributes =
+                executeTool1Span.attributes.asMap().map { (key, value) -> key.key to value }.toMap()
+
+            val expectedExecuteTool1SpanAttributes = mapOf(
+                "gen_ai.tool.name" to TestGetWeatherTool.name,
+                "gen_ai.tool.description" to TestGetWeatherTool.descriptor.description,
+                "input.value" to "{\"location\":\"Paris\"}",
+                "output.value" to toolResponse1,
+            )
+
+            assertEquals(expectedExecuteTool1SpanAttributes.size, actualExecuteTool1SpanAttributes.size)
+            assertMapsEqual(expectedExecuteTool1SpanAttributes, actualExecuteTool1SpanAttributes)
+
+            // Assert Execute Tool 2 Span
+            val actualExecuteTool2SpanAttributes =
+                executeTool2Span.attributes.asMap().map { (key, value) -> key.key to value }.toMap()
+
+            val expectedExecuteTool2SpanAttributes = mapOf(
+                "gen_ai.tool.name" to TestGetWeatherTool.name,
+                "gen_ai.tool.description" to TestGetWeatherTool.descriptor.description,
+                "input.value" to "{\"location\":\"London\"}",
+                "output.value" to toolResponse2,
+            )
+
+            assertEquals(expectedExecuteTool2SpanAttributes.size, actualExecuteTool2SpanAttributes.size)
+            assertMapsEqual(expectedExecuteTool2SpanAttributes, actualExecuteTool2SpanAttributes)
+        }
+    }
+
+    //region Private Methods
+
+    /**
+     * Runs an agent with the given strategy and verifies the spans.
+     */
+    private suspend fun runAgentWithStrategy(
+        strategy: AIAgentStrategy<String, String>,
+        systemPrompt: String? = null,
+        userPrompt: String? = null,
+        promptExecutor: PromptExecutor? = null,
+        toolRegistry: ToolRegistry? = null,
+        model: LLModel? = null,
+        temperature: Double? = null,
+        spanExporter: SpanExporter? = null,
+        verbose: Boolean = true
+    ) {
+        val agentId = "test-agent-id"
+        val promptId = "test-prompt-id"
+        val testClock = Clock.System
+
+        OpenTelemetryTestAPI.createAgent(
+            agentId = agentId,
+            strategy = strategy,
+            promptId = promptId,
+            promptExecutor = promptExecutor,
+            model = model,
+            clock = testClock,
+            temperature = temperature,
+            systemPrompt = systemPrompt,
+            toolRegistry = toolRegistry,
+        ) {
+            install(OpenTelemetry.Feature) {
+                spanExporter?.let { exporter -> addSpanExporter(exporter) }
+                setVerbose(verbose)
+                openTelemetryConfigurator()
+            }
+        }.use { agent ->
+            agent.run(userPrompt ?: "User prompt message")
+        }
+    }
+
+    //endregion Private Methods
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/TraceStructureTestBase.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/TraceStructureTestBase.kt
@@ -11,6 +11,7 @@ import ai.koog.agents.core.dsl.extension.onToolCall
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.assertMapsEqual
+import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryConfig
 import ai.koog.agents.features.opentelemetry.mock.MockSpanExporter
@@ -92,6 +93,7 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
                 "gen_ai.operation.name" to "chat",
                 "gen_ai.request.model" to model.id,
                 "gen_ai.request.temperature" to 0.4,
+                "gen_ai.response.finish_reasons" to listOf(SpanAttributes.Response.FinishReasonType.Stop.id),
 
                 // Langfuse/Weave specific attributes
                 "gen_ai.prompt.0.role" to "system",
@@ -180,6 +182,7 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
                 "gen_ai.operation.name" to "chat",
                 "gen_ai.request.temperature" to temperature,
                 "gen_ai.request.model" to model.id,
+                "gen_ai.response.finish_reasons" to listOf(SpanAttributes.Response.FinishReasonType.ToolCalls.id),
 
                 "gen_ai.prompt.0.role" to Message.Role.System.name.lowercase(),
                 "gen_ai.prompt.0.content" to systemPrompt,
@@ -187,6 +190,7 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
                 "gen_ai.prompt.1.content" to userPrompt,
                 "gen_ai.completion.0.role" to Message.Role.Assistant.name.lowercase(),
                 "gen_ai.completion.0.content" to "[{\"function\":{\"name\":\"${TestGetWeatherTool.name}\",\"arguments\":\"{\"location\":\"Paris\"}\"},\"id\":\"\",\"type\":\"function\"}]",
+                "gen_ai.completion.0.finish_reason" to SpanAttributes.Response.FinishReasonType.ToolCalls.id,
             )
 
             assertEquals(expectedInitialLLMCallSpansAttributes.size, actualInitialLLMCallSpanAttributes.size)
@@ -205,6 +209,7 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
                 "gen_ai.operation.name" to "chat",
                 "gen_ai.request.temperature" to temperature,
                 "gen_ai.request.model" to model.id,
+                "gen_ai.response.finish_reasons" to listOf(SpanAttributes.Response.FinishReasonType.Stop.id),
 
                 "gen_ai.prompt.0.role" to Message.Role.System.name.lowercase(),
                 "gen_ai.prompt.0.content" to systemPrompt,

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseTraceStructureTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseTraceStructureTest.kt
@@ -1,0 +1,16 @@
+package ai.koog.agents.features.opentelemetry.integration.langfuse
+
+import ai.koog.agents.features.opentelemetry.integration.TraceStructureTestBase
+import kotlin.test.Ignore
+
+/**
+ * A test class for verifying trace structures using the Langfuse exporter.
+ */
+// Explicitly ignore this test as we do not have env variables for Langfuse in CI to make these tests passed.
+// Required env variables:
+//   - LANGFUSE_SECRET_KEY
+//   - LANGFUSE_PUBLIC_KEY
+//   - LANGFUSE_HOST
+@Ignore
+class LangfuseTraceStructureTest :
+    TraceStructureTestBase(openTelemetryConfigurator = { addLangfuseExporter(verbose = this.isVerbose) })

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/weave/WeaveTraceStructureTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/weave/WeaveTraceStructureTest.kt
@@ -1,0 +1,15 @@
+package ai.koog.agents.features.opentelemetry.integration.weave
+
+import ai.koog.agents.features.opentelemetry.integration.TraceStructureTestBase
+import kotlin.test.Ignore
+
+/**
+ * A test class for verifying trace structures using the Weave exporter.
+ */
+// Explicitly ignore this test as we do not have env variables for Weave in CI to make these tests passed.
+// Required env variables:
+//   - WEAVE_ENTITY
+//   - WEAVE_API_KEY
+@Ignore
+class WeaveTraceStructureTest :
+    TraceStructureTestBase(openTelemetryConfigurator = { addWeaveExporter(verbose = this.isVerbose) })

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/mock/MockGenAIAgentEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/mock/MockGenAIAgentEvent.kt
@@ -1,18 +1,16 @@
 package ai.koog.agents.features.opentelemetry.mock
 
-import ai.koog.agents.features.opentelemetry.attribute.Attribute
 import ai.koog.agents.features.opentelemetry.event.EventBodyField
 import ai.koog.agents.features.opentelemetry.event.GenAIAgentEvent
 
 internal data class MockGenAIAgentEvent(
     override val name: String = "test_event",
-    override val attributes: List<Attribute> = listOf(),
     private val fields: List<EventBodyField> = emptyList()
-) : GenAIAgentEvent {
+) : GenAIAgentEvent() {
 
-    override val bodyFields: List<EventBodyField> = buildList {
+    init {
         fields.forEach { field ->
-            add(field)
+            addBodyField(field)
         }
     }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/mock/TestToolGetWeather.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/mock/TestToolGetWeather.kt
@@ -10,7 +10,8 @@ import kotlinx.serialization.Serializable
 
 internal object TestGetWeatherTool : SimpleTool<TestGetWeatherTool.Args>() {
 
-    const val RESULT: String = "rainy, 57°F"
+    const val DEFAULT_PARIS_RESULT: String = "rainy, 57°F"
+    const val DEFAULT_LONDON_RESULT: String = "cloudy, 62°F"
 
     @Serializable
     data class Args(val location: String) : ToolArgs
@@ -29,7 +30,12 @@ internal object TestGetWeatherTool : SimpleTool<TestGetWeatherTool.Args>() {
         )
     )
 
-    override suspend fun doExecute(args: Args): String {
-        return RESULT
-    }
+    override suspend fun doExecute(args: Args): String =
+        if (args.location.contains("Paris")) {
+            DEFAULT_PARIS_RESULT
+        } else if (args.location.contains("London")) {
+            DEFAULT_LONDON_RESULT
+        } else {
+            DEFAULT_PARIS_RESULT
+        }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/span/GenAIAgentSpanTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/span/GenAIAgentSpanTest.kt
@@ -103,19 +103,13 @@ class GenAIAgentSpanTest {
         span.span = mockSpan
 
         val events = listOf(
-            MockGenAIAgentEvent(
-                name = "event1",
-                attributes = listOf(
-                    MockAttribute("key1", "value1"),
-                    MockAttribute("key2", 42)
-                )
-            ),
-            MockGenAIAgentEvent(
-                name = "event2",
-                attributes = listOf(
-                    MockAttribute("key3", true)
-                )
-            )
+            MockGenAIAgentEvent(name = "event1").apply {
+                addAttribute(MockAttribute("key1", "value1"))
+                addAttribute(MockAttribute("key2", 42))
+            },
+            MockGenAIAgentEvent(name = "event2").apply {
+                addAttribute(MockAttribute("key3", true))
+            },
         )
 
         events.forEach { event -> span.addEvent(event) }
@@ -132,10 +126,9 @@ class GenAIAgentSpanTest {
         val mockSpan = MockSpan()
         span.span = mockSpan
 
-        val event = MockGenAIAgentEvent(
-            name = "duplicate-event",
-            attributes = listOf(MockAttribute("key", "value"))
-        )
+        val event = MockGenAIAgentEvent(name = "duplicate-event").apply {
+            addAttribute(MockAttribute("key", "value"))
+        }
 
         // Add the same event twice
         span.addEvent(event)
@@ -152,11 +145,10 @@ class GenAIAgentSpanTest {
         val mockSpan = MockSpan()
         span.span = mockSpan
 
-        val event = MockGenAIAgentEvent(
-            name = "event-with-body-fields",
-            attributes = listOf(MockAttribute("key", "value")),
-            fields = listOf(EventBodyFields.Content("test content"))
-        )
+        val event = MockGenAIAgentEvent(name = "event-with-body-fields").apply {
+            addAttribute(MockAttribute("key", "value"))
+            addBodyField(EventBodyFields.Content("test content"))
+        }
 
         span.addEvent(event)
 
@@ -190,8 +182,8 @@ class GenAIAgentSpanTest {
         span.span = mockSpan
 
         val events = listOf(
-            MockGenAIAgentEvent(name = "event1", attributes = listOf(MockAttribute("stringKey", "stringValue"))),
-            MockGenAIAgentEvent(name = "event2", attributes = listOf(MockAttribute("numberKey", 2)))
+            MockGenAIAgentEvent(name = "event1").apply { addAttribute(MockAttribute("stringKey", "stringValue")) },
+            MockGenAIAgentEvent(name = "event2").apply { addAttribute(MockAttribute("numberKey", 2)) },
         )
 
         span.addEvents(events)

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/span/SpanProcessorTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/span/SpanProcessorTest.kt
@@ -374,7 +374,7 @@ class SpanProcessorTest {
         // Assert attributes for the collected event when the verbose flag is set to 'false'
         val expectedEventAttributes = mapOf(
             AttributeKey.stringKey("secretKey") to HiddenString.HIDDEN_STRING_PLACEHOLDER,
-            AttributeKey.stringKey("body") to "{\"content\":\"${HiddenString.HIDDEN_STRING_PLACEHOLDER}\"}",
+            AttributeKey.stringKey("content") to HiddenString.HIDDEN_STRING_PLACEHOLDER,
         )
 
         assertEquals(expectedEventAttributes.size, actualEventAttributes.size)

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/span/SpanProcessorTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/span/SpanProcessorTest.kt
@@ -273,19 +273,14 @@ class SpanProcessorTest {
         assertEquals(1, spanProcessor.spansCount)
 
         // Create test events
-        val event1 = MockGenAIAgentEvent(
-            name = "test_event_1",
-            attributes = listOf(
-                MockAttribute("key1", "value1"),
-                MockAttribute("key2", 42)
-            )
-        )
-        val event2 = MockGenAIAgentEvent(
-            name = "test_event_2",
-            attributes = listOf(
-                MockAttribute("key3", true)
-            )
-        )
+        val event1 = MockGenAIAgentEvent(name = "test_event_1").apply {
+            addAttribute(MockAttribute("key1", "value1"))
+            addAttribute(MockAttribute("key2", 42))
+        }
+
+        val event2 = MockGenAIAgentEvent(name = "test_event_2").apply {
+            addAttribute(MockAttribute("key3", true))
+        }
 
         // Add events to the span
         spanProcessor.addEventsToSpan(spanId, listOf(event1, event2))
@@ -303,12 +298,9 @@ class SpanProcessorTest {
         val nonExistentSpanId = "non-existent-span"
 
         // Create a test event
-        val event = MockGenAIAgentEvent(
-            name = "test_event",
-            attributes = listOf(
-                MockAttribute("key1", "value1")
-            )
-        )
+        val event = MockGenAIAgentEvent(name = "test_event").apply {
+            addAttribute(MockAttribute("key1", "value1"))
+        }
 
         // Try to add event to the non-existent span
         val exception = assertFailsWith<IllegalStateException> {
@@ -366,15 +358,10 @@ class SpanProcessorTest {
         // Event with attribute HiddenString and a body field that contains HiddenString
         // Replace started span with the mock instance
         span.span = mockSpan
-        val event = MockGenAIAgentEvent(
-            name = "event",
-            attributes = listOf(
-                MockAttribute("secretKey", HiddenString("secretValue"))
-            ),
-            fields = listOf(
-                EventBodyFields.Content("some sensitive content")
-            )
-        )
+        val event = MockGenAIAgentEvent(name = "event").apply {
+            addAttribute(MockAttribute("secretKey", HiddenString("secretValue")))
+            addBodyField(EventBodyFields.Content("some sensitive content"))
+        }
         span.addEvent(event)
 
         spanProcessor.endSpan(span)


### PR DESCRIPTION
KG-259:
- Tool execution input and output values might contain sensitive data. Change the type to hide data by default.

KG-218:
- Always add Role attribute to message spans
- Fix logic in methods to convert Attribute and Events from internal objects into OT SDK objects;
- Add missing role attributes for Tool calls;
- Update adapters for Langfuse and Weave;

## Motivation and Context
Open Telemetry for Langfuse and Weave require a custom adapters that configure spans to present data. Update the logic to fix issues in Langfuse and Weave presentation.

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tests improvement
- [x] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
