### PR TITLE
Revive and parallelize integration tests

### DIFF
--- a/.github/workflows/heavy-tests.yml
+++ b/.github/workflows/heavy-tests.yml
@@ -32,9 +32,17 @@ jobs:
             test-group: "ai.koog.integration.tests.agent.*"
             artifact-name: "agent-tests"
             os: ubuntu-latest
-          - job-name: "executor-tests"
-            test-group: "ai.koog.integration.tests.executor.*"
-            artifact-name: "executor-tests"
+          - job-name: "single-llm-executor-tests"
+            test-group: "ai.koog.integration.tests.executor.SingleLLMPromptExecutorIntegrationTest"
+            artifact-name: "single-llm-executor-tests"
+            os: ubuntu-latest
+          - job-name: "multiple-llm-executor-tests"
+            test-group: "ai.koog.integration.tests.executor.MultipleLLMPromptExecutorIntegrationTest"
+            artifact-name: "multiple-llm-executor-tests"
+            os: ubuntu-latest
+          - job-name: "other-executor-tests"
+            test-group: "ai.koog.integration.tests.executor.* --exclude-tests ai.koog.integration.tests.executor.SingleLLMPromptExecutorIntegrationTest --exclude-tests ai.koog.integration.tests.executor.MultipleLLMPromptExecutorIntegrationTest --exclude-tests ai.koog.integration.tests.executor.OllamaExecutorIntegrationTest"
+            artifact-name: "other-executor-tests"
             os: ubuntu-latest
           - job-name: "capabilities-tests"
             test-group: "ai.koog.integration.tests.capabilities.*"

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/DummyAIAgentContext.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/DummyAIAgentContext.kt
@@ -17,6 +17,8 @@ import ai.koog.agents.core.feature.AIAgentGraphPipeline
 import ai.koog.prompt.message.Message
 import org.jetbrains.annotations.TestOnly
 import kotlin.reflect.KType
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 /**
  * A mock implementation of the [AIAgentContext] interface, used for testing purposes.
@@ -388,7 +390,8 @@ public class AIAgentContextMockBuilder() : AIAgentContextMockBuilderBase {
      *
      * The `runId` can be null, indicating that the session has not been associated with an identifier.
      */
-    override var runId: String? = "test-run-id-default"
+    @OptIn(ExperimentalUuidApi::class)
+    override var runId: String? = "test-run-id-${Uuid.random()}"
 
     /**
      * Represents the identifier for the strategy to be used in the agent context.

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
@@ -603,9 +603,8 @@ class AIAgentIntegrationTest {
                 parallelToolCalls.isEmpty(),
                 "There should be no parallel tool calls in a Sequential single run scenario"
             )
-            assertEquals(
-                2,
-                singleToolCalls.size,
+            assertTrue(
+                singleToolCalls.isNotEmpty(),
                 "There should be exactly 2 single tool calls in a Sequential single run scenario"
             )
             assertEquals(

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
@@ -352,10 +352,9 @@ class AIAgentIntegrationTest {
                 getSingleRunAgentWithRunMode(model, runMode, eventHandlerConfig = eventHandlerConfig)
             multiToolAgent.run(twoToolsPrompt)
 
-            assertEquals(
-                2,
-                parallelToolCalls.size,
-                "There should be exactly 2 tool calls in a Multiple tool calls scenario"
+            assertTrue(
+                parallelToolCalls.size >= 2,
+                "There should be at least 2 tool calls in a Multiple tool calls scenario"
             )
             assertTrue(
                 singleToolCalls.isEmpty(),

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
@@ -1025,8 +1025,7 @@ class AIAgentIntegrationTest {
 
         agent.run(testInput)
 
-        // Verify that a checkpoint was created and saved to the file system
-        val checkpoints = fileStorageProvider.getCheckpoints()
+        val checkpoints = fileStorageProvider.getCheckpoints().filter { it.nodeId != "tombstone" }
         assertTrue(checkpoints.isNotEmpty(), noCheckpointsError)
         assertEquals(bye, checkpoints.first().nodeId, incorrectNodeIdError)
     }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
@@ -87,6 +87,8 @@ internal class ReportingLLMLLMClient(
             val tools: List<String>,
             val model: LLModel
         ) : Event
+
+        data object Termination : Event
     }
 
     override suspend fun execute(
@@ -576,12 +578,17 @@ class AIAgentMultipleLLMIntegrationTest {
         Models.assumeAvailable(LLMProvider.OpenAI)
         Models.assumeAvailable(LLMProvider.Anthropic)
 
-        val eventsChannel = Channel<Event>(Channel.UNLIMITED)
         val fs = MockFileSystem()
+        val eventsChannel = Channel<Event>(Channel.UNLIMITED)
+        val eventHandlerConfig: EventHandlerConfig.() -> Unit = {
+            onAgentFinished { _ ->
+                eventsChannel.send(Event.Termination)
+            }
+        }
 
         val agent = createTestMultiLLMAgent(
             fs,
-            { },
+            eventHandlerConfig,
             maxAgentIterations = 42,
             eventsChannel = eventsChannel,
         )

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
@@ -527,7 +527,8 @@ class AIAgentMultipleLLMIntegrationTest {
         val anthropicClient = AnthropicLLMClient(anthropicApiKey)
 
         val executor = MultiLLMPromptExecutor(
-            LLMProvider.OpenAI to openAIClient, LLMProvider.Anthropic to anthropicClient
+            LLMProvider.OpenAI to openAIClient,
+            LLMProvider.Anthropic to anthropicClient
         )
 
         val subgraphTools = listOf(
@@ -563,11 +564,16 @@ class AIAgentMultipleLLMIntegrationTest {
         }
 
         return AIAgent(
-            promptExecutor = executor, strategy = strategy, agentConfig = AIAgentConfig(
+            promptExecutor = executor,
+            strategy = strategy,
+            agentConfig = AIAgentConfig(
                 prompt = prompt("test") {
                     system("You are a helpful assistant.")
-                }, model, maxAgentIterations = 20
-            ), toolRegistry = toolRegistry
+                },
+                model,
+                maxAgentIterations = 20,
+            ),
+            toolRegistry = toolRegistry,
         ) {
             install(EventHandler, eventHandlerConfig)
         }
@@ -683,7 +689,8 @@ class AIAgentMultipleLLMIntegrationTest {
             assertTrue(result.isNotEmpty(), "Agent result should not be empty")
 
             assertTrue(
-                fs.fileCount() > 0, "Agent must have created at least one file using subgraph tools"
+                fs.fileCount() > 0,
+                "Agent must have created at least one file using subgraph tools"
             )
 
             when (val readResult = fs.read("test.txt")) {
@@ -700,7 +707,8 @@ class AIAgentMultipleLLMIntegrationTest {
             }
 
             assertTrue(
-                calledTools.any { it == "create_file" }, "At least one LLM call must have tools available"
+                calledTools.any { it == "create_file" },
+                "At least one LLM call must have tools available"
             )
         }
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
@@ -19,13 +19,14 @@ import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.ToolResult
+import ai.koog.agents.ext.agent.ProvideStringSubgraphResult
+import ai.koog.agents.ext.agent.StringSubgraphResult
+import ai.koog.agents.ext.agent.subgraphWithTask
 import ai.koog.agents.features.eventHandler.feature.EventHandler
 import ai.koog.agents.features.eventHandler.feature.EventHandlerConfig
-import ai.koog.agents.features.tracing.feature.Tracing
 import ai.koog.integration.tests.agent.ReportingLLMLLMClient.Event
 import ai.koog.integration.tests.utils.Models
 import ai.koog.integration.tests.utils.RetryUtils.withRetry
-import ai.koog.integration.tests.utils.TestLogPrinter
 import ai.koog.integration.tests.utils.TestUtils.readTestAnthropicKeyFromEnv
 import ai.koog.integration.tests.utils.TestUtils.readTestOpenAIKeyFromEnv
 import ai.koog.prompt.dsl.ModerationResult
@@ -71,6 +72,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlin.time.Duration.Companion.seconds
 
 internal class ReportingLLMLLMClient(
@@ -85,8 +87,6 @@ internal class ReportingLLMLLMClient(
             val tools: List<String>,
             val model: LLModel
         ) : Event
-
-        data object Termination : Event
     }
 
     override suspend fun execute(
@@ -145,6 +145,12 @@ class AIAgentMultipleLLMIntegrationTest {
 
     companion object {
         private lateinit var testResourcesDir: File
+
+        @JvmStatic
+        fun getModels(): Stream<LLModel> = Stream.of(
+            AnthropicModels.Sonnet_3_7,
+            OpenAIModels.Chat.GPT4o,
+        )
 
         @JvmStatic
         @BeforeAll
@@ -505,10 +511,62 @@ class AIAgentMultipleLLMIntegrationTest {
             agentConfig = AIAgentConfig(prompt, OpenAIModels.Chat.GPT4o, maxAgentIterations),
             toolRegistry = tools,
         ) {
-            install(Tracing) {
-                addMessageProcessor(TestLogPrinter())
+            install(EventHandler, eventHandlerConfig)
+        }
+    }
+
+    private fun createTestAgentWithToolsInSubgraph(
+        fs: MockFileSystem,
+        eventHandlerConfig: EventHandlerConfig.() -> Unit = {},
+        model: LLModel,
+        emptyAgentRegistry: Boolean = true,
+    ): AIAgent<String, String> {
+        val openAIClient = OpenAILLMClient(openAIApiKey)
+        val anthropicClient = AnthropicLLMClient(anthropicApiKey)
+
+        val executor = MultiLLMPromptExecutor(
+            LLMProvider.OpenAI to openAIClient, LLMProvider.Anthropic to anthropicClient
+        )
+
+        val subgraphTools = listOf(
+            CreateFile(fs),
+            ReadFile(fs),
+            ListFiles(fs),
+            DeleteFile(fs),
+        )
+
+        val strategy = strategy<String, String>("test-subgraph-only-tools") {
+            val fileOperationsSubgraph by subgraphWithTask<String>(
+                tools = subgraphTools,
+                llmModel = model,
+                llmParams = LLMParams(toolChoice = LLMParams.ToolChoice.Required)
+            ) { input ->
+                "You are a helpful assistant that can perform file operations. Use the available tools to complete the following task: $input. Make sure to use tools when needed and provide clear feedback about what you've done."
             }
 
+            val extractResult by node<StringSubgraphResult, String> { subgraphResult ->
+                subgraphResult.result
+            }
+
+            nodeStart then fileOperationsSubgraph then extractResult then nodeFinish
+        }
+
+        val toolRegistry = if (emptyAgentRegistry) {
+            ToolRegistry {}
+        } else {
+            ToolRegistry {
+                subgraphTools.forEach { tool(it) }
+                tool(ProvideStringSubgraphResult)
+            }
+        }
+
+        return AIAgent(
+            promptExecutor = executor, strategy = strategy, agentConfig = AIAgentConfig(
+                prompt = prompt("test") {
+                    system("You are a helpful assistant.")
+                }, model, maxAgentIterations = 20
+            ), toolRegistry = toolRegistry
+        ) {
             install(EventHandler, eventHandlerConfig)
         }
     }
@@ -517,25 +575,13 @@ class AIAgentMultipleLLMIntegrationTest {
     fun integration_testOpenAIAnthropicAgent() = runTest(timeout = 600.seconds) {
         Models.assumeAvailable(LLMProvider.OpenAI)
         Models.assumeAvailable(LLMProvider.Anthropic)
-        // Create the clients
+
         val eventsChannel = Channel<Event>(Channel.UNLIMITED)
         val fs = MockFileSystem()
-        val eventHandlerConfig: EventHandlerConfig.() -> Unit = {
-            onToolCall { eventContext ->
-                println(
-                    "Calling tool ${eventContext.tool.name} with arguments ${
-                        eventContext.toolArgs.toString().lines().first().take(100)
-                    }"
-                )
-            }
 
-            onAgentFinished { eventContext ->
-                eventsChannel.send(Event.Termination)
-            }
-        }
         val agent = createTestMultiLLMAgent(
             fs,
-            eventHandlerConfig,
+            { },
             maxAgentIterations = 42,
             eventsChannel = eventsChannel,
         )
@@ -585,31 +631,83 @@ class AIAgentMultipleLLMIntegrationTest {
         )
     }
 
+    @ParameterizedTest
+    @MethodSource("getModels")
+    fun `integration_test agent with not registered subgraph tool result fails`(model: LLModel) =
+        runTest(timeout = 600.seconds) {
+            Models.assumeAvailable(LLMProvider.OpenAI)
+            Models.assumeAvailable(LLMProvider.Anthropic)
+
+            val fs = MockFileSystem()
+            val agent = createTestAgentWithToolsInSubgraph(fs = fs, model = model)
+
+            try {
+                val result = agent.run(
+                    "Create a simple file called 'test.txt' with content 'Hello from subgraph tools!' and then read it back to verify it was created correctly."
+                )
+                fail("Expected AIAgentException but got result: $result")
+            } catch (e: IllegalArgumentException) {
+                assertContains(e.message ?: "", "Tool \"create_file\" is not defined")
+            }
+        }
+
+    @ParameterizedTest
+    @MethodSource("getModels")
+    fun `integration_test agent with registered subgraph tool result runs`(model: LLModel) =
+        runTest(timeout = 600.seconds) {
+            Models.assumeAvailable(LLMProvider.OpenAI)
+            Models.assumeAvailable(LLMProvider.Anthropic)
+
+            val fs = MockFileSystem()
+            val calledTools = mutableListOf<String>()
+            val eventHandlerConfig: EventHandlerConfig.() -> Unit = {
+                onToolCall { eventContext ->
+                    calledTools.add(eventContext.tool.name)
+                }
+            }
+
+            val agent = createTestAgentWithToolsInSubgraph(fs, eventHandlerConfig, model, false)
+
+            val result = agent.run(
+                "Create a simple file called 'test.txt' with content 'Hello from subgraph tools!' and then read it back to verify it was created correctly."
+            )
+
+            assertNotNull(result)
+            assertTrue(result.isNotEmpty(), "Agent result should not be empty")
+
+            assertTrue(
+                fs.fileCount() > 0, "Agent must have created at least one file using subgraph tools"
+            )
+
+            when (val readResult = fs.read("test.txt")) {
+                is OperationResult.Success -> {
+                    assertTrue(
+                        readResult.result.contains("Hello from subgraph tools!"),
+                        "File should contain the expected content"
+                    )
+                }
+
+                is OperationResult.Failure -> {
+                    fail("Failed to read file: ${readResult.error}")
+                }
+            }
+
+            assertTrue(
+                calledTools.any { it == "create_file" }, "At least one LLM call must have tools available"
+            )
+        }
+
     @Test
     fun integration_testTerminationOnIterationsLimitExhaustion() = runTest(timeout = 600.seconds) {
         Models.assumeAvailable(LLMProvider.OpenAI)
         Models.assumeAvailable(LLMProvider.Anthropic)
 
-        val eventsChannel = Channel<Event>(Channel.UNLIMITED)
         val fs = MockFileSystem()
         var errorMessage: String? = null
-        val eventHandlerConfig: EventHandlerConfig.() -> Unit = {
-            onToolCall { eventContext ->
-                println(
-                    "Calling tool ${eventContext.tool.name} with arguments ${
-                        eventContext.toolArgs.toString().lines().first().take(100)
-                    }"
-                )
-            }
-
-            onAgentFinished { eventContext ->
-                eventsChannel.send(Event.Termination)
-            }
-        }
         val steps = 10
         val agent = createTestMultiLLMAgent(
             fs,
-            eventHandlerConfig,
+            { },
             maxAgentIterations = steps,
         )
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/RetryUtils.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/RetryUtils.kt
@@ -13,6 +13,7 @@ object RetryUtils {
     private const val GOOGLE_500_ERROR = "Error from GoogleAI API: 500 Internal Server Error"
     private const val GOOGLE_503_ERROR = "Error from GoogleAI API: 503 Service Unavailable"
     private const val ANTHROPIC_429_ERROR = "Error from Anthropic API: 429 Too Many Requests"
+    private const val ANTHROPIC_500_ERROR = "Error from Anthropic API: 500 Internal Server Error"
     private const val ANTHROPIC_502_ERROR = "Error from Anthropic API: 502 Bad Gateway"
     private const val ANTHROPIC_529_ERROR = "Error from Anthropic API: 529"
     private const val OPENAI_500_ERROR = "Error from OpenAI API: 500 Internal Server Error"
@@ -25,6 +26,7 @@ object RetryUtils {
             GOOGLE_500_ERROR,
             GOOGLE_503_ERROR,
             ANTHROPIC_429_ERROR,
+            ANTHROPIC_500_ERROR,
             ANTHROPIC_502_ERROR,
             ANTHROPIC_529_ERROR,
             OPENAI_500_ERROR,

--- a/integration-tests/src/jvmTest/resources/simplelogger.properties
+++ b/integration-tests/src/jvmTest/resources/simplelogger.properties
@@ -1,9 +1,18 @@
 # Level of logging for the ROOT logger: ERROR, WARN, INFO, DEBUG, TRACE (default is INFO)
-org.slf4j.simpleLogger.defaultLogLevel=DEBUG
+org.slf4j.simpleLogger.defaultLogLevel=INFO
 
 # Log level for specific packages or classes (optional)
-org.slf4j.simpleLogger.log.ai.koog=TRACE
+org.slf4j.simpleLogger.log.ai.koog=INFO
+org.slf4j.simpleLogger.log.ai.koog.prompt=WARN
+org.slf4j.simpleLogger.log.ai.koog.prompt.executor=WARN
+org.slf4j.simpleLogger.log.ai.koog.integration.tests=INFO
 org.slf4j.simpleLogger.log.org.apache.hc=INFO
+org.slf4j.simpleLogger.log.io.ktor=WARN
+org.slf4j.simpleLogger.log.io.ktor.client.HttpClient=WARN
+org.slf4j.simpleLogger.log.io.ktor.client.plugins.HttpRequestTimeoutException=WARN
+org.slf4j.simpleLogger.log.org.apache.http=WARN
+org.slf4j.simpleLogger.log.httpclient=WARN
+org.slf4j.simpleLogger.log.org.apache.http.wire=ERROR
 
 # Whether to display the thread name in log messages (true/false)
 org.slf4j.simpleLogger.showThreadName=true

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/DataModel.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/DataModel.kt
@@ -1,5 +1,8 @@
 package ai.koog.prompt.executor.clients.google
 
+import ai.koog.prompt.executor.clients.google.GoogleFunctionCallingMode.ANY
+import ai.koog.prompt.executor.clients.google.GoogleFunctionCallingMode.AUTO
+import ai.koog.prompt.executor.clients.google.GoogleFunctionCallingMode.NONE
 import ai.koog.utils.serializers.ByteArrayAsBase64Serializer
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerialName
@@ -391,11 +394,11 @@ internal class GooglePromptFeedback(
  */
 @Serializable
 internal class GoogleUsageMetadata(
-    val promptTokenCount: Int,
+    val promptTokenCount: Int? = null,
     val candidatesTokenCount: Int? = null,
     val toolUsePromptTokenCount: Int? = null,
     val thoughtsTokenCount: Int? = null,
-    val totalTokenCount: Int,
+    val totalTokenCount: Int? = null,
 )
 
 internal object GooglePartSerializer : JsonContentPolymorphicSerializer<GooglePart>(GooglePart::class) {


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

Please add a brief description of the proposed change here.
Also, please tick the appropriate points in the checklist below.
-->

## Motivation and Context
Some fixes to revive the integration tests.
1. Relax some assertions as the amount of reasoning is not a determined number;
2. Remove an extensive event handler in Agent integration tests where it wasn't used;
3. Parallelize the execution of `executor` test suite;
4. Filter our `tombstone` checkpoints that were causing test failures (now we count only user checkpoints);
5. Add a test for agent with tools in a subgraph only (and for wrapping an error when the tools aren't registered);
6. Add error 500 from Anthropic to the list of 3-rd parties (won't cause test failure anymore);
7. Reduce extensive logging in the tests;
8. Make `promptTokenCount` and `totalTokenCount` nullable for Gemini models (as sometimes they're not returned in the LLM error answers).

## Breaking Changes
❗ `promptTokenCount` and `totalTokenCount` are now nullable for Gemini models (as sometimes they're not returned in the LLM error answers). ❗ 

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tests improvement
- [x] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
