### PR TITLE
[docs] Update docs with proper Maven dependency example

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Please check the [libs.versions.toml](gradle/libs.versions.toml) to know more ab
     ```
     <dependency>
         <groupId>ai.koog</groupId>
-        <artifactId>koog-agents</artifactId>
+        <artifactId>koog-agents-jvm</artifactId>
         <version>0.3.0</version>
     </dependency>
     ```

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -74,7 +74,7 @@ To use Koog, you need to include all necessary dependencies in your build config
     ```
     <dependency>
         <groupId>ai.koog</groupId>
-        <artifactId>koog-agents</artifactId>
+        <artifactId>koog-agents-jvm</artifactId>
         <version>LATEST_VERSION</version>
     </dependency>
     ```


### PR DESCRIPTION
When using Maven to add Koog dependencies, `-jvm` platform postifx has to be explicitly specified, because in general `pom.xml` file all scopes are set to `runtime`, which leads to compilation errors.  This is by design when publishing KMP artifacts with Gradle, it expects consumers to use richer Gradle-specific metadata file, so for Maven platform has to be specified explicitly.

Fixes #583