### PR TITLE
fix GoogleLLMClient to respect maxTokens and model.maxOutputTokens

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -357,7 +357,7 @@ public open class GoogleLLMClient(
             responseJsonSchema = responseFormat?.responseJsonSchema,
             temperature = if (model.capabilities.contains(LLMCapability.Temperature)) prompt.params.temperature else null,
             candidateCount = if (model.capabilities.contains(LLMCapability.MultipleChoices)) prompt.params.numberOfChoices else null,
-            maxOutputTokens = prompt.params.maxTokens ?: model.maxOutputTokens?.toInt() ?: 2048,
+            maxOutputTokens = prompt.params.maxTokens,
             thinkingConfig = GoogleThinkingConfig(
                 includeThoughts = prompt.params.includeThoughts.takeIf { it == true },
                 thinkingBudget = prompt.params.thinkingBudget

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -357,7 +357,7 @@ public open class GoogleLLMClient(
             responseJsonSchema = responseFormat?.responseJsonSchema,
             temperature = if (model.capabilities.contains(LLMCapability.Temperature)) prompt.params.temperature else null,
             candidateCount = if (model.capabilities.contains(LLMCapability.MultipleChoices)) prompt.params.numberOfChoices else null,
-            maxOutputTokens = 2048,
+            maxOutputTokens = prompt.params.maxTokens ?: model.maxOutputTokens?.toInt() ?: 2048,
             thinkingConfig = GoogleThinkingConfig(
                 includeThoughts = prompt.params.includeThoughts.takeIf { it == true },
                 thinkingBudget = prompt.params.thinkingBudget

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleModelsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleModelsTest.kt
@@ -125,12 +125,12 @@ class GoogleModelsTest {
     @Test
     fun `createGoogleRequest includes maxOutputTokens in request if prompt specifies max tokens`() = runTest {
         val customMax = 1234
-        val p =
+        val prompt =
             Prompt.build("test", params = ai.koog.prompt.params.LLMParams(maxTokens = customMax)) {
                 user("Hello")
             }
 
-        val capturedBody = executeAndCaptureRequestBody(p, GoogleModels.Gemini2_5Flash)
+        val capturedBody = executeAndCaptureRequestBody(prompt, GoogleModels.Gemini2_5Flash)
 
         val json = Json.parseToJsonElement(capturedBody).jsonObject
         val genCfg = json["generationConfig"]!!.jsonObject
@@ -142,9 +142,8 @@ class GoogleModelsTest {
     fun `createGoogleRequest does not include maxOutputTokens in request if prompt does not specify specify max tokens`() =
         runTest {
             val prompt = Prompt.build("test") { user("Hello") }
-            val model = GoogleModels.Gemini2_5Flash.copy(maxOutputTokens = null)
 
-            val capturedBody: String = executeAndCaptureRequestBody(prompt, model)
+            val capturedBody = executeAndCaptureRequestBody(prompt, GoogleModels.Gemini2_5Flash)
 
             val json = Json.parseToJsonElement(capturedBody).jsonObject
             val generationConfig = json["generationConfig"]!!.jsonObject
@@ -155,7 +154,7 @@ class GoogleModelsTest {
             )
         }
 
-    private suspend fun executeAndCaptureRequestBody(p: Prompt, modelWithoutMax: LLModel): String {
+    private suspend fun executeAndCaptureRequestBody(p: Prompt, model: LLModel): String {
         var capturedBody: String? = null
         val mockEngine = MockEngine { request ->
             capturedBody = (request.body as TextContent).text
@@ -167,7 +166,7 @@ class GoogleModelsTest {
         }
         val client = GoogleLLMClient(apiKey = "test-key", baseClient = HttpClient(mockEngine))
 
-        client.execute(prompt = p, model = modelWithoutMax)
+        client.execute(prompt = p, model = model)
         return capturedBody!!
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleModelsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleModelsTest.kt
@@ -78,7 +78,6 @@ private val response = """
     }
 """.trimIndent()
 
-
 class GoogleModelsTest {
 
     @Test
@@ -179,5 +178,4 @@ class GoogleModelsTest {
         client.execute(prompt = p, model = modelWithoutMax)
         return capturedBody!!
     }
-
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleModelsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleModelsTest.kt
@@ -123,7 +123,7 @@ class GoogleModelsTest {
     }
 
     @Test
-    fun `createGoogleRequest uses prompt params maxTokens when present`() = runTest {
+    fun `createGoogleRequest includes maxOutputTokens in request if prompt specifies max tokens`() = runTest {
         val customMax = 1234
         val p =
             Prompt.build("test", params = ai.koog.prompt.params.LLMParams(maxTokens = customMax)) {
@@ -139,29 +139,21 @@ class GoogleModelsTest {
     }
 
     @Test
-    fun `createGoogleRequest uses model maxOutputTokens when prompt maxTokens is absent`() = runTest {
-        val p = Prompt.build("test") {
-            user("Hello")
+    fun `createGoogleRequest does not include maxOutputTokens in request if prompt does not specify specify max tokens`() =
+        runTest {
+            val prompt = Prompt.build("test") { user("Hello") }
+            val model = GoogleModels.Gemini2_5Flash.copy(maxOutputTokens = null)
+
+            val capturedBody: String = executeAndCaptureRequestBody(prompt, model)
+
+            val json = Json.parseToJsonElement(capturedBody).jsonObject
+            val generationConfig = json["generationConfig"]!!.jsonObject
+            assertEquals(
+                false,
+                generationConfig.containsKey("maxOutputTokens"),
+                "maxOutputTokens should not be present in the request"
+            )
         }
-
-        val capturedBody = executeAndCaptureRequestBody(p, GoogleModels.Gemini2_5Flash)
-
-        val json = Json.parseToJsonElement(capturedBody).jsonObject
-        val max = json["generationConfig"]!!.jsonObject["maxOutputTokens"]!!.jsonPrimitive.int
-        assertEquals(65_536, max, "maxOutputTokens should be populated from model")
-    }
-
-    @Test
-    fun `createGoogleRequest uses default 2048 when neither prompt nor model specify max tokens`() = runTest {
-        val prompt = Prompt.build("test") { user("Hello") }
-        val model = GoogleModels.Gemini2_5Flash.copy(maxOutputTokens = null)
-
-        val capturedBody: String = executeAndCaptureRequestBody(prompt, model)
-
-        val json = Json.parseToJsonElement(capturedBody).jsonObject
-        val max = json["generationConfig"]!!.jsonObject["maxOutputTokens"]!!.jsonPrimitive.int
-        assertEquals(2048, max, "maxOutputTokens should fall back to default")
-    }
 
     private suspend fun executeAndCaptureRequestBody(p: Prompt, modelWithoutMax: LLModel): String {
         var capturedBody: String? = null

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleModelsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleModelsTest.kt
@@ -1,17 +1,24 @@
 package ai.koog.prompt.executor.clients.google
 
+import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.list
 import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.TextContent
 import io.ktor.http.headersOf
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
@@ -43,6 +50,34 @@ private val badRequest: String = """
       "responseId": "B0esaJmqKv-0xN8P-dzlwQY"
     }
 """.trimIndent()
+
+// Ordinary text response from Gemini
+private val response = """
+    {
+      "candidates" : [ {
+        "content" : {
+          "parts" : [ {
+            "text" : "pong"
+          } ],
+          "role" : "model"
+        },
+        "finishReason" : "STOP",
+        "index" : 0
+      } ],
+      "usageMetadata" : {
+        "promptTokenCount" : 456,
+        "candidatesTokenCount" : 1,
+        "totalTokenCount" : 457,
+        "promptTokensDetails" : [ {
+          "modality" : "TEXT",
+          "tokenCount" : 456
+        } ]
+      },
+      "modelVersion" : "gemini-2.5-flash",
+      "responseId" : "Vk_aBRaCaDABRAIPrvGj2Q8"
+    }
+""".trimIndent()
+
 
 class GoogleModelsTest {
 
@@ -87,4 +122,62 @@ class GoogleModelsTest {
         assertEquals(36, responses.single().metaInfo.inputTokensCount)
         assertEquals(146, responses.single().metaInfo.totalTokensCount)
     }
+
+    @Test
+    fun `createGoogleRequest uses prompt params maxTokens when present`() = runTest {
+        val customMax = 1234
+        val p =
+            Prompt.build("test", params = ai.koog.prompt.params.LLMParams(maxTokens = customMax)) {
+                user("Hello")
+            }
+
+        val capturedBody = executeAndCaptureRequestBody(p, GoogleModels.Gemini2_5Flash)
+
+        val json = Json.parseToJsonElement(capturedBody).jsonObject
+        val genCfg = json["generationConfig"]!!.jsonObject
+        val max = genCfg["maxOutputTokens"]!!.jsonPrimitive.int
+        assertEquals(customMax, max, "maxOutputTokens should be populated from prompt")
+    }
+
+    @Test
+    fun `createGoogleRequest uses model maxOutputTokens when prompt maxTokens is absent`() = runTest {
+        val p = Prompt.build("test") {
+            user("Hello")
+        }
+
+        val capturedBody = executeAndCaptureRequestBody(p, GoogleModels.Gemini2_5Flash)
+
+        val json = Json.parseToJsonElement(capturedBody).jsonObject
+        val max = json["generationConfig"]!!.jsonObject["maxOutputTokens"]!!.jsonPrimitive.int
+        assertEquals(65_536, max, "maxOutputTokens should be populated from model")
+    }
+
+    @Test
+    fun `createGoogleRequest uses default 2048 when neither prompt nor model specify max tokens`() = runTest {
+        val prompt = Prompt.build("test") { user("Hello") }
+        val model = GoogleModels.Gemini2_5Flash.copy(maxOutputTokens = null)
+
+        val capturedBody: String = executeAndCaptureRequestBody(prompt, model)
+
+        val json = Json.parseToJsonElement(capturedBody).jsonObject
+        val max = json["generationConfig"]!!.jsonObject["maxOutputTokens"]!!.jsonPrimitive.int
+        assertEquals(2048, max, "maxOutputTokens should fall back to default")
+    }
+
+    private suspend fun executeAndCaptureRequestBody(p: Prompt, modelWithoutMax: LLModel): String {
+        var capturedBody: String? = null
+        val mockEngine = MockEngine { request ->
+            capturedBody = (request.body as TextContent).text
+            respond(
+                content = ByteReadChannel(response),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val client = GoogleLLMClient(apiKey = "test-key", baseClient = HttpClient(mockEngine))
+
+        client.execute(prompt = p, model = modelWithoutMax)
+        return capturedBody!!
+    }
+
 }


### PR DESCRIPTION
GoogleLLMClient.kt had maxOutputTokens hardcoded to 2K.

This PR modifies GoogleLLMClient to respect prompt.params.maxTokens 

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
