### PR TITLE
:recycle: move InMemoryFS.kt back to agents-ext

### DIFF
--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/EditFileToolCoreTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/EditFileToolCoreTest.kt
@@ -2,9 +2,9 @@ package ai.koog.agents.ext.tool.file
 
 import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
+import ai.koog.agents.ext.utils.InMemoryFS
 import ai.koog.rag.base.files.readText
 import ai.koog.rag.base.files.writeText
-import ai.koog.test.utils.InMemoryFS
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertContains

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/EditFileToolDifferentFileTypesTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/EditFileToolDifferentFileTypesTest.kt
@@ -2,9 +2,9 @@ package ai.koog.agents.ext.tool.file
 
 import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
+import ai.koog.agents.ext.utils.InMemoryFS
 import ai.koog.rag.base.files.readText
 import ai.koog.rag.base.files.writeText
-import ai.koog.test.utils.InMemoryFS
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/EditFileToolFormattingEdgeCasesTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/EditFileToolFormattingEdgeCasesTest.kt
@@ -2,9 +2,9 @@ package ai.koog.agents.ext.tool.file
 
 import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
+import ai.koog.agents.ext.utils.InMemoryFS
 import ai.koog.rag.base.files.readText
 import ai.koog.rag.base.files.writeText
-import ai.koog.test.utils.InMemoryFS
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/EditFileToolMultilineContentTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/EditFileToolMultilineContentTest.kt
@@ -2,9 +2,9 @@ package ai.koog.agents.ext.tool.file
 
 import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
+import ai.koog.agents.ext.utils.InMemoryFS
 import ai.koog.rag.base.files.readText
 import ai.koog.rag.base.files.writeText
-import ai.koog.test.utils.InMemoryFS
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/utils/InMemoryFS.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/utils/InMemoryFS.kt
@@ -1,4 +1,4 @@
-package ai.koog.test.utils
+package ai.koog.agents.ext.utils
 
 import ai.koog.rag.base.files.FileMetadata
 import ai.koog.rag.base.files.FileSystemProvider
@@ -9,7 +9,7 @@ import kotlinx.io.Source
 /**
  * Minimal in-memory filesystem for tests. Implements ReadWrite<String> and stores text as ByteArray.
  */
-public class InMemoryFS : FileSystemProvider.ReadWrite<String> {
+class InMemoryFS : FileSystemProvider.ReadWrite<String> {
     private val files = mutableMapOf<String, ByteArray>()
     private val directories = mutableSetOf<String>()
 

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -13,7 +13,6 @@ kotlin {
                 api(kotlin("test"))
                 api(libs.kotlinx.coroutines.test)
                 api(libs.kotlinx.serialization.json)
-                api(project(":rag:rag-base"))
             }
         }
 


### PR DESCRIPTION
We don't currently want a dependency from test-utils on rag-base

<!--
Thank you for opening a pull request!

Please add a brief description of the proposed change here.
Also, please tick the appropriate points in the checklist below.
-->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [x] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [ x I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
