### PR TITLE
Update Slack link and add Koog Slack channel documentation

### DIFF
--- a/docs/docs/koog-slack-channel.md
+++ b/docs/docs/koog-slack-channel.md
@@ -1,0 +1,9 @@
+# Koog on Slack
+
+The Koog Slack channel is part of the Kotlin Slack workspace.
+
+* If you already have an account in the workspace,
+  sign in to [Kotlin Slack](http://kotlinlang.slack.com/) and join the `#koog-agentic-framework` channel.
+* If you don't have an account,
+  open the Slack channel in your [browser](https://slack-chats.kotlinlang.org/c/koog-agentic-framework) or request an invitation by providing your email address on the [Kotlin Slack Sign-up](https://surveys.jetbrains.com/s3/kotlin-slack-sign-up) page.
+

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -198,5 +198,5 @@ copyright: Copyright © 2000-2025 JetBrains s.r.o.
 extra:
   social:
     - icon: fontawesome/brands/slack
-      link: https://kotlinlang.slack.com/messages/koog-agentic-framework/
+      link: https://docs.koog.ai/koog-slack-channel/
       name: Koog on Slack

--- a/docs/overrides/partials/header.html
+++ b/docs/overrides/partials/header.html
@@ -109,7 +109,7 @@
         <!-- custom slack icon-link-->
         <div class="md_header__social">
             <a
-                href="https://kotlinlang.slack.com/messages/koog-agentic-framework/"
+                href="https://docs.koog.ai/koog-slack-channel/"
                 target="_blank"
                 title="Koog on Slack"
                 class="md_social-custom"


### PR DESCRIPTION
Created a page that opens when users click the Slack icon on the documentation website. 
The page explains that the Koog channel is part of the Kotlin Slack workspace and provides instructions for users who already have a Kotlin Slack account and those who don’t.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [ ] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [ ] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
