### PR TITLE
(KG-442) [prompt] update BedrockLLMClient constructor to accept more generic CredentialsProvider instead of just keys

### DIFF
--- a/docs/docs/prompt-api.md
+++ b/docs/docs/prompt-api.md
@@ -678,6 +678,7 @@ import ai.koog.prompt.executor.clients.retry.RetryingLLMClient
 import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
 import ai.koog.prompt.llm.LLMProvider
+import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
 
 -->
 ```kotlin
@@ -700,10 +701,13 @@ val multiExecutor = MultiLLMPromptExecutor(
     ),
     // The Bedrock client already has a built-in AWS SDK retry 
     LLMProvider.Bedrock to BedrockLLMClient(
-        awsAccessKeyId = System.getenv("AWS_ACCESS_KEY_ID"),
-        awsSecretAccessKey = System.getenv("AWS_SECRET_ACCESS_KEY"),
-        awsSessionToken = System.getenv("AWS_SESSION_TOKEN"),
-    ))
+        credentialsProvider = StaticCredentialsProvider {
+            accessKeyId = System.getenv("AWS_ACCESS_KEY_ID")
+            secretAccessKey = System.getenv("AWS_SECRET_ACCESS_KEY")
+            sessionToken = System.getenv("AWS_SESSION_TOKEN")
+        },
+    ),
+)
 ```
 <!--- KNIT example-prompt-api-21.kt -->
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SingleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SingleLLMPromptExecutorIntegrationTest.kt
@@ -53,6 +53,7 @@ import ai.koog.prompt.params.LLMParams.ToolChoice
 import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.streaming.filterTextOnly
 import ai.koog.prompt.structure.executeStructured
+import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -95,10 +96,12 @@ class SingleLLMPromptExecutorIntegrationTest {
             val googleClientInstance = GoogleLLMClient(readTestGoogleAIKeyFromEnv())
             val openRouterClientInstance = OpenRouterLLMClient(readTestOpenRouterKeyFromEnv())
             val bedrockClientInstance = BedrockLLMClient(
-                readAwsAccessKeyIdFromEnv(),
-                readAwsSecretAccessKeyFromEnv(),
-                readAwsSessionTokenFromEnv(),
-                BedrockClientSettings()
+                credentialsProvider = StaticCredentialsProvider {
+                    this.accessKeyId = readAwsAccessKeyIdFromEnv()
+                    this.secretAccessKey = readAwsSecretAccessKeyFromEnv()
+                    readAwsSessionTokenFromEnv()?.let { this.sessionToken = it }
+                },
+                settings = BedrockClientSettings()
             )
 
             return Stream.concat(
@@ -119,10 +122,12 @@ class SingleLLMPromptExecutorIntegrationTest {
         @JvmStatic
         fun bedrockCombinations(): Stream<Arguments> {
             val bedrockClientInstance = BedrockLLMClient(
-                readAwsAccessKeyIdFromEnv(),
-                readAwsSecretAccessKeyFromEnv(),
-                readAwsSessionTokenFromEnv(),
-                BedrockClientSettings(),
+                credentialsProvider = StaticCredentialsProvider {
+                    this.accessKeyId = readAwsAccessKeyIdFromEnv()
+                    this.secretAccessKey = readAwsSecretAccessKeyFromEnv()
+                    readAwsSessionTokenFromEnv()?.let { this.sessionToken = it }
+                },
+                settings = BedrockClientSettings()
             )
 
             return Models.bedrockModels().map { model -> Arguments.of(model, bedrockClientInstance) }
@@ -160,10 +165,12 @@ class SingleLLMPromptExecutorIntegrationTest {
             )
 
             LLMProvider.Bedrock -> BedrockLLMClient(
-                readAwsAccessKeyIdFromEnv(),
-                readAwsSecretAccessKeyFromEnv(),
-                readAwsSessionTokenFromEnv(),
-                BedrockClientSettings()
+                credentialsProvider = StaticCredentialsProvider {
+                    this.accessKeyId = readAwsAccessKeyIdFromEnv()
+                    this.secretAccessKey = readAwsSecretAccessKeyFromEnv()
+                    readAwsSessionTokenFromEnv()?.let { this.sessionToken = it }
+                },
+                settings = BedrockClientSettings()
             )
 
             else -> GoogleLLMClient(

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
@@ -39,6 +39,7 @@ import aws.sdk.kotlin.services.bedrockruntime.model.InvokeModelRequest
 import aws.sdk.kotlin.services.bedrockruntime.model.InvokeModelWithResponseStreamRequest
 import aws.sdk.kotlin.services.bedrockruntime.model.InvokeModelWithResponseStreamResponse
 import aws.sdk.kotlin.services.bedrockruntime.model.ResponseStream
+import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
 import aws.smithy.kotlin.runtime.net.url.Url
 import aws.smithy.kotlin.runtime.retries.StandardRetryStrategy
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -104,27 +105,20 @@ public class BedrockLLMClient(
     /**
      * Creates a new Bedrock LLM client configured with the specified AWS credentials and settings.
      *
-     * @param awsAccessKeyId The AWS access key ID for authentication
-     * @param awsSecretAccessKey The AWS secret access key for authentication
-     * @param awsSessionToken Optional session token for temporary credentials
+     * @param credentialsProvider AWS credentials provider for authentication with AWS services,
+     * e.g. [StaticCredentialsProvider] for providing AWS key and token explicitly.
      * @param settings Configuration settings for the Bedrock client, such as region and endpoint
      * @param clock A clock used for time-based operations
      * @return A configured [LLMClient] instance for Bedrock
      */
     public constructor(
-        awsAccessKeyId: String,
-        awsSecretAccessKey: String,
-        awsSessionToken: String? = null,
+        credentialsProvider: CredentialsProvider,
         settings: BedrockClientSettings = BedrockClientSettings(),
         clock: Clock = Clock.System,
     ) : this(
         bedrockClient = BedrockRuntimeClient {
             this.region = settings.region
-            this.credentialsProvider = StaticCredentialsProvider {
-                this.accessKeyId = awsAccessKeyId
-                this.secretAccessKey = awsSecretAccessKey
-                awsSessionToken?.let { this.sessionToken = it }
-            }
+            this.credentialsProvider = credentialsProvider
 
             // Configure a custom endpoint if provided
             settings.endpointUrl?.let { url ->

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClientTest.kt
@@ -9,6 +9,7 @@ import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
 import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
+import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
 import aws.sdk.kotlin.services.bedrockruntime.BedrockRuntimeClient
 import aws.sdk.kotlin.services.bedrockruntime.model.ApplyGuardrailRequest
 import aws.sdk.kotlin.services.bedrockruntime.model.ApplyGuardrailResponse
@@ -49,8 +50,10 @@ class BedrockLLMClientTest {
     @Test
     fun `can create BedrockLLMClient`() {
         val client = BedrockLLMClient(
-            awsAccessKeyId = "test-key",
-            awsSecretAccessKey = "test-secret",
+            credentialsProvider = StaticCredentialsProvider {
+                accessKeyId = "test-key"
+                secretAccessKey = "test-secret"
+            },
             settings = BedrockClientSettings(region = BedrockRegions.US_EAST_1.regionCode),
             clock = Clock.System
         )
@@ -217,8 +220,10 @@ class BedrockLLMClientTest {
         )
 
         val client = BedrockLLMClient(
-            awsAccessKeyId = "test-key",
-            awsSecretAccessKey = "test-secret",
+            credentialsProvider = StaticCredentialsProvider {
+                accessKeyId = "test-key"
+                secretAccessKey = "test-secret"
+            },
             settings = customSettings,
             clock = Clock.System
         )
@@ -307,8 +312,10 @@ class BedrockLLMClientTest {
 
         // Mock client for testing tool call request generation
         val client = BedrockLLMClient(
-            awsAccessKeyId = "test-key",
-            awsSecretAccessKey = "test-secret",
+            credentialsProvider = StaticCredentialsProvider {
+                accessKeyId = "test-key"
+                secretAccessKey = "test-secret"
+            },
             settings = BedrockClientSettings(region = BedrockRegions.US_EAST_1.regionCode),
             clock = Clock.System
         )
@@ -464,8 +471,10 @@ class BedrockLLMClientTest {
     fun `moderate method throws exception when moderation guardrails settings are not provided`() = runTest {
         // Create client without moderation guardrails settings
         val client = BedrockLLMClient(
-            awsAccessKeyId = "test-key",
-            awsSecretAccessKey = "test-secret",
+            credentialsProvider = StaticCredentialsProvider {
+                accessKeyId = "test-key"
+                secretAccessKey = "test-secret"
+            },
             settings = BedrockClientSettings(region = BedrockRegions.US_EAST_1.regionCode),
             clock = Clock.System
         )

--- a/prompt/prompt-executor/prompt-executor-llms-all/src/jvmMain/kotlin/ai/koog/prompt/executor/llms/all/SimplePromptExecutors.jvm.kt
+++ b/prompt/prompt-executor/prompt-executor-llms-all/src/jvmMain/kotlin/ai/koog/prompt/executor/llms/all/SimplePromptExecutors.jvm.kt
@@ -3,6 +3,7 @@ package ai.koog.prompt.executor.llms.all
 import ai.koog.prompt.executor.clients.bedrock.BedrockClientSettings
 import ai.koog.prompt.executor.clients.bedrock.BedrockLLMClient
 import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
+import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
 
 /**
  * Creates an instance of `SingleLLMPromptExecutor` with a `BedrockLLMClient`.
@@ -17,4 +18,13 @@ public fun simpleBedrockExecutor(
     awsSessionToken: String? = null,
     settings: BedrockClientSettings = BedrockClientSettings()
 ): SingleLLMPromptExecutor =
-    SingleLLMPromptExecutor(BedrockLLMClient(awsAccessKeyId, awsSecretAccessKey, awsSessionToken, settings))
+    SingleLLMPromptExecutor(
+        BedrockLLMClient(
+            credentialsProvider = StaticCredentialsProvider {
+                this.accessKeyId = awsAccessKeyId
+                this.secretAccessKey = awsSecretAccessKey
+                awsSessionToken?.let { this.sessionToken = it }
+            },
+            settings = settings,
+        )
+    )


### PR DESCRIPTION
Update secondary constructor in `BedrockLLMClient` to accept `CredentialsProvider` interface type instead of just keys. This would give more flexibility to choose convenient auth method without having to use primary constructor and constructing the whole `BedrockRuntimeClient` by hand

Initiated by #501 , fixes #498 