### PR TITLE
KG-49: Fix enum parsing when type is not mentioned

### DIFF
--- a/agents/agents-mcp/src/jvmMain/kotlin/ai/koog/agents/mcp/McpToolDefinitionParser.kt
+++ b/agents/agents-mcp/src/jvmMain/kotlin/ai/koog/agents/mcp/McpToolDefinitionParser.kt
@@ -91,6 +91,25 @@ public object DefaultMcpToolDescriptorParser : McpToolDescriptorParser {
                     return parseParameterType(nonNullType, depth + 1)
                 }
             }
+
+            /**
+             * Special case for enum string types.
+             * Schema example:
+             * {
+             *   "enumParam": {
+             *     "enum": [
+             *       "value1",
+             *       "value2"
+             *     ],
+             *     "title": "Enum string parameter"
+             *   }
+             * }
+             */
+            val enum = element["enum"]?.jsonArray
+            if (enum != null && enum.isNotEmpty()) {
+                return ToolParameterType.Enum(enum.map { it.jsonPrimitive.content }.toTypedArray())
+            }
+
             val title =
                 element["title"]?.jsonPrimitive?.content ?: element["description"]?.jsonPrimitive?.content.orEmpty()
             throw IllegalArgumentException("Parameter $title must have type property")

--- a/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/DefaultMcpToolDescriptorParserTest.kt
+++ b/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/DefaultMcpToolDescriptorParserTest.kt
@@ -296,6 +296,7 @@ class DefaultMcpToolDescriptorParserTest {
             name = "test-tool",
             description = "A test tool with enum parameter",
             properties = buildJsonObject {
+                // Enum with type
                 putJsonObject("enumParam") {
                     put("type", "enum")
                     put("description", "Enum parameter")
@@ -305,8 +306,18 @@ class DefaultMcpToolDescriptorParserTest {
                         add("option3")
                     }
                 }
+
+                // Enum with a default string type
+                putJsonObject("stringEnumParam") {
+                    put("description", "String enum parameter")
+                    putJsonArray("enum") {
+                        add("option4")
+                        add("option5")
+                        add("option6")
+                    }
+                }
             },
-            required = listOf("enumParam")
+            required = listOf("enumParam", "stringEnumParam")
         )
 
         // Parse the tool
@@ -315,7 +326,7 @@ class DefaultMcpToolDescriptorParserTest {
         // Verify the basic properties
         assertEquals("test-tool", toolDescriptor.name)
         assertEquals("A test tool with enum parameter", toolDescriptor.description)
-        assertEquals(1, toolDescriptor.requiredParameters.size)
+        assertEquals(2, toolDescriptor.requiredParameters.size)
         assertEquals(0, toolDescriptor.optionalParameters.size)
 
         // Verify the enum parameter
@@ -330,6 +341,20 @@ class DefaultMcpToolDescriptorParserTest {
         assertEquals(expectedOptions.size, enumType.entries.size)
         expectedOptions.forEachIndexed { index, option ->
             assertEquals(option, enumType.entries[index])
+        }
+
+        // Verify the enum parameter
+        val specialEnumParam = toolDescriptor.requiredParameters[1]
+        assertEquals("stringEnumParam", specialEnumParam.name)
+        assertEquals("String enum parameter", specialEnumParam.description)
+        assertTrue(specialEnumParam.type is ToolParameterType.Enum)
+
+        // Verify the enum values
+        val specialEnumType = specialEnumParam.type as ToolParameterType.Enum
+        val expectedSpecialOptions = arrayOf("option4", "option5", "option6")
+        assertEquals(expectedSpecialOptions.size, specialEnumType.entries.size)
+        expectedSpecialOptions.forEachIndexed { index, option ->
+            assertEquals(option, specialEnumType.entries[index])
         }
     }
 

--- a/examples/src/main/kotlin/ai/koog/agents/example/mcp/IntellijMcpClient.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/mcp/IntellijMcpClient.kt
@@ -1,0 +1,58 @@
+package ai.koog.agents.example.mcp
+
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.mcp.McpToolRegistryProvider
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Example of using the MCP (Model Context Protocol) integration with IntelliJ MCP Server.
+ *
+ * This example demonstrates how to:
+ * 1. Start an IntelliJ MCP server on port 64342
+ * 2. Connect to the MCP server using the McpToolRegistryProvider's SSE client
+ * 3. Create a ToolRegistry with tools from the MCP server
+ * 4. Use the tools in an AI agent to automate IDE interactions
+ *
+ */
+fun main() {
+    val openAIApiToken = System.getenv("OPENAI_API_KEY") ?: error("OPENAI_API_KEY environment variable not set")
+
+    // Start the Docker container with the Google Maps MCP server
+    val process = ProcessBuilder(
+        "npx",
+        "-y",
+        "@jetbrains/mcp-proxy"
+    ).start()
+
+    // Wait for the server to start
+    Thread.sleep(2000)
+
+    try {
+        runBlocking {
+            // Create the ToolRegistry with tools from the MCP server
+            val toolRegistry = McpToolRegistryProvider.fromTransport(
+                transport = McpToolRegistryProvider.defaultSseTransport("http://localhost:64342/sse")
+            )
+
+            toolRegistry.tools.forEach {
+                println(it.name)
+                println(it.descriptor)
+            }
+
+            // Create the runner
+            val agent = AIAgent(
+                executor = simpleOpenAIExecutor(openAIApiToken),
+                llmModel = OpenAIModels.Chat.GPT4o,
+                toolRegistry = toolRegistry,
+            )
+            val request = "Count number of files in koog project"
+            println(request)
+            agent.run(request + "You can only call tools. Get it by calling intellij tools.")
+        }
+    } finally {
+        // Shutdown the Docker container
+        process.destroy()
+    }
+}


### PR DESCRIPTION
This pull request fixes enum tool parsing for Intellij MCP server tools where the tool argument have enum type and does not mention the type of the enums assuming string by default

Fixes: https://youtrack.jetbrains.com/issue/KG-244

<!--
Thank you for opening a pull request!

Please add a brief description of the proposed change here.
Also, please tick the appropriate points in the checklist below.
-->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [ ] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [ ] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
