### PR TITLE
KG-162. Add tokens usage information for inference span in OTel

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/SpanAttributes.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/SpanAttributes.kt
@@ -254,6 +254,13 @@ internal object SpanAttributes {
             override val key: String = super.key.concatKey("output_tokens")
             override val value: Int = tokens
         }
+
+        // gen_ai.usage.total_tokens
+        // Note: Non-semantic attribute
+        data class TotalTokens(private val tokens: Int) : Usage {
+            override val key: String = super.key.concatKey("total_tokens")
+            override val value: Int = tokens
+        }
     }
 
     // gen_ai.tool

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/Utils.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/Utils.kt
@@ -51,6 +51,22 @@ internal inline fun <reified TBodyField> GenAIAgentSpan.replaceBodyFields(
     eventBodyFields.forEach { bodyField -> event.removeBodyField(bodyField) }
 }
 
+internal inline fun <reified TAttribute : Attribute> GenAIAgentSpan.replaceAttributes(
+    processAttributeAction: GenAIAgentSpan.(TAttribute) -> Attribute
+) {
+    val attributesToReplace = this.attributes.filterIsInstance<TAttribute>()
+
+    if (attributesToReplace.isEmpty()) {
+        return
+    }
+
+    attributesToReplace.forEach { attributeToReplace ->
+        val newAttribute = processAttributeAction(attributeToReplace)
+        removeAttribute(attributeToReplace)
+        addAttribute(newAttribute)
+    }
+}
+
 internal val Any.isSdkArrayPrimitive
     get() = this is HiddenString ||
         this is CharSequence ||

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/weave/WeaveSpanAdapter.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/weave/WeaveSpanAdapter.kt
@@ -1,6 +1,7 @@
 package ai.koog.agents.features.opentelemetry.integration.weave
 
 import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
+import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
 import ai.koog.agents.features.opentelemetry.event.AssistantMessageEvent
 import ai.koog.agents.features.opentelemetry.event.ChoiceEvent
 import ai.koog.agents.features.opentelemetry.event.EventBodyFields
@@ -12,6 +13,7 @@ import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryConfig
 import ai.koog.agents.features.opentelemetry.integration.SpanAdapter
 import ai.koog.agents.features.opentelemetry.integration.bodyFieldsToCustomAttribute
 import ai.koog.agents.features.opentelemetry.integration.isSdkArrayPrimitive
+import ai.koog.agents.features.opentelemetry.integration.replaceAttributes
 import ai.koog.agents.features.opentelemetry.integration.replaceBodyFields
 import ai.koog.agents.features.opentelemetry.span.GenAIAgentSpan
 import ai.koog.agents.features.opentelemetry.span.InferenceSpan
@@ -137,6 +139,15 @@ internal class WeaveSpanAdapter(private val openTelemetryConfig: OpenTelemetryCo
     }
 
     private fun AssistantMessageEvent.convertToCompletion(span: InferenceSpan, index: Int) {
+        // Convert token attributes to Weave format
+        span.replaceAttributes<SpanAttributes.Usage.InputTokens> { attribute ->
+            CustomAttribute("gen_ai.usage.prompt_tokens", attribute.value)
+        }
+
+        span.replaceAttributes<SpanAttributes.Usage.OutputTokens> { attribute ->
+            CustomAttribute("gen_ai.usage.completion_tokens", attribute.value)
+        }
+
         // Convert event data fields into the span attributes
         span.bodyFieldsToCustomAttribute<EventBodyFields.Role>(this) { role ->
             CustomAttribute("gen_ai.completion.$index.${role.key}", role.value)
@@ -176,6 +187,15 @@ internal class WeaveSpanAdapter(private val openTelemetryConfig: OpenTelemetryCo
     }
 
     private fun ChoiceEvent.convertToCompletion(span: InferenceSpan, index: Int) {
+        // Convert tokens attributes to Weave format
+        span.replaceAttributes<SpanAttributes.Usage.InputTokens> { attribute ->
+            CustomAttribute("gen_ai.usage.prompt_tokens", attribute.value)
+        }
+
+        span.replaceAttributes<SpanAttributes.Usage.OutputTokens> { attribute ->
+            CustomAttribute("gen_ai.usage.completion_tokens", attribute.value)
+        }
+
         // Convert event data fields into the span attributes
         span.bodyFieldsToCustomAttribute<EventBodyFields.Role>(this) { role ->
             // Weave expects to have an assistant message for correct displaying the responses from LLM.

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/GenAIAgentSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/GenAIAgentSpan.kt
@@ -96,6 +96,11 @@ internal abstract class GenAIAgentSpan(
         _attributes.addAll(attributes)
     }
 
+    fun removeAttribute(attribute: Attribute): Boolean {
+        logger.debug { "Removing attribute from span (name: $name, id: $spanId): ${attribute.key}" }
+        return _attributes.remove(attribute)
+    }
+
     fun addEvent(event: GenAIAgentEvent) {
         logger.debug { "Adding event to span (name: $name, id: $spanId): ${event.name}" }
         _events.add(event)

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/InferenceSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/InferenceSpan.kt
@@ -14,8 +14,9 @@ internal class InferenceSpan(
     provider: LLMProvider,
     runId: String,
     model: LLModel,
+    promptId: String,
     temperature: Double,
-    private val promptId: String,
+    maxTokens: Int? = null
 ) : GenAIAgentSpan(parent) {
 
     companion object {
@@ -73,5 +74,10 @@ internal class InferenceSpan(
 
         // gen_ai.request.temperature
         addAttribute(SpanAttributes.Request.Temperature(temperature))
+
+        // gen_ai.request.max_tokens
+        maxTokens?.let {
+            addAttribute(SpanAttributes.Request.MaxTokens(it))
+        }
     }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestAPI.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestAPI.kt
@@ -26,13 +26,21 @@ internal object OpenTelemetryTestAPI {
         model: LLModel? = null,
         clock: Clock = Clock.System,
         temperature: Double? = 0.0,
+        maxTokens: Int? = null,
         systemPrompt: String? = null,
         userPrompt: String? = null,
         assistantPrompt: String? = null,
         installFeatures: GraphAIAgent.FeatureContext.() -> Unit = { }
     ): AIAgent<String, String> {
         val agentConfig = AIAgentConfig(
-            prompt = prompt(promptId ?: "Test prompt", clock = clock, params = LLMParams(temperature = temperature)) {
+            prompt = prompt(
+                id = promptId ?: "Test prompt",
+                clock = clock,
+                params = LLMParams(
+                    temperature = temperature,
+                    maxTokens = maxTokens
+                )
+            ) {
                 systemPrompt?.let { system(systemPrompt) }
                 userPrompt?.let { user(userPrompt) }
                 assistantPrompt?.let { assistant(assistantPrompt) }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/UtilsTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/UtilsTest.kt
@@ -1,0 +1,322 @@
+package ai.koog.agents.features.opentelemetry.integration
+
+import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
+import ai.koog.agents.features.opentelemetry.event.EventBodyFields
+import ai.koog.agents.features.opentelemetry.mock.MockAttribute
+import ai.koog.agents.features.opentelemetry.mock.MockEventBodyField
+import ai.koog.agents.features.opentelemetry.mock.MockGenAIAgentEvent
+import ai.koog.agents.features.opentelemetry.mock.MockGenAIAgentSpan
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class UtilsTest {
+
+    //region bodyFieldsToCustomAttribute
+
+    @Test
+    fun `test bodyFieldsToCustomAttribute convert matching body fields into attributes`() {
+        val span = MockGenAIAgentSpan(spanId = "test-span-id")
+
+        val bodyFieldId = EventBodyFields.Id("id-body-field")
+        val bodyFieldContent = EventBodyFields.Content("content-body-field")
+        val mockBodyField = MockEventBodyField("mock-body-field-key", "mock-body-field-value")
+
+        val originalEvent = MockGenAIAgentEvent(
+            name = "event",
+            fields = listOf(bodyFieldId, bodyFieldContent, mockBodyField)
+        )
+
+        span.addEvent(originalEvent)
+
+        span.bodyFieldsToCustomAttribute<EventBodyFields.Content>(originalEvent) { field ->
+            CustomAttribute("new.${field.key}", "new.${field.value}")
+        }
+
+        val expectedAttributes = listOf(
+            CustomAttribute("new.${bodyFieldContent.key}", "new.${bodyFieldContent.value}"),
+        )
+
+        val actualAttributes = span.attributes
+
+        assertEquals(expectedAttributes.size, actualAttributes.size)
+        assertContentEquals(expectedAttributes, actualAttributes)
+
+        val expectedEvents = listOf(originalEvent)
+        val actualEvents = span.events
+
+        assertEquals(expectedEvents.size, actualEvents.size)
+        assertContentEquals(expectedEvents, actualEvents)
+
+        val expectedBodyFields = listOf(bodyFieldId, mockBodyField)
+        val actualBodyFields = originalEvent.bodyFields
+
+        assertEquals(expectedBodyFields.size, actualBodyFields.size)
+        assertContentEquals(expectedBodyFields, actualBodyFields)
+    }
+
+    @Test
+    fun `test bodyFieldsToCustomAttribute does nothing when there are no matching fields`() {
+        val span = MockGenAIAgentSpan(spanId = "test-span-id")
+
+        val mockEventBody1 = MockEventBodyField("mock-event-body-field-key-1", "mock-event-body-field-value-1")
+        val mockEventBody2 = MockEventBodyField("mock-event-body-field-key-2", 42)
+
+        val originalEvent = MockGenAIAgentEvent(
+            name = "event",
+            fields = listOf(mockEventBody1, mockEventBody2)
+        )
+
+        span.addEvent(originalEvent)
+
+        span.bodyFieldsToCustomAttribute<EventBodyFields.Content>(originalEvent) { field ->
+            CustomAttribute("new.${field.key}", field.value)
+        }
+
+        val actualAttributes = span.attributes
+        val expectedAttributes = emptyList<CustomAttribute>()
+
+        assertEquals(expectedAttributes.size, actualAttributes.size)
+        assertContentEquals(expectedAttributes, actualAttributes)
+
+        val actualEvents = span.events
+        val expectedEvents = listOf(originalEvent)
+
+        assertEquals(expectedEvents.size, actualEvents.size)
+        assertContentEquals(expectedEvents, actualEvents)
+
+        val actualBodyFields = originalEvent.bodyFields
+        val expectedBodyFields = listOf(mockEventBody1, mockEventBody2)
+
+        assertEquals(expectedBodyFields.size, actualBodyFields.size)
+        assertContentEquals(expectedBodyFields, actualBodyFields)
+    }
+
+    //endregion bodyFieldsToCustomAttribute
+
+    //region replaceBodyFields
+
+    @Test
+    fun `test replaceBodyFields processes each matching field and removes them from event`() {
+        val span = MockGenAIAgentSpan(spanId = "test-span-id")
+
+        val bodyFieldId = EventBodyFields.Id("id-body-field")
+        val bodyFieldContent = EventBodyFields.Content("content-body-field")
+        val mockBodyField = MockEventBodyField("mock-body-field-key", "mock-body-field-value")
+
+        val originalEvent = MockGenAIAgentEvent(
+            name = "event",
+            fields = listOf(bodyFieldId, bodyFieldContent, mockBodyField)
+        )
+
+        span.addEvent(originalEvent)
+
+        span.replaceBodyFields<EventBodyFields.Content>(originalEvent) { bodyField ->
+            addAttribute(CustomAttribute("new.${bodyField.key}", "new.${bodyField.value}"))
+        }
+
+        val actualAttributes = span.attributes
+        val expectedAttributes = listOf(
+            CustomAttribute("new.${bodyFieldContent.key}", "new.${bodyFieldContent.value}"),
+        )
+
+        assertEquals(expectedAttributes.size, actualAttributes.size)
+        assertContentEquals(expectedAttributes, actualAttributes)
+
+        val actualEvents = span.events
+        val expectedEvents = listOf(originalEvent)
+
+        assertEquals(expectedEvents.size, actualEvents.size)
+        assertContentEquals(expectedEvents, actualEvents)
+
+        val actualBodyFields = originalEvent.bodyFields
+        val expectedBodyFields = listOf(bodyFieldId, mockBodyField)
+
+        assertEquals(expectedBodyFields.size, actualBodyFields.size)
+        assertContentEquals(expectedBodyFields, actualBodyFields)
+    }
+
+    @Test
+    fun `test replaceBodyFields replace multiple fields`() {
+        val span = MockGenAIAgentSpan(spanId = "test-span-id")
+
+        val bodyFieldContent = EventBodyFields.Content("content-body-field")
+        val mockBodyField1 = MockEventBodyField("mock-body-field-key-1", "mock-body-field-value-1")
+        val mockBodyField2 = MockEventBodyField("mock-body-field-key-2", "mock-body-field-value-2")
+
+        val originalEvent = MockGenAIAgentEvent(
+            name = "event",
+            fields = listOf(bodyFieldContent, mockBodyField1, mockBodyField2)
+        )
+
+        span.addEvent(originalEvent)
+
+        span.replaceBodyFields<MockEventBodyField>(originalEvent) { bodyField ->
+            addAttribute(CustomAttribute("new.${bodyField.key}", "new.${bodyField.value}"))
+        }
+
+        val actualAttributes = span.attributes
+        val expectedAttributes = listOf(
+            CustomAttribute("new.${mockBodyField1.key}", "new.${mockBodyField1.value}"),
+            CustomAttribute("new.${mockBodyField2.key}", "new.${mockBodyField2.value}"),
+        )
+
+        assertEquals(expectedAttributes.size, actualAttributes.size)
+        assertContentEquals(expectedAttributes, actualAttributes)
+
+        val actualEvents = span.events
+        val expectedEvents = listOf(originalEvent)
+
+        assertEquals(expectedEvents.size, actualEvents.size)
+        assertContentEquals(expectedEvents, actualEvents)
+
+        val actualBodyFields = originalEvent.bodyFields
+        val expectedBodyFields = listOf(bodyFieldContent)
+
+        assertEquals(expectedBodyFields.size, actualBodyFields.size)
+        assertContentEquals(expectedBodyFields, actualBodyFields)
+    }
+
+    @Test
+    fun `replaceBodyFields does nothing when there are no matching fields`() {
+        val span = MockGenAIAgentSpan(spanId = "test-span-id")
+
+        val mockBodyField1 = MockEventBodyField("mock-body-field-key-1", "mock-body-field-value-1")
+        val mockBodyField2 = MockEventBodyField("mock-body-field-key-2", "mock-body-field-value-2")
+
+        val originalEvent = MockGenAIAgentEvent(
+            name = "event",
+            fields = listOf(mockBodyField1, mockBodyField2)
+        )
+
+        span.addEvent(originalEvent)
+
+        span.replaceBodyFields<EventBodyFields.Content>(originalEvent) { bodyField ->
+            addAttribute(CustomAttribute("new.${bodyField.key}", "new.${bodyField.value}"))
+        }
+
+        val actualAttributes = span.attributes
+        val expectedAttributes = emptyList<CustomAttribute>()
+
+        assertEquals(expectedAttributes.size, actualAttributes.size)
+        assertContentEquals(expectedAttributes, actualAttributes)
+
+        val actualEvents = span.events
+        val expectedEvents = listOf(originalEvent)
+
+        assertEquals(expectedEvents.size, actualEvents.size)
+        assertContentEquals(expectedEvents, actualEvents)
+
+        val actualBodyFields = originalEvent.bodyFields
+        val expectedBodyFields = listOf(mockBodyField1, mockBodyField2)
+
+        assertEquals(expectedBodyFields.size, actualBodyFields.size)
+    }
+
+    //endregion replaceBodyFields
+
+    //region replaceAttributes
+
+    @Test
+    fun `test replace attributes when span has no attribute`() {
+        val span = MockGenAIAgentSpan(spanId = "test-span-id")
+
+        span.replaceAttributes<CustomAttribute> { _ ->
+            CustomAttribute("newKey", "newValue")
+        }
+
+        assertEquals(0, span.attributes.size)
+    }
+
+    @Test
+    fun `test replace attributes when multiple attributes of different types exist`() {
+        val span = MockGenAIAgentSpan(spanId = "test-span-id")
+
+        val customAttribute = CustomAttribute("customAttributeKey", "customAttributeValue")
+        val mockAttribute = MockAttribute("mockAttributeKey", 123)
+        span.addAttributes(listOf(customAttribute, mockAttribute))
+
+        val newAttribute = CustomAttribute("newAttributeKey", "newAttributeValue")
+
+        span.replaceAttributes<CustomAttribute> { _ ->
+            newAttribute
+        }
+
+        val expectedAttributes = listOf(mockAttribute, newAttribute)
+        val actualAttributes = span.attributes
+
+        assertEquals(expectedAttributes.size, actualAttributes.size)
+        assertContentEquals(expectedAttributes, actualAttributes)
+    }
+
+    @Test
+    fun `test replace attributes when span has no attributes of expected type`() {
+        val span = MockGenAIAgentSpan(spanId = "test-span-id")
+
+        val originalAttribute = MockAttribute("mockAttributeKey", "mockAttributeValue")
+        span.addAttribute(originalAttribute)
+
+        span.replaceAttributes<CustomAttribute> { _ ->
+            CustomAttribute("customAttributeKey", "customAttributeValue")
+        }
+
+        val expectedAttributes = listOf(originalAttribute)
+        val actualAttributes = span.attributes
+
+        assertEquals(expectedAttributes.size, actualAttributes.size)
+        assertContentEquals(expectedAttributes, actualAttributes)
+    }
+
+    @Test
+    fun `test replace single attribute when span has one attribute`() {
+        val span = MockGenAIAgentSpan(spanId = "test-span-id")
+
+        val originalAttribute = CustomAttribute("customAttributeKey", "customAttributeValue")
+        span.addAttribute(originalAttribute)
+
+        val newAttribute = CustomAttribute("newCustomAttributeKey", "newCustomAttributeValue")
+
+        span.replaceAttributes<CustomAttribute> { _ ->
+            newAttribute
+        }
+
+        val expectedAttributes = listOf(newAttribute)
+        val actualAttributes = span.attributes
+
+        assertEquals(expectedAttributes.size, actualAttributes.size)
+        assertContentEquals(expectedAttributes, actualAttributes)
+    }
+
+    @Test
+    fun `test replace single attribute when more than one attribute exist`() {
+        val span = MockGenAIAgentSpan(spanId = "test-span-id")
+
+        val customAttribute1 = CustomAttribute("customAttributeKey1", "customAttributeValue1")
+        val customAttribute2 = CustomAttribute("customAttributeKey2", "customAttributeValue2")
+        val actualAttributes = listOf(customAttribute1, customAttribute2)
+        span.addAttributes(actualAttributes)
+
+        val newCustomAttribute = CustomAttribute("newCustomAttributeKey", "newCustomAttributeValue")
+        val newMockAttribute = MockAttribute("newMockAttributeKey", "newMockAttributeValue")
+
+        span.replaceAttributes<CustomAttribute> { existingAttribute ->
+            if (existingAttribute.key == customAttribute1.key) {
+                return@replaceAttributes newCustomAttribute
+            }
+
+            if (existingAttribute.key == customAttribute2.key) {
+                return@replaceAttributes newMockAttribute
+            }
+
+            existingAttribute
+        }
+
+        val expectedAttributes = listOf(newCustomAttribute, newMockAttribute)
+        val actualAttributesAfterReplacement = span.attributes
+
+        assertEquals(expectedAttributes.size, actualAttributesAfterReplacement.size)
+        assertContentEquals(expectedAttributes, actualAttributesAfterReplacement)
+    }
+
+    //endregion replaceAttributes
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseTraceStructureTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseTraceStructureTest.kt
@@ -29,6 +29,7 @@ class LangfuseTraceStructureTest :
         "gen_ai.operation.name" to "chat",
         "gen_ai.request.temperature" to temperature,
         "gen_ai.request.model" to model.id,
+        "gen_ai.request.model" to model.id,
         "gen_ai.response.finish_reasons" to listOf(SpanAttributes.Response.FinishReasonType.ToolCalls.id),
 
         "gen_ai.prompt.0.role" to Message.Role.System.name.lowercase(),
@@ -56,6 +57,68 @@ class LangfuseTraceStructureTest :
         "gen_ai.request.temperature" to temperature,
         "gen_ai.request.model" to model.id,
         "gen_ai.response.finish_reasons" to listOf(SpanAttributes.Response.FinishReasonType.Stop.id),
+
+        "gen_ai.prompt.0.role" to Message.Role.System.name.lowercase(),
+        "gen_ai.prompt.0.content" to systemPrompt,
+        "gen_ai.prompt.1.role" to Message.Role.User.name.lowercase(),
+        "gen_ai.prompt.1.content" to userPrompt,
+        "gen_ai.prompt.2.role" to Message.Role.Tool.name.lowercase(),
+        "gen_ai.prompt.2.content" to "[{\"function\":{\"name\":\"${TestGetWeatherTool.name}\",\"arguments\":\"{\\\"location\\\":\\\"Paris\\\"}\"},\"id\":\"get-weather-tool-call-id\",\"type\":\"function\"}]",
+        "gen_ai.prompt.3.role" to Message.Role.Tool.name.lowercase(),
+        "gen_ai.prompt.3.content" to toolResponse,
+
+        "gen_ai.completion.0.role" to Message.Role.Assistant.name.lowercase(),
+        "gen_ai.completion.0.content" to finalResponse,
+    )
+
+    override fun testTokensCountAttributesGetExpectedInitialLLMCallSpanAttributes(
+        model: LLModel,
+        temperature: Double,
+        maxTokens: Long,
+        systemPrompt: String,
+        userPrompt: String,
+        runId: String,
+        toolCallId: String,
+        outputTokens: Long,
+    ): Map<String, Any> = mapOf(
+        "gen_ai.system" to model.provider.id,
+        "gen_ai.conversation.id" to runId,
+        "gen_ai.operation.name" to "chat",
+        "gen_ai.request.temperature" to temperature,
+        "gen_ai.request.max_tokens" to maxTokens,
+        "gen_ai.request.model" to model.id,
+        "gen_ai.response.finish_reasons" to listOf(SpanAttributes.Response.FinishReasonType.ToolCalls.id),
+        "gen_ai.usage.output_tokens" to outputTokens,
+
+        "gen_ai.prompt.0.role" to Message.Role.System.name.lowercase(),
+        "gen_ai.prompt.0.content" to systemPrompt,
+        "gen_ai.prompt.1.role" to Message.Role.User.name.lowercase(),
+        "gen_ai.prompt.1.content" to userPrompt,
+        "gen_ai.completion.0.role" to Message.Role.Assistant.name.lowercase(),
+        "gen_ai.completion.0.content" to "[{\"function\":{\"name\":\"${TestGetWeatherTool.name}\",\"arguments\":\"{\\\"location\\\":\\\"Paris\\\"}\"},\"id\":\"get-weather-tool-call-id\",\"type\":\"function\"}]",
+        "gen_ai.completion.0.finish_reason" to SpanAttributes.Response.FinishReasonType.ToolCalls.id,
+    )
+
+    override fun testTokensCountAttributesGetExpectedFinalLLMCallSpansAttributes(
+        model: LLModel,
+        temperature: Double,
+        maxTokens: Long,
+        systemPrompt: String,
+        userPrompt: String,
+        runId: String,
+        toolCallId: String,
+        toolResponse: String,
+        finalResponse: String,
+        outputTokens: Long,
+    ): Map<String, Any> = mapOf(
+        "gen_ai.system" to model.provider.id,
+        "gen_ai.conversation.id" to runId,
+        "gen_ai.operation.name" to "chat",
+        "gen_ai.request.temperature" to temperature,
+        "gen_ai.request.model" to model.id,
+        "gen_ai.request.max_tokens" to maxTokens,
+        "gen_ai.response.finish_reasons" to listOf(SpanAttributes.Response.FinishReasonType.Stop.id),
+        "gen_ai.usage.output_tokens" to outputTokens,
 
         "gen_ai.prompt.0.role" to Message.Role.System.name.lowercase(),
         "gen_ai.prompt.0.content" to systemPrompt,

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/weave/WeaveTraceStructureTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/weave/WeaveTraceStructureTest.kt
@@ -75,4 +75,73 @@ class WeaveTraceStructureTest :
         "gen_ai.completion.0.role" to Message.Role.Assistant.name.lowercase(),
         "gen_ai.completion.0.content" to finalResponse,
     )
+
+    override fun testTokensCountAttributesGetExpectedInitialLLMCallSpanAttributes(
+        model: LLModel,
+        temperature: Double,
+        maxTokens: Long,
+        systemPrompt: String,
+        userPrompt: String,
+        runId: String,
+        toolCallId: String,
+        outputTokens: Long,
+    ): Map<String, Any> = mapOf(
+        "gen_ai.system" to model.provider.id,
+        "gen_ai.conversation.id" to runId,
+        "gen_ai.operation.name" to "chat",
+        "gen_ai.request.temperature" to temperature,
+        "gen_ai.request.model" to model.id,
+        "gen_ai.request.max_tokens" to maxTokens,
+        "gen_ai.response.finish_reasons" to listOf(SpanAttributes.Response.FinishReasonType.ToolCalls.id),
+        "gen_ai.usage.completion_tokens" to outputTokens,
+
+        "gen_ai.prompt.0.role" to Message.Role.System.name.lowercase(),
+        "gen_ai.prompt.0.content" to systemPrompt,
+        "gen_ai.prompt.1.role" to Message.Role.User.name.lowercase(),
+        "gen_ai.prompt.1.content" to userPrompt,
+
+        "gen_ai.completion.0.role" to Message.Role.Assistant.name.lowercase(),
+        "gen_ai.completion.0.tool_calls.0.id" to toolCallId,
+        "gen_ai.completion.0.tool_calls.0.function" to "{\"name\":\"${TestGetWeatherTool.name}\",\"arguments\":\"{\\\"location\\\":\\\"Paris\\\"}\"}",
+        "gen_ai.completion.0.tool_calls.0.type" to "function",
+        "gen_ai.completion.0.finish_reason" to SpanAttributes.Response.FinishReasonType.ToolCalls.id,
+    )
+
+    override fun testTokensCountAttributesGetExpectedFinalLLMCallSpansAttributes(
+        model: LLModel,
+        temperature: Double,
+        maxTokens: Long,
+        systemPrompt: String,
+        userPrompt: String,
+        runId: String,
+        toolCallId: String,
+        toolResponse: String,
+        finalResponse: String,
+        outputTokens: Long,
+    ): Map<String, Any> = mapOf(
+        "gen_ai.system" to model.provider.id,
+        "gen_ai.conversation.id" to runId,
+        "gen_ai.operation.name" to "chat",
+        "gen_ai.request.temperature" to temperature,
+        "gen_ai.request.model" to model.id,
+        "gen_ai.request.max_tokens" to maxTokens,
+        "gen_ai.response.finish_reasons" to listOf(SpanAttributes.Response.FinishReasonType.Stop.id),
+        "gen_ai.usage.completion_tokens" to outputTokens,
+
+        "gen_ai.prompt.0.role" to Message.Role.System.name.lowercase(),
+        "gen_ai.prompt.0.content" to systemPrompt,
+        "gen_ai.prompt.1.role" to Message.Role.User.name.lowercase(),
+        "gen_ai.prompt.1.content" to userPrompt,
+        "gen_ai.prompt.2.role" to Message.Role.Assistant.name.lowercase(),
+        "gen_ai.prompt.2.tool_calls.0.type" to "function",
+        "gen_ai.prompt.2.tool_calls.0.id" to toolCallId,
+        "gen_ai.prompt.2.tool_calls.0.function" to "{\"name\":\"Get whether\",\"arguments\":\"{\\\"location\\\":\\\"Paris\\\"}\"}",
+        "gen_ai.prompt.2.finish_reason" to "tool_calls",
+        "gen_ai.prompt.3.role" to Message.Role.Tool.name.lowercase(),
+        "gen_ai.prompt.3.tool_call_id" to toolCallId,
+        "gen_ai.prompt.3.content" to toolResponse,
+
+        "gen_ai.completion.0.role" to Message.Role.Assistant.name.lowercase(),
+        "gen_ai.completion.0.content" to finalResponse,
+    )
 }


### PR DESCRIPTION
[KG-162](https://youtrack.jetbrains.com/issue/KG-162/Support-tokens-span-attributes-in-Koog-events-Open-Telemetry-spans). Add information about tokens usage in Open Telemetry feature spans.

- Add tokens usage statistics for OpenTelemetry feature;
- Update Langfuse and Weave exporters for OTel;
- Add tests to verify output tokens attributes.

## Motivation and Context
Open Telemetry feature needs to have usage statistics about input and output tokens. It can help to evaluate agents execution better.

## Breaking Changes
No

---

#### Type of the changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [x] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
