### PR TITLE
feat: add ServerSSESession.llm() to retrieve PromptExecutor via Koog

### DIFF
--- a/koog-ktor/src/commonMain/kotlin/ai/koog/ktor/Agents.kt
+++ b/koog-ktor/src/commonMain/kotlin/ai/koog/ktor/Agents.kt
@@ -10,6 +10,7 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import io.ktor.server.application.pluginOrNull
 import io.ktor.server.routing.RoutingContext
+import io.ktor.server.sse.ServerSSESession
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
@@ -17,6 +18,12 @@ import kotlin.reflect.typeOf
  * Retrieve the configured llm, or [PromptExecutor] instance from the underlying [Koog] plugin.
  */
 public fun RoutingContext.llm(): PromptExecutor =
+    requireNotNull(call.application.pluginOrNull(Koog)) { "Plugin $Koog is not configured" }.promptExecutor
+
+/**
+ * Retrieve the configured llm, or [PromptExecutor] instance from the underlying [Koog] plugin.
+ */
+public fun ServerSSESession.llm(): PromptExecutor =
     requireNotNull(call.application.pluginOrNull(Koog)) { "Plugin $Koog is not configured" }.promptExecutor
 
 /**


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

Please add a brief description of the proposed change here.
Also, please tick the appropriate points in the checklist below.
-->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
- Previously, llm() was only available on RoutingContext.
- With extension addition using `llm()` becomes available within `ServerSSESession` scope
- Check image attached in which scope it is missing for Ktor

<img width="398" height="231" alt="image" src="https://github.com/user-attachments/assets/31878067-8945-4255-9bcf-b3238f4fa4ee" />

---

#### Type of the changes
- [x] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [x] Docs have been added / updated
