### PR TITLE
Add ReadFileTool to read file content

### DIFF
--- a/agents/agents-tools/build.gradle.kts
+++ b/agents/agents-tools/build.gradle.kts
@@ -13,6 +13,9 @@ kotlin {
         commonMain {
             dependencies {
                 api(libs.kotlinx.serialization.json)
+                api(project(":rag:rag-base"))
+                implementation(project(":prompt:prompt-markdown"))
+                implementation(project(":prompt:prompt-xml"))
             }
         }
 

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/file/tools/ReadFileTool.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/file/tools/ReadFileTool.kt
@@ -110,7 +110,7 @@ public class ReadFileTool<Path>(private val fs: FileSystemProvider.ReadOnly<Path
 
     public companion object {
         /**
-         * Tool descriptor for the read file operation.
+         * Provides a tool descriptor for the read file operation.
          *
          * Configures the tool to read text files with optional line range selection
          * using 0-based indexing.

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/file/tools/ReadFileTool.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/file/tools/ReadFileTool.kt
@@ -1,0 +1,164 @@
+package ai.koog.agents.file.tools
+
+import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolException
+import ai.koog.agents.core.tools.ToolParameterDescriptor
+import ai.koog.agents.core.tools.ToolParameterType
+import ai.koog.agents.core.tools.ToolResult
+import ai.koog.agents.core.tools.fail
+import ai.koog.agents.core.tools.validate
+import ai.koog.agents.file.tools.model.FileSystemEntry
+import ai.koog.agents.file.tools.render.file
+import ai.koog.prompt.text.text
+import ai.koog.rag.base.files.FileMetadata
+import ai.koog.rag.base.files.FileSystemProvider
+import ai.koog.rag.base.files.readText
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+
+/**
+ * Provides functionality to read file contents with configurable start and end line parameters,
+ * returning structured file metadata and content.
+ *
+ * @param Path the filesystem path type used by the provider
+ * @property fs read-only filesystem provider for accessing files
+ */
+public class ReadFileTool<Path>(private val fs: FileSystemProvider.ReadOnly<Path>) :
+    Tool<ReadFileTool.Args, ReadFileTool.Result>() {
+
+    /**
+     * Specifies which file to read and what portion of its content to extract.
+     *
+     * @property path absolute filesystem path to the target file
+     * @property startLine the first line to include (0-based, inclusive), defaults to 0
+     * @property endLine the first line to exclude (0-based, exclusive), -1 means read to end,
+     *   defaults to -1
+     */
+    @Serializable
+    public data class Args(
+        val path: String,
+        val startLine: Int = 0,
+        val endLine: Int = -1,
+    ) : ToolArgs
+
+    /**
+     * Contains the successfully read file with its metadata and extracted content.
+     *
+     * The result encapsulates a [FileSystemEntry.File] which includes:
+     * - File metadata (path, name, extension, size, content type)
+     * - Content as either full text or line-range excerpt
+     * - File attributes (hidden status, file type)
+     *
+     * @property file the file entry containing metadata and content
+     * @constructor creates a new Result instance with the specified file entry
+     */
+    @Serializable
+    public data class Result(val file: FileSystemEntry.File) : ToolResult.JSONSerializable<Result> {
+        /**
+         * Returns the Kotlin serialization serializer for this result type.
+         *
+         * @return serializer instance for Result
+         */
+        override fun getSerializer(): KSerializer<Result> = serializer()
+
+        /**
+         * Converts the result to a structured text representation.
+         *
+         * Renders the file information in the following format:
+         * - File path with metadata in parentheses (content type, size, visibility)
+         * - Content section with either:
+         *     - Full text in a code block for complete file reads
+         *     - Excerpt with line ranges and code blocks for partial reads
+         *     - No content section if content is [FileSystemEntry.File.Content.None]
+         *
+         * @return formatted text representation of the file
+         */
+        override fun toStringDefault(): String = text { file(file) }
+    }
+
+    override val argsSerializer: KSerializer<Args> = Args.serializer()
+    override val descriptor: ToolDescriptor = Companion.descriptor
+
+    /**
+     * Executes the file reading operation with the specified arguments.
+     *
+     * Performs validation before reading:
+     * - Verifies the path exists in the filesystem
+     * - Confirms the path points to a file (not a directory)
+     * - Ensures the file can be successfully read
+     *
+     * @param args arguments specifying the file path and optional line range
+     * @return Result containing the file with its content and metadata
+     * @throws [ToolException.ValidationFailure] if the file doesn't exist, is a directory, or
+     *   cannot be read
+     * @throws IllegalArgumentException if line range parameters are invalid
+     */
+    override suspend fun execute(args: Args): Result {
+        val path = fs.fromAbsolutePathString(args.path)
+
+        validate(fs.exists(path)) { "File does not exist: ${args.path}" }
+        validate(fs.metadata(path)?.type == FileMetadata.FileType.File) {
+            "Path must point to a file, not a directory: ${args.path}"
+        }
+
+        val file = FileSystemEntry.File.of(
+            path,
+            content = FileSystemEntry.File.Content.of(
+                fs.readText(path),
+                args.startLine,
+                args.endLine,
+            ),
+            fs = fs,
+        ) ?: fail("Unable to read file: ${args.path}")
+
+        return Result(file)
+    }
+
+    public companion object {
+        /**
+         * Tool descriptor defining name, description, and parameters.
+         *
+         * Configures the tool as "read-file" with absolute path requirement and optional line range
+         * parameters using 0-based indexing.
+         *
+         * Required parameters:
+         * - `path`: Absolute path to the target file
+         *
+         * Optional parameters:
+         * - `startLine`: First line to include, 0-based, defaults to 0
+         * - `endLine`: First line to exclude, 0-based, -1 for the end of file, defaults to -1
+         */
+        public val descriptor: ToolDescriptor = ToolDescriptor(
+            name = "read-file",
+            description = text {
+                +"Reads text file with optional line range selection."
+                +"Returns formatted content with metadata."
+                newline()
+                +"Uses 0-based line indexing."
+            },
+            requiredParameters = listOf(
+                ToolParameterDescriptor(
+                    name = "path",
+                    description = text { +"Absolute path to target file." },
+                    type = ToolParameterType.String,
+                )
+            ),
+            optionalParameters = listOf(
+                ToolParameterDescriptor(
+                    name = "startLine",
+                    description = text { +"First line to include (0-based, inclusive)." },
+                    type = ToolParameterType.Integer,
+                ),
+                ToolParameterDescriptor(
+                    name = "endLine",
+                    description = text {
+                        +"First line to exclude (0-based, exclusive). Use -1 for end."
+                    },
+                    type = ToolParameterType.Integer,
+                ),
+            ),
+        )
+    }
+}

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/file/tools/ReadFileTool.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/file/tools/ReadFileTool.kt
@@ -131,7 +131,7 @@ public class ReadFileTool<Path>(private val fs: FileSystemProvider.ReadOnly<Path
          * - `endLine`: First line to exclude, 0-based, -1 for the end of file, defaults to -1
          */
         public val descriptor: ToolDescriptor = ToolDescriptor(
-            name = "read-file",
+            name = "__read_file__",
             description = text {
                 +"Reads text file with optional line range selection."
                 +"Returns formatted content with metadata."

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/file/tools/ReadFileTool.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/file/tools/ReadFileTool.kt
@@ -47,30 +47,23 @@ public class ReadFileTool<Path>(private val fs: FileSystemProvider.ReadOnly<Path
      * Contains the successfully read file with its metadata and extracted content.
      *
      * The result encapsulates a [FileSystemEntry.File] which includes:
-     * - File metadata (path, name, extension, size, content type)
+     * - File metadata (path, name, extension, size, content type, hidden status)
      * - Content as either full text or line-range excerpt
-     * - File attributes (hidden status, file type)
      *
      * @property file the file entry containing metadata and content
-     * @constructor creates a new Result instance with the specified file entry
      */
     @Serializable
     public data class Result(val file: FileSystemEntry.File) : ToolResult.JSONSerializable<Result> {
-        /**
-         * Returns the Kotlin serialization serializer for this result type.
-         *
-         * @return serializer instance for Result
-         */
         override fun getSerializer(): KSerializer<Result> = serializer()
 
         /**
          * Converts the result to a structured text representation.
          *
          * Renders the file information in the following format:
-         * - File path with metadata in parentheses (content type, size, visibility)
+         * - File path with metadata in parentheses (size, line count if available, "hidden" if the file is hidden)
          * - Content section with either:
-         *     - Full text in a code block for complete file reads
-         *     - Excerpt with line ranges and code blocks for partial reads
+         *     - Full text for complete file reads
+         *     - Excerpt with line ranges for partial reads
          *     - No content section if content is [FileSystemEntry.File.Content.None]
          *
          * @return formatted text representation of the file
@@ -82,18 +75,17 @@ public class ReadFileTool<Path>(private val fs: FileSystemProvider.ReadOnly<Path
     override val descriptor: ToolDescriptor = Companion.descriptor
 
     /**
-     * Executes the file reading operation with the specified arguments.
+     * Reads file content from the filesystem with optional line range filtering.
      *
      * Performs validation before reading:
      * - Verifies the path exists in the filesystem
      * - Confirms the path points to a file (not a directory)
-     * - Ensures the file can be successfully read
      *
      * @param args arguments specifying the file path and optional line range
-     * @return Result containing the file with its content and metadata
+     * @return [Result] containing the file with its content and metadata
      * @throws [ToolException.ValidationFailure] if the file doesn't exist, is a directory, or
      *   cannot be read
-     * @throws IllegalArgumentException if line range parameters are invalid
+     * @throws [IllegalArgumentException] if line range parameters are invalid
      */
     override suspend fun execute(args: Args): Result {
         val path = fs.fromAbsolutePathString(args.path)
@@ -118,23 +110,16 @@ public class ReadFileTool<Path>(private val fs: FileSystemProvider.ReadOnly<Path
 
     public companion object {
         /**
-         * Tool descriptor defining name, description, and parameters.
+         * Tool descriptor for the read file operation.
          *
-         * Configures the tool as "read-file" with absolute path requirement and optional line range
-         * parameters using 0-based indexing.
-         *
-         * Required parameters:
-         * - `path`: Absolute path to the target file
-         *
-         * Optional parameters:
-         * - `startLine`: First line to include, 0-based, defaults to 0
-         * - `endLine`: First line to exclude, 0-based, -1 for the end of file, defaults to -1
+         * Configures the tool to read text files with optional line range selection
+         * using 0-based indexing.
          */
         public val descriptor: ToolDescriptor = ToolDescriptor(
             name = "__read_file__",
             description = text {
-                +"Reads text file with optional line range selection."
-                +"Returns formatted content with metadata."
+                +"Reads text file content with optional line range selection."
+                +"Returns file content along with metadata (path, size, line count, hidden status)."
                 newline()
                 +"Uses 0-based line indexing."
             },

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/file/tools/model/FileSize.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/file/tools/model/FileSize.kt
@@ -1,0 +1,97 @@
+package ai.koog.agents.file.tools.model
+
+import ai.koog.rag.base.files.FileSystemProvider
+import kotlinx.serialization.Serializable
+import kotlin.math.pow
+
+/**
+ * Provides human-readable file size information.
+ *
+ * Represents sizes as [Bytes] (in bytes, kibibytes, or mebibyte) or as [Lines] (a count of text
+ * lines). Use [of] to create the appropriate instances for a file.
+ */
+@Serializable
+public sealed interface FileSize {
+    /** Returns a formatted string representation of the file size */
+    public fun display(): String
+
+    /** Provides utility methods and constants for file size handling */
+    public companion object {
+        /** Defines 1 kibibyte as 1024 bytes */
+        public const val KIB: Long = 1024L
+
+        /** Defines 1 mebibyte as 1024 × 1024 bytes */
+        public const val MIB: Long = KIB * 1024L
+
+        /**
+         * Creates [FileSize] representations for the given file.
+         *
+         * Always returns a [Bytes] instance. For files ≤ 1 MiB, also returns a [Lines] instance.
+         * For files > 1 MiB, only [Bytes] is returned to avoid loading large content.
+         *
+         * @param Path the filesystem path type
+         * @param path the file path to measure
+         * @param fs the filesystem provider used to access the file
+         * @return a list containing at least a [Bytes] instance and optionally a [Lines] instance
+         */
+        public suspend fun <Path> of(
+            path: Path,
+            fs: FileSystemProvider.ReadOnly<Path>,
+        ): List<FileSize> {
+            val bytes = Bytes(fs.size(path))
+            return if (bytes.bytes > MIB) {
+                listOf(bytes)
+            } else {
+                val content = fs.readBytes(path).decodeToString()
+                val lines = if (content.isEmpty()) 0 else content.lines().size
+                listOf(bytes, Lines(lines))
+            }
+        }
+
+        private fun Double.formatDecimals(decimals: Int): String {
+            val roundedToDecimals =
+                kotlin.math.round(this * 10.0.pow(decimals)) / 10.0.pow(decimals)
+            if (roundedToDecimals == roundedToDecimals.toInt().toDouble()) {
+                return "${roundedToDecimals.toInt()}.${"0".repeat(decimals)}"
+            }
+            return "$roundedToDecimals"
+        }
+    }
+
+    /**
+     * Represents a file's size in bytes with automatic unit selection for display.
+     *
+     * @property bytes the exact size in bytes (non-negative)
+     */
+    @Serializable
+    public data class Bytes(val bytes: Long) : FileSize {
+        /**
+         * Formats the byte count as a human-readable string.
+         *
+         * Rules:
+         * - `0` → `"0 bytes"`
+         * - ≥ 1 MiB → value in MiB with one decimal place
+         * - < 0.1 KiB → `"<0.1 KiB"`
+         * - Otherwise → value in KiB with one decimal place
+         */
+        override fun display(): String {
+            return when {
+                bytes == 0L -> "0 bytes"
+                bytes >= MIB -> "${(bytes.toDouble() / MIB).formatDecimals(1)} MiB"
+                bytes.toDouble() / KIB < 0.1 -> "<0.1 KiB"
+                else -> "${(bytes.toDouble() / KIB).formatDecimals(1)} KiB"
+            }
+        }
+    }
+
+    /**
+     * Represents a file's size as line count.
+     *
+     * @property lines the number of lines (non-negative)
+     */
+    @Serializable
+    public data class Lines(val lines: Int) : FileSize {
+        /** Returns the line count as "1 line" when the value is one or "N lines" otherwise */
+        override fun display(): String = if (lines == 1) "1 line" else "$lines lines"
+    }
+}

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/file/tools/model/FileSystemEntry.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/file/tools/model/FileSystemEntry.kt
@@ -1,0 +1,270 @@
+package ai.koog.agents.file.tools.model
+
+import ai.koog.rag.base.files.DocumentProvider
+import ai.koog.rag.base.files.FileMetadata
+import ai.koog.rag.base.files.FileSystemProvider
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Provides a common interface for files and directories in a filesystem.
+ *
+ * @property name filename or directory name
+ * @property extension file extension without dot, or `null` for directories
+ * @property path complete filesystem path
+ * @property hidden whether this entry is hidden
+ */
+@Serializable
+public sealed interface FileSystemEntry {
+    public val name: String
+    public val extension: String?
+    public val path: String
+    public val hidden: Boolean
+
+    /**
+     * Visits this entry and its descendants in depth-first order.
+     *
+     * @param depth maximum depth to traverse; 0 visits only this entry
+     * @param visitor function called for each visited entry
+     */
+    public suspend fun visit(depth: Int, visitor: suspend (FileSystemEntry) -> Unit)
+
+    /**
+     * Represents a file in the filesystem.
+     *
+     * @property size list of [FileSize] measurements for this file
+     * @property contentType file content type from [FileMetadata.FileContentType]
+     * @property content file content, defaults to [Content.None]
+     */
+    @Serializable
+    public data class File(
+        override val name: String,
+        override val extension: String?,
+        override val path: String,
+        override val hidden: Boolean,
+        public val size: List<FileSize>,
+        @SerialName("content_type") public val contentType: FileMetadata.FileContentType,
+        public val content: Content = Content.None,
+    ) : FileSystemEntry {
+        /**
+         * Visits this file by calling [visitor] once.
+         *
+         * @param depth ignored for files
+         * @param visitor function called with this file
+         */
+        override suspend fun visit(depth: Int, visitor: suspend (FileSystemEntry) -> Unit) {
+            visitor(this)
+        }
+
+        /**
+         * Represents file content as none, full text, or excerpt.
+         */
+        @Serializable
+        public sealed interface Content {
+            /**
+             * Represents no file content.
+             */
+            @Serializable
+            public data object None : Content
+
+            /**
+             * Represents full file content.
+             *
+             * @property text complete file text
+             */
+            @Serializable
+            public data class Text(val text: String) : Content
+
+            /**
+             * Represents multiple separate text selections from a file.
+             *
+             * Each snippet contains text from a different part of the file, allowing
+             * non-contiguous selections.
+             *
+             * @property snippets text selections with their file positions
+             */
+            @Serializable
+            public data class Excerpt(val snippets: List<Snippet>) : Content {
+                /**
+                 * Creates an [Excerpt] from multiple [Snippet]s.
+                 *
+                 * @param snippets the snippets to include
+                 */
+                public constructor(vararg snippets: Snippet) : this(snippets.toList())
+
+                /**
+                 * Represents a text selection with its location in the source file.
+                 *
+                 * @property text the selected text
+                 * @property range position in the file (zero-based, start inclusive, end exclusive)
+                 */
+                @Serializable
+                public data class Snippet(
+                    val text: String,
+                    val range: DocumentProvider.DocumentRange,
+                )
+            }
+
+            public companion object {
+                /**
+                 * Creates file content from a line range.
+                 *
+                 * @param content file text to extract from
+                 * @param startLine first line to include (0-based, inclusive)
+                 * @param endLine first line to exclude (0-based, exclusive) or -1 for the end of the file
+                 * @return [Text] if range covers the entire file, otherwise [Excerpt] with single snippet
+                 * @throws IllegalArgumentException if startLine < 0, endLine < -1, or endLine <= startLine when endLine != -1
+                 */
+                public fun of(content: String, startLine: Int, endLine: Int): Content {
+                    require(startLine >= 0) { "startLine must be >= 0: $startLine" }
+                    require(endLine >= -1) { "endLine must be >= -1: $endLine" }
+                    require(endLine == -1 || endLine > startLine) {
+                        "endLine must be > startLine or -1: startLine=$startLine, endLine=$endLine"
+                    }
+
+                    val lines = content.lines()
+                    val startIndex = startLine.coerceAtLeast(0)
+                    val endIndex = if (endLine == -1) lines.size else endLine.coerceAtMost(lines.size)
+
+                    if (startIndex == 0 && endIndex >= lines.size) {
+                        return Text(content)
+                    }
+
+                    val start = DocumentProvider.Position(startIndex, 0)
+                    val end = DocumentProvider.Position(endIndex, 0)
+                    val range = DocumentProvider.DocumentRange(start, end)
+
+                    return Excerpt(
+                        listOf(
+                            Excerpt.Snippet(
+                                text = range.substring(content),
+                                range = range,
+                            )
+                        )
+                    )
+                }
+            }
+        }
+
+        public companion object {
+            /**
+             * Creates a [File] from a filesystem path.
+             *
+             * @param Path the provider's path type
+             * @param path the file path to examine
+             * @param content the file content, defaults to [Content.None]
+             * @param fs the filesystem provider
+             * @return [File] if the path exists and is a file, otherwise null
+             * @throws kotlinx.io.IOException if I/O error occurs while accessing filesystem
+             */
+            public suspend fun <Path> of(
+                path: Path,
+                content: Content = Content.None,
+                fs: FileSystemProvider.ReadOnly<Path>,
+            ): File? {
+                val metadata = fs.metadata(path) ?: return null
+                if (metadata.type != FileMetadata.FileType.File) return null
+                return File(
+                    name = fs.name(path),
+                    extension = fs.extension(path).takeIf { it.isNotEmpty() },
+                    path = fs.toAbsolutePathString(path),
+                    hidden = metadata.hidden,
+                    contentType = fs.getFileContentType(path),
+                    size = FileSize.of(path, fs),
+                    content = content,
+                )
+            }
+        }
+    }
+
+    /**
+     * Represents a directory in the filesystem.
+     *
+     * @property entries child files and directories, or null if not loaded
+     */
+    @Serializable
+    public data class Folder(
+        override val name: String,
+        override val path: String,
+        override val hidden: Boolean,
+        val entries: List<FileSystemEntry>? = null,
+    ) : FileSystemEntry {
+        /** Always null since directories have no file extensions. */
+        override val extension: String? = null
+
+        /**
+         * Visits this folder and its descendants.
+         *
+         * @param depth maximum recursion depth
+         * @param visitor function called for each visited [FileSystemEntry]
+         */
+        override suspend fun visit(depth: Int, visitor: suspend (FileSystemEntry) -> Unit) {
+            visitor(this)
+            if (depth == 0) return
+            entries?.forEach { it.visit(depth - 1, visitor) }
+        }
+
+        public companion object {
+            /**
+             * Creates a [Folder] from a filesystem path.
+             *
+             * @param Path the provider's path type
+             * @param path the directory path
+             * @param entries child entries for this folder
+             * @param fs the filesystem provider
+             * @return [Folder] if the path exists and is a directory, otherwise null
+             * @throws kotlinx.io.IOException if I/O error occurs while accessing filesystem
+             */
+            public suspend fun <Path> of(
+                path: Path,
+                entries: List<FileSystemEntry>? = null,
+                fs: FileSystemProvider.ReadOnly<Path>,
+            ): Folder? {
+                val metadata = fs.metadata(path) ?: return null
+                if (metadata.type != FileMetadata.FileType.Directory) return null
+                return Folder(
+                    name = fs.name(path),
+                    path = fs.toAbsolutePathString(path),
+                    hidden = metadata.hidden,
+                    entries = entries,
+                )
+            }
+        }
+    }
+
+    public companion object {
+        /**
+         * Creates the appropriate [FileSystemEntry] subtype from a path.
+         *
+         * @param Path the provider's path type
+         * @param path the filesystem path to examine
+         * @param fs the filesystem provider
+         * @return [File] for files, [Folder] for directories, or null if the path does not exist
+         * @throws kotlinx.io.IOException if I/O error occurs while accessing the filesystem
+         */
+        public suspend fun <Path> of(
+            path: Path,
+            fs: FileSystemProvider.ReadOnly<Path>,
+        ): FileSystemEntry? {
+            val metadata = fs.metadata(path) ?: return null
+            return when (metadata.type) {
+                FileMetadata.FileType.File ->
+                    File(
+                        name = fs.name(path),
+                        extension = fs.extension(path).takeIf { it.isNotEmpty() },
+                        path = fs.toAbsolutePathString(path),
+                        hidden = metadata.hidden,
+                        contentType = fs.getFileContentType(path),
+                        size = FileSize.of(path, fs),
+                    )
+
+                FileMetadata.FileType.Directory ->
+                    Folder(
+                        name = fs.name(path),
+                        path = fs.toAbsolutePathString(path),
+                        hidden = metadata.hidden,
+                    )
+            }
+        }
+    }
+}

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/file/tools/render/Text.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/file/tools/render/Text.kt
@@ -1,0 +1,129 @@
+package ai.koog.agents.file.tools.render
+
+import ai.koog.agents.file.tools.model.FileSystemEntry
+import ai.koog.prompt.text.TextContentBuilder
+import ai.koog.rag.base.files.FileMetadata
+
+private const val FOLDER_INDENTATION = "  "
+
+private val CODE_EXTENSIONS = setOf(
+    "kt", "java", "js", "ts", "py", "cpp", "c", "h", "hpp", "cs", "cxx", "cc",
+    "go", "rs", "php", "rb", "swift", "scala", "sh", "bash", "sql", "r",
+    "html", "css", "xml", "json", "yaml", "yml", "toml", "md", "dockerfile",
+    "gradle", "properties", "conf", "ini", "cfg", "makefile", "cmake",
+    "dart", "lua", "perl", "powershell", "ps1", "bat", "cmd", "vim"
+)
+
+private val LANGUAGE_ID_MAPPINGS = mapOf(
+    "kt" to "kotlin", "js" to "javascript", "ts" to "typescript",
+    "py" to "python", "sh" to "bash", "yml" to "yaml",
+    "cpp" to "cpp", "cxx" to "cpp", "cc" to "cpp", "hpp" to "cpp",
+    "cs" to "csharp", "ps1" to "powershell", "md" to "markdown"
+)
+
+public fun TextContentBuilder.entry(entry: FileSystemEntry, parent: FileSystemEntry? = null) {
+    when (entry) {
+        is FileSystemEntry.File -> file(entry, parent)
+        is FileSystemEntry.Folder -> folder(entry, parent)
+    }
+}
+
+public fun TextContentBuilder.folder(folder: FileSystemEntry.Folder, parent: FileSystemEntry? = null) {
+    folder.entries?.singleOrNull()?.let { singleEntry ->
+        entry(singleEntry, parent)
+        return
+    }
+
+    val displayPath = calculateDisplayPath(folder.path, folder.name, parent)
+    val metadataSuffix = if (folder.hidden) " (hidden)" else ""
+
+    +"$displayPath/$metadataSuffix"
+
+    renderFolderEntries(folder)
+}
+
+public fun TextContentBuilder.file(file: FileSystemEntry.File, parent: FileSystemEntry? = null) {
+    val displayPath = calculateDisplayPath(file.path, file.name, parent)
+    val metadata = buildFileMetadata(file)
+
+    +"$displayPath (${metadata.joinToString(", ")})"
+
+    renderFileContent(file.content, file.extension)
+}
+
+private fun calculateDisplayPath(path: String, name: String, parent: FileSystemEntry?): String {
+    return when (parent) {
+        null -> path
+        else -> {
+            val relativePath = path.removePrefix(parent.path).trimStart('/', '\\')
+            relativePath.ifEmpty { name }
+        }
+    }
+}
+
+private fun buildFileMetadata(file: FileSystemEntry.File): List<String> = buildList {
+    if (file.contentType != FileMetadata.FileContentType.Text) {
+        add(file.contentType.display)
+    }
+    add(file.size.joinToString(", ") { it.display() })
+    if (file.hidden) {
+        add("hidden")
+    }
+}
+
+private fun TextContentBuilder.renderFolderEntries(folder: FileSystemEntry.Folder) {
+    val entries = folder.entries
+    if (entries.isNullOrEmpty()) return
+
+    padding(FOLDER_INDENTATION) {
+        entries.forEach { entry(it, folder) }
+    }
+}
+
+private fun TextContentBuilder.renderFileContent(content: FileSystemEntry.File.Content, extension: String?) {
+    when (content) {
+        is FileSystemEntry.File.Content.Excerpt -> renderExcerptContent(content, extension)
+        is FileSystemEntry.File.Content.Text -> renderTextContent(content, extension)
+        FileSystemEntry.File.Content.None -> { /* No content to render */ }
+    }
+}
+
+private fun TextContentBuilder.renderExcerptContent(
+    content: FileSystemEntry.File.Content.Excerpt,
+    extension: String?
+) {
+    if (content.snippets.isEmpty()) {
+        +"(No excerpt)"
+        return
+    }
+
+    +"Excerpt:"
+    content.snippets.forEach { snippet ->
+        +"Lines ${snippet.range.start.line}-${snippet.range.end.line}:"
+        codeBlock(snippet.text.trim(), extension)
+    }
+}
+
+private fun TextContentBuilder.renderTextContent(
+    content: FileSystemEntry.File.Content.Text,
+    extension: String?
+) {
+    +"Content:"
+    codeBlock(content.text.trim(), extension)
+}
+
+private fun TextContentBuilder.codeBlock(text: String, extension: String? = null) {
+    when {
+        extension?.lowercase() in CODE_EXTENSIONS -> {
+            +"```${extension.toLanguageId()}"
+            +text
+            +"```"
+        }
+        else -> +text
+    }
+}
+
+private fun String?.toLanguageId(): String {
+    val lowercase = this?.lowercase() ?: return ""
+    return LANGUAGE_ID_MAPPINGS[lowercase] ?: lowercase
+}

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/file/tools/render/Text.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/file/tools/render/Text.kt
@@ -21,14 +21,33 @@ private val LANGUAGE_ID_MAPPINGS = mapOf(
     "cs" to "csharp", "ps1" to "powershell", "md" to "markdown"
 )
 
-public fun TextContentBuilder.entry(entry: FileSystemEntry, parent: FileSystemEntry? = null) {
+/**
+ * Renders a generic [FileSystemEntry] by delegating to [file] or [folder].
+ *
+ * @param entry the entry to render
+ * @param parent optional parent entry used to compute a relative display path
+ */
+internal fun TextContentBuilder.entry(entry: FileSystemEntry, parent: FileSystemEntry? = null) {
     when (entry) {
         is FileSystemEntry.File -> file(entry, parent)
         is FileSystemEntry.Folder -> folder(entry, parent)
     }
 }
 
-public fun TextContentBuilder.folder(folder: FileSystemEntry.Folder, parent: FileSystemEntry? = null) {
+/**
+ * Renders a folder as a single line with an optional "(hidden)" suffix, followed by its nested entries with indentation.
+ *
+ * Special behavior for single-entry folders: If the folder contains exactly one entry, that entry is rendered
+ * directly instead of the folder itself to avoid unnecessary nesting levels in the output.
+ *
+ * The folder line shows the path ending with "/" and "(hidden)" if the folder is hidden.
+ * Child entries are rendered with 2-space indentation, recursively maintaining the folder hierarchy.
+ * Folders with a null or empty entries list show only the folder line with no children.
+ *
+ * @param folder the folder to render
+ * @param parent optional parent entry used to compute a relative display path
+ */
+internal fun TextContentBuilder.folder(folder: FileSystemEntry.Folder, parent: FileSystemEntry? = null) {
     folder.entries?.singleOrNull()?.let { singleEntry ->
         entry(singleEntry, parent)
         return
@@ -42,7 +61,23 @@ public fun TextContentBuilder.folder(folder: FileSystemEntry.Folder, parent: Fil
     renderFolderEntries(folder)
 }
 
-public fun TextContentBuilder.file(file: FileSystemEntry.File, parent: FileSystemEntry? = null) {
+/**
+ * Renders a file as a single line with metadata, followed by its content if present.
+ *
+ * The metadata line shows the file path and a parenthesized list containing:
+ * - Content type (only for non-text files like "binary")
+ * - File size(s) (e.g., "1.5 MiB", "12 lines")
+ * - "hidden" flag if the file is hidden
+ *
+ * When file content is available, it's rendered below the metadata line:
+ * - Text content becomes a Markdown code block if the file extension is recognized
+ * - Excerpt content shows line ranges and creates code blocks for each snippet
+ * - All content text is trimmed of leading/trailing whitespace
+ *
+ * @param file the file to render
+ * @param parent optional parent entry used to compute a relative display path
+ */
+internal fun TextContentBuilder.file(file: FileSystemEntry.File, parent: FileSystemEntry? = null) {
     val displayPath = calculateDisplayPath(file.path, file.name, parent)
     val metadata = buildFileMetadata(file)
 

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/file/tools/render/Text.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/file/tools/render/Text.kt
@@ -18,7 +18,9 @@ private val LANGUAGE_ID_MAPPINGS = mapOf(
     "kt" to "kotlin", "js" to "javascript", "ts" to "typescript",
     "py" to "python", "sh" to "bash", "yml" to "yaml",
     "cpp" to "cpp", "cxx" to "cpp", "cc" to "cpp", "hpp" to "cpp",
-    "cs" to "csharp", "ps1" to "powershell", "md" to "markdown"
+    "cs" to "csharp", "ps1" to "powershell", "md" to "markdown",
+    "rb" to "ruby", "dockerfile" to "docker", "gradle" to "groovy",
+    "bat" to "batch", "cmd" to "batch"
 )
 
 /**

--- a/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/file/tools/model/FileSizeTest.kt
+++ b/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/file/tools/model/FileSizeTest.kt
@@ -1,0 +1,64 @@
+package ai.koog.agents.file.tools.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FileSizeTest {
+
+    @Test
+    fun `bytes display returns 0 bytes for zero value`() {
+        assertEquals("0 bytes", FileSize.Bytes(0).display())
+    }
+
+    @Test
+    fun `bytes display shows less than 0_1 KiB for small values`() {
+        assertEquals("<0.1 KiB", FileSize.Bytes(50).display())
+        assertEquals("<0.1 KiB", FileSize.Bytes(100).display())
+        assertEquals("<0.1 KiB", FileSize.Bytes(102).display())
+    }
+
+    @Test
+    fun `bytes display shows KiB with proper formatting for values at 0_1 KiB threshold`() {
+        assertEquals("0.1 KiB", FileSize.Bytes(103).display())
+        assertEquals("0.5 KiB", FileSize.Bytes(512).display())
+    }
+
+    @Test
+    fun `bytes display shows KiB with proper formatting`() {
+        assertEquals("1.0 KiB", FileSize.Bytes(1024).display())
+        assertEquals("1.5 KiB", FileSize.Bytes(1500).display())
+        assertEquals("2.0 KiB", FileSize.Bytes(2048).display())
+        assertEquals("10.5 KiB", FileSize.Bytes(10752).display())
+    }
+
+    @Test
+    fun `bytes display shows MiB with proper formatting for values at MiB threshold`() {
+        assertEquals("1.0 MiB", FileSize.Bytes(FileSize.MIB).display())
+        assertEquals("1.0 MiB", FileSize.Bytes(1024 * 1024).display())
+    }
+
+    @Test
+    fun `bytes display shows MiB with proper formatting`() {
+        assertEquals("1.5 MiB", FileSize.Bytes(1024 * 1024 + 512 * 1024).display())
+        assertEquals("2.0 MiB", FileSize.Bytes(2 * 1024 * 1024).display())
+    }
+
+    @Test
+    fun `bytes display handles edge case just below MiB threshold`() {
+        assertEquals("10.3 MiB", FileSize.Bytes(103 * 1024 * 1024 / 10).display())
+    }
+
+    @Test
+    fun `lines display shows correct count format`() {
+        assertEquals("0 lines", FileSize.Lines(0).display())
+        assertEquals("1 line", FileSize.Lines(1).display())
+        assertEquals("42 lines", FileSize.Lines(42).display())
+        assertEquals("1000 lines", FileSize.Lines(1000).display())
+    }
+
+    @Test
+    fun `bytes display handles very large values`() {
+        assertEquals("100.0 MiB", FileSize.Bytes(100 * FileSize.MIB).display())
+        assertEquals("1000.0 MiB", FileSize.Bytes(1000 * FileSize.MIB).display())
+    }
+}

--- a/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/file/tools/model/FileSystemEntryTest.kt
+++ b/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/file/tools/model/FileSystemEntryTest.kt
@@ -1,0 +1,253 @@
+package ai.koog.agents.file.tools.model
+
+import ai.koog.rag.base.files.DocumentProvider
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class FileSystemEntryTest {
+
+    @Test
+    fun `Content - Text stores full text`() {
+        val text = FileSystemEntry.File.Content.Text("test content")
+        assertEquals("test content", text.text)
+    }
+
+    @Test
+    fun `Content - Excerpt with single snippet`() {
+        val snippet =
+            FileSystemEntry.File.Content.Excerpt.Snippet(
+                "snippet text",
+                DocumentProvider.DocumentRange(
+                    DocumentProvider.Position(0, 0),
+                    DocumentProvider.Position(1, 0),
+                ),
+            )
+        val excerpt = FileSystemEntry.File.Content.Excerpt(listOf(snippet))
+
+        assertEquals(1, excerpt.snippets.size)
+        assertEquals(snippet, excerpt.snippets[0])
+    }
+
+    @Test
+    fun `Content - Excerpt vararg constructor`() {
+        val snippet1 =
+            FileSystemEntry.File.Content.Excerpt.Snippet(
+                "snippet1",
+                DocumentProvider.DocumentRange(
+                    DocumentProvider.Position(0, 0),
+                    DocumentProvider.Position(1, 0),
+                ),
+            )
+        val snippet2 =
+            FileSystemEntry.File.Content.Excerpt.Snippet(
+                "snippet2",
+                DocumentProvider.DocumentRange(
+                    DocumentProvider.Position(2, 0),
+                    DocumentProvider.Position(3, 0),
+                ),
+            )
+
+        val excerpt = FileSystemEntry.File.Content.Excerpt(snippet1, snippet2)
+
+        assertEquals(2, excerpt.snippets.size)
+        assertEquals(snippet1, excerpt.snippets[0])
+        assertEquals(snippet2, excerpt.snippets[1])
+    }
+
+    @Test
+    fun `Content_of - Text when selecting full range (-1)`() {
+        val content = "first\nsecond\nthird"
+        val result = FileSystemEntry.File.Content.of(content, startLine = 0, endLine = -1)
+
+        assertTrue(result is FileSystemEntry.File.Content.Text)
+        assertEquals(content, result.text)
+    }
+
+    @Test
+    fun `Content_of - Text when range covers all lines exactly`() {
+        val content = "alpha\nbeta\ngamma"
+        val lineCount = content.lines().size
+
+        val result = FileSystemEntry.File.Content.of(content, startLine = 0, endLine = lineCount)
+
+        assertTrue(result is FileSystemEntry.File.Content.Text)
+        assertEquals(content, result.text)
+    }
+
+    @Test
+    fun `Content_of - Excerpt for partial line range`() {
+        val content = "line0\nline1\nline2\nline3"
+
+        val result = FileSystemEntry.File.Content.of(content, startLine = 1, endLine = 3)
+
+        assertTrue(result is FileSystemEntry.File.Content.Excerpt)
+        assertEquals(1, result.snippets.size)
+
+        val snippet = result.snippets[0]
+        assertEquals("line1\nline2\n", snippet.text)
+        assertEquals(1, snippet.range.start.line)
+        assertEquals(0, snippet.range.start.column)
+        assertEquals(3, snippet.range.end.line)
+        assertEquals(0, snippet.range.end.column)
+    }
+
+    @Test
+    fun `Content_of - Excerpt for single line selection`() {
+        val content = "first\nsecond\nthird"
+
+        val result = FileSystemEntry.File.Content.of(content, startLine = 1, endLine = 2)
+
+        assertTrue(result is FileSystemEntry.File.Content.Excerpt)
+        assertEquals("second\n", result.snippets[0].text)
+    }
+
+    @Test
+    fun `Content_of - Excerpt middle to end`() {
+        val content = "start\nmiddle\nend"
+
+        val result = FileSystemEntry.File.Content.of(content, startLine = 1, endLine = -1)
+
+        assertTrue(result is FileSystemEntry.File.Content.Excerpt)
+        assertEquals("middle\nend", result.snippets[0].text)
+    }
+
+    @Test
+    fun `Content_of handles empty content correctly`() {
+        val result = FileSystemEntry.File.Content.of("", startLine = 0, endLine = -1)
+
+        assertTrue(result is FileSystemEntry.File.Content.Text)
+        assertEquals("", result.text)
+    }
+
+    @Test
+    fun `Content_of handles single line without newline`() {
+        val content = "one_line"
+        val result = FileSystemEntry.File.Content.of(content, startLine = 0, endLine = -1)
+
+        assertTrue(result is FileSystemEntry.File.Content.Text)
+        assertEquals(content, result.text)
+    }
+
+    @Test
+    fun `Content_of clamps range when endLine exceeds content bounds`() {
+        val content = "a\nb"
+        val result = FileSystemEntry.File.Content.of(content, startLine = 0, endLine = 100)
+
+        assertTrue(result is FileSystemEntry.File.Content.Text)
+        assertEquals(content, result.text)
+    }
+
+    @Test
+    fun `Content_of throws IllegalArgumentException when startLine is negative`() {
+        val content = "test\ncontent"
+
+        val exception =
+            assertFailsWith<IllegalArgumentException> {
+                FileSystemEntry.File.Content.of(content, startLine = -1, endLine = -1)
+            }
+        assertTrue(exception.message!!.contains("startLine must be >= 0"))
+    }
+
+    @Test
+    fun `Content_of throws IllegalArgumentException when endLine is less than minus one`() {
+        val content = "test\ncontent"
+
+        val exception =
+            assertFailsWith<IllegalArgumentException> {
+                FileSystemEntry.File.Content.of(content, startLine = 0, endLine = -5)
+            }
+        assertTrue(exception.message!!.contains("endLine must be >= -1"))
+    }
+
+    @Test
+    fun `Content_of throws IllegalArgumentException when endLine not greater than startLine`() {
+        val content = "test\ncontent"
+
+        val exception =
+            assertFailsWith<IllegalArgumentException> {
+                FileSystemEntry.File.Content.of(content, startLine = 2, endLine = 1)
+            }
+        assertTrue(exception.message!!.contains("endLine must be > startLine"))
+    }
+
+    @Test
+    fun `Content_of allows endLine minus one with any valid startLine`() {
+        val content = "line1\nline2\nline3"
+
+        // Should not throw
+        FileSystemEntry.File.Content.of(content, startLine = 0, endLine = -1)
+        FileSystemEntry.File.Content.of(content, startLine = 2, endLine = -1)
+        assertTrue(true)
+    }
+
+    @Test
+    fun `Content_of creates DocumentRange with correct positions`() {
+        val content = "zero\none\ntwo\nthree"
+        val result = FileSystemEntry.File.Content.of(content, startLine = 1, endLine = 3)
+
+        assertTrue(result is FileSystemEntry.File.Content.Excerpt)
+        val snippet = result.snippets[0]
+
+        assertEquals(1, snippet.range.start.line)
+        assertEquals(0, snippet.range.start.column)
+        assertEquals(3, snippet.range.end.line)
+        assertEquals(0, snippet.range.end.column)
+
+        assertEquals(snippet.text, snippet.range.substring(content))
+    }
+
+    @Test
+    fun `Content_of handles content ending without newline correctly`() {
+        val content = "line1\nline2\nline3"
+        val result = FileSystemEntry.File.Content.of(content, startLine = 2, endLine = -1)
+
+        assertTrue(result is FileSystemEntry.File.Content.Excerpt)
+        assertEquals("line3", result.snippets[0].text)
+    }
+
+    @Test
+    fun `Content_of handles whitespace only lines`() {
+        val content = "  \n\t\n   "
+        val result = FileSystemEntry.File.Content.of(content, startLine = 1, endLine = 2)
+
+        assertTrue(result is FileSystemEntry.File.Content.Excerpt)
+        assertEquals("\t\n", result.snippets[0].text)
+    }
+
+    @Test
+    fun `Content - Text without trailing newline`() {
+        val content = "Hello world!"
+        val text = FileSystemEntry.File.Content.Text(content)
+        assertEquals(content, text.text)
+    }
+
+    @Test
+    fun `Content - Excerpt with multiple snippets using list`() {
+        val snippet1 =
+            FileSystemEntry.File.Content.Excerpt.Snippet(
+                text = "part1\n",
+                range =
+                DocumentProvider.DocumentRange(
+                    DocumentProvider.Position(0, 0),
+                    DocumentProvider.Position(1, 0),
+                ),
+            )
+        val snippet2 =
+            FileSystemEntry.File.Content.Excerpt.Snippet(
+                text = "part2\n",
+                range =
+                DocumentProvider.DocumentRange(
+                    DocumentProvider.Position(2, 0),
+                    DocumentProvider.Position(3, 0),
+                ),
+            )
+
+        val excerpt = FileSystemEntry.File.Content.Excerpt(listOf(snippet1, snippet2))
+
+        assertEquals(2, excerpt.snippets.size)
+        assertEquals(snippet1, excerpt.snippets[0])
+        assertEquals(snippet2, excerpt.snippets[1])
+    }
+}

--- a/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/file/tools/render/TextTest.kt
+++ b/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/file/tools/render/TextTest.kt
@@ -1,0 +1,818 @@
+package ai.koog.agents.file.tools.render
+
+import ai.koog.agents.file.tools.model.FileSize
+import ai.koog.agents.file.tools.model.FileSystemEntry
+import ai.koog.prompt.text.text
+import ai.koog.rag.base.files.DocumentProvider
+import ai.koog.rag.base.files.FileMetadata
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TextTest {
+    @Test
+    fun `file - renders with full path when no parent`() {
+        val file = FileSystemEntry.File(
+            name = "test.kt",
+            extension = "kt",
+            path = "/project/src/test.kt",
+            hidden = false,
+            size = listOf(FileSize.Bytes(1024)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.None
+        )
+
+        val actual = text { file(file) }
+
+        assertEquals("/project/src/test.kt (1.0 KiB)", actual)
+    }
+
+    @Test
+    fun `file - renders with relative path when parent provided`() {
+        val parent = FileSystemEntry.Folder(
+            name = "src",
+            path = "/project/src",
+            hidden = false,
+            entries = null
+        )
+        val file = FileSystemEntry.File(
+            name = "test.kt",
+            extension = "kt",
+            path = "/project/src/utils/test.kt",
+            hidden = false,
+            size = listOf(FileSize.Bytes(512)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.None
+        )
+
+        val actual = text { file(file, parent) }
+
+        assertEquals("utils/test.kt (0.5 KiB)", actual)
+    }
+
+    @Test
+    fun `file - shows name when path equals parent path`() {
+        val parent = FileSystemEntry.Folder(
+            name = "src",
+            path = "/project/src",
+            hidden = false,
+            entries = null
+        )
+        val file = FileSystemEntry.File(
+            name = "main.kt",
+            extension = "kt",
+            path = "/project/src",
+            hidden = false,
+            size = listOf(FileSize.Bytes(256)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.None
+        )
+
+        val actual = text { file(file, parent) }
+
+        assertEquals("main.kt (0.2 KiB)", actual)
+    }
+
+    @Test
+    fun `file - renders binary type with metadata`() {
+        val file = FileSystemEntry.File(
+            name = "image.png",
+            extension = "png",
+            path = "/repo/assets/image.png",
+            hidden = false,
+            size = listOf(FileSize.Bytes(1_572_864)),
+            contentType = FileMetadata.FileContentType.Binary,
+            content = FileSystemEntry.File.Content.None
+        )
+
+        val actual = text { file(file) }
+
+        assertEquals("/repo/assets/image.png (binary, 1.5 MiB)", actual)
+    }
+
+    @Test
+    fun `file - renders hidden file with all metadata`() {
+        val file = FileSystemEntry.File(
+            name = "notes.md",
+            extension = "md",
+            path = "/repo/docs/notes.md",
+            hidden = true,
+            size = listOf(FileSize.Bytes(2048), FileSize.Lines(12)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.None
+        )
+
+        val actual = text { file(file) }
+
+        assertEquals("/repo/docs/notes.md (2.0 KiB, 12 lines, hidden)", actual)
+    }
+
+    @Test
+    fun `file - renders with text content and trimming`() {
+        val file = FileSystemEntry.File(
+            name = "notes.md",
+            extension = "md",
+            path = "/repo/docs/notes.md",
+            hidden = true,
+            size = listOf(FileSize.Bytes(2048), FileSize.Lines(12)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.Text("  Hello world!  \n\n")
+        )
+
+        val actual = text { file(file) }
+
+        val expected = listOf(
+            "/repo/docs/notes.md (2.0 KiB, 12 lines, hidden)",
+            "Content:",
+            "```markdown",
+            "Hello world!",
+            "```"
+        ).joinToString("\n")
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `file - renders with empty text content`() {
+        val file = FileSystemEntry.File(
+            name = "empty.txt",
+            extension = "txt",
+            path = "/empty.txt",
+            hidden = false,
+            size = listOf(FileSize.Bytes(0), FileSize.Lines(0)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.Text("")
+        )
+
+        val actual = text { file(file) }
+
+        val expected = listOf(
+            "/empty.txt (0 bytes, 0 lines)",
+            "Content:",
+            ""
+        ).joinToString("\n")
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `file - renders with single excerpt snippet`() {
+        val snippet = FileSystemEntry.File.Content.Excerpt.Snippet(
+            text = "  fun a() = 1  \n",
+            range = DocumentProvider.DocumentRange(
+                DocumentProvider.Position(3, 0),
+                DocumentProvider.Position(5, 0)
+            )
+        )
+        val file = FileSystemEntry.File(
+            name = "code.kt",
+            extension = "kt",
+            path = "/repo/src/code.kt",
+            hidden = false,
+            size = listOf(FileSize.Bytes(512), FileSize.Lines(200)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.Excerpt(listOf(snippet))
+        )
+
+        val actual = text { file(file) }
+
+        val expected = listOf(
+            "/repo/src/code.kt (0.5 KiB, 200 lines)",
+            "Excerpt:",
+            "Lines 3-5:",
+            "```kotlin",
+            "fun a() = 1",
+            "```"
+        ).joinToString("\n")
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `file - renders with multiple excerpt snippets`() {
+        val s1 = FileSystemEntry.File.Content.Excerpt.Snippet(
+            text = "  fun a() = 1  \n",
+            range = DocumentProvider.DocumentRange(
+                DocumentProvider.Position(3, 0),
+                DocumentProvider.Position(5, 0)
+            )
+        )
+        val s2 = FileSystemEntry.File.Content.Excerpt.Snippet(
+            text = "class C\n{\n}\n",
+            range = DocumentProvider.DocumentRange(
+                DocumentProvider.Position(10, 0),
+                DocumentProvider.Position(13, 0)
+            )
+        )
+        val file = FileSystemEntry.File(
+            name = "code.kt",
+            extension = "kt",
+            path = "/repo/src/code.kt",
+            hidden = false,
+            size = listOf(FileSize.Bytes(512), FileSize.Lines(200)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.Excerpt(listOf(s1, s2))
+        )
+
+        val actual = text { file(file) }
+
+        val expected = listOf(
+            "/repo/src/code.kt (0.5 KiB, 200 lines)",
+            "Excerpt:",
+            "Lines 3-5:",
+            "```kotlin",
+            "fun a() = 1",
+            "```",
+            "Lines 10-13:",
+            "```kotlin",
+            "class C\n{\n}",
+            "```"
+        ).joinToString("\n")
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `file - renders empty excerpt with no excerpt message`() {
+        val file = FileSystemEntry.File(
+            name = "empty_excerpt.txt",
+            extension = "txt",
+            path = "/empty_excerpt.txt",
+            hidden = false,
+            size = listOf(FileSize.Bytes(100), FileSize.Lines(5)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.Excerpt(emptyList())
+        )
+
+        val actual = text { file(file) }
+
+        val expected = listOf(
+            "/empty_excerpt.txt (<0.1 KiB, 5 lines)",
+            "(No excerpt)"
+        ).joinToString("\n")
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `file - renders with no content type None`() {
+        val file = FileSystemEntry.File(
+            name = "binary.exe",
+            extension = "exe",
+            path = "/bin/binary.exe",
+            hidden = false,
+            size = listOf(FileSize.Bytes(5_242_880)),
+            contentType = FileMetadata.FileContentType.Binary,
+            content = FileSystemEntry.File.Content.None
+        )
+
+        val actual = text { file(file) }
+
+        assertEquals("/bin/binary.exe (binary, 5.0 MiB)", actual)
+    }
+
+    @Test
+    fun `file - handles whitespace-only text content with proper trimming`() {
+        val file = FileSystemEntry.File(
+            name = "whitespace.txt",
+            extension = "txt",
+            path = "/whitespace.txt",
+            hidden = false,
+            size = listOf(FileSize.Bytes(10), FileSize.Lines(3)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.Text("   \n\n   ")
+        )
+
+        val actual = text { file(file) }
+
+        val expected = listOf(
+            "/whitespace.txt (<0.1 KiB, 3 lines)",
+            "Content:",
+            ""
+        ).joinToString("\n")
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `file - handles excerpt with whitespace snippet and trimming`() {
+        val snippet = FileSystemEntry.File.Content.Excerpt.Snippet(
+            text = "   \n   \n",
+            range = DocumentProvider.DocumentRange(
+                DocumentProvider.Position(1, 0),
+                DocumentProvider.Position(3, 0)
+            )
+        )
+        val file = FileSystemEntry.File(
+            name = "whitespace_excerpt.txt",
+            extension = "txt",
+            path = "/whitespace_excerpt.txt",
+            hidden = false,
+            size = listOf(FileSize.Bytes(20), FileSize.Lines(5)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.Excerpt(listOf(snippet))
+        )
+
+        val actual = text { file(file) }
+
+        val expected = listOf(
+            "/whitespace_excerpt.txt (<0.1 KiB, 5 lines)",
+            "Excerpt:",
+            "Lines 1-3:",
+            ""
+        ).joinToString("\n")
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `file - handles complex path separators in relative path calculation`() {
+        val parent = FileSystemEntry.Folder(
+            name = "root",
+            path = "/root",
+            hidden = false,
+            entries = null
+        )
+        val file = FileSystemEntry.File(
+            name = "test.txt",
+            extension = "txt",
+            path = "/root\\path/with\\mixed/separators/test.txt",
+            hidden = false,
+            size = listOf(FileSize.Bytes(100)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.None
+        )
+
+        val actual = text { file(file, parent) }
+
+        assertEquals("path/with\\mixed/separators/test.txt (<0.1 KiB)", actual)
+    }
+
+    @Test
+    fun `folder - handles complex path separators in relative path calculation`() {
+        val parent = FileSystemEntry.Folder(
+            name = "root",
+            path = "/root",
+            hidden = false,
+            entries = null
+        )
+        val folder = FileSystemEntry.Folder(
+            name = "sub",
+            path = "/root\\path/with\\mixed/separators",
+            hidden = false,
+            entries = emptyList()
+        )
+
+        val actual = text { folder(folder, parent) }
+
+        assertEquals("path/with\\mixed/separators/", actual)
+    }
+
+    @Test
+    fun `file - renders JavaScript with correct language ID`() {
+        val file = FileSystemEntry.File(
+            name = "app.js",
+            extension = "js",
+            path = "/app.js",
+            hidden = false,
+            size = listOf(FileSize.Bytes(100)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.Text("console.log('hello')")
+        )
+
+        val actual = text { file(file) }
+
+        val expected = listOf(
+            "/app.js (<0.1 KiB)",
+            "Content:",
+            "```javascript",
+            "console.log('hello')",
+            "```"
+        ).joinToString("\n")
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `file - renders TypeScript with correct language ID`() {
+        val file = FileSystemEntry.File(
+            name = "app.ts",
+            extension = "ts",
+            path = "/app.ts",
+            hidden = false,
+            size = listOf(FileSize.Bytes(100)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.Text("const x: string = 'hello'")
+        )
+
+        val actual = text { file(file) }
+
+        val expected = listOf(
+            "/app.ts (<0.1 KiB)",
+            "Content:",
+            "```typescript",
+            "const x: string = 'hello'",
+            "```"
+        ).joinToString("\n")
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `file - renders Python with correct language ID`() {
+        val file = FileSystemEntry.File(
+            name = "main.py",
+            extension = "py",
+            path = "/main.py",
+            hidden = false,
+            size = listOf(FileSize.Bytes(100)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.Text("print('hello')")
+        )
+
+        val actual = text { file(file) }
+
+        val expected = listOf(
+            "/main.py (<0.1 KiB)",
+            "Content:",
+            "```python",
+            "print('hello')",
+            "```"
+        ).joinToString("\n")
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `file - renders C++ files with correct language ID`() {
+        val extensions = listOf("cpp", "cxx", "cc", "hpp")
+
+        extensions.forEach { ext ->
+            val file = FileSystemEntry.File(
+                name = "test.$ext",
+                extension = ext,
+                path = "/test.$ext",
+                hidden = false,
+                size = listOf(FileSize.Bytes(100)),
+                contentType = FileMetadata.FileContentType.Text,
+                content = FileSystemEntry.File.Content.Text("#include <iostream>")
+            )
+
+            val actual = text { file(file) }
+
+            val expected = listOf(
+                "/test.$ext (<0.1 KiB)",
+                "Content:",
+                "```cpp",
+                "#include <iostream>",
+                "```"
+            ).joinToString("\n")
+
+            assertEquals(expected, actual, "Failed for extension: $ext")
+        }
+    }
+
+    @Test
+    fun `file - renders unknown code extension with lowercase`() {
+        val file = FileSystemEntry.File(
+            name = "config.toml",
+            extension = "toml",
+            path = "/config.toml",
+            hidden = false,
+            size = listOf(FileSize.Bytes(100)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.Text("[package]\nname = 'test'")
+        )
+
+        val actual = text { file(file) }
+
+        val expected = listOf(
+            "/config.toml (<0.1 KiB)",
+            "Content:",
+            "```toml",
+            "[package]\nname = 'test'",
+            "```"
+        ).joinToString("\n")
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `file - renders non-code file without code block`() {
+        val file = FileSystemEntry.File(
+            name = "notes.unknown",
+            extension = "unknown",
+            path = "/notes.unknown",
+            hidden = false,
+            size = listOf(FileSize.Bytes(100)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.Text("Just some text")
+        )
+
+        val actual = text { file(file) }
+
+        val expected = listOf(
+            "/notes.unknown (<0.1 KiB)",
+            "Content:",
+            "Just some text"
+        ).joinToString("\n")
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `entry - delegates to file for file entries`() {
+        val file = FileSystemEntry.File(
+            name = "test.kt",
+            extension = "kt",
+            path = "/test.kt",
+            hidden = false,
+            size = listOf(FileSize.Bytes(100)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.None
+        )
+
+        val actual = text { entry(file) }
+
+        assertEquals("/test.kt (<0.1 KiB)", actual)
+    }
+
+    @Test
+    fun `entry - delegates to folder for folder entries`() {
+        val folder = FileSystemEntry.Folder(
+            name = "src",
+            path = "/src",
+            hidden = false,
+            entries = emptyList()
+        )
+
+        val actual = text { entry(folder) }
+
+        assertEquals("/src/", actual)
+    }
+
+    @Test
+    fun `folder - renders with full path when no parent`() {
+        val folder = FileSystemEntry.Folder(
+            name = "project",
+            path = "/home/user/project",
+            hidden = false,
+            entries = emptyList()
+        )
+
+        val actual = text { folder(folder) }
+
+        assertEquals("/home/user/project/", actual)
+    }
+
+    @Test
+    fun `folder - renders with relative path when parent provided`() {
+        val parent = FileSystemEntry.Folder(
+            name = "user",
+            path = "/home/user",
+            hidden = false,
+            entries = null
+        )
+        val folder = FileSystemEntry.Folder(
+            name = "project",
+            path = "/home/user/documents/project",
+            hidden = false,
+            entries = emptyList()
+        )
+
+        val actual = text { folder(folder, parent) }
+
+        assertEquals("documents/project/", actual)
+    }
+
+    @Test
+    fun `folder - shows name when path equals parent path`() {
+        val parent = FileSystemEntry.Folder("proj", "/a/b/proj", false, emptyList())
+        val actual = text { folder(parent, parent) }
+        assertEquals("proj/", actual)
+    }
+
+    @Test
+    fun `folder - renders hidden folder with metadata`() {
+        val folder = FileSystemEntry.Folder(
+            name = ".git",
+            path = "/project/.git",
+            hidden = true,
+            entries = emptyList()
+        )
+
+        val actual = text { folder(folder) }
+
+        assertEquals("/project/.git/ (hidden)", actual)
+    }
+
+    @Test
+    fun `folder - renders with null entries`() {
+        val folder = FileSystemEntry.Folder(
+            name = "unknown",
+            path = "/unknown",
+            hidden = false,
+            entries = null
+        )
+
+        val actual = text { folder(folder) }
+
+        assertEquals("/unknown/", actual)
+    }
+
+    @Test
+    fun `folder - collapses single file entry`() {
+        val only = FileSystemEntry.File(
+            name = "only.txt",
+            extension = "txt",
+            path = "/root/only.txt",
+            hidden = false,
+            size = listOf(FileSize.Bytes(0), FileSize.Lines(0)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.None
+        )
+        val folder = FileSystemEntry.Folder(
+            name = "root",
+            path = "/root",
+            hidden = false,
+            entries = listOf(only)
+        )
+
+        val actual = text { folder(folder) }
+
+        assertEquals("/root/only.txt (0 bytes, 0 lines)", actual)
+    }
+
+    @Test
+    fun `folder - collapses single folder entry`() {
+        val subfolder = FileSystemEntry.Folder(
+            name = "sub",
+            path = "/parent/sub",
+            hidden = false,
+            entries = emptyList()
+        )
+        val parent = FileSystemEntry.Folder(
+            name = "parent",
+            path = "/parent",
+            hidden = false,
+            entries = listOf(subfolder)
+        )
+
+        val actual = text { folder(parent) }
+
+        assertEquals("/parent/sub/", actual)
+    }
+
+    @Test
+    fun `folder - renders multiple entries with proper indentation`() {
+        val child1 = FileSystemEntry.File(
+            name = "readme.txt",
+            extension = "txt",
+            path = "/repo/project/readme.txt",
+            hidden = false,
+            size = listOf(FileSize.Bytes(100), FileSize.Lines(5)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.None
+        )
+        val subFolder = FileSystemEntry.Folder(
+            name = "src",
+            path = "/repo/project/src",
+            hidden = true,
+            entries = emptyList()
+        )
+        val root = FileSystemEntry.Folder(
+            name = "project",
+            path = "/repo/project",
+            hidden = false,
+            entries = listOf(child1, subFolder)
+        )
+
+        val actual = text { folder(root) }
+
+        val expected = listOf(
+            "/repo/project/",
+            "  readme.txt (<0.1 KiB, 5 lines)",
+            "  src/ (hidden)"
+        ).joinToString("\n")
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `folder - collapses nested structure with single entries`() {
+        val deepFile = FileSystemEntry.File(
+            name = "deep.txt",
+            extension = "txt",
+            path = "/root/level1/level2/deep.txt",
+            hidden = false,
+            size = listOf(FileSize.Bytes(64)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.None
+        )
+        val level2 = FileSystemEntry.Folder(
+            name = "level2",
+            path = "/root/level1/level2",
+            hidden = false,
+            entries = listOf(deepFile)
+        )
+        val level1 = FileSystemEntry.Folder(
+            name = "level1",
+            path = "/root/level1",
+            hidden = false,
+            entries = listOf(level2)
+        )
+        val root = FileSystemEntry.Folder(
+            name = "root",
+            path = "/root",
+            hidden = false,
+            entries = listOf(level1)
+        )
+
+        val actual = text { folder(root) }
+
+        assertEquals("/root/level1/level2/deep.txt (<0.1 KiB)", actual)
+    }
+
+    @Test
+    fun `folder - renders nested structure with multiple entries and proper indentation`() {
+        val deepFile1 = FileSystemEntry.File(
+            name = "deep1.txt",
+            extension = "txt",
+            path = "/root/level1/level2/deep1.txt",
+            hidden = false,
+            size = listOf(FileSize.Bytes(64)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.None
+        )
+        val deepFile2 = FileSystemEntry.File(
+            name = "deep2.txt",
+            extension = "txt",
+            path = "/root/level1/level2/deep2.txt",
+            hidden = false,
+            size = listOf(FileSize.Bytes(128)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.None
+        )
+        val level2 = FileSystemEntry.Folder(
+            name = "level2",
+            path = "/root/level1/level2",
+            hidden = false,
+            entries = listOf(deepFile1, deepFile2)
+        )
+        val level1File = FileSystemEntry.File(
+            name = "config.txt",
+            extension = "txt",
+            path = "/root/level1/config.txt",
+            hidden = false,
+            size = listOf(FileSize.Bytes(32)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.None
+        )
+        val level1 = FileSystemEntry.Folder(
+            name = "level1",
+            path = "/root/level1",
+            hidden = false,
+            entries = listOf(level1File, level2)
+        )
+        val root = FileSystemEntry.Folder(
+            name = "root",
+            path = "/root",
+            hidden = false,
+            entries = listOf(level1)
+        )
+
+        val actual = text { folder(root) }
+
+        val expected = listOf(
+            "/root/level1/",
+            "  config.txt (<0.1 KiB)",
+            "  level2/",
+            "    deep1.txt (<0.1 KiB)",
+            "    deep2.txt (0.1 KiB)"
+        ).joinToString("\n")
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `file - preserves newlines in text content`() {
+        val file = FileSystemEntry.File(
+            name = "multiline.txt",
+            extension = "txt",
+            path = "/multiline.txt",
+            hidden = false,
+            size = listOf(FileSize.Bytes(100)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.Text("line1\nline2\nline3")
+        )
+
+        val actual = text { file(file) }
+
+        val expected = listOf(
+            "/multiline.txt (<0.1 KiB)",
+            "Content:",
+            "line1\nline2\nline3"
+        ).joinToString("\n")
+
+        assertEquals(expected, actual)
+    }
+}

--- a/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/file/tools/render/TextTest.kt
+++ b/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/file/tools/render/TextTest.kt
@@ -368,6 +368,55 @@ class TextTest {
     }
 
     @Test
+    fun `file - renders code block for uppercase extension and maps language id`() {
+        val file = FileSystemEntry.File(
+            name = "README.MD",
+            extension = "MD",
+            path = "/README.MD",
+            hidden = false,
+            size = listOf(FileSize.Bytes(42)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.Text("Content in markdown")
+        )
+
+        val actual = text { file(file) }
+
+        val expected = listOf(
+            "/README.MD (<0.1 KiB)",
+            "Content:",
+            "```markdown",
+            "Content in markdown",
+            "```"
+        ).joinToString("\n")
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `file - renders empty code block when content is whitespace and extension is code`() {
+        val file = FileSystemEntry.File(
+            name = "Empty.kt",
+            extension = "KT",
+            path = "/Empty.kt",
+            hidden = false,
+            size = listOf(FileSize.Bytes(0)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.Text("   \n\n   ")
+        )
+
+        val actual = text { file(file) }
+
+        val expected = listOf(
+            "/Empty.kt (0 bytes)",
+            "Content:",
+            "```kotlin",
+            "```"
+        ).joinToString("\n")
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
     fun `file - renders JavaScript with correct language ID`() {
         val file = FileSystemEntry.File(
             name = "app.js",
@@ -514,6 +563,29 @@ class TextTest {
             "/notes.unknown (<0.1 KiB)",
             "Content:",
             "Just some text"
+        ).joinToString("\n")
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `file - renders with null extension as plain text`() {
+        val file = FileSystemEntry.File(
+            name = "noext",
+            extension = null,
+            path = "/noext",
+            hidden = false,
+            size = listOf(FileSize.Bytes(100)),
+            contentType = FileMetadata.FileContentType.Text,
+            content = FileSystemEntry.File.Content.Text("Plain text content")
+        )
+
+        val actual = text { file(file) }
+
+        val expected = listOf(
+            "/noext (<0.1 KiB)",
+            "Content:",
+            "Plain text content"
         ).joinToString("\n")
 
         assertEquals(expected, actual)

--- a/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/file/tools/ReadFileToolJvmTest.kt
+++ b/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/file/tools/ReadFileToolJvmTest.kt
@@ -1,0 +1,372 @@
+package ai.koog.agents.file.tools
+
+import ai.koog.agents.core.tools.DirectToolCallsEnabler
+import ai.koog.agents.core.tools.ToolException
+import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
+import ai.koog.agents.file.tools.model.FileSystemEntry
+import ai.koog.rag.base.files.JVMFileSystemProvider
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createFile
+import kotlin.io.path.writeText
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@OptIn(InternalAgentToolsApi::class)
+class ReadFileToolJvmTest {
+
+    private val fs = JVMFileSystemProvider.ReadOnly
+    private val enabler = object : DirectToolCallsEnabler {}
+    private val tool = ReadFileTool(fs)
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private fun createTestFile(name: String, content: String = ""): Path =
+        tempDir.resolve(name).createFile().apply { writeText(content) }
+
+    private suspend fun readFile(path: Path, startLine: Int = 0, endLine: Int = -1): ReadFileTool.Result =
+        tool.executeUnsafe(ReadFileTool.Args(path.toString(), startLine, endLine), enabler)
+
+    @Test
+    fun `reads entire file content successfully`() = runBlocking {
+        val file = createTestFile("simple.txt", "Hello, World!")
+
+        val result = readFile(file)
+
+        assertTrue(result.file.content is FileSystemEntry.File.Content.Text)
+        assertEquals("Hello, World!", result.file.content.text)
+        assertEquals("simple.txt", result.file.name)
+        assertEquals("txt", result.file.extension)
+    }
+
+    @Test
+    fun `reads empty file successfully`() = runBlocking {
+        val file = createTestFile("empty.txt", "")
+
+        val result = readFile(file)
+
+        assertTrue(result.file.content is FileSystemEntry.File.Content.Text)
+        assertEquals("", result.file.content.text)
+        assertEquals("empty.txt", result.file.name)
+    }
+
+    @Test
+    fun `reads file without extension`() = runBlocking {
+        val file = createTestFile("next", "content without extension")
+
+        val result = readFile(file)
+
+        assertEquals("next", result.file.name)
+        assertEquals(null, result.file.extension)
+        assertEquals("content without extension", (result.file.content as FileSystemEntry.File.Content.Text).text)
+    }
+
+    @Test
+    fun `identifies hidden files correctly`() = runBlocking {
+        val file = createTestFile(".hidden", "secret content")
+
+        val result = readFile(file)
+
+        assertTrue(result.file.hidden)
+        assertEquals(".hidden", result.file.name)
+        assertEquals("secret content", (result.file.content as FileSystemEntry.File.Content.Text).text)
+    }
+
+    @Test
+    fun `reads specific line range correctly`() = runBlocking {
+        val content = "line0\nline1\nline2\nline3\nline4"
+        val file = createTestFile("lines.txt", content)
+
+        val result = readFile(file, startLine = 1, endLine = 4)
+
+        assertTrue(result.file.content is FileSystemEntry.File.Content.Excerpt)
+        assertEquals("line1\nline2\nline3\n", result.file.content.snippets[0].text)
+    }
+
+    @Test
+    fun `reads from start line to end when endLine is -1`() = runBlocking {
+        val file = createTestFile("partial.txt", "start\nmiddle\nend")
+
+        val result = readFile(file, startLine = 0, endLine = -1)
+
+        assertTrue(result.file.content is FileSystemEntry.File.Content.Text)
+        assertEquals("start\nmiddle\nend", result.file.content.text)
+    }
+
+    @Test
+    fun `reads single line correctly`() = runBlocking {
+        val file = createTestFile("multiline.txt", "first\nsecond\nthird")
+
+        val result = readFile(file, startLine = 1, endLine = 2)
+
+        assertTrue(result.file.content is FileSystemEntry.File.Content.Excerpt)
+        assertEquals("second\n", result.file.content.snippets[0].text)
+    }
+
+    @Test
+    fun `returns full content when endLine exceeds file length`() = runBlocking {
+        val file = createTestFile("short.txt", "line1\nline2\nline3")
+
+        val result = readFile(file, startLine = 0, endLine = 100)
+
+        assertTrue(result.file.content is FileSystemEntry.File.Content.Text)
+        assertEquals("line1\nline2\nline3", result.file.content.text)
+    }
+
+    @Test
+    fun `returns empty content when startLine exceeds file length`() = runBlocking {
+        val file = createTestFile("short.txt", "line1\nline2")
+
+        val result = readFile(file, startLine = 10, endLine = -1)
+
+        assertTrue(result.file.content is FileSystemEntry.File.Content.Excerpt)
+        assertEquals("", result.file.content.snippets[0].text)
+    }
+
+    @Test
+    fun `handles unicode content correctly`() = runBlocking {
+        val file = createTestFile("unicode.txt", "café ñoño 中文 🚀")
+
+        val result = readFile(file)
+
+        assertEquals("café ñoño 中文 🚀", (result.file.content as FileSystemEntry.File.Content.Text).text)
+    }
+
+    @Test
+    fun `handles mixed line endings`() = runBlocking {
+        val file = createTestFile("mixed.txt", "line1\r\nline2\nline3\r")
+
+        val result = readFile(file, startLine = 1, endLine = 2)
+
+        assertTrue(result.file.content is FileSystemEntry.File.Content.Excerpt)
+        assertEquals("line2\n", result.file.content.snippets[0].text)
+    }
+
+    @Test
+    fun `handles whitespace-only content`() = runBlocking {
+        val file = createTestFile("whitespace.txt", "   \n  \n\t\n")
+
+        val result = readFile(file, startLine = 1, endLine = 3)
+
+        assertTrue(result.file.content is FileSystemEntry.File.Content.Excerpt)
+        assertEquals("  \n\t\n", result.file.content.snippets[0].text)
+    }
+
+    @Test
+    fun `handles file with only newlines`() = runBlocking {
+        val file = createTestFile("newlines.txt", "\n\n\n")
+
+        val result = readFile(file)
+
+        assertEquals("\n\n\n", (result.file.content as FileSystemEntry.File.Content.Text).text)
+    }
+
+    @Test
+    fun `handles single character file`() = runBlocking {
+        val file = createTestFile("single.txt", "x")
+
+        val result = readFile(file)
+
+        assertEquals("x", (result.file.content as FileSystemEntry.File.Content.Text).text)
+    }
+
+    @Test
+    fun `handles file with special characters in name`() = runBlocking {
+        val file = createTestFile("special@#$%.txt", "special content")
+
+        val result = readFile(file)
+
+        assertEquals("special@#$%.txt", result.file.name)
+        assertEquals("special content", (result.file.content as FileSystemEntry.File.Content.Text).text)
+    }
+
+    @Test
+    fun `handles tabs and indentation`() = runBlocking {
+        val file = createTestFile("tabs.txt", "\t\tindented\n    spaces")
+
+        val result = readFile(file, startLine = 0, endLine = 1)
+
+        assertTrue(result.file.content is FileSystemEntry.File.Content.Excerpt)
+        assertEquals("\t\tindented\n", result.file.content.snippets[0].text)
+    }
+
+    @Test
+    fun `throws ValidationFailure for non-existent file`() {
+        val nonExistent = tempDir.resolve("missing.txt")
+
+        assertThrows<ToolException.ValidationFailure> {
+            runBlocking { readFile(nonExistent) }
+        }
+    }
+
+    @Test
+    fun `throws ValidationFailure for directory path`() {
+        val dir = tempDir.resolve("directory").createDirectories()
+
+        assertThrows<ToolException.ValidationFailure> {
+            runBlocking { readFile(dir) }
+        }
+    }
+
+    @Test
+    fun `throws IllegalArgumentException for negative startLine`() {
+        val file = createTestFile("valid.txt", "content")
+
+        assertThrows<IllegalArgumentException> {
+            runBlocking { readFile(file, startLine = -1) }
+        }
+    }
+
+    @Test
+    fun `throws IllegalArgumentException for invalid endLine`() {
+        val file = createTestFile("valid.txt", "content")
+
+        assertThrows<IllegalArgumentException> {
+            runBlocking { readFile(file, startLine = 0, endLine = -5) }
+        }
+    }
+
+    @Test
+    fun `throws IllegalArgumentException when endLine less than startLine`() {
+        val file = createTestFile("valid.txt", "line1\nline2\nline3")
+
+        assertThrows<IllegalArgumentException> {
+            runBlocking { readFile(file, startLine = 2, endLine = 1) }
+        }
+    }
+
+    @Test
+    fun `throws IllegalArgumentException when startLine equals endLine`() {
+        val file = createTestFile("valid.txt", "line1\nline2\nline3")
+
+        assertThrows<IllegalArgumentException> {
+            runBlocking { readFile(file, startLine = 1, endLine = 1) }
+        }
+    }
+
+    @Test
+    fun `Args uses correct default values`() {
+        val args = ReadFileTool.Args("/test/path")
+
+        assertEquals("/test/path", args.path)
+        assertEquals(0, args.startLine)
+        assertEquals(-1, args.endLine)
+    }
+
+    @Test
+    fun `Args accepts custom values`() {
+        val args = ReadFileTool.Args("/test/path", startLine = 5, endLine = 10)
+
+        assertEquals("/test/path", args.path)
+        assertEquals(5, args.startLine)
+        assertEquals(10, args.endLine)
+    }
+
+    @Test
+    fun `Result provides correct serializer`() = runBlocking {
+        val file = createTestFile("serialize.txt", "content")
+        val result = readFile(file)
+
+        assertEquals(ReadFileTool.Result.serializer(), result.getSerializer())
+    }
+
+    @Test
+    fun `Result toStringDefault produces exact expected format`() = runBlocking {
+        val file = createTestFile("format.txt", "test content")
+        val result = readFile(file)
+
+        val stringRepresentation = result.toStringDefault()
+        val expectedString = "${file.toAbsolutePath()} (<0.1 KiB, 1 line)\nContent:\ntest content"
+        assertEquals(expectedString, stringRepresentation)
+    }
+
+    @Test
+    fun `descriptor has correct configuration`() {
+        val descriptor = ReadFileTool.descriptor
+
+        assertEquals("read-file", descriptor.name)
+        assertTrue(descriptor.description.isNotEmpty())
+
+        assertEquals(1, descriptor.requiredParameters.size)
+        assertEquals("path", descriptor.requiredParameters[0].name)
+
+        assertEquals(2, descriptor.optionalParameters.size)
+        val optionalParamNames = descriptor.optionalParameters.map { it.name }
+        assertTrue(optionalParamNames.contains("startLine"))
+        assertTrue(optionalParamNames.contains("endLine"))
+    }
+
+    @Test
+    fun `descriptor parameters have correct types and descriptions`() {
+        val descriptor = ReadFileTool.descriptor
+
+        val pathParam = descriptor.requiredParameters.find { it.name == "path" }
+        assertNotNull(pathParam)
+        assertTrue(pathParam.description.isNotEmpty())
+
+        val startLineParam = descriptor.optionalParameters.find { it.name == "startLine" }
+        assertNotNull(startLineParam)
+        assertTrue(startLineParam.description.isNotEmpty())
+
+        val endLineParam = descriptor.optionalParameters.find { it.name == "endLine" }
+        assertNotNull(endLineParam)
+        assertTrue(endLineParam.description.isNotEmpty())
+    }
+
+    @Test
+    fun `handles extremely large line numbers`() = runBlocking {
+        val file = createTestFile("small.txt", "only one line")
+
+        val result = readFile(file, startLine = 1000, endLine = 2000)
+
+        assertTrue(result.file.content is FileSystemEntry.File.Content.Excerpt)
+        val excerpt = result.file.content
+        assertEquals("", excerpt.snippets[0].text)
+    }
+
+    @Test
+    fun `handles zero-byte file with line range`() = runBlocking {
+        val file = createTestFile("zero.txt", "")
+
+        val result = readFile(file, startLine = 0, endLine = 1)
+
+        assertTrue(result.file.content is FileSystemEntry.File.Content.Text)
+        assertEquals("", result.file.content.text)
+    }
+
+    @Test
+    fun `handles file ending with multiple newlines`() = runBlocking {
+        val file = createTestFile("trailing.txt", "content\n\n\n")
+
+        val result = readFile(file, startLine = 1, endLine = -1)
+
+        assertTrue(result.file.content is FileSystemEntry.File.Content.Excerpt)
+        val excerpt = result.file.content
+        assertEquals("\n\n", excerpt.snippets[0].text)
+    }
+
+    @Test
+    fun `handles very long single line`() = runBlocking {
+        val longLine = "x".repeat(1000)
+        val file = createTestFile("long.txt", longLine)
+
+        val result = readFile(file)
+
+        assertEquals(longLine, (result.file.content as FileSystemEntry.File.Content.Text).text)
+    }
+
+    @Test
+    fun `handles binary-like content as text`() = runBlocking {
+        val file = createTestFile("binary.txt", "\u0000\u0001\u0002text")
+
+        val result = readFile(file)
+
+        assertEquals("\u0000\u0001\u0002text", (result.file.content as FileSystemEntry.File.Content.Text).text)
+    }
+}

--- a/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/file/tools/ReadFileToolJvmTest.kt
+++ b/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/file/tools/ReadFileToolJvmTest.kt
@@ -290,7 +290,7 @@ class ReadFileToolJvmTest {
     fun `descriptor has correct configuration`() {
         val descriptor = ReadFileTool.descriptor
 
-        assertEquals("read-file", descriptor.name)
+        assertEquals("__read_file__", descriptor.name)
         assertTrue(descriptor.description.isNotEmpty())
 
         assertEquals(1, descriptor.requiredParameters.size)

--- a/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/file/tools/ReadFileToolJvmTest.kt
+++ b/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/file/tools/ReadFileToolJvmTest.kt
@@ -8,6 +8,8 @@ import ai.koog.rag.base.files.JVMFileSystemProvider
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.condition.DisabledOnOs
+import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.io.path.createDirectories
@@ -68,6 +70,7 @@ class ReadFileToolJvmTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     fun `identifies hidden files correctly`() = runBlocking {
         val file = createTestFile(".hidden", "secret content")
 

--- a/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/file/tools/model/FileSystemEntryJvmTest.kt
+++ b/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/file/tools/model/FileSystemEntryJvmTest.kt
@@ -1,0 +1,437 @@
+package ai.koog.agents.file.tools.model
+
+import ai.koog.rag.base.files.FileMetadata
+import ai.koog.rag.base.files.JVMFileSystemProvider
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createFile
+import kotlin.io.path.writeText
+
+class FileSystemEntryJvmTest {
+
+    private val fs = JVMFileSystemProvider.ReadOnly
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `File_of - creation from existing file path`() = runBlocking {
+        val testFile = tempDir.resolve("test.txt").apply {
+            createFile()
+            writeText("test content")
+        }
+
+        val fileEntry = FileSystemEntry.File.of(testFile, fs = fs)
+
+        assertNotNull(fileEntry)
+        assertEquals("test.txt", fileEntry!!.name)
+        assertEquals("txt", fileEntry.extension)
+        assertEquals(testFile.toString(), fileEntry.path)
+        assertFalse(fileEntry.hidden)
+        assertEquals(FileMetadata.FileContentType.Text, fileEntry.contentType)
+        assertTrue(fileEntry.size.isNotEmpty())
+        assertEquals(FileSystemEntry.File.Content.None, fileEntry.content)
+    }
+
+    @Test
+    fun `File_of - creation from non-existing path`() = runBlocking {
+        val nonExistentPath = tempDir.resolve("nonexistent.txt")
+
+        val fileEntry = FileSystemEntry.File.of(nonExistentPath, fs = fs)
+
+        assertNull(fileEntry)
+    }
+
+    @Test
+    fun `File_of - creation from directory path`() = runBlocking {
+        val directory = tempDir.resolve("testdir").apply { createDirectories() }
+
+        val fileEntry = FileSystemEntry.File.of(directory, fs = fs)
+
+        assertNull(fileEntry)
+    }
+
+    @Test
+    fun `File_of - creation with explicit content`() = runBlocking {
+        val testFile = tempDir.resolve("test.txt").apply {
+            createFile()
+            writeText("test content")
+        }
+        val content = FileSystemEntry.File.Content.Text("custom content")
+
+        val fileEntry = FileSystemEntry.File.of(testFile, content, fs)
+
+        assertNotNull(fileEntry)
+        assertEquals(content, fileEntry!!.content)
+    }
+
+    @Test
+    fun `File_of - creation with hidden leading-dot file`() = runBlocking {
+        val hiddenFile = tempDir.resolve(".hidden").apply {
+            createFile()
+            writeText("hidden content")
+        }
+
+        val fileEntry = FileSystemEntry.File.of(hiddenFile, fs = fs)
+
+        assertNotNull(fileEntry)
+        assertEquals(".hidden", fileEntry!!.name)
+        assertEquals("hidden", fileEntry.extension)
+    }
+
+    @Test
+    fun `File_of - no extension yields null`() = runBlocking {
+        val fileNoExt = tempDir.resolve("LICENSE").apply {
+            createFile()
+            writeText("license text")
+        }
+        val fileEntry = FileSystemEntry.File.of(fileNoExt, fs = fs)
+        assertNotNull(fileEntry)
+        assertEquals("LICENSE", fileEntry!!.name)
+        assertNull(fileEntry.extension)
+    }
+
+    @Test
+    fun `File_of - hidden multi-dot filename uses last token as extension`() = runBlocking {
+        val hiddenMultiDot = tempDir.resolve(".env.local").apply {
+            createFile()
+            writeText("FOO=bar")
+        }
+        val fileEntry = FileSystemEntry.File.of(hiddenMultiDot, fs = fs)
+        assertNotNull(fileEntry)
+        assertEquals(".env.local", fileEntry!!.name)
+        assertEquals("local", fileEntry.extension)
+    }
+
+    @Test
+    fun `File_visit - calls visitor once`() = runBlocking {
+        val file = FileSystemEntry.File(
+            name = "test.txt",
+            extension = "txt",
+            path = "/test.txt",
+            hidden = false,
+            size = emptyList(),
+            contentType = FileMetadata.FileContentType.Text
+        )
+
+        var visitCount = 0
+        var visitedEntry: FileSystemEntry? = null
+
+        file.visit(0) { entry ->
+            visitCount++
+            visitedEntry = entry
+        }
+
+        assertEquals(1, visitCount)
+        assertEquals(file, visitedEntry)
+    }
+
+    @Test
+    fun `File_visit - ignores depth parameter`() = runBlocking {
+        val file = FileSystemEntry.File(
+            name = "test.txt",
+            extension = "txt",
+            path = "/test.txt",
+            hidden = false,
+            size = emptyList(),
+            contentType = FileMetadata.FileContentType.Text
+        )
+
+        var visitCount = 0
+
+        file.visit(5) { _ ->
+            visitCount++
+        }
+
+        assertEquals(1, visitCount)
+    }
+
+    @Test
+    fun `Folder_of - creation from existing directory path`() = runBlocking {
+        val testDir = tempDir.resolve("test-folder").apply { createDirectories() }
+
+        val folderEntry = FileSystemEntry.Folder.of(testDir, fs = fs)
+
+        assertNotNull(folderEntry)
+        assertEquals("test-folder", folderEntry!!.name)
+        assertNull(folderEntry.extension)
+        assertEquals(testDir.toString(), folderEntry.path)
+        assertFalse(folderEntry.hidden)
+        assertNull(folderEntry.entries)
+    }
+
+    @Test
+    fun `Folder_of - creation from non-existing path`() = runBlocking {
+        val nonExistentPath = tempDir.resolve("nonexistent")
+
+        val folderEntry = FileSystemEntry.Folder.of(nonExistentPath, fs = fs)
+
+        assertNull(folderEntry)
+    }
+
+    @Test
+    fun `Folder_of - creation from file path`() = runBlocking {
+        val file = tempDir.resolve("test.txt").apply {
+            createFile()
+            writeText("test content")
+        }
+
+        val folderEntry = FileSystemEntry.Folder.of(file, fs = fs)
+
+        assertNull(folderEntry)
+    }
+
+    @Test
+    fun `Folder_of - creation with explicit entries`() = runBlocking {
+        val testDir = tempDir.resolve("test-folder").apply { createDirectories() }
+        val entries = listOf<FileSystemEntry>()
+
+        val folderEntry = FileSystemEntry.Folder.of(testDir, entries, fs)
+
+        assertNotNull(folderEntry)
+        assertEquals(entries, folderEntry!!.entries)
+    }
+
+    @Test
+    fun `Folder_of - creation with hidden directory`() = runBlocking {
+        val hiddenDir = tempDir.resolve(".hidden-dir").apply { createDirectories() }
+
+        val folderEntry = FileSystemEntry.Folder.of(hiddenDir, fs = fs)
+
+        assertNotNull(folderEntry)
+        assertEquals(".hidden-dir", folderEntry!!.name)
+    }
+
+    @Test
+    fun `Folder_property - extension is always null`() {
+        val folder = FileSystemEntry.Folder(
+            name = "test-folder",
+            path = "/path/to/test-folder",
+            hidden = false,
+            entries = null
+        )
+
+        assertNull(folder.extension)
+    }
+
+    @Test
+    fun `Folder_visit - depth zero visits only folder`() = runBlocking {
+        val folder = FileSystemEntry.Folder(
+            name = "test-folder",
+            path = "/test-folder",
+            hidden = false,
+            entries = listOf()
+        )
+
+        var visitCount = 0
+        var visitedEntry: FileSystemEntry? = null
+
+        folder.visit(0) { entry ->
+            visitCount++
+            visitedEntry = entry
+        }
+
+        assertEquals(1, visitCount)
+        assertEquals(folder, visitedEntry)
+    }
+
+    @Test
+    fun `Folder_visit - null entries`() = runBlocking {
+        val folder = FileSystemEntry.Folder(
+            name = "test-folder",
+            path = "/test-folder",
+            hidden = false,
+            entries = null
+        )
+
+        var visitCount = 0
+
+        folder.visit(5) { _ ->
+            visitCount++
+        }
+
+        assertEquals(1, visitCount)
+    }
+
+    @Test
+    fun `Folder_visit - empty entries`() = runBlocking {
+        val folder = FileSystemEntry.Folder(
+            name = "test-folder",
+            path = "/test-folder",
+            hidden = false,
+            entries = emptyList()
+        )
+
+        var visitCount = 0
+
+        folder.visit(5) { _ ->
+            visitCount++
+        }
+
+        assertEquals(1, visitCount)
+    }
+
+    @Test
+    fun `Folder_visit - with entries and depth`() = runBlocking {
+        val childFile = FileSystemEntry.File(
+            name = "child.txt",
+            extension = "txt",
+            path = "/test-folder/child.txt",
+            hidden = false,
+            size = emptyList(),
+            contentType = FileMetadata.FileContentType.Text
+        )
+
+        val nestedFolder = FileSystemEntry.Folder(
+            name = "nested",
+            path = "/test-folder/nested",
+            hidden = false,
+            entries = listOf(childFile)
+        )
+
+        val folder = FileSystemEntry.Folder(
+            name = "test-folder",
+            path = "/test-folder",
+            hidden = false,
+            entries = listOf(nestedFolder)
+        )
+
+        var visitCount = 0
+        val visitedEntries = mutableListOf<FileSystemEntry>()
+
+        folder.visit(2) { entry ->
+            visitCount++
+            visitedEntries.add(entry)
+        }
+
+        assertEquals(3, visitCount)
+        assertEquals(folder, visitedEntries[0])
+        assertEquals(nestedFolder, visitedEntries[1])
+        assertEquals(childFile, visitedEntries[2])
+    }
+
+    @Test
+    fun `Folder_visit - respects depth limit`() = runBlocking {
+        val deepFile = FileSystemEntry.File(
+            name = "deep.txt",
+            extension = "txt",
+            path = "/test-folder/nested/deep.txt",
+            hidden = false,
+            size = emptyList(),
+            contentType = FileMetadata.FileContentType.Text
+        )
+
+        val nestedFolder = FileSystemEntry.Folder(
+            name = "nested",
+            path = "/test-folder/nested",
+            hidden = false,
+            entries = listOf(deepFile)
+        )
+
+        val folder = FileSystemEntry.Folder(
+            name = "test-folder",
+            path = "/test-folder",
+            hidden = false,
+            entries = listOf(nestedFolder)
+        )
+
+        var visitCount = 0
+
+        folder.visit(1) { _ ->
+            visitCount++
+        }
+
+        assertEquals(2, visitCount) // folder + nestedFolder, but not deepFile
+    }
+
+    @Test
+    fun `Folder_visit - mixed entries preorder`() = runBlocking {
+        val file1 = FileSystemEntry.File(
+            name = "file1.txt",
+            extension = "txt",
+            path = "/test/file1.txt",
+            hidden = false,
+            size = emptyList(),
+            contentType = FileMetadata.FileContentType.Text
+        )
+
+        val file2 = FileSystemEntry.File(
+            name = "file2.txt",
+            extension = "txt",
+            path = "/test/file2.txt",
+            hidden = false,
+            size = emptyList(),
+            contentType = FileMetadata.FileContentType.Text
+        )
+
+        val nestedFolder = FileSystemEntry.Folder(
+            name = "nested",
+            path = "/test/nested",
+            hidden = false,
+            entries = listOf(file2)
+        )
+
+        val folder = FileSystemEntry.Folder(
+            name = "test",
+            path = "/test",
+            hidden = false,
+            entries = listOf(file1, nestedFolder)
+        )
+
+        val visitedEntries = mutableListOf<FileSystemEntry>()
+
+        folder.visit(2) { entry ->
+            visitedEntries.add(entry)
+        }
+
+        assertEquals(4, visitedEntries.size)
+        assertEquals(folder, visitedEntries[0])
+        assertEquals(file1, visitedEntries[1])
+        assertEquals(nestedFolder, visitedEntries[2])
+        assertEquals(file2, visitedEntries[3])
+    }
+
+    @Test
+    fun `FileSystemEntry_of - with file path`() = runBlocking {
+        val testFile = tempDir.resolve("test.txt").apply {
+            createFile()
+            writeText("test content")
+        }
+
+        val entry = FileSystemEntry.of(testFile, fs)
+
+        assertNotNull(entry)
+        assertTrue(entry is FileSystemEntry.File)
+        assertEquals("test.txt", entry!!.name)
+        assertEquals("txt", entry.extension)
+    }
+
+    @Test
+    fun `FileSystemEntry_of - with directory path`() = runBlocking {
+        val testDir = tempDir.resolve("test-folder").apply { createDirectories() }
+
+        val entry = FileSystemEntry.of(testDir, fs)
+
+        assertNotNull(entry)
+        assertTrue(entry is FileSystemEntry.Folder)
+        assertEquals("test-folder", entry!!.name)
+        assertNull(entry.extension)
+    }
+
+    @Test
+    fun `FileSystemEntry_of - with non-existing path`() = runBlocking {
+        val nonExistentPath = tempDir.resolve("nonexistent")
+
+        val entry = FileSystemEntry.of(nonExistentPath, fs)
+
+        assertNull(entry)
+    }
+}

--- a/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/file/tools/model/FileSystemEntryJvmTest.kt
+++ b/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/file/tools/model/FileSystemEntryJvmTest.kt
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.DisabledOnOs
+import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.io.path.createDirectories
@@ -74,6 +76,7 @@ class FileSystemEntryJvmTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     fun `File_of - creation with hidden leading-dot file`() = runBlocking {
         val hiddenFile = tempDir.resolve(".hidden").apply {
             createFile()
@@ -85,6 +88,7 @@ class FileSystemEntryJvmTest {
         assertNotNull(fileEntry)
         assertEquals(".hidden", fileEntry!!.name)
         assertEquals("hidden", fileEntry.extension)
+        assertTrue(fileEntry.hidden)
     }
 
     @Test

--- a/docs/docs/built-in-tools.md
+++ b/docs/docs/built-in-tools.md
@@ -4,11 +4,12 @@ The Koog framework provides built-in tools that handle common scenarios of agent
 
 The following built-in tools are available:
 
-| Tool      | <div style="width:115px">Name</div> | Description                                                                                                           |
-|-----------|-------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| SayToUser | `__say_to_user__`                   | Lets the agent send a message to the user. It prints the agent message to the console with the `Agent says: ` prefix. |
-| AskUser   | `__ask_user__`                      | Lets the agent ask the user for input. It prints the agent message to the console and waits for user response.        |
-| ExitTool  | `__exit__`                          | Lets the agent finish the conversation and terminate the session.                                                     |
+| Tool         | <div style="width:115px">Name</div> | Description                                                                                                              |
+|--------------|-------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| SayToUser    | `__say_to_user__`                   | Lets the agent send a message to the user. It prints the agent message to the console with the `Agent says: ` prefix.    |
+| AskUser      | `__ask_user__`                      | Lets the agent ask the user for input. It prints the agent message to the console and waits for user response.           |
+| ExitTool     | `__exit__`                          | Lets the agent finish the conversation and terminate the session.                                                        |
+| ReadFileTool | `__read_file__`                     | Reads text file with optional line range selection. Returns formatted content with metadata using 0-based line indexing. |
 
 
 ## Registering built-in tools
@@ -21,8 +22,10 @@ import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.ext.tool.SayToUser
 import ai.koog.agents.ext.tool.AskUser
 import ai.koog.agents.ext.tool.ExitTool
+import ai.koog.agents.file.tools.ReadFileTool
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+import ai.koog.rag.base.files.JVMFileSystemProvider
 
 const val apiToken = ""
 
@@ -33,6 +36,7 @@ val toolRegistry = ToolRegistry {
     tool(SayToUser)
     tool(AskUser)
     tool(ExitTool)
+    tool(ReadFileTool(JVMFileSystemProvider.ReadOnly))
 }
 
 // Pass the registry when creating an agent


### PR DESCRIPTION
This change extracts `ReadFileTool` from CE, simplifies it, and adds tests. It reads file content, either the whole file or a 0 based [start, end) slice, and returns file metadata and the extracted content.

Issue: https://youtrack.jetbrains.com/issue/KG-227/CodeAgent-OSS.-Step-1

---

#### Type of the changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [x] The change was discussed and approved in the issue
- [x] Docs have been added / updated
