### PR TITLE
feat: add support for mocking streaming and enhance MockLLMBuilder

### DIFF
--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/NodeLLMRequestStreamingAndSendResultsTest.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/NodeLLMRequestStreamingAndSendResultsTest.kt
@@ -9,9 +9,12 @@ import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreamingAndSendResults
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.agents.testing.tools.mockLLMAnswer
+import ai.koog.agents.testing.tools.mockLLMStream
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.streaming.streamFrameFlowOf
 import ai.koog.serialization.kotlinx.KotlinxSerializer
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
@@ -71,7 +74,7 @@ class NodeLLMRequestStreamingAndSendResultsTest {
 
         val mockExecutor = getMockExecutor(serializer, clock = testClock) {
             // Match on the test user message from createAgent
-            mockLLMAnswer(assistantResponse) onRequestContains "Test user message"
+            mockLLMStream(streamFrameFlowOf(assistantResponse)) onRequestContains "Test user message"
         }
 
         val agent = createStreamingTestAgent(
@@ -113,8 +116,8 @@ class NodeLLMRequestStreamingAndSendResultsTest {
             )
         }
 
-        val mockExecutor = getMockExecutor(serializer, clock = testClock) {
-            mockLLMAnswer(assistantResponse) onRequestContains "Test user message"
+        val mockExecutor = getMockExecutor(clock = testClock) {
+            mockLLMStream(streamFrameFlowOf(assistantResponse)) onRequestContains "Test user message"
         }
 
         val agent = createStreamingTestAgent(
@@ -195,8 +198,8 @@ class NodeLLMRequestStreamingAndSendResultsTest {
             )
         }
 
-        val mockExecutor = getMockExecutor(serializer, clock = testClock) {
-            mockLLMAnswer(assistantResponse) onRequestContains "Test user message"
+        val mockExecutor = getMockExecutor(clock = testClock) {
+            mockLLMStream(streamFrameFlowOf(assistantResponse)) onRequestContains "Test user message"
         }
 
         val agent = createStreamingTestAgent(strategy, promptExecutor = mockExecutor) {

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/StreamingEventHandlerTest.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/StreamingEventHandlerTest.kt
@@ -7,7 +7,9 @@ import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreaming
 import ai.koog.agents.testing.tools.MockExecutorDSLBuilder
 import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.agents.testing.tools.mockLLMStream
 import ai.koog.prompt.streaming.collectText
+import ai.koog.prompt.streaming.streamFrameFlowOf
 import ai.koog.serialization.kotlinx.KotlinxSerializer
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -27,7 +29,9 @@ class StreamingEventHandlerTest {
         // Using nodeLLMRequestStreaming to actually test streaming events
         val eventsCollector = mockStreaming(
             strategy = streamTextStrategy("streaming-test-strategy"),
-            buildLlmMock = { mockLLMAnswer(assistantResponse) onRequestContains userMessage }
+            buildLlmMock = {
+                mockLLMStream(streamFrameFlowOf(assistantResponse)) onRequestContains userMessage
+            }
         ) { agent ->
             agent.run(userMessage, null)
         }
@@ -56,7 +60,9 @@ class StreamingEventHandlerTest {
         val testResponse = "This is a response about streaming functionality"
         val eventsCollector = mockStreaming(
             strategy = streamTextStrategy("streaming-test-strategy-2"),
-            buildLlmMock = { mockLLMAnswer(testResponse) onRequestContains testMessage }
+            buildLlmMock = {
+                mockLLMStream(streamFrameFlowOf(testResponse)) onRequestContains testMessage
+            }
         ) { agent ->
             agent.run(testMessage, null)
         }

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockExecutorDSLBuilder.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockExecutorDSLBuilder.kt
@@ -1,17 +1,18 @@
 package ai.koog.agents.testing.tools
 
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
+import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.ToolResult
 import ai.koog.prompt.dsl.ModerationResult
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.streaming.streamFrameFlowOf
 import ai.koog.prompt.tokenizer.Tokenizer
-import ai.koog.serialization.JSONSerializer
-import ai.koog.serialization.kotlinx.KotlinxSerializer
-import ai.koog.serialization.kotlinx.toKoogJSONObject
-import kotlin.jvm.JvmName
-import kotlin.time.Clock
+import kotlinx.coroutines.flow.Flow
+import kotlinx.datetime.Clock
 
 /**
  * Represents a condition for a tool call and its corresponding result.
@@ -23,13 +24,11 @@ import kotlin.time.Clock
  * @param Args The type of arguments the tool accepts
  * @param Result The type of result the tool produces
  * @property tool The tool to be mocked
- * @property serializer The JSON serializer to use for encoding and decoding args/results
  * @property argsCondition A function that determines if the tool call matches this condition
  * @property produceResult A function that produces the result when the condition is satisfied
  */
-public class ToolCondition<Args, Result>(
+public class ToolCondition<Args : ToolArgs, Result : ToolResult>(
     public val tool: Tool<Args, Result>,
-    public val serializer: JSONSerializer,
     public val argsCondition: suspend (Args) -> Boolean,
     public val produceResult: suspend (Args) -> Result
 ) {
@@ -40,7 +39,7 @@ public class ToolCondition<Args, Result>(
      * @return True if the tool name matches and the arguments satisfy the condition
      */
     internal suspend fun satisfies(toolCall: Message.Tool.Call) =
-        tool.name == toolCall.tool && argsCondition(tool.decodeArgs(toolCall.contentJson.toKoogJSONObject(), serializer))
+        tool.name == toolCall.tool && argsCondition(tool.decodeArgs(toolCall.contentJson))
 
     /**
      * Invokes the tool with the arguments from the tool call.
@@ -49,7 +48,7 @@ public class ToolCondition<Args, Result>(
      * @return The result produced by the tool
      */
     internal suspend fun invoke(toolCall: Message.Tool.Call) =
-        produceResult(tool.decodeArgs(toolCall.contentJson.toKoogJSONObject(), serializer))
+        produceResult(tool.decodeArgs(toolCall.contentJson))
 
     /**
      * Invokes the tool and serializes the result.
@@ -58,8 +57,8 @@ public class ToolCondition<Args, Result>(
      * @return A pair of the result object and its serialized string representation
      */
     internal suspend fun invokeAndSerialize(toolCall: Message.Tool.Call): Pair<Result, String> {
-        val toolResult = produceResult(tool.decodeArgs(toolCall.contentJson.toKoogJSONObject(), serializer))
-        return toolResult to tool.encodeResultToString(toolResult, serializer)
+        val toolResult = produceResult(tool.decodeArgs(toolCall.contentJson))
+        return toolResult to tool.encodeResultToString(toolResult)
     }
 }
 
@@ -70,25 +69,38 @@ public class ToolCondition<Args, Result>(
  * It allows you to define how the LLM should respond to different inputs and how tools should
  * behave when called during testing.
  *
- * @see getMockExecutor Prefer it for creating and configuring mock LLM executors.
  *
- * @param clock A clock that is used for mock message timestamps
- * @param serializer Serializer used to serialize and deserialize tool arguments and results
- * @param tokenizer Optional tokenizer that will be used to estimate token counts in mock messages
+ * Example usage:
+ * ```kotlin
+ * val mockLLMApi = getMockExecutor(toolRegistry) {
+ *     // Mock LLM text responses
+ *     mockLLMAnswer("Hello!") onRequestContains "Hello"
+ *     mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+ *
+ *     // Mock LLM tool calls
+ *     mockLLMToolCall(CreateTool, CreateTool.Args("solve")) onRequestEquals "Solve task"
+ *
+ *     // Mock tool behavior
+ *     mockTool(PositiveToneTool) alwaysReturns "The text has a positive tone."
+ *     mockTool(NegativeToneTool) alwaysTells {
+ *         println("Negative tone tool called")
+ *         "The text has a negative tone."
+ *     }
+ * }
+ * ```
+ *
+ * @property clock: A clock that is used for mock message timestamps
+ * @property tokenizer: Tokenizer that will be used to estimate token counts in mock messages
  */
-public class MockExecutorDSLBuilder(
-    private val clock: Clock,
-    private val serializer: JSONSerializer,
-    private val tokenizer: Tokenizer? = null
-) {
+public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tokenizer? = null) {
     private val toolCallExactMatches = mutableMapOf<String, List<Message.Tool.Call>>()
     private val toolCallPartialMatches = mutableMapOf<String, List<Message.Tool.Call>>()
-    private val toolCallConditionalMatches = mutableMapOf<(String) -> Boolean, List<Message.Tool.Call>>()
+    private var toolRegistry: ToolRegistry? = null
     private var toolActions: MutableList<ToolCondition<*, *>> = mutableListOf()
 
     private val assistantPartialMatches = mutableMapOf<String, List<String>>()
     private val assistantExactMatches = mutableMapOf<String, List<String>>()
-    private val conditionalResponses = mutableMapOf<(String) -> Boolean, List<String>>()
+    private val conditionalResponses = mutableMapOf<(String) -> Boolean, String>()
     private var defaultResponse: String = ""
 
     private val moderationPartialMatches = mutableMapOf<String, ModerationResult>()
@@ -98,38 +110,32 @@ public class MockExecutorDSLBuilder(
         categories = emptyMap()
     )
 
+    private val streamPartialMatches = mutableMapOf<String, Flow<StreamFrame>>()
+    private val streamExactMatches = mutableMapOf<String, Flow<StreamFrame>>()
+    private var defaultStreamResponse: Flow<StreamFrame> = streamFrameFlowOf()
+
     /**
      * Determines whether the last message handled in a sequence should focus specifically on
      * the most recent message categorized as `Message.Assistant` when resolving mock responses.
      *
      * Useful in scenarios where the mock response handling involves mixed results
      * from the LLM, and there is a need to differentiate between handling the general
-     * last message vs. the last assistant-specific message.
+     * last message vs the last assistant-specific message.
      */
     public var handleLastAssistantMessage: Boolean = false
 
     /**
-     * Creates a mock LLM text response.
-     *
-     * This function is the entry point for configuring how the LLM should respond with text
-     * when it receives specific inputs.
-     *
-     * @param response The text response to return
-     * @return A [DefaultResponseReceiver] for further configuration
-     *
-     * Example usage:
-     * ```kotlin
-     * // Mock a simple text response
-     * mockLLMAnswer("Hello!") onRequestContains "Hello"
-     *
-     * // Mock a default response
-     * mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
-     * ```
+     * Companion object for the MockLLMBuilder class.
+     * Provides access to the current builder instance during configuration.
      */
-    public fun mockLLMAnswer(response: String): DefaultResponseReceiver = DefaultResponseReceiver(response, this)
+    internal companion object {
+        var currentBuilder: MockLLMBuilder? = null
+    }
 
     /**
      * Sets the default response to be returned when no other response matches.
+     *
+     * @param response The default response string
      */
     public fun setDefaultResponse(response: String) {
         defaultResponse = response
@@ -137,9 +143,20 @@ public class MockExecutorDSLBuilder(
 
     /**
      * Sets the default moderation response to the provided result.
+     *
+     * @param result the moderation result to set as the default response
      */
     public fun setDefaultModerationResponse(result: ModerationResult) {
         defaultModerationResponse = result
+    }
+
+    /**
+     * Sets the tool registry to be used for tool execution.
+     *
+     * @param registry The tool registry containing all available tools
+     */
+    public fun setToolRegistry(registry: ToolRegistry) {
+        toolRegistry = registry
     }
 
     /**
@@ -149,24 +166,19 @@ public class MockExecutorDSLBuilder(
      * @param tool The tool to be called when the input matches
      * @param args The arguments to pass to the tool
      */
-    public fun <Args> addLLMAnswerExactPattern(
+    public fun <Args : ToolArgs> addLLMAnswerExactPattern(
         pattern: String,
         tool: Tool<Args, *>,
         args: Args,
         toolCallId: String?
     ) {
-        toolCallExactMatches[pattern] = tool.encodeArgsToString(args, serializer).let { toolContent ->
+        toolCallExactMatches[pattern] = tool.encodeArgsToString(args).let { toolContent ->
             listOf(
                 Message.Tool.Call(
                     id = toolCallId,
                     tool = tool.name,
                     content = toolContent,
-                    metaInfo = ResponseMetaInfo.create(
-                        clock,
-                        inputTokensCount = null, // Will be updated at runtime with actual input
-                        outputTokensCount = tokenizer?.countTokens(toolContent),
-                        totalTokensCount = null // Will be calculated at runtime
-                    )
+                    metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(toolContent))
                 )
             )
         }
@@ -179,23 +191,14 @@ public class MockExecutorDSLBuilder(
      * @param tool The tool to be called when the input matches
      * @param args The arguments to pass to the tool
      */
-    public fun <Args> addLLMAnswerPartialPattern(
-        pattern: String,
-        tool: Tool<Args, *>,
-        args: Args
-    ) {
-        toolCallPartialMatches[pattern] = tool.encodeArgsToString(args, serializer).let { toolContent ->
+    public fun <Args : ToolArgs> addLLMAnswerPartialPattern(pattern: String, tool: Tool<Args, *>, args: Args) {
+        toolCallPartialMatches[pattern] = tool.encodeArgsToString(args).let { toolContent ->
             listOf(
                 Message.Tool.Call(
                     id = null,
                     tool = tool.name,
                     content = toolContent,
-                    metaInfo = ResponseMetaInfo.create(
-                        clock,
-                        inputTokensCount = null, // Will be updated at runtime with actual input
-                        outputTokensCount = tokenizer?.countTokens(toolContent),
-                        totalTokensCount = null // Will be calculated at runtime
-                    )
+                    metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(toolContent))
                 )
             )
         }
@@ -208,22 +211,17 @@ public class MockExecutorDSLBuilder(
      * @param toolCalls A list of pairs, where each pair consists of a tool and the arguments
      *                  to pass to the tool. These tool calls will be triggered when the input matches the pattern.
      */
-    public fun <Args> addLLMAnswerPartialPattern(
+    public fun <Args : ToolArgs> addLLMAnswerPartialPattern(
         pattern: String,
         toolCalls: List<Pair<Tool<Args, *>, Args>>
     ) {
         toolCallPartialMatches[pattern] = toolCalls.map { (tool, args) ->
-            tool.encodeArgsToString(args, serializer).let { toolContent ->
+            tool.encodeArgsToString(args).let { toolContent ->
                 Message.Tool.Call(
                     id = null,
                     tool = tool.name,
                     content = toolContent,
-                    metaInfo = ResponseMetaInfo.create(
-                        clock,
-                        inputTokensCount = null, // Will be updated at runtime with actual input
-                        outputTokensCount = tokenizer?.countTokens(toolContent),
-                        totalTokensCount = null // Will be calculated at runtime
-                    )
+                    metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(toolContent))
                 )
             }
         }
@@ -235,22 +233,14 @@ public class MockExecutorDSLBuilder(
      * @param pattern The exact input string to match
      * @param toolCalls Tool calls with args
      */
-    public fun <Args> addLLMAnswerExactPattern(
-        pattern: String,
-        toolCalls: List<Pair<Tool<Args, *>, Args>>
-    ) {
+    public fun <Args : ToolArgs> addLLMAnswerExactPattern(pattern: String, toolCalls: List<Pair<Tool<Args, *>, Args>>) {
         toolCallExactMatches[pattern] = toolCalls.map { (tool, args) ->
-            tool.encodeArgsToString(args, serializer).let { toolContent ->
+            tool.encodeArgsToString(args).let { toolContent ->
                 Message.Tool.Call(
                     id = null,
                     tool = tool.name,
                     content = toolContent,
-                    metaInfo = ResponseMetaInfo.create(
-                        clock,
-                        inputTokensCount = null, // Will be updated at runtime with actual input
-                        outputTokensCount = tokenizer?.countTokens(toolContent),
-                        totalTokensCount = null // Will be calculated at runtime
-                    )
+                    metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(toolContent))
                 )
             }
         }
@@ -264,23 +254,18 @@ public class MockExecutorDSLBuilder(
      * @param toolCalls A list of tool call and argument pairs to be triggered when the input matches.
      * @param responses A list of response strings corresponding to each tool call.
      */
-    public fun <Args> addLLMAnswerExactPattern(
+    public fun <Args : ToolArgs> addLLMAnswerExactPattern(
         pattern: String,
         toolCalls: List<Pair<Tool<Args, *>, Args>>,
         responses: List<String>
     ) {
         toolCallExactMatches[pattern] = toolCalls.map { (tool, args) ->
-            tool.encodeArgsToString(args, serializer).let { toolContent ->
+            tool.encodeArgsToString(args).let { toolContent ->
                 Message.Tool.Call(
                     id = null,
                     tool = tool.name,
                     content = toolContent,
-                    metaInfo = ResponseMetaInfo.create(
-                        clock,
-                        inputTokensCount = null, // Will be updated at runtime with actual input
-                        outputTokensCount = tokenizer?.countTokens(toolContent),
-                        totalTokensCount = null // Will be calculated at runtime
-                    )
+                    metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(toolContent))
                 )
             }
         }
@@ -289,73 +274,11 @@ public class MockExecutorDSLBuilder(
     }
 
     /**
-     * Adds a conditional match for a tool call to the LLM answer processing system.
-     * This method associates a condition with a tool and its arguments, allowing conditional execution
-     * of the tool when the specified condition matches.
-     *
-     * @param condition A predicate function that takes a string input and returns a Boolean, indicating whether the condition is met.
-     * @param tool The tool object to be called if the condition is satisfied.
-     * @param args The arguments to be passed to the tool, which will be encoded to a string for the tool call.
-     */
-    public fun <Args> addLLMAnswerConditionalMatches(
-        condition: (String) -> Boolean,
-        tool: Tool<Args, *>,
-        args: Args
-    ) {
-        toolCallConditionalMatches[condition] = tool.encodeArgsToString(args, serializer).let { toolContent ->
-            listOf(
-                Message.Tool.Call(
-                    id = null,
-                    tool = tool.name,
-                    content = toolContent,
-                    metaInfo = ResponseMetaInfo.create(
-                        clock,
-                        inputTokensCount = null, // Cannot determine input tokens for conditional matches without the actual input string
-                        outputTokensCount = tokenizer?.countTokens(toolContent),
-                        totalTokensCount = null // Will be calculated at runtime
-                    )
-                )
-            )
-        }
-    }
-
-    /**
-     * Registers conditional matches linking logical conditions to tool calls and corresponding responses.
-     *
-     * @param condition A predicate function that takes a String and returns a Boolean indicating whether the condition is satisfied.
-     * @param toolCalls A list of tool calls represented as pairs where the first element is the tool reference and the second is its arguments.
-     * @param responses A list of response strings to be associated with the condition.
-     */
-    public fun <Args> addLLMAnswerConditionalMatches(
-        condition: (String) -> Boolean,
-        toolCalls: List<Pair<Tool<Args, *>, Args>>,
-        responses: List<String>,
-    ) {
-        toolCallConditionalMatches[condition] = toolCalls.map { (tool, args) ->
-            tool.encodeArgsToString(args, serializer).let { toolContent ->
-                Message.Tool.Call(
-                    id = null,
-                    tool = tool.name,
-                    content = toolContent,
-                    metaInfo = ResponseMetaInfo.create(
-                        clock,
-                        inputTokensCount = null, // Cannot determine input tokens for conditional matches without the actual input string
-                        outputTokensCount = tokenizer?.countTokens(toolContent),
-                        totalTokensCount = null // Will be calculated at runtime
-                    )
-                )
-            }
-        }
-
-        conditionalResponses[condition] = responses
-    }
-
-    /**
      * Adds a specific moderation response for an exact pattern match.
      *
      * @param pattern The exact string pattern that should be matched.
      * @param response*/
-    public fun addModerationResponseExactPattern(pattern: String, response: ModerationResult) {
+    public fun <Args : ToolArgs> addModerationResponseExactPattern(pattern: String, response: ModerationResult) {
         moderationExactMatches[pattern] = response
     }
 
@@ -367,23 +290,18 @@ public class MockExecutorDSLBuilder(
      * @param toolCalls A list of tool call and argument pairs to be triggered when the input matches.
      * @param responses A list of response strings corresponding to each tool call.
      */
-    public fun <Args> addLLMAnswerPartialPattern(
+    public fun <Args : ToolArgs> addLLMAnswerPartialPattern(
         pattern: String,
         toolCalls: List<Pair<Tool<Args, *>, Args>>,
         responses: List<String>
     ) {
         toolCallPartialMatches[pattern] = toolCalls.map { (tool, args) ->
-            tool.encodeArgsToString(args, serializer).let { toolContent ->
+            tool.encodeArgsToString(args).let { toolContent ->
                 Message.Tool.Call(
                     id = null,
                     tool = tool.name,
                     content = toolContent,
-                    metaInfo = ResponseMetaInfo.create(
-                        clock,
-                        inputTokensCount = tokenizer?.countTokens(pattern),
-                        outputTokensCount = tokenizer?.countTokens(toolContent),
-                        totalTokensCount = null // Will be calculated at runtime
-                    )
+                    metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(toolContent))
                 )
             }
         }
@@ -397,7 +315,7 @@ public class MockExecutorDSLBuilder(
      * @param pattern The string pattern to be used as a key for the moderation response.
      * @param response The ModerationResult object that corresponds to the given pattern.
      */
-    public fun addModerationResponsePartialPattern(pattern: String, response: ModerationResult) {
+    public fun <Args : ToolArgs> addModerationResponsePartialPattern(pattern: String, response: ModerationResult) {
         moderationPartialMatches[pattern] = response
     }
 
@@ -408,12 +326,12 @@ public class MockExecutorDSLBuilder(
      * @param argsCondition A function that determines if the tool call arguments match this action
      * @param action A function that produces the result when the condition is satisfied
      */
-    public fun <Args, Result> addToolAction(
+    public fun <Args : ToolArgs, Result : ToolResult> addToolAction(
         tool: Tool<Args, Result>,
         argsCondition: suspend (Args) -> Boolean = { true },
         action: suspend (Args) -> Result
     ) {
-        toolActions += ToolCondition(tool, serializer, argsCondition, action)
+        toolActions += ToolCondition(tool, argsCondition, action)
     }
 
     /**
@@ -426,12 +344,12 @@ public class MockExecutorDSLBuilder(
      * @param args The arguments to pass to the tool
      * @return A [ToolCallReceiver] for further configuration
      */
-    public fun <Args> mockLLMToolCall(
+    public inline fun <reified Args : ToolArgs> mockLLMToolCall(
         tool: Tool<Args, *>,
         args: Args,
         toolCallId: String? = null
     ): ToolCallReceiver<Args> =
-        ToolCallReceiver(tool, args, toolCallId, this)
+        ToolCallReceiver(tool, args, toolCallId)
 
     /**
      * Creates a mock for a list of LLM tool calls.
@@ -443,10 +361,10 @@ public class MockExecutorDSLBuilder(
      *                  These define the mock calls to be returned by the LLM.
      * @return A [MultiToolCallReceiver] to configure further mock behavior for the provided tool calls.
      */
-    public fun <Args> mockLLMToolCall(
+    public fun <Args : ToolArgs> mockLLMToolCall(
         toolCalls: List<Pair<Tool<Args, *>, Args>>
     ): MultiToolCallReceiver<Args> =
-        MultiToolCallReceiver(toolCalls, this)
+        MultiToolCallReceiver(toolCalls)
 
     /**
      * Creates a mock response with a combination of tool calls and predefined string responses.
@@ -459,11 +377,11 @@ public class MockExecutorDSLBuilder(
      *                  what the LLM should output for each tool call.
      * @return A [MixedResultsReceiver] to configure further mock behavior for the provided tool calls and responses.
      */
-    public fun <Args> mockLLMMixedResponse(
+    public fun <Args : ToolArgs> mockLLMMixedResponse(
         toolCalls: List<Pair<Tool<Args, *>, Args>>,
         responses: List<String>
     ): MixedResultsReceiver<Args> =
-        MixedResultsReceiver(toolCalls, responses, this)
+        MixedResultsReceiver(toolCalls, responses)
 
     /**
      * Creates a mock for a tool.
@@ -474,44 +392,72 @@ public class MockExecutorDSLBuilder(
      * @param tool The tool to be mocked
      * @return A [MockToolReceiver] for further configuration
      */
-    public fun <Args, Result> mockTool(
+    public fun <Args : ToolArgs, Result : ToolResult> mockTool(
         tool: Tool<Args, Result>
     ): MockToolReceiver<Args, Result> {
         return MockToolReceiver(tool, this)
     }
 
     /**
-     * Configures the LLM to respond with this string when the user request contains the specified pattern.
+     * Configures the LLM to respond with the [receiver][R] when the user request contains the specified pattern.
      *
      * @param pattern The substring to look for in the user request
-     * @return The MockLLMBuilder instance for method chaining
+     * @return The receiver for method chaining
      */
-    public infix fun String.onUserRequestContains(pattern: String): MockExecutorDSLBuilder {
-        assistantPartialMatches[pattern] = listOf(this)
-        return this@MockExecutorDSLBuilder
+    public infix fun <R : MockReceiver.ByLLMClient> R.onRequestContains(pattern: String): R {
+        when (val receiver = this) {
+            is LLMResponseReceiver -> assistantPartialMatches[pattern] = listOf(receiver.response)
+            is LLMStreamReceiver -> streamPartialMatches[pattern] = receiver.stream
+            is ToolCallReceiver<*> -> receiver.addOnRequestContains(this@MockLLMBuilder, pattern)
+            is MixedResultsReceiver<*> -> receiver.addOnRequestContains(this@MockLLMBuilder, pattern)
+            is MultiToolCallReceiver<*> -> receiver.addOnRequestContains(this@MockLLMBuilder, pattern)
+        }
+        return this
     }
 
     /**
-     * Configures the LLM to respond with this string when the user request exactly matches the specified pattern.
+     * Configures the LLM to respond with the [receiver][R] when the user request exactly matches the specified pattern.
      *
      * @param pattern The exact string to match in the user request
-     * @return The MockLLMBuilder instance for method chaining
+     * @return The receiver for method chaining
      */
-    public infix fun String.onUserRequestEquals(pattern: String): MockExecutorDSLBuilder {
-        assistantExactMatches[pattern] = listOf(this)
-        return this@MockExecutorDSLBuilder
+    public infix fun <R : MockReceiver.ByLLMClient> R.onRequestEquals(pattern: String): R {
+        when (val receiver = this) {
+            is LLMResponseReceiver -> assistantExactMatches[pattern] = listOf(receiver.response)
+            is LLMStreamReceiver -> streamExactMatches[pattern] = receiver.stream
+            is ToolCallReceiver<*> -> receiver.addOnRequestExact(this@MockLLMBuilder, pattern)
+            is MixedResultsReceiver<*> -> receiver.addOnRequestEquals(this@MockLLMBuilder, pattern)
+            is MultiToolCallReceiver<*> -> receiver.addOnRequestEquals(this@MockLLMBuilder, pattern)
+        }
+        return this
     }
 
     /**
-     * Configures the LLM to respond with this string when the user request satisfies the specified condition.
+     * Configures the LLM to respond with the [receiver][LLMResponseReceiver] when the user request satisfies the specified condition.
      *
      * @param condition A function that evaluates the user request and returns true if it matches
-     * @return The MockLLMBuilder instance for method chaining
+     * @return The receiver for method chaining
      */
-    public infix fun String.onCondition(condition: (String) -> Boolean): MockExecutorDSLBuilder {
-        conditionalResponses[condition] = listOf(this)
-        return this@MockExecutorDSLBuilder
+    public infix fun LLMResponseReceiver.onCondition(condition: (String) -> Boolean): LLMResponseReceiver {
+        conditionalResponses[condition] = response
+        return this
     }
+
+    /**
+     * Sets the default response associated with the [receiver][LLMResponseReceiver].
+     *
+     * @return The receiver for method chaining
+     */
+    public val LLMResponseReceiver.asDefaultResponse: LLMResponseReceiver
+        get() = apply { defaultResponse = response }
+
+    /**
+     * Sets the default response associated with the [receiver][LLMStreamReceiver].
+     *
+     * @return The receiver for method chaining
+     */
+    public val LLMStreamReceiver.asDefaultResponse: LLMStreamReceiver
+        get() = apply { defaultStreamResponse = stream }
 
     /**
      * Receiver class for configuring tool call responses from the LLM.
@@ -522,105 +468,38 @@ public class MockExecutorDSLBuilder(
      * @param Args The type of arguments the tool accepts
      * @property tool The tool to be called
      * @property args The arguments to pass to the tool
-     * @property builder The parent MockLLMBuilder instance
      */
-    public class ToolCallReceiver<Args>(
+    public class ToolCallReceiver<Args : ToolArgs>(
         private val tool: Tool<Args, *>,
         private val args: Args,
-        private val toolCallId: String?,
-        private val builder: MockExecutorDSLBuilder
-    ) {
-        /**
-         * Configures the LLM to respond with a tool call when the user request exactly matches the specified pattern.
-         *
-         * @param pattern The exact string to match in the user request
-         * @return The [pattern] string for method chaining
-         */
-        public infix fun onRequestEquals(pattern: String): String {
-            // Using the llmAnswer directly as the response, which should contain the tool call JSON
+        private val toolCallId: String?
+    ) : MockReceiver.ByLLMClient {
+
+        internal fun addOnRequestExact(builder: MockLLMBuilder, pattern: String) =
             builder.addLLMAnswerExactPattern(pattern, tool = tool, args = args, toolCallId = toolCallId)
 
-            // Return the llmAnswer as is, which should be a valid tool call JSON
-            return pattern
-        }
-
-        /**
-         * Configures the system to partially match user requests containing the specified pattern.
-         * If the pattern is found within a user request, the associated tool call response will be triggered.
-         *
-         * @param pattern The substring pattern to match within user requests.
-         * @return The [pattern] string for method chaining
-         */
-        public infix fun onRequestContains(pattern: String): String {
+        internal fun addOnRequestContains(builder: MockLLMBuilder, pattern: String) =
             builder.addLLMAnswerPartialPattern(pattern, tool, args)
-
-            return pattern
-        }
-
-        /**
-         * Configures the LLM to respond with a tool call based on a custom condition.
-         *
-         * @param condition A predicate function that takes a string input and returns a Boolean.
-         * The condition determines whether the associated tool call should be triggered.
-         */
-        public infix fun onCondition(condition: (String) -> Boolean) {
-            builder.addLLMAnswerConditionalMatches(condition, tool, args)
-        }
     }
 
     /**
      * Represents a class responsible for handling and managing mixed tool call results
      * based on mock responses and predefined configurations.
      *
-     * @param Args The type of tool arguments.
+     * @param Args The type of tool arguments extending [ToolArgs].
      * @property toolCalls A list of tool-arguments pairs representing mocked tool calls and their configurations.
      * @property responses A list of response strings to be used when handling tool call results.
-     * @property builder An instance of [MockExecutorDSLBuilder] used to configure and mock behaviors.
      */
-    public class MixedResultsReceiver<Args>(
+    public class MixedResultsReceiver<Args : ToolArgs>(
         private val toolCalls: List<Pair<Tool<Args, *>, Args>>,
-        private val responses: List<String>,
-        private val builder: MockExecutorDSLBuilder
-    ) {
-        /**
-         * Configures the LLM to respond with a tool call when the user request exactly matches the specified pattern.
-         *
-         * @param pattern The exact string to match in the user request
-         * @return The [pattern] string for method chaining
-         */
-        public infix fun onRequestEquals(pattern: String): String {
-            // Using the llmAnswer directly as the response, which should contain the tool call JSON
+        private val responses: List<String>
+    ) : MockReceiver.ByLLMClient {
+
+        internal fun addOnRequestEquals(builder: MockLLMBuilder, pattern: String) =
             builder.addLLMAnswerExactPattern(pattern, toolCalls, responses)
 
-            // Return the llmAnswer as is, which should be a valid tool call JSON
-            return pattern
-        }
-
-        /**
-         * Configures the system to partially match user requests containing the specified pattern.
-         * If the pattern is found within a user request, the associated tool call response will be triggered.
-         *
-         * @param pattern The substring pattern to match within user requests.
-         * @return The [pattern] string for method chaining
-         */
-        public infix fun onRequestContains(pattern: String): String {
+        internal fun addOnRequestContains(builder: MockLLMBuilder, pattern: String) =
             builder.addLLMAnswerPartialPattern(pattern, toolCalls, responses)
-
-            return pattern
-        }
-
-        /**
-         * Configures a conditional response or tool call based on a custom condition provided as a lambda.
-         * The condition evaluates user input, and if the condition is satisfied, the associated responses
-         * or tool calls are utilized.
-         *
-         * @param condition A lambda function that takes a user input string and returns a boolean.
-         * If the lambda returns `true`, the predefined responses or tool calls associated with this condition
-         * will be triggered.
-         */
-        public infix fun onCondition(condition: (String) -> Boolean) {
-            builder.addLLMAnswerConditionalMatches(condition, toolCalls, responses)
-        }
     }
 
     /**
@@ -628,36 +507,15 @@ public class MockExecutorDSLBuilder(
      * This class is part of the fluent API for configuring how the LLM should respond
      * with tool calls when it receives specific inputs.
      */
-    public class MultiToolCallReceiver<Args>(
-        private val toolCalls: List<Pair<Tool<Args, *>, Args>>,
-        private val builder: MockExecutorDSLBuilder
-    ) {
-        /**
-         * Configures the LLM to respond with a tool call when the user request exactly matches the specified pattern.
-         *
-         * @param pattern The exact string to match in the user request
-         * @return The [pattern] string for method chaining
-         */
-        public infix fun onRequestEquals(pattern: String): String {
-            // Using the llmAnswer directly as the response, which should contain the tool call JSON
+    public class MultiToolCallReceiver<Args : ToolArgs>(
+        private val toolCalls: List<Pair<Tool<Args, *>, Args>>
+    ) : MockReceiver.ByLLMClient {
+
+        internal fun addOnRequestEquals(builder: MockLLMBuilder, pattern: String) =
             builder.addLLMAnswerExactPattern(pattern, toolCalls)
 
-            // Return the llmAnswer as is, which should be a valid tool call JSON
-            return pattern
-        }
-
-        /**
-         * Configures the system to partially match user requests containing the specified pattern.
-         * If the pattern is found within a user request, the associated tool call response will be triggered.
-         *
-         * @param pattern The substring pattern to match within user requests.
-         * @return The [pattern] string for method chaining
-         */
-        public infix fun onRequestContains(pattern: String): String {
+        internal fun addOnRequestContains(builder: MockLLMBuilder, pattern: String) =
             builder.addLLMAnswerPartialPattern(pattern, toolCalls)
-
-            return pattern
-        }
     }
 
     /**
@@ -671,10 +529,11 @@ public class MockExecutorDSLBuilder(
      * @property tool The tool to be mocked
      * @property builder The parent MockLLMBuilder instance
      */
-    public class MockToolReceiver<Args, Result>(
+    public class MockToolReceiver<Args : ToolArgs, Result : ToolResult>(
         internal val tool: Tool<Args, Result>,
-        internal val builder: MockExecutorDSLBuilder
-    ) {
+        internal val builder: MockLLMBuilder
+    ) : MockReceiver {
+
         /**
          * Builder class for configuring conditional tool responses.
          *
@@ -687,10 +546,10 @@ public class MockExecutorDSLBuilder(
          * @property action A function that produces the result
          * @property builder The parent MockLLMBuilder instance
          */
-        public class MockToolResponseBuilder<Args, Result>(
+        public class MockToolResponseBuilder<Args : ToolArgs, Result : ToolResult>(
             private val tool: Tool<Args, Result>,
             private val action: suspend () -> Result,
-            private val builder: MockExecutorDSLBuilder
+            private val builder: MockLLMBuilder
         ) {
             /**
              * Configures the tool to return the specified result when it receives exactly the specified arguments.
@@ -754,7 +613,7 @@ public class MockExecutorDSLBuilder(
      * @param response The string to return
      * @return The result of the alwaysReturns call
      */
-    public infix fun <Args> MockToolReceiver<Args, ToolResult.Text>.alwaysReturns(response: String): Unit =
+    public infix fun <Args : ToolArgs> MockToolReceiver<Args, ToolResult.Text>.alwaysReturns(response: String): Unit =
         alwaysReturns(ToolResult.Text(response))
 
     /**
@@ -764,20 +623,7 @@ public class MockExecutorDSLBuilder(
      * @param action A function that produces the string result
      * @return The result of the alwaysDoes call
      */
-    public infix fun <Args> MockToolReceiver<Args, String>.alwaysTells(
-        action: suspend () -> String
-    ): Unit =
-        alwaysDoes { action() }
-
-    /**
-     * Convenience extension function for configuring a text tool to always execute the specified action
-     * and return its string result.
-     *
-     * @param action A function that produces the string result
-     * @return The result of the alwaysDoes call
-     */
-    @JvmName("alwaysTellsText")
-    public infix fun <Args> MockToolReceiver<Args, ToolResult.Text>.alwaysTells(
+    public infix fun <Args : ToolArgs> MockToolReceiver<Args, ToolResult.Text>.alwaysTells(
         action: suspend () -> String
     ): Unit =
         alwaysDoes { ToolResult.Text(action()) }
@@ -789,7 +635,7 @@ public class MockExecutorDSLBuilder(
      * @param action A function that produces the string result
      * @return The result of the does call
      */
-    public infix fun <Args> MockToolReceiver<Args, ToolResult.Text>.doesStr(
+    public infix fun <Args : ToolArgs> MockToolReceiver<Args, ToolResult.Text>.doesStr(
         action: suspend () -> String
     ): MockToolReceiver.MockToolResponseBuilder<Args, ToolResult.Text> =
         does { ToolResult.Text(action()) }
@@ -803,41 +649,28 @@ public class MockExecutorDSLBuilder(
      * @return A configured MockLLMExecutor instance
      */
     public fun build(): PromptExecutor {
-        // Exact Matches
-        val processedAssistantExactMatches = assistantExactMatches.mapValues { (_, value) ->
+        val processedAssistantMatches = assistantExactMatches.mapValues { (_, value) ->
             val texts = value.map { text -> text.trimIndent() }
             texts.map { text ->
                 Message.Assistant(
                     text,
-                    ResponseMetaInfo.create(
-                        clock,
-                        inputTokensCount = null, // Will be updated at runtime with actual input
-                        outputTokensCount = tokenizer?.countTokens(text),
-                        totalTokensCount = null // Will be calculated at runtime
-                    )
+                    ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(text))
                 )
             }
         }
 
-        val combinedExactMatches =
-            (processedAssistantExactMatches.keys + toolCallExactMatches.keys).associateWith { key ->
-                val assistantList = processedAssistantExactMatches[key] ?: emptyList()
-                val toolCallList = toolCallExactMatches[key] ?: emptyList()
-                assistantList + toolCallList
-            }
+        val combinedExactMatches = (processedAssistantMatches.keys + toolCallExactMatches.keys).associateWith { key ->
+            val assistantList = processedAssistantMatches[key] ?: emptyList()
+            val toolCallList = toolCallExactMatches[key] ?: emptyList()
+            assistantList + toolCallList
+        }
 
-        // Partial Matches
         val processedAssistantPartialMatches = assistantPartialMatches.mapValues { (_, value) ->
             val texts = value.map { text -> text.trimIndent() }
             texts.map { text ->
                 Message.Assistant(
                     text,
-                    ResponseMetaInfo.create(
-                        clock,
-                        inputTokensCount = null, // Will be updated at runtime with actual input
-                        outputTokensCount = tokenizer?.countTokens(text),
-                        totalTokensCount = null // Will be calculated at runtime
-                    )
+                    ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(text))
                 )
             }
         }
@@ -849,45 +682,18 @@ public class MockExecutorDSLBuilder(
                 assistantList + toolCallList
             }
 
-        // Conditional Matches
-        val processedAssistantConditionalMatches: Map<(String) -> Boolean, List<Message.Response>> =
-            conditionalResponses.takeIf { it.isNotEmpty() }?.mapValues { (_, textResponse) ->
-                textResponse.map { response ->
-                    Message.Assistant(
-                        content = response,
-                        metaInfo = ResponseMetaInfo.create(
-                            clock,
-                            inputTokensCount = null, // Cannot determine input tokens for conditional matches without the actual input string
-                            outputTokensCount = tokenizer?.countTokens(response),
-                            totalTokensCount = null // Will be calculated at runtime
-                        )
-                    )
-                }
-            } ?: emptyMap()
-
-        val combinedConditionalMatches =
-            (processedAssistantConditionalMatches.keys + toolCallConditionalMatches.keys).associateWith { key ->
-                buildList {
-                    processedAssistantConditionalMatches[key]?.let { addAll(it) }
-                    toolCallConditionalMatches[key]?.let { addAll(it) }
-                }
-            }
-
         val responseMatcher = ResponseMatcher(
             partialMatches = combinedPartialMatches.takeIf { it.isNotEmpty() },
             exactMatches = combinedExactMatches.takeIf { it.isNotEmpty() },
-            conditional = combinedConditionalMatches,
-            defaultResponse = listOf(
-                Message.Assistant(
-                    defaultResponse,
-                    ResponseMetaInfo.create(
-                        clock,
-                        inputTokensCount = null, // Will be updated at runtime with actual input
-                        outputTokensCount = tokenizer?.countTokens(defaultResponse),
-                        totalTokensCount = null // Will be calculated at runtime
+            conditional = conditionalResponses.takeIf { it.isNotEmpty() }?.mapValues { (_, textResponse) ->
+                listOf(
+                    Message.Assistant(
+                        content = textResponse,
+                        metaInfo = ResponseMetaInfo.create(clock)
                     )
                 )
-            )
+            },
+            defaultResponse = listOf(Message.Assistant(defaultResponse, ResponseMetaInfo.create(clock)))
         )
 
         val moderationResponseMatcher = ResponseMatcher(
@@ -897,16 +703,71 @@ public class MockExecutorDSLBuilder(
             defaultResponse = defaultModerationResponse
         )
 
-        return MockPromptExecutor(
+        val streamResponseMatcher = ResponseMatcher(
+            partialMatches = streamPartialMatches,
+            exactMatches = streamExactMatches,
+            conditional = null, // TODO: support later once required
+            defaultResponse = defaultStreamResponse
+        )
+
+        return MockLLMExecutor(
             handleLastAssistantMessage,
             responseMatcher = responseMatcher,
             moderationResponseMatcher = moderationResponseMatcher,
+            streamResponseMatcher = streamResponseMatcher,
+            toolRegistry = toolRegistry,
             toolActions = toolActions,
             clock = clock,
             tokenizer = tokenizer
         )
     }
 }
+
+/**
+ * Creates a mock LLM text response.
+ *
+ * This function is the entry point for configuring how the LLM should respond with text
+ * when it receives specific inputs.
+ *
+ * @param response The text response to return
+ * @return A [LLMResponseReceiver] for further configuration
+ *
+ * Example usage:
+ * ```kotlin
+ * // Mock a simple text response
+ * mockLLMAnswer("Hello!") onRequestContains "Hello"
+ *
+ * // Mock a default response
+ * mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+ * ```
+ */
+public fun mockLLMAnswer(response: String): LLMResponseReceiver = LLMResponseReceiver(response)
+
+/**
+ * Mocks a stream of responses from an LLM, allowing for controlled testing of streaming behavior.
+ *
+ * @param stream A flow of StreamFrame objects that represent the streaming response from the LLM.
+ * @return A [LLMStreamReceiver] that can be used to configure and manage the mocked LLM stream.
+ */
+public fun mockLLMStream(stream: Flow<StreamFrame>): LLMStreamReceiver =
+    LLMStreamReceiver(stream)
+
+/**
+ * Represents a receiver for configuring mocked behavior.
+ */
+public sealed interface MockReceiver {
+
+    /**
+     * Receiver class for configuring how the LLM should respond.
+     */
+    public sealed interface ByLLMClient : MockReceiver
+}
+
+/**
+ * Receiver class for configuring stream responses from the LLM.
+ */
+public class LLMStreamReceiver(public val stream: Flow<StreamFrame>) :
+    MockReceiver.ByLLMClient
 
 /**
  * Receiver class for configuring text responses from the LLM.
@@ -916,63 +777,7 @@ public class MockExecutorDSLBuilder(
  *
  * @property response The text response to return
  */
-public open class DefaultResponseReceiver(
-    internal val response: String,
-    internal val builder: MockExecutorDSLBuilder,
-) {
-    /**
-     * Sets this response as the default response to be returned when no other response matches.
-     *
-     * @return The response string for method chaining
-     */
-    public val asDefaultResponse: String
-        get() {
-            builder.setDefaultResponse(response)
-            return response
-        }
-
-    /**
-     * Configures the LLM to respond with this string when the user request contains the specified pattern.
-     *
-     * @param pattern The substring to look for in the user request
-     * @return The response string for method chaining
-     */
-    public infix fun onRequestContains(pattern: String): String {
-        with(builder) {
-            response.onUserRequestContains(pattern)
-        }
-
-        return response
-    }
-
-    /**
-     * Configures the LLM to respond with this string when the user request exactly matches the specified pattern.
-     *
-     * @param pattern The exact string to match in the user request
-     * @return The response string for method chaining
-     */
-    public infix fun onRequestEquals(pattern: String): String {
-        with(builder) {
-            response.onUserRequestEquals(pattern)
-        }
-
-        return response
-    }
-
-    /**
-     * Configures the LLM to respond with this string when the user request satisfies the specified condition.
-     *
-     * @param condition A function that evaluates the user request and returns true if it matches
-     * @return The response string for method chaining
-     */
-    public infix fun onCondition(condition: (String) -> Boolean): String {
-        with(builder) {
-            response.onCondition(condition)
-        }
-
-        return response
-    }
-}
+public class LLMResponseReceiver(public val response: String) : MockReceiver.ByLLMClient
 
 /**
  * Creates a mock LLM executor for testing.
@@ -981,15 +786,15 @@ public open class DefaultResponseReceiver(
  * tool registry and configuration. It handles the setup of the MockLLMBuilder and applies
  * all the configured responses and tool actions.
  *
- * @param serializer Serializer used to serialize and deserialize tool arguments and results
+ * @param toolRegistry Optional tool registry to be used for tool execution
  * @param clock: A clock that is used for mock message timestamps
  * @param tokenizer: Tokenizer that will be used to estimate token counts in mock messages
  * @param init A lambda with receiver that configures the mock LLM executor
- * @return Сonfigured PromptExecutor for testing
+ * @return A configured PromptExecutor for testing
  *
  * Example usage:
  * ```kotlin
- * val mockLLMApi = getMockExecutor(serializer) {
+ * val mockLLMApi = getMockExecutor(toolRegistry) {
  *     // Mock LLM text responses
  *     mockLLMAnswer("Hello!") onRequestContains "Hello"
  *     mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
@@ -1007,16 +812,19 @@ public open class DefaultResponseReceiver(
  * ```
  */
 public fun getMockExecutor(
-    serializer: JSONSerializer = KotlinxSerializer(),
+    toolRegistry: ToolRegistry? = null,
     clock: Clock = Clock.System,
     tokenizer: Tokenizer? = null,
     handleLastAssistantMessage: Boolean = false,
-    init: MockExecutorDSLBuilder.() -> Unit
+    init: MockLLMBuilder.() -> Unit
 ): PromptExecutor {
-    return MockExecutorDSLBuilder(clock, serializer, tokenizer)
-        .apply {
-            this.handleLastAssistantMessage = handleLastAssistantMessage
-            init()
-        }
-        .build()
+    // Call MockLLMBuilder and apply toolRegistry, eventHandler and set currentBuilder to this (to add mocked tool calls)
+    val builder = MockLLMBuilder(clock, tokenizer).apply {
+        this.handleLastAssistantMessage = handleLastAssistantMessage
+        toolRegistry?.let { setToolRegistry(it) }
+        MockLLMBuilder.currentBuilder = this
+        init()
+        MockLLMBuilder.currentBuilder = null
+    }
+    return builder.build()
 }

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockExecutorDSLBuilder.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockExecutorDSLBuilder.kt
@@ -1,8 +1,6 @@
 package ai.koog.agents.testing.tools
 
 import ai.koog.agents.core.tools.Tool
-import ai.koog.agents.core.tools.ToolArgs
-import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.ToolResult
 import ai.koog.prompt.dsl.ModerationResult
 import ai.koog.prompt.executor.model.PromptExecutor
@@ -11,8 +9,12 @@ import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.streaming.streamFrameFlowOf
 import ai.koog.prompt.tokenizer.Tokenizer
+import ai.koog.serialization.JSONSerializer
+import ai.koog.serialization.kotlinx.KotlinxSerializer
+import ai.koog.serialization.kotlinx.toKoogJSONObject
 import kotlinx.coroutines.flow.Flow
-import kotlinx.datetime.Clock
+import kotlin.jvm.JvmName
+import kotlin.time.Clock
 
 /**
  * Represents a condition for a tool call and its corresponding result.
@@ -24,11 +26,13 @@ import kotlinx.datetime.Clock
  * @param Args The type of arguments the tool accepts
  * @param Result The type of result the tool produces
  * @property tool The tool to be mocked
+ * @property serializer The JSON serializer to use for encoding and decoding args/results
  * @property argsCondition A function that determines if the tool call matches this condition
  * @property produceResult A function that produces the result when the condition is satisfied
  */
-public class ToolCondition<Args : ToolArgs, Result : ToolResult>(
+public class ToolCondition<Args, Result>(
     public val tool: Tool<Args, Result>,
+    public val serializer: JSONSerializer,
     public val argsCondition: suspend (Args) -> Boolean,
     public val produceResult: suspend (Args) -> Result
 ) {
@@ -39,7 +43,7 @@ public class ToolCondition<Args : ToolArgs, Result : ToolResult>(
      * @return True if the tool name matches and the arguments satisfy the condition
      */
     internal suspend fun satisfies(toolCall: Message.Tool.Call) =
-        tool.name == toolCall.tool && argsCondition(tool.decodeArgs(toolCall.contentJson))
+        tool.name == toolCall.tool && argsCondition(tool.decodeArgs(toolCall.contentJson.toKoogJSONObject(), serializer))
 
     /**
      * Invokes the tool with the arguments from the tool call.
@@ -48,7 +52,7 @@ public class ToolCondition<Args : ToolArgs, Result : ToolResult>(
      * @return The result produced by the tool
      */
     internal suspend fun invoke(toolCall: Message.Tool.Call) =
-        produceResult(tool.decodeArgs(toolCall.contentJson))
+        produceResult(tool.decodeArgs(toolCall.contentJson.toKoogJSONObject(), serializer))
 
     /**
      * Invokes the tool and serializes the result.
@@ -57,8 +61,8 @@ public class ToolCondition<Args : ToolArgs, Result : ToolResult>(
      * @return A pair of the result object and its serialized string representation
      */
     internal suspend fun invokeAndSerialize(toolCall: Message.Tool.Call): Pair<Result, String> {
-        val toolResult = produceResult(tool.decodeArgs(toolCall.contentJson))
-        return toolResult to tool.encodeResultToString(toolResult)
+        val toolResult = produceResult(tool.decodeArgs(toolCall.contentJson.toKoogJSONObject(), serializer))
+        return toolResult to tool.encodeResultToString(toolResult, serializer)
     }
 }
 
@@ -69,38 +73,25 @@ public class ToolCondition<Args : ToolArgs, Result : ToolResult>(
  * It allows you to define how the LLM should respond to different inputs and how tools should
  * behave when called during testing.
  *
+ * @see getMockExecutor Prefer it for creating and configuring mock LLM executors.
  *
- * Example usage:
- * ```kotlin
- * val mockLLMApi = getMockExecutor(toolRegistry) {
- *     // Mock LLM text responses
- *     mockLLMAnswer("Hello!") onRequestContains "Hello"
- *     mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
- *
- *     // Mock LLM tool calls
- *     mockLLMToolCall(CreateTool, CreateTool.Args("solve")) onRequestEquals "Solve task"
- *
- *     // Mock tool behavior
- *     mockTool(PositiveToneTool) alwaysReturns "The text has a positive tone."
- *     mockTool(NegativeToneTool) alwaysTells {
- *         println("Negative tone tool called")
- *         "The text has a negative tone."
- *     }
- * }
- * ```
- *
- * @property clock: A clock that is used for mock message timestamps
- * @property tokenizer: Tokenizer that will be used to estimate token counts in mock messages
+ * @param clock A clock that is used for mock message timestamps
+ * @param serializer Serializer used to serialize and deserialize tool arguments and results
+ * @param tokenizer Optional tokenizer that will be used to estimate token counts in mock messages
  */
-public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tokenizer? = null) {
+public class MockExecutorDSLBuilder(
+    private val clock: Clock,
+    private val serializer: JSONSerializer,
+    private val tokenizer: Tokenizer? = null
+) {
     private val toolCallExactMatches = mutableMapOf<String, List<Message.Tool.Call>>()
     private val toolCallPartialMatches = mutableMapOf<String, List<Message.Tool.Call>>()
-    private var toolRegistry: ToolRegistry? = null
+    private val toolCallConditionalMatches = mutableMapOf<(String) -> Boolean, List<Message.Tool.Call>>()
     private var toolActions: MutableList<ToolCondition<*, *>> = mutableListOf()
 
     private val assistantPartialMatches = mutableMapOf<String, List<String>>()
     private val assistantExactMatches = mutableMapOf<String, List<String>>()
-    private val conditionalResponses = mutableMapOf<(String) -> Boolean, String>()
+    private val conditionalResponses = mutableMapOf<(String) -> Boolean, List<String>>()
     private var defaultResponse: String = ""
 
     private val moderationPartialMatches = mutableMapOf<String, ModerationResult>()
@@ -109,9 +100,8 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
         isHarmful = false,
         categories = emptyMap()
     )
-
-    private val streamPartialMatches = mutableMapOf<String, Flow<StreamFrame>>()
-    private val streamExactMatches = mutableMapOf<String, Flow<StreamFrame>>()
+    internal val streamPartialMatches = mutableMapOf<String, Flow<StreamFrame>>()
+    internal val streamExactMatches = mutableMapOf<String, Flow<StreamFrame>>()
     private var defaultStreamResponse: Flow<StreamFrame> = streamFrameFlowOf()
 
     /**
@@ -120,22 +110,44 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      *
      * Useful in scenarios where the mock response handling involves mixed results
      * from the LLM, and there is a need to differentiate between handling the general
-     * last message vs the last assistant-specific message.
+     * last message vs. the last assistant-specific message.
      */
     public var handleLastAssistantMessage: Boolean = false
 
     /**
-     * Companion object for the MockLLMBuilder class.
-     * Provides access to the current builder instance during configuration.
+     * Creates a mock LLM text response.
+     *
+     * This function is the entry point for configuring how the LLM should respond with text
+     * when it receives specific inputs.
+     *
+     * @param response The text response to return
+     * @return A [DefaultResponseReceiver] for further configuration
+     *
+     * Example usage:
+     * ```kotlin
+     * // Mock a simple text response
+     * mockLLMAnswer("Hello!") onRequestContains "Hello"
+     *
+     * // Mock a default response
+     * mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+     * ```
      */
-    internal companion object {
-        var currentBuilder: MockLLMBuilder? = null
-    }
+    public fun mockLLMAnswer(response: String): DefaultResponseReceiver = DefaultResponseReceiver(response, this)
+
+    /**
+     * Creates a mock LLM streaming response.
+     *
+     * This function is the entry point for configuring how the LLM should respond with stream frames
+     * when it receives specific inputs.
+     *
+     * @param stream The stream response to return
+     * @return A [StreamResponseReceiver] for further configuration
+     */
+    public fun mockLLMStream(stream: Flow<StreamFrame>): StreamResponseReceiver =
+        StreamResponseReceiver(stream, this)
 
     /**
      * Sets the default response to be returned when no other response matches.
-     *
-     * @param response The default response string
      */
     public fun setDefaultResponse(response: String) {
         defaultResponse = response
@@ -143,20 +155,16 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
 
     /**
      * Sets the default moderation response to the provided result.
-     *
-     * @param result the moderation result to set as the default response
      */
     public fun setDefaultModerationResponse(result: ModerationResult) {
         defaultModerationResponse = result
     }
 
     /**
-     * Sets the tool registry to be used for tool execution.
-     *
-     * @param registry The tool registry containing all available tools
+     * Sets the default stream response to be returned when no other stream response matches.
      */
-    public fun setToolRegistry(registry: ToolRegistry) {
-        toolRegistry = registry
+    public fun setDefaultStreamResponse(stream: Flow<StreamFrame>) {
+        defaultStreamResponse = stream
     }
 
     /**
@@ -166,19 +174,24 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param tool The tool to be called when the input matches
      * @param args The arguments to pass to the tool
      */
-    public fun <Args : ToolArgs> addLLMAnswerExactPattern(
+    public fun <Args> addLLMAnswerExactPattern(
         pattern: String,
         tool: Tool<Args, *>,
         args: Args,
         toolCallId: String?
     ) {
-        toolCallExactMatches[pattern] = tool.encodeArgsToString(args).let { toolContent ->
+        toolCallExactMatches[pattern] = tool.encodeArgsToString(args, serializer).let { toolContent ->
             listOf(
                 Message.Tool.Call(
                     id = toolCallId,
                     tool = tool.name,
                     content = toolContent,
-                    metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(toolContent))
+                    metaInfo = ResponseMetaInfo.create(
+                        clock,
+                        inputTokensCount = null, // Will be updated at runtime with actual input
+                        outputTokensCount = tokenizer?.countTokens(toolContent),
+                        totalTokensCount = null // Will be calculated at runtime
+                    )
                 )
             )
         }
@@ -191,14 +204,23 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param tool The tool to be called when the input matches
      * @param args The arguments to pass to the tool
      */
-    public fun <Args : ToolArgs> addLLMAnswerPartialPattern(pattern: String, tool: Tool<Args, *>, args: Args) {
-        toolCallPartialMatches[pattern] = tool.encodeArgsToString(args).let { toolContent ->
+    public fun <Args> addLLMAnswerPartialPattern(
+        pattern: String,
+        tool: Tool<Args, *>,
+        args: Args
+    ) {
+        toolCallPartialMatches[pattern] = tool.encodeArgsToString(args, serializer).let { toolContent ->
             listOf(
                 Message.Tool.Call(
                     id = null,
                     tool = tool.name,
                     content = toolContent,
-                    metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(toolContent))
+                    metaInfo = ResponseMetaInfo.create(
+                        clock,
+                        inputTokensCount = null, // Will be updated at runtime with actual input
+                        outputTokensCount = tokenizer?.countTokens(toolContent),
+                        totalTokensCount = null // Will be calculated at runtime
+                    )
                 )
             )
         }
@@ -211,17 +233,22 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param toolCalls A list of pairs, where each pair consists of a tool and the arguments
      *                  to pass to the tool. These tool calls will be triggered when the input matches the pattern.
      */
-    public fun <Args : ToolArgs> addLLMAnswerPartialPattern(
+    public fun <Args> addLLMAnswerPartialPattern(
         pattern: String,
         toolCalls: List<Pair<Tool<Args, *>, Args>>
     ) {
         toolCallPartialMatches[pattern] = toolCalls.map { (tool, args) ->
-            tool.encodeArgsToString(args).let { toolContent ->
+            tool.encodeArgsToString(args, serializer).let { toolContent ->
                 Message.Tool.Call(
                     id = null,
                     tool = tool.name,
                     content = toolContent,
-                    metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(toolContent))
+                    metaInfo = ResponseMetaInfo.create(
+                        clock,
+                        inputTokensCount = null, // Will be updated at runtime with actual input
+                        outputTokensCount = tokenizer?.countTokens(toolContent),
+                        totalTokensCount = null // Will be calculated at runtime
+                    )
                 )
             }
         }
@@ -233,14 +260,22 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param pattern The exact input string to match
      * @param toolCalls Tool calls with args
      */
-    public fun <Args : ToolArgs> addLLMAnswerExactPattern(pattern: String, toolCalls: List<Pair<Tool<Args, *>, Args>>) {
+    public fun <Args> addLLMAnswerExactPattern(
+        pattern: String,
+        toolCalls: List<Pair<Tool<Args, *>, Args>>
+    ) {
         toolCallExactMatches[pattern] = toolCalls.map { (tool, args) ->
-            tool.encodeArgsToString(args).let { toolContent ->
+            tool.encodeArgsToString(args, serializer).let { toolContent ->
                 Message.Tool.Call(
                     id = null,
                     tool = tool.name,
                     content = toolContent,
-                    metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(toolContent))
+                    metaInfo = ResponseMetaInfo.create(
+                        clock,
+                        inputTokensCount = null, // Will be updated at runtime with actual input
+                        outputTokensCount = tokenizer?.countTokens(toolContent),
+                        totalTokensCount = null // Will be calculated at runtime
+                    )
                 )
             }
         }
@@ -254,18 +289,23 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param toolCalls A list of tool call and argument pairs to be triggered when the input matches.
      * @param responses A list of response strings corresponding to each tool call.
      */
-    public fun <Args : ToolArgs> addLLMAnswerExactPattern(
+    public fun <Args> addLLMAnswerExactPattern(
         pattern: String,
         toolCalls: List<Pair<Tool<Args, *>, Args>>,
         responses: List<String>
     ) {
         toolCallExactMatches[pattern] = toolCalls.map { (tool, args) ->
-            tool.encodeArgsToString(args).let { toolContent ->
+            tool.encodeArgsToString(args, serializer).let { toolContent ->
                 Message.Tool.Call(
                     id = null,
                     tool = tool.name,
                     content = toolContent,
-                    metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(toolContent))
+                    metaInfo = ResponseMetaInfo.create(
+                        clock,
+                        inputTokensCount = null, // Will be updated at runtime with actual input
+                        outputTokensCount = tokenizer?.countTokens(toolContent),
+                        totalTokensCount = null // Will be calculated at runtime
+                    )
                 )
             }
         }
@@ -274,11 +314,73 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
     }
 
     /**
+     * Adds a conditional match for a tool call to the LLM answer processing system.
+     * This method associates a condition with a tool and its arguments, allowing conditional execution
+     * of the tool when the specified condition matches.
+     *
+     * @param condition A predicate function that takes a string input and returns a Boolean, indicating whether the condition is met.
+     * @param tool The tool object to be called if the condition is satisfied.
+     * @param args The arguments to be passed to the tool, which will be encoded to a string for the tool call.
+     */
+    public fun <Args> addLLMAnswerConditionalMatches(
+        condition: (String) -> Boolean,
+        tool: Tool<Args, *>,
+        args: Args
+    ) {
+        toolCallConditionalMatches[condition] = tool.encodeArgsToString(args, serializer).let { toolContent ->
+            listOf(
+                Message.Tool.Call(
+                    id = null,
+                    tool = tool.name,
+                    content = toolContent,
+                    metaInfo = ResponseMetaInfo.create(
+                        clock,
+                        inputTokensCount = null, // Cannot determine input tokens for conditional matches without the actual input string
+                        outputTokensCount = tokenizer?.countTokens(toolContent),
+                        totalTokensCount = null // Will be calculated at runtime
+                    )
+                )
+            )
+        }
+    }
+
+    /**
+     * Registers conditional matches linking logical conditions to tool calls and corresponding responses.
+     *
+     * @param condition A predicate function that takes a String and returns a Boolean indicating whether the condition is satisfied.
+     * @param toolCalls A list of tool calls represented as pairs where the first element is the tool reference and the second is its arguments.
+     * @param responses A list of response strings to be associated with the condition.
+     */
+    public fun <Args> addLLMAnswerConditionalMatches(
+        condition: (String) -> Boolean,
+        toolCalls: List<Pair<Tool<Args, *>, Args>>,
+        responses: List<String>,
+    ) {
+        toolCallConditionalMatches[condition] = toolCalls.map { (tool, args) ->
+            tool.encodeArgsToString(args, serializer).let { toolContent ->
+                Message.Tool.Call(
+                    id = null,
+                    tool = tool.name,
+                    content = toolContent,
+                    metaInfo = ResponseMetaInfo.create(
+                        clock,
+                        inputTokensCount = null, // Cannot determine input tokens for conditional matches without the actual input string
+                        outputTokensCount = tokenizer?.countTokens(toolContent),
+                        totalTokensCount = null // Will be calculated at runtime
+                    )
+                )
+            }
+        }
+
+        conditionalResponses[condition] = responses
+    }
+
+    /**
      * Adds a specific moderation response for an exact pattern match.
      *
      * @param pattern The exact string pattern that should be matched.
      * @param response*/
-    public fun <Args : ToolArgs> addModerationResponseExactPattern(pattern: String, response: ModerationResult) {
+    public fun addModerationResponseExactPattern(pattern: String, response: ModerationResult) {
         moderationExactMatches[pattern] = response
     }
 
@@ -290,18 +392,23 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param toolCalls A list of tool call and argument pairs to be triggered when the input matches.
      * @param responses A list of response strings corresponding to each tool call.
      */
-    public fun <Args : ToolArgs> addLLMAnswerPartialPattern(
+    public fun <Args> addLLMAnswerPartialPattern(
         pattern: String,
         toolCalls: List<Pair<Tool<Args, *>, Args>>,
         responses: List<String>
     ) {
         toolCallPartialMatches[pattern] = toolCalls.map { (tool, args) ->
-            tool.encodeArgsToString(args).let { toolContent ->
+            tool.encodeArgsToString(args, serializer).let { toolContent ->
                 Message.Tool.Call(
                     id = null,
                     tool = tool.name,
                     content = toolContent,
-                    metaInfo = ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(toolContent))
+                    metaInfo = ResponseMetaInfo.create(
+                        clock,
+                        inputTokensCount = tokenizer?.countTokens(pattern),
+                        outputTokensCount = tokenizer?.countTokens(toolContent),
+                        totalTokensCount = null // Will be calculated at runtime
+                    )
                 )
             }
         }
@@ -315,7 +422,7 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param pattern The string pattern to be used as a key for the moderation response.
      * @param response The ModerationResult object that corresponds to the given pattern.
      */
-    public fun <Args : ToolArgs> addModerationResponsePartialPattern(pattern: String, response: ModerationResult) {
+    public fun addModerationResponsePartialPattern(pattern: String, response: ModerationResult) {
         moderationPartialMatches[pattern] = response
     }
 
@@ -326,12 +433,12 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param argsCondition A function that determines if the tool call arguments match this action
      * @param action A function that produces the result when the condition is satisfied
      */
-    public fun <Args : ToolArgs, Result : ToolResult> addToolAction(
+    public fun <Args, Result> addToolAction(
         tool: Tool<Args, Result>,
         argsCondition: suspend (Args) -> Boolean = { true },
         action: suspend (Args) -> Result
     ) {
-        toolActions += ToolCondition(tool, argsCondition, action)
+        toolActions += ToolCondition(tool, serializer, argsCondition, action)
     }
 
     /**
@@ -344,12 +451,12 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param args The arguments to pass to the tool
      * @return A [ToolCallReceiver] for further configuration
      */
-    public inline fun <reified Args : ToolArgs> mockLLMToolCall(
+    public fun <Args> mockLLMToolCall(
         tool: Tool<Args, *>,
         args: Args,
         toolCallId: String? = null
     ): ToolCallReceiver<Args> =
-        ToolCallReceiver(tool, args, toolCallId)
+        ToolCallReceiver(tool, args, toolCallId, this)
 
     /**
      * Creates a mock for a list of LLM tool calls.
@@ -361,10 +468,10 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      *                  These define the mock calls to be returned by the LLM.
      * @return A [MultiToolCallReceiver] to configure further mock behavior for the provided tool calls.
      */
-    public fun <Args : ToolArgs> mockLLMToolCall(
+    public fun <Args> mockLLMToolCall(
         toolCalls: List<Pair<Tool<Args, *>, Args>>
     ): MultiToolCallReceiver<Args> =
-        MultiToolCallReceiver(toolCalls)
+        MultiToolCallReceiver(toolCalls, this)
 
     /**
      * Creates a mock response with a combination of tool calls and predefined string responses.
@@ -377,11 +484,11 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      *                  what the LLM should output for each tool call.
      * @return A [MixedResultsReceiver] to configure further mock behavior for the provided tool calls and responses.
      */
-    public fun <Args : ToolArgs> mockLLMMixedResponse(
+    public fun <Args> mockLLMMixedResponse(
         toolCalls: List<Pair<Tool<Args, *>, Args>>,
         responses: List<String>
     ): MixedResultsReceiver<Args> =
-        MixedResultsReceiver(toolCalls, responses)
+        MixedResultsReceiver(toolCalls, responses, this)
 
     /**
      * Creates a mock for a tool.
@@ -392,72 +499,44 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param tool The tool to be mocked
      * @return A [MockToolReceiver] for further configuration
      */
-    public fun <Args : ToolArgs, Result : ToolResult> mockTool(
+    public fun <Args, Result> mockTool(
         tool: Tool<Args, Result>
     ): MockToolReceiver<Args, Result> {
         return MockToolReceiver(tool, this)
     }
 
     /**
-     * Configures the LLM to respond with the [receiver][R] when the user request contains the specified pattern.
+     * Configures the LLM to respond with this string when the user request contains the specified pattern.
      *
      * @param pattern The substring to look for in the user request
-     * @return The receiver for method chaining
+     * @return The MockLLMBuilder instance for method chaining
      */
-    public infix fun <R : MockReceiver.ByLLMClient> R.onRequestContains(pattern: String): R {
-        when (val receiver = this) {
-            is LLMResponseReceiver -> assistantPartialMatches[pattern] = listOf(receiver.response)
-            is LLMStreamReceiver -> streamPartialMatches[pattern] = receiver.stream
-            is ToolCallReceiver<*> -> receiver.addOnRequestContains(this@MockLLMBuilder, pattern)
-            is MixedResultsReceiver<*> -> receiver.addOnRequestContains(this@MockLLMBuilder, pattern)
-            is MultiToolCallReceiver<*> -> receiver.addOnRequestContains(this@MockLLMBuilder, pattern)
-        }
-        return this
+    public infix fun String.onUserRequestContains(pattern: String): MockExecutorDSLBuilder {
+        assistantPartialMatches[pattern] = listOf(this)
+        return this@MockExecutorDSLBuilder
     }
 
     /**
-     * Configures the LLM to respond with the [receiver][R] when the user request exactly matches the specified pattern.
+     * Configures the LLM to respond with this string when the user request exactly matches the specified pattern.
      *
      * @param pattern The exact string to match in the user request
-     * @return The receiver for method chaining
+     * @return The MockLLMBuilder instance for method chaining
      */
-    public infix fun <R : MockReceiver.ByLLMClient> R.onRequestEquals(pattern: String): R {
-        when (val receiver = this) {
-            is LLMResponseReceiver -> assistantExactMatches[pattern] = listOf(receiver.response)
-            is LLMStreamReceiver -> streamExactMatches[pattern] = receiver.stream
-            is ToolCallReceiver<*> -> receiver.addOnRequestExact(this@MockLLMBuilder, pattern)
-            is MixedResultsReceiver<*> -> receiver.addOnRequestEquals(this@MockLLMBuilder, pattern)
-            is MultiToolCallReceiver<*> -> receiver.addOnRequestEquals(this@MockLLMBuilder, pattern)
-        }
-        return this
+    public infix fun String.onUserRequestEquals(pattern: String): MockExecutorDSLBuilder {
+        assistantExactMatches[pattern] = listOf(this)
+        return this@MockExecutorDSLBuilder
     }
 
     /**
-     * Configures the LLM to respond with the [receiver][LLMResponseReceiver] when the user request satisfies the specified condition.
+     * Configures the LLM to respond with this string when the user request satisfies the specified condition.
      *
      * @param condition A function that evaluates the user request and returns true if it matches
-     * @return The receiver for method chaining
+     * @return The MockLLMBuilder instance for method chaining
      */
-    public infix fun LLMResponseReceiver.onCondition(condition: (String) -> Boolean): LLMResponseReceiver {
-        conditionalResponses[condition] = response
-        return this
+    public infix fun String.onCondition(condition: (String) -> Boolean): MockExecutorDSLBuilder {
+        conditionalResponses[condition] = listOf(this)
+        return this@MockExecutorDSLBuilder
     }
-
-    /**
-     * Sets the default response associated with the [receiver][LLMResponseReceiver].
-     *
-     * @return The receiver for method chaining
-     */
-    public val LLMResponseReceiver.asDefaultResponse: LLMResponseReceiver
-        get() = apply { defaultResponse = response }
-
-    /**
-     * Sets the default response associated with the [receiver][LLMStreamReceiver].
-     *
-     * @return The receiver for method chaining
-     */
-    public val LLMStreamReceiver.asDefaultResponse: LLMStreamReceiver
-        get() = apply { defaultStreamResponse = stream }
 
     /**
      * Receiver class for configuring tool call responses from the LLM.
@@ -468,38 +547,105 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param Args The type of arguments the tool accepts
      * @property tool The tool to be called
      * @property args The arguments to pass to the tool
+     * @property builder The parent MockLLMBuilder instance
      */
-    public class ToolCallReceiver<Args : ToolArgs>(
+    public class ToolCallReceiver<Args>(
         private val tool: Tool<Args, *>,
         private val args: Args,
-        private val toolCallId: String?
-    ) : MockReceiver.ByLLMClient {
-
-        internal fun addOnRequestExact(builder: MockLLMBuilder, pattern: String) =
+        private val toolCallId: String?,
+        private val builder: MockExecutorDSLBuilder
+    ) {
+        /**
+         * Configures the LLM to respond with a tool call when the user request exactly matches the specified pattern.
+         *
+         * @param pattern The exact string to match in the user request
+         * @return The [pattern] string for method chaining
+         */
+        public infix fun onRequestEquals(pattern: String): String {
+            // Using the llmAnswer directly as the response, which should contain the tool call JSON
             builder.addLLMAnswerExactPattern(pattern, tool = tool, args = args, toolCallId = toolCallId)
 
-        internal fun addOnRequestContains(builder: MockLLMBuilder, pattern: String) =
+            // Return the llmAnswer as is, which should be a valid tool call JSON
+            return pattern
+        }
+
+        /**
+         * Configures the system to partially match user requests containing the specified pattern.
+         * If the pattern is found within a user request, the associated tool call response will be triggered.
+         *
+         * @param pattern The substring pattern to match within user requests.
+         * @return The [pattern] string for method chaining
+         */
+        public infix fun onRequestContains(pattern: String): String {
             builder.addLLMAnswerPartialPattern(pattern, tool, args)
+
+            return pattern
+        }
+
+        /**
+         * Configures the LLM to respond with a tool call based on a custom condition.
+         *
+         * @param condition A predicate function that takes a string input and returns a Boolean.
+         * The condition determines whether the associated tool call should be triggered.
+         */
+        public infix fun onCondition(condition: (String) -> Boolean) {
+            builder.addLLMAnswerConditionalMatches(condition, tool, args)
+        }
     }
 
     /**
      * Represents a class responsible for handling and managing mixed tool call results
      * based on mock responses and predefined configurations.
      *
-     * @param Args The type of tool arguments extending [ToolArgs].
+     * @param Args The type of tool arguments.
      * @property toolCalls A list of tool-arguments pairs representing mocked tool calls and their configurations.
      * @property responses A list of response strings to be used when handling tool call results.
+     * @property builder An instance of [MockExecutorDSLBuilder] used to configure and mock behaviors.
      */
-    public class MixedResultsReceiver<Args : ToolArgs>(
+    public class MixedResultsReceiver<Args>(
         private val toolCalls: List<Pair<Tool<Args, *>, Args>>,
-        private val responses: List<String>
-    ) : MockReceiver.ByLLMClient {
-
-        internal fun addOnRequestEquals(builder: MockLLMBuilder, pattern: String) =
+        private val responses: List<String>,
+        private val builder: MockExecutorDSLBuilder
+    ) {
+        /**
+         * Configures the LLM to respond with a tool call when the user request exactly matches the specified pattern.
+         *
+         * @param pattern The exact string to match in the user request
+         * @return The [pattern] string for method chaining
+         */
+        public infix fun onRequestEquals(pattern: String): String {
+            // Using the llmAnswer directly as the response, which should contain the tool call JSON
             builder.addLLMAnswerExactPattern(pattern, toolCalls, responses)
 
-        internal fun addOnRequestContains(builder: MockLLMBuilder, pattern: String) =
+            // Return the llmAnswer as is, which should be a valid tool call JSON
+            return pattern
+        }
+
+        /**
+         * Configures the system to partially match user requests containing the specified pattern.
+         * If the pattern is found within a user request, the associated tool call response will be triggered.
+         *
+         * @param pattern The substring pattern to match within user requests.
+         * @return The [pattern] string for method chaining
+         */
+        public infix fun onRequestContains(pattern: String): String {
             builder.addLLMAnswerPartialPattern(pattern, toolCalls, responses)
+
+            return pattern
+        }
+
+        /**
+         * Configures a conditional response or tool call based on a custom condition provided as a lambda.
+         * The condition evaluates user input, and if the condition is satisfied, the associated responses
+         * or tool calls are utilized.
+         *
+         * @param condition A lambda function that takes a user input string and returns a boolean.
+         * If the lambda returns `true`, the predefined responses or tool calls associated with this condition
+         * will be triggered.
+         */
+        public infix fun onCondition(condition: (String) -> Boolean) {
+            builder.addLLMAnswerConditionalMatches(condition, toolCalls, responses)
+        }
     }
 
     /**
@@ -507,15 +653,36 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * This class is part of the fluent API for configuring how the LLM should respond
      * with tool calls when it receives specific inputs.
      */
-    public class MultiToolCallReceiver<Args : ToolArgs>(
-        private val toolCalls: List<Pair<Tool<Args, *>, Args>>
-    ) : MockReceiver.ByLLMClient {
-
-        internal fun addOnRequestEquals(builder: MockLLMBuilder, pattern: String) =
+    public class MultiToolCallReceiver<Args>(
+        private val toolCalls: List<Pair<Tool<Args, *>, Args>>,
+        private val builder: MockExecutorDSLBuilder
+    ) {
+        /**
+         * Configures the LLM to respond with a tool call when the user request exactly matches the specified pattern.
+         *
+         * @param pattern The exact string to match in the user request
+         * @return The [pattern] string for method chaining
+         */
+        public infix fun onRequestEquals(pattern: String): String {
+            // Using the llmAnswer directly as the response, which should contain the tool call JSON
             builder.addLLMAnswerExactPattern(pattern, toolCalls)
 
-        internal fun addOnRequestContains(builder: MockLLMBuilder, pattern: String) =
+            // Return the llmAnswer as is, which should be a valid tool call JSON
+            return pattern
+        }
+
+        /**
+         * Configures the system to partially match user requests containing the specified pattern.
+         * If the pattern is found within a user request, the associated tool call response will be triggered.
+         *
+         * @param pattern The substring pattern to match within user requests.
+         * @return The [pattern] string for method chaining
+         */
+        public infix fun onRequestContains(pattern: String): String {
             builder.addLLMAnswerPartialPattern(pattern, toolCalls)
+
+            return pattern
+        }
     }
 
     /**
@@ -529,11 +696,10 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @property tool The tool to be mocked
      * @property builder The parent MockLLMBuilder instance
      */
-    public class MockToolReceiver<Args : ToolArgs, Result : ToolResult>(
+    public class MockToolReceiver<Args, Result>(
         internal val tool: Tool<Args, Result>,
-        internal val builder: MockLLMBuilder
-    ) : MockReceiver {
-
+        internal val builder: MockExecutorDSLBuilder
+    ) {
         /**
          * Builder class for configuring conditional tool responses.
          *
@@ -546,10 +712,10 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
          * @property action A function that produces the result
          * @property builder The parent MockLLMBuilder instance
          */
-        public class MockToolResponseBuilder<Args : ToolArgs, Result : ToolResult>(
+        public class MockToolResponseBuilder<Args, Result>(
             private val tool: Tool<Args, Result>,
             private val action: suspend () -> Result,
-            private val builder: MockLLMBuilder
+            private val builder: MockExecutorDSLBuilder
         ) {
             /**
              * Configures the tool to return the specified result when it receives exactly the specified arguments.
@@ -613,7 +779,7 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param response The string to return
      * @return The result of the alwaysReturns call
      */
-    public infix fun <Args : ToolArgs> MockToolReceiver<Args, ToolResult.Text>.alwaysReturns(response: String): Unit =
+    public infix fun <Args> MockToolReceiver<Args, ToolResult.Text>.alwaysReturns(response: String): Unit =
         alwaysReturns(ToolResult.Text(response))
 
     /**
@@ -623,7 +789,20 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param action A function that produces the string result
      * @return The result of the alwaysDoes call
      */
-    public infix fun <Args : ToolArgs> MockToolReceiver<Args, ToolResult.Text>.alwaysTells(
+    public infix fun <Args> MockToolReceiver<Args, String>.alwaysTells(
+        action: suspend () -> String
+    ): Unit =
+        alwaysDoes { action() }
+
+    /**
+     * Convenience extension function for configuring a text tool to always execute the specified action
+     * and return its string result.
+     *
+     * @param action A function that produces the string result
+     * @return The result of the alwaysDoes call
+     */
+    @JvmName("alwaysTellsText")
+    public infix fun <Args> MockToolReceiver<Args, ToolResult.Text>.alwaysTells(
         action: suspend () -> String
     ): Unit =
         alwaysDoes { ToolResult.Text(action()) }
@@ -635,7 +814,7 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @param action A function that produces the string result
      * @return The result of the does call
      */
-    public infix fun <Args : ToolArgs> MockToolReceiver<Args, ToolResult.Text>.doesStr(
+    public infix fun <Args> MockToolReceiver<Args, ToolResult.Text>.doesStr(
         action: suspend () -> String
     ): MockToolReceiver.MockToolResponseBuilder<Args, ToolResult.Text> =
         does { ToolResult.Text(action()) }
@@ -649,28 +828,41 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
      * @return A configured MockLLMExecutor instance
      */
     public fun build(): PromptExecutor {
-        val processedAssistantMatches = assistantExactMatches.mapValues { (_, value) ->
+        // Exact Matches
+        val processedAssistantExactMatches = assistantExactMatches.mapValues { (_, value) ->
             val texts = value.map { text -> text.trimIndent() }
             texts.map { text ->
                 Message.Assistant(
                     text,
-                    ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(text))
+                    ResponseMetaInfo.create(
+                        clock,
+                        inputTokensCount = null, // Will be updated at runtime with actual input
+                        outputTokensCount = tokenizer?.countTokens(text),
+                        totalTokensCount = null // Will be calculated at runtime
+                    )
                 )
             }
         }
 
-        val combinedExactMatches = (processedAssistantMatches.keys + toolCallExactMatches.keys).associateWith { key ->
-            val assistantList = processedAssistantMatches[key] ?: emptyList()
-            val toolCallList = toolCallExactMatches[key] ?: emptyList()
-            assistantList + toolCallList
-        }
+        val combinedExactMatches =
+            (processedAssistantExactMatches.keys + toolCallExactMatches.keys).associateWith { key ->
+                val assistantList = processedAssistantExactMatches[key] ?: emptyList()
+                val toolCallList = toolCallExactMatches[key] ?: emptyList()
+                assistantList + toolCallList
+            }
 
+        // Partial Matches
         val processedAssistantPartialMatches = assistantPartialMatches.mapValues { (_, value) ->
             val texts = value.map { text -> text.trimIndent() }
             texts.map { text ->
                 Message.Assistant(
                     text,
-                    ResponseMetaInfo.create(clock, outputTokensCount = tokenizer?.countTokens(text))
+                    ResponseMetaInfo.create(
+                        clock,
+                        inputTokensCount = null, // Will be updated at runtime with actual input
+                        outputTokensCount = tokenizer?.countTokens(text),
+                        totalTokensCount = null // Will be calculated at runtime
+                    )
                 )
             }
         }
@@ -682,18 +874,45 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
                 assistantList + toolCallList
             }
 
+        // Conditional Matches
+        val processedAssistantConditionalMatches: Map<(String) -> Boolean, List<Message.Response>> =
+            conditionalResponses.takeIf { it.isNotEmpty() }?.mapValues { (_, textResponse) ->
+                textResponse.map { response ->
+                    Message.Assistant(
+                        content = response,
+                        metaInfo = ResponseMetaInfo.create(
+                            clock,
+                            inputTokensCount = null, // Cannot determine input tokens for conditional matches without the actual input string
+                            outputTokensCount = tokenizer?.countTokens(response),
+                            totalTokensCount = null // Will be calculated at runtime
+                        )
+                    )
+                }
+            } ?: emptyMap()
+
+        val combinedConditionalMatches =
+            (processedAssistantConditionalMatches.keys + toolCallConditionalMatches.keys).associateWith { key ->
+                buildList {
+                    processedAssistantConditionalMatches[key]?.let { addAll(it) }
+                    toolCallConditionalMatches[key]?.let { addAll(it) }
+                }
+            }
+
         val responseMatcher = ResponseMatcher(
             partialMatches = combinedPartialMatches.takeIf { it.isNotEmpty() },
             exactMatches = combinedExactMatches.takeIf { it.isNotEmpty() },
-            conditional = conditionalResponses.takeIf { it.isNotEmpty() }?.mapValues { (_, textResponse) ->
-                listOf(
-                    Message.Assistant(
-                        content = textResponse,
-                        metaInfo = ResponseMetaInfo.create(clock)
+            conditional = combinedConditionalMatches,
+            defaultResponse = listOf(
+                Message.Assistant(
+                    defaultResponse,
+                    ResponseMetaInfo.create(
+                        clock,
+                        inputTokensCount = null, // Will be updated at runtime with actual input
+                        outputTokensCount = tokenizer?.countTokens(defaultResponse),
+                        totalTokensCount = null // Will be calculated at runtime
                     )
                 )
-            },
-            defaultResponse = listOf(Message.Assistant(defaultResponse, ResponseMetaInfo.create(clock)))
+            )
         )
 
         val moderationResponseMatcher = ResponseMatcher(
@@ -706,68 +925,21 @@ public class MockLLMBuilder(private val clock: Clock, private val tokenizer: Tok
         val streamResponseMatcher = ResponseMatcher(
             partialMatches = streamPartialMatches,
             exactMatches = streamExactMatches,
-            conditional = null, // TODO: support later once required
+            conditional = null,
             defaultResponse = defaultStreamResponse
         )
 
-        return MockLLMExecutor(
+        return MockPromptExecutor(
             handleLastAssistantMessage,
             responseMatcher = responseMatcher,
             moderationResponseMatcher = moderationResponseMatcher,
             streamResponseMatcher = streamResponseMatcher,
-            toolRegistry = toolRegistry,
             toolActions = toolActions,
             clock = clock,
             tokenizer = tokenizer
         )
     }
 }
-
-/**
- * Creates a mock LLM text response.
- *
- * This function is the entry point for configuring how the LLM should respond with text
- * when it receives specific inputs.
- *
- * @param response The text response to return
- * @return A [LLMResponseReceiver] for further configuration
- *
- * Example usage:
- * ```kotlin
- * // Mock a simple text response
- * mockLLMAnswer("Hello!") onRequestContains "Hello"
- *
- * // Mock a default response
- * mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
- * ```
- */
-public fun mockLLMAnswer(response: String): LLMResponseReceiver = LLMResponseReceiver(response)
-
-/**
- * Mocks a stream of responses from an LLM, allowing for controlled testing of streaming behavior.
- *
- * @param stream A flow of StreamFrame objects that represent the streaming response from the LLM.
- * @return A [LLMStreamReceiver] that can be used to configure and manage the mocked LLM stream.
- */
-public fun mockLLMStream(stream: Flow<StreamFrame>): LLMStreamReceiver =
-    LLMStreamReceiver(stream)
-
-/**
- * Represents a receiver for configuring mocked behavior.
- */
-public sealed interface MockReceiver {
-
-    /**
-     * Receiver class for configuring how the LLM should respond.
-     */
-    public sealed interface ByLLMClient : MockReceiver
-}
-
-/**
- * Receiver class for configuring stream responses from the LLM.
- */
-public class LLMStreamReceiver(public val stream: Flow<StreamFrame>) :
-    MockReceiver.ByLLMClient
 
 /**
  * Receiver class for configuring text responses from the LLM.
@@ -777,7 +949,113 @@ public class LLMStreamReceiver(public val stream: Flow<StreamFrame>) :
  *
  * @property response The text response to return
  */
-public class LLMResponseReceiver(public val response: String) : MockReceiver.ByLLMClient
+public open class DefaultResponseReceiver(
+    internal val response: String,
+    internal val builder: MockExecutorDSLBuilder,
+) {
+    /**
+     * Sets this response as the default response to be returned when no other response matches.
+     *
+     * @return The response string for method chaining
+     */
+    public val asDefaultResponse: String
+        get() {
+            builder.setDefaultResponse(response)
+            return response
+        }
+
+    /**
+     * Configures the LLM to respond with this string when the user request contains the specified pattern.
+     *
+     * @param pattern The substring to look for in the user request
+     * @return The response string for method chaining
+     */
+    public infix fun onRequestContains(pattern: String): String {
+        with(builder) {
+            response.onUserRequestContains(pattern)
+        }
+
+        return response
+    }
+
+    /**
+     * Configures the LLM to respond with this string when the user request exactly matches the specified pattern.
+     *
+     * @param pattern The exact string to match in the user request
+     * @return The response string for method chaining
+     */
+    public infix fun onRequestEquals(pattern: String): String {
+        with(builder) {
+            response.onUserRequestEquals(pattern)
+        }
+
+        return response
+    }
+
+    /**
+     * Configures the LLM to respond with this string when the user request satisfies the specified condition.
+     *
+     * @param condition A function that evaluates the user request and returns true if it matches
+     * @return The response string for method chaining
+     */
+    public infix fun onCondition(condition: (String) -> Boolean): String {
+        with(builder) {
+            response.onCondition(condition)
+        }
+
+        return response
+    }
+}
+
+/**
+ * Receiver class for configuring streaming responses from the LLM.
+ *
+ * This class is part of the fluent API for configuring how the LLM should respond
+ * with stream frames when it receives specific inputs.
+ *
+ * @property stream The stream response to return
+ */
+public class StreamResponseReceiver(
+    internal val stream: Flow<StreamFrame>,
+    internal val builder: MockExecutorDSLBuilder,
+) {
+    /**
+     * Sets this stream as the default response to be returned when no other response matches.
+     */
+    public val asDefaultResponse: Flow<StreamFrame>
+        get() {
+            builder.setDefaultStreamResponse(stream)
+            return stream
+        }
+
+    /**
+     * Configures the LLM to respond with this stream when the user request contains the specified pattern.
+     */
+    public infix fun onRequestContains(pattern: String): Flow<StreamFrame> {
+        builder.streamPartialMatches[pattern] = stream
+        return stream
+    }
+
+    /**
+     * Configures the LLM to respond with this stream when the user request exactly matches the specified pattern.
+     */
+    public infix fun onRequestEquals(pattern: String): Flow<StreamFrame> {
+        builder.streamExactMatches[pattern] = stream
+        return stream
+    }
+}
+
+/**
+ * Top-level wrapper for importing `mockLLMAnswer` into DSL-based tests.
+ */
+public fun MockExecutorDSLBuilder.mockLLMAnswer(response: String): DefaultResponseReceiver =
+    this.mockLLMAnswer(response)
+
+/**
+ * Top-level wrapper for importing `mockLLMStream` into DSL-based tests.
+ */
+public fun MockExecutorDSLBuilder.mockLLMStream(stream: Flow<StreamFrame>): StreamResponseReceiver =
+    this.mockLLMStream(stream)
 
 /**
  * Creates a mock LLM executor for testing.
@@ -786,15 +1064,15 @@ public class LLMResponseReceiver(public val response: String) : MockReceiver.ByL
  * tool registry and configuration. It handles the setup of the MockLLMBuilder and applies
  * all the configured responses and tool actions.
  *
- * @param toolRegistry Optional tool registry to be used for tool execution
+ * @param serializer Serializer used to serialize and deserialize tool arguments and results
  * @param clock: A clock that is used for mock message timestamps
  * @param tokenizer: Tokenizer that will be used to estimate token counts in mock messages
  * @param init A lambda with receiver that configures the mock LLM executor
- * @return A configured PromptExecutor for testing
+ * @return Сonfigured PromptExecutor for testing
  *
  * Example usage:
  * ```kotlin
- * val mockLLMApi = getMockExecutor(toolRegistry) {
+ * val mockLLMApi = getMockExecutor(serializer) {
  *     // Mock LLM text responses
  *     mockLLMAnswer("Hello!") onRequestContains "Hello"
  *     mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
@@ -812,19 +1090,16 @@ public class LLMResponseReceiver(public val response: String) : MockReceiver.ByL
  * ```
  */
 public fun getMockExecutor(
-    toolRegistry: ToolRegistry? = null,
+    serializer: JSONSerializer = KotlinxSerializer(),
     clock: Clock = Clock.System,
     tokenizer: Tokenizer? = null,
     handleLastAssistantMessage: Boolean = false,
-    init: MockLLMBuilder.() -> Unit
+    init: MockExecutorDSLBuilder.() -> Unit
 ): PromptExecutor {
-    // Call MockLLMBuilder and apply toolRegistry, eventHandler and set currentBuilder to this (to add mocked tool calls)
-    val builder = MockLLMBuilder(clock, tokenizer).apply {
-        this.handleLastAssistantMessage = handleLastAssistantMessage
-        toolRegistry?.let { setToolRegistry(it) }
-        MockLLMBuilder.currentBuilder = this
-        init()
-        MockLLMBuilder.currentBuilder = null
-    }
-    return builder.build()
+    return MockExecutorDSLBuilder(clock, serializer, tokenizer)
+        .apply {
+            this.handleLastAssistantMessage = handleLastAssistantMessage
+            init()
+        }
+        .build()
 }

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockPromptExecutor.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockPromptExecutor.kt
@@ -1,23 +1,18 @@
 package ai.koog.agents.testing.tools
 
-import ai.koog.agents.annotations.JavaAPI
 import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.prompt.dsl.ModerationResult
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
-import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.streaming.StreamFrame
-import ai.koog.prompt.streaming.toStreamFrames
 import ai.koog.prompt.tokenizer.Tokenizer
-import ai.koog.serialization.JSONSerializer
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlin.jvm.JvmStatic
-import kotlin.time.Clock
+import kotlinx.datetime.Clock
 
 /**
  * A utility class for matching strings to associated responses based on different matching strategies.
@@ -41,9 +36,9 @@ internal class ResponseMatcher<TResponse>(
  *
  * This class simulates an LLM by returning predefined responses based on the input prompt.
  * It supports different types of matching:
- * 1. Exact matching - Returns a response when the input exactly matches pattern
+ * 1. Exact matching - Returns a response when the input exactly matches a pattern
  * 2. Partial matching - Returns a response when the input contains a pattern
- * 3. Conditional matching - Returns a response when the input satisfies condition
+ * 3. Conditional matching - Returns a response when the input satisfies a condition
  * 4. Default response - Returns a default response when no other matches are found
  *
  * It also supports tool calls and can be configured to return specific tool results.
@@ -54,25 +49,23 @@ internal class ResponseMatcher<TResponse>(
  *           including support for exact, partial, and conditional matches as well as default responses.
  * @property moderationResponseMatcher Defines the rules for evaluating moderation
  *           matches for prompt messages.
+ * @property toolRegistry Optional tool registry for tool execution
  * @property logger Logger for debugging
  * @property toolActions List of tool conditions and their corresponding actions
  * @property clock: A clock that is used for mock message timestamps
  * @property tokenizer: Tokenizer that will be used to estimate token counts in mock messages
  */
-public class MockPromptExecutor internal constructor(
+internal class MockLLMExecutor(
     private val handleLastAssistantMessage: Boolean,
     private val responseMatcher: ResponseMatcher<List<Message.Response>>,
     private val moderationResponseMatcher: ResponseMatcher<ModerationResult>,
-    private val logger: KLogger = KotlinLogging.logger(MockPromptExecutor::class.simpleName.toString()),
-    internal val toolActions: List<ToolCondition<*, *>> = emptyList(),
+    private val streamResponseMatcher: ResponseMatcher<Flow<StreamFrame>>,
+    private val toolRegistry: ToolRegistry? = null,
+    private val logger: KLogger = KotlinLogging.logger(MockLLMExecutor::class.simpleName!!),
+    val toolActions: List<ToolCondition<*, *>> = emptyList(),
     private val clock: Clock = Clock.System,
     private val tokenizer: Tokenizer? = null
-) : PromptExecutor() {
-    public companion object {
-        @JvmStatic
-        @JavaAPI
-        public fun builder(serializer: JSONSerializer): MockExecutorBuilder = MockExecutorBuilder(serializer)
-    }
+) : PromptExecutor {
 
     /**
      * Executes a prompt with tools and returns a list of responses.
@@ -102,8 +95,12 @@ public class MockPromptExecutor internal constructor(
         prompt: Prompt,
         model: LLModel,
         tools: List<ToolDescriptor>
-    ): Flow<StreamFrame> = flow {
-        execute(prompt = prompt, model = model).toStreamFrames().forEach { emit(it) }
+    ): Flow<StreamFrame> {
+        val lastMessage = getLastMessage(prompt) ?: return streamResponseMatcher.defaultResponse
+
+        return findExactResponse(lastMessage, streamResponseMatcher.exactMatches)
+            ?: findPartialResponse(lastMessage, streamResponseMatcher.partialMatches)
+            ?: streamResponseMatcher.defaultResponse
     }
 
     /**
@@ -142,14 +139,16 @@ public class MockPromptExecutor internal constructor(
      * 1. First checking for exact matches
      * 2. Then checking for partial matches
      * 3. Then checking for conditional matches
-     * 4. Finally, returning the default response if no matches are found
+     * 4. Finally returning the default response if no matches are found
      *
      * @param prompt The prompt to handle
      * @return The appropriate response based on the configured matches
      */
-    private fun handlePrompt(prompt: Prompt): List<Message.Response> {
+    fun handlePrompt(prompt: Prompt): List<Message.Response> {
         logger.debug { "Handling prompt with messages:" }
         prompt.messages.forEach { logger.debug { "Message content: ${it.content.take(300)}..." } }
+
+        val inputTokensCount = tokenizer?.let { prompt.messages.map { it.content }.sumOf(it::countTokens) }
 
         val lastMessage = getLastMessage(prompt) ?: return responseMatcher.defaultResponse
 
@@ -160,31 +159,29 @@ public class MockPromptExecutor internal constructor(
         }
 
         // Check partial response match
-        val partiallyMatchedResponse =
-            if (exactMatchedResponse == null) {
-                findPartialResponse(lastMessage, responseMatcher.partialMatches)
-                    ?: listOf()
-            } else {
-                listOf()
-            }
+        val partiallyMatchedResponse = exactMatchedResponse?.let { emptyList() }
+            ?: findPartialResponse(lastMessage, responseMatcher.partialMatches)
+            ?: listOf()
+
         if (partiallyMatchedResponse.any()) {
             logger.debug { "Returning response for partial prompt match: $partiallyMatchedResponse" }
         }
 
         // Check request conditions
-        val conditionals = getConditionalResponse(lastMessage) ?: listOf()
+        val conditionals = getConditionalResponse(lastMessage, inputTokensCount) ?: listOf()
 
         val result = (exactMatchedResponse ?: listOf()) + partiallyMatchedResponse + conditionals
         if (result.any()) {
-            return updateTokenCounts(result, lastMessage.content)
+            return result
         }
 
         // Process the default LLM response
-        return updateTokenCounts(responseMatcher.defaultResponse, lastMessage.content)
+        return responseMatcher.defaultResponse
     }
 
     private fun getConditionalResponse(
         lastMessage: Message,
+        inputTokensCount: Int?
     ): List<Message.Response>? = if (!responseMatcher.conditional.isNullOrEmpty()) {
         responseMatcher.conditional.entries.firstOrNull { it.key(lastMessage.content) }?.let { (_, response) ->
             logger.debug { "Returning response for conditional match: $response" }
@@ -192,51 +189,6 @@ public class MockPromptExecutor internal constructor(
         }
     } else {
         emptyList()
-    }
-
-    /**
-     * Updates the token counts in response metadata to use the input string.
-     */
-    private fun updateTokenCounts(
-        responses: List<Message.Response>,
-        input: String,
-    ): List<Message.Response> {
-        if (tokenizer == null) return responses
-
-        val inputTokenCount = tokenizer.countTokens(input)
-
-        return responses.map { response ->
-            when (response) {
-                is Message.Assistant -> {
-                    val outputTokenCount = tokenizer.countTokens(response.content)
-                    val updatedMetaInfo = ResponseMetaInfo.create(
-                        clock = clock,
-                        inputTokensCount = inputTokenCount,
-                        outputTokensCount = outputTokenCount,
-                        totalTokensCount = inputTokenCount + outputTokenCount
-                    )
-                    Message.Assistant(response.content, updatedMetaInfo)
-                }
-
-                is Message.Tool.Call -> {
-                    val outputTokenCount = tokenizer.countTokens(response.content)
-                    val updatedMetaInfo = ResponseMetaInfo.create(
-                        clock = clock,
-                        inputTokensCount = inputTokenCount,
-                        outputTokensCount = outputTokenCount,
-                        totalTokensCount = inputTokenCount + outputTokenCount
-                    )
-                    Message.Tool.Call(
-                        id = response.id,
-                        tool = response.tool,
-                        content = response.content,
-                        metaInfo = updatedMetaInfo
-                    )
-                }
-
-                else -> response // Keep other response types unchanged
-            }
-        }
     }
 
     /*
@@ -282,6 +234,4 @@ public class MockPromptExecutor internal constructor(
             }
         }
     }
-
-    override fun close() {}
 }

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockPromptExecutor.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockPromptExecutor.kt
@@ -1,18 +1,23 @@
 package ai.koog.agents.testing.tools
 
+import ai.koog.agents.annotations.JavaAPI
 import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.prompt.dsl.ModerationResult
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.streaming.toStreamFrames
 import ai.koog.prompt.tokenizer.Tokenizer
+import ai.koog.serialization.JSONSerializer
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
-import kotlinx.datetime.Clock
+import kotlinx.coroutines.flow.flow
+import kotlin.jvm.JvmStatic
+import kotlin.time.Clock
 
 /**
  * A utility class for matching strings to associated responses based on different matching strategies.
@@ -36,9 +41,9 @@ internal class ResponseMatcher<TResponse>(
  *
  * This class simulates an LLM by returning predefined responses based on the input prompt.
  * It supports different types of matching:
- * 1. Exact matching - Returns a response when the input exactly matches a pattern
+ * 1. Exact matching - Returns a response when the input exactly matches pattern
  * 2. Partial matching - Returns a response when the input contains a pattern
- * 3. Conditional matching - Returns a response when the input satisfies a condition
+ * 3. Conditional matching - Returns a response when the input satisfies condition
  * 4. Default response - Returns a default response when no other matches are found
  *
  * It also supports tool calls and can be configured to return specific tool results.
@@ -49,23 +54,26 @@ internal class ResponseMatcher<TResponse>(
  *           including support for exact, partial, and conditional matches as well as default responses.
  * @property moderationResponseMatcher Defines the rules for evaluating moderation
  *           matches for prompt messages.
- * @property toolRegistry Optional tool registry for tool execution
  * @property logger Logger for debugging
  * @property toolActions List of tool conditions and their corresponding actions
  * @property clock: A clock that is used for mock message timestamps
  * @property tokenizer: Tokenizer that will be used to estimate token counts in mock messages
  */
-internal class MockLLMExecutor(
+public class MockPromptExecutor internal constructor(
     private val handleLastAssistantMessage: Boolean,
     private val responseMatcher: ResponseMatcher<List<Message.Response>>,
     private val moderationResponseMatcher: ResponseMatcher<ModerationResult>,
     private val streamResponseMatcher: ResponseMatcher<Flow<StreamFrame>>,
-    private val toolRegistry: ToolRegistry? = null,
-    private val logger: KLogger = KotlinLogging.logger(MockLLMExecutor::class.simpleName!!),
-    val toolActions: List<ToolCondition<*, *>> = emptyList(),
+    private val logger: KLogger = KotlinLogging.logger(MockPromptExecutor::class.simpleName.toString()),
+    internal val toolActions: List<ToolCondition<*, *>> = emptyList(),
     private val clock: Clock = Clock.System,
     private val tokenizer: Tokenizer? = null
-) : PromptExecutor {
+) : PromptExecutor() {
+    public companion object {
+        @JvmStatic
+        @JavaAPI
+        public fun builder(serializer: JSONSerializer): MockExecutorBuilder = MockExecutorBuilder(serializer)
+    }
 
     /**
      * Executes a prompt with tools and returns a list of responses.
@@ -96,11 +104,15 @@ internal class MockLLMExecutor(
         model: LLModel,
         tools: List<ToolDescriptor>
     ): Flow<StreamFrame> {
-        val lastMessage = getLastMessage(prompt) ?: return streamResponseMatcher.defaultResponse
+        val lastMessage = getLastMessage(prompt)
+        val matchedStream = lastMessage?.let {
+            findExactResponse(it, streamResponseMatcher.exactMatches)
+                ?: findPartialResponse(it, streamResponseMatcher.partialMatches)
+        }
 
-        return findExactResponse(lastMessage, streamResponseMatcher.exactMatches)
-            ?: findPartialResponse(lastMessage, streamResponseMatcher.partialMatches)
-            ?: streamResponseMatcher.defaultResponse
+        return matchedStream ?: flow {
+            execute(prompt = prompt, model = model).toStreamFrames().forEach { emit(it) }
+        }
     }
 
     /**
@@ -139,16 +151,14 @@ internal class MockLLMExecutor(
      * 1. First checking for exact matches
      * 2. Then checking for partial matches
      * 3. Then checking for conditional matches
-     * 4. Finally returning the default response if no matches are found
+     * 4. Finally, returning the default response if no matches are found
      *
      * @param prompt The prompt to handle
      * @return The appropriate response based on the configured matches
      */
-    fun handlePrompt(prompt: Prompt): List<Message.Response> {
+    private fun handlePrompt(prompt: Prompt): List<Message.Response> {
         logger.debug { "Handling prompt with messages:" }
         prompt.messages.forEach { logger.debug { "Message content: ${it.content.take(300)}..." } }
-
-        val inputTokensCount = tokenizer?.let { prompt.messages.map { it.content }.sumOf(it::countTokens) }
 
         val lastMessage = getLastMessage(prompt) ?: return responseMatcher.defaultResponse
 
@@ -159,29 +169,31 @@ internal class MockLLMExecutor(
         }
 
         // Check partial response match
-        val partiallyMatchedResponse = exactMatchedResponse?.let { emptyList() }
-            ?: findPartialResponse(lastMessage, responseMatcher.partialMatches)
-            ?: listOf()
-
+        val partiallyMatchedResponse =
+            if (exactMatchedResponse == null) {
+                findPartialResponse(lastMessage, responseMatcher.partialMatches)
+                    ?: listOf()
+            } else {
+                listOf()
+            }
         if (partiallyMatchedResponse.any()) {
             logger.debug { "Returning response for partial prompt match: $partiallyMatchedResponse" }
         }
 
         // Check request conditions
-        val conditionals = getConditionalResponse(lastMessage, inputTokensCount) ?: listOf()
+        val conditionals = getConditionalResponse(lastMessage) ?: listOf()
 
         val result = (exactMatchedResponse ?: listOf()) + partiallyMatchedResponse + conditionals
         if (result.any()) {
-            return result
+            return updateTokenCounts(result, lastMessage.content)
         }
 
         // Process the default LLM response
-        return responseMatcher.defaultResponse
+        return updateTokenCounts(responseMatcher.defaultResponse, lastMessage.content)
     }
 
     private fun getConditionalResponse(
         lastMessage: Message,
-        inputTokensCount: Int?
     ): List<Message.Response>? = if (!responseMatcher.conditional.isNullOrEmpty()) {
         responseMatcher.conditional.entries.firstOrNull { it.key(lastMessage.content) }?.let { (_, response) ->
             logger.debug { "Returning response for conditional match: $response" }
@@ -189,6 +201,51 @@ internal class MockLLMExecutor(
         }
     } else {
         emptyList()
+    }
+
+    /**
+     * Updates the token counts in response metadata to use the input string.
+     */
+    private fun updateTokenCounts(
+        responses: List<Message.Response>,
+        input: String,
+    ): List<Message.Response> {
+        if (tokenizer == null) return responses
+
+        val inputTokenCount = tokenizer.countTokens(input)
+
+        return responses.map { response ->
+            when (response) {
+                is Message.Assistant -> {
+                    val outputTokenCount = tokenizer.countTokens(response.content)
+                    val updatedMetaInfo = ResponseMetaInfo.create(
+                        clock = clock,
+                        inputTokensCount = inputTokenCount,
+                        outputTokensCount = outputTokenCount,
+                        totalTokensCount = inputTokenCount + outputTokenCount
+                    )
+                    Message.Assistant(response.content, updatedMetaInfo)
+                }
+
+                is Message.Tool.Call -> {
+                    val outputTokenCount = tokenizer.countTokens(response.content)
+                    val updatedMetaInfo = ResponseMetaInfo.create(
+                        clock = clock,
+                        inputTokensCount = inputTokenCount,
+                        outputTokensCount = outputTokenCount,
+                        totalTokensCount = inputTokenCount + outputTokenCount
+                    )
+                    Message.Tool.Call(
+                        id = response.id,
+                        tool = response.tool,
+                        content = response.content,
+                        metaInfo = updatedMetaInfo
+                    )
+                }
+
+                else -> response // Keep other response types unchanged
+            }
+        }
     }
 
     /*
@@ -234,4 +291,6 @@ internal class MockLLMExecutor(
             }
         }
     }
+
+    override fun close() {}
 }

--- a/agents/agents-test/src/commonTest/kotlin/ai/koog/agents/testing/tools/MockLLMBuilderTests.kt
+++ b/agents/agents-test/src/commonTest/kotlin/ai/koog/agents/testing/tools/MockLLMBuilderTests.kt
@@ -1,19 +1,13 @@
 package ai.koog.agents.testing.tools
 
 import ai.koog.agents.core.tools.Tool
-import ai.koog.agents.core.tools.ToolArgs
-import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.agents.core.tools.ToolRegistry
-import ai.koog.agents.core.tools.ToolResult
 import ai.koog.prompt.dsl.prompt
-import ai.koog.prompt.llm.OllamaModels
+import ai.koog.prompt.executor.ollama.client.OllamaModels
 import ai.koog.prompt.message.Message
-import ai.koog.prompt.streaming.emitAppend
-import ai.koog.prompt.streaming.emitEnd
-import ai.koog.prompt.streaming.streamFrameFlow
+import ai.koog.prompt.streaming.streamFrameFlowOf
+import ai.koog.serialization.kotlinx.KotlinxSerializer
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializer
 import kotlin.test.Test
@@ -24,33 +18,29 @@ import kotlin.test.assertTrue
 
 @Suppress("USELESS_CAST")
 class MockLLMBuilderTests {
+    private val serializer = KotlinxSerializer()
 
     // Sample tool for testing
-    private object TestTool : Tool<TestTool.Args, ToolResult.Text>() {
+    private object TestTool : Tool<TestTool.Args, String>(
+        argsSerializer = serializer<Args>(),
+        resultSerializer = serializer<String>(),
+        name = "test_tool",
+        description = "A test tool for testing"
+    ) {
         @Serializable
-        data class Args(val input: String) : ToolArgs
+        data class Args(val input: String)
 
-        override val argsSerializer: KSerializer<Args> = serializer()
-
-        override val descriptor: ToolDescriptor = ToolDescriptor(
-            name = "test_tool",
-            description = "A test tool for testing"
-        )
-
-        override suspend fun execute(args: Args): ToolResult.Text {
-            return ToolResult.Text("Executed with: ${args.input}")
-        }
+        override suspend fun execute(args: Args): String =
+            "Executed with: ${args.input}"
     }
 
     @Test
     fun testBasicMockLLMAnswer() = runTest {
-        // Create a mock executor with a simple response
-        val mockExecutor = getMockExecutor {
+        val mockExecutor = getMockExecutor(serializer) {
             mockLLMAnswer("Hello, world!") onRequestContains "hello"
             mockLLMAnswer("Default response").asDefaultResponse
         }
 
-        // Test that the executor returns the expected response
         val prompt = prompt("test") {
             user("Say hello to me")
         }
@@ -58,7 +48,6 @@ class MockLLMBuilderTests {
         val response = mockExecutor.execute(prompt, OllamaModels.Meta.LLAMA_3_2).single()
         assertEquals("Hello, world!", response.content)
 
-        // Test default response
         val prompt2 = prompt("test2") {
             user("Something unrelated")
         }
@@ -69,7 +58,7 @@ class MockLLMBuilderTests {
 
     @Test
     fun testExactMatchResponse() = runTest {
-        val mockExecutor = getMockExecutor {
+        val mockExecutor = getMockExecutor(serializer) {
             mockLLMAnswer("Exact match response") onRequestEquals "exact match query"
             mockLLMAnswer("Default response").asDefaultResponse
         }
@@ -81,7 +70,6 @@ class MockLLMBuilderTests {
         val response = mockExecutor.execute(prompt, OllamaModels.Meta.LLAMA_3_2).single()
         assertEquals("Exact match response", response.content)
 
-        // Test that partial match doesn't work for exact matching
         val prompt2 = prompt("test-exact-partial") {
             user("This contains exact match query somewhere")
         }
@@ -92,12 +80,11 @@ class MockLLMBuilderTests {
 
     @Test
     fun testPartialMatchResponse() = runTest {
-        val mockExecutor = getMockExecutor {
+        val mockExecutor = getMockExecutor(serializer) {
             mockLLMAnswer("Partial match response") onRequestContains "partial match"
             mockLLMAnswer("Default response").asDefaultResponse
         }
 
-        // Test that partial match works
         val prompt = prompt("test-partial") {
             user("This contains partial match somewhere")
         }
@@ -108,12 +95,11 @@ class MockLLMBuilderTests {
 
     @Test
     fun testConditionalMatchResponse() = runTest {
-        val mockExecutor = getMockExecutor {
+        val mockExecutor = getMockExecutor(serializer) {
             mockLLMAnswer("Conditional response") onCondition { it.length > 20 }
             mockLLMAnswer("Default response").asDefaultResponse
         }
 
-        // Test that conditional match works
         val prompt = prompt("test-conditional") {
             user("This is a long message that should match the condition")
         }
@@ -121,7 +107,6 @@ class MockLLMBuilderTests {
         val response = mockExecutor.execute(prompt, OllamaModels.Meta.LLAMA_3_2).single()
         assertEquals("Conditional response", response.content)
 
-        // Test that condition not matching returns default
         val prompt2 = prompt("test-conditional-short") {
             user("Short message")
         }
@@ -135,29 +120,18 @@ class MockLLMBuilderTests {
         val prompt = prompt("test-stream") {
             user("hello")
         }
-        val expectedStream = streamFrameFlow {
-            emitAppend("hi")
-            emitAppend(", ho")
-            emitAppend("w are you?")
-            emitEnd()
-        }
-        val mockExecutor = getMockExecutor {
+        val expectedStream = streamFrameFlowOf("hi", ", ho", "w are you?")
+        val mockExecutor = getMockExecutor(serializer) {
             mockLLMStream(expectedStream) onRequestEquals "hello"
         }
+
         val actualStream = mockExecutor.executeStreaming(prompt, OllamaModels.Meta.LLAMA_3_2)
-        assertContentEquals(
-            expected = expectedStream.toList(),
-            actual = actualStream.toList()
-        )
+        assertContentEquals(expectedStream.toList(), actualStream.toList())
     }
 
     @Test
     fun testToolCallMocking() = runTest {
-        val toolRegistry = ToolRegistry {
-            tool(TestTool)
-        }
-
-        val mockExecutor = getMockExecutor(toolRegistry) {
+        val mockExecutor = getMockExecutor(serializer) {
             mockLLMToolCall(TestTool, TestTool.Args("test input")) onRequestContains "use tool"
             mockLLMAnswer("Default response").asDefaultResponse
         }
@@ -174,16 +148,12 @@ class MockLLMBuilderTests {
 
     @Test
     fun testMultipleToolCallsMocking() = runTest {
-        val toolRegistry = ToolRegistry {
-            tool(TestTool)
-        }
-
         val toolCalls = listOf(
             TestTool to TestTool.Args("first input"),
             TestTool to TestTool.Args("second input")
         )
 
-        val mockExecutor = getMockExecutor(toolRegistry) {
+        val mockExecutor = getMockExecutor(serializer) {
             mockLLMToolCall(toolCalls) onRequestContains "use multiple tools"
             mockLLMAnswer("Default response").asDefaultResponse
         }
@@ -192,10 +162,8 @@ class MockLLMBuilderTests {
             user("Please use multiple tools to do something")
         }
 
-        // In this case, we expect a list of responses with tool calls
         val responses = mockExecutor.execute(prompt, OllamaModels.Meta.LLAMA_3_2, listOf())
 
-        // Verify we have the expected number of tool calls
         val responseToolCalls = responses.filterIsInstance<Message.Tool.Call>()
         assertEquals(2, responseToolCalls.size)
         assertEquals("test_tool", responseToolCalls[0].tool)
@@ -204,17 +172,12 @@ class MockLLMBuilderTests {
 
     @Test
     fun testMixedResponseMocking() = runTest {
-        val toolRegistry = ToolRegistry {
-            tool(TestTool)
-        }
-
         val mixedToolCalls = listOf(
             TestTool to TestTool.Args("mixed input")
         )
-
         val textResponses = listOf("This is a mixed response with tool calls")
 
-        val mockExecutor = getMockExecutor(toolRegistry) {
+        val mockExecutor = getMockExecutor(serializer) {
             mockLLMMixedResponse(mixedToolCalls, textResponses) onRequestContains "mixed response"
             mockLLMAnswer("Default response").asDefaultResponse
         }
@@ -225,8 +188,6 @@ class MockLLMBuilderTests {
 
         val responses = mockExecutor.execute(prompt, OllamaModels.Meta.LLAMA_3_2, listOf())
         assertEquals(2, responses.size)
-
-        // Check that we have both text and tool responses
         assertTrue(responses.any { it is Message.Assistant })
         assertTrue(responses.any { it is Message.Tool.Call })
 
@@ -239,15 +200,8 @@ class MockLLMBuilderTests {
 
     @Test
     fun testToolBehaviorMocking() = runTest {
-        val toolRegistry = ToolRegistry {
-            tool(TestTool)
-        }
-
-        val mockExecutor = getMockExecutor(toolRegistry) {
-            // Mock the tool behavior
-            mockTool(TestTool) alwaysReturns ToolResult.Text("Mocked result")
-
-            // Set up a tool call that will use the mocked tool
+        val mockExecutor = getMockExecutor(serializer) {
+            mockTool(TestTool) alwaysReturns "Mocked result"
             mockLLMToolCall(TestTool, TestTool.Args("test input")) onRequestContains "use tool"
         }
 
@@ -255,43 +209,30 @@ class MockLLMBuilderTests {
             user("Please use tool to do something")
         }
 
-        // Execute the prompt to get a tool call
         val response = mockExecutor.execute(prompt, OllamaModels.Meta.LLAMA_3_2).single()
         assertTrue(response is Message.Tool.Call)
 
-        // Now simulate executing the tool
         val toolCall = response as Message.Tool.Call
-
-        // Find the tool condition that matches this call
-        val toolCondition = (mockExecutor as MockLLMExecutor).toolActions.firstOrNull {
+        val toolCondition = (mockExecutor as MockPromptExecutor).toolActions.firstOrNull {
             it.tool.name == toolCall.tool
         }
 
         assertNotNull(toolCondition)
 
-        // Execute the tool and check the result
         val result = toolCondition.invoke(toolCall)
-        assertTrue(result is ToolResult.Text)
-        assertEquals("Mocked result", (result as ToolResult.Text).text)
+        assertTrue(result is String)
+        assertEquals("Mocked result", result)
     }
 
     @Test
     fun testToolBehaviorWithCondition() = runTest {
-        val toolRegistry = ToolRegistry {
-            tool(TestTool)
-        }
-
-        val mockExecutor = getMockExecutor(toolRegistry) {
-            // Mock the tool behavior with a condition
-            mockTool(TestTool).returns(ToolResult.Text("Specific result")).onArguments(TestTool.Args("specific input"))
-            mockTool(TestTool) alwaysReturns ToolResult.Text("Default result")
-
-            // Set up tool calls
+        val mockExecutor = getMockExecutor(serializer) {
+            mockTool(TestTool).returns("Specific result").onArguments(TestTool.Args("specific input"))
+            mockTool(TestTool) alwaysReturns "Default result"
             mockLLMToolCall(TestTool, TestTool.Args("specific input")) onRequestContains "specific"
             mockLLMToolCall(TestTool, TestTool.Args("other input")) onRequestContains "other"
         }
 
-        // Test the specific input
         val specificPrompt = prompt("test-specific") {
             user("Please use tool with specific input")
         }
@@ -300,15 +241,14 @@ class MockLLMBuilderTests {
         assertTrue(specificResponse is Message.Tool.Call)
 
         val specificToolCall = specificResponse as Message.Tool.Call
-        val specificToolCondition = (mockExecutor as MockLLMExecutor).toolActions.first {
+        val specificToolCondition = (mockExecutor as MockPromptExecutor).toolActions.first {
             it.satisfies(specificToolCall)
         }
 
         val specificResult = specificToolCondition.invoke(specificToolCall)
-        assertTrue(specificResult is ToolResult.Text)
-        assertEquals("Specific result", (specificResult as ToolResult.Text).text)
+        assertTrue(specificResult is String)
+        assertEquals("Specific result", specificResult)
 
-        // Test the default behavior
         val otherPrompt = prompt("test-other") {
             user("Please use tool with other input")
         }
@@ -317,31 +257,24 @@ class MockLLMBuilderTests {
         assertTrue(otherResponse is Message.Tool.Call)
 
         val otherToolCall = otherResponse as Message.Tool.Call
-        val otherToolCondition = (mockExecutor as MockLLMExecutor).toolActions.first {
+        val otherToolCondition = (mockExecutor as MockPromptExecutor).toolActions.first {
             it.satisfies(otherToolCall)
         }
 
         val otherResult = otherToolCondition.invoke(otherToolCall)
-        assertTrue(otherResult is ToolResult.Text)
-        assertEquals("Default result", (otherResult as ToolResult.Text).text)
+        assertTrue(otherResult is String)
+        assertEquals("Default result", otherResult)
     }
 
     @Test
     fun testToolBehaviorWithCustomAction() = runTest {
-        val toolRegistry = ToolRegistry {
-            tool(TestTool)
-        }
-
         var actionCalled = false
 
-        val mockExecutor = getMockExecutor(toolRegistry) {
-            // Mock the tool behavior with a custom action
+        val mockExecutor = getMockExecutor(serializer) {
             mockTool(TestTool) alwaysDoes {
                 actionCalled = true
-                ToolResult.Text("Custom action result")
+                "Custom action result"
             }
-
-            // Set up a tool call
             mockLLMToolCall(TestTool, TestTool.Args("test input")) onRequestContains "use tool"
         }
 
@@ -353,13 +286,13 @@ class MockLLMBuilderTests {
         assertTrue(response is Message.Tool.Call)
 
         val toolCall = response
-        val toolCondition = (mockExecutor as MockLLMExecutor).toolActions.first {
+        val toolCondition = (mockExecutor as MockPromptExecutor).toolActions.first {
             it.satisfies(toolCall)
         }
 
         val result = toolCondition.invoke(toolCall)
         assertTrue(actionCalled)
-        assertTrue(result is ToolResult.Text)
-        assertEquals("Custom action result", (result as ToolResult.Text).text)
+        assertTrue(result is String)
+        assertEquals("Custom action result", result)
     }
 }

--- a/agents/agents-test/src/commonTest/kotlin/ai/koog/agents/testing/tools/MockLLMBuilderTests.kt
+++ b/agents/agents-test/src/commonTest/kotlin/ai/koog/agents/testing/tools/MockLLMBuilderTests.kt
@@ -1,40 +1,51 @@
 package ai.koog.agents.testing.tools
 
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolArgs
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.core.tools.ToolResult
 import ai.koog.prompt.dsl.prompt
-import ai.koog.prompt.executor.ollama.client.OllamaModels
+import ai.koog.prompt.llm.OllamaModels
 import ai.koog.prompt.message.Message
-import ai.koog.serialization.kotlinx.KotlinxSerializer
+import ai.koog.prompt.streaming.emitAppend
+import ai.koog.prompt.streaming.emitEnd
+import ai.koog.prompt.streaming.streamFrameFlow
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializer
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 @Suppress("USELESS_CAST")
 class MockLLMBuilderTests {
-    private val serializer = KotlinxSerializer()
 
     // Sample tool for testing
-    private object TestTool : Tool<TestTool.Args, String>(
-        argsSerializer = serializer<Args>(),
-        resultSerializer = serializer<String>(),
-        name = "test_tool",
-        description = "A test tool for testing"
-    ) {
+    private object TestTool : Tool<TestTool.Args, ToolResult.Text>() {
         @Serializable
-        data class Args(val input: String)
+        data class Args(val input: String) : ToolArgs
 
-        override suspend fun execute(args: Args): String =
-            "Executed with: ${args.input}"
+        override val argsSerializer: KSerializer<Args> = serializer()
+
+        override val descriptor: ToolDescriptor = ToolDescriptor(
+            name = "test_tool",
+            description = "A test tool for testing"
+        )
+
+        override suspend fun execute(args: Args): ToolResult.Text {
+            return ToolResult.Text("Executed with: ${args.input}")
+        }
     }
 
     @Test
     fun testBasicMockLLMAnswer() = runTest {
         // Create a mock executor with a simple response
-        val mockExecutor = getMockExecutor(serializer) {
+        val mockExecutor = getMockExecutor {
             mockLLMAnswer("Hello, world!") onRequestContains "hello"
             mockLLMAnswer("Default response").asDefaultResponse
         }
@@ -58,7 +69,7 @@ class MockLLMBuilderTests {
 
     @Test
     fun testExactMatchResponse() = runTest {
-        val mockExecutor = getMockExecutor(serializer) {
+        val mockExecutor = getMockExecutor {
             mockLLMAnswer("Exact match response") onRequestEquals "exact match query"
             mockLLMAnswer("Default response").asDefaultResponse
         }
@@ -81,7 +92,7 @@ class MockLLMBuilderTests {
 
     @Test
     fun testPartialMatchResponse() = runTest {
-        val mockExecutor = getMockExecutor(serializer) {
+        val mockExecutor = getMockExecutor {
             mockLLMAnswer("Partial match response") onRequestContains "partial match"
             mockLLMAnswer("Default response").asDefaultResponse
         }
@@ -97,7 +108,7 @@ class MockLLMBuilderTests {
 
     @Test
     fun testConditionalMatchResponse() = runTest {
-        val mockExecutor = getMockExecutor(serializer) {
+        val mockExecutor = getMockExecutor {
             mockLLMAnswer("Conditional response") onCondition { it.length > 20 }
             mockLLMAnswer("Default response").asDefaultResponse
         }
@@ -120,8 +131,33 @@ class MockLLMBuilderTests {
     }
 
     @Test
+    fun testStreamMocking() = runTest {
+        val prompt = prompt("test-stream") {
+            user("hello")
+        }
+        val expectedStream = streamFrameFlow {
+            emitAppend("hi")
+            emitAppend(", ho")
+            emitAppend("w are you?")
+            emitEnd()
+        }
+        val mockExecutor = getMockExecutor {
+            mockLLMStream(expectedStream) onRequestEquals "hello"
+        }
+        val actualStream = mockExecutor.executeStreaming(prompt, OllamaModels.Meta.LLAMA_3_2)
+        assertContentEquals(
+            expected = expectedStream.toList(),
+            actual = actualStream.toList()
+        )
+    }
+
+    @Test
     fun testToolCallMocking() = runTest {
-        val mockExecutor = getMockExecutor(serializer) {
+        val toolRegistry = ToolRegistry {
+            tool(TestTool)
+        }
+
+        val mockExecutor = getMockExecutor(toolRegistry) {
             mockLLMToolCall(TestTool, TestTool.Args("test input")) onRequestContains "use tool"
             mockLLMAnswer("Default response").asDefaultResponse
         }
@@ -138,12 +174,16 @@ class MockLLMBuilderTests {
 
     @Test
     fun testMultipleToolCallsMocking() = runTest {
+        val toolRegistry = ToolRegistry {
+            tool(TestTool)
+        }
+
         val toolCalls = listOf(
             TestTool to TestTool.Args("first input"),
             TestTool to TestTool.Args("second input")
         )
 
-        val mockExecutor = getMockExecutor(serializer) {
+        val mockExecutor = getMockExecutor(toolRegistry) {
             mockLLMToolCall(toolCalls) onRequestContains "use multiple tools"
             mockLLMAnswer("Default response").asDefaultResponse
         }
@@ -164,13 +204,17 @@ class MockLLMBuilderTests {
 
     @Test
     fun testMixedResponseMocking() = runTest {
+        val toolRegistry = ToolRegistry {
+            tool(TestTool)
+        }
+
         val mixedToolCalls = listOf(
             TestTool to TestTool.Args("mixed input")
         )
 
         val textResponses = listOf("This is a mixed response with tool calls")
 
-        val mockExecutor = getMockExecutor(serializer) {
+        val mockExecutor = getMockExecutor(toolRegistry) {
             mockLLMMixedResponse(mixedToolCalls, textResponses) onRequestContains "mixed response"
             mockLLMAnswer("Default response").asDefaultResponse
         }
@@ -195,9 +239,13 @@ class MockLLMBuilderTests {
 
     @Test
     fun testToolBehaviorMocking() = runTest {
-        val mockExecutor = getMockExecutor(serializer) {
+        val toolRegistry = ToolRegistry {
+            tool(TestTool)
+        }
+
+        val mockExecutor = getMockExecutor(toolRegistry) {
             // Mock the tool behavior
-            mockTool(TestTool) alwaysReturns "Mocked result"
+            mockTool(TestTool) alwaysReturns ToolResult.Text("Mocked result")
 
             // Set up a tool call that will use the mocked tool
             mockLLMToolCall(TestTool, TestTool.Args("test input")) onRequestContains "use tool"
@@ -215,7 +263,7 @@ class MockLLMBuilderTests {
         val toolCall = response as Message.Tool.Call
 
         // Find the tool condition that matches this call
-        val toolCondition = (mockExecutor as MockPromptExecutor).toolActions.firstOrNull {
+        val toolCondition = (mockExecutor as MockLLMExecutor).toolActions.firstOrNull {
             it.tool.name == toolCall.tool
         }
 
@@ -223,16 +271,20 @@ class MockLLMBuilderTests {
 
         // Execute the tool and check the result
         val result = toolCondition.invoke(toolCall)
-        assertTrue(result is String)
-        assertEquals("Mocked result", result)
+        assertTrue(result is ToolResult.Text)
+        assertEquals("Mocked result", (result as ToolResult.Text).text)
     }
 
     @Test
     fun testToolBehaviorWithCondition() = runTest {
-        val mockExecutor = getMockExecutor(serializer) {
+        val toolRegistry = ToolRegistry {
+            tool(TestTool)
+        }
+
+        val mockExecutor = getMockExecutor(toolRegistry) {
             // Mock the tool behavior with a condition
-            mockTool(TestTool).returns("Specific result").onArguments(TestTool.Args("specific input"))
-            mockTool(TestTool) alwaysReturns "Default result"
+            mockTool(TestTool).returns(ToolResult.Text("Specific result")).onArguments(TestTool.Args("specific input"))
+            mockTool(TestTool) alwaysReturns ToolResult.Text("Default result")
 
             // Set up tool calls
             mockLLMToolCall(TestTool, TestTool.Args("specific input")) onRequestContains "specific"
@@ -248,13 +300,13 @@ class MockLLMBuilderTests {
         assertTrue(specificResponse is Message.Tool.Call)
 
         val specificToolCall = specificResponse as Message.Tool.Call
-        val specificToolCondition = (mockExecutor as MockPromptExecutor).toolActions.first {
+        val specificToolCondition = (mockExecutor as MockLLMExecutor).toolActions.first {
             it.satisfies(specificToolCall)
         }
 
         val specificResult = specificToolCondition.invoke(specificToolCall)
-        assertTrue(specificResult is String)
-        assertEquals("Specific result", specificResult)
+        assertTrue(specificResult is ToolResult.Text)
+        assertEquals("Specific result", (specificResult as ToolResult.Text).text)
 
         // Test the default behavior
         val otherPrompt = prompt("test-other") {
@@ -265,24 +317,28 @@ class MockLLMBuilderTests {
         assertTrue(otherResponse is Message.Tool.Call)
 
         val otherToolCall = otherResponse as Message.Tool.Call
-        val otherToolCondition = (mockExecutor as MockPromptExecutor).toolActions.first {
+        val otherToolCondition = (mockExecutor as MockLLMExecutor).toolActions.first {
             it.satisfies(otherToolCall)
         }
 
         val otherResult = otherToolCondition.invoke(otherToolCall)
-        assertTrue(otherResult is String)
-        assertEquals("Default result", otherResult)
+        assertTrue(otherResult is ToolResult.Text)
+        assertEquals("Default result", (otherResult as ToolResult.Text).text)
     }
 
     @Test
     fun testToolBehaviorWithCustomAction() = runTest {
+        val toolRegistry = ToolRegistry {
+            tool(TestTool)
+        }
+
         var actionCalled = false
 
-        val mockExecutor = getMockExecutor(serializer) {
+        val mockExecutor = getMockExecutor(toolRegistry) {
             // Mock the tool behavior with a custom action
             mockTool(TestTool) alwaysDoes {
                 actionCalled = true
-                "Custom action result"
+                ToolResult.Text("Custom action result")
             }
 
             // Set up a tool call
@@ -297,13 +353,13 @@ class MockLLMBuilderTests {
         assertTrue(response is Message.Tool.Call)
 
         val toolCall = response
-        val toolCondition = (mockExecutor as MockPromptExecutor).toolActions.first {
+        val toolCondition = (mockExecutor as MockLLMExecutor).toolActions.first {
             it.satisfies(toolCall)
         }
 
         val result = toolCondition.invoke(toolCall)
         assertTrue(actionCalled)
-        assertTrue(result is String)
-        assertEquals("Custom action result", result)
+        assertTrue(result is ToolResult.Text)
+        assertEquals("Custom action result", (result as ToolResult.Text).text)
     }
 }

--- a/agents/agents-test/src/jvmMain/kotlin/ai/koog/agents/testing/tools/MockExecutorDSLBuilder.jvm.kt
+++ b/agents/agents-test/src/jvmMain/kotlin/ai/koog/agents/testing/tools/MockExecutorDSLBuilder.jvm.kt
@@ -2,8 +2,7 @@ package ai.koog.agents.testing.tools
 
 import ai.koog.agents.core.tools.reflect.ToolFromCallable
 import ai.koog.agents.core.tools.reflect.asTool
-import ai.koog.agents.testing.tools.MockLLMBuilder.ToolCallReceiver
-import kotlinx.serialization.json.Json
+import ai.koog.agents.testing.tools.MockExecutorDSLBuilder.ToolCallReceiver
 import kotlin.reflect.KFunction
 
 /**
@@ -13,12 +12,11 @@ import kotlin.reflect.KFunction
  * @param args The arguments to be passed to the tool function.
  * @return A `ToolCallReceiver` instance configured with the tool and its arguments.
  */
-@Suppress("UnusedReceiverParameter")
-public fun MockLLMBuilder.mockLLMToolCall(
+public fun MockExecutorDSLBuilder.mockLLMToolCall(
     tool: KFunction<*>,
     vararg args: Any?,
     toolCallId: String? = null
-): ToolCallReceiver<ToolFromCallable.VarArgs> {
+): ToolCallReceiver<ToolFromCallable.Args> {
     val params = tool.parameters
 
     val argsMap = (params zip args).associate { (param, arg) ->
@@ -27,8 +25,9 @@ public fun MockLLMBuilder.mockLLMToolCall(
 
     return ToolCallReceiver(
         tool = tool.asTool(),
-        args = ToolFromCallable.VarArgs(argsMap),
+        args = ToolFromCallable.Args(argsMap),
         toolCallId = toolCallId,
+        builder = this
     )
 }
 
@@ -37,11 +36,11 @@ public fun MockLLMBuilder.mockLLMToolCall(
  *
  * @param Result The type of result produced by the callable
  * @property callable The callable function being mocked
- * @property builder The instance of [MockLLMBuilder] used to construct the mock
+ * @property builder The instance of [MockExecutorDSLBuilder] used to construct the mock
  */
 public class MockToolFromCallableReceiver<Result>(
     internal val callable: KFunction<Result>,
-    internal val builder: MockLLMBuilder
+    internal val builder: MockExecutorDSLBuilder
 ) {
 
     /**
@@ -49,12 +48,12 @@ public class MockToolFromCallableReceiver<Result>(
      *
      * @param callable The callable (function or method) that the mock tool corresponds to.
      * @param action The action to execute when the mock tool is invoked.
-     * @param builder The [MockLLMBuilder] used to configure and manage the mock tool's behavior.
+     * @param builder The [MockExecutorDSLBuilder] used to configure and manage the mock tool's behavior.
      */
     public class MockToolFromCallableResponseBuilder<Result>(
         internal val callable: KFunction<Result>,
         private val action: suspend () -> Result,
-        private val builder: MockLLMBuilder
+        private val builder: MockExecutorDSLBuilder
     ) {
         /**
          * Configures the mock tool to respond when it is called with the specified arguments.
@@ -67,19 +66,19 @@ public class MockToolFromCallableReceiver<Result>(
 
             builder.addToolAction(
                 callable.asTool(),
-                { it == ToolFromCallable.VarArgs(argsMap) }
-            ) { buildResult(action(), callable) }
+                { it == ToolFromCallable.Args(argsMap) }
+            ) { action() }
         }
 
         /**
          * Configures a mock behavior for the associated callable to be triggered when the supplied condition
          * is satisfied based on the provided arguments.
          *
-         * @param condition A suspendable condition function that takes an instance of [ToolFromCallable.VarArgs]
+         * @param condition A suspendable condition function that takes an instance of [ToolFromCallable.Args]
          * and evaluates to `true` if the action should be executed for the given arguments.
          */
-        public fun onArgumentsMatching(condition: suspend (ToolFromCallable.VarArgs) -> Boolean) {
-            builder.addToolAction(callable.asTool(), condition) { buildResult(action(), callable) }
+        public fun onArgumentsMatching(condition: suspend (ToolFromCallable.Args) -> Boolean) {
+            builder.addToolAction(callable.asTool(), condition) { action() }
         }
     }
 
@@ -90,7 +89,7 @@ public class MockToolFromCallableReceiver<Result>(
      */
     public infix fun alwaysReturns(response: Result) {
         builder.addToolAction(callable.asTool()) {
-            buildResult(response, callable)
+            response
         }
     }
 
@@ -101,7 +100,7 @@ public class MockToolFromCallableReceiver<Result>(
      */
     public infix fun alwaysDoes(action: suspend () -> Result) {
         builder.addToolAction(callable.asTool()) {
-            buildResult(action(), callable)
+            action()
         }
     }
 
@@ -130,20 +129,6 @@ public class MockToolFromCallableReceiver<Result>(
  * @param tool The function to be used as the tool in the mock setup.
  * @return A MockToolFromCallableReceiver instance configured with the provided tool function and the current MockLLMBuilder.
  */
-public infix fun <Result> MockLLMBuilder.mockTool(tool: KFunction<Result>): MockToolFromCallableReceiver<Result> {
+public infix fun <Result> MockExecutorDSLBuilder.mockTool(tool: KFunction<Result>): MockToolFromCallableReceiver<Result> {
     return MockToolFromCallableReceiver(tool, this)
 }
-
-/**
- * Builds a result object containing the response from the callable, its return type, and a JSON serializer.
- *
- * @param response The result produced by invoking the callable.
- * @param callable The callable whose metadata (such as return type) is used in constructing the result object.
- * @return A [ToolFromCallable.Result] instance encapsulating the callable's result, its return type, and a JSON serializer.
- */
-private fun <Result> buildResult(response: Result, callable: KFunction<Result>): ToolFromCallable.Result =
-    ToolFromCallable.Result(
-        result = response,
-        type = callable.returnType,
-        json = Json
-    )

--- a/agents/agents-test/src/jvmMain/kotlin/ai/koog/agents/testing/tools/MockExecutorDSLBuilder.jvm.kt
+++ b/agents/agents-test/src/jvmMain/kotlin/ai/koog/agents/testing/tools/MockExecutorDSLBuilder.jvm.kt
@@ -2,7 +2,8 @@ package ai.koog.agents.testing.tools
 
 import ai.koog.agents.core.tools.reflect.ToolFromCallable
 import ai.koog.agents.core.tools.reflect.asTool
-import ai.koog.agents.testing.tools.MockExecutorDSLBuilder.ToolCallReceiver
+import ai.koog.agents.testing.tools.MockLLMBuilder.ToolCallReceiver
+import kotlinx.serialization.json.Json
 import kotlin.reflect.KFunction
 
 /**
@@ -12,11 +13,12 @@ import kotlin.reflect.KFunction
  * @param args The arguments to be passed to the tool function.
  * @return A `ToolCallReceiver` instance configured with the tool and its arguments.
  */
-public fun MockExecutorDSLBuilder.mockLLMToolCall(
+@Suppress("UnusedReceiverParameter")
+public fun MockLLMBuilder.mockLLMToolCall(
     tool: KFunction<*>,
     vararg args: Any?,
     toolCallId: String? = null
-): ToolCallReceiver<ToolFromCallable.Args> {
+): ToolCallReceiver<ToolFromCallable.VarArgs> {
     val params = tool.parameters
 
     val argsMap = (params zip args).associate { (param, arg) ->
@@ -25,9 +27,8 @@ public fun MockExecutorDSLBuilder.mockLLMToolCall(
 
     return ToolCallReceiver(
         tool = tool.asTool(),
-        args = ToolFromCallable.Args(argsMap),
+        args = ToolFromCallable.VarArgs(argsMap),
         toolCallId = toolCallId,
-        builder = this
     )
 }
 
@@ -36,11 +37,11 @@ public fun MockExecutorDSLBuilder.mockLLMToolCall(
  *
  * @param Result The type of result produced by the callable
  * @property callable The callable function being mocked
- * @property builder The instance of [MockExecutorDSLBuilder] used to construct the mock
+ * @property builder The instance of [MockLLMBuilder] used to construct the mock
  */
 public class MockToolFromCallableReceiver<Result>(
     internal val callable: KFunction<Result>,
-    internal val builder: MockExecutorDSLBuilder
+    internal val builder: MockLLMBuilder
 ) {
 
     /**
@@ -48,12 +49,12 @@ public class MockToolFromCallableReceiver<Result>(
      *
      * @param callable The callable (function or method) that the mock tool corresponds to.
      * @param action The action to execute when the mock tool is invoked.
-     * @param builder The [MockExecutorDSLBuilder] used to configure and manage the mock tool's behavior.
+     * @param builder The [MockLLMBuilder] used to configure and manage the mock tool's behavior.
      */
     public class MockToolFromCallableResponseBuilder<Result>(
         internal val callable: KFunction<Result>,
         private val action: suspend () -> Result,
-        private val builder: MockExecutorDSLBuilder
+        private val builder: MockLLMBuilder
     ) {
         /**
          * Configures the mock tool to respond when it is called with the specified arguments.
@@ -66,19 +67,19 @@ public class MockToolFromCallableReceiver<Result>(
 
             builder.addToolAction(
                 callable.asTool(),
-                { it == ToolFromCallable.Args(argsMap) }
-            ) { action() }
+                { it == ToolFromCallable.VarArgs(argsMap) }
+            ) { buildResult(action(), callable) }
         }
 
         /**
          * Configures a mock behavior for the associated callable to be triggered when the supplied condition
          * is satisfied based on the provided arguments.
          *
-         * @param condition A suspendable condition function that takes an instance of [ToolFromCallable.Args]
+         * @param condition A suspendable condition function that takes an instance of [ToolFromCallable.VarArgs]
          * and evaluates to `true` if the action should be executed for the given arguments.
          */
-        public fun onArgumentsMatching(condition: suspend (ToolFromCallable.Args) -> Boolean) {
-            builder.addToolAction(callable.asTool(), condition) { action() }
+        public fun onArgumentsMatching(condition: suspend (ToolFromCallable.VarArgs) -> Boolean) {
+            builder.addToolAction(callable.asTool(), condition) { buildResult(action(), callable) }
         }
     }
 
@@ -89,7 +90,7 @@ public class MockToolFromCallableReceiver<Result>(
      */
     public infix fun alwaysReturns(response: Result) {
         builder.addToolAction(callable.asTool()) {
-            response
+            buildResult(response, callable)
         }
     }
 
@@ -100,7 +101,7 @@ public class MockToolFromCallableReceiver<Result>(
      */
     public infix fun alwaysDoes(action: suspend () -> Result) {
         builder.addToolAction(callable.asTool()) {
-            action()
+            buildResult(action(), callable)
         }
     }
 
@@ -129,6 +130,20 @@ public class MockToolFromCallableReceiver<Result>(
  * @param tool The function to be used as the tool in the mock setup.
  * @return A MockToolFromCallableReceiver instance configured with the provided tool function and the current MockLLMBuilder.
  */
-public infix fun <Result> MockExecutorDSLBuilder.mockTool(tool: KFunction<Result>): MockToolFromCallableReceiver<Result> {
+public infix fun <Result> MockLLMBuilder.mockTool(tool: KFunction<Result>): MockToolFromCallableReceiver<Result> {
     return MockToolFromCallableReceiver(tool, this)
 }
+
+/**
+ * Builds a result object containing the response from the callable, its return type, and a JSON serializer.
+ *
+ * @param response The result produced by invoking the callable.
+ * @param callable The callable whose metadata (such as return type) is used in constructing the result object.
+ * @return A [ToolFromCallable.Result] instance encapsulating the callable's result, its return type, and a JSON serializer.
+ */
+private fun <Result> buildResult(response: Result, callable: KFunction<Result>): ToolFromCallable.Result =
+    ToolFromCallable.Result(
+        result = response,
+        type = callable.returnType,
+        json = Json
+    )

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameExt.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameExt.kt
@@ -57,6 +57,7 @@ public fun Message.Response.toStreamFrames(index: Int? = null): List<StreamFrame
  * @return A list of [Message.Response] objects.
  */
 public fun Iterable<StreamFrame>.toMessageResponses(): List<Message.Response> {
+    val textDeltasByIndex = linkedMapOf<Int?, StringBuilder>()
     val textMessagesCompleteFrames = mutableListOf<StreamFrame.TextComplete>()
     val reasoningCompleteFrames = mutableListOf<StreamFrame.ReasoningComplete>()
     val toolCallCompleteFrames = mutableListOf<StreamFrame.ToolCallComplete>()
@@ -64,6 +65,7 @@ public fun Iterable<StreamFrame>.toMessageResponses(): List<Message.Response> {
 
     forEach { frame ->
         when (frame) {
+            is StreamFrame.TextDelta -> textDeltasByIndex.getOrPut(frame.index) { StringBuilder() }.append(frame.text)
             is StreamFrame.TextComplete -> textMessagesCompleteFrames.add(frame)
             is StreamFrame.ReasoningComplete -> reasoningCompleteFrames.add(frame)
             is StreamFrame.ToolCallComplete -> toolCallCompleteFrames.add(frame)
@@ -71,6 +73,13 @@ public fun Iterable<StreamFrame>.toMessageResponses(): List<Message.Response> {
             else -> {}
         }
     }
+
+    val completeTextIndexes = textMessagesCompleteFrames.mapTo(mutableSetOf()) { it.index }
+    val synthesizedTextMessages = textDeltasByIndex
+        .filterKeys { it !in completeTextIndexes }
+        .values
+        .map(StringBuilder::toString)
+        .filter(String::isNotEmpty)
 
     return buildList {
         reasoningCompleteFrames.forEach {
@@ -80,6 +89,15 @@ public fun Iterable<StreamFrame>.toMessageResponses(): List<Message.Response> {
                     parts = it.text.map { textPart -> ContentPart.Text(textPart) },
                     summary = it.summary?.map { summaryPart -> ContentPart.Text(summaryPart) },
                     encrypted = it.encrypted,
+                    metaInfo = end?.metaInfo ?: ResponseMetaInfo.Empty
+                )
+            )
+        }
+        synthesizedTextMessages.forEach {
+            add(
+                Message.Assistant(
+                    content = it,
+                    finishReason = end?.finishReason,
                     metaInfo = end?.metaInfo ?: ResponseMetaInfo.Empty
                 )
             )

--- a/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameExtTest.kt
+++ b/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameExtTest.kt
@@ -335,6 +335,28 @@ internal class StreamFrameExtTest {
     }
 
     @Test
+    fun testToMessageResponsesBuildsAssistantFromTextDeltasOnly() {
+        val frames = listOf(
+            StreamFrame.TextDelta("Hello"),
+            StreamFrame.TextDelta(", World"),
+            StreamFrame.End("stop", ResponseMetaInfo.Empty)
+        )
+
+        val messages = frames.toMessageResponses()
+
+        assertEquals(
+            listOf(
+                Message.Assistant(
+                    parts = listOf(ContentPart.Text("Hello, World")),
+                    finishReason = "stop",
+                    metaInfo = ResponseMetaInfo.Empty
+                )
+            ),
+            messages
+        )
+    }
+
+    @Test
     fun testToMessageResponsesWithEmptyFrames() {
         val frames = emptyList<StreamFrame>()
 


### PR DESCRIPTION
- Refactored `MockLLMBuilder`, extracted common sealed receiver interface `MockReceiver` to simplify the api.
- Added `mockLLMStream` receiver type for mocking a flow of `StreamFrame` objects.

## Motivation and Context
Previously it was not possible to mock streams, now it is. I have also refactored the `MockLLMBuilder`, extracting common logic for configuring receivers (though much more work can be done here still).

## Breaking Changes
No breaking changes. 

---

#### Type of the changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Tests improvement
- [x] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed