### PR TITLE
KG-383. Add agent start event for non-graph agents

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
@@ -1,15 +1,22 @@
 package ai.koog.agents.core.agent
 
+import ai.koog.agents.core.agent.config.AIAgentConfigBase
 import ai.koog.agents.utils.Closeable
 
 /**
  * Represents a basic interface for AI agent.
  */
 public interface AIAgent<Input, Output> : Closeable {
+
     /**
      * Represents the unique identifier for the AI agent.
      */
     public val id: String
+
+    /**
+     * The configuration for the AI agent.
+     */
+    public val agentConfig: AIAgentConfigBase
 
     /**
      * Executes the AI agent with the given input and retrieves the resulting output.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentFunctionalContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentFunctionalContext.kt
@@ -1,6 +1,6 @@
 package ai.koog.agents.core.agent
 
-import ai.koog.agents.core.agent.config.AIAgentConfigBase
+import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.context.AIAgentContext
 import ai.koog.agents.core.agent.context.AIAgentLLMContext
 import ai.koog.agents.core.agent.entity.AIAgentStateManager
@@ -14,7 +14,7 @@ import ai.koog.prompt.message.Message
 
 /**
  * Represents the execution context for an AI agent operating in a loop.
- * It provides access to critical components such as the environment, configuration, large language model (LLM) context,
+ * It provides access to critical parts such as the environment, configuration, large language model (LLM) context,
  * state management, and storage. Additionally, it enables the agent to store, retrieve, and manage context-specific data
  * during its execution lifecycle.
  *
@@ -38,7 +38,7 @@ public class AIAgentFunctionalContext(
     override val agentId: String,
     override val runId: String,
     override val agentInput: Any?,
-    override val config: AIAgentConfigBase,
+    override val config: AIAgentConfig,
     override val llm: AIAgentLLMContext,
     override val stateManager: AIAgentStateManager,
     override val storage: AIAgentStorage,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgents.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgents.kt
@@ -2,7 +2,6 @@ package ai.koog.agents.core.agent
 
 import ai.koog.agents.core.agent.GraphAIAgent.FeatureContext
 import ai.koog.agents.core.agent.config.AIAgentConfig
-import ai.koog.agents.core.agent.config.AIAgentConfigBase
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.prompt.dsl.prompt
@@ -30,7 +29,7 @@ import kotlin.uuid.Uuid
 @OptIn(ExperimentalUuidApi::class)
 public inline fun <reified Input, reified Output> AIAgent(
     promptExecutor: PromptExecutor,
-    agentConfig: AIAgentConfigBase,
+    agentConfig: AIAgentConfig,
     toolRegistry: ToolRegistry = ToolRegistry.EMPTY,
     strategy: AIAgentGraphStrategy<Input, Output>,
     id: String = Uuid.random().toString(),

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/FunctionalAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/FunctionalAIAgent.kt
@@ -41,7 +41,7 @@ import kotlin.uuid.Uuid
 @ExperimentalUuidApi
 public class FunctionalAIAgent<Input, Output>(
     public val promptExecutor: PromptExecutor,
-    public val agentConfig: AIAgentConfigBase,
+    override val agentConfig: AIAgentConfigBase,
     public val toolRegistry: ToolRegistry = ToolRegistry.EMPTY,
     public val strategy: AIAgentFunctionalStrategy<Input, Output>,
     id: String? = null,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/FunctionalAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/FunctionalAIAgent.kt
@@ -4,7 +4,6 @@ package ai.koog.agents.core.agent
 
 import ai.koog.agents.core.agent.FunctionalAIAgent.FeatureContext
 import ai.koog.agents.core.agent.config.AIAgentConfig
-import ai.koog.agents.core.agent.config.AIAgentConfigBase
 import ai.koog.agents.core.agent.context.AIAgentLLMContext
 import ai.koog.agents.core.agent.context.element.AgentRunInfoContextElement
 import ai.koog.agents.core.agent.entity.AIAgentStateManager
@@ -41,7 +40,7 @@ import kotlin.uuid.Uuid
 @ExperimentalUuidApi
 public class FunctionalAIAgent<Input, Output>(
     public val promptExecutor: PromptExecutor,
-    override val agentConfig: AIAgentConfigBase,
+    override val agentConfig: AIAgentConfig,
     public val toolRegistry: ToolRegistry = ToolRegistry.EMPTY,
     public val strategy: AIAgentFunctionalStrategy<Input, Output>,
     id: String? = null,
@@ -175,7 +174,7 @@ public class FunctionalAIAgent<Input, Output>(
  */
 public fun <Input, Output> functionalAIAgent(
     promptExecutor: PromptExecutor,
-    agentConfig: AIAgentConfigBase,
+    agentConfig: AIAgentConfig,
     toolRegistry: ToolRegistry = ToolRegistry.EMPTY,
     func: suspend AIAgentFunctionalContext.(input: Input) -> Output
 ): AIAgent<Input, Output> {

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/GraphAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/GraphAIAgent.kt
@@ -2,7 +2,7 @@
 
 package ai.koog.agents.core.agent
 
-import ai.koog.agents.core.agent.config.AIAgentConfigBase
+import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.context.AIAgentGraphContext
 import ai.koog.agents.core.agent.context.AIAgentLLMContext
 import ai.koog.agents.core.agent.context.element.AgentRunInfoContextElement
@@ -54,7 +54,7 @@ public open class GraphAIAgent<Input, Output>(
     public val inputType: KType,
     public val outputType: KType,
     public val promptExecutor: PromptExecutor,
-    override val agentConfig: AIAgentConfigBase,
+    override val agentConfig: AIAgentConfig,
     public val toolRegistry: ToolRegistry = ToolRegistry.EMPTY,
     private val strategy: AIAgentGraphStrategy<Input, Output>,
     id: String? = null,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/config/AIAgentConfig.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/config/AIAgentConfig.kt
@@ -6,7 +6,7 @@ import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.llm.LLModel
 
 /**
- * Configuration class for a AI agent that specifies the prompt, execution parameters, and behavior.
+ * Configuration class for an AI agent that specifies the prompt, execution parameters, and behavior.
  *
  * This class is responsible for defining the various settings and components required
  * for an AI agent to operate. It includes the prompt configuration, iteration limits,
@@ -15,13 +15,17 @@ import ai.koog.prompt.llm.LLModel
  * @param prompt The initial prompt configuration for the agent, encapsulating messages, model, and parameters.
  * @param model The model to use for the agent's prompt execution
  * @param maxAgentIterations The maximum number of iterations allowed for an agent during its execution to prevent infinite loops.
- * @param missingToolsConversionStrategy Strategy to handle missing tool definitions in the prompt. Defaults to applying formatting for missing tools. Ex.: if in the LLM history, there are some tools that are currently undefined in the agent (sub)graph.
+ * @param missingToolsConversionStrategy Strategy used to determine how tool calls,
+ *        present in the prompt but lacking definitions, are handled during agent execution.
+ *        This property provides a mechanism to convert or format missing tool calls and result messages when they occur,
+ *        typically due to differences in tool sets between steps or subgraphs while the same history is reused.
+ *        This ensures the prompt remains consistent and readable for the model, even with undefined tools.
  */
 public class AIAgentConfig(
     override val prompt: Prompt,
     override val model: LLModel,
-    override val maxAgentIterations: Int,
-    override val missingToolsConversionStrategy: MissingToolsConversionStrategy =
+    public val maxAgentIterations: Int,
+    public val missingToolsConversionStrategy: MissingToolsConversionStrategy =
         MissingToolsConversionStrategy.Missing(ToolCallDescriber.JSON)
 ) : AIAgentConfigBase {
 
@@ -40,7 +44,7 @@ public class AIAgentConfig(
          * This function initializes an instance of `AIAgentConfig` using the provided system-level prompt
          * and other optional parameters, such as the language model, configuration ID, and maximum agent iterations.
          *
-         * @param prompt The content of the system prompt to define the context and instructions for the AI agent.
+         * @param prompt The content of the system prompts to define the context and instructions for the AI agent.
          * @param llm The Large Language Model (LLM) to be used for the AI agent. Defaults to OpenAIModels.Chat.GPT4o.
          * @param id The identifier for the agent configuration. Defaults to "koog-agents".
          * @param maxAgentIterations The maximum number of iterations the agent can perform to avoid infinite loops. Defaults to 3.
@@ -51,7 +55,7 @@ public class AIAgentConfig(
             llm: LLModel = OpenAIModels.Chat.GPT4o,
             id: String = "koog-agents",
             maxAgentIterations: Int = 3,
-        ): AIAgentConfigBase =
+        ): AIAgentConfig =
             AIAgentConfig(
                 prompt = prompt(id) {
                     system(prompt)

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/config/AIAgentConfigBase.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/config/AIAgentConfigBase.kt
@@ -9,7 +9,7 @@ import ai.koog.prompt.llm.LLModel
 public interface AIAgentConfigBase {
 
     /**
-     * Defines the `Prompt` to be utilized in the AI agent's configuration.
+     * Defines the `Prompt` to be used in the AI agent's configuration.
      *
      * The `prompt` serves as the input structure for generating outputs from the language model and consists
      * of a list of messages, a unique identifier, and optional parameters. This property plays a role
@@ -26,26 +26,4 @@ public interface AIAgentConfigBase {
      * in response to user prompts and tasks.
      */
     public val model: LLModel
-
-    /**
-     * Specifies the maximum number of iterations an AI agent is allowed to perform during its operation.
-     *
-     * This value acts as a safeguard to prevent infinite loops in scenarios where the agent's logic
-     * might otherwise continue indefinitely. It determines the number of steps the agent can take
-     * while executing its task, and exceeding this limit will halt the agent's processing.
-     */
-    public val maxAgentIterations: Int
-
-    /**
-     * Strategy used to determine how tool calls, present in the prompt but lacking definitions,
-     * are handled during agent execution.
-     *
-     * This property provides a mechanism to convert or format missing tool call and result messages when they occur,
-     * typically due to differences in tool sets between steps or subgraphs while the same history is reused. This ensures
-     * the prompt remains consistent and readable for the model, even with undefined tools.
-     *
-     * The specific behavior is determined by the selected `MissingToolsConversionStrategy`, which may either replace
-     * all tool-related messages or only those corresponding to missing tool definitions.
-     */
-    public val missingToolsConversionStrategy: MissingToolsConversionStrategy
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentContext.kt
@@ -1,6 +1,6 @@
 package ai.koog.agents.core.agent.context
 
-import ai.koog.agents.core.agent.config.AIAgentConfigBase
+import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentStateManager
 import ai.koog.agents.core.agent.entity.AIAgentStorage
 import ai.koog.agents.core.agent.entity.AIAgentStorageKey
@@ -50,11 +50,11 @@ public interface AIAgentContext {
     /**
      * Represents the configuration for an AI agent.
      *
-     * This configuration is utilized during the execution to enforce constraints
+     * This configuration is used during the execution to enforce constraints
      * such as the maximum number of iterations an agent can perform, as well as providing
      * the agent's prompt configuration.
      */
-    public val config: AIAgentConfigBase
+    public val config: AIAgentConfig
 
     /**
      * Represents the AI agent's LLM context, providing mechanisms for managing tools, prompts,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentGraphContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentGraphContext.kt
@@ -1,6 +1,6 @@
 package ai.koog.agents.core.agent.context
 
-import ai.koog.agents.core.agent.config.AIAgentConfigBase
+import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentStateManager
 import ai.koog.agents.core.agent.entity.AIAgentStorage
 import ai.koog.agents.core.agent.entity.AIAgentStorageKey
@@ -50,7 +50,7 @@ public interface AIAgentGraphContextBase : AIAgentContext {
      * Creates a copy of the current [AIAgentGraphContext], allowing for selective overriding of its properties.
      *
      * @param environment The [AIAgentEnvironment] to be used in the new context, or `null` to retain the current one.
-     * @param config The [AIAgentConfigBase] for the new context, or `null` to retain the current configuration.
+     * @param config The [AIAgentConfig] for the new context, or `null` to retain the current configuration.
      * @param llm The [AIAgentLLMContext] to be used, or `null` to retain the current LLM context.
      * @param stateManager The [AIAgentStateManager] to be used, or `null` to retain the current state manager.
      * @param storage The [AIAgentStorage] to be used, or `null` to retain the current storage.
@@ -62,7 +62,7 @@ public interface AIAgentGraphContextBase : AIAgentContext {
         environment: AIAgentEnvironment = this.environment,
         agentInput: Any? = this.agentInput,
         agentInputType: KType = this.agentInputType,
-        config: AIAgentConfigBase = this.config,
+        config: AIAgentConfig = this.config,
         llm: AIAgentLLMContext = this.llm,
         stateManager: AIAgentStateManager = this.stateManager,
         storage: AIAgentStorage = this.storage,
@@ -121,7 +121,7 @@ public class AIAgentGraphContext(
     override val environment: AIAgentEnvironment,
     override val agentInputType: KType,
     override val agentInput: Any?,
-    override val config: AIAgentConfigBase,
+    override val config: AIAgentConfig,
     llm: AIAgentLLMContext,
     stateManager: AIAgentStateManager,
     storage: AIAgentStorage,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
@@ -2,7 +2,7 @@
 
 package ai.koog.agents.core.agent.context
 
-import ai.koog.agents.core.agent.config.AIAgentConfigBase
+import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.session.AIAgentLLMReadSession
 import ai.koog.agents.core.agent.session.AIAgentLLMWriteSession
 import ai.koog.agents.core.environment.AIAgentEnvironment
@@ -56,7 +56,7 @@ public class AIAgentLLMContext(
     @property:DetachedPromptExecutorAPI
     public val promptExecutor: PromptExecutor,
     private val environment: AIAgentEnvironment,
-    private val config: AIAgentConfigBase,
+    private val config: AIAgentConfig,
     private val clock: Clock
 ) {
     /**
@@ -108,7 +108,7 @@ public class AIAgentLLMContext(
         model: LLModel = this.model,
         promptExecutor: PromptExecutor = this.promptExecutor,
         environment: AIAgentEnvironment = this.environment,
-        config: AIAgentConfigBase = this.config,
+        config: AIAgentConfig = this.config,
         clock: Clock = this.clock,
     ): AIAgentLLMContext = rwLock.withReadLock {
         AIAgentLLMContext(
@@ -168,7 +168,7 @@ public class AIAgentLLMContext(
         model: LLModel = this.model,
         promptExecutor: PromptExecutor = this.promptExecutor,
         environment: AIAgentEnvironment = this.environment,
-        config: AIAgentConfigBase = this.config,
+        config: AIAgentConfig = this.config,
         clock: Clock = this.clock
     ): AIAgentLLMContext {
         return AIAgentLLMContext(tools, toolRegistry, prompt, model, promptExecutor, environment, config, clock)

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMReadSession.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMReadSession.kt
@@ -1,6 +1,6 @@
 package ai.koog.agents.core.agent.session
 
-import ai.koog.agents.core.agent.config.AIAgentConfigBase
+import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
@@ -23,5 +23,5 @@ public class AIAgentLLMReadSession internal constructor(
     executor: PromptExecutor,
     prompt: Prompt,
     model: LLModel,
-    config: AIAgentConfigBase,
+    config: AIAgentConfig,
 ) : AIAgentLLMSession(executor, tools, prompt, model, config)

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMSession.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMSession.kt
@@ -1,6 +1,6 @@
 package ai.koog.agents.core.agent.session
 
-import ai.koog.agents.core.agent.config.AIAgentConfigBase
+import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.utils.ActiveProperty
@@ -34,7 +34,7 @@ public sealed class AIAgentLLMSession(
     tools: List<ToolDescriptor>,
     prompt: Prompt,
     model: LLModel,
-    protected val config: AIAgentConfigBase,
+    protected val config: AIAgentConfig,
 ) : AutoCloseable {
     /**
      * Represents the current prompt associated with the LLM session.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
@@ -1,6 +1,6 @@
 package ai.koog.agents.core.agent.session
 
-import ai.koog.agents.core.agent.config.AIAgentConfigBase
+import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.environment.AIAgentEnvironment
 import ai.koog.agents.core.environment.SafeTool
 import ai.koog.agents.core.tools.Tool
@@ -45,7 +45,7 @@ public class AIAgentLLMWriteSession internal constructor(
     @PublishedApi internal val toolRegistry: ToolRegistry,
     prompt: Prompt,
     model: LLModel,
-    config: AIAgentConfigBase,
+    config: AIAgentConfig,
     public val clock: Clock
 ) : AIAgentLLMSession(executor, tools, prompt, model, config) {
     /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/builder/AIAgentParallelNodesMergeContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/builder/AIAgentParallelNodesMergeContext.kt
@@ -1,6 +1,6 @@
 package ai.koog.agents.core.dsl.builder
 
-import ai.koog.agents.core.agent.config.AIAgentConfigBase
+import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.context.AIAgentContext
 import ai.koog.agents.core.agent.context.AIAgentGraphContextBase
 import ai.koog.agents.core.agent.context.AIAgentLLMContext
@@ -35,7 +35,7 @@ public class AIAgentParallelNodesMergeContext<Input, Output>(
     override val agentId: String get() = underlyingContextBase.agentId
     override val agentInput: Any? get() = underlyingContextBase.agentInput
     override val agentInputType: KType get() = underlyingContextBase.agentInputType
-    override val config: AIAgentConfigBase get() = underlyingContextBase.config
+    override val config: AIAgentConfig get() = underlyingContextBase.config
     override val llm: AIAgentLLMContext get() = underlyingContextBase.llm
     override val stateManager: AIAgentStateManager get() = underlyingContextBase.stateManager
     override val storage: AIAgentStorage get() = underlyingContextBase.storage
@@ -74,7 +74,7 @@ public class AIAgentParallelNodesMergeContext<Input, Output>(
         environment: AIAgentEnvironment,
         agentInput: Any?,
         agentInputType: KType,
-        config: AIAgentConfigBase,
+        config: AIAgentConfig,
         llm: AIAgentLLMContext,
         stateManager: AIAgentStateManager,
         storage: AIAgentStorage,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/AgentEventHandlerContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/AgentEventHandlerContext.kt
@@ -1,5 +1,6 @@
 package ai.koog.agents.core.feature.handler
 
+import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.GraphAIAgent
 import ai.koog.agents.core.agent.context.AIAgentContext
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
@@ -33,14 +34,12 @@ public class AgentTransformEnvironmentContext<TFeature>(
  * Represents the context available during the start of an AI agent.
  *
  * @param TFeature The type of the feature object associated with this context.
- * @property strategy The AI agent strategy that defines the workflow and execution logic.
  * @property agent The AI agent associated with this context.
  * @property feature The feature-specific data associated with this context.
  */
-public data class GraphAgentStartContext<TFeature>(
-    public val agent: GraphAIAgent<*, *>,
+public data class AgentStartContext<TFeature>(
+    public val agent: AIAgent<*, *>,
     public val runId: String,
-    public val strategy: AIAgentGraphStrategy<*, *>,
     public val feature: TFeature,
     public val context: AIAgentContext,
 ) : AgentEventHandlerContext

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/AgentHandler.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/AgentHandler.kt
@@ -93,7 +93,7 @@ public class AgentHandler<TFeature : Any>(public val feature: TFeature) {
      * @param context The context containing necessary information about the agent,
      *                strategy, and feature to be processed before the agent starts.
      */
-    public suspend fun handleBeforeAgentStarted(context: GraphAgentStartContext<TFeature>) {
+    public suspend fun handleBeforeAgentStarted(context: AgentStartContext<TFeature>) {
         beforeAgentStartedHandler.handle(context)
     }
 
@@ -106,8 +106,8 @@ public class AgentHandler<TFeature : Any>(public val feature: TFeature) {
      */
     @Suppress("UNCHECKED_CAST")
     @InternalAgentsApi
-    public suspend fun handleBeforeAgentStartedUnsafe(eventContext: GraphAgentStartContext<*>) {
-        handleBeforeAgentStarted(eventContext as GraphAgentStartContext<TFeature>)
+    public suspend fun handleBeforeAgentStartedUnsafe(eventContext: AgentStartContext<*>) {
+        handleBeforeAgentStarted(eventContext as AgentStartContext<TFeature>)
     }
 }
 
@@ -161,7 +161,7 @@ public fun interface BeforeAgentStartedHandler<TFeature : Any> {
      *
      * @param context The context that encapsulates the agent, its strategy, and the associated feature
      */
-    public suspend fun handle(context: GraphAgentStartContext<TFeature>)
+    public suspend fun handle(context: AgentStartContext<TFeature>)
 }
 
 /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/StrategyEventHandlerContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/StrategyEventHandlerContext.kt
@@ -1,5 +1,6 @@
 package ai.koog.agents.core.feature.handler
 
+import ai.koog.agents.core.agent.context.AIAgentContext
 import ai.koog.agents.core.agent.entity.AIAgentStrategy
 import kotlin.reflect.KType
 
@@ -21,7 +22,8 @@ public interface StrategyEventHandlerContext : EventHandlerContext
 public class StrategyStartContext<TFeature>(
     public val runId: String,
     public val strategy: AIAgentStrategy<*, *, *>,
-    public val feature: TFeature
+    public val feature: TFeature,
+    public val context: AIAgentContext,
 ) : StrategyEventHandlerContext
 
 /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/featureEventTypes.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/featureEventTypes.kt
@@ -55,13 +55,11 @@ public sealed class DefinedFeatureEvent() : FeatureEvent {
  *
  * @property agentId The unique identifier of the AI agent;
  * @property runId The unique identifier of the AI agen run;
- * @property strategyName The name of the strategy that the AI agent has started executing.
  */
 @Serializable
 public data class AIAgentStartedEvent(
     val agentId: String,
     val runId: String,
-    val strategyName: String,
     override val eventId: String = AIAgentStartedEvent::class.simpleName!!,
 ) : DefinedFeatureEvent()
 

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/context/AgentTestBase.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/context/AgentTestBase.kt
@@ -2,7 +2,6 @@ package ai.koog.agents.core.agent.context
 
 import ai.koog.agents.core.CalculatorChatExecutor.testClock
 import ai.koog.agents.core.agent.config.AIAgentConfig
-import ai.koog.agents.core.agent.config.AIAgentConfigBase
 import ai.koog.agents.core.agent.config.MissingToolsConversionStrategy
 import ai.koog.agents.core.agent.config.ToolCallDescriber
 import ai.koog.agents.core.agent.entity.AIAgentStateManager
@@ -37,7 +36,7 @@ open class AgentTestBase {
         }
     }
 
-    protected fun createTestConfig(id: String = "test-config"): AIAgentConfigBase {
+    protected fun createTestConfig(id: String = "test-config"): AIAgentConfig {
         return AIAgentConfig(
             prompt = createTestPrompt(),
             model = OllamaModels.Meta.LLAMA_3_2,
@@ -76,7 +75,7 @@ open class AgentTestBase {
 
     protected open fun createTestContext(
         environment: AIAgentEnvironment = createTestEnvironment(),
-        config: AIAgentConfigBase = createTestConfig(),
+        config: AIAgentConfig = createTestConfig(),
         llmContext: AIAgentLLMContext = createTestLLMContext(),
         stateManager: AIAgentStateManager = createTestStateManager(),
         storage: AIAgentStorage = createTestStorage(),

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/context/element/NodeInfoContextElementTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/context/element/NodeInfoContextElementTest.kt
@@ -41,7 +41,7 @@ class NodeInfoContextElementTest {
     fun testGetNodeInfoElement() = runTest {
         val element = NodeInfoContextElement(nodeName = nodeName)
 
-        // Test with element in context
+        // Test with an element in context
         withContext(element) {
             val retrievedElement = coroutineContext.getNodeInfoElement()
             assertNotNull(retrievedElement)
@@ -58,7 +58,6 @@ class NodeInfoContextElementTest {
         val nodeElement = NodeInfoContextElement(nodeName = nodeName)
         val testPrompt = prompt("test-prompt") {}
         val testModel = OllamaModels.Meta.LLAMA_3_2
-        val testStrategy = MissingToolsConversionStrategy.All(ToolCallDescriber.JSON)
 
         val agentElement = AgentRunInfoContextElement(
             agentId = "test-agent",
@@ -66,8 +65,6 @@ class NodeInfoContextElementTest {
             agentConfig = object : AIAgentConfigBase {
                 override val prompt: Prompt = testPrompt
                 override val model: LLModel = testModel
-                override val maxAgentIterations: Int = 10
-                override val missingToolsConversionStrategy: MissingToolsConversionStrategy = testStrategy
             },
             strategyName = "test-strategy"
         )

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/context/element/NodeInfoContextElementTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/context/element/NodeInfoContextElementTest.kt
@@ -1,8 +1,6 @@
 package ai.koog.agents.core.agent.context.element
 
 import ai.koog.agents.core.agent.config.AIAgentConfigBase
-import ai.koog.agents.core.agent.config.MissingToolsConversionStrategy
-import ai.koog.agents.core.agent.config.ToolCallDescriber
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.llm.LLModel

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContextConcurrencyTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContextConcurrencyTest.kt
@@ -2,7 +2,6 @@ package ai.koog.agents.core.agent.context
 
 import ai.koog.agents.core.CalculatorChatExecutor
 import ai.koog.agents.core.agent.config.AIAgentConfig
-import ai.koog.agents.core.agent.config.AIAgentConfigBase
 import ai.koog.agents.core.agent.config.MissingToolsConversionStrategy
 import ai.koog.agents.core.agent.config.ToolCallDescriber
 import ai.koog.agents.core.environment.AIAgentEnvironment
@@ -176,7 +175,7 @@ class AIAgentLLMContextConcurrencyTest {
         }
     }
 
-    private fun createTestConfig(): AIAgentConfigBase {
+    private fun createTestConfig(): AIAgentConfig {
         return AIAgentConfig(
             prompt = createTestPrompt(),
             model = OllamaModels.Meta.LLAMA_3_2,

--- a/agents/agents-features/agents-features-debugger/src/commonMain/kotlin/ai/koog/agents/features/debugger/feature/Debugger.kt
+++ b/agents/agents-features/agents-features-debugger/src/commonMain/kotlin/ai/koog/agents/features/debugger/feature/Debugger.kt
@@ -91,7 +91,6 @@ public class Debugger {
                 val event = AIAgentStartedEvent(
                     agentId = eventContext.agent.id,
                     runId = eventContext.runId,
-                    strategyName = eventContext.strategy.name,
                 )
                 writer.processMessage(event)
             }

--- a/agents/agents-features/agents-features-debugger/src/jvmTest/kotlin/ai/koog/agents/features/debugger/feature/DebuggerTest.kt
+++ b/agents/agents-features/agents-features-debugger/src/jvmTest/kotlin/ai/koog/agents/features/debugger/feature/DebuggerTest.kt
@@ -196,7 +196,6 @@ class DebuggerTest {
                     AIAgentStartedEvent(
                         agentId = agentId,
                         runId = clientEventsCollector.runId,
-                        strategyName = strategyName
                     ),
                     AIAgentStrategyStartEvent(
                         runId = clientEventsCollector.runId,
@@ -388,7 +387,6 @@ class DebuggerTest {
                     AIAgentStartedEvent(
                         agentId = agentId,
                         runId = clientEventsCollector.runId,
-                        strategyName = strategyName
                     ),
                     AIAgentStrategyStartEvent(
                         runId = clientEventsCollector.runId,
@@ -494,7 +492,6 @@ class DebuggerTest {
                     AIAgentStartedEvent(
                         agentId = agentId,
                         runId = clientEventsCollector.runId,
-                        strategyName = strategyName
                     ),
                     AIAgentStrategyStartEvent(
                         runId = clientEventsCollector.runId,

--- a/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerConfig.kt
+++ b/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerConfig.kt
@@ -1,16 +1,12 @@
 package ai.koog.agents.features.eventHandler.feature
 
-import ai.koog.agents.core.agent.GraphAIAgent
-import ai.koog.agents.core.agent.context.AIAgentContext
-import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
-import ai.koog.agents.core.agent.entity.AIAgentNodeBase
 import ai.koog.agents.core.feature.config.FeatureConfig
 import ai.koog.agents.core.feature.handler.AfterLLMCallContext
 import ai.koog.agents.core.feature.handler.AgentBeforeCloseContext
 import ai.koog.agents.core.feature.handler.AgentFinishedContext
 import ai.koog.agents.core.feature.handler.AgentRunErrorContext
+import ai.koog.agents.core.feature.handler.AgentStartContext
 import ai.koog.agents.core.feature.handler.BeforeLLMCallContext
-import ai.koog.agents.core.feature.handler.GraphAgentStartContext
 import ai.koog.agents.core.feature.handler.NodeAfterExecuteContext
 import ai.koog.agents.core.feature.handler.NodeBeforeExecuteContext
 import ai.koog.agents.core.feature.handler.NodeExecutionErrorContext
@@ -20,15 +16,6 @@ import ai.koog.agents.core.feature.handler.ToolCallContext
 import ai.koog.agents.core.feature.handler.ToolCallFailureContext
 import ai.koog.agents.core.feature.handler.ToolCallResultContext
 import ai.koog.agents.core.feature.handler.ToolValidationErrorContext
-import ai.koog.agents.core.tools.Tool
-import ai.koog.agents.core.tools.ToolArgs
-import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.agents.core.tools.ToolResult
-import ai.koog.prompt.dsl.Prompt
-import ai.koog.prompt.llm.LLModel
-import ai.koog.prompt.message.Message
-import kotlin.uuid.ExperimentalUuidApi
-import kotlin.uuid.Uuid
 
 /**
  * Configuration class for the EventHandler feature.
@@ -57,7 +44,7 @@ public class EventHandlerConfig : FeatureConfig() {
 
     //region Agent Handlers
 
-    private var _onBeforeAgentStarted: suspend (eventHandler: GraphAgentStartContext<EventHandler>) -> Unit = { _ -> }
+    private var _onBeforeAgentStarted: suspend (eventHandler: AgentStartContext<EventHandler>) -> Unit = { _ -> }
 
     private var _onAgentFinished: suspend (eventHandler: AgentFinishedContext) -> Unit = { _ -> }
 
@@ -105,294 +92,12 @@ public class EventHandlerConfig : FeatureConfig() {
 
     //endregion Tool Call Handlers
 
-    //region Deprecated Agent Handlers
-
-    /**
-     * A handler invoked before an AI agent is started.
-     *
-     * Deprecated: Use the corresponding `onBeforeAgentStarted` function instead to append event handlers.
-     *
-     * The handler is a suspendable function that receives an `AIAgentStrategy` and an `AIAgent` as parameters. It can be used
-     * to perform custom logic or setup tasks before the agent's execution begins.
-     *
-     * To ensure future compatibility, transition to the recommended function-based approach for appending handlers.
-     */
-    @Deprecated(
-        message = "Please use onBeforeAgentStarted() instead",
-        replaceWith = ReplaceWith("onBeforeAgentStarted(handler)")
-    )
-    public var onBeforeAgentStarted: suspend (
-        strategy: AIAgentGraphStrategy<*, *>,
-        agent: GraphAIAgent<*, *>
-    ) -> Unit = { _: AIAgentGraphStrategy<*, *>, _: GraphAIAgent<*, *> -> }
-        set(value) {
-            this.onBeforeAgentStarted { eventContext ->
-                value(eventContext.strategy, eventContext.agent)
-            }
-        }
-
-    /**
-     * A deprecated handler invoked when an agent finishes execution.
-     *
-     * Provides the name of the strategy and an optional result of the execution.
-     *
-     * It is recommended to use the `onAgentFinished()` function instead to append handlers.
-     *
-     * @deprecated Use `onAgentFinished(handler)` instead.
-     */
-    @Deprecated(message = "Please use onAgentFinished() instead", replaceWith = ReplaceWith("onAgentFinished(handler)"))
-    public var onAgentFinished: suspend (
-        strategyName: String,
-        result: Any?
-    ) -> Unit = { strategyName: String, result: Any? -> }
-        set(value) {
-            this.onAgentFinished { eventContext ->
-                value("", eventContext.result)
-            }
-        }
-
-    /**
-     * A deprecated variable used to define a handler that is called when an error occurs during agent execution.
-     *
-     * This handler is invoked with the strategy name, an optional session UUID, and the throwable that caused the error.
-     *
-     * @deprecated Use the `onAgentRunError` function instead for appending custom error handlers.
-     */
-    @OptIn(ExperimentalUuidApi::class)
-    @Deprecated(message = "Please use onAgentRunError() instead", replaceWith = ReplaceWith("onAgentRunError(handler)"))
-    public var onAgentRunError: suspend (
-        strategyName: String,
-        sessionUuid: Uuid?,
-        throwable: Throwable
-    ) -> Unit = { _: String, _: Uuid?, _: Throwable -> }
-        set(value) {
-            this.onAgentRunError { eventContext ->
-                value("", Uuid.parse(eventContext.runId), eventContext.throwable)
-            }
-        }
-
-    //endregion Deprecated Agent Handlers
-
-    //region Deprecated Node Handlers
-
-    /**
-     * A handler invoked before a node in the agent's execution graph is processed.
-     *
-     * This property is deprecated and should be replaced with the `onBeforeNode` method.
-     * It accepts a suspend function that takes the following parameters:
-     * - `node`: The node being processed.
-     * - `context`: The context in which the node is being executed.
-     * - `input`: The input provided to the node.
-     *
-     * Deprecated: Use the `onBeforeNode(handler)` method for appending handlers to the event.
-     */
-    @Deprecated(message = "Please use onBeforeNode() instead", replaceWith = ReplaceWith("onBeforeNode(handler)"))
-    public var onBeforeNode: suspend (
-        node: AIAgentNodeBase<*, *>,
-        context: AIAgentContext,
-        input: Any?
-    ) -> Unit = { _: AIAgentNodeBase<*, *>, _: AIAgentContext, _: Any? -> }
-        set(value) {
-            this.onBeforeNode { eventContext ->
-                value(eventContext.node, eventContext.context, eventContext.input)
-            }
-        }
-
-    /**
-     * A deprecated variable used to define a handler that is called after a node
-     * in the agent's execution graph has been processed.
-     *
-     * The handler is a suspend function that receives the following parameters:
-     * - `node`: The node that was processed, represented by an instance of `AIAgentNodeBase`.
-     * - `context`: The context of the agent containing relevant execution state and data.
-     * - `input`: The input passed to the node during processing.
-     * - `output`: The output produced after the node was processed.
-     *
-     * It is recommended to use the function `onAfterNode(handler)` to set the handler,
-     * as this variable is deprecated.
-     */
-    @Deprecated(message = "Please use onAfterNode() instead", replaceWith = ReplaceWith("onAfterNode(handler)"))
-    public var onAfterNode: suspend (
-        node: AIAgentNodeBase<*, *>,
-        context: AIAgentContext,
-        input: Any?,
-        output: Any?
-    ) -> Unit = { node: AIAgentNodeBase<*, *>, context: AIAgentContext, input: Any?, output: Any? -> }
-        set(value) {
-            this.onAfterNode { eventContext ->
-                value(eventContext.node, eventContext.context, eventContext.input, eventContext.output)
-            }
-        }
-
-    //endregion Deprecated Node Handlers
-
-    //region Deprecated LLM Call Handlers
-
-    /**
-     * Deprecated variable used to define a handler that is invoked before a call is made to the language model.
-     *
-     * It allows custom logic to be executed before making a call to the language model with the given prompt,
-     * tools, model, and session UUID.
-     *
-     * @deprecated Use the `onBeforeLLMCall(handler)` function to achieve the same functionality.
-     */
-    @OptIn(ExperimentalUuidApi::class)
-    @Deprecated(message = "Please use onBeforeLLMCall() instead", replaceWith = ReplaceWith("onBeforeLLMCall(handler)"))
-    public var onBeforeLLMCall: suspend (
-        prompt: Prompt,
-        tools: List<ToolDescriptor>,
-        model: LLModel,
-        sessionUuid: Uuid
-    ) -> Unit = { _: Prompt, _: List<ToolDescriptor>, _: LLModel, _: Uuid -> }
-        set(value) {
-            this.onBeforeLLMCall { eventContext ->
-                value(eventContext.prompt, eventContext.tools, eventContext.model, Uuid.parse(eventContext.runId))
-            }
-        }
-
-    /**
-     * A deprecated property to handle events triggered after a response is received from the language model (LLM).
-     *
-     * Use the `onAfterLLMCall(handler: suspend (prompt, tools, model, responses, sessionUuid) -> Unit)` method instead.
-     *
-     * The handler is a suspending function that is executed after an LLM call and receives the following parameters:
-     * - `prompt`: The prompt that was sent to the language model.
-     * - `tools`: A list of available tool descriptors.
-     * - `model`: The language model instance that processed the request.
-     * - `responses`: A list of responses returned by the language model.
-     * - `sessionUuid`: The unique identifier for the session in which this call occurred.
-     *
-     * Updating this property will automatically delegate to the newer `onAfterLLMCall` method.
-     */
-    @OptIn(ExperimentalUuidApi::class)
-    @Deprecated(message = "Please use onAfterLLMCall() instead", replaceWith = ReplaceWith("onAfterLLMCall(handler)"))
-    public var onAfterLLMCall: suspend (
-        prompt: Prompt,
-        tools: List<ToolDescriptor>,
-        model: LLModel,
-        responses: List<Message.Response>,
-        sessionUuid: Uuid
-    ) -> Unit = {
-            _: Prompt,
-            _: List<ToolDescriptor>,
-            _: LLModel,
-            _: List<Message.Response>,
-            _: Uuid
-        ->
-    }
-        set(value) {
-            this.onAfterLLMCall { eventContext ->
-                value(
-                    eventContext.prompt,
-                    eventContext.tools,
-                    eventContext.model,
-                    eventContext.responses,
-                    Uuid.parse(eventContext.runId)
-                )
-            }
-        }
-
-    //endregion Deprecated LLM Call Handlers
-
-    //region Deprecated Tool Call Handlers
-
-    /**
-     * A deprecated variable for appending a handler called when a tool is about to be invoked.
-     *
-     * Use the `onToolCall` function to properly append a handler for tool invocation events.
-     *
-     * @deprecated Use `onToolCall(handler)` instead for appending handlers in a preferred manner.
-     */
-    @Deprecated(message = "Please use onToolCall() instead", replaceWith = ReplaceWith("onToolCall(handler)"))
-    public var onToolCall: suspend (
-        tool: Tool<*, *>,
-        toolArgs: ToolArgs
-    ) -> Unit = { _: Tool<*, *>, _: ToolArgs -> }
-        set(value) {
-            this.onToolCall { eventContext ->
-                value(eventContext.tool, eventContext.toolArgs)
-            }
-        }
-
-    /**
-     * A deprecated variable representing the handler invoked when a validation error occurs during a tool call.
-     * Use `onToolValidationError(handler)` instead to register error handling logic.
-     *
-     * The handler receives the following parameters:
-     * - `tool`: The tool instance where the validation error occurred.
-     * - `toolArgs`: The arguments provided to the tool during the call.
-     * - `value`: The string representing the invalid value or other contextual information about the error.
-     *
-     * This property is deprecated and maintained for backward compatibility.
-     */
-    @Deprecated(
-        message = "Please use onToolValidationError() instead",
-        replaceWith = ReplaceWith("onToolValidationError(handler)")
-    )
-    public var onToolValidationError: suspend (
-        tool: Tool<*, *>,
-        toolArgs: ToolArgs,
-        value: String
-    ) -> Unit = { tool: Tool<*, *>, toolArgs: ToolArgs, value: String -> }
-        set(value) {
-            this.onToolValidationError { eventContext ->
-                value(eventContext.tool, eventContext.toolArgs, eventContext.error)
-            }
-        }
-
-    /**
-     * Defines a handler invoked when a tool call fails due to an exception.
-     *
-     * This property is deprecated and will be removed in future versions.
-     * Use the `onToolCallFailure(handler: suspend (tool: Tool<*, *>, toolArgs: Tool.Args, throwable: Throwable) -> Unit)` function instead to add handlers for tool call failure events.
-     *
-     * Replacing this property with the newer `onToolCallFailure` function ensures better consistency and management of handlers.
-     */
-    @Deprecated(
-        message = "Please use onToolCallFailure() instead",
-        replaceWith = ReplaceWith("onToolCallFailure(handler)")
-    )
-    public var onToolCallFailure: suspend (
-        tool: Tool<*, *>,
-        toolArgs: ToolArgs,
-        throwable: Throwable
-    ) -> Unit = { tool: Tool<*, *>, toolArgs: ToolArgs, throwable: Throwable -> }
-        set(value) {
-            this.onToolCallFailure { eventContext ->
-                value(eventContext.tool, eventContext.toolArgs, eventContext.throwable)
-            }
-        }
-
-    /**
-     * Deprecated variable representing a handler invoked when a tool call is completed successfully.
-     * The handler is a suspend function with parameters for the tool, its arguments, and the result of the tool call.
-     *
-     * @deprecated Use the `onToolCallResult(handler)` function instead. This property will be removed in future versions.
-     * @see onToolCallResult
-     */
-    @Deprecated(
-        message = "Please use onToolCallResult() instead",
-        replaceWith = ReplaceWith("onToolCallResult(handler)")
-    )
-    public var onToolCallResult: suspend (
-        tool: Tool<*, *>,
-        toolArgs: ToolArgs,
-        result: ToolResult?
-    ) -> Unit = { tool: Tool<*, *>, toolArgs: ToolArgs, result: ToolResult? -> }
-        set(value) {
-            this.onToolCallResult { eventContext ->
-                value(eventContext.tool, eventContext.toolArgs, eventContext.result)
-            }
-        }
-
-    //endregion Deprecated Tool Call Handlers
-
     //region Agent Handlers
 
     /**
      * Append handler called when an agent is started.
      */
-    public fun onBeforeAgentStarted(handler: suspend (eventContext: GraphAgentStartContext<*>) -> Unit) {
+    public fun onBeforeAgentStarted(handler: suspend (eventContext: AgentStartContext<*>) -> Unit) {
         val originalHandler = this._onBeforeAgentStarted
         this._onBeforeAgentStarted = { eventContext ->
             originalHandler(eventContext)
@@ -578,7 +283,7 @@ public class EventHandlerConfig : FeatureConfig() {
     /**
      * Invoke handlers for an event when an agent is started.
      */
-    internal suspend fun invokeOnBeforeAgentStarted(eventContext: GraphAgentStartContext<EventHandler>) {
+    internal suspend fun invokeOnBeforeAgentStarted(eventContext: AgentStartContext<EventHandler>) {
         _onBeforeAgentStarted.invoke(eventContext)
     }
 

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerTest.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerTest.kt
@@ -49,7 +49,7 @@ class EventHandlerTest {
         val runId = eventsCollector.runId
 
         val expectedEvents = listOf(
-            "OnBeforeAgentStarted (agent id: test-agent-id, run id: $runId, strategy: $strategyName)",
+            "OnBeforeAgentStarted (agent id: test-agent-id, run id: $runId)",
             "OnStrategyStarted (run id: $runId, strategy: $strategyName)",
             "OnBeforeNode (run id: $runId, node: __start__, input: $agentInput)",
             "OnAfterNode (run id: $runId, node: __start__, input: $agentInput, output: $agentInput)",
@@ -93,7 +93,7 @@ class EventHandlerTest {
         val runId = eventsCollector.runId
 
         val expectedEvents = listOf(
-            "OnBeforeAgentStarted (agent id: test-agent-id, run id: $runId, strategy: $strategyName)",
+            "OnBeforeAgentStarted (agent id: test-agent-id, run id: $runId)",
             "OnStrategyStarted (run id: $runId, strategy: $strategyName)",
             "OnBeforeNode (run id: $runId, node: __start__, input: $agentInput)",
             "OnAfterNode (run id: $runId, node: __start__, input: $agentInput, output: $agentInput)",
@@ -162,7 +162,7 @@ class EventHandlerTest {
         val runId = eventsCollector.runId
 
         val expectedEvents = listOf(
-            "OnBeforeAgentStarted (agent id: $agentId, run id: $runId, strategy: $strategyName)",
+            "OnBeforeAgentStarted (agent id: $agentId, run id: $runId)",
             "OnStrategyStarted (run id: $runId, strategy: $strategyName)",
             "OnBeforeNode (run id: $runId, node: __start__, input: $userPrompt)",
             "OnAfterNode (run id: $runId, node: __start__, input: $userPrompt, output: $userPrompt)",
@@ -219,7 +219,7 @@ class EventHandlerTest {
         val runId = eventsCollector.runId
 
         val expectedEvents = listOf(
-            "OnBeforeAgentStarted (agent id: test-agent-id, run id: $runId, strategy: $strategyName)",
+            "OnBeforeAgentStarted (agent id: test-agent-id, run id: $runId)",
             "OnStrategyStarted (run id: $runId, strategy: $strategyName)",
             "OnBeforeNode (run id: $runId, node: __start__, input: $agentInput)",
             "OnAfterNode (run id: $runId, node: __start__, input: $agentInput, output: $agentInput)",
@@ -277,7 +277,7 @@ class EventHandlerTest {
         val runId = eventsCollector.runId
 
         val expectedEvents = listOf(
-            "OnBeforeAgentStarted (agent id: $agentId, run id: $runId, strategy: $strategyName)",
+            "OnBeforeAgentStarted (agent id: $agentId, run id: $runId)",
             "OnStrategyStarted (run id: $runId, strategy: $strategyName)",
             "OnBeforeNode (run id: $runId, node: __start__, input: $agentInput)",
             "OnAfterNode (run id: $runId, node: __start__, input: $agentInput, output: $agentInput)",
@@ -304,19 +304,20 @@ class EventHandlerTest {
         var runId = ""
 
         val agent = createAgent(
+            agentId = "test-agent-id",
             strategy = strategy,
             installFeatures = {
                 install(EventHandler) {
                     onBeforeAgentStarted { eventContext ->
                         runId = eventContext.runId
                         collectedEvents.add(
-                            "OnBeforeAgentStarted first (agent id: ${eventContext.agent.id}, strategy: ${eventContext.strategy.name})"
+                            "OnBeforeAgentStarted first (agent id: ${eventContext.agent.id})"
                         )
                     }
 
                     onBeforeAgentStarted { eventContext ->
                         collectedEvents.add(
-                            "OnBeforeAgentStarted second (agent id: ${eventContext.agent.id}, strategy: ${eventContext.strategy.name})"
+                            "OnBeforeAgentStarted second (agent id: ${eventContext.agent.id})"
                         )
                     }
 
@@ -333,9 +334,9 @@ class EventHandlerTest {
         agent.run(agentInput)
 
         val expectedEvents = listOf(
-            "OnBeforeAgentStarted first (agent id: test-agent-id, strategy: $strategyName)",
-            "OnBeforeAgentStarted second (agent id: test-agent-id, strategy: $strategyName)",
-            "OnAgentFinished (agent id: test-agent-id, run id: $runId, result: $agentResult)",
+            "OnBeforeAgentStarted first (agent id: ${agent.id})",
+            "OnBeforeAgentStarted second (agent id: ${agent.id})",
+            "OnAgentFinished (agent id: ${agent.id}, run id: $runId, result: $agentResult)",
         )
 
         assertEquals(expectedEvents.size, collectedEvents.size)

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/TestEventsCollector.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/TestEventsCollector.kt
@@ -20,7 +20,7 @@ class TestEventsCollector {
         onBeforeAgentStarted { eventContext ->
             runId = eventContext.runId
             _collectedEvents.add(
-                "OnBeforeAgentStarted (agent id: ${eventContext.agent.id}, run id: ${eventContext.runId}, strategy: ${eventContext.strategy.name})"
+                "OnBeforeAgentStarted (agent id: ${eventContext.agent.id}, run id: ${eventContext.runId})"
             )
         }
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
@@ -104,7 +104,6 @@ public class OpenTelemetry {
                     provider = eventContext.agent.agentConfig.model.provider,
                     agentId = eventContext.agent.id,
                     runId = eventContext.runId,
-                    strategyName = eventContext.strategy.name
                 )
 
                 spanAdapter?.onBeforeSpanStarted(invokeAgentSpan)

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/InvokeAgentSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/InvokeAgentSpan.kt
@@ -1,7 +1,6 @@
 package ai.koog.agents.features.opentelemetry.span
 
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
-import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
 import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
 import ai.koog.prompt.llm.LLMProvider
 import io.opentelemetry.api.trace.SpanKind
@@ -14,7 +13,6 @@ internal class InvokeAgentSpan(
     provider: LLMProvider,
     runId: String,
     agentId: String,
-    strategyName: String,
 ) : GenAIAgentSpan(parent) {
 
     companion object {
@@ -72,8 +70,5 @@ internal class InvokeAgentSpan(
 
         // gen_ai.conversation.id
         addAttribute(SpanAttributes.Conversation.Id(runId))
-
-        // custom: strategy name
-        addAttribute(CustomAttribute("koog.agent.strategy.name", strategyName))
     }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryTest.kt
@@ -192,7 +192,6 @@ class OpenTelemetryTest {
                     "run.${mockExporter.lastRunId}" to mapOf(
                         "attributes" to mapOf(
                             "gen_ai.operation.name" to "invoke_agent",
-                            "koog.agent.strategy.name" to "test-strategy",
                             "gen_ai.system" to model.provider.id,
                             "gen_ai.agent.id" to agentId,
                             "gen_ai.conversation.id" to mockExporter.lastRunId
@@ -348,7 +347,6 @@ class OpenTelemetryTest {
                     "run.${mockExporter.runIds[1]}" to mapOf(
                         "attributes" to mapOf(
                             "gen_ai.operation.name" to "invoke_agent",
-                            "koog.agent.strategy.name" to "test-strategy",
                             "gen_ai.system" to model.provider.id,
                             "gen_ai.agent.id" to agentId,
                             "gen_ai.conversation.id" to mockExporter.runIds[1]
@@ -422,7 +420,6 @@ class OpenTelemetryTest {
                     "run.${mockExporter.runIds[0]}" to mapOf(
                         "attributes" to mapOf(
                             "gen_ai.operation.name" to "invoke_agent",
-                            "koog.agent.strategy.name" to "test-strategy",
                             "gen_ai.system" to model.provider.id,
                             "gen_ai.agent.id" to agentId,
                             "gen_ai.conversation.id" to mockExporter.runIds[0]
@@ -579,7 +576,6 @@ class OpenTelemetryTest {
                             "gen_ai.agent.id" to agentId,
                             "gen_ai.conversation.id" to mockExporter.lastRunId,
                             "gen_ai.operation.name" to "invoke_agent",
-                            "koog.agent.strategy.name" to "test-strategy",
                         ),
                         "events" to emptyMap()
                     )
@@ -802,7 +798,6 @@ class OpenTelemetryTest {
                             "gen_ai.agent.id" to agentId,
                             "gen_ai.conversation.id" to mockExporter.lastRunId,
                             "gen_ai.operation.name" to "invoke_agent",
-                            "koog.agent.strategy.name" to "test-strategy",
                         ),
                         "events" to emptyMap()
                     )
@@ -1189,7 +1184,6 @@ class OpenTelemetryTest {
                         "attributes" to mapOf(
                             "gen_ai.operation.name" to "invoke_agent",
                             "gen_ai.response.finish_reasons" to listOf(FinishReasonType.Error.id),
-                            "koog.agent.strategy.name" to "test-strategy",
                             "gen_ai.system" to model.provider.id,
                             "gen_ai.agent.id" to agentId,
                             "gen_ai.conversation.id" to mockExporter.lastRunId
@@ -1289,7 +1283,6 @@ class OpenTelemetryTest {
 
                     "run.${mockExporter.lastRunId}" to mapOf(
                         "attributes" to mapOf(
-                            "koog.agent.strategy.name" to strategyName,
                             "gen_ai.conversation.id" to mockExporter.lastRunId,
                             customBeforeStartAttribute.key to customBeforeStartAttribute.value,
                             customBeforeFinishAttribute.key to customBeforeFinishAttribute.value,

--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/Persistency.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/Persistency.kt
@@ -3,6 +3,7 @@ package ai.koog.agents.snapshot.feature
 import ai.koog.agents.core.agent.context.AIAgentContext
 import ai.koog.agents.core.agent.context.AgentContextData
 import ai.koog.agents.core.agent.context.store
+import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.agent.entity.AIAgentStorageKey
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.feature.AIAgentFeature
@@ -98,8 +99,9 @@ public class Persistency(private val persistencyStorageProvider: PersistencyStor
                 return@interceptContextAgentFeature featureImpl
             }
 
-            pipeline.interceptBeforeAgentStarted(interceptContext) { ctx ->
-                require(ctx.strategy.metadata.uniqueNames) {
+            pipeline.interceptStrategyStarted(interceptContext) { ctx ->
+                val strategy = ctx.strategy as AIAgentGraphStrategy<*, *>
+                require(strategy.metadata.uniqueNames) {
                     "Checkpoint feature requires unique node names in the strategy metadata"
                 }
                 val checkpoint = ctx.feature.rollbackToLatestCheckpoint(ctx.context)

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/NodeUniquenessCheckpointTest.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/NodeUniquenessCheckpointTest.kt
@@ -74,8 +74,8 @@ class NodeUniquenessCheckpointTest {
     }
 
     /**
-     * Test that verifies an error is produced when AgentCheckpoint feature is present
-     * and graph's nodes are non-unique.
+     * Test that verifies an error is produced when the AgentCheckpoint feature is present
+     * and the graph's nodes are non-unique.
      */
     @Test
     fun `test error when AgentCheckpoint feature is present and nodes are non-unique`() = runTest {

--- a/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/feature/Tracing.kt
+++ b/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/feature/Tracing.kt
@@ -125,7 +125,6 @@ public class Tracing {
                 val event = AIAgentStartedEvent(
                     agentId = eventContext.agent.id,
                     runId = eventContext.runId,
-                    strategyName = eventContext.strategy.name,
                 )
                 processMessage(config, event)
             }

--- a/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/writer/traceMessageFormat.kt
+++ b/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/writer/traceMessageFormat.kt
@@ -32,7 +32,7 @@ internal val FeatureStringMessage.featureStringMessage
     get() = "Feature string message (message: $message)"
 
 internal val AIAgentStartedEvent.agentStartedEventFormat
-    get() = "$eventId (agent id: $agentId, run id: $runId, strategy: $strategyName)"
+    get() = "$eventId (agent id: $agentId, run id: $runId)"
 
 internal val AIAgentFinishedEvent.agentFinishedEventFormat
     get() = "$eventId (agent id: $agentId, run id: $runId, result: $result)"

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageFileWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageFileWriterTest.kt
@@ -154,7 +154,7 @@ class TraceFeatureMessageFileWriterTest {
             }
 
             val expectedMessages = listOf(
-                "${AIAgentStartedEvent::class.simpleName} (agent id: $agentId, run id: $runId, strategy: $strategyName)",
+                "${AIAgentStartedEvent::class.simpleName} (agent id: $agentId, run id: $runId)",
                 "${AIAgentStrategyStartEvent::class.simpleName} (run id: $runId, strategy: $strategyName)",
                 "${AIAgentNodeExecutionStartEvent::class.simpleName} (run id: $runId, node: __start__, input: $userPrompt)",
                 "${AIAgentNodeExecutionEndEvent::class.simpleName} (run id: $runId, node: __start__, input: $userPrompt, output: $userPrompt)",
@@ -265,11 +265,10 @@ class TraceFeatureMessageFileWriterTest {
 
         val agentId = "test-agent-id"
         val runId = "test-run-id"
-        val strategyName = "test-strategy"
 
         val messagesToProcess = listOf(
             FeatureStringMessage("Test string message"),
-            AIAgentStartedEvent(agentId = agentId, runId = runId, strategyName = strategyName)
+            AIAgentStartedEvent(agentId = agentId, runId = runId)
         )
 
         val expectedMessages = listOf(

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageLogWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageLogWriterTest.kt
@@ -143,7 +143,7 @@ class TraceFeatureMessageLogWriterTest {
             }
 
             val expectedLogMessages = listOf(
-                "[INFO] Received feature message [event]: ${AIAgentStartedEvent::class.simpleName} (agent id: $agentId, run id: $runId, strategy: $strategyName)",
+                "[INFO] Received feature message [event]: ${AIAgentStartedEvent::class.simpleName} (agent id: $agentId, run id: $runId)",
                 "[INFO] Received feature message [event]: ${AIAgentStrategyStartEvent::class.simpleName} (run id: $runId, strategy: $strategyName)",
                 "[INFO] Received feature message [event]: ${AIAgentNodeExecutionStartEvent::class.simpleName} (run id: $runId, node: __start__, input: $userPrompt)",
                 "[INFO] Received feature message [event]: ${AIAgentNodeExecutionEndEvent::class.simpleName} (run id: $runId, node: __start__, input: $userPrompt, output: $userPrompt)",
@@ -252,11 +252,10 @@ class TraceFeatureMessageLogWriterTest {
 
         val agentId = "test-agent-id"
         val runId = "test-run-id"
-        val strategyName = "test-strategy"
 
         val actualMessages = listOf(
             FeatureStringMessage("Test string message"),
-            AIAgentStartedEvent(agentId = agentId, runId = runId, strategyName = strategyName)
+            AIAgentStartedEvent(agentId = agentId, runId = runId)
         )
 
         val expectedMessages = listOf(

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageRemoteWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageRemoteWriterTest.kt
@@ -256,7 +256,6 @@ class TraceFeatureMessageRemoteWriterTest {
                     AIAgentStartedEvent(
                         agentId = agentId,
                         runId = runId,
-                        strategyName = strategyName
                     ),
                     AIAgentStrategyStartEvent(
                         runId = runId,

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/feature/TestingFeature.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/feature/TestingFeature.kt
@@ -5,7 +5,7 @@ package ai.koog.agents.testing.feature
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.GraphAIAgent
 import ai.koog.agents.core.agent.GraphAIAgent.FeatureContext
-import ai.koog.agents.core.agent.config.AIAgentConfigBase
+import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.context.AIAgentGraphContextBase
 import ai.koog.agents.core.agent.context.AIAgentLLMContext
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
@@ -755,7 +755,7 @@ public class Testing {
                     environment: AIAgentEnvironment?,
                     agentInput: Any?,
                     agentInputType: KType?,
-                    config: AIAgentConfigBase?,
+                    config: AIAgentConfig?,
                     llm: AIAgentLLMContext?,
                     stateManager: AIAgentStateManager?,
                     storage: AIAgentStorage?,
@@ -863,7 +863,7 @@ public class Testing {
                     environment: AIAgentEnvironment?,
                     agentInput: Any?,
                     agentInputType: KType?,
-                    config: AIAgentConfigBase?,
+                    config: AIAgentConfig?,
                     llm: AIAgentLLMContext?,
                     stateManager: AIAgentStateManager?,
                     storage: AIAgentStorage?,

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/DummyAIAgentContext.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/DummyAIAgentContext.kt
@@ -2,7 +2,7 @@
 
 package ai.koog.agents.testing.tools
 
-import ai.koog.agents.core.agent.config.AIAgentConfigBase
+import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.context.AIAgentContext
 import ai.koog.agents.core.agent.context.AIAgentGraphContextBase
 import ai.koog.agents.core.agent.context.AIAgentLLMContext
@@ -52,7 +52,7 @@ public class DummyAIAgentContext(
     private var _environment: AIAgentEnvironment? = builder.environment
     private var _agentInput: Any? = builder.agentInput
     private var _agentInputType: KType? = builder.agentInputType
-    private var _config: AIAgentConfigBase? = builder.config
+    private var _config: AIAgentConfig? = builder.config
     private var _llm: AIAgentLLMContext? = builder.llm
     private var _stateManager: AIAgentStateManager? = builder.stateManager
     private var _storage: AIAgentStorage? = builder.storage
@@ -65,13 +65,13 @@ public class DummyAIAgentContext(
     override val environment: AIAgentEnvironment
         get() = _environment ?: throw NotImplementedError("Environment is not mocked")
 
-    override val agentInput: Any?
+    override val agentInput: Any
         get() = _agentInput ?: throw NotImplementedError("Agent input is not mocked")
 
     override val agentInputType: KType
         get() = _agentInputType ?: throw NotImplementedError("Agent input type is not mocked")
 
-    override val config: AIAgentConfigBase
+    override val config: AIAgentConfig
         get() = _config ?: throw NotImplementedError("Config is not mocked")
 
     override val llm: AIAgentLLMContext
@@ -97,7 +97,7 @@ public class DummyAIAgentContext(
         throw NotImplementedError("store() is not supported for mock")
     }
 
-    override fun <T> get(key: AIAgentStorageKey<*>): T? {
+    override fun <T> get(key: AIAgentStorageKey<*>): T {
         throw NotImplementedError("get() is not supported for mock")
     }
 
@@ -105,10 +105,10 @@ public class DummyAIAgentContext(
         throw NotImplementedError("remove() is not supported for mock")
     }
 
-    override fun <Feature : Any> feature(key: AIAgentStorageKey<Feature>): Feature? =
+    override fun <Feature : Any> feature(key: AIAgentStorageKey<Feature>): Feature =
         throw NotImplementedError("feature() getting in runtime is not supported for mock")
 
-    override fun <Feature : Any> feature(feature: AIAgentFeature<*, Feature>): Feature? =
+    override fun <Feature : Any> feature(feature: AIAgentFeature<*, Feature>): Feature =
         throw NotImplementedError("feature()  getting in runtime is not supported for mock")
 
     override suspend fun getHistory(): List<Message> = emptyList()
@@ -121,7 +121,7 @@ public class DummyAIAgentContext(
      * @param agentInput The input object provided to the AI agent, representing data or context for the agent to process.
      * @param agentInputType The type of the agent input, used to interpret the structure or nature of the input.
      * @param config The configuration settings for the AI agent, such as model specifics and operational limits.
-     * @param llm The language model context utilized by the AI agent for generating responses or processing input.
+     * @param llm The language model context used by the AI agent for generating responses or processing input.
      * @param stateManager The state management associated with the AI agent, responsible for tracking execution state and history.
      * @param storage A storage mechanism for the AI agent, enabling persistence of key-value information.
      * @param runId A unique identifier for the current execution or operational instance of the AI agent.
@@ -133,7 +133,7 @@ public class DummyAIAgentContext(
         environment: AIAgentEnvironment,
         agentInput: Any?,
         agentInputType: KType,
-        config: AIAgentConfigBase,
+        config: AIAgentConfig,
         llm: AIAgentLLMContext,
         stateManager: AIAgentStateManager,
         storage: AIAgentStorage,
@@ -206,14 +206,14 @@ public interface AIAgentContextMockBuilderBase : BaseBuilder<AIAgentContext> {
     /**
      * Specifies the configuration for the AI agent.
      *
-     * This property allows setting an instance of [AIAgentConfigBase], which defines various parameters
+     * This property allows setting an instance of [AIAgentConfig], which defines various parameters
      * and settings for the AI agent, such as the model, prompt structure, execution strategies, and constraints.
      * It provides the core configuration required for the agent's setup and behavior.
      *
      * If null, the configuration will not be explicitly defined, and the agent may rely on default or externally
      * supplied configurations.
      */
-    public var config: AIAgentConfigBase?
+    public var config: AIAgentConfig?
 
     /**
      * Represents the LLM context associated with an AI agent during testing scenarios.
@@ -277,7 +277,7 @@ public interface AIAgentContextMockBuilderBase : BaseBuilder<AIAgentContext> {
         environment: AIAgentEnvironment? = this.environment,
         agentInput: Any? = this.agentInput,
         agentInputType: KType? = this.agentInputType,
-        config: AIAgentConfigBase? = this.config,
+        config: AIAgentConfig? = this.config,
         llm: AIAgentLLMContext? = this.llm,
         stateManager: AIAgentStateManager? = this.stateManager,
         storage: AIAgentStorage? = this.storage,
@@ -320,7 +320,7 @@ public class AIAgentContextMockBuilder() : AIAgentContextMockBuilderBase {
      * Represents the agent's input data used in constructing or testing the agent's context.
      *
      * This property is optional and can be null, indicating that no specific input is provided for the agent.
-     * It is utilized during the construction or copying of an agent's context to define the data the agent operates on.
+     * It is used during the construction or copying of an agent's context to define the data the agent operates on.
      */
     override var agentInput: Any? = null
 
@@ -334,13 +334,13 @@ public class AIAgentContextMockBuilder() : AIAgentContextMockBuilderBase {
      *
      * This property holds the agent's configuration, which may include the parameters for prompts,
      * the language model to be used, iteration limits, and strategies for handling missing tools.
-     * It is utilized in constructing or copying an AI agent context during testing or mock setup.
+     * It is used in constructing or copying an AI agent context during testing or mock setup.
      *
-     * The configuration, represented by [AIAgentConfigBase], can be modified or replaced
+     * The configuration, represented by [AIAgentConfig], can be modified or replaced
      * depending on the requirements of the mock or testing scenario. A `null` value indicates
      * the absence of a specific configuration.
      */
-    override var config: AIAgentConfigBase? = null
+    override var config: AIAgentConfig? = null
 
     /**
      * Represents the context for accessing and managing an AI agent's LLM (Large Language Model) configuration
@@ -349,7 +349,7 @@ public class AIAgentContextMockBuilder() : AIAgentContextMockBuilderBase {
      *
      * Can be used for dependency injection, mock testing, or modifying the LLM behavior dynamically during
      * runtime. If set to `null`, it indicates that no specific LLM context is defined, and defaults or
-     * fallback mechanisms may be utilized by the containing class.
+     * fallback mechanisms may be used by the containing class.
      */
     override var llm: AIAgentLLMContext? = null
 
@@ -411,7 +411,7 @@ public class AIAgentContextMockBuilder() : AIAgentContextMockBuilderBase {
         environment: AIAgentEnvironment?,
         agentInput: Any?,
         agentInputType: KType?,
-        config: AIAgentConfigBase?,
+        config: AIAgentConfig?,
         llm: AIAgentLLMContext?,
         stateManager: AIAgentStateManager?,
         storage: AIAgentStorage?,
@@ -513,7 +513,7 @@ public class AIAgentContextMockBuilder() : AIAgentContextMockBuilderBase {
                  * @throws IllegalStateException This function always throws an exception indicating unimplemented property access.
                  */
                 @Suppress("UNUSED_PARAMETER")
-                operator fun get(propertyName: String): Any? {
+                operator fun get(propertyName: String): Any {
                     error("Unimplemented property access: $name.$propertyName")
                 }
 
@@ -528,7 +528,7 @@ public class AIAgentContextMockBuilder() : AIAgentContextMockBuilderBase {
                  * @return This function does not return a value as it throws an error instead.
                  */
                 @Suppress("UNUSED_PARAMETER")
-                fun invoke(methodName: String, vararg args: Any?): Any? {
+                fun invoke(methodName: String, vararg args: Any?): Any {
                     error("Unimplemented method call: $name.$methodName(${args.joinToString()})")
                 }
             } as T

--- a/docs/docs/complex-workflow-agents.md
+++ b/docs/docs/complex-workflow-agents.md
@@ -315,7 +315,7 @@ For example, to install the event handler feature, you need to do the following:
 <!--- INCLUDE
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.feature.handler.AgentFinishedContext
-import ai.koog.agents.core.feature.handler.GraphAgentStartContext
+import ai.koog.agents.core.feature.handler.AgentStartContext
 import ai.koog.agents.features.eventHandler.feature.EventHandler
 import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
 import ai.koog.prompt.llm.OllamaModels
@@ -331,8 +331,8 @@ val agent = AIAgent(
 // install the EventHandler feature
 installFeatures = {
     install(EventHandler) {
-        onBeforeAgentStarted { eventContext: GraphAgentStartContext<*> ->
-            println("Starting strategy: ${eventContext.strategy.name}")
+        onBeforeAgentStarted { eventContext: AgentStartContext<*> ->
+            println("Starting agent: ${eventContext.agent.id}")
         }
         onAgentFinished { eventContext: AgentFinishedContext ->
             println("Result: ${eventContext.result}")
@@ -350,7 +350,7 @@ Create the agent with the configuration option created in the previous stages an
 <!--- INCLUDE
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.feature.handler.AgentFinishedContext
-import ai.koog.agents.core.feature.handler.GraphAgentStartContext
+import ai.koog.agents.core.feature.handler.AgentStartContext
 import ai.koog.agents.example.exampleComplexWorkflowAgents01.promptExecutor
 import ai.koog.agents.example.exampleComplexWorkflowAgents06.agentStrategy
 import ai.koog.agents.example.exampleComplexWorkflowAgents07.agentConfig
@@ -366,8 +366,8 @@ val agent = AIAgent(
     agentConfig = agentConfig,
     installFeatures = {
         install(EventHandler) {
-            onBeforeAgentStarted { eventContext: GraphAgentStartContext<*> ->
-                println("Starting strategy: ${eventContext.strategy.name}")
+            onBeforeAgentStarted { eventContext: AgentStartContext<*> ->
+                println("Starting agent: ${eventContext.agent.id}")
             }
             onAgentFinished { eventContext: AgentFinishedContext ->
                 println("Result: ${eventContext.result}")
@@ -409,7 +409,7 @@ import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.*
 import ai.koog.agents.core.feature.handler.AgentFinishedContext
-import ai.koog.agents.core.feature.handler.GraphAgentStartContext
+import ai.koog.agents.core.feature.handler.AgentStartContext
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.core.tools.annotations.Tool
@@ -509,8 +509,8 @@ val agent = AIAgent(
     agentConfig = agentConfig,
     installFeatures = {
         install(EventHandler) {
-            onBeforeAgentStarted { eventContext: GraphAgentStartContext<*> ->
-                println("Starting strategy: ${eventContext.strategy.name}")
+            onBeforeAgentStarted { eventContext: AgentStartContext<*> ->
+                println("Starting agent: ${eventContext.agent.id}")
             }
             onAgentFinished { eventContext: AgentFinishedContext ->
                 println("Result: ${eventContext.result}")

--- a/examples/src/main/kotlin/ai/koog/agents/example/features/logging/Logging.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/features/logging/Logging.kt
@@ -44,7 +44,7 @@ class Logging(val logger: Logger) {
          *
          * The method integrates the feature capabilities into the agent pipeline by setting up interceptors
          * to log information during agent creation, before processing nodes, and after processing nodes by a predefined
-         * hooks, e.g. [BeforeNodeHandler], etc.
+         * hook, e.g. [BeforeNodeHandler], etc.
          *
          * @param config The configuration for the LoggingFeature, providing logger details.
          * @param pipeline The agent pipeline where logging functionality will be installed.
@@ -56,7 +56,7 @@ class Logging(val logger: Logger) {
             val logging = Logging(LoggerFactory.getLogger(config.loggerName))
             val interceptContext = InterceptContext(this, logging)
             pipeline.interceptBeforeAgentStarted(interceptContext) { eventContext ->
-                logging.logger.info("Agent is going to be started with strategy: ${eventContext.strategy.name}.")
+                logging.logger.info("Agent is going to be started (id: ${eventContext.agent.id})")
             }
 
             pipeline.interceptStrategyStarted(interceptContext) { eventContext ->

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OllamaSimpleAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/OllamaSimpleAgentIntegrationTest.kt
@@ -27,7 +27,7 @@ class OllamaSimpleAgentIntegrationTest {
     val eventHandlerConfig: EventHandlerConfig.() -> Unit = {
         onBeforeAgentStarted { eventContext ->
             println(
-                "Agent started: strategy=${eventContext.strategy.javaClass.simpleName}, agent=${eventContext.agent.javaClass.simpleName}"
+                "Agent started: agentId=${eventContext.agent.javaClass.simpleName}"
             )
         }
 


### PR DESCRIPTION
KG-383. Restore agent start event for non-graph agent agents.

## Motivation and Context
Non-graph agent should have a tracking over the agent events, including agent start event that is common for both graph and non-graph agents. Restore the agent start event in base agent pipeline class and updated related logic.

## Breaking Changes
Yes 

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
