### PR TITLE
Make `objectType` nullable in `OpenAIChatCompletion`.

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIChatCompletion.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIChatCompletion.kt
@@ -227,7 +227,7 @@ public class OpenAIChatCompletionResponse(
     public val serviceTier: String? = null,
     public val systemFingerprint: String? = null,
     @SerialName("object")
-    public val objectType: String,
+    public val objectType: String? = null,
     public val usage: OpenAIUsage? = null,
 ) : OpenAIBaseLLMResponse
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIChatCompletion.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIChatCompletion.kt
@@ -227,7 +227,7 @@ public class OpenAIChatCompletionResponse(
     public val serviceTier: String? = null,
     public val systemFingerprint: String? = null,
     @SerialName("object")
-    public val objectType: String = "text_completion",
+    public val objectType: String?,
     public val usage: OpenAIUsage? = null,
 ) : OpenAIBaseLLMResponse
 
@@ -270,6 +270,6 @@ public class OpenAIChatCompletionStreamResponse(
     public val serviceTier: String? = null,
     public val systemFingerprint: String? = null,
     @SerialName("object")
-    public val objectType: String = "text_completion",
+    public val objectType: String?,
     public val usage: OpenAIUsage? = null,
 ) : OpenAIBaseLLMStreamResponse

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIChatCompletion.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIChatCompletion.kt
@@ -227,7 +227,7 @@ public class OpenAIChatCompletionResponse(
     public val serviceTier: String? = null,
     public val systemFingerprint: String? = null,
     @SerialName("object")
-    public val objectType: String? = null,
+    public val objectType: String,
     public val usage: OpenAIUsage? = null,
 ) : OpenAIBaseLLMResponse
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIChatCompletion.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIChatCompletion.kt
@@ -227,7 +227,7 @@ public class OpenAIChatCompletionResponse(
     public val serviceTier: String? = null,
     public val systemFingerprint: String? = null,
     @SerialName("object")
-    public val objectType: String,
+    public val objectType: String = "text_completion",
     public val usage: OpenAIUsage? = null,
 ) : OpenAIBaseLLMResponse
 
@@ -270,6 +270,6 @@ public class OpenAIChatCompletionStreamResponse(
     public val serviceTier: String? = null,
     public val systemFingerprint: String? = null,
     @SerialName("object")
-    public val objectType: String,
+    public val objectType: String = "text_completion",
     public val usage: OpenAIUsage? = null,
 ) : OpenAIBaseLLMStreamResponse

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIChatCompletionDeserializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIChatCompletionDeserializationTest.kt
@@ -1,0 +1,166 @@
+package ai.koog.prompt.executor.clients.openai.models
+
+import ai.koog.test.utils.verifyDeserialization
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNamingStrategy
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OpenAIChatCompletionDeserializationTest {
+
+    private val jsonSnakeCase: Json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        explicitNulls = false
+        encodeDefaults = true
+        namingStrategy = JsonNamingStrategy.SnakeCase
+    }
+
+    @Test
+    fun `should deserialize chat completion response when object is not null`() {
+        // language=JSON
+        val payload = """
+            {
+              "choices": [
+                {
+                  "index": 0,
+                  "message": {
+                    "role": "assistant",
+                    "content": "The capital of France is **Paris**."
+                  },
+                  "finish_reason": "stop"
+                }
+              ],
+              "created": 1716920000,
+              "id": "chatcmpl-123",
+              "model": "gpt-4o-2024-11-20",
+              "object": "chat.completion",
+              "usage": {
+                "prompt_tokens": 9,
+                "completion_tokens": 9,
+                "total_tokens": 18
+              }
+            }
+        """.trimIndent()
+
+        val response: OpenAIChatCompletionResponse = verifyDeserialization(payload, jsonSnakeCase)
+
+        assertEquals("chat.completion", response.objectType)
+        assertEquals("chatcmpl-123", response.id)
+        assertEquals("gpt-4o-2024-11-20", response.model)
+        assertEquals(1, response.choices.size)
+        assertEquals("stop", response.choices[0].finishReason)
+        assertEquals("The capital of France is **Paris**.", response.choices[0].message.content?.text())
+    }
+
+    @Test
+    fun `should deserialize chat completion response  when object is null`() {
+        // language=JSON
+        val payload = """
+            {
+              "choices": [
+                {
+                  "index": 0,
+                  "message": {
+                    "role": "assistant",
+                    "content": "The capital of France is **Paris**."
+                  },
+                  "finish_reason": "stop"
+                }
+              ],
+              "created": 1716920000,
+              "id": "chatcmpl-123",
+              "model": "gpt-4o-2024-11-20",
+              "usage": {
+                "prompt_tokens": 9,
+                "completion_tokens": 9,
+                "total_tokens": 18
+              }
+            }
+        """.trimIndent()
+
+        val response: OpenAIChatCompletionResponse = verifyDeserialization(payload, jsonSnakeCase)
+
+        assertEquals(null, response.objectType)
+        assertEquals("chatcmpl-123", response.id)
+        assertEquals("gpt-4o-2024-11-20", response.model)
+        assertEquals(1, response.choices.size)
+        assertEquals("stop", response.choices[0].finishReason)
+        assertEquals("The capital of France is **Paris**.", response.choices[0].message.content?.text())
+    }
+
+    @Test
+    fun `should deserialize chat stream completion response when object is not null`() {
+        // language=JSON
+        val payload = """
+            {
+              "choices": [
+                {
+                  "index": 0,
+                  "message": {
+                    "role": "assistant",
+                    "content": "The capital of France is **Paris**."
+                  },
+                  "finish_reason": "stop"
+                }
+              ],
+              "created": 1716920000,
+              "id": "chatcmpl-123",
+              "model": "gpt-4o-2024-11-20",
+              "object": "chat.completion",
+              "usage": {
+                "prompt_tokens": 9,
+                "completion_tokens": 9,
+                "total_tokens": 18
+              }
+            }
+        """.trimIndent()
+
+        val response: OpenAIChatCompletionStreamResponse = verifyDeserialization(payload, jsonSnakeCase)
+
+        assertEquals("chat.completion", response.objectType)
+        assertEquals("chatcmpl-123", response.id)
+        assertEquals("gpt-4o-2024-11-20", response.model)
+        assertEquals(1, response.choices.size)
+        assertEquals("stop", response.choices[0].finishReason)
+        assertEquals("The capital of France is **Paris**.", response.choices[0].delta.content)
+    }
+
+    @Test
+    fun `should deserialize chat stream completion response  when object is null`() {
+        // language=JSON
+        val payload = """
+            {
+              "choices": [
+                {
+                  "index": 0,
+                  "message": {
+                    "role": "assistant",
+                    "content": "The capital of France is **Paris**."
+                  },
+                  "finish_reason": "stop"
+                }
+              ],
+              "created": 1716920000,
+              "id": "chatcmpl-123",
+              "model": "gpt-4o-2024-11-20",
+              "usage": {
+                "prompt_tokens": 9,
+                "completion_tokens": 9,
+                "total_tokens": 18
+              }
+            }
+        """.trimIndent()
+
+        val response: OpenAIChatCompletionStreamResponse = verifyDeserialization(payload, jsonSnakeCase)
+
+        assertEquals(null, response.objectType)
+        assertEquals("chatcmpl-123", response.id)
+        assertEquals("gpt-4o-2024-11-20", response.model)
+        assertEquals(1, response.choices.size)
+        assertEquals("stop", response.choices[0].finishReason)
+        assertEquals("The capital of France is **Paris**.", response.choices[0].delta.content)
+    }
+}
+
+


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

Please add a brief description of the proposed change here.
Also, please tick the appropriate points in the checklist below.
-->

Add nullability to the object in OpenAIChatCompletion.

Because in the OpenAI compatibility interface of the BigModel platform/Z.ai platform, this is null.

Fix #749 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
