### PR TITLE
Add OpenAI retry message pattern support to `DefaultRetryAfterExtractor`

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfig.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfig.kt
@@ -153,7 +153,8 @@ public object DefaultRetryAfterExtractor : RetryAfterExtractor {
     private val patterns = listOf(
         Regex("retry\\s+after\\s+(\\d+)\\s+second", RegexOption.IGNORE_CASE),
         Regex("retry-after:\\s*(\\d+)", RegexOption.IGNORE_CASE),
-        Regex("wait\\s+(\\d+)\\s+second", RegexOption.IGNORE_CASE)
+        Regex("wait\\s+(\\d+)\\s+second", RegexOption.IGNORE_CASE),
+        Regex("try again in\\s+(\\d+)(\\.\\d{1,3})?s", RegexOption.IGNORE_CASE)
     )
 
     override fun extract(message: String): Duration? {

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfigTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfigTest.kt
@@ -207,6 +207,10 @@ class RetryAfterExtractorTest {
         assertEquals(10.seconds, extractor.extract("retry-after: 10"))
         assertEquals(30.seconds, extractor.extract("Please retry after 30 seconds"))
         assertEquals(60.seconds, extractor.extract("Wait 60 seconds"))
+        assertEquals(7.seconds, extractor.extract("try again in 7.934s"))
+        assertEquals(7.seconds, extractor.extract("try again in 7.93s"))
+        assertEquals(7.seconds, extractor.extract("try again in 7.9s"))
+        assertEquals(7.seconds, extractor.extract("try again in 7s"))
     }
 
     @Test


### PR DESCRIPTION
OpenAI returns this error message in the response body along with the `429 Too Many Requests` response:

> Rate limit reached for o3 in organization org-XXX on tokens per min (TPM): Limit 30000, Used 27418, Requested 6549. Please try again in 7.934s. Visit https://platform.openai.com/account/rate-limits to learn more.

Currently `DefaultRetryAfterExtractor` does not handle `try again in X.XXXs` pattern:
https://github.com/JetBrains/koog/blob/3c87f2a6bb1f6ee640e8b2a078a74b0eb56afaa8/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfig.kt#L152-L157

This PR adds support for the OpenAI retry message regex pattern and includes a test to verify it.