### PR TITLE
Refactor streaming api to support tool calls with backwards compatibility

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AgentLoopContextExt.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AgentLoopContextExt.kt
@@ -11,6 +11,7 @@ import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolResult
 import ai.koog.prompt.message.Message
+import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.structure.StructureFixingParser
 import ai.koog.prompt.structure.StructuredDataDefinition
 import ai.koog.prompt.structure.StructuredResponse
@@ -171,12 +172,12 @@ public suspend inline fun <reified T> AIAgentFunctionalContext.requestLLMStructu
  *
  * @param message The content of the message to be sent to the LLM.
  * @param structureDefinition Optional structure to guide the LLM response.
- * @return A flow of string chunks from the LLM response.
+ * @return A flow of [StreamFrame] objects from the LLM response.
  */
 public suspend fun AIAgentFunctionalContext.requestLLMStreaming(
     message: String,
     structureDefinition: StructuredDataDefinition? = null
-): Flow<String> {
+): Flow<StreamFrame> {
     return llm.writeSession {
         updatePrompt {
             user(message)

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
@@ -16,6 +16,7 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.params.LLMParams
+import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.structure.StructureFixingParser
 import ai.koog.prompt.structure.StructuredDataDefinition
 import ai.koog.prompt.structure.StructuredOutputConfig
@@ -477,9 +478,9 @@ public class AIAgentLLMWriteSession internal constructor(
      *
      * @param definition an optional parameter to define a structured data format. When provided, it will be used
      * in constructing the prompt for the language model request.
-     * @return a flow of strings that streams the responses from the language model.
+     * @return a flow of `StreamingFrame` objects that streams the responses from the language model.
      */
-    public fun requestLLMStreaming(definition: StructuredDataDefinition? = null): Flow<String> {
+    public fun requestLLMStreaming(definition: StructuredDataDefinition? = null): Flow<StreamFrame> {
         if (definition != null) {
             val prompt = prompt(prompt, clock) {
                 user {
@@ -488,7 +489,6 @@ public class AIAgentLLMWriteSession internal constructor(
             }
             this.prompt = prompt
         }
-
-        return executor.executeStreaming(prompt, model)
+        return executor.executeStreaming(prompt, model, tools)
     }
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
@@ -489,6 +489,6 @@ public class AIAgentLLMWriteSession internal constructor(
             }
             this.prompt = prompt
         }
-        return executor.executeStreaming(prompt, model, tools)
+        return executor.executeStreamingFrames(prompt, model, tools)
     }
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/AIAgentPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/AIAgentPipeline.kt
@@ -9,6 +9,8 @@ import ai.koog.agents.core.environment.AIAgentEnvironment
 import ai.koog.agents.core.feature.config.FeatureConfig
 import ai.koog.agents.core.feature.handler.AfterLLMCallContext
 import ai.koog.agents.core.feature.handler.AfterLLMCallHandler
+import ai.koog.agents.core.feature.handler.AfterStreamContext
+import ai.koog.agents.core.feature.handler.AfterStreamHandler
 import ai.koog.agents.core.feature.handler.AgentBeforeCloseContext
 import ai.koog.agents.core.feature.handler.AgentBeforeCloseHandler
 import ai.koog.agents.core.feature.handler.AgentContextHandler
@@ -23,6 +25,8 @@ import ai.koog.agents.core.feature.handler.AgentTransformEnvironmentContext
 import ai.koog.agents.core.feature.handler.BeforeAgentStartedHandler
 import ai.koog.agents.core.feature.handler.BeforeLLMCallContext
 import ai.koog.agents.core.feature.handler.BeforeLLMCallHandler
+import ai.koog.agents.core.feature.handler.BeforeStreamContext
+import ai.koog.agents.core.feature.handler.BeforeStreamHandler
 import ai.koog.agents.core.feature.handler.ExecuteLLMHandler
 import ai.koog.agents.core.feature.handler.ExecuteToolHandler
 import ai.koog.agents.core.feature.handler.StrategyFinishContext
@@ -30,6 +34,9 @@ import ai.koog.agents.core.feature.handler.StrategyFinishedHandler
 import ai.koog.agents.core.feature.handler.StrategyHandler
 import ai.koog.agents.core.feature.handler.StrategyStartContext
 import ai.koog.agents.core.feature.handler.StrategyStartedHandler
+import ai.koog.agents.core.feature.handler.StreamFrameContext
+import ai.koog.agents.core.feature.handler.StreamFrameHandler
+import ai.koog.agents.core.feature.handler.StreamHandler
 import ai.koog.agents.core.feature.handler.ToolCallContext
 import ai.koog.agents.core.feature.handler.ToolCallFailureContext
 import ai.koog.agents.core.feature.handler.ToolCallFailureHandler
@@ -46,6 +53,7 @@ import ai.koog.prompt.dsl.ModerationResult
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
+import ai.koog.prompt.streaming.StreamFrame
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -116,6 +124,12 @@ public abstract class AIAgentPipeline {
      * Keys are feature storage keys, values are LLM execution handlers.
      */
     protected val executeLLMHandlers: MutableMap<AIAgentStorageKey<*>, ExecuteLLMHandler> = mutableMapOf()
+
+    /**
+     * Map of feature storage keys to their stream handlers.
+     * These handlers manage the streaming lifecycle events (before, during, and after streaming).
+     */
+    protected val streamHandlers: MutableMap<AIAgentStorageKey<*>, StreamHandler> = mutableMapOf()
 
     internal suspend fun prepareFeatures() {
         withContext(featurePrepareDispatcher) {
@@ -200,6 +214,57 @@ public abstract class AIAgentPipeline {
     ) {
         val eventContext = AgentRunErrorContext(agentId = agentId, runId = runId, throwable = throwable)
         agentHandlers.values.forEach { handler -> handler.agentRunErrorHandler.handle(eventContext) }
+    }
+
+    /**
+     * Invoked before streaming from a language model begins.
+     *
+     * This method notifies all registered stream handlers that streaming is about to start,
+     * allowing them to perform preprocessing or logging operations.
+     *
+     * @param runId The unique identifier for this streaming session
+     * @param prompt The prompt being sent to the language model
+     * @param model The language model being used for streaming
+     * @param tools The list of available tool descriptors for this streaming session
+     */
+    public suspend fun onBeforeStream(runId: String, prompt: Prompt, model: LLModel, tools: List<ToolDescriptor>) {
+        val eventContext = BeforeStreamContext(runId, prompt, model, tools)
+        streamHandlers.values.forEach { handler -> handler.beforeStreamHandler.handle(eventContext) }
+    }
+
+    /**
+     * Invoked when a stream frame is received during the streaming process.
+     *
+     * This method notifies all registered stream handlers about each incoming stream frame,
+     * allowing them to process, transform, or aggregate the streaming content in real-time.
+     *
+     * @param runId The unique identifier for this streaming session
+     * @param streamFrame The individual stream frame containing partial response data
+     */
+    public suspend fun onStreamFrame(runId: String, streamFrame: StreamFrame) {
+        val eventContext = StreamFrameContext(runId, streamFrame)
+        streamHandlers.values.forEach { handler -> handler.streamFrameHandler.handle(eventContext) }
+    }
+
+    /**
+     * Invoked after streaming from a language model completes.
+     *
+     * This method notifies all registered stream handlers that streaming has finished,
+     * allowing them to perform post-processing, cleanup, or final logging operations.
+     *
+     * @param runId The unique identifier for this streaming session
+     * @param prompt The prompt that was sent to the language model
+     * @param model The language model that was used for streaming
+     * @param tools The list of tool descriptors that were available for this streaming session
+     */
+    public suspend fun onAfterStream(
+        runId: String,
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>
+    ) {
+        val eventContext = AfterStreamContext(runId, prompt, model, tools)
+        streamHandlers.values.forEach { handler -> handler.afterStreamHandler.handle(eventContext) }
     }
 
     /**
@@ -657,6 +722,87 @@ public abstract class AIAgentPipeline {
         val existingHandler = executeLLMHandlers.getOrPut(interceptContext.feature.key) { ExecuteLLMHandler() }
 
         existingHandler.afterLLMCallHandler = AfterLLMCallHandler { eventContext: AfterLLMCallContext ->
+            with(interceptContext.featureImpl) { handle(eventContext) }
+        }
+    }
+
+    /**
+     * Intercepts streaming operations before they begin to modify or log the streaming request.
+     *
+     * This method allows features to hook into the streaming pipeline before streaming starts,
+     * enabling preprocessing, validation, or logging of streaming requests.
+     *
+     * @param interceptContext The context containing the feature and its implementation
+     * @param handle The handler that processes before-stream events
+     *
+     * Example:
+     * ```
+     * pipeline.interceptBeforeStream(InterceptContext) { eventContext ->
+     *     logger.info("About to start streaming with prompt: ${eventContext.prompt.messages.last().content}")
+     * }
+     * ```
+     */
+    public fun <TFeature : Any> interceptBeforeStream(
+        interceptContext: InterceptContext<TFeature>,
+        handle: suspend TFeature.(eventContext: BeforeStreamContext) -> Unit
+    ) {
+        val existingHandler = streamHandlers.getOrPut(interceptContext.feature.key) { StreamHandler() }
+
+        existingHandler.beforeStreamHandler = BeforeStreamHandler { eventContext: BeforeStreamContext ->
+            with(interceptContext.featureImpl) { handle(eventContext) }
+        }
+    }
+
+    /**
+     * Intercepts stream frames as they are received during the streaming process.
+     *
+     * This method allows features to process individual stream frames in real-time,
+     * enabling monitoring, transformation, or aggregation of streaming content.
+     *
+     * @param interceptContext The context containing the feature and its implementation
+     * @param handle The handler that processes stream frame events
+     *
+     * Example:
+     * ```
+     * pipeline.interceptOnStreamFrame(InterceptContext) { eventContext ->
+     *     logger.debug("Received stream frame: ${eventContext.streamFrame}")
+     * }
+     * ```
+     */
+    public fun <TFeature : Any> interceptOnStreamFrame(
+        interceptContext: InterceptContext<TFeature>,
+        handle: suspend TFeature.(eventContext: StreamFrameContext) -> Unit
+    ) {
+        val existingHandler = streamHandlers.getOrPut(interceptContext.feature.key) { StreamHandler() }
+
+        existingHandler.streamFrameHandler = StreamFrameHandler { eventContext: StreamFrameContext ->
+            with(interceptContext.featureImpl) { handle(eventContext) }
+        }
+    }
+
+    /**
+     * Intercepts streaming operations after they complete to perform post-processing or cleanup.
+     *
+     * This method allows features to hook into the streaming pipeline after streaming finishes,
+     * enabling post-processing, cleanup, or final logging of the streaming session.
+     *
+     * @param interceptContext The context containing the feature and its implementation
+     * @param handle The handler that processes after-stream events
+     *
+     * Example:
+     * ```
+     * pipeline.interceptAfterStream(InterceptContext) { eventContext ->
+     *     logger.info("Streaming completed for run: ${eventContext.runId}")
+     * }
+     * ```
+     */
+    public fun <TFeature : Any> interceptAfterStream(
+        interceptContext: InterceptContext<TFeature>,
+        handle: suspend TFeature.(eventContext: AfterStreamContext) -> Unit
+    ) {
+        val existingHandler = streamHandlers.getOrPut(interceptContext.feature.key) { StreamHandler() }
+
+        existingHandler.afterStreamHandler = AfterStreamHandler { eventContext: AfterStreamContext ->
             with(interceptContext.featureImpl) { handle(eventContext) }
         }
     }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/PromptExecutorProxy.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/PromptExecutorProxy.kt
@@ -56,13 +56,13 @@ public class PromptExecutorProxy(
      * @param tools The list of available tool descriptors for the streaming call
      * @return A Flow of StreamFrame objects representing the streaming response
      */
-    override fun executeStreaming(
+    override fun executeStreamingFrames(
         prompt: Prompt,
         model: LLModel,
         tools: List<ToolDescriptor>
     ): Flow<StreamFrame> {
         logger.debug { "Executing LLM streaming call (prompt: $prompt, tools: [${tools.joinToString { it.name }}])" }
-        return executor.executeStreaming(prompt, model, tools)
+        return executor.executeStreamingFrames(prompt, model, tools)
             .onStart {
                 pipeline.onBeforeStream(runId, prompt, model, tools)
             }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/PromptExecutorProxy.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/PromptExecutorProxy.kt
@@ -7,8 +7,12 @@ import ai.koog.prompt.executor.model.LLMChoice
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
+import ai.koog.prompt.streaming.StreamFrame
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
 
 /**
  * A wrapper around [ai.koog.prompt.executor.model.PromptExecutor] that allows for adding internal functionality to the executor
@@ -39,11 +43,35 @@ public class PromptExecutorProxy(
         return responses
     }
 
-    override fun executeStreaming(prompt: Prompt, model: LLModel): Flow<String> {
-        logger.debug { "Executing LLM streaming call (prompt: $prompt)" }
-        val stream = executor.executeStreaming(prompt, model)
-
-        return stream
+    /**
+     * Executes a streaming call to the language model with tool support.
+     *
+     * This method wraps the underlying executor's streaming functionality with pipeline hooks
+     * to enable monitoring and processing of stream events. It triggers before-stream handlers
+     * before starting, stream-frame handlers for each frame received, and after-stream handlers
+     * upon completion.
+     *
+     * @param prompt The prompt to send to the language model
+     * @param model The language model to use for streaming
+     * @param tools The list of available tool descriptors for the streaming call
+     * @return A Flow of StreamFrame objects representing the streaming response
+     */
+    override fun executeStreaming(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>
+    ): Flow<StreamFrame> {
+        logger.debug { "Executing LLM streaming call (prompt: $prompt, tools: [${tools.joinToString { it.name }}])" }
+        return executor.executeStreaming(prompt, model, tools)
+            .onStart {
+                pipeline.onBeforeStream(runId, prompt, model, tools)
+            }
+            .onEach {
+                pipeline.onStreamFrame(runId, it)
+            }
+            .onCompletion {
+                pipeline.onAfterStream(runId, prompt, model, tools)
+            }
     }
 
     override suspend fun executeMultipleChoices(

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/StreamHandler.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/StreamHandler.kt
@@ -1,0 +1,94 @@
+package ai.koog.agents.core.feature.handler
+
+/**
+ * A handler responsible for managing the streaming flow of Large Language Model (LLM) responses.
+ * It allows customization of logic to be executed before streaming starts, during streaming frames,
+ * and after streaming completes.
+ */
+public class StreamHandler {
+
+    /**
+     * A handler that is invoked before streaming from the Language Learning Model (LLM) begins.
+     *
+     * This handler enables customization or preprocessing steps to be applied before the stream starts.
+     * It accepts the prompt, a list of tools, the model, and a run ID as inputs, allowing
+     * users to define specific logic or modifications to these inputs before streaming begins.
+     */
+    public var beforeStreamHandler: BeforeStreamHandler =
+        BeforeStreamHandler { _ -> }
+
+    /**
+     * A handler invoked when stream frames are sent out during the streaming process.
+     *
+     * This variable represents a custom implementation of the `StreamFrameHandler` functional interface,
+     * allowing real-time processing or custom logic to be performed as each stream frame is received
+     * from the LLM.
+     *
+     * The handler receives the stream frame data and a unique run identifier, enabling real-time
+     * monitoring, transformation, or aggregation of streaming content.
+     *
+     * Customize this handler to implement specific behavior required during the streaming process.
+     */
+    public var streamFrameHandler: StreamFrameHandler =
+        StreamFrameHandler { _ -> }
+
+    /**
+     * A handler invoked after streaming from the language model (LLM) is complete.
+     *
+     * This variable represents a custom implementation of the `AfterStreamHandler` functional interface,
+     * allowing post-processing or custom logic to be performed once streaming has finished.
+     *
+     * The handler receives various pieces of information about the stream, including the original prompt,
+     * the tools used, the model invoked, and a unique run identifier.
+     *
+     * Customize this handler to implement specific behavior required after streaming completes.
+     */
+    public var afterStreamHandler: AfterStreamHandler =
+        AfterStreamHandler { _ -> }
+}
+
+/**
+ * A functional interface implemented to handle logic that occurs before streaming from a large language model (LLM) begins.
+ * It allows preprocessing steps or validation based on the provided prompt, available tools, targeted LLM model,
+ * and a unique run identifier.
+ *
+ * This can be particularly useful for custom input manipulation, logging, validation, or applying
+ * configurations to the streaming request based on external context.
+ */
+public fun interface BeforeStreamHandler {
+    /**
+     * Handles the initialization of a streaming interaction by processing the given prompt, tools, model, and run ID.
+     *
+     * @param eventContext The context for the before-stream event
+     */
+    public suspend fun handle(eventContext: BeforeStreamContext)
+}
+
+/**
+ * A functional interface for handling stream frames as they are received during the streaming process.
+ * The implementation of this interface provides a mechanism to perform real-time processing of
+ * streaming content, such as aggregation, transformation, or monitoring.
+ */
+public fun interface StreamFrameHandler {
+    /**
+     * Handles individual stream frames as they are sent out during the streaming process.
+     *
+     * @param eventContext The context for the stream frame event
+     */
+    public suspend fun handle(eventContext: StreamFrameContext)
+}
+
+/**
+ * Represents a functional interface for handling operations or logic that should occur after streaming
+ * from a large language model (LLM) is complete. The implementation of this interface provides a mechanism
+ * to perform custom logic or processing based on the provided inputs, such as the prompt, tools,
+ * model, and the completion of the stream.
+ */
+public fun interface AfterStreamHandler {
+    /**
+     * Handles the post-processing of a streaming session and its associated data after streaming completes.
+     *
+     * @param eventContext The context for the after-stream event
+     */
+    public suspend fun handle(eventContext: AfterStreamContext)
+}

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/StreamHandlerContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/StreamHandlerContext.kt
@@ -1,0 +1,55 @@
+package ai.koog.agents.core.feature.handler
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.streaming.StreamFrame
+
+/**
+ * Represents the context for handling streaming-specific events within the framework.
+ */
+public interface StreamHandlerContext : EventHandlerContext
+
+/**
+ * Represents the context for handling a before-stream event.
+ * This context is provided when streaming is about to begin.
+ *
+ * @property runId The unique identifier for this streaming session.
+ * @property prompt The prompt that will be sent to the language model for streaming.
+ * @property model The language model instance being used for streaming.
+ * @property tools The list of tool descriptors available for the streaming call.
+ */
+public data class BeforeStreamContext(
+    val runId: String,
+    val prompt: Prompt,
+    val model: LLModel,
+    val tools: List<ToolDescriptor>,
+) : StreamHandlerContext
+
+/**
+ * Represents the context for handling individual stream frame events.
+ * This context is provided when stream frames are sent out during the streaming process.
+ *
+ * @property runId The unique identifier for this streaming session.
+ * @property streamFrame The individual stream frame containing partial response data from the LLM.
+ */
+public data class StreamFrameContext(
+    val runId: String,
+    val streamFrame: StreamFrame,
+) : StreamHandlerContext
+
+/**
+ * Represents the context for handling an after-stream event.
+ * This context is provided when streaming is complete.
+ *
+ * @property runId The unique identifier for this streaming session.
+ * @property prompt The prompt that was sent to the language model for streaming.
+ * @property model The language model instance that was used for streaming.
+ * @property tools The list of tool descriptors that were available for the streaming call.
+ */
+public data class AfterStreamContext(
+    val runId: String,
+    val prompt: Prompt,
+    val model: LLModel,
+    val tools: List<ToolDescriptor>
+) : StreamHandlerContext

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/CalculatorPromptExecutor.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/CalculatorPromptExecutor.kt
@@ -53,7 +53,7 @@ object CalculatorChatExecutor : PromptExecutor {
         return listOf(result)
     }
 
-    override fun executeStreaming(
+    override fun executeStreamingFrames(
         prompt: Prompt,
         model: LLModel,
         tools: List<ToolDescriptor>

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/dsl/extension/TestLLMExecutor.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/dsl/extension/TestLLMExecutor.kt
@@ -7,8 +7,10 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.streaming.toStreamFrame
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.datetime.Clock
 
 class TestLLMExecutor : PromptExecutor {
@@ -35,9 +37,12 @@ class TestLLMExecutor : PromptExecutor {
         return listOf(handlePrompt(prompt))
     }
 
-    override fun executeStreaming(prompt: Prompt, model: LLModel): Flow<String> = flow {
-        emit(handlePrompt(prompt).content)
-    }
+    override fun executeStreaming(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>
+    ): Flow<StreamFrame> =
+        flowOf(handlePrompt(prompt).toStreamFrame())
 
     override suspend fun moderate(
         prompt: Prompt,

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/dsl/extension/TestLLMExecutor.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/dsl/extension/TestLLMExecutor.kt
@@ -37,7 +37,7 @@ class TestLLMExecutor : PromptExecutor {
         return listOf(handlePrompt(prompt))
     }
 
-    override fun executeStreaming(
+    override fun executeStreamingFrames(
         prompt: Prompt,
         model: LLModel,
         tools: List<ToolDescriptor>

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/llm/choice/ChoiceSelectionStrategyTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/llm/choice/ChoiceSelectionStrategyTest.kt
@@ -10,8 +10,9 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.llm.OllamaModels
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.streaming.streamFrameFlowOf
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -64,9 +65,12 @@ class ChoiceSelectionStrategyTest {
                 )
             }
 
-            override fun executeStreaming(prompt: Prompt, model: LLModel): Flow<String> = flow {
-                emit("Default streaming response")
-            }
+            override fun executeStreaming(
+                prompt: Prompt,
+                model: LLModel,
+                tools: List<ToolDescriptor>
+            ): Flow<StreamFrame> =
+                streamFrameFlowOf("Default streaming response")
 
             override suspend fun executeMultipleChoices(
                 prompt: Prompt,

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/llm/choice/ChoiceSelectionStrategyTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/llm/choice/ChoiceSelectionStrategyTest.kt
@@ -65,7 +65,7 @@ class ChoiceSelectionStrategyTest {
                 )
             }
 
-            override fun executeStreaming(
+            override fun executeStreamingFrames(
                 prompt: Prompt,
                 model: LLModel,
                 tools: List<ToolDescriptor>

--- a/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandler.kt
+++ b/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandler.kt
@@ -10,10 +10,13 @@ import ai.koog.agents.core.feature.AIAgentNonGraphPipeline
 import ai.koog.agents.core.feature.AIAgentPipeline
 import ai.koog.agents.core.feature.InterceptContext
 import ai.koog.agents.core.feature.handler.AfterLLMCallContext
+import ai.koog.agents.core.feature.handler.AfterStreamContext
 import ai.koog.agents.core.feature.handler.BeforeLLMCallContext
+import ai.koog.agents.core.feature.handler.BeforeStreamContext
 import ai.koog.agents.core.feature.handler.NodeAfterExecuteContext
 import ai.koog.agents.core.feature.handler.NodeBeforeExecuteContext
 import ai.koog.agents.core.feature.handler.NodeExecutionErrorContext
+import ai.koog.agents.core.feature.handler.StreamFrameContext
 import ai.koog.agents.core.feature.handler.ToolCallContext
 import ai.koog.agents.core.feature.handler.ToolCallFailureContext
 import ai.koog.agents.core.feature.handler.ToolCallResultContext
@@ -158,6 +161,18 @@ public class EventHandler {
 
             pipeline.interceptToolCallResult(interceptContext) intercept@{ eventContext: ToolCallResultContext ->
                 config.invokeOnToolCallResult(eventContext)
+            }
+
+            pipeline.interceptBeforeStream(interceptContext) intercept@{ eventContext: BeforeStreamContext ->
+                config.invokeOnBeforeStream(eventContext)
+            }
+
+            pipeline.interceptOnStreamFrame(interceptContext) intercept@{ eventContext: StreamFrameContext ->
+                config.invokeOnStreamFrame(eventContext)
+            }
+
+            pipeline.interceptAfterStream(interceptContext) intercept@{ eventContext: AfterStreamContext ->
+                config.invokeOnAfterStream(eventContext)
             }
         }
 

--- a/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerConfig.kt
+++ b/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerConfig.kt
@@ -2,16 +2,19 @@ package ai.koog.agents.features.eventHandler.feature
 
 import ai.koog.agents.core.feature.config.FeatureConfig
 import ai.koog.agents.core.feature.handler.AfterLLMCallContext
+import ai.koog.agents.core.feature.handler.AfterStreamContext
 import ai.koog.agents.core.feature.handler.AgentBeforeCloseContext
 import ai.koog.agents.core.feature.handler.AgentFinishedContext
 import ai.koog.agents.core.feature.handler.AgentRunErrorContext
 import ai.koog.agents.core.feature.handler.AgentStartContext
 import ai.koog.agents.core.feature.handler.BeforeLLMCallContext
+import ai.koog.agents.core.feature.handler.BeforeStreamContext
 import ai.koog.agents.core.feature.handler.NodeAfterExecuteContext
 import ai.koog.agents.core.feature.handler.NodeBeforeExecuteContext
 import ai.koog.agents.core.feature.handler.NodeExecutionErrorContext
 import ai.koog.agents.core.feature.handler.StrategyFinishContext
 import ai.koog.agents.core.feature.handler.StrategyStartContext
+import ai.koog.agents.core.feature.handler.StreamFrameContext
 import ai.koog.agents.core.feature.handler.ToolCallContext
 import ai.koog.agents.core.feature.handler.ToolCallFailureContext
 import ai.koog.agents.core.feature.handler.ToolCallResultContext
@@ -91,6 +94,16 @@ public class EventHandlerConfig : FeatureConfig() {
     private var _onToolCallResult: suspend (eventHandler: ToolCallResultContext) -> Unit = { _ -> }
 
     //endregion Tool Call Handlers
+
+    //region Stream Handlers
+
+    private var _onBeforeStream: suspend (eventHandler: BeforeStreamContext) -> Unit = { _ -> }
+
+    private var _onStreamFrame: suspend (eventHandler: StreamFrameContext) -> Unit = { _ -> }
+
+    private var _onAfterStream: suspend (eventHandler: AfterStreamContext) -> Unit = { _ -> }
+
+    //endregion Stream Handlers
 
     //region Agent Handlers
 
@@ -278,6 +291,87 @@ public class EventHandlerConfig : FeatureConfig() {
 
     //endregion Tool Call Handlers
 
+    //region Stream Handlers
+
+    /**
+     * Registers a handler to be invoked before streaming from a language model begins.
+     *
+     * This handler is called immediately before starting a streaming operation,
+     * allowing you to perform preprocessing, validation, or logging of the streaming request.
+     *
+     * @param handler The handler function that receives a [BeforeStreamContext] containing
+     *                the run ID, prompt, model, and available tools for the streaming session.
+     *
+     * Example:
+     * ```
+     * onBeforeStream { eventContext ->
+     *     logger.info("Starting stream for run: ${eventContext.runId}")
+     *     logger.debug("Prompt: ${eventContext.prompt}")
+     * }
+     * ```
+     */
+    public fun onBeforeStream(handler: suspend (eventContext: BeforeStreamContext) -> Unit) {
+        val originalHandler = this._onBeforeStream
+        this._onBeforeStream = { eventContext ->
+            originalHandler(eventContext)
+            handler.invoke(eventContext)
+        }
+    }
+
+    /**
+     * Registers a handler to be invoked when stream frames are received during streaming.
+     *
+     * This handler is called for each individual stream frame as it arrives from the language model,
+     * enabling real-time processing, monitoring, or aggregation of streaming content.
+     *
+     * @param handler The handler function that receives a [StreamFrameContext] containing
+     *                the run ID and the stream frame with partial response data.
+     *
+     * Example:
+     * ```
+     * onStreamFrame { eventContext ->
+     *     when (val frame = eventContext.streamFrame) {
+     *         is StreamFrame.TextDelta -> processText(frame.text)
+     *         is StreamFrame.ToolCall -> processTool(frame)
+     *     }
+     * }
+     * ```
+     */
+    public fun onStreamFrame(handler: suspend (eventContext: StreamFrameContext) -> Unit) {
+        val originalHandler = this._onStreamFrame
+        this._onStreamFrame = { eventContext ->
+            originalHandler(eventContext)
+            handler.invoke(eventContext)
+        }
+    }
+
+    /**
+     * Registers a handler to be invoked after streaming from a language model completes.
+     *
+     * This handler is called when the streaming operation finishes,
+     * allowing you to perform post-processing, cleanup, or final logging operations.
+     *
+     * @param handler The handler function that receives an [AfterStreamContext] containing
+     *                the run ID, prompt, model, and tools that were used for the streaming session.
+     *
+     * Example:
+     * ```
+     * onAfterStream { eventContext ->
+     *     logger.info("Stream completed for run: ${eventContext.runId}")
+     *     // Perform any cleanup or aggregation of collected stream data
+     * }
+     * ```
+     */
+    public fun onAfterStream(handler: suspend (eventContext: AfterStreamContext) -> Unit) {
+        val originalHandler = this._onAfterStream
+        this._onAfterStream = { eventContext ->
+            originalHandler(eventContext)
+            handler.invoke(eventContext)
+        }
+    }
+
+    //endregion Stream Handlers
+
     //region Invoke Agent Handlers
 
     /**
@@ -402,4 +496,35 @@ public class EventHandlerConfig : FeatureConfig() {
     }
 
     //endregion Invoke Tool Call Handlers
+
+    //region Invoke Stream Handlers
+
+    /**
+     * Invokes the handler associated with the event that occurs before streaming starts.
+     *
+     * @param eventContext The context containing information about the streaming session about to begin
+     */
+    internal suspend fun invokeOnBeforeStream(eventContext: BeforeStreamContext) {
+        _onBeforeStream.invoke(eventContext)
+    }
+
+    /**
+     * Invokes the handler associated with stream frame events during streaming.
+     *
+     * @param eventContext The context containing the stream frame data
+     */
+    internal suspend fun invokeOnStreamFrame(eventContext: StreamFrameContext) {
+        _onStreamFrame.invoke(eventContext)
+    }
+
+    /**
+     * Invokes the handler associated with the event that occurs after streaming completes.
+     *
+     * @param eventContext The context containing information about the completed streaming session
+     */
+    internal suspend fun invokeOnAfterStream(eventContext: AfterStreamContext) {
+        _onAfterStream.invoke(eventContext)
+    }
+
+    //endregion Invoke Stream Handlers
 }

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/NodeLLMRequestStreamingAndSendResultsTest.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/NodeLLMRequestStreamingAndSendResultsTest.kt
@@ -1,0 +1,211 @@
+package ai.koog.agents.features.eventHandler.feature
+
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.GraphAIAgent
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
+import ai.koog.agents.core.dsl.builder.forwardTo
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreamingAndSendResults
+import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.agents.testing.tools.mockLLMAnswer
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import ai.koog.prompt.executor.model.PromptExecutor
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for nodeLLMRequestStreamingAndSendResults function.
+ * Verifies that the node correctly streams responses, collects them, and updates the prompt.
+ */
+class NodeLLMRequestStreamingAndSendResultsTest {
+
+    // Helper function to create agent without assistant message in initial prompt
+    private fun createStreamingTestAgent(
+        strategy: AIAgentGraphStrategy<String, String>,
+        promptExecutor: PromptExecutor,
+        installFeatures: GraphAIAgent.FeatureContext.() -> Unit = { }
+    ): AIAgent<String, String> {
+        val agentConfig = AIAgentConfig(
+            prompt = prompt("test", clock = testClock) {
+                system("Test system message")
+                user("Test user message")
+                // No assistant message here to avoid mock executor issues
+            },
+            model = OpenAIModels.Chat.GPT4o,
+            maxAgentIterations = 10
+        )
+
+        return AIAgent(
+            id = "test-agent-id",
+            promptExecutor = promptExecutor,
+            strategy = strategy,
+            agentConfig = agentConfig,
+            toolRegistry = ToolRegistry { },
+            clock = testClock,
+            installFeatures = installFeatures
+        )
+    }
+
+    @Test
+    fun `test nodeLLMRequestStreamingAndSendResults collects text responses`() = runBlocking {
+        val eventsCollector = TestEventsCollector()
+        val assistantResponse = "This is a streamed response that will be collected"
+
+        val strategy = strategy<String, String>("streaming-collect-strategy") {
+            val streamAndCollectNode by nodeLLMRequestStreamingAndSendResults<String>("stream-and-collect")
+
+            edge(nodeStart forwardTo streamAndCollectNode)
+            edge(
+                streamAndCollectNode forwardTo nodeFinish transformed { messages ->
+                    // Convert List<Message.Response> to String for the test
+                    messages.firstOrNull()?.content ?: ""
+                }
+            )
+        }
+
+        val mockExecutor = getMockExecutor(clock = testClock) {
+            // Match on the test user message from createAgent
+            mockLLMAnswer(assistantResponse) onRequestContains "Test user message"
+        }
+
+        val agent = createStreamingTestAgent(
+            strategy = strategy,
+            promptExecutor = mockExecutor,
+            installFeatures = {
+                install(EventHandler, eventsCollector.eventHandlerFeatureConfig)
+            }
+        )
+
+        val result = agent.run("input")
+        agent.close()
+
+        // Verify the result contains the assistant response
+        assertEquals(assistantResponse, result, "Should contain the expected response")
+
+        // Verify streaming events were captured
+        val streamingEvents = eventsCollector.collectedEvents.filter {
+            it.contains("OnBeforeStream") || it.contains("OnStreamFrame") || it.contains("OnAfterStream")
+        }
+        assertTrue(streamingEvents.isNotEmpty(), "Should have captured streaming events")
+    }
+
+    @Test
+    fun `test nodeLLMRequestStreamingAndSendResults returns collected messages`() = runBlocking {
+        val eventsCollector = TestEventsCollector()
+        val assistantResponse = "Response from streaming LLM"
+
+        val strategy = strategy<String, String>("streaming-response-strategy") {
+            val streamNode by nodeLLMRequestStreamingAndSendResults<String>("stream-collect")
+
+            edge(nodeStart forwardTo streamNode)
+            edge(
+                streamNode forwardTo nodeFinish transformed { messages ->
+                    // Verify we got messages back
+                    assertTrue(messages.isNotEmpty(), "Should have collected messages")
+                    messages.firstOrNull()?.content ?: ""
+                }
+            )
+        }
+
+        val mockExecutor = getMockExecutor(clock = testClock) {
+            mockLLMAnswer(assistantResponse) onRequestContains "Test user message"
+        }
+
+        val agent = createStreamingTestAgent(
+            strategy = strategy,
+            promptExecutor = mockExecutor,
+            installFeatures = {
+                install(EventHandler, eventsCollector.eventHandlerFeatureConfig)
+            }
+        )
+
+        val result = agent.run("input")
+        agent.close()
+
+        // Verify the response was collected correctly
+        assertEquals(assistantResponse, result, "Should return the streamed response")
+
+        // Verify streaming events occurred
+        val streamingEvents = eventsCollector.collectedEvents.filter {
+            it.contains("OnBeforeStream") || it.contains("OnAfterStream")
+        }
+        assertTrue(streamingEvents.isNotEmpty(), "Should have streaming events")
+    }
+
+    @Test
+    fun `test nodeLLMRequestStreamingAndSendResults with empty response`() = runBlocking {
+        val eventsCollector = TestEventsCollector()
+
+        val strategy = strategy<String, String>("empty-streaming-strategy") {
+            val streamNode by nodeLLMRequestStreamingAndSendResults<String>("stream-empty")
+
+            edge(nodeStart forwardTo streamNode)
+            edge(
+                streamNode forwardTo nodeFinish transformed { messages ->
+                    messages.firstOrNull()?.content ?: ""
+                }
+            )
+        }
+
+        val mockExecutor = getMockExecutor(clock = testClock) {
+            // Return empty response for test user message
+            mockLLMAnswer("") onRequestContains "Test user message"
+        }
+
+        val agent = createStreamingTestAgent(strategy, promptExecutor = mockExecutor) {
+            install(EventHandler, eventsCollector.eventHandlerFeatureConfig)
+        }
+
+        val result = agent.run("input")
+        agent.close()
+
+        // Should return empty content
+        assertEquals("", result, "Content should be empty")
+    }
+
+    // Define a data class for typed input
+    data class TestData(val value: Int, val description: String)
+
+    @Test
+    fun `test nodeLLMRequestStreamingAndSendResults preserves input type`() = runBlocking {
+        val eventsCollector = TestEventsCollector()
+        val inputData = TestData(value = 42, description = "Test input")
+        val assistantResponse = "Response for structured input"
+
+        // Strategy that takes TestData as input to the streaming node
+        val strategy = strategy<String, String>("typed-input-strategy") {
+            val streamNode by nodeLLMRequestStreamingAndSendResults<TestData>("stream-typed")
+
+            edge(
+                nodeStart forwardTo streamNode transformed { userInput ->
+                    // Transform String input to TestData
+                    inputData
+                }
+            )
+            edge(
+                streamNode forwardTo nodeFinish transformed { messages ->
+                    messages.firstOrNull()?.content ?: ""
+                }
+            )
+        }
+
+        val mockExecutor = getMockExecutor(clock = testClock) {
+            mockLLMAnswer(assistantResponse) onRequestContains "Test user message"
+        }
+
+        val agent = createStreamingTestAgent(strategy, promptExecutor = mockExecutor) {
+            install(EventHandler, eventsCollector.eventHandlerFeatureConfig)
+        }
+
+        val result = agent.run("trigger")
+        agent.close()
+
+        // Verify the result
+        assertEquals(assistantResponse, result, "Should contain the expected response")
+    }
+}

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/StreamingEventHandlerTest.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/StreamingEventHandlerTest.kt
@@ -1,0 +1,114 @@
+package ai.koog.agents.features.eventHandler.feature
+
+import ai.koog.agents.core.dsl.builder.forwardTo
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreaming
+import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.agents.testing.tools.mockLLMAnswer
+import ai.koog.prompt.streaming.collectText
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Tests for streaming event handlers.
+ * These tests verify that the streaming handlers (onBeforeStream, onStreamFrame, onAfterStream)
+ * are properly invoked during LLM streaming operations.
+ */
+class StreamingEventHandlerTest {
+
+    @Test
+    fun `test streaming event handlers are invoked`() = runBlocking {
+        val eventsCollector = TestEventsCollector()
+        val strategyName = "streaming-test-strategy"
+        val userMessage = "Test streaming"
+        val assistantResponse = "Streaming response"
+
+        // Using nodeLLMRequestStreaming to actually test streaming events
+        val strategy = strategy<String, String>(strategyName) {
+            val llmNode by nodeLLMRequestStreaming("streaming-llm-node")
+
+            edge(nodeStart forwardTo llmNode)
+            edge(
+                llmNode forwardTo nodeFinish transformed { stream ->
+                    stream.collectText()
+                }
+            )
+        }
+
+        val mockExecutor = getMockExecutor(clock = testClock) {
+            mockLLMAnswer(assistantResponse) onRequestContains userMessage
+        }
+
+        val agent = createAgent(strategy, promptExecutor = mockExecutor) {
+            install(EventHandler, eventsCollector.eventHandlerFeatureConfig)
+        }
+
+        agent.run(userMessage)
+        agent.close()
+
+        // Verify events are captured
+        assertTrue(eventsCollector.collectedEvents.isNotEmpty(), "Should have collected events")
+
+        // Verify streaming events are captured when using nodeLLMRequestsStreaming
+        val beforeStreamEvents = eventsCollector.collectedEvents.filter { it.contains("OnBeforeStream") }
+        val streamFrameEvents = eventsCollector.collectedEvents.filter { it.contains("OnStreamFrame") }
+        val afterStreamEvents = eventsCollector.collectedEvents.filter { it.contains("OnAfterStream") }
+
+        assertTrue(beforeStreamEvents.isNotEmpty(), "Should have OnBeforeStream events")
+        assertTrue(streamFrameEvents.isNotEmpty(), "Should have OnStreamFrame events")
+        assertTrue(afterStreamEvents.isNotEmpty(), "Should have OnAfterStream events")
+
+        // Verify the stream frame contains the expected response
+        val frameWithContent = streamFrameEvents.firstOrNull { it.contains(assistantResponse) }
+        assertTrue(frameWithContent != null, "Stream frame should contain the assistant response")
+    }
+
+    @Test
+    fun `test streaming events are captured with actual streaming nodes`() = runBlocking {
+        // This test verifies that streaming events are properly captured when using streaming nodes
+        val eventsCollector = TestEventsCollector()
+        val testMessage = "Generate a response about streaming"
+        val testResponse = "This is a response about streaming functionality"
+
+        // Create an agent that actually uses streaming nodes
+        val strategy = strategy<String, String>("streaming-test-strategy-2") {
+            val streamingNode by nodeLLMRequestStreaming("actual-streaming-node")
+
+            edge(nodeStart forwardTo streamingNode)
+            edge(
+                streamingNode forwardTo nodeFinish transformed { stream ->
+                    // Collect the stream and return as a string
+                    val frames = mutableListOf<String>()
+                    stream.collect { frame ->
+                        if (frame is ai.koog.prompt.streaming.StreamFrame.Append) {
+                            frames.add(frame.text)
+                        }
+                    }
+                    frames.joinToString("")
+                }
+            )
+        }
+
+        val mockExecutor = getMockExecutor(clock = testClock) {
+            mockLLMAnswer(testResponse) onRequestContains testMessage
+        }
+
+        val agent = createAgent(strategy, promptExecutor = mockExecutor) {
+            install(EventHandler, eventsCollector.eventHandlerFeatureConfig)
+        }
+
+        agent.run(testMessage)
+        agent.close()
+
+        // Verify that streaming events were captured
+        val streamingEventTypes = listOf("OnBeforeStream", "OnStreamFrame", "OnAfterStream")
+        streamingEventTypes.forEach { eventType ->
+            val eventsOfType = eventsCollector.collectedEvents.filter { it.contains(eventType) }
+            assertTrue(eventsOfType.isNotEmpty(), "Should have captured $eventType events")
+        }
+
+        // Verify the overall event collection is working
+        assertTrue(eventsCollector.collectedEvents.isNotEmpty(), "Should have captured events")
+    }
+}

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/TestEventsCollector.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/TestEventsCollector.kt
@@ -113,6 +113,28 @@ class TestEventsCollector {
                 "OnToolCallResult (run id: ${eventContext.runId}, tool: ${eventContext.tool.name}, args: ${eventContext.toolArgs}, result: ${eventContext.result})"
             )
         }
+
+        onBeforeStream { eventContext ->
+            _collectedEvents.add(
+                "OnBeforeStream (run id: ${eventContext.runId}, prompt: ${eventContext.prompt.traceString}, model: ${eventContext.model.eventString}, tools: [${
+                    eventContext.tools.joinToString { it.name }
+                }])"
+            )
+        }
+
+        onStreamFrame { eventContext ->
+            _collectedEvents.add(
+                "OnStreamFrame (run id: ${eventContext.runId}, frame: ${eventContext.streamFrame})"
+            )
+        }
+
+        onAfterStream { eventContext ->
+            _collectedEvents.add(
+                "OnAfterStream (run id: ${eventContext.runId}, prompt: ${eventContext.prompt.traceString}, model: ${eventContext.model.eventString}, tools: [${
+                    eventContext.tools.joinToString { it.name }
+                }])"
+            )
+        }
     }
 
     @Suppress("unused")

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/TestLLMExecutor.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/TestLLMExecutor.kt
@@ -7,8 +7,10 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.streaming.toStreamFrame
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.datetime.Clock
 
 class TestLLMExecutor(val clock: Clock) : PromptExecutor {
@@ -16,9 +18,12 @@ class TestLLMExecutor(val clock: Clock) : PromptExecutor {
         return listOf(handlePrompt(prompt))
     }
 
-    override fun executeStreaming(prompt: Prompt, model: LLModel): Flow<String> = flow {
-        emit(handlePrompt(prompt).content)
-    }
+    override fun executeStreaming(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>
+    ): Flow<StreamFrame> =
+        flowOf(handlePrompt(prompt).toStreamFrame())
 
     private fun handlePrompt(prompt: Prompt): Message.Response {
         // For a compression test, return a summary

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/TestLLMExecutor.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/TestLLMExecutor.kt
@@ -18,7 +18,7 @@ class TestLLMExecutor(val clock: Clock) : PromptExecutor {
         return listOf(handlePrompt(prompt))
     }
 
-    override fun executeStreaming(
+    override fun executeStreamingFrames(
         prompt: Prompt,
         model: LLModel,
         tools: List<ToolDescriptor>

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/mock/MockLLMExecutor.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/mock/MockLLMExecutor.kt
@@ -7,6 +7,8 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.streaming.toStreamFrame
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.datetime.Clock
@@ -22,9 +24,12 @@ class MockLLMExecutor : PromptExecutor {
         return listOf(handlePrompt(prompt))
     }
 
-    override fun executeStreaming(prompt: Prompt, model: LLModel): Flow<String> = flow {
-        emit(handlePrompt(prompt).content)
-    }
+    override fun executeStreaming(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>
+    ): Flow<StreamFrame> =
+        flow { emit(handlePrompt(prompt).toStreamFrame()) }
 
     private fun handlePrompt(prompt: Prompt): Message.Response {
         val lastMessage = prompt.messages.last()

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/mock/MockLLMExecutor.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/mock/MockLLMExecutor.kt
@@ -24,7 +24,7 @@ class MockLLMExecutor : PromptExecutor {
         return listOf(handlePrompt(prompt))
     }
 
-    override fun executeStreaming(
+    override fun executeStreamingFrames(
         prompt: Prompt,
         model: LLModel,
         tools: List<ToolDescriptor>

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/client/CapturingLLMClient.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/client/CapturingLLMClient.kt
@@ -7,6 +7,7 @@ import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.model.LLMChoice
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
+import ai.koog.prompt.streaming.StreamFrame
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
@@ -24,7 +25,7 @@ import kotlinx.coroutines.flow.flowOf
  */
 public class CapturingLLMClient(
     private val executeResponses: List<Message.Response> = emptyList(),
-    private val streamingChunks: List<String> = emptyList(),
+    private val streamingChunks: List<StreamFrame> = emptyList(),
     private val choices: List<LLMChoice> = emptyList(),
     private val moderationResult: ModerationResult = ModerationResult(isHarmful = false, categories = emptyMap()),
 ) : LLMClient {
@@ -78,7 +79,11 @@ public class CapturingLLMClient(
      * Simulates a streaming LLM execution.
      * Captures input parameters and emits the predefined [streamingChunks].
      */
-    override fun executeStreaming(prompt: Prompt, model: LLModel): Flow<String> {
+    override fun executeStreaming(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>
+    ): Flow<StreamFrame> {
         lastStreamingPrompt = prompt
         lastStreamingModel = model
         return flowOf(*streamingChunks.toTypedArray())

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMExecutor.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMExecutor.kt
@@ -7,6 +7,8 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
+import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.streaming.toStreamFrame
 import ai.koog.prompt.tokenizer.Tokenizer
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -87,11 +89,17 @@ internal class MockLLMExecutor(
      *
      * @param prompt The prompt to execute
      * @param model The LLM model to use (ignored in mock implementation)
+     * @param tools The list of tools available for the execution
      * @return A flow containing a single string response
      */
-    override fun executeStreaming(prompt: Prompt, model: LLModel): Flow<String> = flow {
-        val response = execute(prompt = prompt, model = model).single()
-        emit(response.content)
+    override fun executeStreaming(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>
+    ): Flow<StreamFrame> = flow {
+        execute(prompt = prompt, model = model).forEach {
+            emit(it.toStreamFrame())
+        }
     }
 
     /**

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMExecutor.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMExecutor.kt
@@ -92,7 +92,7 @@ internal class MockLLMExecutor(
      * @param tools The list of tools available for the execution
      * @return A flow containing a single string response
      */
-    override fun executeStreaming(
+    override fun executeStreamingFrames(
         prompt: Prompt,
         model: LLModel,
         tools: List<ToolDescriptor>

--- a/agents/agents-utils/src/commonMain/kotlin/ai/koog/agents/utils/KoogHttpClient.kt
+++ b/agents/agents-utils/src/commonMain/kotlin/ai/koog/agents/utils/KoogHttpClient.kt
@@ -64,14 +64,14 @@ public interface KoogHttpClient {
      * @return A [Flow] emitting processed strings derived from the streamed chunks of data.
      */
     @Suppress("LongParameterList")
-    public fun <T : Any, R : Any> sse(
+    public fun <T : Any, R : Any, O : Any> sse(
         path: String,
         request: T,
         requestBodyType: KClass<T>,
         dataFilter: (String?) -> Boolean = { true },
         decodeStreamingResponse: (String) -> R,
-        processStreamingChunk: (R) -> String?
-    ): Flow<String>
+        processStreamingChunk: (R) -> O?
+    ): Flow<O>
 
     public companion object
 }

--- a/agents/agents-utils/src/commonMain/kotlin/ai/koog/agents/utils/KoogKtorHttpClient.kt
+++ b/agents/agents-utils/src/commonMain/kotlin/ai/koog/agents/utils/KoogKtorHttpClient.kt
@@ -89,14 +89,14 @@ internal class KoogKtorHttpClient internal constructor(
         }
     }
 
-    override fun <T : Any, R : Any> sse(
+    override fun <T : Any, R : Any, O : Any> sse(
         path: String,
         request: T,
         requestBodyType: KClass<T>,
         dataFilter: (String?) -> Boolean,
         decodeStreamingResponse: (String) -> R,
-        processStreamingChunk: (R) -> String?
-    ): Flow<String> = flow {
+        processStreamingChunk: (R) -> O?
+    ): Flow<O> = flow {
         @Suppress("TooGenericExceptionCaught")
         try {
             ktorClient.sse(

--- a/docs/docs/nodes-and-components.md
+++ b/docs/docs/nodes-and-components.md
@@ -527,7 +527,7 @@ streaming data, processes it, and potentially calls tools with the processed dat
 <!--- INCLUDE
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.example.exampleStreamingApi08.Book
+import ai.koog.agents.example.exampleStreamingApi03.Book
 import ai.koog.agents.example.exampleStreamingApi04.markdownBookDefinition
 import ai.koog.agents.example.exampleStreamingApi06.parseMarkdownStreamToBooks
 -->

--- a/docs/docs/streaming-api.md
+++ b/docs/docs/streaming-api.md
@@ -1,31 +1,74 @@
 # Streaming API
 
+
 ## Introduction
 
-The Streaming API in the Koog framework lets you process structured data from Large Language Models 
-(LLMs) as it arrives, rather than waiting for the entire response.
-This page explains how to use the Streaming API to efficiently handle structured data in Markdown format.
+Koog’s **Streaming API** lets you consume **LLM output incrementally** as a `Flow<StreamFrame>`. Instead of waiting for a full response, your code can:
+
+- render assistant text as it arrives,
+- detect **tool calls** live and act on them,
+- know when a stream **ends** and why.
+
+The stream carries **typed frames**:
+
+- `StreamFrame.Append(text: String)` — incremental assistant text
+- `StreamFrame.ToolCall(id: String?, name: String, content: String)` — tool invocation (combined safely)
+- `StreamFrame.End(finishReason: String?)` — end-of-stream marker
+
+Helpers are provided to extract plain text, convert frames to `Message.Response` objects, and safely **combine chunked tool calls**.
+
+---
 
 ## Streaming API overview
 
-The Streaming API enables real-time processing of structured data from LLM responses. Instead of waiting for the
-complete response, you can:
+With streaming you can:
 
-- Process data as it arrives in chunks
-- Parse structured information on the fly
-- Emit structured objects as they are completed
-- Handle these objects immediately (collect them or pass to tools)
+- Process data as it arrives (improves UI responsiveness)
+- Parse structured info on the fly (Markdown/JSON/etc.)
+- Emit objects as they complete
+- Trigger tools in real time
 
-This approach is particularly useful as it provides the following benefits:
+You can operate either on the **frames** themselves or on **plain text** derived from frames.
 
-- Improving responsiveness in user interfaces
-- Processing large responses efficiently
-- Implementing real-time data processing pipelines
+---
+## Usage
 
-The Streaming API allows parsing the output as *structured data* from the .md format or as a set of *plain text*
-chunks.
+### Working with frames directly
 
-## Working with a raw string stream
+This is the most general approach: react to each frame kind.
+
+<!--- INCLUDE
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.structure.markdown.MarkdownStructuredDataDefinition
+
+val strategy = strategy<String, String>("strategy_name") {
+    val node by node<Unit, Unit> {
+-->
+<!--- SUFFIX
+   }
+}
+-->
+```kotlin
+llm.writeSession {
+    updatePrompt { user("Tell me a joke, then call a tool with JSON args.") }
+
+    val stream = requestLLMStreaming() // Flow<StreamFrame>
+
+    stream.collect { frame ->
+        when (frame) {
+            is StreamFrame.Append -> print(frame.text)
+            is StreamFrame.ToolCall -> {
+                println("\n🔧 Tool call: ${frame.name} args=${frame.content}")
+                // Optionally parse lazily:
+                // val json = frame.contentJson
+            }
+            is StreamFrame.End -> println("\n[END] reason=${frame.finishReason}")
+        }
+    }
+}
+```
+<!--- KNIT example-streaming-api-01.kt -->
 
 It is important to note that you can parse the output by working directly with a raw string stream.
 This approach gives you more flexibility and control over the parsing process.
@@ -59,13 +102,17 @@ llm.writeSession {
     }
 }
 ```
-<!--- KNIT example-streaming-api-01.kt -->
+<!--- KNIT example-streaming-api-02.kt -->
 
-This is an example of a raw string stream without the definition:
+### Working with a raw text stream (derived)
+
+If you have existing streaming parsers that expect `Flow<String>`, 
+derive text chunks via `filterTextOnly()` or collect them with `collectText()`.
 
 <!--- INCLUDE
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.prompt.structure.markdown.MarkdownStructuredDataDefinition
+import ai.koog.prompt.streaming.filterTextOnly
+import ai.koog.prompt.streaming.collectText
 
 val strategy = strategy<String, String>("strategy_name") {
     val node by node<Unit, Unit> {
@@ -76,20 +123,66 @@ val strategy = strategy<String, String>("strategy_name") {
 -->
 ```kotlin
 llm.writeSession {
-    val stream = requestLLMStreaming()
-    // Access the raw string chunks directly
-    stream.collect { chunk ->
-        // Process each chunk of text as it arrives
-        println("Received chunk: $chunk") // The chunks will not be structured in a specific way
+    val frames = requestLLMStreaming()
+
+    // Stream text chunks as they come:
+    frames.filterTextOnly().collect { chunk -> print(chunk) }
+
+    // Or, gather all text into one String after End:
+    val fullText = frames.collectText()
+    println("\n---\n$fullText")
+}
+```
+<!--- KNIT example-streaming-api-02-01.kt -->
+
+### Listening to stream events in event handlers
+
+You can listen to stream events in [agent events](agent-events.md).
+
+<!--- INCLUDE
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.core.agent.GraphAIAgent
+import ai.koog.agents.features.eventHandler.feature.handleEvents
+import ai.koog.prompt.streaming.StreamFrame
+
+fun GraphAIAgent.FeatureContext.installStreamingApi() {
+-->
+<!--- SUFFIX
+}
+-->
+```kotlin
+handleEvents {
+    onToolCall { context ->
+        println("\n🔧 Using ${context.tool.name} with ${context.toolArgs}... ")
+    }
+
+    onStreamFrame { context ->
+        (context.streamFrame as? StreamFrame.Append)?.let { frame ->
+            print(frame.text)
+        }
+    }
+    onAfterStream {
+        println("")
     }
 }
 ```
-<!--- KNIT example-streaming-api-02.kt -->
+<!--- KNIT example-streaming-api-02-02.kt -->
 
-## Working with a stream of structured data
+### Converting frames to `Message.Response`
+
+You can transform a collected list of frames to standard message objects:
+- `toAssistantMessageOrNull()`
+- `toToolCallMessages()`
+- `toMessageResponses()`
+
+---
+
+## Examples
+
+### Structured data while streaming (Markdown example)
 
 Although it is possible to work with a raw string stream,
-it is often more convenient to work with [structured data](structured-data.md).
+it is often more convenient to work with [structured data](structured-output.md).
 
 The structured data approach includes the following key components:
 
@@ -100,11 +193,12 @@ The structured data approach includes the following key components:
 
 The sections below provide step-by-step instructions and code samples related to processing a stream of structured data. 
 
-### 1. Define your data structure
+#### 1. Define your data structure
 
 First, define a data class to represent your structured data:
 
 <!--- INCLUDE
+import ai.koog.agents.core.tools.ToolArgs
 import kotlinx.serialization.Serializable
 -->
 ```kotlin
@@ -113,11 +207,11 @@ data class Book(
     val title: String,
     val author: String,
     val description: String
-)
+): ToolArgs
 ```
 <!--- KNIT example-streaming-api-03.kt -->
 
-### 2. Define the Markdown structure
+#### 2. Define the Markdown structure
 
 Create a definition that specifies how your data should be structured in Markdown with the
 `MarkdownStructuredDataDefinition` class:
@@ -149,7 +243,7 @@ fun markdownBookDefinition(): MarkdownStructuredDataDefinition {
 ```
 <!--- KNIT example-streaming-api-04.kt -->
 
-### 3. Create a parser for your data structure
+#### 3. Create a parser for your data structure
 
 The `markdownStreamingParser` provides several handlers for different Markdown elements:
 
@@ -158,7 +252,6 @@ import ai.koog.agents.example.exampleStreamingApi03.Book
 import ai.koog.prompt.structure.markdown.markdownStreamingParser
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-
 
 fun parseMarkdownStreamToBooks(markdownStream: Flow<String>): Flow<Book> {
     return flow {
@@ -169,31 +262,16 @@ fun parseMarkdownStreamToBooks(markdownStream: Flow<String>): Flow<Book> {
 -->
 ```kotlin
 markdownStreamingParser {
-    // Handle level 1 headings
-    // The heading level can be from 1 to 6
-    onHeader(1) { headerText ->
-        // Process heading text
-    }
-
+    // Handle level 1 headings (level ranges from 1 to 6)
+    onHeader(1) { headerText -> }
     // Handle bullet points
-    onBullet { bulletText ->
-        // Process bullet text
-    }
-
+    onBullet { bulletText -> }
     // Handle code blocks
-    onCodeBlock { codeBlockContent ->
-        // Process code block content
-    }
-
+    onCodeBlock { codeBlockContent -> }
     // Handle lines matching a regex pattern
-    onLineMatching(Regex("pattern")) { line ->
-        // Process matching lines
-    }
-
+    onLineMatching(Regex("pattern")) { line -> }
     // Handle the end of the stream
-    onFinishStream { remainingText ->
-        // Process any remaining text or perform cleanup
-    }
+    onFinishStream { remainingText -> }
 }
 ```
 <!--- KNIT example-streaming-api-05.kt -->
@@ -202,14 +280,16 @@ Using the defined handlers, you can implement a function that parses the Markdow
 with the `markdownStreamingParser` function.
 
 <!--- INCLUDE
-import ai.koog.agents.example.exampleStreamingApi08.Book
+import ai.koog.agents.example.exampleStreamingApi03.Book
 import ai.koog.prompt.structure.markdown.markdownStreamingParser
+import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.streaming.filterTextOnly
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 -->
 ```kotlin
-fun parseMarkdownStreamToBooks(markdownStream: Flow<String>): Flow<Book> {
+fun parseMarkdownStreamToBooks(markdownStream: Flow<StreamFrame>): Flow<Book> {
    return flow {
       markdownStreamingParser {
          var currentBookTitle = ""
@@ -242,18 +322,18 @@ fun parseMarkdownStreamToBooks(markdownStream: Flow<String>): Flow<Book> {
                emit(Book(currentBookTitle, author, description))
             }
          }
-      }.parseStream(markdownStream)
+      }.parseStream(markdownStream.filterTextOnly())
    }
 }
 ```
 <!--- KNIT example-streaming-api-06.kt -->
 
-### 4. Use the parser in your agent strategy
+#### 4. Use the parser in your agent strategy
 
 <!--- INCLUDE
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.example.exampleStreamingApi08.Book
+import ai.koog.agents.example.exampleStreamingApi03.Book
 import ai.koog.agents.example.exampleStreamingApi04.markdownBookDefinition
 import ai.koog.agents.example.exampleStreamingApi06.parseMarkdownStreamToBooks
 -->
@@ -284,47 +364,40 @@ val agentStrategy = strategy<String, List<Book>>("library-assistant") {
 ```
 <!--- KNIT example-streaming-api-07.kt -->
 
-## Advanced usage: Streaming with tools
+### Advanced usage: Streaming with tools
 
-You can also use the Streaming API with tools to process data as it arrives. The following sections provide a brief
-step-by-step guide on how to define a tool and use it with streaming data.
+You can also use the Streaming API with tools to process data as it arrives. 
+The following sections provide a brief step-by-step guide on how to define a tool and use it with streaming data.
 
 ### 1. Define a tool for your data structure
 
 <!--- INCLUDE
 import ai.koog.agents.core.tools.SimpleTool
-import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.example.exampleStreamingApi03.Book
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
+
 -->
 ```kotlin
-@Serializable
-data class Book(
-   val title: String,
-   val author: String,
-   val description: String
-) : ToolArgs
-
 class BookTool(): SimpleTool<Book>() {
-   companion object {
-      const val NAME = "book"
-   }
+    
+    companion object { const val NAME = "book" }
 
-   override suspend fun doExecute(args: Book): String {
-      println("${args.title} by ${args.author}:\n ${args.description}")
-      return "Done"
-   }
+    override suspend fun doExecute(args: Book): String {
+        println("${args.title} by ${args.author}:\n ${args.description}")
+        return "Done"
+    }
 
-   override val argsSerializer: KSerializer<Book>
-      get() = Book.serializer()
-   override val descriptor: ToolDescriptor
-      get() = ToolDescriptor(
-         name = NAME,
-         description = "A tool to parse book information from Markdown",
-         requiredParameters = listOf(),
-         optionalParameters = listOf()
-      )
+    override val argsSerializer: KSerializer<Book>
+        get() = Book.serializer()
+    
+    override val descriptor: ToolDescriptor
+        get() = ToolDescriptor(
+            name = NAME,
+            description = "A tool to parse book information from Markdown",
+            requiredParameters = listOf(),
+            optionalParameters = listOf()
+        )
 }
 ```
 <!--- KNIT example-streaming-api-08.kt -->

--- a/examples/src/main/kotlin/ai/koog/agents/example/streaming/StreamingAgentWithTools.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/streaming/StreamingAgentWithTools.kt
@@ -1,0 +1,141 @@
+package ai.koog.agents.example.streaming
+
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.GraphAIAgent.FeatureContext
+import ai.koog.agents.core.dsl.builder.forwardTo
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.core.dsl.extension.nodeExecuteMultipleTools
+import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreamingAndSendResults
+import ai.koog.agents.core.dsl.extension.onMultipleToolCalls
+import ai.koog.agents.core.environment.ReceivedToolResult
+import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.core.tools.reflect.asTools
+import ai.koog.agents.example.ApiKeyService
+import ai.koog.agents.example.simpleapi.Switch
+import ai.koog.agents.example.simpleapi.SwitchTools
+import ai.koog.agents.features.eventHandler.feature.handleEvents
+import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import ai.koog.prompt.executor.llms.all.simpleAnthropicExecutor
+import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.RequestMetaInfo
+import ai.koog.prompt.streaming.StreamFrame
+import kotlinx.coroutines.runBlocking
+
+fun main(): Unit = runBlocking {
+    val switch = Switch()
+
+    /*
+     *
+     * You can also use the DSL to create a tool registry:
+     *   val toolRegistry = SimpleToolRegistry {
+     *       tool(SwitchTool(switch))
+     *       tool(SwitchStateTool(switch))
+     *   }
+     * */
+    val toolRegistry = ToolRegistry {
+        tools(SwitchTools(switch).asTools())
+    }
+    val agent = openAiAgent(toolRegistry) {
+        handleEvents {
+            onToolCall { context ->
+                println("\n🔧 Using ${context.tool.name} with ${context.toolArgs}... ")
+            }
+
+            onStreamFrame { context ->
+                (context.streamFrame as? StreamFrame.Append)?.let { frame ->
+                    print(frame.text)
+                }
+            }
+            onAfterStream {
+                println("")
+            }
+        }
+    }
+
+    println("Streaming chat agent started\nUse /quit to quit\nEnter your message:")
+    var input = ""
+    while (input != "/quit") {
+        input = readln()
+
+        // Example message:
+        // Tell me if the switch if on or off. Elaborate on how you will determine that. After that, if it was off, turn it on. Be very verbose in all the steps
+
+        agent.run(input)
+
+        println()
+        println("Enter your message:")
+    }
+}
+
+private fun openAiAgent(
+    toolRegistry: ToolRegistry,
+    installFeatures: FeatureContext.() -> Unit = {}
+) = AIAgent(
+    promptExecutor = simpleOpenAIExecutor(ApiKeyService.openAIApiKey),
+    strategy = streamingWithToolsStrategy(),
+    llmModel = OpenAIModels.CostOptimized.GPT4oMini,
+    systemPrompt = "You're responsible for running a Switch and perform operations on it by request",
+    temperature = 0.0,
+    toolRegistry = toolRegistry,
+    installFeatures = installFeatures
+)
+
+@Suppress("unused")
+private fun anthropicAgent(
+    toolRegistry: ToolRegistry,
+    installFeatures: FeatureContext.() -> Unit = {}
+) = AIAgent(
+    promptExecutor = simpleAnthropicExecutor(ApiKeyService.anthropicApiKey),
+    strategy = streamingWithToolsStrategy(),
+    llmModel = AnthropicModels.Sonnet_3_7,
+    systemPrompt = "You're responsible for running a Switch and perform operations on it by request",
+    temperature = 0.0,
+    toolRegistry = toolRegistry,
+    installFeatures = installFeatures
+)
+
+fun streamingWithToolsStrategy() = strategy("streaming_loop") {
+    val executeMultipleTools by nodeExecuteMultipleTools(parallelTools = true)
+    val nodeStreaming by nodeLLMRequestStreamingAndSendResults()
+
+    val mapStringToRequests by node<String, List<Message.Request>> { input ->
+        listOf(Message.User(content = input, metaInfo = RequestMetaInfo.Empty))
+    }
+
+    val applyRequestToSession by node<List<Message.Request>, List<Message.Request>> { input ->
+        llm.writeSession {
+            updatePrompt {
+                input.filterIsInstance<Message.User>()
+                    .forEach {
+                        user(it.content)
+                    }
+
+                tool {
+                    input.filterIsInstance<Message.Tool.Result>()
+                        .forEach {
+                            result(it)
+                        }
+                }
+            }
+            input
+        }
+    }
+
+    val mapToolCallsToRequests by node<List<ReceivedToolResult>, List<Message.Request>> { input ->
+        input.map { it.toMessage() }
+    }
+
+    edge(nodeStart forwardTo mapStringToRequests)
+    edge(mapStringToRequests forwardTo applyRequestToSession)
+    edge(applyRequestToSession forwardTo nodeStreaming)
+    edge(nodeStreaming forwardTo executeMultipleTools onMultipleToolCalls { true })
+    edge(executeMultipleTools forwardTo mapToolCallsToRequests)
+    edge(mapToolCallsToRequests forwardTo applyRequestToSession)
+    edge(
+        nodeStreaming forwardTo nodeFinish onCondition {
+            it.filterIsInstance<Message.Tool.Call>().isEmpty()
+        }
+    )
+}

--- a/examples/src/main/kotlin/ai/koog/agents/example/streaming/Switch.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/streaming/Switch.kt
@@ -1,0 +1,33 @@
+package ai.koog.agents.example.streaming
+
+import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.agents.core.tools.annotations.Tool
+import ai.koog.agents.core.tools.reflect.ToolSet
+
+class Switch {
+    private var state: Boolean = false
+
+    fun switch(on: Boolean) {
+        state = on
+    }
+
+    fun isOn(): Boolean {
+        return state
+    }
+}
+
+// Tools from this tool set class are used in BasicChatWithTools example
+class SwitchTools(val switch: Switch) : ToolSet {
+    @Tool
+    @LLMDescription("Switches the state of the switch")
+    fun switch(state: Boolean): String {
+        switch.switch(state)
+        return "Switched to ${if (state) "on" else "off"}"
+    }
+
+    @Tool
+    @LLMDescription("Returns the state of the switch")
+    fun switchState(state: Boolean): String {
+        return "Switch is ${if (switch.isOn()) "on" else "off"}"
+    }
+}

--- a/examples/src/main/kotlin/ai/koog/agents/example/structuredoutput/markdown/MarkdownStreamingDataExample.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/structuredoutput/markdown/MarkdownStreamingDataExample.kt
@@ -7,6 +7,7 @@ import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.example.ApiKeyService
 import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
 import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.streaming.filterTextOnly
 import kotlinx.coroutines.runBlocking
 
 fun main(): Unit = runBlocking {
@@ -19,7 +20,7 @@ fun main(): Unit = runBlocking {
 
             llm.writeSession {
                 updatePrompt { user(input) }
-                val markdownStream = requestLLMStreaming(mdDefinition)
+                val markdownStream = requestLLMStreaming(mdDefinition).filterTextOnly()
                 parseMarkdownStreamToBooks(markdownStream).collect { book ->
                     books.add(book)
                     println("Parsed Book: ${book.bookName} by ${book.author}")

--- a/examples/src/main/kotlin/ai/koog/agents/example/structuredoutput/markdown/MarkdownStreamingWithToolsExample.kt
+++ b/examples/src/main/kotlin/ai/koog/agents/example/structuredoutput/markdown/MarkdownStreamingWithToolsExample.kt
@@ -8,6 +8,7 @@ import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.example.ApiKeyService
 import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
 import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.streaming.filterTextOnly
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.runBlocking
 
@@ -20,7 +21,7 @@ fun main(): Unit = runBlocking {
 
             llm.writeSession {
                 updatePrompt { user(input) }
-                val markdownStream = requestLLMStreaming(mdDefinition)
+                val markdownStream = requestLLMStreaming(mdDefinition).filterTextOnly()
 
                 parseMarkdownStreamToBooks(markdownStream).collect { book ->
                     callToolRaw(BookTool.Companion.NAME, book)

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
@@ -43,6 +43,7 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.markdown.markdown
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.params.LLMParams
+import ai.koog.prompt.streaming.StreamFrame
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.channels.Channel
@@ -105,7 +106,11 @@ internal class ReportingLLMLLMClient(
         return underlyingClient.execute(prompt, model, tools)
     }
 
-    override fun executeStreaming(prompt: Prompt, model: LLModel): Flow<String> = flow {
+    override fun executeStreaming(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>
+    ): Flow<StreamFrame> = flow {
         coroutineScope {
             eventsChannel.send(
                 Event.Message(
@@ -117,7 +122,7 @@ internal class ReportingLLMLLMClient(
                 )
             )
         }
-        underlyingClient.executeStreaming(prompt, model)
+        underlyingClient.executeStreaming(prompt, model, tools)
             .collect(this)
     }
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/MultipleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/MultipleLLMPromptExecutorIntegrationTest.kt
@@ -43,6 +43,8 @@ import ai.koog.prompt.message.Attachment
 import ai.koog.prompt.message.AttachmentContent
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.params.LLMParams.ToolChoice
+import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.streaming.filterTextOnly
 import ai.koog.prompt.structure.executeStructured
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
@@ -200,7 +202,9 @@ class MultipleLLMPromptExecutorIntegrationTest {
         }
 
         withRetry(times = 3, testName = "integration_testExecuteStreaming[${model.id}]") {
-            val responseChunks = executor.executeStreaming(prompt, model).toList()
+            val responseChunks = executor.executeStreaming(prompt, model)
+                .filterTextOnly()
+                .toList()
 
             assertNotNull(responseChunks, "Response chunks should not be null")
             assertTrue(responseChunks.isNotEmpty(), "Response chunks should not be empty")
@@ -490,7 +494,7 @@ class MultipleLLMPromptExecutorIntegrationTest {
             user("Count from 1 to 5.")
         }
 
-        val responseChunks = mutableListOf<String>()
+        val responseChunks = mutableListOf<StreamFrame>()
         val client = when (model.provider) {
             is LLMProvider.Anthropic -> anthropicClient
             is LLMProvider.Google -> googleClient

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/OllamaExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/OllamaExecutorIntegrationTest.kt
@@ -479,7 +479,7 @@ class OllamaExecutorIntegrationTest {
         }
 
         val flow = executor
-            .executeStreaming(prompt, model)
+            .executeStreamingFrames(prompt, model)
             .filterTextOnly()
 
         var totalText = ""
@@ -652,7 +652,7 @@ class OllamaExecutorIntegrationTest {
             )
         }
 
-        val markdownStream = executor.executeStreaming(prompt, model)
+        val markdownStream = executor.executeStreamingFrames(prompt, model)
 
         parseMarkdownStreamToCountries(markdownStream).collect { country ->
             countries.add(country)

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SingleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SingleLLMPromptExecutorIntegrationTest.kt
@@ -50,6 +50,8 @@ import ai.koog.prompt.message.Attachment
 import ai.koog.prompt.message.AttachmentContent
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.params.LLMParams.ToolChoice
+import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.streaming.filterTextOnly
 import ai.koog.prompt.structure.executeStructured
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
@@ -238,7 +240,9 @@ class SingleLLMPromptExecutorIntegrationTest {
         }
 
         withRetry(times = 3, testName = "integration_testExecuteStreaming[${model.id}]") {
-            val responseChunks = executor.executeStreaming(prompt, model).toList()
+            val responseChunks = executor.executeStreaming(prompt, model)
+                .filterTextOnly()
+                .toList()
             assertNotNull(responseChunks, "Response chunks should not be null")
             assertTrue(responseChunks.isNotEmpty(), "Response chunks should not be empty")
 
@@ -509,7 +513,7 @@ class SingleLLMPromptExecutorIntegrationTest {
             user("Count from 1 to 5.")
         }
 
-        val responseChunks = mutableListOf<String>()
+        val responseChunks = mutableListOf<StreamFrame>()
 
         withRetry(times = 3, testName = "integration_testRawStringStreaming[${model.id}]") {
             client.executeStreaming(prompt, model).collect { chunk ->

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SingleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SingleLLMPromptExecutorIntegrationTest.kt
@@ -243,7 +243,7 @@ class SingleLLMPromptExecutorIntegrationTest {
         }
 
         withRetry(times = 3, testName = "integration_testExecuteStreaming[${model.id}]") {
-            val responseChunks = executor.executeStreaming(prompt, model)
+            val responseChunks = executor.executeStreamingFrames(prompt, model)
                 .filterTextOnly()
                 .toList()
             assertNotNull(responseChunks, "Response chunks should not be null")

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/TestUtils.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/TestUtils.kt
@@ -9,6 +9,8 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.streaming.filterTextOnly
 import ai.koog.prompt.structure.RegisteredStandardJsonSchemaGenerators
 import ai.koog.prompt.structure.StructureFixingParser
 import ai.koog.prompt.structure.StructuredOutput
@@ -286,7 +288,7 @@ object TestUtils {
         }
     }
 
-    fun parseMarkdownStreamToCountries(markdownStream: Flow<String>): Flow<Country> {
+    fun parseMarkdownStreamToCountries(markdownStream: Flow<StreamFrame>): Flow<Country> {
         return flow {
             val countries = mutableListOf<Country>()
             var currentCountryName = ""
@@ -321,7 +323,7 @@ object TestUtils {
                 }
             }
 
-            parser.parseStream(markdownStream)
+            parser.parseStream(markdownStream.filterTextOnly())
 
             countries.forEach { emit(it) }
         }

--- a/prompt/prompt-executor/prompt-executor-cached/src/commonMain/kotlin/ai/koog/prompt/executor/cached/CachedPromptExecutor.kt
+++ b/prompt/prompt-executor/prompt-executor-cached/src/commonMain/kotlin/ai/koog/prompt/executor/cached/CachedPromptExecutor.kt
@@ -35,7 +35,7 @@ public class CachedPromptExecutor(
         return getOrPut(prompt, tools, model)
     }
 
-    override fun executeStreaming(
+    override fun executeStreamingFrames(
         prompt: Prompt,
         model: LLModel,
         tools: List<ToolDescriptor>

--- a/prompt/prompt-executor/prompt-executor-cached/src/jvmTest/kotlin/ai/koog/prompt/executor/cached/CachedPromptExecutorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-cached/src/jvmTest/kotlin/ai/koog/prompt/executor/cached/CachedPromptExecutorTest.kt
@@ -11,8 +11,9 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.streaming.streamFrameFlowOf
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlin.test.Test
@@ -66,9 +67,13 @@ class CachedPromptExecutorTest {
             return testResponse
         }
 
-        override fun executeStreaming(prompt: Prompt, model: LLModel): Flow<String> {
+        override fun executeStreaming(
+            prompt: Prompt,
+            model: LLModel,
+            tools: List<ToolDescriptor>
+        ): Flow<StreamFrame> {
             executeStreamingCalled = true
-            return flowOf("Streaming response from executor")
+            return streamFrameFlowOf("Streaming response from executor")
         }
 
         override suspend fun moderate(

--- a/prompt/prompt-executor/prompt-executor-cached/src/jvmTest/kotlin/ai/koog/prompt/executor/cached/CachedPromptExecutorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-cached/src/jvmTest/kotlin/ai/koog/prompt/executor/cached/CachedPromptExecutorTest.kt
@@ -67,7 +67,7 @@ class CachedPromptExecutorTest {
             return testResponse
         }
 
-        override fun executeStreaming(
+        override fun executeStreamingFrames(
             prompt: Prompt,
             model: LLModel,
             tools: List<ToolDescriptor>

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/DataModel.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/DataModel.kt
@@ -351,16 +351,16 @@ public sealed class AnthropicResponseContent {
 /**
  * Represents the usage statistics of the Anthropic LLM API.
  *
- * @property inputTokens The number of tokens sent as input to the LLM.
- * @property outputTokens The number of tokens received as output from the LLM.
+ * @property inputTokens The number of tokens sent as input to the LLM. Optional in streaming responses.
+ * @property outputTokens The number of tokens received as output from the LLM. Optional in streaming responses.
  *
  * Note: This API is marked with [InternalLLMClientApi] and is intended for internal use only.
  */
 @InternalLLMClientApi
 @Serializable
 public data class AnthropicUsage(
-    val inputTokens: Int,
-    val outputTokens: Int
+    val inputTokens: Int? = null,
+    val outputTokens: Int? = null,
 )
 
 /**
@@ -369,16 +369,24 @@ public data class AnthropicUsage(
  * This data class encapsulates the structure of a streamed response,
  * including its type, any delta updates to the content, and the complete message data when applicable.
  *
- * @property type The type of the response.
+ * @property type The type of the response (e.g., "content_block_start", "content_block_delta", "message_delta").
+ * @property index The index of the content block in streaming responses. Present in content block events.
+ * @property contentBlock The content block data for "content_block_start" events, containing tool use information.
  * @property delta An optional incremental update to the message content, represented as [AnthropicStreamDelta].
  * @property message An optional complete response message, represented as [AnthropicResponse].
+ * @property usage Optional usage statistics for the response, including token counts.
+ * @property error Optional error information if an error occurred during streaming.
  */
 @InternalLLMClientApi
 @Serializable
 public data class AnthropicStreamResponse(
     val type: String,
+    val index: Int? = null,
+    val contentBlock: AnthropicContent? = null,
     val delta: AnthropicStreamDelta? = null,
-    val message: AnthropicResponse? = null
+    val message: AnthropicResponse? = null,
+    val usage: AnthropicUsage? = null,
+    val error: AnthropicStreamError? = null
 )
 
 /**
@@ -389,14 +397,35 @@ public data class AnthropicStreamResponse(
  *
  * @property type The type of the update provided by Anthropic.
  * @property text Optional text content associated with the delta update.
- * @property toolUse Optional data about tool usage associated with the delta update, if applicable.
+ * @property partialJson Optional partial JSON content for tool use streaming.
+ * @property stopReason Optional reason why the generation process was stopped, if applicable.
+ * @property toolUse Optional tool usage data associated with the delta update (deprecated).
  */
 @InternalLLMClientApi
 @Serializable
 public data class AnthropicStreamDelta(
-    val type: String,
+    val type: String? = null,
     val text: String? = null,
+    val partialJson: String? = null,
+    val stopReason: String? = null,
     val toolUse: AnthropicResponseContent.ToolUse? = null
+)
+
+/**
+ * Represents an error that occurred during Anthropic streaming response processing.
+ *
+ * This data class encapsulates error information received from the Anthropic API
+ * during streaming operations, providing details about the type and nature of the error.
+ *
+ * @property type The type or category of the error that occurred.
+ * @property message An optional descriptive message providing additional details about the error.
+ * Defaults to null if no message is provided.
+ */
+@InternalLLMClientApi
+@Serializable
+public data class AnthropicStreamError(
+    val type: String,
+    val message: String? = null,
 )
 
 /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/meta/LlamaDataModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/meta/LlamaDataModels.kt
@@ -37,5 +37,11 @@ public data class LlamaResponse(
 @Serializable
 public data class LlamaStreamChunk(
     @SerialName("generation")
-    val generation: String? = null
+    val generation: String? = null,
+    @SerialName("prompt_token_count")
+    val promptTokenCount: Int? = null,
+    @SerialName("generation_token_count")
+    val generationTokenCount: Int? = null,
+    @SerialName("stop_reason")
+    val stopReason: String? = null
 )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/BedrockAI21JambaSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/BedrockAI21JambaSerializationTest.kt
@@ -11,6 +11,7 @@ import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.params.LLMParams
+import ai.koog.prompt.streaming.StreamFrame
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.serialization.json.jsonObject
@@ -342,7 +343,7 @@ class BedrockAI21JambaSerializationTest {
         """.trimIndent()
 
         val content = BedrockAI21JambaSerialization.parseJambaStreamChunk(chunkJson)
-        assertEquals("Paris is ", content)
+        assertEquals(listOf("Paris is ").map(StreamFrame::Append), content)
     }
 
     @Test
@@ -362,7 +363,7 @@ class BedrockAI21JambaSerializationTest {
         """.trimIndent()
 
         val content = BedrockAI21JambaSerialization.parseJambaStreamChunk(chunkJson)
-        assertEquals("", content)
+        assertEquals(listOf("").map(StreamFrame::Append), content)
     }
 
     @Test
@@ -382,6 +383,6 @@ class BedrockAI21JambaSerializationTest {
         """.trimIndent()
 
         val content = BedrockAI21JambaSerialization.parseJambaStreamChunk(chunkJson)
-        assertEquals("", content)
+        assertEquals(emptyList(), content)
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/meta/BedrockMetaLlamaSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/meta/BedrockMetaLlamaSerializationTest.kt
@@ -7,6 +7,7 @@ import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.params.LLMParams
+import ai.koog.prompt.streaming.StreamFrame
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlin.test.Test
@@ -153,7 +154,7 @@ class BedrockMetaLlamaSerializationTest {
         """.trimIndent()
 
         val content = BedrockMetaLlamaSerialization.parseLlamaStreamChunk(chunkJson)
-        assertEquals("Hello, ", content)
+        assertEquals(listOf("Hello, ").map(StreamFrame::Append), content)
     }
 
     @Test
@@ -165,7 +166,7 @@ class BedrockMetaLlamaSerializationTest {
         """.trimIndent()
 
         val content = BedrockMetaLlamaSerialization.parseLlamaStreamChunk(chunkJson)
-        assertEquals("", content)
+        assertEquals(listOf("").map(StreamFrame::Append), content)
     }
 
     @Test
@@ -177,6 +178,6 @@ class BedrockMetaLlamaSerializationTest {
         """.trimIndent()
 
         val content = BedrockMetaLlamaSerialization.parseLlamaStreamChunk(chunkJson)
-        assertEquals("", content)
+        assertEquals(emptyList(), content)
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/models/OpenAIDataModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/models/OpenAIDataModels.kt
@@ -296,6 +296,24 @@ public class OpenAIToolCall(
 }
 
 /**
+ * Represents a tool call in the OpenAI stream, specifying the function invoked and its related metadata.
+ *
+ * @property id The unique identifier associated with the tool call. This value can be null.
+ * @property function The function object containing the name and arguments of the function invoked.
+ * This value can be null if no function call is associated.
+ * @property type The type of the tool call. This is always set to "function" for denoting function-based calls.
+ */
+@Serializable
+public class OpenAIStreamToolCall(
+    public val index: Int,
+    public val id: String?,
+    public val function: OpenAIStreamFunction?
+) {
+    /** The type of the tool. Currently, only `function` is supported. */
+    public val type: String = "function"
+}
+
+/**
  * Function call from an OpenAI model, containing the function name and arguments.
  *
  * @property name The name of the function to call
@@ -308,6 +326,18 @@ public class OpenAIToolCall(
 public class OpenAIFunction(
     public val name: String,
     public val arguments: String
+)
+
+/**
+ * Represents a function object used in OpenAI stream tool calls.
+ *
+ * @property name The name of the function that was called.
+ * @property arguments The arguments that were passed to the function call.
+ */
+@Serializable
+public class OpenAIStreamFunction(
+    public val name: String?,
+    public val arguments: String?
 )
 
 /**
@@ -887,7 +917,7 @@ public class OpenAIStreamDelta(
     public val content: String? = null,
     public val refusal: String? = null,
     public val role: String? = null,
-    public val toolCalls: List<OpenAIToolCall>? = null
+    public val toolCalls: List<OpenAIStreamToolCall>? = null
 )
 
 internal object ContentSerializer : KSerializer<Content> {

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/LLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/LLMClient.kt
@@ -6,6 +6,7 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.LLMChoice
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
+import ai.koog.prompt.streaming.StreamFrame
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -32,9 +33,14 @@ public interface LLMClient {
      *
      * @param prompt The prompt to execute
      * @param model The LLM model to use
+     * @param tools Optional list of tools that can be used by the LLM
      * @return Flow of response chunks
      */
-    public fun executeStreaming(prompt: Prompt, model: LLModel): Flow<String>
+    public fun executeStreaming(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor> = emptyList()
+    ): Flow<StreamFrame> = error("Not implemented for this client")
 
     /**
      * Executes a prompt and returns a list of LLM choices.

--- a/prompt/prompt-executor/prompt-executor-llms-all/src/jvmTest/kotlin/ai/koog/prompt/executor/llms/all/MultipleLLMPromptExecutorMockTest.kt
+++ b/prompt/prompt-executor/prompt-executor-llms-all/src/jvmTest/kotlin/ai/koog/prompt/executor/llms/all/MultipleLLMPromptExecutorMockTest.kt
@@ -154,7 +154,7 @@ class MultipleLLMPromptExecutorMockTest {
             user("What is the capital of France?")
         }
 
-        val responseChunks = executor.executeStreaming(prompt, OpenAIModels.Chat.GPT4o)
+        val responseChunks = executor.executeStreamingFrames(prompt, OpenAIModels.Chat.GPT4o)
             .filterTextOnly()
             .toList()
 
@@ -174,7 +174,6 @@ class MultipleLLMPromptExecutorMockTest {
         }
 
         val responseChunks = executor.executeStreaming(prompt, AnthropicModels.Sonnet_3_7)
-            .filterTextOnly()
             .toList()
 
         assertEquals(3, responseChunks.size, "Response should have three chunks")
@@ -193,7 +192,6 @@ class MultipleLLMPromptExecutorMockTest {
         }
 
         val responseChunks = executor.executeStreaming(prompt, GoogleModels.Gemini2_0Flash)
-            .filterTextOnly()
             .toList()
 
         assertEquals(3, responseChunks.size, "Response should have three chunks")

--- a/prompt/prompt-executor/prompt-executor-llms/src/commonMain/kotlin/ai/koog/prompt/executor/llms/MultiLLMPromptExecutor.kt
+++ b/prompt/prompt-executor/prompt-executor-llms/src/commonMain/kotlin/ai/koog/prompt/executor/llms/MultiLLMPromptExecutor.kt
@@ -9,6 +9,7 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
+import ai.koog.prompt.streaming.StreamFrame
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
 
@@ -138,14 +139,19 @@ public open class MultiLLMPromptExecutor(
      *
      * @param prompt The prompt to execute, containing the messages and parameters.
      * @param model The LLM model to use for execution.
+     * @param tools A list of `ToolDescriptor` objects representing external tools available for use during execution.
      **/
-    override fun executeStreaming(prompt: Prompt, model: LLModel): Flow<String> {
+    override fun executeStreaming(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>
+    ): Flow<StreamFrame> {
         logger.debug { "Executing streaming prompt: $prompt with model: $model" }
 
         val provider = model.provider
         val client = requireNotNull(llmClients[model.provider]) { "No client found for provider: $provider" }
 
-        return client.executeStreaming(prompt, model)
+        return client.executeStreaming(prompt, model, tools)
     }
 
     /**

--- a/prompt/prompt-executor/prompt-executor-llms/src/commonMain/kotlin/ai/koog/prompt/executor/llms/MultiLLMPromptExecutor.kt
+++ b/prompt/prompt-executor/prompt-executor-llms/src/commonMain/kotlin/ai/koog/prompt/executor/llms/MultiLLMPromptExecutor.kt
@@ -141,7 +141,7 @@ public open class MultiLLMPromptExecutor(
      * @param model The LLM model to use for execution.
      * @param tools A list of `ToolDescriptor` objects representing external tools available for use during execution.
      **/
-    override fun executeStreaming(
+    override fun executeStreamingFrames(
         prompt: Prompt,
         model: LLModel,
         tools: List<ToolDescriptor>

--- a/prompt/prompt-executor/prompt-executor-llms/src/commonMain/kotlin/ai/koog/prompt/executor/llms/SingleLLMPromptExecutor.kt
+++ b/prompt/prompt-executor/prompt-executor-llms/src/commonMain/kotlin/ai/koog/prompt/executor/llms/SingleLLMPromptExecutor.kt
@@ -8,6 +8,7 @@ import ai.koog.prompt.executor.model.LLMChoice
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
+import ai.koog.prompt.streaming.StreamFrame
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
 
@@ -36,10 +37,13 @@ public open class SingleLLMPromptExecutor(
         return response
     }
 
-    override fun executeStreaming(prompt: Prompt, model: LLModel): Flow<String> {
-        logger.debug { "Executing streaming prompt: $prompt with model: $model" }
-
-        return llmClient.executeStreaming(prompt, model)
+    override fun executeStreaming(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>
+    ): Flow<StreamFrame> {
+        logger.debug { "Executing streaming prompt: $prompt with tools: $tools and model: $model" }
+        return llmClient.executeStreaming(prompt, model, tools)
     }
 
     override suspend fun executeMultipleChoices(

--- a/prompt/prompt-executor/prompt-executor-llms/src/commonMain/kotlin/ai/koog/prompt/executor/llms/SingleLLMPromptExecutor.kt
+++ b/prompt/prompt-executor/prompt-executor-llms/src/commonMain/kotlin/ai/koog/prompt/executor/llms/SingleLLMPromptExecutor.kt
@@ -37,7 +37,7 @@ public open class SingleLLMPromptExecutor(
         return response
     }
 
-    override fun executeStreaming(
+    override fun executeStreamingFrames(
         prompt: Prompt,
         model: LLModel,
         tools: List<ToolDescriptor>

--- a/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/MockOpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/MockOpenAILLMClient.kt
@@ -7,8 +7,10 @@ import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.prompt.streaming.StreamFrame
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Clock
 import kotlin.jvm.JvmOverloads
 
@@ -35,9 +37,12 @@ internal class MockOpenAILLMClient @JvmOverloads constructor(
         }
     }
 
-    override fun executeStreaming(prompt: Prompt, model: LLModel): Flow<String> {
-        return flowOf("OpenAI", " streaming", " response")
-    }
+    override fun executeStreaming(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>
+    ): Flow<StreamFrame> =
+        flowOf("OpenAI", " streaming", " response").map(StreamFrame::Append)
 
     override suspend fun moderate(prompt: Prompt, model: LLModel): ModerationResult {
         throw UnsupportedOperationException("Moderation is not supported by mock client.")

--- a/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/MultiLLMPromptExecutorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/MultiLLMPromptExecutorTest.kt
@@ -146,7 +146,7 @@ class MultiLLMPromptExecutorTest {
             user("What is the capital of France?")
         }
 
-        val responseChunks = executor.executeStreaming(prompt, model)
+        val responseChunks = executor.executeStreamingFrames(prompt, model)
             .filterTextOnly()
             .toList()
         assertEquals(3, responseChunks.size, "Response should have three chunks")
@@ -171,7 +171,7 @@ class MultiLLMPromptExecutorTest {
             user("What is the capital of France?")
         }
 
-        val responseChunks = executor.executeStreaming(prompt, model)
+        val responseChunks = executor.executeStreamingFrames(prompt, model)
             .filterTextOnly()
             .toList()
         assertEquals(3, responseChunks.size, "Response should have three chunks")
@@ -196,7 +196,7 @@ class MultiLLMPromptExecutorTest {
             user("What is the capital of France?")
         }
 
-        val responseChunks = executor.executeStreaming(prompt, model)
+        val responseChunks = executor.executeStreamingFrames(prompt, model)
             .filterTextOnly()
             .toList()
         assertEquals(3, responseChunks.size, "Response should have three chunks")

--- a/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/SingleLLMPromptExecutorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/SingleLLMPromptExecutorTest.kt
@@ -11,6 +11,7 @@ import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.prompt.streaming.StreamFrame
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
@@ -58,7 +59,7 @@ class SingleLLMPromptExecutorTest {
 
     @Test
     fun testExecuteStreaming() = runTest {
-        val chunks = listOf("hello", " ", "world")
+        val chunks = listOf("hello", " ", "world").map(StreamFrame::Append)
         val client = CapturingLLMClient(streamingChunks = chunks)
         val executor = SingleLLMPromptExecutor(client)
         val prompt = Prompt.build("p2") { user("Hello!") }

--- a/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/SingleLLMPromptExecutorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/SingleLLMPromptExecutorTest.kt
@@ -64,7 +64,7 @@ class SingleLLMPromptExecutorTest {
         val executor = SingleLLMPromptExecutor(client)
         val prompt = Prompt.build("p2") { user("Hello!") }
 
-        val collected = executor.executeStreaming(prompt, mockModel).toList()
+        val collected = executor.executeStreamingFrames(prompt, mockModel).toList()
 
         assertEquals(chunks, collected, "Response chunks should match, got: $collected")
         assertEquals(prompt, client.lastStreamingPrompt, "Prompt should match, got: ${client.lastStreamingPrompt}")

--- a/prompt/prompt-executor/prompt-executor-model/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-model/build.gradle.kts
@@ -18,6 +18,12 @@ kotlin {
             }
         }
 
+        commonTest {
+            dependencies {
+                implementation(project(":test-utils"))
+            }
+        }
+
         jvmMain {
             dependencies {
                 api(libs.kotlinx.coroutines.jdk8)

--- a/prompt/prompt-executor/prompt-executor-model/src/commonMain/kotlin/ai/koog/prompt/executor/model/PromptExecutor.kt
+++ b/prompt/prompt-executor/prompt-executor-model/src/commonMain/kotlin/ai/koog/prompt/executor/model/PromptExecutor.kt
@@ -5,6 +5,7 @@ import ai.koog.prompt.dsl.ModerationResult
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
+import ai.koog.prompt.streaming.StreamFrame
 import kotlinx.coroutines.flow.Flow
 
 public typealias LLMChoice = List<Message.Response>
@@ -33,13 +34,18 @@ public interface PromptExecutor {
     ): List<Message.Response>
 
     /**
-     * Executes a given prompt using the specified language model and returns a stream of output as a flow of strings.
+     * Executes a given prompt using the specified language model and returns a stream of output as a flow of `StreamFrame` objects.
      *
      * @param prompt The prompt containing input messages and parameters to guide the language model execution.
      * @param model The language model to be used for processing the prompt.
-     * @return A flow emitting strings that represent the streaming output of the language model.
+     * @param tools A list of `ToolDescriptor` objects that define the tools available for the execution.
+     * @return A flow emitting `StreamFrame` objects that represent the streaming output of the language model.
      */
-    public fun executeStreaming(prompt: Prompt, model: LLModel): Flow<String>
+    public fun executeStreaming(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor> = emptyList()
+    ): Flow<StreamFrame>
 
     /**
      * Receives multiple independent choices from the LLM.

--- a/prompt/prompt-executor/prompt-executor-model/src/commonMain/kotlin/ai/koog/prompt/executor/model/PromptExecutor.kt
+++ b/prompt/prompt-executor/prompt-executor-model/src/commonMain/kotlin/ai/koog/prompt/executor/model/PromptExecutor.kt
@@ -6,7 +6,9 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.streaming.filterTextOnly
 import kotlinx.coroutines.flow.Flow
+import org.jetbrains.annotations.ApiStatus
 
 public typealias LLMChoice = List<Message.Response>
 
@@ -15,12 +17,14 @@ public typealias LLMChoice = List<Message.Response>
  * This defines methods for executing prompts against models with or without tool assistance,
  * as well as for streaming responses.
  *
- * Note: a single [PromptExecutor] might embed multiple LLM clients for different LLM providers supporting different models.
+ * Note: a single [PromptExecutor] might embed multiple LLM clients
+ * for different LLM providers supporting different models.
  */
 public interface PromptExecutor {
 
     /**
-     * Executes a given prompt using the specified language model and tools, returning a list of responses from the model.
+     * Executes a given prompt using the specified language model and tools,
+     * returning a list of responses from the model.
      *
      * @param prompt The `Prompt` object containing the messages to be used in the execution.
      * @param model The instance of `LLModel` that specifies the language model to be used.
@@ -34,18 +38,40 @@ public interface PromptExecutor {
     ): List<Message.Response>
 
     /**
-     * Executes a given prompt using the specified language model and returns a stream of output as a flow of `StreamFrame` objects.
+     * Executes a given prompt using the specified language model
+     * and returns a stream of output as a flow of `StreamFrame` objects.
      *
      * @param prompt The prompt containing input messages and parameters to guide the language model execution.
      * @param model The language model to be used for processing the prompt.
      * @param tools A list of `ToolDescriptor` objects that define the tools available for the execution.
      * @return A flow emitting `StreamFrame` objects that represent the streaming output of the language model.
      */
-    public fun executeStreaming(
+    @ApiStatus.Experimental
+    public fun executeStreamingFrames(
         prompt: Prompt,
         model: LLModel,
         tools: List<ToolDescriptor> = emptyList()
     ): Flow<StreamFrame>
+
+    /**
+     * Executes a given prompt using the specified language model and returns a stream of output as a flow of strings.
+     *
+     * NB! This method might change to return the [Flow] of [StreamFrame]
+     *
+     * @param prompt The prompt containing input messages and parameters to guide the language model execution.
+     * @param model The language model to be used for processing the prompt.
+     * @return A flow emitting strings that represent the streaming output of the language model.
+     */
+    @ApiStatus.Obsolete
+    public fun executeStreaming(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor> = emptyList()
+    ): Flow<String> = executeStreamingFrames(
+        prompt = prompt,
+        model = model,
+        tools = tools,
+    ).filterTextOnly()
 
     /**
      * Receives multiple independent choices from the LLM.

--- a/prompt/prompt-executor/prompt-executor-model/src/commonTest/kotlin/ai/koog/prompt/executor/model/PromptExecutorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-model/src/commonTest/kotlin/ai/koog/prompt/executor/model/PromptExecutorTest.kt
@@ -1,0 +1,62 @@
+package ai.koog.prompt.executor.model
+
+import ai.koog.prompt.dsl.ModerationResult
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.streaming.StreamFrame
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PromptExecutorTest {
+
+    private class FakePromptExecutor : PromptExecutor {
+        override suspend fun execute(
+            prompt: Prompt,
+            model: LLModel,
+            tools: List<ai.koog.agents.core.tools.ToolDescriptor>
+        ): List<Message.Response> = TODO()
+
+        override fun executeStreamingFrames(
+            prompt: Prompt,
+            model: LLModel,
+            tools: List<ai.koog.agents.core.tools.ToolDescriptor>
+        ): Flow<StreamFrame> {
+            return flow {
+                emit(StreamFrame.Append("hello"))
+                emit(StreamFrame.End())
+            }
+        }
+
+        override suspend fun moderate(prompt: Prompt, model: LLModel): ModerationResult = TODO()
+    }
+
+    @Test
+    fun `executeStreaming should call executeStreamingFrames`() = runTest {
+        val executor = FakePromptExecutor()
+        val model = LLModel(
+            provider = LLMProvider.OpenAI,
+            id = "test-model",
+            capabilities = emptyList(),
+            contextLength = 4096,
+            maxOutputTokens = null,
+        )
+
+        val collected = mutableListOf<String>()
+        executor.executeStreaming(
+            prompt = Prompt.Empty,
+            model = model,
+            tools = emptyList()
+        ).collect { collected.add(it) }
+
+        assertEquals(
+            expected = listOf("hello"),
+            actual = collected,
+            message = "Text emitted by executeStreamingFrames should be propagated by executeStreaming"
+        )
+    }
+}

--- a/prompt/prompt-model/build.gradle.kts
+++ b/prompt/prompt-model/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
         commonMain {
             dependencies {
                 api(project(":prompt:prompt-llm"))
+                api(libs.kotlinx.coroutines.core)
                 api(libs.kotlinx.serialization.json)
                 api(libs.kotlinx.datetime)
                 api(libs.kotlinx.io.core)
@@ -22,6 +23,7 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(kotlin("test"))
+                implementation(libs.kotlinx.coroutines.test)
             }
         }
 

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrame.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrame.kt
@@ -1,0 +1,57 @@
+package ai.koog.prompt.streaming
+
+import ai.koog.prompt.message.ResponseMetaInfo
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * Represents a frame of a streaming response from a LLM.
+ */
+@Serializable
+public sealed interface StreamFrame {
+
+    /**
+     * Represents a frame of a streaming response from a LLM that appends some text.
+     *
+     * @property text The text to append to the response.
+     */
+    @Serializable
+    public data class Append(
+        val text: String
+    ) : StreamFrame
+
+    /**
+     * Represents a frame of a streaming response from a LLM that contains a tool call.
+     *
+     * @property id The ID of the tool call. Can be null for partial frames.
+     * @property name The name of the tool being called. Can be null for partial frames.
+     * @property content The content/arguments of the tool call. Can be null for partial frames.
+     */
+    @Serializable
+    public data class ToolCall(
+        val id: String?,
+        val name: String,
+        val content: String
+    ) : StreamFrame {
+
+        /**
+         * Lazily parses the content of the tool call as a JSON object.
+         */
+        val contentJson: JsonObject by lazy {
+            Json.parseToJsonElement(content).jsonObject
+        }
+    }
+
+    /**
+     * Represents a frame of a streaming response from a LLM that signals the end of the stream.
+     *
+     * @property finishReason The reason for the stream to end.
+     */
+    @Serializable
+    public data class End(
+        val finishReason: String? = null,
+        val metaInfo: ResponseMetaInfo = ResponseMetaInfo.Empty
+    ) : StreamFrame
+}

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameExt.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameExt.kt
@@ -1,0 +1,74 @@
+package ai.koog.prompt.streaming
+
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.ResponseMetaInfo
+
+/**
+ * Converts a [Message.Response] to a [StreamFrame].
+ */
+public fun Message.Response.toStreamFrame(): StreamFrame =
+    when (this) {
+        is Message.Assistant -> StreamFrame.Append(content)
+        is Message.Tool.Call -> StreamFrame.ToolCall(id, tool, content)
+    }
+
+/**
+ * Converts frames into [Message.Response] objects.
+ *
+ * - Collects all assistant text (`Append`) into one [Message.Assistant].
+ * - Preserves all [StreamFrame.ToolCall] as [Message.Tool.Call].
+ * - Uses the last [StreamFrame.End] (if any) for finishReason/metaInfo.
+ *
+ * @return A list of [Message.Response] objects.
+ */
+public fun Iterable<StreamFrame>.toMessageResponses(): List<Message.Response> {
+    var assistantContent: String? = null
+    val toolCalls = mutableListOf<StreamFrame.ToolCall>()
+    var end: StreamFrame.End? = null
+
+    forEach { frame ->
+        when (frame) {
+            is StreamFrame.Append -> assistantContent = (assistantContent ?: "") + frame.text
+            is StreamFrame.ToolCall -> toolCalls += frame
+            is StreamFrame.End -> end = frame
+        }
+    }
+
+    return buildList {
+        toolCalls.forEach {
+            add(
+                Message.Tool.Call(
+                    id = it.id,
+                    tool = it.name,
+                    content = it.content,
+                    metaInfo = end?.metaInfo ?: ResponseMetaInfo.Empty
+                )
+            )
+        }
+        assistantContent?.let {
+            add(
+                Message.Assistant(
+                    content = it,
+                    finishReason = end?.finishReason,
+                    metaInfo = end?.metaInfo ?: ResponseMetaInfo.Empty
+                )
+            )
+        }
+    }
+}
+
+/**
+ * Extracts only tool calls from frames.
+ *
+ * @return A list of [Message.Tool.Call] objects.
+ */
+public fun Iterable<StreamFrame>.toToolCallMessages(): List<Message.Tool.Call> =
+    toMessageResponses().filterIsInstance<Message.Tool.Call>()
+
+/**
+ * Extracts the assistant response from frames, if any.
+ *
+ * @return A [Message.Assistant] object, or `null` if not found.
+ */
+public fun Iterable<StreamFrame>.toAssistantMessageOrNull(): Message.Assistant? =
+    toMessageResponses().filterIsInstance<Message.Assistant>().singleOrNull()

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
@@ -1,0 +1,138 @@
+package ai.koog.prompt.streaming
+
+import ai.koog.prompt.message.ResponseMetaInfo
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.experimental.ExperimentalTypeInference
+
+/**
+ * Create a [Flow] of [StreamFrame.Append] objects from a list of [String] content.
+ */
+public fun streamFrameFlowOf(vararg content: String): Flow<StreamFrame.Append> =
+    content.asFlow().map(StreamFrame::Append)
+
+/**
+ * Builds a [Flow] of [StreamFrame] objects.
+ *
+ * @see emitAppend for emitting a [StreamFrame.Append] object.
+ * @see emitToolCall for emitting a [StreamFrame.ToolCall] object.
+ * @see emitEnd for emitting a [StreamFrame.End] object.
+ */
+@OptIn(ExperimentalTypeInference::class)
+public fun streamFrameFlow(@BuilderInference block: suspend FlowCollector<StreamFrame>.() -> Unit): Flow<StreamFrame> =
+    flow(block)
+
+/**
+ * Emits a [StreamFrame.Append] with the given [text].
+ */
+public suspend fun FlowCollector<StreamFrame>.emitAppend(text: String): Unit =
+    emit(StreamFrame.Append(text))
+
+/**
+ * Emits a [StreamFrame.End] with the given [finishReason].
+ */
+public suspend fun FlowCollector<StreamFrame>.emitEnd(
+    finishReason: String? = null,
+    metaInfo: ResponseMetaInfo? = null
+): Unit =
+    emit(StreamFrame.End(finishReason, metaInfo ?: ResponseMetaInfo.Empty))
+
+/**
+ * Emits a [StreamFrame.ToolCall] with the given [id], [name] and [content].
+ */
+public suspend fun FlowCollector<StreamFrame>.emitToolCall(id: String?, name: String, content: String): Unit =
+    emit(StreamFrame.ToolCall(id, name, content))
+
+/**
+ * Builds a [Flow] of [StreamFrame] objects.
+ */
+public fun buildStreamFrameFlow(block: suspend StreamFrameFlowBuilder.() -> Unit): Flow<StreamFrame> =
+    streamFrameFlow {
+        val builder = StreamFrameFlowBuilder(this)
+        block(builder)
+    }
+
+/**
+ * Represents a wrapper around a [FlowCollector] that provides methods for emitting [StreamFrame] objects.
+ *
+ * This is mainly used for combining chunked tool calls and only emit completed tool calls.
+ *
+ * @property flowCollector The underlying [FlowCollector] used for emitting [StreamFrame] objects.
+ */
+@OptIn(ExperimentalAtomicApi::class)
+public class StreamFrameFlowBuilder(
+    private val flowCollector: FlowCollector<StreamFrame>,
+) {
+
+    private val pendingToolCallRef = AtomicReference<PendingToolCall?>(null)
+
+    /**
+     * Emits a [StreamFrame.Append] with the given [text].
+     */
+    public suspend fun emitAppend(text: String) {
+        tryEmitPendingToolCall()
+        flowCollector.emitAppend(text)
+    }
+
+    /**
+     * Emits a [StreamFrame.End] with the given [finishReason].
+     */
+    public suspend fun emitEnd(finishReason: String? = null, metaInfo: ResponseMetaInfo? = null) {
+        tryEmitPendingToolCall()
+        flowCollector.emitEnd(finishReason, metaInfo)
+    }
+
+    /**
+     * Emits a [pendingToolCallRef] if it exists and then clears it.
+     */
+    public suspend fun tryEmitPendingToolCall() {
+        val pendingToolCall = pendingToolCallRef.exchange(null)
+        if (pendingToolCall != null) {
+            flowCollector.emitToolCall(
+                id = pendingToolCall.id,
+                name = pendingToolCall.name ?: "",
+                content = pendingToolCall.argumentsDelta ?: "{}"
+            )
+        }
+    }
+
+    /**
+     * Updates the coroutine context to signal we're currently combining a tool call,
+     * this does not emit anything yet, that happens only in [tryEmitPendingToolCall].
+     */
+    public suspend fun upsertToolCall(
+        index: Int,
+        id: String? = null,
+        name: String? = null,
+        args: String? = null
+    ) {
+        val new: PendingToolCall = if (id != null) {
+            tryEmitPendingToolCall()
+            PendingToolCall(index, id, name, args)
+        } else {
+            val previous = pendingToolCallRef.load()
+            if (previous == null) {
+                error("No tool call is in progress, and no tool call id was provided.")
+            } else if (previous.index != index) {
+                error("Tool call index mismatch. Expected ${previous.index}, got $index.")
+            }
+            previous.appendArgumentsDelta(args)
+        }
+        pendingToolCallRef.store(new)
+    }
+
+    private data class PendingToolCall(
+        val index: Int,
+        val id: String,
+        val name: String?,
+        val argumentsDelta: String?
+    ) {
+        fun appendArgumentsDelta(argumentsDelta: String?): PendingToolCall =
+            copy(argumentsDelta = (this.argumentsDelta ?: "") + argumentsDelta)
+    }
+}

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowExt.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowExt.kt
@@ -1,0 +1,19 @@
+package ai.koog.prompt.streaming
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.fold
+import kotlinx.coroutines.flow.map
+
+/**
+ * Returns a transformed flow of [StreamFrame.Append] objects that contains only the textual content.
+ */
+public fun Flow<StreamFrame>.filterTextOnly(): Flow<String> =
+    filterIsInstance<StreamFrame.Append>()
+        .map { frame -> frame.text }
+
+/**
+ * Collects the textual content of a [Flow] of [StreamFrame] objects and returns it as a single string.
+ */
+public suspend fun Flow<StreamFrame>.collectText(): String =
+    filterTextOnly().fold("") { acc, s -> acc + s }

--- a/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameExtTest.kt
+++ b/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameExtTest.kt
@@ -1,0 +1,99 @@
+package ai.koog.prompt.streaming
+
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.ResponseMetaInfo
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+internal class StreamFrameExtTest {
+
+    @Test
+    fun `convert Assistant Message to Append StreamFrame`() {
+        assertEquals(
+            expected = appendFrame("test"),
+            actual = assistantMessage("test")
+                .toStreamFrame()
+        )
+    }
+
+    @Test
+    fun `convert Call Tool Message to ToolCall StreamFrame`() {
+        assertEquals(
+            expected = toolCallFrame("123", "tool", "{}"),
+            actual = toolCallMessage("123", "tool", "{}")
+                .toStreamFrame()
+        )
+    }
+
+    @Test
+    fun `convert StreamFrame Iterable to Message List`() = runTest {
+        val meta = ResponseMetaInfo.create(
+            clock = Clock.System,
+            inputTokensCount = 1337,
+            outputTokensCount = 69,
+            totalTokensCount = 420,
+        )
+        assertContentEquals(
+            expected = listOf(
+                toolCallMessage("123", "tool", "{}", meta),
+                assistantMessage("test", null, meta),
+            ),
+            actual = listOf(
+                appendFrame("te"),
+                toolCallFrame("123", "tool", "{}"),
+                appendFrame("st"),
+                endFrame(null, meta),
+            ).toMessageResponses()
+        )
+        assertContentEquals(
+            expected = listOf(assistantMessage("test", "end", meta)),
+            actual = listOf(
+                appendFrame("test"),
+                endFrame("end", meta),
+            ).toMessageResponses()
+        )
+    }
+
+    @Test
+    fun `convert StreamFrame Iterable to Tool Call Message List`() {
+        assertContentEquals(
+            expected = listOf(toolCallMessage("456", "tool2", "{ a: 1 }")),
+            actual = listOf(toolCallFrame("456", "tool2", "{ a: 1 }"))
+                .toToolCallMessages()
+        )
+    }
+
+    @Test
+    fun `convert StreamFrame Iterable to Assistant Message`() {
+        assertEquals(
+            expected = assistantMessage("test"),
+            actual = listOf(appendFrame("test")).toAssistantMessageOrNull()
+        )
+    }
+
+    @Test
+    fun `no Assistant Message in StreamFrame Iterable`() {
+        assertEquals(
+            expected = null,
+            actual = listOf(endFrame()).toAssistantMessageOrNull()
+        )
+    }
+}
+
+private fun toolCallFrame(id: String, name: String, content: String) =
+    StreamFrame.ToolCall(id, name, content)
+
+private fun appendFrame(content: String) =
+    StreamFrame.Append(content)
+
+private fun endFrame(finishReason: String? = null, metaInfo: ResponseMetaInfo = ResponseMetaInfo.Empty) =
+    StreamFrame.End(finishReason, metaInfo)
+
+private fun toolCallMessage(id: String, name: String, content: String, info: ResponseMetaInfo = ResponseMetaInfo.Empty) =
+    Message.Tool.Call(id, name, content, info)
+
+private fun assistantMessage(content: String, finishReason: String? = null, metaInfo: ResponseMetaInfo = ResponseMetaInfo.Empty) =
+    Message.Assistant(content, metaInfo, finishReason = finishReason)

--- a/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderTest.kt
+++ b/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderTest.kt
@@ -1,0 +1,77 @@
+package ai.koog.prompt.streaming
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+
+class StreamFrameFlowBuilderTest {
+
+    private val weatherCallId = "call_get_weather_1"
+    private val weatherFunName = "get_weather"
+    private val weatherArgList = listOf("{\"", "location", "\":\"", "Netherlands", "\"}")
+    private val weatherArgString = weatherArgList.joinToString("")
+
+    @Test
+    fun testCombiningOfPartialToolCallsWithManualEmit() = runTest {
+        buildStreamFrameFlow {
+            appendWeatherToolAsParts(0)
+            tryEmitPendingToolCall()
+        } assertContentEquals {
+            emitWeatherToolCall()
+        }
+    }
+
+    @Test
+    fun testCombiningOfPartialToolCallsWithAutomaticEmitOnAppend() = runTest {
+        buildStreamFrameFlow {
+            appendWeatherToolAsParts(0)
+            emitAppend("emitted tool?")
+        } assertContentEquals {
+            emitWeatherToolCall()
+            emitAppend("emitted tool?")
+        }
+    }
+
+    @Test
+    fun testCombiningOfPartialToolCallsWithAutomaticEmitOnEnd() = runTest {
+        buildStreamFrameFlow {
+            appendWeatherToolAsParts(0)
+            emitEnd()
+        } assertContentEquals {
+            emitWeatherToolCall()
+            emitEnd()
+        }
+    }
+
+    @Test
+    fun testAutomaticEmitOnNewToolCallId() = runTest {
+        buildStreamFrameFlow {
+            upsertToolCall(index = 0, id = "some_other_id", name = "some_other_tool", args = "")
+            appendWeatherToolAsParts(index = 1)
+            tryEmitPendingToolCall()
+        } assertContentEquals {
+            emitToolCall(id = "some_other_id", name = "some_other_tool", content = "")
+            emitWeatherToolCall()
+        }
+    }
+
+    private suspend fun StreamFrameFlowBuilder.appendWeatherToolAsParts(index: Int) {
+        upsertToolCall(index = index, id = weatherCallId, name = weatherFunName, args = "")
+        weatherArgList.forEach {
+            upsertToolCall(index = index, args = it)
+        }
+    }
+
+    private suspend fun FlowCollector<StreamFrame>.emitWeatherToolCall() =
+        emitToolCall(id = weatherCallId, name = weatherFunName, content = weatherArgString)
+}
+
+private suspend infix fun Flow<StreamFrame>.assertContentEquals(expected: suspend FlowCollector<StreamFrame>.() -> Unit) =
+    assertContentEquals(
+        expected = flow(expected).toList(),
+        actual = toList()
+    )

--- a/prompt/prompt-model/src/jvmTest/kotlin/ai/koog/prompt/PromptTest.kt
+++ b/prompt/prompt-model/src/jvmTest/kotlin/ai/koog/prompt/PromptTest.kt
@@ -7,14 +7,12 @@ import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.params.LLMParams
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
-import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
@@ -421,11 +419,11 @@ class PromptTest {
 
     @Test
     fun testInvalidToolCallJsonContent() {
+        // contentJson property is now on StreamFrame.ToolCall, not Message.Tool.Call
+        // This test is no longer applicable for Message.Tool.Call
         val toolCallWithInvalidJson = Message.Tool.Call(toolCallId, toolName, "invalid json", testRespMetaInfo)
-
-        assertThrows<SerializationException> {
-            toolCallWithInvalidJson.contentJson
-        }
+        // Just verify the content is stored as-is
+        assertEquals("invalid json", toolCallWithInvalidJson.content)
     }
 
     @Test


### PR DESCRIPTION
Some changes on top of #747 to keep `PromptExecutor.executeStreaming(...): Flow<String>` signature intact to avoid incompatible changes right away 💥 

## Motivation and Context

#747 provides a very valuable feature, but breaks compatibility. It might be better to address the method signature change separately with appropriate doc updates.

## Breaking Changes
Some breaking change in the internal methods, but the public api should not be affected.

---

#### Type of the changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [ ] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
