### PR TITLE
Fix streaming chat execution for Ollama

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/build.gradle.kts
@@ -64,6 +64,7 @@ kotlin {
             dependencies {
                 implementation(project(":test-utils"))
                 implementation(project(":agents:agents-features:agents-features-event-handler"))
+                implementation(libs.ktor.client.mock)
             }
         }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -43,6 +43,7 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.get
 import io.ktor.client.request.post
+import io.ktor.client.request.preparePost
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsChannel
 import io.ktor.http.ContentType
@@ -245,31 +246,31 @@ public class OllamaClient(
             )
         )
 
-        val response = client.post(DEFAULT_MESSAGE_PATH) {
+        client.preparePost(DEFAULT_MESSAGE_PATH) {
             setBody(request)
-        }
+        }.execute { response ->
+            val channel = response.bodyAsChannel()
 
-        val channel = response.bodyAsChannel()
+            while (!channel.isClosedForRead) {
+                val line = channel.readUTF8Line() ?: break
+                if (line.isBlank()) continue
 
-        while (!channel.isClosedForRead) {
-            val line = channel.readUTF8Line() ?: break
-            if (line.isBlank()) continue
-
-            try {
-                val chunk = ollamaJson.decodeFromString<OllamaChatResponseDTO>(line)
-                chunk.message?.let { message ->
-                    emitAppend(message.content)
-                    message.toolCalls?.forEach { toolCall ->
-                        emitToolCall(
-                            id = null,
-                            name = toolCall.function.name,
-                            content = toolCall.function.arguments.toString()
-                        )
+                try {
+                    val chunk = ollamaJson.decodeFromString<OllamaChatResponseDTO>(line)
+                    chunk.message?.let { message ->
+                        emitAppend(message.content)
+                        message.toolCalls?.forEach { toolCall ->
+                            emitToolCall(
+                                id = null,
+                                name = toolCall.function.name,
+                                content = toolCall.function.arguments.toString()
+                            )
+                        }
                     }
+                } catch (_: Exception) {
+                    // Skip malformed JSON lines
+                    continue
                 }
-            } catch (_: Exception) {
-                // Skip malformed JSON lines
-                continue
             }
         }
     }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClientExecuteStreamingTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClientExecuteStreamingTest.kt
@@ -1,0 +1,121 @@
+package ai.koog.prompt.executor.ollama.client
+
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.llm.OllamaModels
+import ai.koog.prompt.params.LLMParams
+import ai.koog.prompt.streaming.StreamFrame
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteChannel
+import io.ktor.utils.io.writeStringUtf8
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+class OllamaClientExecuteStreamingTest {
+
+    private companion object {
+
+        const val TEST_PROMPT_ID = "test_id"
+        const val TEST_USER_MESSAGE = "Hello World!"
+
+        const val START_PART_STREAMING_RESPONSE =
+            "{\"model\":\"llama3.2:4b\"," +
+                "\"created_at\":\"2025-09-25T18:06:14.69926367Z\"," +
+                "\"message\":{\"role\":\"assistant\",\"content\":\"Hello\"}," +
+                "\"done\":false}"
+
+        const val SECOND_PART_STREAMING_RESPONSE =
+            "{\"model\":\"llama3.2:4b\"," +
+                "\"created_at\":\"2025-09-25T18:06:14.707835046Z\"," +
+                "\"message\":{\"role\":\"assistant\",\"content\":\" Koog!\"}," +
+                "\"done\":false}"
+
+        const val FINISH_PART_STREAMING_RESPONSE =
+            "{\"model\":\"llama3.2:4b\"," +
+                "\"created_at\":\"2025-09-25T18:06:18.076319558Z\"," +
+                "\"message\":{\"role\":\"assistant\",\"content\":\"\"}," +
+                "\"done\":true," +
+                "\"done_reason\":\"stop\"," +
+                "\"total_duration\":11904140967," +
+                "\"load_duration\":82197934," +
+                "\"prompt_eval_count\":71," +
+                "\"prompt_eval_duration\":55799582," +
+                "\"eval_count\":1400," +
+                "\"eval_duration\":11765729971}"
+    }
+
+    private fun createStreamingResponseChunks(): List<String> {
+        return listOf(
+            START_PART_STREAMING_RESPONSE,
+            SECOND_PART_STREAMING_RESPONSE,
+            FINISH_PART_STREAMING_RESPONSE
+        )
+    }
+
+    private fun createExpectedResponseChunks(): List<StreamFrame> {
+        return listOf(
+            StreamFrame.Append("Hello"),
+            StreamFrame.Append(" Koog!"),
+            StreamFrame.Append(""),
+        )
+    }
+
+    @Test
+    fun `GIVEN OllamaClient WHEN executeStreaming is invoked THEN chek that all chunks are received`() =
+        runTest(timeout = 30.seconds) {
+            val signalChannel = Channel<Unit>(Channel.RENDEZVOUS)
+
+            val mockEngine = MockEngine {
+                val responseChannel = ByteChannel(autoFlush = true)
+
+                launch {
+                    createStreamingResponseChunks().forEach { chunk ->
+                        responseChannel.writeStringUtf8("$chunk\n")
+                        signalChannel.receive()
+                    }
+                    responseChannel.close()
+                }
+
+                respond(
+                    content = responseChannel,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(
+                        name = HttpHeaders.ContentType,
+                        value = ContentType.Application.Json.toString()
+                    )
+                )
+            }
+
+            val client = OllamaClient(baseClient = HttpClient(mockEngine))
+
+            val result = client.executeStreaming(
+                prompt = prompt(
+                    id = TEST_PROMPT_ID,
+                    params = LLMParams()
+                ) { user(content = TEST_USER_MESSAGE) },
+                model = OllamaModels.Meta.LLAMA_3_2
+            ).onEach { _ ->
+                // Client received a frame, signal the server to send the next one.
+                signalChannel.send(Unit)
+            }.catch { error ->
+                // close channel to avoid freezing the test
+                signalChannel.close()
+                throw error
+            }.toList()
+
+            signalChannel.close()
+            assertEquals(createExpectedResponseChunks(), result)
+        }
+}


### PR DESCRIPTION

## Motivation and Context
### Problem:
The executeStreaming method in OllamaClient does not function as expected. It incorrectly waits for the full API response before returning, defeating the purpose of a streaming call. This is caused by the underlying Ktor post call, which resolves to the non-streaming fetchResponse method.

### Solution:
This pull request modifies the implementation to use preparePost().execute() instead of the direct .post() method. This pattern ensures that Ktor's fetchStreamingResponse is called, enabling true, asynchronous streaming of the response.
## Breaking Changes
There isn't any broken changes.

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [x] The change was discussed and approved in the issue
- [x] Docs have been added / updated
