### PR TITLE
[prompt] Throw exception on nullable types in OpenAI JSON Schema generators explicitly

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/structure/OpenAIBasicJsonSchemaGenerator.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/structure/OpenAIBasicJsonSchemaGenerator.kt
@@ -20,6 +20,14 @@ public open class OpenAIBasicJsonSchemaGenerator : BasicJsonSchemaGenerator() {
      */
     public companion object Default : OpenAIBasicJsonSchemaGenerator()
 
+    override fun process(context: GenerationContext): JsonObject {
+        if (context.descriptor.isNullable) {
+            throw IllegalArgumentException("OpenAI JSON schema doesn't support nullable types")
+        }
+
+        return super.process(context)
+    }
+
     override fun processMap(context: GenerationContext): JsonObject {
         throw UnsupportedOperationException("OpenAI JSON schema doesn't support maps")
     }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/structure/OpenAIStandardJsonSchemaGenerator.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/structure/OpenAIStandardJsonSchemaGenerator.kt
@@ -70,6 +70,14 @@ public open class OpenAIStandardJsonSchemaGenerator : StandardJsonSchemaGenerato
         return param.copy(schema = JsonObject(schema))
     }
 
+    override fun process(context: GenerationContext): JsonObject {
+        if (context.descriptor.isNullable) {
+            throw IllegalArgumentException("OpenAI JSON schema doesn't support nullable types")
+        }
+
+        return super.process(context)
+    }
+
     override fun processMap(context: GenerationContext): JsonObject {
         throw UnsupportedOperationException("OpenAI JSON schema doesn't support maps")
     }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/structure/OpenAIBasicJsonSchemaGeneratorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/structure/OpenAIBasicJsonSchemaGeneratorTest.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class OpenAIBasicJsonSchemaGeneratorTest {
     private val json = Json {
@@ -71,6 +72,9 @@ class OpenAIBasicJsonSchemaGeneratorTest {
             High
         }
     }
+
+    @Serializable
+    data class NullableTest(val nullableProperty: String?)
 
     @Test
     fun testGenerateOpenAIBasicJsonSchemaWeatherForecast() {
@@ -159,5 +163,12 @@ class OpenAIBasicJsonSchemaGeneratorTest {
         """.trimIndent()
 
         assertEquals(expectedSchema, schema)
+    }
+
+    @Test
+    fun testOpenAIBasicJsonSchemaFailsWithNullable() {
+        assertFailsWith<IllegalArgumentException> {
+            basicGenerator.generate(json, "NullableTest", serializer<NullableTest>(), emptyMap())
+        }
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/structure/OpenAIBasicJsonSchemaGeneratorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/structure/OpenAIBasicJsonSchemaGeneratorTest.kt
@@ -28,8 +28,6 @@ class OpenAIBasicJsonSchemaGeneratorTest {
         val temperature: Int,
         @property:LLMDescription("Weather conditions (e.g., sunny, cloudy, rainy)")
         val conditions: String = "sunny",
-        @property:LLMDescription("Chance of precipitation in percentage")
-        val precipitation: Int?,
         @property:LLMDescription("Coordinates of the location")
         val latLon: LatLon,
         @property:LLMDescription("Pollution level")
@@ -93,11 +91,6 @@ class OpenAIBasicJsonSchemaGeneratorTest {
                   "type": "string",
                   "description": "Weather conditions (e.g., sunny, cloudy, rainy)"
                 },
-                "precipitation": {
-                  "type": "integer",
-                  "description": "Chance of precipitation in percentage",
-                  "nullable": true
-                },
                 "latLon": {
                   "type": "object",
                   "properties": {
@@ -153,7 +146,6 @@ class OpenAIBasicJsonSchemaGeneratorTest {
               "required": [
                 "temperature",
                 "conditions",
-                "precipitation",
                 "latLon",
                 "pollution",
                 "news"

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/structure/OpenAIStandardJsonSchemaGeneratorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/structure/OpenAIStandardJsonSchemaGeneratorTest.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class OpenAIStandardJsonSchemaGeneratorTest {
     private val json = Json {
@@ -115,6 +116,9 @@ class OpenAIStandardJsonSchemaGeneratorTest {
             ) : WeatherAlert()
         }
     }
+
+    @Serializable
+    data class NullableTest(val nullableProperty: String?)
 
     @Test
     fun testGenerateOpenAIStandardJsonSchemaWeatherForecast() {
@@ -407,5 +411,12 @@ class OpenAIStandardJsonSchemaGeneratorTest {
         """.trimIndent()
 
         assertEquals(expectedSchema, schema)
+    }
+
+    @Test
+    fun testOpenAIBasicJsonSchemaFailsWithNullable() {
+        assertFailsWith<IllegalArgumentException> {
+            fullGenerator.generate(json, "NullableTest", serializer<NullableTest>(), emptyMap())
+        }
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/structure/OpenAIStandardJsonSchemaGeneratorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/structure/OpenAIStandardJsonSchemaGeneratorTest.kt
@@ -31,8 +31,6 @@ class OpenAIStandardJsonSchemaGeneratorTest {
         val temperature: Int,
         @property:LLMDescription("Weather conditions (e.g., sunny, cloudy, rainy)")
         val conditions: String = "sunny",
-        @property:LLMDescription("Chance of precipitation in percentage")
-        val precipitation: Int?,
         @property:LLMDescription("Coordinates of the location")
         val latLon: LatLon,
         val pollution: Pollution,
@@ -283,13 +281,6 @@ class OpenAIStandardJsonSchemaGeneratorTest {
                       "type": "string",
                       "description": "Weather conditions (e.g., sunny, cloudy, rainy)"
                     },
-                    "precipitation": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ],
-                      "description": "Chance of precipitation in percentage"
-                    },
                     "latLon": {
                       "description": "Coordinates of the location",
                       "anyOf": [
@@ -331,7 +322,6 @@ class OpenAIStandardJsonSchemaGeneratorTest {
                   "required": [
                     "temperature",
                     "conditions",
-                    "precipitation",
                     "latLon",
                     "pollution",
                     "alert",
@@ -350,13 +340,6 @@ class OpenAIStandardJsonSchemaGeneratorTest {
                 "conditions": {
                   "type": "string",
                   "description": "Weather conditions (e.g., sunny, cloudy, rainy)"
-                },
-                "precipitation": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Chance of precipitation in percentage"
                 },
                 "latLon": {
                   "description": "Coordinates of the location",
@@ -399,7 +382,6 @@ class OpenAIStandardJsonSchemaGeneratorTest {
               "required": [
                 "temperature",
                 "conditions",
-                "precipitation",
                 "latLon",
                 "pollution",
                 "alert",


### PR DESCRIPTION
OpenAI structured output doesn't support nullable types. Currently, in this case you get an error from the API about an invalid schema, which isn't helpful because it doesn't explain why the schema is invalid exactly. Update our schema generators to throw descriptive exception explicitly during generation.