### PR TITLE
Add GPT-5 variants (GPT5, GPT5 Mini, GPT5 Nano)

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/Module.md
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/Module.md
@@ -22,10 +22,13 @@ requirements.
 
 #### Chat Models
 
-| Model   | Speed  | Context | Input Support       | Output Support | Pricing (per 1M tokens) |
-|---------|--------|---------|---------------------|----------------|-------------------------|
-| GPT-4o  | Medium | 128K    | Text, Images, Tools | Text, Tools    | $2.5-$10                |
-| GPT-4.1 | Medium | 1M      | Text, Images, Tools | Text, Tools    | $2-$8                   |
+| Model     | Speed     | Context | Input Support         | Output Support | Pricing (per 1M tokens) |
+|-----------|-----------|---------|-----------------------|----------------|-------------------------|
+| GPT-4o    | Medium    | 128K    | Text, Images, Tools   | Text, Tools    | $2.5-$10                |
+| GPT-4.1   | Medium    | 1M      | Text, Images, Tools   | Text, Tools    | $2-$8                   |
+| GPT5      | Medium    | 400K    | Text, Image, Document | Text, Tools    | $1.25-$10               |
+| GPT5 Mini | Fast      | 400K    | Text, Image, Document | Text, Tools    | $0.25-$2                |
+| GPT5 Nano | Very fast | 400K    | Text, Image, Document | Text, Tools    | $0.05-$0.4              |
 
 #### Audio Models
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIModels.kt
@@ -13,28 +13,32 @@ import ai.koog.prompt.llm.LLModel
  *
  * Note: All models with vision (image) capabilities also support sending PDF files.
  *
- * | Name                                | Speed     | Price              | Input                        | Output             |
- * |-------------------------------------|-----------|--------------------|------------------------------|--------------------|
+ * | Name                             | Speed     | Price              | Input                        | Output             |
+ * |----------------------------------|-----------|--------------------|------------------------------|--------------------|
  * | [Reasoning.O4Mini]               | Medium    | $1.1-$4.4          | Text, Image, Tools, Document | Text, Tools        |
- * | [Reasoning.O3Mini]                  | Medium    | $1.1-$4.4          | Text, Tools                  | Text, Tools        |
- * | [Reasoning.O1Mini]                  | Slow      | $1.1-$4.4          | Text                         | Text               |
- * | [Reasoning.O3]                      | Slowest   | $10-$40            | Text, Image, Tools, Document | Text, Tools        |
- * | [Reasoning.O1]                      | Slowest   | $15-$60            | Text, Image, Tools, Document | Text, Tools        |
- * | [Chat.GPT4o]                        | Medium    | $2.5-$10           | Text, Image, Tools, Document | Text, Tools        |
- * | [Chat.GPT4_1]                       | Medium    | $2-$8              | Text, Image, Tools, Document | Text, Tools        |
- * | [Audio.GPT4oMiniAudio]              | Fast      | $0.15-$0.6/$10-$20 | Text, Audio, Tools           | Text, Audio, Tools |
- * | [Audio.GPT4oAudio]                  | Medium    | $2.5-$10/$40-$80   | Text, Audio, Tools           | Text, Audio, Tools |
- * | [CostOptimized.O4Mini]              | Medium    | $1.1-$4.4          | Text, Image, Tools, Document | Text, Tools        |
- * | [CostOptimized.GPT4_1Nano]          | Very fast | $0.1-$0.4          | Text, Image, Tools, Document | Text, Tools        |
- * | [CostOptimized.GPT4_1Mini]          | Fast      | $0.4-$1.6          | Text, Image, Tools, Document | Text, Tools        |
- * | [CostOptimized.GPT4oMini]           | Fast      | $0.15-$0.6         | Text, Image, Tools           | Text, Tools        |
- * | [CostOptimized.O1Mini]              | Slow      | $1.1-$4.4          | Text                         | Text               |
- * | [CostOptimized.O3Mini]              | Medium    | $1.1-$4.4          | Text, Tools                  | Text, Tools        |
- * | [Embeddings.TextEmbedding3Small]    | Medium    | $0.02              | Text                         | Text               |
- * | [Embeddings.TextEmbedding3Large]    | Slow      | $0.13              | Text                         | Text               |
- * | [Embeddings.TextEmbeddingAda002]    | Slow      | $0.1               | Text                         | Text               |
- * | [Moderation.Text]                   | Medium    | -                  | Text                         | Moderation Result  |
- * | [Moderation.Omni]                   | Medium    | $4.40              | Text                         | Moderation Result  |
+ * | [Reasoning.O3Mini]               | Medium    | $1.1-$4.4          | Text, Tools                  | Text, Tools        |
+ * | [Reasoning.O1Mini]               | Slow      | $1.1-$4.4          | Text                         | Text               |
+ * | [Reasoning.O3]                   | Slowest   | $10-$40            | Text, Image, Tools, Document | Text, Tools        |
+ * | [Reasoning.O1]                   | Slowest   | $15-$60            | Text, Image, Tools, Document | Text, Tools        |
+ * | [Chat.GPT4o]                     | Medium    | $2.5-$10           | Text, Image, Tools, Document | Text, Tools        |
+ * | [Chat.GPT4_1]                    | Medium    | $2-$8              | Text, Image, Tools, Document | Text, Tools        |
+ * | [Chat.GPT5]                      | Medium    | $1.25-$10          | Text, Image, Tools, Document | Text, Tools        |
+ * | [Chat.GPT5Mini]                  | Fast      | $0.25-$2           | Text, Image, Tools, Document | Text, Tools        |
+ * | [Chat.GPT5Nano]                  | Very fast | $0.05-$0.4         | Text, Image, Tools, Document | Text, Tools        |
+ * | [Audio.GPT4oMiniAudio]           | Fast      | $0.15-$0.6/$10-$20 | Text, Audio, Tools           | Text, Audio, Tools |
+ * | [Audio.GPT4oAudio]               | Medium    | $2.5-$10/$40-$80   | Text, Audio, Tools           | Text, Audio, Tools |
+ * | [CostOptimized.O4Mini]           | Medium    | $1.1-$4.4          | Text, Image, Tools, Document | Text, Tools        |
+ * | [CostOptimized.GPT4_1Nano]       | Very fast | $0.1-$0.4          | Text, Image, Tools, Document | Text, Tools        |
+ * | [CostOptimized.GPT4_1Mini]       | Fast      | $0.4-$1.6          | Text, Image, Tools, Document | Text, Tools        |
+ * | [CostOptimized.GPT4oMini]        | Fast      | $0.15-$0.6         | Text, Image, Tools           | Text, Tools        |
+ * | [CostOptimized.O1Mini]           | Slow      | $1.1-$4.4          | Text                         | Text               |
+ * | [CostOptimized.O3Mini]           | Medium    | $1.1-$4.4          | Text, Tools                  | Text, Tools        |
+ * | [Embeddings.TextEmbedding3Small] | Medium    | $0.02              | Text                         | Text               |
+ * | [Embeddings.TextEmbedding3Large] | Slow      | $0.13              | Text                         | Text               |
+ * | [Embeddings.TextEmbeddingAda002] | Slow      | $0.1               | Text                         | Text               |
+ * | [Moderation.Text]                | Medium    | -                  | Text                         | Moderation Result  |
+ * | [Moderation.Omni]                | Medium    | $4.40              | Text                         | Moderation Result  |
+ *
  */
 public object OpenAIModels : LLModelDefinitions {
     // TODO: support thinking tokens
@@ -278,13 +282,12 @@ public object OpenAIModels : LLModelDefinitions {
         )
 
         /**
-         * GPT-4.1 is a flagship model for complex tasks.
+         * GPT-4.1 is a model for complex tasks.
          * It is well suited for problem solving across domains.
          *
          * 1,047,576 context window
          * 32,768 max output tokens
          * Jun 01, 2024 knowledge cutoff
-         *
          *
          * @see <a href="https://platform.openai.com/docs/models/gpt-4.1">
          */
@@ -305,6 +308,94 @@ public object OpenAIModels : LLModelDefinitions {
             ),
             contextLength = 1_047_576,
             maxOutputTokens = 32_768,
+        )
+
+        /**
+         * GPT-5 is a flagship model for coding, reasoning, and agentic tasks across domains.
+         *
+         * 400,000 context window
+         * 128,000 max output tokens
+         * Sep 30, 2024 knowledge cutoff
+         * Reasoning token support
+         *
+         * @see <a href="https://platform.openai.com/docs/models/gpt-5">
+         */
+        public val GPT5: LLModel = LLModel(
+            provider = LLMProvider.OpenAI,
+            id = "gpt-5",
+            capabilities = listOf(
+                LLMCapability.Temperature,
+                LLMCapability.Schema.JSON.Basic,
+                LLMCapability.Schema.JSON.Standard,
+                LLMCapability.Speculation,
+                LLMCapability.Tools,
+                LLMCapability.ToolChoice,
+                LLMCapability.Vision.Image,
+                LLMCapability.Document,
+                LLMCapability.Completion,
+                LLMCapability.MultipleChoices
+            ),
+            contextLength = 400_000,
+            maxOutputTokens = 128_000,
+        )
+
+        /**
+         * GPT-5 mini is a faster, cost-efficient version of GPT-5 for well-defined tasks.
+         *
+         * 400,000 context window
+         * 128,000 max output tokens
+         * May 31, 2024 knowledge cutoff
+         * Reasoning token support
+         *
+         * @see <a href="https://platform.openai.com/docs/models/gpt-5-mini">
+         */
+        public val GPT5Mini: LLModel = LLModel(
+            provider = LLMProvider.OpenAI,
+            id = "gpt-5-mini",
+            capabilities = listOf(
+                LLMCapability.Temperature,
+                LLMCapability.Schema.JSON.Basic,
+                LLMCapability.Schema.JSON.Standard,
+                LLMCapability.Speculation,
+                LLMCapability.Tools,
+                LLMCapability.ToolChoice,
+                LLMCapability.Vision.Image,
+                LLMCapability.Document,
+                LLMCapability.Completion,
+                LLMCapability.MultipleChoices
+            ),
+            contextLength = 400_000,
+            maxOutputTokens = 128_000,
+        )
+
+        /**
+         * GPT-5 nano is the fastest, most cost-efficient version of GPT-5.
+         * Great for summarization and classification tasks.
+         *
+         * 400,000 context window
+         * 128,000 max output tokens
+         * May 31, 2024 knowledge cutoff
+         * Reasoning token support
+         *
+         * @see <a href="https://platform.openai.com/docs/models/gpt-5-nano">
+         */
+        public val GPT5Nano: LLModel = LLModel(
+            provider = LLMProvider.OpenAI,
+            id = "gpt-5-nano",
+            capabilities = listOf(
+                LLMCapability.Temperature,
+                LLMCapability.Schema.JSON.Basic,
+                LLMCapability.Schema.JSON.Standard,
+                LLMCapability.Speculation,
+                LLMCapability.Tools,
+                LLMCapability.ToolChoice,
+                LLMCapability.Vision.Image,
+                LLMCapability.Document,
+                LLMCapability.Completion,
+                LLMCapability.MultipleChoices
+            ),
+            contextLength = 400_000,
+            maxOutputTokens = 128_000,
         )
     }
 


### PR DESCRIPTION
[KG-264](https://youtrack.jetbrains.com/issue/KG-264) Add GPT-5 to OpenAI models list

## Motivation and Context
This PR adds new gpt5 models.
They are added to the `Chat` section, since OpenAI has updated its model structure, and koog no longer matches it

## Breaking Changes
No

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
