### PR TITLE
[agents] Make `AIAgentStorageKey` in agent storage actually unique by removing `data` modifier

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentStorage.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentStorage.kt
@@ -11,7 +11,9 @@ import kotlinx.coroutines.sync.withLock
  *
  * @param name The string identifier that uniquely represents the storage key.
  */
-public class AIAgentStorageKey<T : Any>(public val name: String)
+public class AIAgentStorageKey<T : Any>(public val name: String) {
+    override fun toString(): String = "${super.toString()}(name=$name)"
+}
 
 /**
  * Creates a storage key for a specific type, allowing identification and retrieval of values associated with it.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentStorage.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentStorage.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.sync.withLock
  *
  * @param name The string identifier that uniquely represents the storage key.
  */
-public data class AIAgentStorageKey<T : Any>(val name: String)
+public class AIAgentStorageKey<T : Any>(public val name: String)
 
 /**
  * Creates a storage key for a specific type, allowing identification and retrieval of values associated with it.

--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/Persistency.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/Persistency.kt
@@ -67,8 +67,7 @@ public class Persistency(private val persistencyStorageProvider: PersistencyStor
         /**
          * The storage key used to identify this feature in the agent's feature registry.
          */
-        override val key: AIAgentStorageKey<Persistency>
-            get() = AIAgentStorageKey("agents-features-snapshot")
+        override val key: AIAgentStorageKey<Persistency> = AIAgentStorageKey("agents-features-snapshot")
 
         /**
          * Creates the default configuration for this feature.


### PR DESCRIPTION
There's an issue in `AIAgentStorage` implementation where `AIAgentStorageKey` is incorrectly defined as a data class. This causes keys with identical names to be treated as equal due to auto-generated equals/hashCode methods, contradicting the documented behavior that each key instance should be unique regardless of name.
The fix is straightforward - remove the data modifier from the class definition. This ensures storage keys are compared by instance identity rather than content equality.