### PR TITLE
docs: Fix user prompt in relevance search example

### DIFF
--- a/docs/docs/ranked-document-storage.md
+++ b/docs/docs/ranked-document-storage.md
@@ -137,7 +137,7 @@ suspend fun solveUserRequest(query: String) {
         prompt = prompt("context") {
             system("You are a helpful assistant. Use the provided context to answer the user's question accurately.")
             user {
-                "Relevant context"
+                +"Relevant context"
                 attachments {
                     relevantDocuments.forEach {
                         file(it.pathString, "text/plain")


### PR DESCRIPTION
There's currently a minor issue with the code snippet example on relevance search where the user prompt ends up empty.

This is because within the `MessageContentBuilder` scope, the prompt is missing the unary plus operator. Adding this will result in the string being wrapped in `textWithNewLine`, resulting in it appearing in the user prompt.

## Motivation and Context

To fix a minor documentation issue which may result in users having an empty user prompt when they were expecting one.

A minimal reproducible example of the issue can be found [here](https://github.com/suvanl/koog-document-storage-docs-mre/blob/main/src/main/kotlin/com/suvanl/example/Main.kt).

## Breaking Changes

None, documentation change only.

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [ ] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
