### PR TITLE
Make `NoPartialToolCallToComplete` error a class

### DIFF
--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
@@ -120,7 +120,7 @@ public class StreamFrameFlowBuilder(
             val previous: PendingToolCall? = pendingToolCallRef.load()
             when {
                 previous == null ->
-                    throw StreamFrameFlowBuilderError.NoPartialToolCallToComplete
+                    throw StreamFrameFlowBuilderError.NoPartialToolCallToComplete()
 
                 previous.index != index ->
                     throw StreamFrameFlowBuilderError.UnexpectedPartialToolCallIndex(previous.index, index)

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderError.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderError.kt
@@ -11,7 +11,7 @@ public sealed class StreamFrameFlowBuilderError(message: String) : Throwable(mes
      *
      * The first partial tool call data for a new tool call should always include the `id`.
      */
-    public object NoPartialToolCallToComplete :
+    public class NoPartialToolCallToComplete :
         StreamFrameFlowBuilderError("Error constructing tool call, no tool call to complete or no tool call id was provided.")
 
     /**


### PR DESCRIPTION
This is a nitpick change from #747 