### PR TITLE
KG-268 EventBodyField for function call is valid JSON

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/EventBodyFieldTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/EventBodyFieldTest.kt
@@ -141,7 +141,7 @@ class EventBodyFieldTest {
             value = list,
             verbose = true,
             expectedKey = "body",
-            expectedValue = "{\"testKey\":${list.joinToString(separator = ",", prefix = "[", postfix = "]") { "$it"}}}",
+            expectedValue = "{\"testKey\":${list.joinToString(separator = ",", prefix = "[", postfix = "]") { "\"$it\""}}}",
         )
     }
 
@@ -169,7 +169,7 @@ class EventBodyFieldTest {
             value = unsupportedType,
             verbose = true,
             expectedKey = "body",
-            expectedValue = "{\"testKey\":$unsupportedType}",
+            expectedValue = "{\"testKey\":\"$unsupportedType\"}",
         )
     }
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/extension/EventBodyFieldExtTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/extension/EventBodyFieldExtTest.kt
@@ -3,6 +3,9 @@ package ai.koog.agents.features.opentelemetry.extension
 import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
 import ai.koog.agents.features.opentelemetry.event.EventBodyField
 import ai.koog.agents.features.opentelemetry.mock.MockEventBodyField
+import ai.koog.agents.utils.HiddenString
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.assertDoesNotThrow
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -28,5 +31,29 @@ class EventBodyFieldExtTest {
 
         assertEquals("custom.key", attribute.key)
         assertEquals("custom.value", attribute.value)
+    }
+
+    @Test
+    fun `valueString returns a valid JSON for tool calling events`() {
+        val functionCallEvent: EventBodyField = MockEventBodyField(
+            "key",
+            listOf(
+                mapOf(
+                    "function" to mapOf(
+                        "name" to HiddenString("HelloTool"),
+                        "arguments" to HiddenString("""{"name" : "Bob"}""")
+                    ),
+                    "id" to "call_1234567890",
+                    "type" to "function"
+                )
+            )
+        )
+
+        val value = functionCallEvent.valueString(true)
+        val jsonBuilder = Json { prettyPrint = true }
+
+        assertDoesNotThrow("Invalid JSON") {
+            jsonBuilder.parseToJsonElement(value)
+        }
     }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
@@ -687,7 +687,7 @@ class OpenTelemetryTest {
                                 "gen_ai.system" to model.provider.id,
                                 "index" to 0L,
                                 "role" to Message.Role.Tool.name.lowercase(),
-                                "tool_calls" to "[{\"function\":{\"name\":\"${TestGetWeatherTool.name}\",\"arguments\":\"${TestGetWeatherTool.encodeArgsToString(TestGetWeatherTool.Args("Paris"))}\"},\"id\":\"\",\"type\":\"function\"}]",
+                                "tool_calls" to """[{"function":{"name":"${TestGetWeatherTool.name}","arguments":"{\"location\":\"Paris\"}"},"id":"","type":"function"}]""",
                                 "finish_reason" to FinishReasonType.ToolCalls.id,
                             ),
                         )


### PR DESCRIPTION
## Motivation and Context
See https://youtrack.jetbrains.com/issue/KG-268/Assistant-tool-calls-in-OTEL-traces-of-are-not-valid-JSONs

## Breaking Changes
No

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
