### PR TITLE
fix: Inefficient agent creation in `aiAgent` function

### DIFF
--- a/koog-ktor/src/commonMain/kotlin/ai/koog/ktor/Agents.kt
+++ b/koog-ktor/src/commonMain/kotlin/ai/koog/ktor/Agents.kt
@@ -37,14 +37,14 @@ public suspend fun <Input, Output> RoutingContext.aiAgent(
     tools: ToolRegistry = ToolRegistry.EMPTY,
 ): AIAgent<Input, Output> {
     val plugin = requireNotNull(call.application.pluginOrNull(Koog)) { "Plugin $Koog is not configured" }
-
+    val agentConfig = plugin.agentConfig(model)
     return GraphAIAgent(
         inputType = inputType,
         outputType = outputType,
         promptExecutor = plugin.promptExecutor,
         strategy = strategy,
-        agentConfig = plugin.agentConfig(model),
-        toolRegistry = plugin.agentConfig.toolRegistry + tools,
+        agentConfig = agentConfig,
+        toolRegistry = agentConfig.toolRegistry + tools,
     ) {
         for (feature in plugin.agentFeatures) {
             this.feature()


### PR DESCRIPTION
Please add a brief description of the proposed change here.
An inefficiency in Agents.kt. The aiAgent function calls plugin.agentConfig(model) twice. I have corrected this by storing the result in a variable, agentConfig, and then using that variable in the AIAgent constructor.

## Motivation and Context
An inefficiency in Agents.kt. The aiAgent function calls plugin.agentConfig(model) twice. I have corrected this by storing the result in a variable, agentConfig, and then using that variable in the AIAgent constructor.

## Breaking Changes
None.
---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
