### PR TITLE
fix: ToolFromCallable with custom name

### DIFF
--- a/agents/agents-tools/src/jvmMain/kotlin/ai/koog/agents/core/tools/reflect/ToolFromCallable.kt
+++ b/agents/agents-tools/src/jvmMain/kotlin/ai/koog/agents/core/tools/reflect/ToolFromCallable.kt
@@ -109,7 +109,7 @@ public class ToolFromCallable(
     override val argsSerializer: KSerializer<VarArgs>
         get() = VarArgsSerializer(callable)
 
-    override val name: String = callable.name
+    override val name: String = descriptor.name
     override val description: String = descriptor.description
 
     /**

--- a/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/core/tools/reflect/ToolsFromCallableTest.kt
+++ b/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/core/tools/reflect/ToolsFromCallableTest.kt
@@ -83,6 +83,9 @@ interface ToolSet1 : ToolSet1BaseInterface, ToolSet {
         @LLMDescription("int argument overridden")
         intArg: Int
     ): String
+
+    @Tool("customName")
+    fun toolWithCustomName(): String
 }
 
 open class ToolSet1Impl : ToolSet1 {
@@ -116,6 +119,10 @@ open class ToolSet1Impl : ToolSet1 {
 
     override fun toolBase2OverriddenInInterface(intArg: Int): String {
         return "toolBase2OverriddenInInterface called: $intArg"
+    }
+
+    override fun toolWithCustomName(): String {
+        return "toolWithCustomName called"
     }
 }
 
@@ -280,6 +287,7 @@ class ToolsFromCallableTest {
 #2: ToolDescriptor(name=tool4, description=Perfect tool 4, requiredParameters=[ToolParameterDescriptor(name=arg, description=int argument, type=Integer)], optionalParameters=[])
 #3: ToolDescriptor(name=toolBase1, description=Base tool 1, requiredParameters=[], optionalParameters=[])
 #4: ToolDescriptor(name=toolBase2OverriddenInInterface, description=Base tool 2 description overridden, requiredParameters=[ToolParameterDescriptor(name=intArg, description=int argument overridden, type=Integer)], optionalParameters=[])
+#5: ToolDescriptor(name=customName, description=toolWithCustomName, requiredParameters=[], optionalParameters=[])
 """.trim()
                 ),
                 Arguments.of(
@@ -291,6 +299,7 @@ class ToolsFromCallableTest {
 #3: ToolDescriptor(name=tool4, description=Perfect tool 4, requiredParameters=[ToolParameterDescriptor(name=arg, description=int argument, type=Integer)], optionalParameters=[])
 #4: ToolDescriptor(name=toolBase1, description=Base tool 1, requiredParameters=[], optionalParameters=[])
 #5: ToolDescriptor(name=toolBase2OverriddenInInterface, description=Base tool 2 description overridden, requiredParameters=[ToolParameterDescriptor(name=intArg, description=int argument overridden, type=Integer)], optionalParameters=[])
+#6: ToolDescriptor(name=customName, description=toolWithCustomName, requiredParameters=[], optionalParameters=[])
 """.trim()
                 ),
                 Arguments.of(
@@ -299,6 +308,7 @@ class ToolsFromCallableTest {
 #0: ToolDescriptor(name=tool1, description=The best tool number 1, requiredParameters=[ToolParameterDescriptor(name=arg, description=int argument, type=Integer)], optionalParameters=[])
 #1: ToolDescriptor(name=toolBase1, description=Base tool 1, requiredParameters=[], optionalParameters=[])
 #2: ToolDescriptor(name=toolBase2OverriddenInInterface, description=Base tool 2 description overridden, requiredParameters=[ToolParameterDescriptor(name=intArg, description=int argument overridden, type=Integer)], optionalParameters=[])
+#3: ToolDescriptor(name=customName, description=toolWithCustomName, requiredParameters=[], optionalParameters=[])
 """.trim()
                 ),
             )
@@ -334,5 +344,26 @@ class ToolsFromCallableTest {
             }
         }.trim()
         assertEquals(expectedDescription, rendered)
+    }
+
+    @Test
+    fun testToolPropertiesOnClasses() {
+        val tools = ToolSet1Impl().asTools(json)
+        val rendered = buildString {
+            for ((i, tool) in tools.withIndex()) {
+                appendLine("#$i: name=${tool.name} description=${tool.description}")
+            }
+        }.trim()
+        assertEquals(
+            """
+#0: name=tool1 description=The best tool number 1
+#1: name=tool2 description=Wonderful tool number 2
+#2: name=tool4 description=Perfect tool 4
+#3: name=toolBase1 description=Base tool 1
+#4: name=toolBase2OverriddenInInterface description=Base tool 2 description overridden
+#5: name=customName description=toolWithCustomName
+            """.trim(),
+            rendered
+        )
     }
 }


### PR DESCRIPTION
Fixes `@Tool("customName")` not working after #791.
The `name` of the Tool should read from `descriptor.name`.

## Motivation and Context
Fixes custom tool naming on `@Tool` annotated functions.

## Breaking Changes
None
---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [X] Tests improvement
- [ ] Refactoring

#### Checklist
- [X] The pull request has a description of the proposed change
- [X] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [X] The pull request uses **`develop`** as the base branch
- [X] Tests for the changes have been added
- [X] All new and existing tests passed