### PR TITLE
update: Streamline onBefore and onAfter for Stream and LLCall

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/AIAgentPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/AIAgentPipeline.kt
@@ -32,15 +32,11 @@ import ai.koog.agents.core.feature.handler.strategy.StrategyCompletedHandler
 import ai.koog.agents.core.feature.handler.strategy.StrategyEventHandler
 import ai.koog.agents.core.feature.handler.strategy.StrategyStartingContext
 import ai.koog.agents.core.feature.handler.strategy.StrategyStartingHandler
-import ai.koog.agents.core.feature.handler.streaming.LLMStreamingCompletedContext
-import ai.koog.agents.core.feature.handler.streaming.LLMStreamingCompletedHandler
 import ai.koog.agents.core.feature.handler.streaming.LLMStreamingEventHandler
 import ai.koog.agents.core.feature.handler.streaming.LLMStreamingFailedContext
 import ai.koog.agents.core.feature.handler.streaming.LLMStreamingFailedHandler
 import ai.koog.agents.core.feature.handler.streaming.LLMStreamingFrameReceivedContext
 import ai.koog.agents.core.feature.handler.streaming.LLMStreamingFrameReceivedHandler
-import ai.koog.agents.core.feature.handler.streaming.LLMStreamingStartingContext
-import ai.koog.agents.core.feature.handler.streaming.LLMStreamingStartingHandler
 import ai.koog.agents.core.feature.handler.tool.ToolCallFailureHandler
 import ai.koog.agents.core.feature.handler.tool.ToolCallHandler
 import ai.koog.agents.core.feature.handler.tool.ToolCallResultHandler
@@ -438,22 +434,6 @@ public abstract class AIAgentPipeline(public val clock: Clock) {
     //region Trigger LLM Streaming
 
     /**
-     * Invoked before streaming from a language model begins.
-     *
-     * This method notifies all registered stream handlers that streaming is about to start,
-     * allowing them to perform preprocessing or logging operations.
-     *
-     * @param runId The unique identifier for this streaming session
-     * @param prompt The prompt being sent to the language model
-     * @param model The language model being used for streaming
-     * @param tools The list of available tool descriptors for this streaming session
-     */
-    public suspend fun onLLMStreamingStarting(runId: String, prompt: Prompt, model: LLModel, tools: List<ToolDescriptor>) {
-        val eventContext = LLMStreamingStartingContext(runId, prompt, model, tools)
-        llmStreamingEventHandlers.values.forEach { handler -> handler.llmStreamingStartingHandler.handle(eventContext) }
-    }
-
-    /**
      * Invoked when a stream frame is received during the streaming process.
      *
      * This method notifies all registered stream handlers about each incoming stream frame,
@@ -479,27 +459,6 @@ public abstract class AIAgentPipeline(public val clock: Clock) {
     public suspend fun onLLMStreamingFailed(runId: String, throwable: Throwable) {
         val eventContext = LLMStreamingFailedContext(runId, throwable)
         llmStreamingEventHandlers.values.forEach { handler -> handler.llmStreamingFailedHandler.handle(eventContext) }
-    }
-
-    /**
-     * Invoked after streaming from a language model completes.
-     *
-     * This method notifies all registered stream handlers that streaming has finished,
-     * allowing them to perform post-processing, cleanup, or final logging operations.
-     *
-     * @param runId The unique identifier for this streaming session
-     * @param prompt The prompt that was sent to the language model
-     * @param model The language model that was used for streaming
-     * @param tools The list of tool descriptors that were available for this streaming session
-     */
-    public suspend fun onLLMStreamingCompleted(
-        runId: String,
-        prompt: Prompt,
-        model: LLModel,
-        tools: List<ToolDescriptor>
-    ) {
-        val eventContext = LLMStreamingCompletedContext(runId, prompt, model, tools)
-        llmStreamingEventHandlers.values.forEach { handler -> handler.llmStreamingCompletedHandler.handle(eventContext) }
     }
 
     //endregion Trigger LLM Streaming
@@ -769,32 +728,6 @@ public abstract class AIAgentPipeline(public val clock: Clock) {
     }
 
     /**
-     * Intercepts streaming operations before they begin to modify or log the streaming request.
-     *
-     * This method allows features to hook into the streaming pipeline before streaming starts,
-     * enabling preprocessing, validation, or logging of streaming requests.
-     *
-     * @param interceptContext The context containing the feature and its implementation
-     * @param handle The handler that processes before-stream events
-     *
-     * Example:
-     * ```
-     * pipeline.interceptLLMStreamingStarting(interceptContext) { eventContext ->
-     *     logger.info("About to start streaming with prompt: ${eventContext.prompt.messages.last().content}")
-     * }
-     * ```
-     */
-    public fun <TFeature : Any> interceptLLMStreamingStarting(
-        interceptContext: InterceptContext<TFeature>,
-        handle: suspend TFeature.(eventContext: LLMStreamingStartingContext) -> Unit
-    ) {
-        val handler = llmStreamingEventHandlers.getOrPut(interceptContext.feature.key) { LLMStreamingEventHandler() }
-        handler.llmStreamingStartingHandler = LLMStreamingStartingHandler(
-            function = createConditionalHandler(interceptContext, handle)
-        )
-    }
-
-    /**
      * Intercepts stream frames as they are received during the streaming process.
      *
      * This method allows features to process individual stream frames in real-time,
@@ -832,32 +765,6 @@ public abstract class AIAgentPipeline(public val clock: Clock) {
     ) {
         val handler = llmStreamingEventHandlers.getOrPut(interceptContext.feature.key) { LLMStreamingEventHandler() }
         handler.llmStreamingFailedHandler = LLMStreamingFailedHandler(
-            function = createConditionalHandler(interceptContext, handle)
-        )
-    }
-
-    /**
-     * Intercepts streaming operations after they complete to perform post-processing or cleanup.
-     *
-     * This method allows features to hook into the streaming pipeline after streaming finishes,
-     * enabling post-processing, cleanup, or final logging of the streaming session.
-     *
-     * @param interceptContext The context containing the feature and its implementation
-     * @param handle The handler that processes after-stream events
-     *
-     * Example:
-     * ```
-     * pipeline.interceptLLMStreamingCompleted(interceptContext) { eventContext ->
-     *     logger.info("Streaming completed for run: ${eventContext.runId}")
-     * }
-     * ```
-     */
-    public fun <TFeature : Any> interceptLLMStreamingCompleted(
-        interceptContext: InterceptContext<TFeature>,
-        handle: suspend TFeature.(eventContext: LLMStreamingCompletedContext) -> Unit
-    ) {
-        val handler = llmStreamingEventHandlers.getOrPut(interceptContext.feature.key) { LLMStreamingEventHandler() }
-        handler.llmStreamingCompletedHandler = LLMStreamingCompletedHandler(
             function = createConditionalHandler(interceptContext, handle)
         )
     }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/PromptExecutorProxy.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/PromptExecutorProxy.kt
@@ -8,6 +8,7 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.streaming.toMessageResponses
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -48,9 +49,8 @@ public class PromptExecutorProxy(
      * Executes a streaming call to the language model with tool support.
      *
      * This method wraps the underlying executor's streaming functionality with pipeline hooks
-     * to enable monitoring and processing of stream events. It triggers before-stream handlers
-     * before starting, stream-frame handlers for each frame received, and after-stream handlers
-     * upon completion.
+     * to enable monitoring and processing of stream events. It triggers before-LLM handlers
+     * before starting and after-LLM handlers upon completion.
      *
      * @param prompt The prompt to send to the language model
      * @param model The language model to use for streaming
@@ -63,10 +63,12 @@ public class PromptExecutorProxy(
         tools: List<ToolDescriptor>
     ): Flow<StreamFrame> {
         logger.debug { "Executing LLM streaming call (prompt: $prompt, tools: [${tools.joinToString { it.name }}])" }
+
+        val responses = mutableListOf<StreamFrame>()
         return executor.executeStreaming(prompt, model, tools)
             .onStart {
                 logger.debug { "Starting LLM streaming call" }
-                pipeline.onLLMStreamingStarting(runId, prompt, model, tools)
+                pipeline.onLLMCallStarting(runId, prompt, model, tools)
             }
             .onEach {
                 logger.debug { "Received frame from LLM streaming call: $it" }
@@ -79,7 +81,13 @@ public class PromptExecutorProxy(
             }
             .onCompletion { error ->
                 logger.debug(error) { "Finished LLM streaming call" }
-                pipeline.onLLMStreamingCompleted(runId, prompt, model, tools)
+                pipeline.onLLMCallCompleted(
+                    runId,
+                    prompt,
+                    model,
+                    tools,
+                    responses.toMessageResponses()
+                )
             }
     }
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/AgentLifecycleEventType.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/AgentLifecycleEventType.kt
@@ -111,11 +111,6 @@ public sealed interface AgentLifecycleEventType {
     //region LLM Streaming
 
     /**
-     * Represents an event triggered before streaming from a language model begins.
-     */
-    public object LLMStreamingStarting : AgentLifecycleEventType
-
-    /**
      * Represents an event triggered when a streaming frame is received from a language model.
      */
     public object LLMStreamingFrameReceived : AgentLifecycleEventType
@@ -124,11 +119,6 @@ public sealed interface AgentLifecycleEventType {
      * Represents an event triggered when an error occurs during streaming from a language model.
      */
     public object LLMStreamingFailed : AgentLifecycleEventType
-
-    /**
-     * Represents an event triggered after streaming from a language model completes.
-     */
-    public object LLMStreamingCompleted : AgentLifecycleEventType
 
     //endregion LLM Streaming
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/streaming/LLMStreamingEventContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/streaming/LLMStreamingEventContext.kt
@@ -2,33 +2,12 @@ package ai.koog.agents.core.feature.handler.streaming
 
 import ai.koog.agents.core.feature.handler.AgentLifecycleEventContext
 import ai.koog.agents.core.feature.handler.AgentLifecycleEventType
-import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.prompt.dsl.Prompt
-import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.streaming.StreamFrame
 
 /**
  * Represents the context for handling streaming-specific events within the framework.
  */
 public interface LLMStreamingEventContext : AgentLifecycleEventContext
-
-/**
- * Represents the context for handling a before-stream event.
- * This context is provided when streaming is about to begin.
- *
- * @property runId The unique identifier for this streaming session.
- * @property prompt The prompt that will be sent to the language model for streaming.
- * @property model The language model instance being used for streaming.
- * @property tools The list of tool descriptors available for the streaming call.
- */
-public data class LLMStreamingStartingContext(
-    val runId: String,
-    val prompt: Prompt,
-    val model: LLModel,
-    val tools: List<ToolDescriptor>,
-) : LLMStreamingEventContext {
-    override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.LLMStreamingStarting
-}
 
 /**
  * Represents the context for handling individual stream frame events.
@@ -45,8 +24,8 @@ public data class LLMStreamingFrameReceivedContext(
 }
 
 /**
- * Represents the context for handling an error event during streaming.
- * This context is provided when an error occurs during streaming.
+ * Represents the context for handling errors during streaming.
+ * This context is provided when an error occurs during the streaming process.
  *
  * @property runId The unique identifier for this streaming session.
  * @property error The exception or error that occurred during streaming.
@@ -56,22 +35,4 @@ public data class LLMStreamingFailedContext(
     val error: Throwable
 ) : LLMStreamingEventContext {
     override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.LLMStreamingFailed
-}
-
-/**
- * Represents the context for handling an after-stream event.
- * This context is provided when streaming is complete.
- *
- * @property runId The unique identifier for this streaming session.
- * @property prompt The prompt that was sent to the language model for streaming.
- * @property model The language model instance that was used for streaming.
- * @property tools The list of tool descriptors that were available for the streaming call.
- */
-public data class LLMStreamingCompletedContext(
-    val runId: String,
-    val prompt: Prompt,
-    val model: LLModel,
-    val tools: List<ToolDescriptor>
-) : LLMStreamingEventContext {
-    override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.LLMStreamingCompleted
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/streaming/LLMStreamingEventContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/streaming/LLMStreamingEventContext.kt
@@ -24,8 +24,8 @@ public data class LLMStreamingFrameReceivedContext(
 }
 
 /**
- * Represents the context for handling errors during streaming.
- * This context is provided when an error occurs during the streaming process.
+ * Represents the context for handling an error event during streaming.
+ * This context is provided when an error occurs during streaming.
  *
  * @property runId The unique identifier for this streaming session.
  * @property error The exception or error that occurred during streaming.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/streaming/LLMStreamingEventHandler.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/streaming/LLMStreamingEventHandler.kt
@@ -1,21 +1,13 @@
 package ai.koog.agents.core.feature.handler.streaming
 
 /**
+ * Handler for processing individual stream frames during streaming.
+ * This handler is invoked for each frame received from the streaming response.
  * A handler responsible for managing the streaming flow of Large Language Model (LLM) responses.
  * It allows customization of logic to be executed before streaming starts, during streaming frames,
  * and after streaming completes.
  */
 public class LLMStreamingEventHandler {
-
-    /**
-     * A handler invoked before streaming from the Language Learning Model (LLM) begins.
-     *
-     * This handler enables customization or preprocessing steps to be applied before the stream starts.
-     * It accepts the prompt, a list of tools, the model, and a run ID as inputs, allowing
-     * users to define specific logic or modifications to these inputs before streaming begins.
-     */
-    public var llmStreamingStartingHandler: LLMStreamingStartingHandler =
-        LLMStreamingStartingHandler { _ -> }
 
     /**
      * A handler invoked when stream frames are sent out during the streaming process.
@@ -45,37 +37,6 @@ public class LLMStreamingEventHandler {
      */
     public var llmStreamingFailedHandler: LLMStreamingFailedHandler =
         LLMStreamingFailedHandler { _ -> }
-
-    /**
-     * A handler invoked after streaming from the language model (LLM) is complete.
-     *
-     * This variable represents a custom implementation of the `AfterStreamHandler` functional interface,
-     * allowing post-processing or custom logic to be performed once streaming has finished.
-     *
-     * The handler receives various pieces of information about the stream, including the original prompt,
-     * the tools used, the model invoked, and a unique run identifier.
-     *
-     * Customize this handler to implement specific behavior required after streaming completes.
-     */
-    public var llmStreamingCompletedHandler: LLMStreamingCompletedHandler =
-        LLMStreamingCompletedHandler { _ -> }
-}
-
-/**
- * A functional interface implemented to handle logic that occurs before streaming from a large language model (LLM) begins.
- * It allows preprocessing steps or validation based on the provided prompt, available tools, targeted LLM model,
- * and a unique run identifier.
- *
- * This can be particularly useful for custom input manipulation, logging, validation, or applying
- * configurations to the streaming request based on external context.
- */
-public fun interface LLMStreamingStartingHandler {
-    /**
-     * Handles the initialization of a streaming interaction by processing the given prompt, tools, model, and run ID.
-     *
-     * @param eventContext The context for the before-stream event
-     */
-    public suspend fun handle(eventContext: LLMStreamingStartingContext)
 }
 
 /**
@@ -85,38 +46,20 @@ public fun interface LLMStreamingStartingHandler {
  */
 public fun interface LLMStreamingFrameReceivedHandler {
     /**
-     * Handles individual stream frames as they are sent out during the streaming process.
-     *
-     * @param eventContext The context for the stream frame event
+     * Handles a stream frame event.
+     * @param eventContext The context containing the stream frame data
      */
     public suspend fun handle(eventContext: LLMStreamingFrameReceivedContext)
 }
 
 /**
- * A functional interface for handling streaming errors.
- * The implementation of this interface provides a mechanism to perform error handling or logging
- * based on the provided error message and run ID.
+ * Handler for processing errors that occur during streaming.
+ * This handler is invoked when an error occurs in the streaming flow.
  */
 public fun interface LLMStreamingFailedHandler {
     /**
-     * Handles streaming errors by processing the provided error message and run ID.
-     *
-     * @param eventContext The context for the stream error event
+     * Handles a stream error event.
+     * @param eventContext The context containing the error information
      */
     public suspend fun handle(eventContext: LLMStreamingFailedContext)
-}
-
-/**
- * Represents a functional interface for handling operations or logic that should occur after streaming
- * from a large language model (LLM) is complete. The implementation of this interface provides a mechanism
- * to perform custom logic or processing based on the provided inputs, such as the prompt, tools,
- * model, and the completion of the stream.
- */
-public fun interface LLMStreamingCompletedHandler {
-    /**
-     * Handles the post-processing of a streaming session and its associated data after streaming completes.
-     *
-     * @param eventContext The context for the after-stream event
-     */
-    public suspend fun handle(eventContext: LLMStreamingCompletedContext)
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/streaming/LLMStreamingEventHandler.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/streaming/LLMStreamingEventHandler.kt
@@ -46,20 +46,23 @@ public class LLMStreamingEventHandler {
  */
 public fun interface LLMStreamingFrameReceivedHandler {
     /**
-     * Handles a stream frame event.
-     * @param eventContext The context containing the stream frame data
+     * Handles individual stream frames as they are sent out during the streaming process.
+     *
+     * @param eventContext The context for the stream frame event
      */
     public suspend fun handle(eventContext: LLMStreamingFrameReceivedContext)
 }
 
 /**
- * Handler for processing errors that occur during streaming.
- * This handler is invoked when an error occurs in the streaming flow.
+ * A functional interface for handling streaming errors.
+ * The implementation of this interface provides a mechanism to perform error handling or logging
+ * based on the provided error message and run ID.
  */
 public fun interface LLMStreamingFailedHandler {
     /**
-     * Handles a stream error event.
-     * @param eventContext The context containing the error information
+     * Handles streaming errors by processing the provided error message and run ID.
+     *
+     * @param eventContext The context for the stream error event
      */
     public suspend fun handle(eventContext: LLMStreamingFailedContext)
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/streaming/LLMStreamingEventHandler.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/streaming/LLMStreamingEventHandler.kt
@@ -3,9 +3,6 @@ package ai.koog.agents.core.feature.handler.streaming
 /**
  * Handler for processing individual stream frames during streaming.
  * This handler is invoked for each frame received from the streaming response.
- * A handler responsible for managing the streaming flow of Large Language Model (LLM) responses.
- * It allows customization of logic to be executed before streaming starts, during streaming frames,
- * and after streaming completes.
  */
 public class LLMStreamingEventHandler {
 

--- a/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandler.kt
+++ b/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandler.kt
@@ -14,9 +14,7 @@ import ai.koog.agents.core.feature.handler.llm.LLMCallStartingContext
 import ai.koog.agents.core.feature.handler.node.NodeExecutionCompletedContext
 import ai.koog.agents.core.feature.handler.node.NodeExecutionFailedContext
 import ai.koog.agents.core.feature.handler.node.NodeExecutionStartingContext
-import ai.koog.agents.core.feature.handler.streaming.LLMStreamingCompletedContext
 import ai.koog.agents.core.feature.handler.streaming.LLMStreamingFrameReceivedContext
-import ai.koog.agents.core.feature.handler.streaming.LLMStreamingStartingContext
 import ai.koog.agents.core.feature.handler.tool.ToolExecutionCompletedContext
 import ai.koog.agents.core.feature.handler.tool.ToolExecutionFailedContext
 import ai.koog.agents.core.feature.handler.tool.ToolExecutionStartingContext
@@ -163,20 +161,12 @@ public class EventHandler {
                 config.invokeOnToolExecutionCompleted(eventContext)
             }
 
-            pipeline.interceptLLMStreamingStarting(interceptContext) intercept@{ eventContext: LLMStreamingStartingContext ->
-                config.invokeOnLLMStreammingStarting(eventContext)
-            }
-
             pipeline.interceptLLMStreamingFrameReceived(interceptContext) intercept@{ eventContext: LLMStreamingFrameReceivedContext ->
                 config.invokeOnLLMStreamingFrameReceived(eventContext)
             }
 
             pipeline.interceptLLMStreamingFailed(interceptContext) intercept@{ eventContext ->
                 config.invokeOnLLMStreamingFailed(eventContext)
-            }
-
-            pipeline.interceptLLMStreamingCompleted(interceptContext) intercept@{ eventContext: LLMStreamingCompletedContext ->
-                config.invokeOnLLMStreamingCompleted(eventContext)
             }
         }
 

--- a/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerConfig.kt
+++ b/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerConfig.kt
@@ -27,10 +27,8 @@ import ai.koog.agents.core.feature.handler.node.NodeExecutionFailedContext
 import ai.koog.agents.core.feature.handler.node.NodeExecutionStartingContext
 import ai.koog.agents.core.feature.handler.strategy.StrategyCompletedContext
 import ai.koog.agents.core.feature.handler.strategy.StrategyStartingContext
-import ai.koog.agents.core.feature.handler.streaming.LLMStreamingCompletedContext
 import ai.koog.agents.core.feature.handler.streaming.LLMStreamingFailedContext
 import ai.koog.agents.core.feature.handler.streaming.LLMStreamingFrameReceivedContext
-import ai.koog.agents.core.feature.handler.streaming.LLMStreamingStartingContext
 import ai.koog.agents.core.feature.handler.tool.ToolExecutionCompletedContext
 import ai.koog.agents.core.feature.handler.tool.ToolExecutionFailedContext
 import ai.koog.agents.core.feature.handler.tool.ToolExecutionStartingContext
@@ -113,13 +111,9 @@ public class EventHandlerConfig : FeatureConfig() {
 
     //region Private Stream Handlers
 
-    private var _onLLMStreamingStarting: suspend (eventHandler: LLMStreamingStartingContext) -> Unit = { _ -> }
-
     private var _onLLMStreamingFrameReceived: suspend (eventHandler: LLMStreamingFrameReceivedContext) -> Unit = { _ -> }
 
     private var _onLLMStreamingFailed: suspend (eventHandler: LLMStreamingFailedContext) -> Unit = { _ -> }
-
-    private var _onLLMStreamingCompleted: suspend (eventHandler: LLMStreamingCompletedContext) -> Unit = { _ -> }
 
     //endregion Private Stream Handlers
 
@@ -312,31 +306,6 @@ public class EventHandlerConfig : FeatureConfig() {
     //region Stream Handlers
 
     /**
-     * Registers a handler to be invoked before streaming from a language model begins.
-     *
-     * This handler is called immediately before starting a streaming operation,
-     * allowing you to perform preprocessing, validation, or logging of the streaming request.
-     *
-     * @param handler The handler function that receives a [LLMStreamingStartingContext] containing
-     *                the run ID, prompt, model, and available tools for the streaming session.
-     *
-     * Example:
-     * ```
-     * onLLMStreamingStarting { eventContext ->
-     *     logger.info("Starting stream for run: ${eventContext.runId}")
-     *     logger.debug("Prompt: ${eventContext.prompt}")
-     * }
-     * ```
-     */
-    public fun onLLMStreamingStarting(handler: suspend (eventContext: LLMStreamingStartingContext) -> Unit) {
-        val originalHandler = this._onLLMStreamingStarting
-        this._onLLMStreamingStarting = { eventContext ->
-            originalHandler(eventContext)
-            handler.invoke(eventContext)
-        }
-    }
-
-    /**
      * Registers a handler to be invoked when stream frames are received during streaming.
      *
      * This handler is called for each stream frame as it arrives from the language model,
@@ -382,31 +351,6 @@ public class EventHandlerConfig : FeatureConfig() {
     public fun onLLMStreamingFailed(handler: suspend (eventContext: LLMStreamingFailedContext) -> Unit) {
         val originalHandler = this._onLLMStreamingFailed
         this._onLLMStreamingFailed = { eventContext ->
-            originalHandler(eventContext)
-            handler.invoke(eventContext)
-        }
-    }
-
-    /**
-     * Registers a handler to be invoked after streaming from a language model completes.
-     *
-     * This handler is called when the streaming operation finishes,
-     * allowing you to perform post-processing, cleanup, or final logging operations.
-     *
-     * @param handler The handler function that receives an [LLMStreamingCompletedContext] containing
-     *                the run ID, prompt, model, and tools that were used for the streaming session.
-     *
-     * Example:
-     * ```
-     * onLLMStreamingCompleted { eventContext ->
-     *     logger.info("Stream completed for run: ${eventContext.runId}")
-     *     // Perform any cleanup or aggregation of collected stream data
-     * }
-     * ```
-     */
-    public fun onLLMStreamingCompleted(handler: suspend (eventContext: LLMStreamingCompletedContext) -> Unit) {
-        val originalHandler = this._onLLMStreamingCompleted
-        this._onLLMStreamingCompleted = { eventContext ->
             originalHandler(eventContext)
             handler.invoke(eventContext)
         }
@@ -712,15 +656,6 @@ public class EventHandlerConfig : FeatureConfig() {
     //region Invoke Stream Handlers
 
     /**
-     * Invokes the handler associated with the event that occurs before streaming starts.
-     *
-     * @param eventContext The context containing information about the streaming session about to begin
-     */
-    internal suspend fun invokeOnLLMStreammingStarting(eventContext: LLMStreamingStartingContext) {
-        _onLLMStreamingStarting.invoke(eventContext)
-    }
-
-    /**
      * Invokes the handler associated with stream frame events during streaming.
      *
      * @param eventContext The context containing the stream frame data
@@ -736,15 +671,6 @@ public class EventHandlerConfig : FeatureConfig() {
      */
     internal suspend fun invokeOnLLMStreamingFailed(eventContext: LLMStreamingFailedContext) {
         _onLLMStreamingFailed.invoke(eventContext)
-    }
-
-    /**
-     * Invokes the handler associated with the event that occurs after streaming completes.
-     *
-     * @param eventContext The context containing information about the completed streaming session
-     */
-    internal suspend fun invokeOnLLMStreamingCompleted(eventContext: LLMStreamingCompletedContext) {
-        _onLLMStreamingCompleted.invoke(eventContext)
     }
 
     //endregion Invoke Stream Handlers

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/NodeLLMRequestStreamingAndSendResultsTest.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/NodeLLMRequestStreamingAndSendResultsTest.kt
@@ -89,7 +89,7 @@ class NodeLLMRequestStreamingAndSendResultsTest {
 
         // Verify streaming events were captured
         val streamingEvents = eventsCollector.collectedEvents.filter {
-            it.contains("OnBeforeStream") || it.contains("OnStreamFrame") || it.contains("OnAfterStream")
+            it.contains("OnBeforeLLMCall") || it.contains("OnStreamFrame") || it.contains("OnAfterLLMCall")
         }
         assertTrue(streamingEvents.isNotEmpty(), "Should have captured streaming events")
     }
@@ -132,7 +132,7 @@ class NodeLLMRequestStreamingAndSendResultsTest {
 
         // Verify streaming events occurred
         val streamingEvents = eventsCollector.collectedEvents.filter {
-            it.contains("OnBeforeStream") || it.contains("OnAfterStream")
+            it.contains("OnBeforeLLMCall") || it.contains("OnAfterLLMCall") || it.contains("OnStreamFrame")
         }
         assertTrue(streamingEvents.isNotEmpty(), "Should have streaming events")
     }

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/StreamingEventHandlerTest.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/StreamingEventHandlerTest.kt
@@ -14,8 +14,8 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 
 /**
- * Tests for streaming event handlers.
- * These tests verify that the streaming handlers (onBeforeStream, onStreamFrame, onAfterStream)
+ * Tests for streaming functionality with event handlers.
+ * These tests verify that LLM handlers (onBeforeLLMCall, onAfterLLMCall)
  * are properly invoked during LLM streaming operations.
  */
 class StreamingEventHandlerTest {
@@ -35,14 +35,14 @@ class StreamingEventHandlerTest {
         // Verify events are captured
         assertEventsCollected(eventsCollector)
 
-        // Verify streaming events are captured when using nodeLLMRequestsStreaming
-        val beforeStreamEvents = eventsCollector.collectedEvents.filter { it.contains("OnBeforeStream") }
+        // Verify LLM events are captured when using nodeLLMRequestsStreaming
+        val beforeLLMEvents = eventsCollector.collectedEvents.filter { it.contains("OnBeforeLLMCall") }
+        val afterLLMEvents = eventsCollector.collectedEvents.filter { it.contains("OnAfterLLMCall") }
         val streamFrameEvents = eventsCollector.collectedEvents.filter { it.contains("OnStreamFrame") }
-        val afterStreamEvents = eventsCollector.collectedEvents.filter { it.contains("OnAfterStream") }
 
-        assertTrue(beforeStreamEvents.isNotEmpty(), "Should have OnBeforeStream events")
+        assertTrue(beforeLLMEvents.isNotEmpty(), "Should have OnBeforeLLMCall events for streaming")
+        assertTrue(afterLLMEvents.isNotEmpty(), "Should have OnAfterLLMCall events for streaming")
         assertTrue(streamFrameEvents.isNotEmpty(), "Should have OnStreamFrame events")
-        assertTrue(afterStreamEvents.isNotEmpty(), "Should have OnAfterStream events")
 
         // Verify the stream frame contains the expected response
         val frameWithContent = streamFrameEvents.firstOrNull { it.contains(assistantResponse) }
@@ -62,11 +62,11 @@ class StreamingEventHandlerTest {
         }
         // Verify the overall event collection is working
         assertEventsCollected(eventsCollector)
-        // Verify that streaming events were captured
-        val streamingEventTypes = listOf("OnBeforeStream", "OnStreamFrame", "OnAfterStream")
+        // Verify that both LLM and streaming events were captured
+        val eventTypes = listOf("OnBeforeLLMCall", "OnAfterLLMCall", "OnStreamFrame")
         assertTrue(
-            actual = eventsCollector.collectedEvents.any { streamingEventTypes.any(it::contains) },
-            message = "Should have captured at least one streaming event (${streamingEventTypes.joinToString()})"
+            actual = eventsCollector.collectedEvents.any { eventTypes.any(it::contains) },
+            message = "Should have captured at least one event for streaming (${eventTypes.joinToString()})"
         )
     }
 }

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/TestEventsCollector.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/TestEventsCollector.kt
@@ -114,14 +114,6 @@ class TestEventsCollector {
             )
         }
 
-        onLLMStreamingStarting { eventContext ->
-            _collectedEvents.add(
-                "OnBeforeStream (run id: ${eventContext.runId}, prompt: ${eventContext.prompt.traceString}, model: ${eventContext.model.eventString}, tools: [${
-                    eventContext.tools.joinToString { it.name }
-                }])"
-            )
-        }
-
         onLLMStreamingFrameReceived { eventContext ->
             _collectedEvents.add(
                 "OnStreamFrame (run id: ${eventContext.runId}, frame: ${eventContext.streamFrame})"
@@ -131,14 +123,6 @@ class TestEventsCollector {
         onLLMStreamingFailed { eventContext ->
             _collectedEvents.add(
                 "OnStreamError (run id: ${eventContext.runId}, error: ${eventContext.error.message})"
-            )
-        }
-
-        onLLMStreamingCompleted { eventContext ->
-            _collectedEvents.add(
-                "OnAfterStream (run id: ${eventContext.runId}, prompt: ${eventContext.prompt.traceString}, model: ${eventContext.model.eventString}, tools: [${
-                    eventContext.tools.joinToString { it.name }
-                }])"
             )
         }
     }

--- a/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpTool.kt
+++ b/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpTool.kt
@@ -6,6 +6,7 @@ import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolResult
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.modelcontextprotocol.kotlin.sdk.PromptMessageContent
+import io.modelcontextprotocol.kotlin.sdk.TextContent
 import io.modelcontextprotocol.kotlin.sdk.client.Client
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
@@ -117,7 +118,10 @@ public class McpTool(
 
             // Format each content item and join them with newlines
             return promptMessageContents.joinToString("\n") { content ->
-                content.toString()
+                when (content) {
+                    is TextContent -> content.text ?: ""
+                    else -> content.toString()
+                }
             }
         }
     }

--- a/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/McpToolTest.kt
+++ b/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/McpToolTest.kt
@@ -5,6 +5,7 @@ import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
+import io.modelcontextprotocol.kotlin.sdk.ImageContent
 import io.modelcontextprotocol.kotlin.sdk.TextContent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
@@ -103,5 +104,55 @@ class McpToolTest {
 
         val contentWithTitle = resultWithTitle.promptMessageContents.first() as TextContent
         assertEquals("Hello, Mr. Test!", contentWithTitle.text)
+    }
+
+    @Test
+    fun `test McpTool Result toStringDefault with empty content`() {
+        val result = McpTool.Result(emptyList())
+        assertEquals("[No content]", result.toStringDefault())
+    }
+
+    @Test
+    fun `test McpTool Result toStringDefault with single TextContent`() {
+        val content = TextContent("Hello, World!")
+        val result = McpTool.Result(listOf(content))
+        assertEquals("Hello, World!", result.toStringDefault())
+    }
+
+    @Test
+    fun `test McpTool Result toStringDefault with null text in TextContent`() {
+        val content = TextContent(null)
+        val result = McpTool.Result(listOf(content))
+        assertEquals("", result.toStringDefault())
+    }
+
+    @Test
+    fun `test McpTool Result toStringDefault with multiple TextContent`() {
+        val content1 = TextContent("First line")
+        val content2 = TextContent("Second line")
+        val content3 = TextContent("Third line")
+        val result = McpTool.Result(listOf(content1, content2, content3))
+        assertEquals("First line\nSecond line\nThird line", result.toStringDefault())
+    }
+
+    @Test
+    fun `test McpTool Result toStringDefault with mixed content types`() {
+        val textContent = TextContent("Some text")
+        val imageContent = ImageContent("image/png", "base64data")
+        val result = McpTool.Result(listOf(textContent, imageContent))
+        val resultString = result.toStringDefault()
+
+        // The string should contain the text content and the toString representation of the image
+        assert(resultString.contains("Some text"))
+        assert(resultString.contains("ImageContent"))
+    }
+
+    @Test
+    fun `test McpTool Result toStringDefault with mixed null and non-null text`() {
+        val content1 = TextContent("Valid text")
+        val content2 = TextContent(null)
+        val content3 = TextContent("Another text")
+        val result = McpTool.Result(listOf(content1, content2, content3))
+        assertEquals("Valid text\n\nAnother text", result.toStringDefault())
     }
 }

--- a/docs/docs/streaming-api.md
+++ b/docs/docs/streaming-api.md
@@ -155,15 +155,23 @@ handleEvents {
     onToolExecutionStarting { context ->
         println("\n🔧 Using ${context.tool.name} with ${context.toolArgs}... ")
     }
+
+    onLLMCallStarting { context ->
+        // This is called before both regular and streaming LLM calls
+        println("📡 Starting LLM call...")
+    }
+
     onLLMStreamingFrameReceived { context ->
         (context.streamFrame as? StreamFrame.Append)?.let { frame ->
             print(frame.text)
         }
     }
+
     onLLMStreamingFailed { context -> 
         println("❌ Error: ${context.error}")
     }
-    onLLMStreamingCompleted {
+
+    onLLMCallCompleted {
         println("🏁 Done")
     }
 }

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/streaming/StreamingAgentWithTools.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/streaming/StreamingAgentWithTools.kt
@@ -31,18 +31,21 @@ fun main(): Unit = runBlocking {
     }
     val agent = openAiAgent(toolRegistry) {
         handleEvents {
-            onToolCall { context ->
+            onToolExecutionStarting { context ->
                 println("\n🔧 Using ${context.tool.name} with ${context.toolArgs}... ")
             }
+
             onLLMStreamingFrameReceived { context ->
                 (context.streamFrame as? StreamFrame.Append)?.let { frame ->
                     print(frame.text)
                 }
             }
+
             onLLMStreamingFailed {
                 println("❌ Error: ${it.error}")
             }
-            onLLMStreamingCompleted {
+
+            onLLMCallCompleted {
                 println("")
             }
         }


### PR DESCRIPTION
## Motivation and Context
The current streaming implementation has a `onBeforeStream` and `onAfterStream`, but the parameters should be the same as `onBeforeLLMCall` and `onAfterLLMCall`. Since this change, streaming strategies would break for OpenTelemetry and other Tracing integrations

Instead of making this unique for streaming, this PR proposes to streamline the calls for simplicity.

[See issue](https://youtrack.jetbrains.com/issue/KG-426/Streaming-introduced-regression-for-OpenTelemetry-or-Tracing)

## Breaking Changes
- `onBeforeStream` is now going to be `onBeforeLLMCall`
- `onAfterStream` is now going to be `onAfterLLMCall`

As the streaming functionality is not released yet, this feel appropriate to change it now

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
