### PR TITLE
[docs] Treat warnings as errors to always maintain the latest API in code snippets in docs, fix warnings

### DIFF
--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -9,6 +9,10 @@ plugins {
     alias(libs.plugins.knit)
 }
 
+kotlin {
+    compilerOptions.allWarningsAsErrors.set(true)
+}
+
 dependencies {
     implementation(project(":agents:agents-test"))
     implementation(project(":koog-agents"))

--- a/docs/docs/class-based-tools.md
+++ b/docs/docs/class-based-tools.md
@@ -156,7 +156,6 @@ If you are not happy with JSON results sent to LLM (in some cases, LLMs can work
 
 <!--- INCLUDE
 import ai.koog.agents.core.tools.Tool
-import ai.koog.agents.core.tools.ToolResult
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
@@ -178,19 +177,19 @@ object EditFile : Tool<EditFile.Args, EditFile.Result>() {
     @Serializable
     public data class Result(
         private val patchApplyResult: PatchApplyResult
-    ) : ToolResult.TextSerializable() {
+    ) {
 
         @Serializable
         public sealed interface PatchApplyResult {
             @Serializable
             public data class Success(val updatedContent: String) : PatchApplyResult
-            
+
             @Serializable
             public sealed class Failure(public val reason: String) : PatchApplyResult
         }
-        
+
         // Textual output (in Markdown format) that will be visible to the LLM after the tool finishes.
-        override fun textForLLM(): String = markdown {
+        fun textForLLM(): String = markdown {
             if (patchApplyResult is PatchApplyResult.Success) {
                 line {
                     bold("Successfully").text(" edited file (patch applied)")
@@ -213,7 +212,7 @@ object EditFile : Tool<EditFile.Args, EditFile.Result>() {
 
     // Description of the tool, visible to LLM
     override val description = "Edits the given file"
-    
+
     // Function that executes the tool with the provided arguments
     override suspend fun execute(args: Args): Result {
         return TODO("Implement file edit")

--- a/docs/docs/custom-subgraphs.md
+++ b/docs/docs/custom-subgraphs.md
@@ -253,7 +253,6 @@ import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResult
 import ai.koog.agents.core.dsl.extension.onAssistantMessage
 import ai.koog.agents.core.dsl.extension.onToolCall
 import ai.koog.agents.core.tools.SimpleTool
-import ai.koog.agents.core.tools.ToolArgs
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.prompt.dsl.prompt
 import kotlinx.serialization.KSerializer

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -224,8 +224,7 @@ Start by validating the fundamental structure of your agent's graph:
 <!--- INCLUDE
 
 import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.tools.ToolResult
-import ai.koog.agents.example.exampleCustomNodes11.ToolArgs
+import ai.koog.agents.core.environment.ReceivedToolResult
 import ai.koog.agents.example.exampleTesting02.mockLLMApi
 import ai.koog.agents.example.exampleTesting02.toolRegistry
 import ai.koog.agents.testing.feature.testGraph
@@ -266,7 +265,7 @@ AIAgent(
 
             // Assert nodes by name
             val askLLM = assertNodeByName<String, Message.Response>("callLLM")
-            val callTool = assertNodeByName<ToolArgs, ToolResult>("executeTool")
+            val callTool = assertNodeByName<Message.Tool.Call, ReceivedToolResult>("executeTool")
 
             // Assert node reachability
             assertReachable(start, askLLM)

--- a/docs/docs/tools-overview.md
+++ b/docs/docs/tools-overview.md
@@ -118,8 +118,6 @@ You can also call tools in parallel using the `toParallelToolCallsRaw` extension
 <!--- INCLUDE
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.tools.SimpleTool
-import ai.koog.agents.core.tools.ToolArgs
-import ai.koog.agents.core.tools.ToolDescriptor
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import kotlinx.serialization.KSerializer


### PR DESCRIPTION
Enable warnings as errors option in `docs` module to ensure the latest API in code snippets in docs.