### PR TITLE
KG-315 Exclude Ktor engine dependencies

### DIFF
--- a/agents/agents-core/build.gradle.kts
+++ b/agents/agents-core/build.gradle.kts
@@ -48,6 +48,7 @@ kotlin {
                 implementation(kotlin("test-junit5"))
                 implementation("org.jetbrains.lincheck:lincheck:3.1")
                 implementation(libs.junit.jupiter.params)
+                implementation(libs.ktor.client.cio)
             }
         }
     }

--- a/agents/agents-features/agents-features-memory/build.gradle.kts
+++ b/agents/agents-features/agents-features-memory/build.gradle.kts
@@ -29,17 +29,12 @@ kotlin {
             }
         }
 
-        jvmMain {
-            dependencies {
-                api(libs.ktor.client.cio)
-            }
-        }
-
         jvmTest {
             dependencies {
                 implementation(kotlin("test-junit5"))
                 implementation(project(":agents:agents-test"))
                 implementation(libs.mockk)
+                implementation(libs.ktor.client.cio)
             }
         }
     }

--- a/agents/agents-features/agents-features-tokenizer/build.gradle.kts
+++ b/agents/agents-features/agents-features-tokenizer/build.gradle.kts
@@ -26,8 +26,6 @@ kotlin {
         jvmMain {
             dependencies {
                 api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client"))
-                api(libs.ktor.client.cio)
-                api(libs.ktor.server.cio)
             }
         }
 
@@ -44,6 +42,8 @@ kotlin {
                 implementation(kotlin("test"))
                 implementation(kotlin("test-junit5"))
                 implementation(libs.kotlinx.coroutines.test)
+                implementation(libs.ktor.client.cio)
+                implementation(libs.ktor.server.cio)
             }
         }
     }

--- a/agents/agents-features/agents-features-trace/build.gradle.kts
+++ b/agents/agents-features/agents-features-trace/build.gradle.kts
@@ -25,8 +25,6 @@ kotlin {
         jvmMain {
             dependencies {
                 api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client"))
-                api(libs.ktor.client.cio)
-                api(libs.ktor.server.cio)
             }
         }
 
@@ -41,6 +39,8 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-junit5"))
                 implementation(project(":agents:agents-test"))
+                implementation(libs.ktor.client.cio)
+                implementation(libs.ktor.server.cio)
             }
         }
     }

--- a/agents/agents-mcp-server/build.gradle.kts
+++ b/agents/agents-mcp-server/build.gradle.kts
@@ -23,6 +23,7 @@ kotlin {
                 implementation(libs.kotlinx.coroutines.test)
                 implementation(project(":agents:agents-mcp"))
                 implementation(project(":agents:agents-test"))
+                runtimeOnly(libs.ktor.client.cio)
                 runtimeOnly(libs.slf4j.simple)
             }
         }

--- a/agents/agents-mcp/build.gradle.kts
+++ b/agents/agents-mcp/build.gradle.kts
@@ -24,7 +24,6 @@ kotlin {
                 api(libs.kotlinx.serialization.json)
                 api(libs.kotlinx.io.core)
                 api(libs.kotlinx.coroutines.core)
-                api(libs.ktor.client.cio)
                 implementation(libs.oshai.kotlin.logging)
             }
         }
@@ -32,7 +31,6 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(project(":test-utils"))
-                implementation(libs.ktor.client.cio)
             }
         }
 
@@ -40,6 +38,7 @@ kotlin {
             dependencies {
                 implementation(project(":agents:agents-test"))
                 implementation(libs.mcp.server)
+                implementation(libs.ktor.client.cio)
             }
         }
     }

--- a/agents/agents-test/build.gradle.kts
+++ b/agents/agents-test/build.gradle.kts
@@ -30,15 +30,13 @@ kotlin {
 
         commonTest {
             dependencies {
-                implementation(libs.kotlinx.coroutines.test)
+                implementation(project(":test-utils"))
             }
         }
 
         jvmTest {
             dependencies {
                 implementation(project(":agents:agents-features:agents-features-event-handler"))
-                implementation(kotlin("test-junit5"))
-                implementation(libs.junit.jupiter.params)
                 implementation(libs.ktor.client.cio)
             }
         }

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -48,17 +48,23 @@ For detailed guidance on using these providers with dedicated LLM clients, refer
 
 To use Koog, you need to include all necessary dependencies in your build configuration.
 
+**NB!** Ktor [client](https://ktor.io/docs/client-engines.html) and [server](https://ktor.io/docs/server-engines.html) engine dependencies are not included in the library by default, so you should add engines of your choice yourself.
+
 ### Gradle
 
 #### Gradle (Kotlin DSL)
 
 1. Add dependencies to the `build.gradle.kts` file:
 
-    ```
+    ```kotlin
     dependencies {
         implementation("ai.koog:koog-agents:LATEST_VERSION")
+       // include Ktor client dependency explicitly
+        implementation("io.ktor:ktor-client-cio:$ktor_version")
     }
     ```
+   Ktor [client](https://ktor.io/docs/client-engines.html) and [server](https://ktor.io/docs/server-engines.html) 
+   engine dependencies are not included in the library by default, so you should add engines of your choice yourself. 
 
 2. Make sure that you have `mavenCentral()` in the list of repositories.
 
@@ -69,6 +75,7 @@ To use Koog, you need to include all necessary dependencies in your build config
     ```
     dependencies {
         implementation 'ai.koog:koog-agents:LATEST_VERSION'
+        implementation 'io.ktor:ktor-client-cio:KTOR_VERSION'
     }
     ```
 
@@ -78,12 +85,42 @@ To use Koog, you need to include all necessary dependencies in your build config
 
 1. Add dependencies to the `pom.xml` file:
 
-    ```
+    ```xml
     <dependency>
         <groupId>ai.koog</groupId>
         <artifactId>koog-agents-jvm</artifactId>
         <version>LATEST_VERSION</version>
     </dependency>
+    ```
+
+2. Add Ktor dependencies. Check for Ktor versions [here](https://mvnrepository.com/artifact/io.ktor/ktor-bom).
+    ```xml
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.ktor</groupId>
+                <artifactId>ktor-bom</artifactId>
+                <version>KTOR_VERSION</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+   
+    <dependencies>
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-client-cio-jvm</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <!-- Add a Ktor server dependency if you are using features like MCP -->
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-server-netty-jvm</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
     ```
 
 2. Make sure that you have `mavenCentral` in the list of repositories.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -56,7 +56,7 @@ To use Koog, you need to include all necessary dependencies in your build config
 
 1. Add dependencies to the `build.gradle.kts` file:
 
-    ```kotlin
+    ```
     dependencies {
         implementation("ai.koog:koog-agents:LATEST_VERSION")
        // include Ktor client dependency explicitly

--- a/docs/docs/single-run-agents.md
+++ b/docs/docs/single-run-agents.md
@@ -30,7 +30,7 @@ To learn more about configuration options, see [API reference](https://api.koog.
 
 To use the `AIAgent` functionality, include all necessary dependencies in your build configuration:
 
-```kotlin
+```
 dependencies {
     implementation("ai.koog:koog-agents:$koog_version")
     // include Ktor client dependency explicitly

--- a/docs/docs/single-run-agents.md
+++ b/docs/docs/single-run-agents.md
@@ -30,9 +30,11 @@ To learn more about configuration options, see [API reference](https://api.koog.
 
 To use the `AIAgent` functionality, include all necessary dependencies in your build configuration:
 
-```
+```kotlin
 dependencies {
-    implementation("ai.koog:koog-agents:VERSION")
+    implementation("ai.koog:koog-agents:$koog_version")
+    // include Ktor client dependency explicitly
+    implementation("io.ktor:ktor-client-cio:$ktor_version")
 }
 ```
 

--- a/examples/demo-compose-app/app/build.gradle.kts
+++ b/examples/demo-compose-app/app/build.gradle.kts
@@ -63,25 +63,34 @@ kotlin {
             implementation(libs.kotlinx.serialization.core)
             implementation(libs.kotlinx.serialization.json)
             implementation(project.dependencies.platform(libs.koin.bom))
+            implementation(project.dependencies.platform(libs.ktor.bom))
         }
 
         androidMain.dependencies {
             implementation(compose.uiTooling)
             implementation(libs.androidx.datastore.preferences)
             implementation(libs.kotlinx.coroutines.android)
+            implementation(libs.ktor.client.okhttp)
         }
 
         jvmMain.dependencies {
             implementation(compose.desktop.currentOs)
             implementation(libs.androidx.datastore.preferences)
             implementation(libs.kotlinx.coroutines.swing)
+            implementation(libs.ktor.client.apache5)
         }
 
         iosMain.dependencies {
             implementation(libs.androidx.datastore.preferences)
+            implementation(libs.ktor.client.darwin)
         }
 
         webMain.dependencies {
+            implementation(libs.ktor.client.js)
+        }
+
+        wasmJsMain.dependencies {
+            implementation(libs.ktor.client.js)
         }
     }
 }
@@ -146,9 +155,3 @@ compose.desktop {
 tasks.withType<ComposeHotRun>().configureEach {
     mainClass = "MainKt"
 }
-
-configurations.all {
-    // FIXME exclude netty from Koog dependencies?
-    exclude(group = "io.netty", module = "*")
-}
-

--- a/examples/demo-compose-app/gradle/libs.versions.toml
+++ b/examples/demo-compose-app/gradle/libs.versions.toml
@@ -7,7 +7,8 @@ hotReload = "1.0.0-beta08"
 jetbrains-lifecycle = "2.9.4"
 jetbrains-navigation = "2.9.0"
 koin-bom = "4.1.1"
-koog = "0.4.3-feat-100-06"
+koog = "0.4.3-develop-20250927-0204"
+ktor = "3.3.0"
 kotlin = "2.2.20"
 kotlinx-serialization = "1.9.0"
 
@@ -17,6 +18,7 @@ jetbrains-navigation-compose = { module = "org.jetbrains.androidx.navigation:nav
 
 koin-bom = { module = "io.insert-koin:koin-bom", version.ref = "koin-bom" }
 koin-compose = { module = "io.insert-koin:koin-compose" }
+ktor-bom = { module = "io.ktor:ktor-bom", version.ref = "ktor" }
 
 # Kotlinx Serialization
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
@@ -33,6 +35,11 @@ androidx-datastore-preferences = { module = "androidx.datastore:datastore-prefer
 # Koog
 koog-agents-core = { module = "ai.koog:agents-core", version.ref = "koog" }
 koog-prompt-executor-llms-all = { module = "ai.koog:prompt-executor-llms-all", version.ref = "koog" }
+
+ktor-client-apache5 = { module = "io.ktor:ktor-client-apache5" }
+ktor-client-darwin = { module = "io.ktor:ktor-client-darwin" }
+ktor-client-js = { module = "io.ktor:ktor-client-js" }
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/examples/simple-examples/build.gradle.kts
+++ b/examples/simple-examples/build.gradle.kts
@@ -34,9 +34,11 @@ dependencies {
     implementation(libs.logback.classic)
 
     implementation(platform(libs.opentelemetry.bom))
+    implementation(platform(libs.ktor.bom))
     implementation(libs.opentelemetry.exporter.logging)
     implementation(libs.opentelemetry.exporter.otlp)
 
+    implementation(libs.ktor.client.cio)
     implementation(libs.ktor.server.cio)
 
     testImplementation(kotlin("test"))

--- a/examples/simple-examples/gradle/libs.versions.toml
+++ b/examples/simple-examples/gradle/libs.versions.toml
@@ -13,7 +13,9 @@ oshai-logging = "7.0.7"
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
-ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor3" }
+ktor-bom = { module = "io.ktor:ktor-bom", version.ref = "ktor3" }
+ktor-server-cio = { module = "io.ktor:ktor-server-cio" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 opentelemetry-bom = { module = "io.opentelemetry:opentelemetry-bom", version.ref = "opentelemetry" }

--- a/examples/spring-boot-java/pom.xml
+++ b/examples/spring-boot-java/pom.xml
@@ -28,12 +28,12 @@
     </scm>
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
-        <spring.boot.version>3.5.5</spring.boot.version>
-        <!-- <koog.version>0.4.2</koog.version> -->
-        <koog.version>0.4.1-develop-2025-09-05</koog.version>
+        <spring.boot.version>3.5.6</spring.boot.version>
+<!--         <koog.version>0.4.3-SNAPSHOT</koog.version>-->
+        <koog.version>0.4.3-develop-20250926-0205</koog.version>
         <!-- Kotlinx-serialization version must be aligned -->
         <kotlinx-serialization.version>1.8.1</kotlinx-serialization.version>
-        <ktor.version>3.2.13</ktor.version>
+        <ktor.version>3.2.3</ktor.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/examples/spring-boot-java/pom.xml
+++ b/examples/spring-boot-java/pom.xml
@@ -33,6 +33,7 @@
         <koog.version>0.4.1-develop-2025-09-05</koog.version>
         <!-- Kotlinx-serialization version must be aligned -->
         <kotlinx-serialization.version>1.8.1</kotlinx-serialization.version>
+        <ktor.version>3.2.13</ktor.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -47,6 +48,13 @@
                 <groupId>ai.koog</groupId>
                 <artifactId>koog-spring-boot-starter</artifactId>
                 <version>${koog.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.ktor</groupId>
+                <artifactId>ktor-bom</artifactId>
+                <version>${ktor.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>

--- a/examples/spring-boot-java/pom.xml
+++ b/examples/spring-boot-java/pom.xml
@@ -30,7 +30,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <spring.boot.version>3.5.6</spring.boot.version>
 <!--         <koog.version>0.4.3-SNAPSHOT</koog.version>-->
-        <koog.version>0.4.3-develop-20250926-0205</koog.version>
+        <koog.version>0.4.3-develop-20250927-0204</koog.version>
         <!-- Kotlinx-serialization version must be aligned -->
         <kotlinx-serialization.version>1.8.1</kotlinx-serialization.version>
         <ktor.version>3.2.3</ktor.version>
@@ -78,6 +78,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-client-apache5-jvm</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,6 +63,7 @@ ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor3" }
 ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor3" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor3" }
 ktor-client-apache5 = { module = "io.ktor:ktor-client-apache5", version.ref = "ktor3" }
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor3" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor3" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor3" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor3" }

--- a/koog-agents/build.gradle.kts
+++ b/koog-agents/build.gradle.kts
@@ -118,6 +118,26 @@ kotlin {
                 }
             }
         }
+
+        androidMain.dependencies {
+            api(libs.ktor.client.okhttp)
+        }
+
+        jvmMain.dependencies {
+            api(libs.ktor.client.apache5)
+        }
+
+        appleMain.dependencies {
+            api(libs.ktor.client.darwin)
+        }
+
+        jsMain.dependencies {
+            api(libs.ktor.client.js)
+        }
+
+        wasmJsMain.dependencies {
+            api(libs.ktor.client.js)
+        }
     }
 }
 

--- a/koog-ktor/build.gradle.kts
+++ b/koog-ktor/build.gradle.kts
@@ -34,9 +34,16 @@ kotlin {
             }
         }
 
+        androidUnitTest {
+            dependencies {
+                implementation(libs.ktor.client.cio)
+            }
+        }
+
         jsTest {
             dependencies {
                 implementation(kotlin("test-js"))
+                implementation(libs.ktor.client.js)
             }
         }
 
@@ -44,6 +51,7 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-junit5"))
                 implementation(libs.kotlinx.coroutines.test)
+                implementation(libs.ktor.client.cio)
             }
         }
     }

--- a/koog-ktor/build.gradle.kts
+++ b/koog-ktor/build.gradle.kts
@@ -54,6 +54,12 @@ kotlin {
                 implementation(libs.ktor.client.cio)
             }
         }
+
+        appleTest {
+            dependencies {
+                implementation(libs.ktor.client.darwin)
+            }
+        }
     }
 
     explicitApi()

--- a/koog-spring-boot-starter/build.gradle.kts
+++ b/koog-spring-boot-starter/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation(project.dependencies.platform(libs.spring.boot.bom))
     api(libs.bundles.spring.boot.core)
     api(libs.reactor.kotlin.extensions)
+    runtimeOnly(libs.ktor.client.apache5)
 
     testImplementation(libs.spring.boot.starter.test)
     testRuntimeOnly(libs.junit.platform.launcher)

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/build.gradle.kts
@@ -25,12 +25,6 @@ kotlin {
             }
         }
 
-        jvmMain {
-            dependencies {
-                implementation(libs.ktor.client.cio)
-            }
-        }
-
         jsMain {
             dependencies {
                 implementation(libs.ktor.client.js)
@@ -41,6 +35,12 @@ kotlin {
             dependencies {
                 implementation(project(":test-utils"))
                 implementation(libs.kotest.assertions.json)
+            }
+        }
+
+        jvmTest {
+            dependencies {
+                implementation(libs.ktor.client.cio)
             }
         }
     }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/build.gradle.kts
@@ -30,7 +30,6 @@ kotlin {
 
         jvmMain {
             dependencies {
-                api(libs.ktor.client.cio)
                 implementation(
                     project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-anthropic-client")
                 )
@@ -46,6 +45,7 @@ kotlin {
 
         jvmTest {
             dependencies {
+                implementation(libs.ktor.client.cio)
             }
         }
     }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/build.gradle.kts
@@ -26,9 +26,9 @@ kotlin {
             }
         }
 
-        jsMain {
+        jsTest {
             dependencies {
-                api(libs.ktor.client.js)
+                implementation(libs.ktor.client.js)
             }
         }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/build.gradle.kts
@@ -26,12 +26,6 @@ kotlin {
             }
         }
 
-        jvmMain {
-            dependencies {
-                api(libs.ktor.client.cio)
-            }
-        }
-
         jsMain {
             dependencies {
                 api(libs.ktor.client.js)
@@ -47,6 +41,7 @@ kotlin {
         jvmTest {
             dependencies {
                 implementation(libs.ktor.client.mock)
+                implementation(libs.ktor.client.cio)
             }
         }
     }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/build.gradle.kts
@@ -31,33 +31,27 @@ kotlin {
             }
         }
 
-        androidMain {
+        androidUnitTest {
             dependencies {
                 implementation(libs.ktor.client.cio)
             }
         }
 
-        appleMain {
+        appleTest {
             dependencies {
-                api(libs.ktor.client.darwin)
+                implementation(libs.ktor.client.darwin)
             }
         }
 
-        jsMain {
+        jsTest {
             dependencies {
-                api(libs.ktor.client.js)
+                implementation(libs.ktor.client.js)
             }
         }
 
-        wasmJsMain {
+        wasmJsTest {
             dependencies {
-                api(libs.ktor.client.cio)
-            }
-        }
-
-        jvmMain {
-            dependencies {
-                api(libs.ktor.client.cio)
+                implementation(libs.ktor.client.cio)
             }
         }
 
@@ -76,6 +70,7 @@ kotlin {
                 implementation(project(":agents:agents-core"))
                 implementation(project(":agents:agents-features:agents-features-event-handler"))
                 implementation(project(":agents:agents-features:agents-features-trace"))
+                implementation(libs.ktor.client.cio)
             }
         }
     }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/androidMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.android.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/androidMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.android.kt
@@ -1,6 +1,0 @@
-package ai.koog.prompt.executor.ollama.client
-
-import io.ktor.client.engine.HttpClientEngineFactory
-import io.ktor.client.engine.cio.CIO
-
-internal actual fun engineFactoryProvider(): HttpClientEngineFactory<*> = CIO

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/appleMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.apple.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/appleMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.apple.kt
@@ -1,6 +1,0 @@
-package ai.koog.prompt.executor.ollama.client
-
-import io.ktor.client.engine.HttpClientEngineFactory
-import io.ktor.client.engine.darwin.Darwin
-
-internal actual fun engineFactoryProvider(): HttpClientEngineFactory<*> = Darwin

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -36,7 +36,6 @@ import ai.koog.prompt.streaming.streamFrameFlow
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.engine.HttpClientEngineFactory
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
@@ -69,7 +68,7 @@ import kotlinx.serialization.json.Json
  */
 public class OllamaClient(
     public val baseUrl: String = "http://localhost:11434",
-    baseClient: HttpClient = HttpClient(engineFactoryProvider()),
+    baseClient: HttpClient = HttpClient(),
     timeoutConfig: ConnectionTimeoutConfig = ConnectionTimeoutConfig(),
     private val clock: Clock = Clock.System,
     private val contextWindowStrategy: ContextWindowStrategy = ContextWindowStrategy.Companion.None,
@@ -446,5 +445,3 @@ public class OllamaClient(
         }
     }
 }
-
-internal expect fun engineFactoryProvider(): HttpClientEngineFactory<*>

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/jsMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.js.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/jsMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.js.kt
@@ -1,6 +1,0 @@
-package ai.koog.prompt.executor.ollama.client
-
-import io.ktor.client.engine.HttpClientEngineFactory
-import io.ktor.client.engine.js.Js
-
-internal actual fun engineFactoryProvider(): HttpClientEngineFactory<*> = Js

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/jvmMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.jvm.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/jvmMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.jvm.kt
@@ -1,6 +1,0 @@
-package ai.koog.prompt.executor.ollama.client
-
-import io.ktor.client.engine.HttpClientEngineFactory
-import io.ktor.client.engine.cio.CIO
-
-internal actual fun engineFactoryProvider(): HttpClientEngineFactory<*> = CIO

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/wasmJsMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.wasmJs.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/wasmJsMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.wasmJs.kt
@@ -1,5 +1,0 @@
-package ai.koog.prompt.executor.ollama.client
-
-import io.ktor.client.engine.cio.CIO
-
-internal actual fun engineFactoryProvider(): io.ktor.client.engine.HttpClientEngineFactory<*> = CIO

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/build.gradle.kts
@@ -19,11 +19,6 @@ kotlin {
                 implementation(libs.oshai.kotlin.logging)
             }
         }
-        jvmMain {
-            dependencies {
-                api(libs.ktor.client.cio)
-            }
-        }
 
         jsMain {
             dependencies {
@@ -40,6 +35,7 @@ kotlin {
         jvmTest {
             dependencies {
                 implementation(kotlin("test-junit5"))
+                implementation(libs.ktor.client.cio)
             }
         }
     }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/build.gradle.kts
@@ -20,7 +20,7 @@ kotlin {
             }
         }
 
-        jsMain {
+        jsTest {
             dependencies {
                 api(libs.ktor.client.js)
             }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/build.gradle.kts
@@ -24,6 +24,12 @@ kotlin {
                 implementation(project(":test-utils"))
             }
         }
+
+        jvmTest {
+            dependencies {
+                implementation(libs.ktor.client.cio)
+            }
+        }
     }
 
     explicitApi()

--- a/prompt/prompt-executor/prompt-executor-llms-all/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-llms-all/build.gradle.kts
@@ -32,11 +32,7 @@ kotlin {
                 api(libs.ktor.client.content.negotiation)
             }
         }
-        jvmMain {
-            dependencies {
-                api(libs.ktor.client.cio)
-            }
-        }
+
         commonTest {
             dependencies {
                 implementation(kotlin("test"))
@@ -46,6 +42,7 @@ kotlin {
         jvmTest {
             dependencies {
                 implementation(kotlin("test-junit5"))
+                implementation(libs.ktor.client.cio)
                 implementation(libs.ktor.client.mock)
                 runtimeOnly(libs.slf4j.simple)
             }


### PR DESCRIPTION
## Motivation and Context

KG-315 / #710 To avoid Ktor CIO dependency leak, it was excluded from API dependencies in all modules.
Client and server Ktor engine dependencies should be manually included in the end application and tests.

## Changes

- Removed platform-specific `HttpClientEngineFactory` implementations from the `prompt-executor-ollama-client` module.
- Consolidated `HttpClient` initialization using the default engine.
- Adjusted build configurations to reallocate `ktor-client-cio` dependencies under appropriate test source sets.
- Updated relevant documentation and examples to explicitly include engine dependencies where necessary.
- Rename deprecated onAgentFinished to onAgentCompleted across tests
- Updated dependencies in example: add ktor client dependencies explicitly 

## Breaking Changes
Client and server Ktor engine dependencies should now be manually included.

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Tests improvement
- [x] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
