### PR TITLE
KG-428 Document setVerbose(true) for message visibility in Langfuse

### DIFF
--- a/docs/docs/opentelemetry-langfuse-exporter.md
+++ b/docs/docs/opentelemetry-langfuse-exporter.md
@@ -10,7 +10,7 @@ For background on Koog’s OpenTelemetry support, see the [OpenTelemetry support
 ### Setup instructions
 
 1. Create a Langfuse project. Follow the setup guide at [Create new project in Langfuse](https://langfuse.com/docs/get-started#create-new-project-in-langfuse)
-2. Obtain API credentials. Retrieve your Langfuse `public key` and `secret key` as described in [Where are Langfuse API keys?](https://langfuse.com/faq/all/where-are-langfuse-api-keys)
+2. Get API credentials. Retrieve your Langfuse `public key` and `secret key` as described in [Where are Langfuse API keys?](https://langfuse.com/faq/all/where-are-langfuse-api-keys)
 3. Pass the Langfuse host, private key, and secret key to the Langfuse exporter. 
 This can be done by providing them as parameters to the `addLangfuseExporter()` function, 
 or by setting environment variables as shown below:
@@ -68,7 +68,36 @@ When enabled, the Langfuse exporter captures the same spans as Koog’s general 
 - **Tool calls**: execution traces for tool invocations
 - **System context**: metadata such as model name, environment, Koog version
 
-Koog also captures span attributes required by Langfuse to show [Agent Graphs](https://langfuse.com/docs/observability/features/agent-graphs). 
+Koog also captures span attributes required by Langfuse to show [Agent Graphs](https://langfuse.com/docs/observability/features/agent-graphs).
+
+For security reasons, the content of LLM messages is not propagated to Langfuse by default. 
+To make the content available in Langfuse, use the [setVerbose](opentelemetry-support.md#setverbose) method in the OpenTelemetry configuration and set its `verbose` argument to `true` as follows:
+
+<!--- INCLUDE
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
+import ai.koog.agents.features.opentelemetry.integration.langfuse.addLangfuseExporter
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+
+const val apiKey = ""
+
+val agent = AIAgent(
+    promptExecutor = simpleOpenAIExecutor(apiKey),
+    llmModel = OpenAIModels.Chat.GPT4o,
+    systemPrompt = "You are a helpful assistant."
+) {
+-->
+<!--- SUFFIX
+}
+-->
+```kotlin
+install(OpenTelemetry) {
+    addLangfuseExporter()
+    setVerbose(true)
+}
+```
+<!--- KNIT example-langfuse-exporter-02.kt -->
 
 When visualized in Langfuse, the trace appears as follows:
 ![Langfuse traces](img/opentelemetry-langfuse-exporter-light.png#only-light)

--- a/docs/docs/opentelemetry-langfuse-exporter.md
+++ b/docs/docs/opentelemetry-langfuse-exporter.md
@@ -121,7 +121,7 @@ When enabled, the Langfuse exporter captures the same spans as Koog’s general 
 
 Koog also captures span attributes required by Langfuse to show [Agent Graphs](https://langfuse.com/docs/observability/features/agent-graphs).
 
-For security reasons, the content of LLM messages is not propagated to Langfuse by default. 
+For security reasons, some content of OpenTelemetry spans is masked by default. 
 To make the content available in Langfuse, use the [setVerbose](opentelemetry-support.md#setverbose) method in the OpenTelemetry configuration and set its `verbose` argument to `true` as follows:
 
 <!--- INCLUDE
@@ -148,7 +148,7 @@ install(OpenTelemetry) {
     setVerbose(true)
 }
 ```
-<!--- KNIT example-langfuse-exporter-02.kt -->
+<!--- KNIT example-langfuse-exporter-03.kt -->
 
 When visualized in Langfuse, the trace appears as follows:
 ![Langfuse traces](img/opentelemetry-langfuse-exporter-light.png#only-light)

--- a/docs/docs/opentelemetry-support.md
+++ b/docs/docs/opentelemetry-support.md
@@ -167,6 +167,11 @@ Enables or disables verbose logging for debugging OpenTelemetry configuration. T
 |-----------|-----------|----------|---------------|-----------------------------------------------------------------|
 | `verbose` | `Boolean` | Yes      | `false`       | If true, the application collects more detailed telemetry data. |
 
+!!! note
+
+    When using [Langfuse Exporter](opentelemetry-langfuse-exporter.md), set the value of the `verbose` argument to `true` to see the content of LLM messages in Langfuse. 
+    Otherwise, the message content appears in Langfuse as `HIDDEN:non-empty` for security reasons.
+
 #### setSdk
 
 Injects a pre-configured OpenTelemetrySdk instance.
@@ -174,9 +179,9 @@ Injects a pre-configured OpenTelemetrySdk instance.
 - When you call setSdk(sdk), the provided SDK is used as-is, and any custom configuration applied via addSpanExporter, addSpanProcessor, addResourceAttributes, or setSampler is ignored.
 - The tracer’s instrumentation scope name/version are aligned with your service info.
 
-| Name | Data type         | Required | Description                           |
-|------|-------------------|----------|---------------------------------------|
-| `sdk`| `OpenTelemetrySdk`| Yes      | The SDK instance to use in the agent. |
+| Name  | Data type          | Required | Description                           |
+|-------|--------------------|----------|---------------------------------------|
+| `sdk` | `OpenTelemetrySdk` | Yes      | The SDK instance to use in the agent. |
 
 ### Advanced configuration
 

--- a/docs/docs/opentelemetry-support.md
+++ b/docs/docs/opentelemetry-support.md
@@ -161,7 +161,7 @@ Sets the sampling strategy to control which spans are collected. Takes the follo
 
 #### setVerbose
 
-Enables or disables verbose logging for debugging OpenTelemetry configuration. Takes the following argument:
+Enables or disables verbose logging. Takes the following argument:
 
 | Name      | Data type | Required | Default value | Description                                                     |
 |-----------|-----------|----------|---------------|-----------------------------------------------------------------|
@@ -169,8 +169,7 @@ Enables or disables verbose logging for debugging OpenTelemetry configuration. T
 
 !!! note
 
-    When using [Langfuse Exporter](opentelemetry-langfuse-exporter.md), set the value of the `verbose` argument to `true` to see the content of LLM messages in Langfuse. 
-    Otherwise, the message content appears in Langfuse as `HIDDEN:non-empty` for security reasons.
+    Some content of OpenTelemetry spans is masked by default for security reasons. For example, LLM messages are masked as `HIDDEN:non-empty` instead of the actual message content. To get the content, set the value of the `verbose` argument to `true`.
 
 #### setSdk
 

--- a/docs/docs/opentelemetry-weave-exporter.md
+++ b/docs/docs/opentelemetry-weave-exporter.md
@@ -75,6 +75,35 @@ When enabled, the Weave exporter captures the same spans as Koog’s general Ope
 - **Tool calls**: execution traces for tool invocations
 - **System context**: metadata such as model name, environment, Koog version
 
+For security reasons, some content of OpenTelemetry spans is masked by default.
+To make the content available in Weave, use the [setVerbose](opentelemetry-support.md#setverbose) method in the OpenTelemetry configuration and set its `verbose` argument to `true` as follows:
+
+<!--- INCLUDE
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
+import ai.koog.agents.features.opentelemetry.integration.weave.addWeaveExporter
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+
+const val apiKey = ""
+
+val agent = AIAgent(
+    promptExecutor = simpleOpenAIExecutor(apiKey),
+    llmModel = OpenAIModels.Chat.GPT4o,
+    systemPrompt = "You are a helpful assistant."
+) {
+-->
+<!--- SUFFIX
+}
+-->
+```kotlin
+install(OpenTelemetry) {
+    addWeaveExporter()
+    setVerbose(true)
+}
+```
+<!--- KNIT example-weave-exporter-02.kt -->
+
 When visualized in W&B Weave, the trace appears as follows:
 ![W&B Weave traces](img/opentelemetry-weave-exporter-light.png#only-light)
 ![W&B Weave traces](img/opentelemetry-weave-exporter-dark.png#only-dark)


### PR DESCRIPTION
Added notes that `setVerbose` needs to be set to true when installing/configuring the OpenTelemetry feature if the user wants to see LLM message content in Langfuse. Otherwise, message content shows up as `HIDDEN:non-empty` in Langfuse.

Changes added to the following pages and sections:

https://docs.koog.ai/opentelemetry-support/#setverbose
https://docs.koog.ai/opentelemetry-langfuse-exporter/#what-gets-traced

## Motivation and Context
Based on feedback from users.

## Breaking Changes
None.

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [x] Docs have been added / updated
