### PR TITLE
Hotfix: GoogleGenerationConfig.maxOutputTokens changed from 2048 to u…

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -365,7 +365,7 @@ public open class GoogleLLMClient(
             responseJsonSchema = responseFormat?.responseJsonSchema,
             temperature = if (model.capabilities.contains(LLMCapability.Temperature)) prompt.params.temperature else null,
             candidateCount = if (model.capabilities.contains(LLMCapability.MultipleChoices)) prompt.params.numberOfChoices else null,
-            maxOutputTokens = 2048,
+            maxOutputTokens = prompt.params.maxTokens,
             thinkingConfig = GoogleThinkingConfig(
                 includeThoughts = prompt.params.includeThoughts.takeIf { it == true },
                 thinkingBudget = prompt.params.thinkingBudget


### PR DESCRIPTION
Hotfix for GoogleGenerationConfig inside the GoogleLLMClient's createGoogleRequest method. The maxOutputTokens value was fixed to 2048, now using maxTokens value of LLMParams.

## Motivation and Context
The maxOutputTokens value of GoogleGenerationConfig inside the GoogleLLMClient's createGoogleRequest method was fixed to 2048 before, ignoring the maxTokens value of the LLMParams of a prompt. This had lead to MAX_TOKENS errors during prompt execution.

## Breaking Changes
No

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x ] The pull request has a description of the proposed change
- [ x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x ] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ x] All new and existing tests passed
No test added, because createGoogleRequest is a private method that cannot be tested isolated.

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
