### PR TITLE
Add `llmProvider` method to LLM clients, extend `MultiLLMPromptExecutor` constructors, register Spring bean

### DIFF
--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/client/CapturingLLMClient.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/client/CapturingLLMClient.kt
@@ -5,6 +5,7 @@ import ai.koog.prompt.dsl.ModerationResult
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.model.LLMChoice
+import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.streaming.StreamFrame
@@ -22,12 +23,14 @@ import kotlinx.coroutines.flow.flowOf
  * @property streamingChunks The sequence of chunks to emit from [executeStreaming].
  * @property choices The list of [LLMChoice] to return from [executeMultipleChoices].
  * @property moderationResult The [ModerationResult] to return from [moderate].
+ * @property llmProvider [LLMPrivider] associated with the client or [LLMProvider.OpenAI], if not defined
  */
 public class CapturingLLMClient(
     private val executeResponses: List<Message.Response> = emptyList(),
     private val streamingChunks: List<StreamFrame> = emptyList(),
     private val choices: List<LLMChoice> = emptyList(),
     private val moderationResult: ModerationResult = ModerationResult(isHarmful = false, categories = emptyMap()),
+    private val llmProvider: LLMProvider = LLMProvider.OpenAI
 ) : LLMClient {
 
     /** The last [Prompt] passed to [execute], or null if it hasn't been called yet. */
@@ -59,6 +62,8 @@ public class CapturingLLMClient(
 
     /** The last [LLModel] passed to [moderate], or null if it hasn't been called yet. */
     public var lastModerationModel: LLModel? = null
+
+    override fun llmProvider(): LLMProvider = llmProvider
 
     /**
      * Simulates a non-streaming LLM execution.

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
@@ -76,6 +76,8 @@ internal class ReportingLLMLLMClient(
     private val eventsChannel: Channel<Event>,
     private val underlyingClient: LLMClient
 ) : LLMClient {
+
+    override fun llmProvider(): LLMProvider = underlyingClient.llmProvider()
     sealed interface Event {
         data class Message(
             val llmClient: String,

--- a/koog-spring-boot-starter/src/main/kotlin/ai/koog/spring/prompt/executor/MultiLLMAutoConfiguration.kt
+++ b/koog-spring-boot-starter/src/main/kotlin/ai/koog/spring/prompt/executor/MultiLLMAutoConfiguration.kt
@@ -1,0 +1,16 @@
+package ai.koog.spring.prompt.executor
+
+import ai.koog.prompt.executor.clients.LLMClient
+import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.context.annotation.Bean
+
+@AutoConfiguration
+public class MultiLLMAutoConfiguration {
+
+    @Bean
+    public fun multiLLMPromptExecutor(@Autowired llmClients: List<LLMClient>): MultiLLMPromptExecutor {
+        return MultiLLMPromptExecutor(llmClients = llmClients.toTypedArray())
+    }
+}

--- a/koog-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/koog-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -4,3 +4,4 @@ ai.koog.spring.prompt.executor.clients.google.GoogleLLMAutoConfiguration
 ai.koog.spring.prompt.executor.clients.ollama.OllamaLLMAutoConfiguration
 ai.koog.spring.prompt.executor.clients.openai.OpenAILLMAutoConfiguration
 ai.koog.spring.prompt.executor.clients.openrouter.OpenRouterLLMAutoConfiguration
+ai.koog.spring.prompt.executor.MultiLLMAutoConfiguration

--- a/koog-spring-boot-starter/src/test/kotlin/ai/koog/spring/KoogAutoConfigurationIntegrationTest.kt
+++ b/koog-spring-boot-starter/src/test/kotlin/ai/koog/spring/KoogAutoConfigurationIntegrationTest.kt
@@ -6,6 +6,7 @@ import ai.koog.prompt.executor.clients.deepseek.DeepSeekLLMClient
 import ai.koog.prompt.executor.clients.google.GoogleLLMClient
 import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
 import ai.koog.prompt.executor.clients.openrouter.OpenRouterLLMClient
+import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
 import ai.koog.prompt.executor.ollama.client.OllamaClient
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -24,7 +25,7 @@ import org.springframework.test.context.TestPropertySource
         KoogAutoConfigurationIntegrationTest.TestConfig::class,
     ],
     properties = [
-        "debug=false", // set to true for troubleshooting
+        "debug=true", // set to true for troubleshooting
         "spring.main.banner-mode=off"
     ],
     webEnvironment = SpringBootTest.WebEnvironment.NONE
@@ -55,8 +56,18 @@ class KoogAutoConfigurationIntegrationTest {
             OllamaClient::class,
         ]
     )
-    fun `Should register beans(classes)`(clazz: Class<*>) {
+    fun `Should register LLMClient`(clazz: Class<*>) {
         verifyBeanIsRegistered<LLMClient>(clazz)
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        classes = [
+            MultiLLMPromptExecutor::class,
+        ]
+    )
+    fun `Should register beans(classes)`(clazz: Class<*>) {
+        verifyBeanIsRegistered<Any>(clazz)
     }
 
     @ParameterizedTest
@@ -98,9 +109,11 @@ class KoogAutoConfigurationIntegrationTest {
             "Bean of type ${clazz.simpleName} should have been registered"
         }
 
-        val bean = applicationContext.getBean(clazz)
-        assertTrue(bean is EXTRA) {
-            "Registered bean of type $clazz should be also a ${EXTRA::class}"
+        if (EXTRA::class != Any::class) {
+            val bean = applicationContext.getBean(clazz)
+            assertTrue(bean is EXTRA) {
+                "Registered bean of type $clazz should be also a ${EXTRA::class}"
+            }
         }
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
@@ -8,6 +8,7 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Attachment
 import ai.koog.prompt.message.AttachmentContent
@@ -119,6 +120,16 @@ public open class AnthropicLLMClient(
             socketTimeoutMillis = settings.timeoutConfig.socketTimeoutMillis
         }
     }
+
+    /**
+     * Provides the specific Large Language Model (LLM) provider used by the client.
+     *
+     * This method returns the LLM provider that the client is configured to use,
+     * allowing identification and configuration of provider-specific features.
+     *
+     * @return The LLM provider associated with this client, specifically `LLMProvider.Anthropic`.
+     */
+    override fun llmProvider(): LLMProvider = LLMProvider.Anthropic
 
     override suspend fun execute(prompt: Prompt, model: LLModel, tools: List<ToolDescriptor>): List<Message.Response> {
         logger.debug { "Executing prompt: $prompt with tools: $tools and model: $model" }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
@@ -158,6 +158,13 @@ public class BedrockLLMClient(
         }
     }
 
+    /**
+     * Provides the current language learning model provider utilized by this client.
+     *
+     * @return the [LLMProvider] instance, specifically `LLMProvider.Bedrock` for this client.
+     */
+    override fun llmProvider(): LLMProvider = LLMProvider.Bedrock
+
     override suspend fun execute(
         prompt: Prompt,
         model: LLModel,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
@@ -26,7 +26,6 @@ import ai.koog.prompt.structure.annotations.InternalStructuredOutputApi
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import kotlinx.datetime.Clock
-import kotlin.collections.set
 
 /**
  * Configuration settings for connecting to the DeepSeek API.
@@ -70,6 +69,16 @@ public class DeepSeekLLMClient(
             RegisteredStandardJsonSchemaGenerators[LLMProvider.DeepSeek] = OpenAIStandardJsonSchemaGenerator
         }
     }
+
+    /**
+     * Returns the specific implementation of the `LLMProvider` associated with this client.
+     *
+     * In this case, it identifies the `DeepSeek` provider as the designated LLM provider
+     * for the client.
+     *
+     * @return The `LLMProvider` instance representing DeepSeek.
+     */
+    override fun llmProvider(): LLMProvider = LLMProvider.DeepSeek
 
     override fun serializeProviderChatRequest(
         messages: List<OpenAIMessage>,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -132,6 +132,13 @@ public open class GoogleLLMClient(
         }
     }
 
+    /**
+     * Provides the Large Language Model (LLM) provider associated with this client.
+     *
+     * @return The LLM provider, which is Google for this implementation.
+     */
+    override fun llmProvider(): LLMProvider = LLMProvider.Google
+
     override suspend fun execute(prompt: Prompt, model: LLModel, tools: List<ToolDescriptor>): List<Message.Response> {
         logger.debug { "Executing prompt: $prompt with tools: $tools and model: $model" }
         require(model.capabilities.contains(LLMCapability.Completion)) {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -148,6 +148,13 @@ public class OllamaClient(
         }
     }
 
+    /**
+     * Provides the type of Language Learning Model (LLM) provider used by the client.
+     *
+     * @return The specific LLMProvider implementation, which is of type LLMProvider.Ollama.
+     */
+    override fun llmProvider(): LLMProvider = LLMProvider.Ollama
+
     override suspend fun execute(
         prompt: Prompt,
         model: LLModel,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -114,6 +114,16 @@ public open class OpenAILLMClient(
         }
     }
 
+    /**
+     * Returns the specific implementation of the `LLMProvider` associated with this client.
+     *
+     * In this case, it identifies the `OpenAI` provider as the designated LLM provider
+     * for the client.
+     *
+     * @return The `LLMProvider` instance representing OpenAI.
+     */
+    override fun llmProvider(): LLMProvider = LLMProvider.OpenAI
+
     override fun serializeProviderChatRequest(
         messages: List<OpenAIMessage>,
         model: LLModel,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
@@ -72,6 +72,16 @@ public class OpenRouterLLMClient(
         }
     }
 
+    /**
+     * Returns the specific implementation of the `LLMProvider` associated with this client.
+     *
+     * In this case, it identifies the `OpenRouter` provider as the designated LLM provider
+     * for the client.
+     *
+     * @return The `LLMProvider` instance representing OpenRouter.
+     */
+    override fun llmProvider(): LLMProvider = LLMProvider.OpenRouter
+
     override fun serializeProviderChatRequest(
         messages: List<OpenAIMessage>,
         model: LLModel,

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/LLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/LLMClient.kt
@@ -4,6 +4,7 @@ import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.prompt.dsl.ModerationResult
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.LLMChoice
+import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.streaming.StreamFrame
@@ -65,6 +66,13 @@ public interface LLMClient {
      * @return The result of the moderation analysis, encapsulated in a ModerationResult object.
      */
     public suspend fun moderate(prompt: Prompt, model: LLModel): ModerationResult
+
+    /**
+     * Retrieves the LLMProvider instance associated with this client.
+     *
+     * @return The LLMProvider instance used for executing prompts and managing LLM operations.
+     */
+    public fun llmProvider(): LLMProvider
 }
 
 /**

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClient.kt
@@ -5,6 +5,7 @@ import ai.koog.prompt.dsl.ModerationResult
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.model.LLMChoice
+import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.streaming.StreamFrame
@@ -36,6 +37,17 @@ public class RetryingLLMClient(
     private val delegate: LLMClient,
     internal val config: RetryConfig = RetryConfig()
 ) : LLMClient {
+
+    /**
+     * Retrieves the configured instance of the `LLMProvider` in use.
+     *
+     * This method returns the `LLMProvider` instance associated with the client,
+     * facilitating identification or interaction with the specific provider of
+     * large language models (e.g., Google, OpenAI, Meta, etc.).
+     *
+     * @return the current `LLMProvider` associated with this client.
+     */
+    override fun llmProvider(): LLMProvider = delegate.llmProvider()
 
     private companion object {
         private val logger = KotlinLogging.logger { }

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClientTest.kt
@@ -393,7 +393,8 @@ class RetryingLLMClientTest {
         private var failuresBeforeSuccess: Int = 0,
         private var streamFailuresBeforeSuccess: Int = 0,
         private val failureMessage: String = "Mock failure",
-        private val throwCancellation: Boolean = false
+        private val throwCancellation: Boolean = false,
+        private val llmProvider: LLMProvider = LLMProvider.OpenAI,
     ) : LLMClient {
 
         var executeCalls = 0
@@ -405,6 +406,8 @@ class RetryingLLMClientTest {
         private var streamFailures = 0
         private var multipleChoicesFailures = 0
         private var moderateFailures = 0
+
+        override fun llmProvider(): LLMProvider = llmProvider
 
         override suspend fun execute(
             prompt: Prompt,

--- a/prompt/prompt-executor/prompt-executor-llms/src/commonMain/kotlin/ai/koog/prompt/executor/llms/MultiLLMPromptExecutor.kt
+++ b/prompt/prompt-executor/prompt-executor-llms/src/commonMain/kotlin/ai/koog/prompt/executor/llms/MultiLLMPromptExecutor.kt
@@ -62,7 +62,22 @@ public open class MultiLLMPromptExecutor(
      * @param llmClients Variable number of pairs, where each pair consists of an `LLMProvider` representing
      *                   the provider and a `LLMClient` for communication with that provider.
      */
-    public constructor(vararg llmClients: Pair<LLMProvider, LLMClient>) : this(mapOf(*llmClients))
+    public constructor(
+        vararg llmClients: Pair<LLMProvider, LLMClient>,
+        fallback: FallbackPromptExecutorSettings? = null
+    ) : this(llmClients = mapOf(*llmClients), fallback = fallback)
+
+    /**
+     * Secondary constructor for `MultiLLMPromptExecutor` that accepts a variable number of `LLMClient` instances.
+     * The provided clients are processed to create a mapping of `LLMProvider` to their respective `LLMClient`.
+     *
+     * @param llmClients Vararg parameter of `LLMClient` instances used to construct the executor.
+     */
+    public constructor(vararg llmClients: LLMClient) : this(
+        llmClients.map {
+            it.llmProvider() to it
+        }.associateBy({ it.first }, { it.second })
+    )
 
     /**
      * Companion object for `MultiLLMPromptExecutor` class.

--- a/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/MockOpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/MockOpenAILLMClient.kt
@@ -4,6 +4,7 @@ import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.prompt.dsl.ModerationResult
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.LLMClient
+import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
@@ -19,6 +20,8 @@ internal class MockOpenAILLMClient @JvmOverloads constructor(
     private val throwException: Boolean = false,
     private val clock: Clock = Clock.System,
 ) : LLMClient {
+
+    override fun llmProvider(): LLMProvider = LLMProvider.OpenAI
 
     override suspend fun execute(
         prompt: Prompt,

--- a/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/MultiLLMPromptExecutorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/MultiLLMPromptExecutorTest.kt
@@ -41,6 +41,8 @@ class MultiLLMPromptExecutorTest {
             return listOf(Message.Assistant("Anthropic response", ResponseMetaInfo.create(clock = mockClock)))
         }
 
+        override fun llmProvider(): LLMProvider = LLMProvider.Anthropic
+
         override fun executeStreaming(
             prompt: Prompt,
             model: LLModel,
@@ -62,6 +64,8 @@ class MultiLLMPromptExecutorTest {
         ): List<Message.Response> {
             return listOf(Message.Assistant("Gemini response", ResponseMetaInfo.create(clock = mockClock)))
         }
+
+        override fun llmProvider(): LLMProvider = LLMProvider.Google
 
         override fun executeStreaming(
             prompt: Prompt,
@@ -160,9 +164,9 @@ class MultiLLMPromptExecutorTest {
     @Test
     fun testExecuteStreamingWithAnthropic() = runTest {
         val executor = MultiLLMPromptExecutor(
-            LLMProvider.OpenAI to MockOpenAILLMClient(clock = mockClock),
-            LLMProvider.Anthropic to MockAnthropicLLMClient(),
-            LLMProvider.Google to MockGoogleLLMClient()
+            MockOpenAILLMClient(clock = mockClock),
+            MockAnthropicLLMClient(),
+            MockGoogleLLMClient()
         )
 
         val model = AnthropicModels.Sonnet_3_7
@@ -185,9 +189,9 @@ class MultiLLMPromptExecutorTest {
     @Test
     fun testExecuteStreamingWithGoogle() = runTest {
         val executor = MultiLLMPromptExecutor(
-            LLMProvider.OpenAI to MockOpenAILLMClient(clock = mockClock),
-            LLMProvider.Anthropic to MockAnthropicLLMClient(),
-            LLMProvider.Google to MockGoogleLLMClient()
+            MockOpenAILLMClient(clock = mockClock),
+            MockAnthropicLLMClient(),
+            MockGoogleLLMClient()
         )
 
         val model = GoogleModels.Gemini2_0Flash


### PR DESCRIPTION
# Add `llmProvider` method to LLM clients and extend `MultiLLMPromptExecutor` constructors

- Implemented `llmProvider` method for all LLM client implementations for better provider identification.
- Updated `MultiLLMPromptExecutor` to accept `LLMClient` instances directly, simplifying constructor usage.
- Adjusted tests and documentation accordingly.
- Register MultiLLMPromptExecutor as Spring bean

## Motivation and Context
LLMClient is de-facto associated with LLMProvider as 1-to-1

## Breaking Changes
No

---

#### Type of the changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [x] Refactoring

#### Checklist
- [ ] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [ ] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
