### PR TITLE
Refactor `TestAgentLogsCollector` to fix `PersistencyRunsTwiceTest` flakiness

### DIFF
--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/PersistencyRunsTwiceTest.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/PersistencyRunsTwiceTest.kt
@@ -42,7 +42,7 @@ class PersistencyRunsTwiceTest {
         agent.run("Start the test")
 
         // Assert
-        testCollector.logs shouldContainExactly listOf(
+        testCollector.logs() shouldContainExactly listOf(
             "First Step",
             "Second Step"
         )
@@ -99,7 +99,7 @@ class PersistencyRunsTwiceTest {
         // Assert: first run fails
         assert(result.isFailure)
 
-        testCollector.logs shouldContainExactly listOf(
+        testCollector.logs() shouldContainExactly listOf(
             "First Step",
             "Second Step"
         )
@@ -110,12 +110,13 @@ class PersistencyRunsTwiceTest {
             }
         }
 
-        testCollector.logs.clear()
+        testCollector.clear()
+
         val secondRunResult = runCatching { agent.run("Start the test") }
 
         // Assert: second run is successful
         assert(secondRunResult.isSuccess)
-        testCollector.logs shouldContainExactly listOf(
+        testCollector.logs() shouldContainExactly listOf(
             "Second Step",
             "Second try successful",
         )

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/PersistencyTestUtils.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/PersistencyTestUtils.kt
@@ -1,7 +1,16 @@
-import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.LinkedBlockingQueue
 
 internal class TestAgentLogsCollector {
-    val logs = ConcurrentLinkedQueue<String>()
+    private val logs = LinkedBlockingQueue<String>()
+
+    fun logs(): List<String> {
+        return logs.toList()
+    }
+
+    fun clear() {
+        logs.clear()
+    }
+
     fun log(message: String) {
         logs.add(message)
     }


### PR DESCRIPTION
TestAgentLogsCollector: Use LinkedBlockingQueue for optimized, but atomic access

## Motivation and Context

PersistencyRunsTwiceTest was [flaky](https://github.com/JetBrains/koog/actions/runs/18075231558/job/51430711984) on Windows

## Breaking Changes
No

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tests improvement
- [ ] Refactoring

#### Checklist
- [ ] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [ ] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
