### PR TITLE
Add LLM client retry support to Spring Boot auto-configuration

### DIFF
--- a/koog-spring-boot-starter/src/main/kotlin/ai/koog/spring/AnthropicKoogProperties.kt
+++ b/koog-spring-boot-starter/src/main/kotlin/ai/koog/spring/AnthropicKoogProperties.kt
@@ -15,7 +15,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = AnthropicKoogProperties.PREFIX)
 public class AnthropicKoogProperties(
     public val apiKey: String = "",
-    public val baseUrl: String = "https://api.anthropic.com"
+    public val baseUrl: String = "https://api.anthropic.com",
+    public val retry: RetryConfigKoogProperties? = null
 ) {
     /**
      * Companion object for the AnthropicKoogProperties class, providing constant values and

--- a/koog-spring-boot-starter/src/main/kotlin/ai/koog/spring/DeepSeekKoogProperties.kt
+++ b/koog-spring-boot-starter/src/main/kotlin/ai/koog/spring/DeepSeekKoogProperties.kt
@@ -15,7 +15,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = DeepSeekKoogProperties.PREFIX)
 public class DeepSeekKoogProperties(
     public val apiKey: String = "",
-    public val baseUrl: String = "https://api.deepseek.com"
+    public val baseUrl: String = "https://api.deepseek.com",
+    public val retry: RetryConfigKoogProperties? = null
 ) {
     /**
      * Companion object for the DeepSeekKoogProperties class, providing constant values and

--- a/koog-spring-boot-starter/src/main/kotlin/ai/koog/spring/GoogleKoogProperties.kt
+++ b/koog-spring-boot-starter/src/main/kotlin/ai/koog/spring/GoogleKoogProperties.kt
@@ -15,7 +15,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = GoogleKoogProperties.PREFIX)
 public class GoogleKoogProperties(
     public val apiKey: String = "",
-    public val baseUrl: String = "https://generativelanguage.googleapis.com"
+    public val baseUrl: String = "https://generativelanguage.googleapis.com",
+    public val retry: RetryConfigKoogProperties? = null
 ) {
     /**
      * Companion object for the GoogleKoogProperties class, providing constant values and

--- a/koog-spring-boot-starter/src/main/kotlin/ai/koog/spring/OllamaKoogProperties.kt
+++ b/koog-spring-boot-starter/src/main/kotlin/ai/koog/spring/OllamaKoogProperties.kt
@@ -13,7 +13,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  */
 @ConfigurationProperties(prefix = OllamaKoogProperties.PREFIX)
 public class OllamaKoogProperties(
-    public val baseUrl: String = "http://localhost:11434"
+    public val baseUrl: String = "http://localhost:11434",
+    public val retry: RetryConfigKoogProperties? = null
 ) {
     /**
      * Companion object for the OllamaKoogProperties class, providing constant values and

--- a/koog-spring-boot-starter/src/main/kotlin/ai/koog/spring/OpenAIKoogProperties.kt
+++ b/koog-spring-boot-starter/src/main/kotlin/ai/koog/spring/OpenAIKoogProperties.kt
@@ -15,7 +15,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = OpenAIKoogProperties.PREFIX)
 public class OpenAIKoogProperties(
     public val apiKey: String = "",
-    public val baseUrl: String = "https://api.openai.com"
+    public val baseUrl: String = "https://api.openai.com",
+    public val retry: RetryConfigKoogProperties? = null
 ) {
     /**
      * Companion object for the OpenAIKoogProperties class, providing constant values and

--- a/koog-spring-boot-starter/src/main/kotlin/ai/koog/spring/OpenRouterKoogProperties.kt
+++ b/koog-spring-boot-starter/src/main/kotlin/ai/koog/spring/OpenRouterKoogProperties.kt
@@ -15,7 +15,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = OpenRouterKoogProperties.PREFIX)
 public class OpenRouterKoogProperties(
     public val apiKey: String = "",
-    public val baseUrl: String = "https://openrouter.ai"
+    public val baseUrl: String = "https://openrouter.ai",
+    public val retry: RetryConfigKoogProperties? = null
 ) {
     /**
      * Companion object for the OpenRouterKoogProperties class, providing constant values and

--- a/koog-spring-boot-starter/src/main/kotlin/ai/koog/spring/RetryConfigKoogProperties.kt
+++ b/koog-spring-boot-starter/src/main/kotlin/ai/koog/spring/RetryConfigKoogProperties.kt
@@ -1,0 +1,19 @@
+package ai.koog.spring
+
+import org.springframework.boot.convert.DurationUnit
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+
+/**
+ * Configuration properties for the Koog library used for LLM clients retry configuration.
+ */
+public class RetryConfigKoogProperties(
+    public val enabled: Boolean = false,
+    public val maxAttempts: Int? = null,
+    @param:DurationUnit(ChronoUnit.SECONDS)
+    public val initialDelay: Duration? = null,
+    @param:DurationUnit(ChronoUnit.SECONDS)
+    public val maxDelay: Duration? = null,
+    public val backoffMultiplier: Double? = null,
+    public val jitterFactor: Double? = null
+)

--- a/koog-spring-boot-starter/src/test/kotlin/ai/koog/spring/KoogAutoConfigurationTest.kt
+++ b/koog-spring-boot-starter/src/test/kotlin/ai/koog/spring/KoogAutoConfigurationTest.kt
@@ -9,6 +9,8 @@ import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
 import ai.koog.prompt.executor.clients.openai.base.AbstractOpenAILLMClient
 import ai.koog.prompt.executor.clients.openai.base.OpenAIBasedSettings
 import ai.koog.prompt.executor.clients.openrouter.OpenRouterLLMClient
+import ai.koog.prompt.executor.clients.retry.RetryConfig
+import ai.koog.prompt.executor.clients.retry.RetryingLLMClient
 import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
 import ai.koog.prompt.executor.ollama.client.OllamaClient
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -21,8 +23,11 @@ import org.springframework.beans.factory.getBean
 import org.springframework.beans.factory.getBeanNamesForType
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import kotlin.time.Duration.Companion.seconds
 
 class KoogAutoConfigurationTest {
+    private val defaultRetryConfig = RetryConfig()
+
     @Test
     fun `should not supply executor beans if no apiKey is provided`() {
         ApplicationContextRunner()
@@ -74,6 +79,89 @@ class KoogAutoConfigurationTest {
     }
 
     @Test
+    fun `should supply OpenAI executor bean with retry client and default config`() {
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(KoogAutoConfiguration::class.java))
+            .withPropertyValues("ai.koog.openai.api-key=some_api_key")
+            .withPropertyValues("ai.koog.openai.retry.enabled=true")
+            .run { context ->
+                val executor = context.getBean<SingleLLMPromptExecutor>()
+                val retryingClient = getPrivateFieldValue(executor, "llmClient")
+                assertInstanceOf<RetryingLLMClient>(retryingClient)
+
+                val config = getPrivateFieldValue(retryingClient, "config") as RetryConfig
+                assertEquals(defaultRetryConfig.maxAttempts, config.maxAttempts)
+                assertEquals(defaultRetryConfig.initialDelay, config.initialDelay)
+                assertEquals(defaultRetryConfig.maxDelay, config.maxDelay)
+                assertEquals(defaultRetryConfig.backoffMultiplier, config.backoffMultiplier)
+                assertEquals(defaultRetryConfig.jitterFactor, config.jitterFactor)
+
+                val llmClient = getPrivateFieldValue(retryingClient, "delegate")
+                assertInstanceOf<OpenAILLMClient>(llmClient)
+            }
+    }
+
+    @Test
+    fun `should supply OpenAI executor bean with retry client and full custom config`() {
+        val maxAttempts = 5
+        val initialDelay = 10
+        val maxDelay = 60
+        val backoffMultiplier = 5.0
+        val jitterFactor = 0.5
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(KoogAutoConfiguration::class.java))
+            .withPropertyValues("ai.koog.openai.api-key=some_api_key")
+            .withPropertyValues("ai.koog.openai.retry.enabled=true")
+            .withPropertyValues("ai.koog.openai.retry.max-attempts=$maxAttempts")
+            .withPropertyValues("ai.koog.openai.retry.initial-delay=$initialDelay")
+            .withPropertyValues("ai.koog.openai.retry.max-delay=$maxDelay")
+            .withPropertyValues("ai.koog.openai.retry.backoff-multiplier=$backoffMultiplier")
+            .withPropertyValues("ai.koog.openai.retry.jitter-factor=$jitterFactor")
+            .run { context ->
+                val executor = context.getBean<SingleLLMPromptExecutor>()
+                val retryingClient = getPrivateFieldValue(executor, "llmClient")
+                assertInstanceOf<RetryingLLMClient>(retryingClient)
+
+                val config = getPrivateFieldValue(retryingClient, "config") as RetryConfig
+                assertEquals(maxAttempts, config.maxAttempts)
+                assertEquals(initialDelay.seconds, config.initialDelay)
+                assertEquals(maxDelay.seconds, config.maxDelay)
+                assertEquals(backoffMultiplier, config.backoffMultiplier)
+                assertEquals(jitterFactor, config.jitterFactor)
+
+                val llmClient = getPrivateFieldValue(retryingClient, "delegate")
+                assertInstanceOf<OpenAILLMClient>(llmClient)
+            }
+    }
+
+    @Test
+    fun `should supply OpenAI executor bean with retry client and partial custom config`() {
+        val maxAttempts = 5
+        val initialDelay = 10
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(KoogAutoConfiguration::class.java))
+            .withPropertyValues("ai.koog.openai.api-key=some_api_key")
+            .withPropertyValues("ai.koog.openai.retry.enabled=true")
+            .withPropertyValues("ai.koog.openai.retry.max-attempts=$maxAttempts")
+            .withPropertyValues("ai.koog.openai.retry.initial-delay=$initialDelay")
+            .run { context ->
+                val executor = context.getBean<SingleLLMPromptExecutor>()
+                val retryingClient = getPrivateFieldValue(executor, "llmClient")
+                assertInstanceOf<RetryingLLMClient>(retryingClient)
+
+                val config = getPrivateFieldValue(retryingClient, "config") as RetryConfig
+                assertEquals(maxAttempts, config.maxAttempts)
+                assertEquals(initialDelay.seconds, config.initialDelay)
+                assertEquals(defaultRetryConfig.maxDelay, config.maxDelay)
+                assertEquals(defaultRetryConfig.backoffMultiplier, config.backoffMultiplier)
+                assertEquals(defaultRetryConfig.jitterFactor, config.jitterFactor)
+
+                val llmClient = getPrivateFieldValue(retryingClient, "delegate")
+                assertInstanceOf<OpenAILLMClient>(llmClient)
+            }
+    }
+
+    @Test
     fun `should supply Anthropic executor bean with provided apiKey and default baseUrl`() {
         val configApiKey = "some_api_key"
         ApplicationContextRunner()
@@ -91,6 +179,25 @@ class KoogAutoConfigurationTest {
                 val baseUrl = getPrivateFieldValue(settings, "baseUrl")
 
                 assertEquals("https://api.anthropic.com", baseUrl)
+            }
+    }
+
+    @Test
+    fun `should supply Anthropic executor bean with retry client and default config`() {
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(KoogAutoConfiguration::class.java))
+            .withPropertyValues("ai.koog.anthropic.api-key=some_api_key")
+            .withPropertyValues("ai.koog.anthropic.retry.enabled=true")
+            .run { context ->
+                val executor = context.getBean<SingleLLMPromptExecutor>()
+                val retryingClient = getPrivateFieldValue(executor, "llmClient")
+                assertInstanceOf<RetryingLLMClient>(retryingClient)
+
+                val config = getPrivateFieldValue(retryingClient, "config")
+                assertInstanceOf<RetryConfig>(config)
+
+                val llmClient = getPrivateFieldValue(retryingClient, "delegate")
+                assertInstanceOf<AnthropicLLMClient>(llmClient)
             }
     }
 
@@ -156,6 +263,25 @@ class KoogAutoConfigurationTest {
     }
 
     @Test
+    fun `should supply Google executor bean with retry client and default config`() {
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(KoogAutoConfiguration::class.java))
+            .withPropertyValues("ai.koog.google.api-key=some_api_key")
+            .withPropertyValues("ai.koog.google.retry.enabled=true")
+            .run { context ->
+                val executor = context.getBean<SingleLLMPromptExecutor>()
+                val retryingClient = getPrivateFieldValue(executor, "llmClient")
+                assertInstanceOf<RetryingLLMClient>(retryingClient)
+
+                val config = getPrivateFieldValue(retryingClient, "config")
+                assertInstanceOf<RetryConfig>(config)
+
+                val llmClient = getPrivateFieldValue(retryingClient, "delegate")
+                assertInstanceOf<GoogleLLMClient>(llmClient)
+            }
+    }
+
+    @Test
     fun `should supply OpenRouter executor bean with provided apiKey and default baseUrl`() {
         val configApiKey = "some_api_key"
         ApplicationContextRunner()
@@ -193,6 +319,25 @@ class KoogAutoConfigurationTest {
                 val baseUrl = getPrivateFieldValue(settings, "baseUrl")
 
                 assertEquals(configBaseUrl, baseUrl)
+            }
+    }
+
+    @Test
+    fun `should supply OpenRouter executor bean with retry client and default config`() {
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(KoogAutoConfiguration::class.java))
+            .withPropertyValues("ai.koog.openrouter.api-key=some_api_key")
+            .withPropertyValues("ai.koog.openrouter.retry.enabled=true")
+            .run { context ->
+                val executor = context.getBean<SingleLLMPromptExecutor>()
+                val retryingClient = getPrivateFieldValue(executor, "llmClient")
+                assertInstanceOf<RetryingLLMClient>(retryingClient)
+
+                val config = getPrivateFieldValue(retryingClient, "config")
+                assertInstanceOf<RetryConfig>(config)
+
+                val llmClient = getPrivateFieldValue(retryingClient, "delegate")
+                assertInstanceOf<OpenRouterLLMClient>(llmClient)
             }
     }
 
@@ -238,6 +383,25 @@ class KoogAutoConfigurationTest {
     }
 
     @Test
+    fun `should supply DeepSeek executor bean with retry client and default config`() {
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(KoogAutoConfiguration::class.java))
+            .withPropertyValues("ai.koog.deepseek.api-key=some_api_key")
+            .withPropertyValues("ai.koog.deepseek.retry.enabled=true")
+            .run { context ->
+                val executor = context.getBean<SingleLLMPromptExecutor>()
+                val retryingClient = getPrivateFieldValue(executor, "llmClient")
+                assertInstanceOf<RetryingLLMClient>(retryingClient)
+
+                val config = getPrivateFieldValue(retryingClient, "config")
+                assertInstanceOf<RetryConfig>(config)
+
+                val llmClient = getPrivateFieldValue(retryingClient, "delegate")
+                assertInstanceOf<DeepSeekLLMClient>(llmClient)
+            }
+    }
+
+    @Test
     fun `should supply Ollama executor bean with provided baseUrl`() {
         val configBaseUrl = "https://some-url.com"
         ApplicationContextRunner()
@@ -251,6 +415,25 @@ class KoogAutoConfigurationTest {
                 val baseUrl = getPrivateFieldValue(llmClient, "baseUrl")
 
                 assertEquals(configBaseUrl, baseUrl)
+            }
+    }
+
+    @Test
+    fun `should supply Ollama executor bean with retry client and default config`() {
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(KoogAutoConfiguration::class.java))
+            .withPropertyValues("ai.koog.ollama.base-url=https://some-url.com")
+            .withPropertyValues("ai.koog.ollama.retry.enabled=true")
+            .run { context ->
+                val executor = context.getBean<SingleLLMPromptExecutor>()
+                val retryingClient = getPrivateFieldValue(executor, "llmClient")
+                assertInstanceOf<RetryingLLMClient>(retryingClient)
+
+                val config = getPrivateFieldValue(retryingClient, "config")
+                assertInstanceOf<RetryConfig>(config)
+
+                val llmClient = getPrivateFieldValue(retryingClient, "delegate")
+                assertInstanceOf<OllamaClient>(llmClient)
             }
     }
 


### PR DESCRIPTION
This PR adds LLM client retry support to the Spring Boot starter auto-configuration.

Example `application.properties` configuration for using `RetryingLLMClient` (wrapping the original `OpenAILLMClient`) with `SingleLLMPromptExecutor`:
```
ai.koog.openai.api-key=${OPENAI_API_KEY}
ai.koog.openai.retry.enabled=true
ai.koog.openai.retry.max-attempts=4
ai.koog.openai.retry.initial-delay=3
ai.koog.openai.retry.max-delay=60
ai.koog.openai.retry.backoff-multiplier=3
ai.koog.openai.retry.jitter-factor=0.5
```

Tests have also been added to verify the retry configuration behavior.