### PR TITLE
KG-440. Handle Assistant message in subgraphWithTask method

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentSubgraph.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentSubgraph.kt
@@ -184,7 +184,7 @@ public open class AIAgentSubgraph<TInput, TOutput>(
 
     @OptIn(InternalAgentsApi::class)
     private suspend fun executeWithInnerContext(context: AIAgentGraphContextBase, initialInput: TInput): TOutput? {
-        logger.info { formatLog(context, "Executing subgraph $name") }
+        logger.info { formatLog(context, "Executing subgraph '$name'") }
 
         var currentNode: AIAgentNodeBase<*, *> = start
         var currentInput: Any? = initialInput
@@ -215,9 +215,9 @@ public open class AIAgentSubgraph<TInput, TOutput>(
             }
 
             // run the current node and get its output
-            logger.info { formatLog(context, "Executing node ${currentNode.name}") }
+            logger.debug { formatLog(context, "Executing node '${currentNode.name}'") }
             val nodeOutput: Any? = currentNode.executeUnsafe(context, currentInput)
-            logger.info { formatLog(context, "Completed node ${currentNode.name}") }
+            logger.debug { formatLog(context, "Completed node '${currentNode.name}'") }
 
             // forced context data means that we've requested interruption due to jump to other node / rolling back to checkpoint
             if (context.getAgentContextData() != null) {
@@ -242,7 +242,7 @@ public open class AIAgentSubgraph<TInput, TOutput>(
             currentInput = resolvedEdge.output
         }
 
-        logger.info { formatLog(context, "Completed subgraph $name") }
+        logger.debug { formatLog(context, "Completed subgraph $name") }
         @Suppress("UNCHECKED_CAST")
         val result = (currentInput as? TOutput) ?: run {
             logger.error {

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/SubgraphWithTaskTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/SubgraphWithTaskTest.kt
@@ -1,0 +1,362 @@
+package ai.koog.agents.ext.agent
+
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.GraphAIAgent.FeatureContext
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.ext.mock.MockTools
+import ai.koog.agents.features.eventHandler.feature.EventHandler
+import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.agents.testing.tools.mockLLMAnswer
+import ai.koog.agents.utils.use
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.llm.OllamaModels
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.params.LLMParams
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.js.JsName
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+
+class SubgraphWithTaskTest {
+
+    //region Model With tool_choice Support
+
+    @Test
+    @JsName("testSubgraphWithTaskToolChoiceSupportSuccess")
+    fun `test subgraphWithTask tool_choice support success`() = runTest {
+        val blankTool = MockTools.BlankTool()
+        val finishTool = MockTools.FinishTool
+
+        val toolRegistry = ToolRegistry {
+            tool(blankTool)
+        }
+
+        val model = OpenAIModels.Chat.GPT4o
+
+        val inputRequest = "Test input"
+        val blankToolResult = "I'm done"
+
+        val mockExecutor = getMockExecutor {
+            mockLLMToolCall(blankTool, MockTools.BlankTool.Args(blankToolResult)) onRequestEquals inputRequest
+            mockLLMToolCall(finishTool, MockTools.FinishTool.Args()) onRequestContains blankToolResult
+        }
+
+        val actualToolCalls = mutableListOf<String>()
+
+        val expectedToolCalls = listOf(
+            blankTool.name,
+        )
+
+        createAgent(
+            model = model,
+            toolRegistry = toolRegistry,
+            executor = mockExecutor,
+            finishTool = finishTool,
+            installFeatures = {
+                install(EventHandler) {
+                    onToolCallStarting {
+                        actualToolCalls += it.tool.name
+                    }
+                }
+            }
+        ).use { agent ->
+            agent.run(inputRequest)
+
+            assertEquals(expectedToolCalls.size, actualToolCalls.size)
+            assertContentEquals(expectedToolCalls, actualToolCalls)
+        }
+    }
+
+    @Test
+    @JsName("testSubgraphWithTaskToolChoiceSupportReceiveAssistantMessage")
+    fun `test subgraphWithTask tool_choice support receive assistant message`() = runTest {
+        val model = OpenAIModels.Chat.GPT4o
+
+        val inputRequest = "Test input"
+        val testAssistantResponse = "Test assistant response"
+
+        val mockExecutor = getMockExecutor {
+            mockLLMAnswer(testAssistantResponse) onRequestEquals inputRequest
+        }
+
+        createAgent(
+            model = model,
+            executor = mockExecutor,
+        ).use { agent ->
+            val throwable = assertFails { agent.run(inputRequest) }
+
+            val expectedMessage =
+                "Subgraph with task must always call tools, but no ${Message.Tool.Call::class.simpleName} was generated, " +
+                    "got instead: ${Message.Assistant::class.simpleName}"
+
+            assertEquals(expectedMessage, throwable.message)
+        }
+    }
+
+    //endregion Model With tool_choice Support
+
+    //region Model Without tool_choice Support
+
+    @Test
+    @JsName("testSubgraphWithTaskNoToolChoiceSupportSuccess")
+    fun `test subgraphWithTask no tool_choice support success`() = runTest {
+        val blankTool = MockTools.BlankTool()
+        val finishTool = MockTools.FinishTool
+
+        val toolRegistry = ToolRegistry {
+            tool(blankTool)
+        }
+
+        val model = OllamaModels.Meta.LLAMA_3_2
+
+        val inputRequest = "Test input"
+        val blankToolResult = "I'm done"
+
+        val mockExecutor = getMockExecutor {
+            mockLLMToolCall(blankTool, MockTools.BlankTool.Args(blankToolResult)) onRequestEquals inputRequest
+            mockLLMToolCall(finishTool, MockTools.FinishTool.Args()) onRequestContains blankToolResult
+        }
+
+        val actualLLMCalls = mutableListOf<String>()
+        val actualToolCalls = mutableListOf<String>()
+
+        val expectedLLMCalls = listOf(
+            inputRequest,
+            Json.encodeToString(blankToolResult)
+        )
+
+        val expectedToolCalls = listOf(
+            blankTool.name,
+        )
+
+        createAgent(
+            model = model,
+            toolRegistry = toolRegistry,
+            executor = mockExecutor,
+            finishTool = finishTool,
+            installFeatures = {
+                install(EventHandler) {
+                    onToolCallStarting {
+                        actualToolCalls += it.tool.name
+                    }
+
+                    onLLMCallStarting {
+                        actualLLMCalls += it.prompt.messages.last().content
+                    }
+                }
+            }
+        ).use { agent ->
+            agent.run(inputRequest)
+
+            assertEquals(expectedToolCalls.size, actualToolCalls.size)
+            assertContentEquals(expectedToolCalls, actualToolCalls)
+
+            assertEquals(expectedLLMCalls.size, actualLLMCalls.size)
+            assertContentEquals(expectedLLMCalls, actualLLMCalls)
+        }
+    }
+
+    @Test
+    @JsName("testSubgraphWithTaskNoToolChoiceSupportReceiveAssistantMessageSuccess")
+    fun `test subgraphWithTask no tool_choice support receive assistant message success`() = runTest {
+        val blankTool = MockTools.BlankTool()
+        val finishTool = MockTools.FinishTool
+
+        val toolRegistry = ToolRegistry {
+            tool(blankTool)
+        }
+
+        val model = OllamaModels.Meta.LLAMA_3_2
+
+        val inputRequest = "Test input"
+        val blankToolResult = "I'm done"
+        val mockResponse = "Test assistant response"
+        var assistantResponded = 0
+
+        val mockExecutor = getMockExecutor {
+            mockLLMToolCall(blankTool, MockTools.BlankTool.Args(blankToolResult)) onRequestEquals inputRequest
+
+            mockLLMAnswer(mockResponse) onCondition { input ->
+                input.contains(inputRequest) && assistantResponded++ < SubgraphWithTaskUtils.ASSISTANT_RESPONSE_REPEAT_MAX
+            }
+
+            mockLLMToolCall(finishTool, MockTools.FinishTool.Args()) onCondition { input ->
+                input.contains("CALL TOOLS") && assistantResponded++ >= SubgraphWithTaskUtils.ASSISTANT_RESPONSE_REPEAT_MAX
+            }
+        }
+
+        val actualLLMCalls = mutableListOf<String>()
+        val actualToolCalls = mutableListOf<String>()
+
+        val expectedToolCallAssistantRequest =
+            "# DO NOT CHAT WITH ME DIRECTLY! CALL TOOLS, INSTEAD.\n## IF YOU HAVE FINISHED, CALL `${finishTool.name}` TOOL!"
+
+        val expectedLLMCalls = listOf(
+            inputRequest,
+            Json.encodeToString(blankToolResult),
+            expectedToolCallAssistantRequest,
+            expectedToolCallAssistantRequest,
+            expectedToolCallAssistantRequest,
+        )
+
+        val expectedToolCalls = listOf(
+            blankTool.name,
+        )
+
+        createAgent(
+            model = model,
+            toolRegistry = toolRegistry,
+            executor = mockExecutor,
+            finishTool = finishTool,
+            installFeatures = {
+                install(EventHandler) {
+                    onToolCallStarting {
+                        actualToolCalls += it.tool.name
+                    }
+
+                    onLLMCallStarting {
+                        actualLLMCalls += it.prompt.messages.last().content
+                    }
+                }
+            }
+        ).use { agent ->
+            agent.run(inputRequest)
+
+            assertEquals(expectedToolCalls.size, actualToolCalls.size)
+            assertContentEquals(expectedToolCalls, actualToolCalls)
+
+            assertEquals(expectedLLMCalls.size, actualLLMCalls.size)
+            assertContentEquals(expectedLLMCalls, actualLLMCalls)
+        }
+    }
+
+    @Test
+    @JsName("testSubgraphWithTaskNoToolChoiceSupportReceiveAssistantMessageExceedMaxAttempts")
+    fun `test subgraphWithTask no tool_choice support receive assistant message exceed maxAttempts`() = runTest {
+        val blankTool = MockTools.BlankTool()
+        val finishTool = MockTools.FinishTool
+
+        val toolRegistry = ToolRegistry {
+            tool(blankTool)
+        }
+
+        val model = OllamaModels.Meta.LLAMA_3_2
+
+        val inputRequest = "Test input"
+        val blankToolResult = "I'm done"
+        val mockResponse = "Test assistant response"
+        var assistantResponded = 0
+
+        val mockExecutor = getMockExecutor {
+            mockLLMToolCall(blankTool, MockTools.BlankTool.Args(blankToolResult)) onRequestEquals inputRequest
+
+            mockLLMAnswer(mockResponse) onCondition { input ->
+                input.contains(inputRequest) && assistantResponded++ > SubgraphWithTaskUtils.ASSISTANT_RESPONSE_REPEAT_MAX
+            }
+        }
+
+        val actualLLMCalls = mutableListOf<String>()
+        val actualToolCalls = mutableListOf<String>()
+
+        val expectedToolCallAssistantRequest =
+            "# DO NOT CHAT WITH ME DIRECTLY! CALL TOOLS, INSTEAD.\n## IF YOU HAVE FINISHED, CALL `${finishTool.name}` TOOL!"
+
+        val expectedLLMCalls = listOf(
+            inputRequest,
+            Json.encodeToString(blankToolResult),
+            expectedToolCallAssistantRequest,
+            expectedToolCallAssistantRequest,
+            expectedToolCallAssistantRequest,
+        )
+
+        val expectedToolCalls = listOf(
+            blankTool.name,
+        )
+
+        createAgent(
+            model = model,
+            toolRegistry = toolRegistry,
+            executor = mockExecutor,
+            finishTool = finishTool,
+            installFeatures = {
+                install(EventHandler) {
+                    onToolCallStarting {
+                        actualToolCalls += it.tool.name
+                    }
+
+                    onLLMCallStarting {
+                        actualLLMCalls += it.prompt.messages.last().content
+                    }
+                }
+            }
+        ).use { agent ->
+            val throwable = assertFails { agent.run(inputRequest) }
+
+            val expectedErrorMessage =
+                "Unable to finish subgraph with task. Reason: the model '${model.id}' does not support tool choice, " +
+                    "and was not able to call `${finishTool.name}` tool after <${SubgraphWithTaskUtils.ASSISTANT_RESPONSE_REPEAT_MAX}> attempts."
+
+            assertEquals(expectedErrorMessage, throwable.message)
+
+            assertEquals(expectedToolCalls.size, actualToolCalls.size)
+            assertContentEquals(expectedToolCalls, actualToolCalls)
+
+            assertEquals(expectedLLMCalls.size, actualLLMCalls.size)
+            assertContentEquals(expectedLLMCalls, actualLLMCalls)
+        }
+    }
+
+    //endregion Model Without tool_choice Support
+
+    //region Private Methods
+
+    fun createAgent(
+        model: LLModel,
+        toolRegistry: ToolRegistry? = null,
+        finishTool: Tool<MockTools.FinishTool.Args, String>? = null,
+        executor: PromptExecutor? = null,
+        installFeatures: FeatureContext.() -> Unit = {},
+    ): AIAgent<String, String> {
+        val finishTool = finishTool ?: MockTools.FinishTool
+        val toolRegistry = toolRegistry ?: ToolRegistry { }
+        val llmParams = LLMParams()
+
+        val strategy = strategy("test-strategy") {
+            val testSubgraphWithTask by subgraphWithTask<String, MockTools.FinishTool.Args, String>(
+                tools = toolRegistry.tools,
+                finishTool = finishTool,
+                llmModel = model,
+                llmParams = llmParams,
+            ) { input -> input }
+
+            nodeStart then testSubgraphWithTask then nodeFinish
+        }
+
+        val agentConfig = AIAgentConfig(
+            prompt = prompt("test-agent") {
+                system("You are a test agent.")
+            },
+            model = model,
+            maxAgentIterations = 20,
+        )
+
+        return AIAgent(
+            promptExecutor = executor ?: getMockExecutor { },
+            strategy = strategy,
+            agentConfig = agentConfig,
+            toolRegistry = toolRegistry,
+            installFeatures = installFeatures,
+        )
+    }
+
+    //endregion Private Methods
+}

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/SubgraphWithTaskTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/SubgraphWithTaskTest.kt
@@ -18,6 +18,7 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.llm.OllamaModels
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.params.LLMParams
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlin.js.JsName
@@ -27,6 +28,10 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFails
 
 class SubgraphWithTaskTest {
+
+    companion object {
+        private val logger = KotlinLogging.logger { }
+    }
 
     //region Model With tool_choice Support
 
@@ -69,7 +74,8 @@ class SubgraphWithTaskTest {
                 }
             }
         ).use { agent ->
-            agent.run(inputRequest)
+            val agentResult = agent.run(inputRequest)
+            logger.info { "Agent is finished with result: $agentResult" }
 
             assertEquals(expectedToolCalls.size, actualToolCalls.size)
             assertContentEquals(expectedToolCalls, actualToolCalls)
@@ -155,7 +161,8 @@ class SubgraphWithTaskTest {
                 }
             }
         ).use { agent ->
-            agent.run(inputRequest)
+            val agentResult = agent.run(inputRequest)
+            logger.info { "Agent is finished with result: $agentResult" }
 
             assertEquals(expectedToolCalls.size, actualToolCalls.size)
             assertContentEquals(expectedToolCalls, actualToolCalls)
@@ -229,7 +236,8 @@ class SubgraphWithTaskTest {
                 }
             }
         ).use { agent ->
-            agent.run(inputRequest)
+            val agentResult = agent.run(inputRequest)
+            logger.info { "Agent is finished with result: $agentResult" }
 
             assertEquals(expectedToolCalls.size, actualToolCalls.size)
             assertContentEquals(expectedToolCalls, actualToolCalls)

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/mock/MockTools.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/mock/MockTools.kt
@@ -1,0 +1,46 @@
+package ai.koog.agents.ext.mock
+
+import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.annotations.LLMDescription
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.serializer
+
+object MockTools {
+
+    object FinishTool : Tool<FinishTool.Args, String>() {
+
+        @Serializable
+        data class Args(
+            @property:LLMDescription("Finish output") val output: String = ""
+        )
+
+        override val argsSerializer: KSerializer<Args> = serializer<Args>()
+
+        override val resultSerializer: KSerializer<String> = serializer<String>()
+
+        override val description: String = "test-finish-tool"
+
+        override suspend fun execute(args: Args): String {
+            return args.output
+        }
+    }
+
+    class BlankTool : Tool<BlankTool.Args, String>() {
+
+        @Serializable
+        data class Args(
+            @property:LLMDescription("Dummy parameter") val args: String = ""
+        )
+
+        override val argsSerializer: KSerializer<Args> = serializer<Args>()
+
+        override val resultSerializer: KSerializer<String> = serializer<String>()
+
+        override val description: String = "test-finish-tool"
+
+        override suspend fun execute(args: Args): String {
+            return args.args
+        }
+    }
+}


### PR DESCRIPTION
[KG-440](https://youtrack.jetbrains.com/issue/KG-440/Update-the-subgraphWithTask-to-use-giveFeedback-node-with-assistant-response). SubgraphWithTask API supports models with no "tool_choice" capability.

- Add ability to use `subgraphWithTask` API with models that does not have `tool_choice` capability;
- Update mock test framework logic to be able to set conditions on tool call mocks.

## Breaking Changes
No

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [x] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
