### PR TITLE
KG-312 Add Java-compatible prompt executor (non-streaming)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,37 +1,42 @@
 [versions]
 annotations = "26.0.2"
+assertj="3.27.4"
+aws-sdk-kotlin = "1.4.119"
+dokka = "2.0.0"
+jetsign = "45.47"
 junit = "5.8.2"
+knit = "0.5.0"
 kotlin = "2.1.21"
 kotlinx-coroutines = "1.10.2"
 kotlinx-datetime = "0.6.2"
 kotlinx-io = "0.7.0"
 kotlinx-serialization = "1.8.1" # check with IJ
+kover = "0.9.1"
+ktlint = "13.0.0"
 ktor3 = "3.2.2"
 lettuce = "6.5.5.RELEASE"
 logback = "1.5.13"
-oshai-logging = "7.0.7"
+mcp = "0.6.0"
+mockito="5.19.0"
 mockk = "1.13.8"
+opentelemetry = "1.51.0"
+oshai-logging = "7.0.7"
 shadow = "8.1.1"
 slf4j = "2.0.17"
-mcp = "0.6.0"
-dokka = "2.0.0"
-jetsign = "45.47"
-testcontainers = "1.19.7"
-kover = "0.9.1"
 spring-boot = "3.5.3"
 spring-management = "1.1.7"
-opentelemetry = "1.51.0"
-aws-sdk-kotlin = "1.4.119"
-ktlint = "13.0.0"
-knit = "0.5.0"
+testcontainers = "1.19.7"
 
 [libraries]
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "annotations" }
+mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
+assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-jdk8 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-reactive = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactive", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }

--- a/prompt/prompt-executor/prompt-executor-llms/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-llms/build.gradle.kts
@@ -32,11 +32,12 @@ kotlin {
                 implementation(libs.kotlinx.coroutines.test)
             }
         }
+
         jvmTest {
             dependencies {
-                implementation(kotlin("test-junit5"))
-
-                implementation(libs.ktor.client.cio)
+                implementation(project(":test-utils"))
+                implementation(libs.mockito.junit.jupiter)
+                implementation(libs.assertj.core)
             }
         }
     }

--- a/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/MockOpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/MockOpenAILLMClient.kt
@@ -1,0 +1,45 @@
+package ai.koog.prompt.executor.llms
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.prompt.dsl.ModerationResult
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.executor.clients.LLMClient
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.ResponseMetaInfo
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.datetime.Clock
+import kotlin.jvm.JvmOverloads
+
+internal class MockOpenAILLMClient @JvmOverloads constructor(
+    private val executeResponseContent: String = "OpenAI response",
+    private val throwException: Boolean = false,
+    private val clock: Clock = Clock.System,
+) : LLMClient {
+
+    override suspend fun execute(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>
+    ): List<Message.Response> {
+        if (throwException) {
+            error("Throw exception for test")
+        } else {
+            return listOf(
+                Message.Assistant(
+                    executeResponseContent,
+                    ResponseMetaInfo.create(clock)
+                )
+            )
+        }
+    }
+
+    override fun executeStreaming(prompt: Prompt, model: LLModel): Flow<String> {
+        return flowOf("OpenAI", " streaming", " response")
+    }
+
+    override suspend fun moderate(prompt: Prompt, model: LLModel): ModerationResult {
+        throw UnsupportedOperationException("Moderation is not supported by mock client.")
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/MultiLLMPromptExecutorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/MultiLLMPromptExecutorTest.kt
@@ -27,25 +27,6 @@ class MultiLLMPromptExecutorTest {
         override fun now(): Instant = Instant.parse("2023-01-01T00:00:00Z")
     }
 
-    // Mock client for OpenAI
-    private inner class MockOpenAILLMClient : LLMClient {
-        override suspend fun execute(
-            prompt: Prompt,
-            model: LLModel,
-            tools: List<ToolDescriptor>
-        ): List<Message.Response> {
-            return listOf(Message.Assistant("OpenAI response", ResponseMetaInfo.create(mockClock)))
-        }
-
-        override fun executeStreaming(prompt: Prompt, model: LLModel): Flow<String> {
-            return flowOf("OpenAI", " streaming", " response")
-        }
-
-        override suspend fun moderate(prompt: Prompt, model: LLModel): ModerationResult {
-            throw UnsupportedOperationException("Moderation is not supported by mock client.")
-        }
-    }
-
     // Mock client for Anthropic
     private inner class MockAnthropicLLMClient : LLMClient {
         override suspend fun execute(
@@ -53,7 +34,7 @@ class MultiLLMPromptExecutorTest {
             model: LLModel,
             tools: List<ToolDescriptor>
         ): List<Message.Response> {
-            return listOf(Message.Assistant("Anthropic response", ResponseMetaInfo.create(mockClock)))
+            return listOf(Message.Assistant("Anthropic response", ResponseMetaInfo.create(clock = mockClock)))
         }
 
         override fun executeStreaming(prompt: Prompt, model: LLModel): Flow<String> {
@@ -72,7 +53,7 @@ class MultiLLMPromptExecutorTest {
             model: LLModel,
             tools: List<ToolDescriptor>
         ): List<Message.Response> {
-            return listOf(Message.Assistant("Gemini response", ResponseMetaInfo.create(mockClock)))
+            return listOf(Message.Assistant("Gemini response", ResponseMetaInfo.create(clock = mockClock)))
         }
 
         override fun executeStreaming(prompt: Prompt, model: LLModel): Flow<String> {
@@ -87,7 +68,7 @@ class MultiLLMPromptExecutorTest {
     @Test
     fun testExecuteWithOpenAI() = runTest {
         val executor = MultiLLMPromptExecutor(
-            LLMProvider.OpenAI to MockOpenAILLMClient(),
+            LLMProvider.OpenAI to MockOpenAILLMClient(clock = mockClock),
             LLMProvider.Anthropic to MockAnthropicLLMClient(),
             LLMProvider.Google to MockGoogleLLMClient()
         )
@@ -106,7 +87,7 @@ class MultiLLMPromptExecutorTest {
     @Test
     fun testExecuteWithAnthropic() = runTest {
         val executor = MultiLLMPromptExecutor(
-            LLMProvider.OpenAI to MockOpenAILLMClient(),
+            LLMProvider.OpenAI to MockOpenAILLMClient(clock = mockClock),
             LLMProvider.Anthropic to MockAnthropicLLMClient(),
             LLMProvider.Google to MockGoogleLLMClient()
         )
@@ -125,7 +106,7 @@ class MultiLLMPromptExecutorTest {
     @Test
     fun testExecuteWithGoogle() = runTest {
         val executor = MultiLLMPromptExecutor(
-            LLMProvider.OpenAI to MockOpenAILLMClient(),
+            LLMProvider.OpenAI to MockOpenAILLMClient(clock = mockClock),
             LLMProvider.Anthropic to MockAnthropicLLMClient(),
             LLMProvider.Google to MockGoogleLLMClient()
         )
@@ -144,7 +125,7 @@ class MultiLLMPromptExecutorTest {
     @Test
     fun testExecuteStreamingWithOpenAI() = runTest {
         val executor = MultiLLMPromptExecutor(
-            LLMProvider.OpenAI to MockOpenAILLMClient(),
+            LLMProvider.OpenAI to MockOpenAILLMClient(clock = mockClock),
             LLMProvider.Anthropic to MockAnthropicLLMClient(),
             LLMProvider.Google to MockGoogleLLMClient()
         )
@@ -167,7 +148,7 @@ class MultiLLMPromptExecutorTest {
     @Test
     fun testExecuteStreamingWithAnthropic() = runTest {
         val executor = MultiLLMPromptExecutor(
-            LLMProvider.OpenAI to MockOpenAILLMClient(),
+            LLMProvider.OpenAI to MockOpenAILLMClient(clock = mockClock),
             LLMProvider.Anthropic to MockAnthropicLLMClient(),
             LLMProvider.Google to MockGoogleLLMClient()
         )
@@ -190,7 +171,7 @@ class MultiLLMPromptExecutorTest {
     @Test
     fun testExecuteStreamingWithGoogle() = runTest {
         val executor = MultiLLMPromptExecutor(
-            LLMProvider.OpenAI to MockOpenAILLMClient(),
+            LLMProvider.OpenAI to MockOpenAILLMClient(clock = mockClock),
             LLMProvider.Anthropic to MockAnthropicLLMClient(),
             LLMProvider.Google to MockGoogleLLMClient()
         )
@@ -227,7 +208,7 @@ class MultiLLMPromptExecutorTest {
 
     @Test
     fun testExecuteStreamingWithUnsupportedProvider() = runTest {
-        val executor = MultiLLMPromptExecutor(LLMProvider.OpenAI to MockOpenAILLMClient())
+        val executor = MultiLLMPromptExecutor(LLMProvider.OpenAI to MockOpenAILLMClient(clock = mockClock))
         val model = AnthropicModels.Sonnet_3_7
         val prompt = Prompt.build("test-prompt") {
             system("You are a helpful assistant.")

--- a/prompt/prompt-executor/prompt-executor-llms/src/jvmMain/kotlin/ai/koog/prompt/executor/llms/Executors.kt
+++ b/prompt/prompt-executor/prompt-executor-llms/src/jvmMain/kotlin/ai/koog/prompt/executor/llms/Executors.kt
@@ -1,0 +1,63 @@
+package ai.koog.prompt.executor.llms
+
+import ai.koog.prompt.executor.clients.LLMClient
+import ai.koog.prompt.executor.model.JavaPromptExecutor
+import ai.koog.prompt.llm.LLMProvider
+import org.jetbrains.annotations.ApiStatus
+
+/**
+ * Provides utility methods for creating instances of `JavaPromptExecutor`.
+ *
+ * The `Executors` object is designed to simplify the process of configuring and initializing
+ * prompt executors that interact with Large Language Model (LLM) clients. It supports both
+ * single and multiple LLM providers, enabling flexibility in execution configurations.
+ *
+ * This utility ensures that appropriate `JavaPromptExecutor` instances are created with
+ * the required delegates or configurations.
+ *
+ * Note: This API is experimental and may change in future versions.
+ */
+@ApiStatus.Experimental
+public object Executors {
+
+    /**
+     * Creates a new instance of `JavaPromptExecutor` using the provided map of LLM clients.
+     * The `JavaPromptExecutor` is configured with a delegated instance of `MultiLLMPromptExecutor`
+     * to handle prompts across multiple LLM providers.
+     *
+     * @param llmClients A map where keys are `LLMProvider` instances representing the language model providers
+     *                   and values are `LLMClient` instances for interacting with the respective providers.
+     * @return A configured `JavaPromptExecutor` instance ready to handle prompt execution.
+     */
+    @JvmStatic
+    @ApiStatus.Experimental
+    public fun promptExecutor(llmClients: Map<LLMProvider, LLMClient>): JavaPromptExecutor =
+        JavaPromptExecutor(
+            delegate = MultiLLMPromptExecutor(llmClients)
+        )
+
+    /**
+     * Creates an instance of [JavaPromptExecutor] by associating a specific [LLMProvider] with an [LLMClient].
+     *
+     * @param llmProvider The `LLMProvider` instance specifying the large language model provider.
+     * @param llmClient The `LLMClient` instance used to execute prompts and interact with the specified provider.
+     * @return A `JavaPromptExecutor` configured with the given provider and client.
+     */
+    @JvmStatic
+    @ApiStatus.Experimental
+    public fun promptExecutor(llmProvider: LLMProvider, llmClient: LLMClient): JavaPromptExecutor =
+        promptExecutor(mapOf(llmProvider to llmClient))
+
+    /**
+     * Creates and returns a Java-friendly prompt executor that delegates prompt execution
+     * to a [SingleLLMPromptExecutor].
+     *
+     * @param llmClient The client used for direct communication with a large language model (LLM) provider.
+     * @return An instance of [JavaPromptExecutor] that wraps a [SingleLLMPromptExecutor].
+     */
+    @JvmStatic
+    public fun promptExecutor(llmClient: LLMClient): JavaPromptExecutor =
+        JavaPromptExecutor(
+            delegate = SingleLLMPromptExecutor(llmClient)
+        )
+}

--- a/prompt/prompt-executor/prompt-executor-llms/src/jvmTest/java/ai/koog/prompt/executor/llms/ExecutorsTest.java
+++ b/prompt/prompt-executor/prompt-executor-llms/src/jvmTest/java/ai/koog/prompt/executor/llms/ExecutorsTest.java
@@ -1,0 +1,129 @@
+package ai.koog.prompt.executor.llms;
+
+import ai.koog.prompt.dsl.Prompt;
+import ai.koog.prompt.executor.clients.LLMClient;
+import ai.koog.prompt.executor.model.JavaPromptExecutor;
+import ai.koog.prompt.llm.LLMProvider;
+import ai.koog.prompt.llm.LLModel;
+import ai.koog.prompt.message.Message;
+import ai.koog.prompt.message.RequestMetaInfo;
+import ai.koog.prompt.params.LLMParams;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ExecutorsTest {
+
+    @Mock(strictness = Mock.Strictness.LENIENT)
+    LLModel model;
+
+    LLMProvider provider = mock(LLMProvider.class);
+
+    LLMClient llmClient = new MockOpenAILLMClient("Hello from LLM");
+    LLMClient failingClient = new MockOpenAILLMClient("Hello from LLM", true);
+
+    Iterable<JavaPromptExecutor> promptExecutors() {
+        return List.of(
+            Executors.promptExecutor(provider, llmClient),
+            Executors.promptExecutor(Map.of(provider, llmClient)),
+            Executors.promptExecutor(llmClient)
+        );
+    }
+
+    Iterable<JavaPromptExecutor> failingPromptExecutors() {
+        return List.of(
+            Executors.promptExecutor(provider, failingClient),
+            Executors.promptExecutor(Map.of(provider, failingClient)),
+            Executors.promptExecutor(failingClient)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("promptExecutors")
+    void shouldExecutePromptAsync(JavaPromptExecutor promptExecutor) {
+        when(model.getProvider()).thenReturn(provider);
+        // given
+        assertThat(promptExecutor).isNotNull();
+
+        final var requestMeta = RequestMetaInfo.Companion.getEmpty();
+
+        final var systemMessage = new Message.System(
+            "You are helpful assistant", requestMeta);
+
+        final var userMessage = new Message.User(
+            "Say Hello", requestMeta);
+
+        final Prompt prompt = new Prompt(
+            List.of(systemMessage, userMessage),
+            UUID.randomUUID().toString(),
+            new LLMParams()
+        );
+
+        // when
+        final var future = promptExecutor.executeAsync(prompt, model);
+
+        // then
+        assertThat(future)
+            .succeedsWithin(Duration.ofSeconds(1))
+            .satisfies(responses -> {
+                    assertThat(responses)
+                        .hasSize(1)
+                        .first().satisfies(assistantResponse -> {
+                            assertThat(assistantResponse)
+                                .isNotNull()
+                                .isInstanceOf(Message.Assistant.class);
+                            assertThat(assistantResponse.getRole()).isEqualTo(Message.Role.Assistant);
+                            assertThat(assistantResponse.getContent()).isEqualTo("Hello from LLM");
+                        });
+                }
+            );
+    }
+
+    @ParameterizedTest
+    @MethodSource("failingPromptExecutors")
+    void shouldExecutePromptAsyncWithError(JavaPromptExecutor promptExecutor) {
+        when(model.getProvider()).thenReturn(provider);
+        // given
+        assertThat(promptExecutor).isNotNull();
+
+        final var requestMeta = RequestMetaInfo.Companion.getEmpty();
+
+        final var systemMessage = new Message.System(
+            "You are helpful assistant", requestMeta);
+
+        final var userMessage = new Message.User(
+            "Say Hello", requestMeta);
+
+        final Prompt prompt = new Prompt(
+            List.of(systemMessage, userMessage),
+            UUID.randomUUID().toString(),
+            new LLMParams()
+        );
+
+        // when
+        final var future = promptExecutor.executeAsync(prompt, model);
+
+        // then
+        assertThat(future)
+            .completesExceptionallyWithin(Duration.ofSeconds(1))
+            .withThrowableThat().satisfies(throwable -> {
+                assertThat(throwable).isInstanceOf(ExecutionException.class);
+                assertThat(throwable).hasRootCauseMessage("Throw exception for test");
+            });
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-model/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-model/build.gradle.kts
@@ -17,6 +17,12 @@ kotlin {
                 api(libs.oshai.kotlin.logging)
             }
         }
+
+        jvmMain {
+            dependencies {
+                api(libs.kotlinx.coroutines.jdk8)
+            }
+        }
     }
 
     explicitApi()

--- a/prompt/prompt-executor/prompt-executor-model/src/jvmMain/kotlin/ai/koog/prompt/executor/model/JavaPromptExecutor.kt
+++ b/prompt/prompt-executor/prompt-executor-model/src/jvmMain/kotlin/ai/koog/prompt/executor/model/JavaPromptExecutor.kt
@@ -1,0 +1,48 @@
+package ai.koog.prompt.executor.model
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.Message
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.future.future
+import org.jetbrains.annotations.ApiStatus
+import java.util.concurrent.CompletableFuture
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * A wrapper for [PromptExecutor] that exposes a Java-friendly API.
+ *
+ * @property delegate The [PromptExecutor] instance to wrap.
+ * @constructor Creates a new [JavaPromptExecutor] instance.
+ */
+@ApiStatus.Experimental
+public class JavaPromptExecutor(
+    private val delegate: PromptExecutor
+) : PromptExecutor by delegate {
+
+    /**
+     * Executes the given prompt asynchronously using the specified model and tools.
+     *
+     * @param prompt The prompt input to be executed.
+     * @param model The language model to process the prompt.
+     * @param tools An optional list of tool descriptors that may assist in processing the prompt.
+     * @param coroutineContext The coroutine context to execute the operation, defaulting to `Dispatchers.IO`.
+     * @return A CompletableFuture containing a list of response messages produced by the execution.
+     */
+    @JvmOverloads
+    public fun executeAsync(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor> = emptyList(),
+        coroutineContext: CoroutineContext = Dispatchers.IO
+    ): CompletableFuture<List<Message.Response>> = CoroutineScope(coroutineContext).future {
+        execute(prompt, model, tools)
+    }
+}
+
+/**
+ * Converts a [PromptExecutor] instance to a [JavaPromptExecutor] instance.
+ */
+public fun PromptExecutor.asJava(): JavaPromptExecutor = JavaPromptExecutor(delegate = this)

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/Prompt.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/Prompt.kt
@@ -6,6 +6,7 @@ import ai.koog.prompt.params.LLMParams.Schema
 import ai.koog.prompt.params.LLMParams.ToolChoice
 import kotlinx.datetime.Clock
 import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmOverloads
 import kotlin.time.Duration
 
 /**
@@ -18,7 +19,7 @@ import kotlin.time.Duration
  */
 // FIXME move it from dsl package up to the module root package?
 @Serializable
-public data class Prompt(
+public data class Prompt @JvmOverloads constructor(
     val messages: List<Message>,
     val id: String,
     val params: LLMParams = LLMParams()
@@ -46,6 +47,7 @@ public data class Prompt(
          * @param init The initialization logic applied to the `PromptBuilder`.
          * @return The constructed `Prompt` object.
          */
+        @JvmOverloads
         public fun build(
             id: String,
             params: LLMParams = LLMParams(),

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
+import kotlin.jvm.JvmOverloads
 
 /**
  * Represents a message exchanged in a chat with LLM. Messages can be categorized
@@ -107,10 +108,10 @@ public sealed interface Message {
      * @property role The role of the message, which is fixed as [Role.User] for this implementation.
      */
     @Serializable
-    public data class User(
+    public data class User @JvmOverloads constructor(
         override val content: String,
         override val metaInfo: RequestMetaInfo,
-        override val attachments: List<Attachment> = emptyList(),
+        override val attachments: List<Attachment> = emptyList()
     ) : Request, WithAttachments {
         override val role: Role = Role.User
     }

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -19,8 +19,7 @@ kotlin {
         jvmMain {
             dependencies {
                 api(kotlin("test-junit5"))
-                implementation(libs.junit.jupiter.params)
-                implementation(libs.kotlinx.coroutines.test)
+                api(libs.junit.jupiter.params)
             }
         }
     }


### PR DESCRIPTION
Add Java-compatible prompt executor and refactor tests to mock OpenAI client

## Motivation and Context

Calling Koog Api from Java is not easy because of Coroutines API (KG-312)
**NB! Supports only non-streaming API yet**. Streaming api will be supported in the separate PR

## Changes

- Introduced `JavaPromptExecutor` to expose a Java-friendly API for prompt execution. 
- Enhanced `Prompt` and `Message` data classes with `@JvmOverloads` for improved interop with Java.
- Moved mock OpenAI client (`MockOpenAILLMClient`) for unit testing prompt execution.
- Updated `build.gradle.kts` to include new dependencies: Mockito and AssertJ.
- Refactored `MultiLLMPromptExecutorTest` to reuse mock OpenAI client with configurable `Clock`.

---

#### Type of the changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tests improvement
- [x] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists KG-312
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
