### PR TITLE
fix: Ktor Koog reading application.yaml when config is set programmatically

### DIFF
--- a/koog-ktor/src/commonMain/kotlin/ai/koog/ktor/Koog.kt
+++ b/koog-ktor/src/commonMain/kotlin/ai/koog/ktor/Koog.kt
@@ -64,12 +64,7 @@ public class Koog(
             val job = Job(application.coroutineContext[Job])
             val scope = CoroutineScope(Dispatchers.SuitableForIO + job)
 
-            val config = try {
-                pipeline.environment.loadAgentsConfig(scope)
-            } catch (e: Exception) {
-                pipeline.environment.log.error("Failed to read Koog configuration from application config", e)
-                KoogAgentsConfig(scope)
-            }.apply(configure)
+            val config = resolveKoogConfig(pipeline, scope, configure)
 
             job.complete()
 
@@ -83,6 +78,36 @@ public class Koog(
                 config.agentFeatures,
                 job
             )
+        }
+
+        /**
+         * Resolves the effective Koog configuration used by the plugin.
+         *
+         * Behavior:
+         * - If the programmatic DSL (install(Koog) { ... }) explicitly configured at least one LLM connection,
+         *   this programmatic configuration is used as-is.
+         * - Otherwise, the configuration is loaded from the Ktor ApplicationConfig (application.yaml/application.conf)
+         *
+         * @param pipeline The Ktor application call pipeline (routing or application) providing access to the environment.
+         * @param scope The coroutine scope used to create KoogAgentsConfig and its internals.
+         * @param configure The programmatic Koog DSL block supplied by the user within install(Koog) { ... }.
+         * @return The resolved, final [KoogAgentsConfig] instance to be used by the plugin.
+         */
+        private fun resolveKoogConfig(
+            pipeline: ApplicationCallPipeline,
+            scope: CoroutineScope,
+            configure: KoogAgentsConfig.() -> Unit
+        ): KoogAgentsConfig {
+            val programmatic = KoogAgentsConfig(scope).apply(configure)
+            if (programmatic.llmConnections.isNotEmpty()) return programmatic
+
+            val env = try {
+                pipeline.environment.loadAgentsConfig(scope)
+            } catch (e: Exception) {
+                pipeline.environment.log.error("Failed to read Koog configuration from application config", e)
+                null
+            }
+            return (env ?: KoogAgentsConfig(scope)).apply(configure)
         }
 
         /**


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

Please add a brief description of the proposed change here.
Also, please tick the appropriate points in the checklist below.
-->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Using programmatic configuration still tries to read `application.yaml` even though properties are set using `llm()` DSL builder in `KoogAgentsConfig` resulting into an error

```
2025-09-01 22:42:45.723 [main] INFO  [Koin] - Started 2 definitions in 0.426 ms
2025-09-01 22:42:45.739 [main] ERROR Application - Failed to read Koog configuration from application config
io.ktor.server.config.ApplicationConfigurationException: Path koog.openai not found.
	at io.ktor.server.config.yaml.YamlConfig.config(YamlConfig.kt:84)
	at ai.koog.ktor.utils.EnvConfigLoaderKt.openAI(EnvConfigLoader.kt:109)
	at ai.koog.ktor.utils.EnvConfigLoaderKt.loadAgentsConfig(EnvConfigLoader.kt:22)
	at ai.koog.ktor.Koog$Companion.install(Koog.kt:68)
	at ai.koog.ktor.Koog$Companion.install(Koog.kt:56)
	at io.ktor.server.application.ApplicationPluginKt.install(ApplicationPlugin.kt:121)
	at com.lizz.application.plugins.KoogKt.configureKoog(Koog.kt:11)
	at com.lizz.application.ApplicationKt.module(Application.kt:13)
2025-09-01 22:42:45.791 [main] INFO  Application - Application started in 0.255 seconds.
2025-09-01 22:42:45.850 [main] INFO  Application - Responding at http://0.0.0.0:8080
```

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
