### PR TITLE
Add params for google and anthropic and refactor LLMParams

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
@@ -7,6 +7,20 @@ import ai.koog.prompt.dsl.ModerationResult
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
 import ai.koog.prompt.executor.clients.LLMClient
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicContent
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicMessage
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicMessageRequest
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicMessageRequestSerializer
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicResponse
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicResponseContent
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicStreamResponse
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicTool
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicToolChoice
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicToolSchema
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicUsage
+import ai.koog.prompt.executor.clients.anthropic.models.DocumentSource
+import ai.koog.prompt.executor.clients.anthropic.models.ImageSource
+import ai.koog.prompt.executor.clients.anthropic.models.SystemAnthropicMessage
 import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
@@ -365,7 +379,20 @@ public open class AnthropicLLMClient(
             )
         }
 
-        val toolChoice = when (val toolChoice = prompt.params.toolChoice) {
+        return serializeAnthropicMessageRequest(messages, systemMessage, model, anthropicTools, prompt.params, stream)
+    }
+
+    private fun serializeAnthropicMessageRequest(
+        messages: List<AnthropicMessage>,
+        systemMessages: List<SystemAnthropicMessage>,
+        model: LLModel,
+        tools: List<AnthropicTool>,
+        params: LLMParams,
+        stream: Boolean
+    ): String {
+        val anthropicParams = params.toAnthropicParams()
+
+        val toolChoice = when (val toolChoice = anthropicParams.toolChoice) {
             LLMParams.ToolChoice.Auto -> AnthropicToolChoice.Auto
             LLMParams.ToolChoice.None -> AnthropicToolChoice.None
             LLMParams.ToolChoice.Required -> AnthropicToolChoice.Any
@@ -373,23 +400,29 @@ public open class AnthropicLLMClient(
             null -> null
         }
 
-        require(prompt.params.schema == null) {
+        require(anthropicParams.schema == null) {
             "Anthropic does not currently support native structured output."
         }
 
         // Always include max_tokens as it's required by the API
         val request = AnthropicMessageRequest(
-            model = settings.modelVersionsMap[model]
-                ?: throw IllegalArgumentException("Unsupported model: $model"),
+            model = settings.modelVersionsMap[model] ?: throw IllegalArgumentException("Unsupported model: $model"),
             messages = messages,
-            maxTokens = prompt.params.maxTokens ?: AnthropicMessageRequest.MAX_TOKENS_DEFAULT,
-            temperature = prompt.params.temperature,
-            system = systemMessage,
-            tools = if (tools.isNotEmpty()) anthropicTools else emptyList(), // Always provide a list for tools
+            maxTokens = anthropicParams.maxTokens ?: AnthropicMessageRequest.MAX_TOKENS_DEFAULT,
+            container = anthropicParams.container,
+            mcpServers = anthropicParams.mcpServers,
+            serviceTier = anthropicParams.serviceTier,
+            stopSequence = anthropicParams.stopSequences,
             stream = stream,
+            system = systemMessages,
+            temperature = anthropicParams.temperature,
             toolChoice = toolChoice,
-            additionalProperties = prompt.params.additionalProperties
+            tools = tools.ifEmpty { emptyList() }, // Always provide a list for tools
+            topK = anthropicParams.topK,
+            topP = anthropicParams.topP,
+            additionalProperties = anthropicParams.additionalProperties
         )
+
         return json.encodeToString(AnthropicMessageRequestSerializer, request)
     }
 
@@ -424,7 +457,11 @@ public open class AnthropicLLMClient(
 
                         val documentSource: DocumentSource = when (val content = attachment.content) {
                             is AttachmentContent.URL -> DocumentSource.Url(content.url)
-                            is AttachmentContent.Binary -> DocumentSource.Base64(content.asBase64(), attachment.mimeType)
+                            is AttachmentContent.Binary -> DocumentSource.Base64(
+                                content.asBase64(),
+                                attachment.mimeType
+                            )
+
                             is AttachmentContent.PlainText -> DocumentSource.PlainText(
                                 content.text,
                                 attachment.mimeType

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
@@ -417,7 +417,7 @@ public open class AnthropicLLMClient(
             system = systemMessages,
             temperature = anthropicParams.temperature,
             toolChoice = toolChoice,
-            tools = tools.ifEmpty { emptyList() }, // Always provide a list for tools
+            tools = tools, // Always provide a list for tools
             topK = anthropicParams.topK,
             topP = anthropicParams.topP,
             additionalProperties = anthropicParams.additionalProperties

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicParams.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicParams.kt
@@ -1,0 +1,191 @@
+package ai.koog.prompt.executor.clients.anthropic
+
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicMCPServerURLDefinition
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicServiceTier
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicThinking
+import ai.koog.prompt.params.LLMParams
+import kotlinx.serialization.json.JsonElement
+
+internal fun LLMParams.toAnthropicParams(): AnthropicParams {
+    if (this is AnthropicParams) return this
+    return AnthropicParams(
+        temperature = temperature,
+        maxTokens = maxTokens,
+        numberOfChoices = numberOfChoices,
+        speculation = speculation,
+        schema = schema,
+        toolChoice = toolChoice,
+        user = user,
+        additionalProperties = additionalProperties,
+    )
+}
+
+/**
+ * Anthropic Messages API parameters layered on top of [LLMParams].
+ *
+ * @property temperature Sampling temperature in [0.0, 1.0]. Higher ⇒ more random;
+ *   lower ⇒ more deterministic. Use closer to 0.0 for analytical tasks, closer to 1.0
+ *   for creative tasks. Adjust this **or** [topP], not both.
+ * @property maxTokens Maximum number of tokens the model may generate for this response.
+ * @property numberOfChoices Number of completions to generate for the prompt (cost scales with N).
+ * @property speculation Provider-specific control for speculative decoding / draft acceleration.
+ * @property schema JSON Schema to constrain model output (validated when supported).
+ * @property toolChoice Controls if/which tool must be called (`none`/`auto`/`required`/specific).
+ * @property user not used for Anthropic
+ * @property additionalProperties Additional properties that can be used to store custom parameters.
+ * @property topP Nucleus sampling in (0.0, 1.0]; use **instead of** [temperature].
+ * Cuts off token sampling at a cumulative probability threshold.
+ * @property topK Sample only from top K options for each subsequent token (≥ 0). Recommended for advanced use cases.
+ * @property stopSequences Custom text sequences that cause the model to stop generating.
+ * If matched, response will have stop_reason of "stop_sequence".
+ * @property container Container identifier for reuse across requests.
+ * @property mcpServers MCP servers to be used in this request
+ * @property serviceTier Determines whether to use priority capacity (if available) or standard capacity for this request.
+ * @property thinking Configuration for enabling Claude's extended thinking.
+ */
+@Suppress("LongParameterList")
+public class AnthropicParams(
+    temperature: Double? = null,
+    maxTokens: Int? = null,
+    numberOfChoices: Int? = null,
+    speculation: String? = null,
+    schema: Schema? = null,
+    toolChoice: ToolChoice? = null,
+    user: String? = null,
+    additionalProperties: Map<String, JsonElement>? = null,
+    public val topP: Double? = null,
+    public val topK: Int? = null,
+    public val stopSequences: List<String>? = null,
+    public val container: String? = null,
+    public val mcpServers: List<AnthropicMCPServerURLDefinition>? = null,
+    public val serviceTier: AnthropicServiceTier? = null,
+    public val thinking: AnthropicThinking? = null,
+) : LLMParams(
+    temperature,
+    maxTokens,
+    numberOfChoices,
+    speculation,
+    schema,
+    toolChoice,
+    user,
+    additionalProperties,
+) {
+    init {
+        require(temperature == null || temperature in 0.0..1.0) {
+            "temperature must be in [0.0, 1.0], but was $temperature"
+        }
+        require(maxTokens == null || maxTokens >= 1) {
+            "maxTokens must be >= 1, but was $maxTokens"
+        }
+        require(topP == null || topP in 0.0..1.0) {
+            "topP must be in [0.0, 1.0], but was $topP"
+        }
+        require(topK == null || topK >= 0) {
+            "topK must be >= 0, but was $topK"
+        }
+        require(container == null || container.isNotBlank()) {
+            "container must be non-blank when provided"
+        }
+
+        // --- Stop sequences ---
+        if (stopSequences != null) {
+            require(stopSequences.isNotEmpty()) { "stopSequences must not be empty when provided." }
+            require(stopSequences.all { it.isNotBlank() }) { "stopSequences must not be blank." }
+        }
+
+        // --- MCP servers ---
+        if (mcpServers != null) {
+            require(mcpServers.size <= 20) {
+                "mcpServers supports at most 20 servers, but was ${mcpServers.size}"
+            }
+        }
+    }
+
+    /**
+     * Creates a copy of this instance with the ability to modify any of its properties.
+     */
+    public fun copy(
+        temperature: Double? = this.temperature,
+        maxTokens: Int? = this.maxTokens,
+        numberOfChoices: Int? = this.numberOfChoices,
+        speculation: String? = this.speculation,
+        schema: Schema? = this.schema,
+        toolChoice: ToolChoice? = this.toolChoice,
+        user: String? = this.user,
+        additionalProperties: Map<String, JsonElement>? = this.additionalProperties,
+        topP: Double? = this.topP,
+        topK: Int? = this.topK,
+        stopSequences: List<String>? = this.stopSequences,
+        container: String? = this.container,
+        mcpServers: List<AnthropicMCPServerURLDefinition>? = this.mcpServers,
+        serviceTier: AnthropicServiceTier? = this.serviceTier,
+        thinking: AnthropicThinking? = this.thinking,
+    ): AnthropicParams = AnthropicParams(
+        temperature = temperature,
+        maxTokens = maxTokens,
+        numberOfChoices = numberOfChoices,
+        speculation = speculation,
+        schema = schema,
+        toolChoice = toolChoice,
+        user = user,
+        additionalProperties = additionalProperties,
+        topP = topP,
+        topK = topK,
+        stopSequences = stopSequences,
+        container = container,
+        mcpServers = mcpServers,
+        serviceTier = serviceTier,
+        thinking = thinking,
+    )
+
+    override fun equals(other: Any?): Boolean = when {
+        this === other -> true
+        other !is AnthropicParams -> false
+        else ->
+            temperature == other.temperature &&
+                maxTokens == other.maxTokens &&
+                numberOfChoices == other.numberOfChoices &&
+                speculation == other.speculation &&
+                schema == other.schema &&
+                toolChoice == other.toolChoice &&
+                user == other.user &&
+                additionalProperties == other.additionalProperties &&
+                topP == other.topP &&
+                topK == other.topK &&
+                stopSequences == other.stopSequences &&
+                container == other.container &&
+                mcpServers == other.mcpServers &&
+                serviceTier == other.serviceTier &&
+                thinking == other.thinking
+    }
+
+    override fun hashCode(): Int = listOf(
+        temperature, maxTokens, numberOfChoices,
+        speculation, schema, toolChoice, user,
+        additionalProperties, topP, topK,
+        stopSequences, container, mcpServers,
+        serviceTier, thinking
+    ).fold(0) { acc, element ->
+        31 * acc + (element?.hashCode() ?: 0)
+    }
+
+    override fun toString(): String = buildString {
+        append("AnthropicParams(")
+        append("temperature=$temperature")
+        append(", maxTokens=$maxTokens")
+        append(", numberOfChoices=$numberOfChoices")
+        append(", speculation=$speculation")
+        append(", schema=$schema")
+        append(", toolChoice=$toolChoice")
+        append(", user=$user")
+        append(", additionalProperties=$additionalProperties")
+        append(", topP=$topP")
+        append(", topK=$topK")
+        append(", stopSequences=$stopSequences")
+        append(", container=$container")
+        append(", mcpServers=$mcpServers")
+        append(", serviceTier=$serviceTier")
+        append(", thinking=$thinking")
+        append(")")
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonTest/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonTest/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicSerializationTest.kt
@@ -1,5 +1,9 @@
 package ai.koog.prompt.executor.clients.anthropic
 
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicContent
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicMessage
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicMessageRequest
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicMessageRequestSerializer
 import ai.koog.test.utils.verifyDeserialization
 import io.kotest.assertions.json.shouldEqualJson
 import kotlinx.serialization.json.Json

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicModelsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicModelsTest.kt
@@ -1,5 +1,6 @@
 package ai.koog.prompt.executor.clients.anthropic
 
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicMessageRequest
 import ai.koog.prompt.executor.clients.list
 import ai.koog.prompt.llm.LLMProvider
 import kotlin.test.Test

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/BedrockDataClasses.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/BedrockDataClasses.kt
@@ -1,6 +1,6 @@
 package ai.koog.prompt.executor.clients.bedrock.modelfamilies
 
-import ai.koog.prompt.executor.clients.anthropic.AnthropicResponseContent
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicResponseContent
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/anthropic/BedrockAnthropicClaudeSerialization.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/anthropic/BedrockAnthropicClaudeSerialization.kt
@@ -2,8 +2,8 @@ package ai.koog.prompt.executor.clients.bedrock.modelfamilies.anthropic
 
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.prompt.dsl.Prompt
-import ai.koog.prompt.executor.clients.anthropic.AnthropicResponseContent
-import ai.koog.prompt.executor.clients.anthropic.AnthropicStreamResponse
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicResponseContent
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicStreamResponse
 import ai.koog.prompt.executor.clients.bedrock.modelfamilies.BedrockAnthropicInvokeModel
 import ai.koog.prompt.executor.clients.bedrock.modelfamilies.BedrockAnthropicInvokeModelContent
 import ai.koog.prompt.executor.clients.bedrock.modelfamilies.BedrockAnthropicInvokeModelMessage

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/JambaDataModelsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/JambaDataModelsTest.kt
@@ -1,7 +1,7 @@
 package ai.koog.prompt.executor.clients.bedrock.modelfamilies.ai21
 
-import ai.koog.prompt.executor.clients.anthropic.AnthropicMessageRequest
 import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicMessageRequest
 import ai.koog.prompt.executor.clients.bedrock.modelfamilies.ai21.JambaRequest.Companion.MAX_TOKENS_DEFAULT
 import ai.koog.test.utils.verifyDeserialization
 import kotlinx.serialization.json.Json

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/dashscope/DashscopeParams.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/dashscope/DashscopeParams.kt
@@ -13,19 +13,7 @@ internal fun LLMParams.toDashscopeParams(): DashscopeParams {
         schema = schema,
         toolChoice = toolChoice,
         user = user,
-        includeThoughts = includeThoughts,
-        thinkingBudget = thinkingBudget,
         additionalProperties = additionalProperties,
-        // DashScope-specific parameters default to null when converting from base LLMParams
-        enableSearch = null,
-        parallelToolCalls = null,
-        enableThinking = null,
-        frequencyPenalty = null,
-        presencePenalty = null,
-        logprobs = null,
-        stop = null,
-        topLogprobs = null,
-        topP = null,
     )
 }
 
@@ -40,8 +28,6 @@ internal fun LLMParams.toDashscopeParams(): DashscopeParams {
  * @property schema JSON Schema to constrain model output (validated when supported).
  * @property toolChoice Controls if/which tool must be called (`none`/`auto`/`required`/specific).
  * @property user A unique identifier for the end-user, which can help DashScope to monitor and detect abuse.
- * @property includeThoughts Request inclusion of model "thoughts"/reasoning traces (model-dependent).
- * @property thinkingBudget Soft cap on tokens spent on internal reasoning (reasoning models).
  * @property additionalProperties Additional properties that can be used to store custom parameters.
  * @property enableSearch Whether to enable web search functionality (DashScope-specific).
  * @property parallelToolCalls Whether multiple tool calls can be made in parallel (DashScope-specific).
@@ -62,8 +48,6 @@ public class DashscopeParams(
     schema: Schema? = null,
     toolChoice: ToolChoice? = null,
     user: String? = null,
-    includeThoughts: Boolean? = null,
-    thinkingBudget: Int? = null,
     additionalProperties: Map<String, JsonElement>? = null,
     public val enableSearch: Boolean? = null,
     public val parallelToolCalls: Boolean? = null,
@@ -75,9 +59,14 @@ public class DashscopeParams(
     public val topLogprobs: Int? = null,
     public val topP: Double? = null,
 ) : LLMParams(
-    temperature, maxTokens, numberOfChoices,
-    speculation, schema, toolChoice,
-    user, includeThoughts, thinkingBudget, additionalProperties,
+    temperature,
+    maxTokens,
+    numberOfChoices,
+    speculation,
+    schema,
+    toolChoice,
+    user,
+    additionalProperties,
 ) {
     init {
         require(topP == null || topP in 0.0..1.0) {
@@ -117,8 +106,6 @@ public class DashscopeParams(
         schema: Schema? = this.schema,
         toolChoice: ToolChoice? = this.toolChoice,
         user: String? = this.user,
-        includeThoughts: Boolean? = this.includeThoughts,
-        thinkingBudget: Int? = this.thinkingBudget,
         additionalProperties: Map<String, JsonElement>? = this.additionalProperties,
         enableSearch: Boolean? = this.enableSearch,
         parallelToolCalls: Boolean? = this.parallelToolCalls,
@@ -137,8 +124,6 @@ public class DashscopeParams(
         schema = schema,
         toolChoice = toolChoice,
         user = user,
-        includeThoughts = includeThoughts,
-        thinkingBudget = thinkingBudget,
         additionalProperties = additionalProperties,
         enableSearch = enableSearch,
         parallelToolCalls = parallelToolCalls,
@@ -162,8 +147,6 @@ public class DashscopeParams(
                 schema == other.schema &&
                 toolChoice == other.toolChoice &&
                 user == other.user &&
-                includeThoughts == other.includeThoughts &&
-                thinkingBudget == other.thinkingBudget &&
                 additionalProperties == other.additionalProperties &&
                 enableSearch == other.enableSearch &&
                 parallelToolCalls == other.parallelToolCalls &&
@@ -178,8 +161,7 @@ public class DashscopeParams(
 
     override fun hashCode(): Int = listOf(
         temperature, maxTokens, numberOfChoices,
-        speculation, schema, toolChoice,
-        user, includeThoughts, thinkingBudget,
+        speculation, schema, toolChoice, user,
         additionalProperties, enableSearch, parallelToolCalls,
         enableThinking, frequencyPenalty, presencePenalty,
         logprobs, stop, topLogprobs, topP,
@@ -196,8 +178,6 @@ public class DashscopeParams(
         append(", schema=$schema")
         append(", toolChoice=$toolChoice")
         append(", user=$user")
-        append(", includeThoughts=$includeThoughts")
-        append(", thinkingBudget=$thinkingBudget")
         append(", additionalProperties=$additionalProperties")
         append(", enableSearch=$enableSearch")
         append(", parallelToolCalls=$parallelToolCalls")

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/dashscope/DashscopeParamsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/dashscope/DashscopeParamsTest.kt
@@ -57,8 +57,6 @@ class DashscopeParamsTest {
             schema = LLMParams.Schema.JSON.Basic("test", JsonObject(mapOf())),
             toolChoice = LLMParams.ToolChoice.Named("calculator"),
             user = "alice",
-            includeThoughts = true,
-            thinkingBudget = 500,
             additionalProperties = mapOf("foo" to JsonPrimitive("bar")),
             enableSearch = true,
             parallelToolCalls = false,
@@ -83,7 +81,6 @@ class DashscopeParamsTest {
             numberOfChoices = 3,
             speculation = "sp",
             user = "uid",
-            includeThoughts = false,
             additionalProperties = mapOf("foo" to JsonPrimitive("bar"))
         )
         val ds = base.toDashscopeParams()
@@ -92,6 +89,5 @@ class DashscopeParamsTest {
         assertEquals(base.numberOfChoices, ds.numberOfChoices)
         assertEquals(base.speculation, ds.speculation)
         assertEquals(base.user, ds.user)
-        assertEquals(base.includeThoughts, ds.includeThoughts)
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekParamsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekParamsTest.kt
@@ -57,8 +57,6 @@ class DeepSeekParamsTest {
             schema = LLMParams.Schema.JSON.Basic("test", JsonObject(mapOf())),
             toolChoice = LLMParams.ToolChoice.Named("calculator"),
             user = "alice",
-            includeThoughts = true,
-            thinkingBudget = 500,
             additionalProperties = mapOf("foo" to JsonPrimitive("bar")),
             frequencyPenalty = 0.5,
             presencePenalty = 0.6,
@@ -80,7 +78,6 @@ class DeepSeekParamsTest {
             numberOfChoices = 3,
             speculation = "sp",
             user = "uid",
-            includeThoughts = false,
             additionalProperties = mapOf("foo" to JsonPrimitive("bar"))
         )
         val ds = base.toDeepSeekParams()
@@ -89,6 +86,5 @@ class DeepSeekParamsTest {
         assertEquals(base.numberOfChoices, ds.numberOfChoices)
         assertEquals(base.speculation, ds.speculation)
         assertEquals(base.user, ds.user)
-        assertEquals(base.includeThoughts, ds.includeThoughts)
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -8,6 +8,18 @@ import ai.koog.prompt.dsl.ModerationResult
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
 import ai.koog.prompt.executor.clients.LLMClient
+import ai.koog.prompt.executor.clients.google.models.GoogleCandidate
+import ai.koog.prompt.executor.clients.google.models.GoogleContent
+import ai.koog.prompt.executor.clients.google.models.GoogleData
+import ai.koog.prompt.executor.clients.google.models.GoogleFunctionCallingConfig
+import ai.koog.prompt.executor.clients.google.models.GoogleFunctionCallingMode
+import ai.koog.prompt.executor.clients.google.models.GoogleFunctionDeclaration
+import ai.koog.prompt.executor.clients.google.models.GoogleGenerationConfig
+import ai.koog.prompt.executor.clients.google.models.GooglePart
+import ai.koog.prompt.executor.clients.google.models.GoogleRequest
+import ai.koog.prompt.executor.clients.google.models.GoogleResponse
+import ai.koog.prompt.executor.clients.google.models.GoogleTool
+import ai.koog.prompt.executor.clients.google.models.GoogleToolConfig
 import ai.koog.prompt.executor.clients.google.structure.GoogleBasicJsonSchemaGenerator
 import ai.koog.prompt.executor.clients.google.structure.GoogleResponseFormat
 import ai.koog.prompt.executor.clients.google.structure.GoogleStandardJsonSchemaGenerator
@@ -368,7 +380,9 @@ public open class GoogleLLMClient(
             .takeIf { it.isNotEmpty() }
             ?.let { GoogleContent(parts = it) }
 
-        val responseFormat: GoogleResponseFormat? = prompt.params.schema?.let { schema ->
+        val googleParams = prompt.params.toGoogleParams()
+
+        val responseFormat: GoogleResponseFormat? = googleParams.schema?.let { schema ->
             require(schema.capability in model.capabilities) {
                 "Model ${model.id} does not support structured output schema ${schema.name}"
             }
@@ -393,17 +407,16 @@ public open class GoogleLLMClient(
             responseMimeType = responseFormat?.responseMimeType,
             responseSchema = responseFormat?.responseSchema,
             responseJsonSchema = responseFormat?.responseJsonSchema,
-            temperature = if (model.capabilities.contains(LLMCapability.Temperature)) prompt.params.temperature else null,
-            candidateCount = if (model.capabilities.contains(LLMCapability.MultipleChoices)) prompt.params.numberOfChoices else null,
-            maxOutputTokens = prompt.params.maxTokens,
-            thinkingConfig = GoogleThinkingConfig(
-                includeThoughts = prompt.params.includeThoughts.takeIf { it == true },
-                thinkingBudget = prompt.params.thinkingBudget
-            ).takeIf { it.includeThoughts != null || it.thinkingBudget != null },
-            additionalProperties = prompt.params.additionalProperties
+            maxOutputTokens = googleParams.maxTokens,
+            temperature = if (model.capabilities.contains(LLMCapability.Temperature)) googleParams.temperature else null,
+            candidateCount = if (model.capabilities.contains(LLMCapability.MultipleChoices)) googleParams.numberOfChoices else null,
+            topP = googleParams.topP,
+            topK = googleParams.topK,
+            thinkingConfig = googleParams.thinkingConfig,
+            additionalProperties = googleParams.additionalProperties
         )
 
-        val functionCallingConfig = when (val toolChoice = prompt.params.toolChoice) {
+        val functionCallingConfig = when (val toolChoice = googleParams.toolChoice) {
             LLMParams.ToolChoice.Auto -> GoogleFunctionCallingConfig(GoogleFunctionCallingMode.AUTO)
             LLMParams.ToolChoice.None -> GoogleFunctionCallingConfig(GoogleFunctionCallingMode.NONE)
             LLMParams.ToolChoice.Required -> GoogleFunctionCallingConfig(GoogleFunctionCallingMode.ANY)

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleParams.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleParams.kt
@@ -1,11 +1,12 @@
-package ai.koog.prompt.executor.clients.deepseek
+package ai.koog.prompt.executor.clients.google
 
+import ai.koog.prompt.executor.clients.google.models.GoogleThinkingConfig
 import ai.koog.prompt.params.LLMParams
 import kotlinx.serialization.json.JsonElement
 
-internal fun LLMParams.toDeepSeekParams(): DeepSeekParams {
-    if (this is DeepSeekParams) return this
-    return DeepSeekParams(
+internal fun LLMParams.toGoogleParams(): GoogleParams {
+    if (this is GoogleParams) return this
+    return GoogleParams(
         temperature = temperature,
         maxTokens = maxTokens,
         numberOfChoices = numberOfChoices,
@@ -18,26 +19,25 @@ internal fun LLMParams.toDeepSeekParams(): DeepSeekParams {
 }
 
 /**
- * DeepSeek chat-completions parameters layered on top of [LLMParams].
+ * Google Generate API parameters layered on top of [LLMParams].
  *
  * @property temperature Sampling temperature in [0.0, 2.0]. Higher ⇒ more random;
- *   lower ⇒ more deterministic. Adjust this **or** [topP], not both.
+ *   lower ⇒ more deterministic. Use closer to 0.0 for analytical tasks, closer to 1.0
+ *   for creative tasks.
  * @property maxTokens Maximum number of tokens the model may generate for this response.
  * @property numberOfChoices Number of completions to generate for the prompt (cost scales with N).
  * @property speculation Provider-specific control for speculative decoding / draft acceleration.
  * @property schema JSON Schema to constrain model output (validated when supported).
  * @property toolChoice Controls if/which tool must be called (`none`/`auto`/`required`/specific).
- * @property user not used for DeepSeek
+ * @property user not used for Google
  * @property additionalProperties Additional properties that can be used to store custom parameters.
- * @property frequencyPenalty Number in [-2.0, 2.0]—penalizes frequent tokens to reduce repetition.
- * @property presencePenalty Number in [-2.0, 2.0]—encourages introduction of new tokens/topics.
- * @property logprobs Whether to include log-probabilities for output tokens.
- * @property stop Stop sequences (0–4 items); generation halts before any of these.
- * @property topLogprobs Number of top alternatives per position (0–20). Requires [logprobs] = true.
- * @property topP Nucleus sampling in (0.0, 1.0]; use **instead of** [temperature].
+ * @property topP The maximum cumulative probability of tokens to consider when sampling.
+ * @property topK The maximum number of tokens to consider when sampling.
+ * @property thinkingConfig Controls whether the model should expose its chain-of-thought
+ * and how many tokens it may spend on it (see [GoogleThinkingConfig]).
  */
 @Suppress("LongParameterList")
-public class DeepSeekParams(
+public class GoogleParams(
     temperature: Double? = null,
     maxTokens: Int? = null,
     numberOfChoices: Int? = null,
@@ -46,12 +46,9 @@ public class DeepSeekParams(
     toolChoice: ToolChoice? = null,
     user: String? = null,
     additionalProperties: Map<String, JsonElement>? = null,
-    public val frequencyPenalty: Double? = null,
-    public val presencePenalty: Double? = null,
-    public val logprobs: Boolean? = null,
-    public val stop: List<String>? = null,
-    public val topLogprobs: Int? = null,
     public val topP: Double? = null,
+    public val topK: Int? = null,
+    public val thinkingConfig: GoogleThinkingConfig? = null,
 ) : LLMParams(
     temperature,
     maxTokens,
@@ -63,29 +60,14 @@ public class DeepSeekParams(
     additionalProperties,
 ) {
     init {
+        require(temperature == null || temperature in 0.0..2.0) {
+            "temperature must be in [0.0, 2.0], but was $temperature"
+        }
         require(topP == null || topP in 0.0..1.0) {
-            "topP must be in (0.0, 1.0], but was $topP"
+            "topP must be in [0.0, 1.0], but was $topP"
         }
-        if (topLogprobs != null) {
-            require(logprobs == true) {
-                "`topLogprobs` requires `logprobs=true`."
-            }
-            require(topLogprobs in 0..20) {
-                "topLogprobs must be in [0, 20], but was $topLogprobs"
-            }
-        }
-        require(frequencyPenalty == null || frequencyPenalty in -2.0..2.0) {
-            "frequencyPenalty must be in [-2.0, 2.0], but was $frequencyPenalty"
-        }
-        require(presencePenalty == null || presencePenalty in -2.0..2.0) {
-            "presencePenalty must be in [-2.0, 2.0], but was $presencePenalty"
-        }
-
-        // --- Stop sequences ---
-        if (stop != null) {
-            require(stop.isNotEmpty()) { "stop must not be empty when provided." }
-            require(stop.size <= 4) { "stop supports at most 4 sequences, but was ${stop.size}" }
-            require(stop.all { it.isNotBlank() }) { "stop sequences must not be blank." }
+        require(topK == null || topK >= 0) {
+            "topK must be >= 0, but was $topK"
         }
     }
 
@@ -101,13 +83,10 @@ public class DeepSeekParams(
         toolChoice: ToolChoice? = this.toolChoice,
         user: String? = this.user,
         additionalProperties: Map<String, JsonElement>? = this.additionalProperties,
-        frequencyPenalty: Double? = this.frequencyPenalty,
-        presencePenalty: Double? = this.presencePenalty,
-        logprobs: Boolean? = this.logprobs,
-        stop: List<String>? = this.stop,
-        topLogprobs: Int? = this.topLogprobs,
         topP: Double? = this.topP,
-    ): DeepSeekParams = DeepSeekParams(
+        topK: Int? = this.topK,
+        thinkingConfig: GoogleThinkingConfig? = this.thinkingConfig,
+    ): GoogleParams = GoogleParams(
         temperature = temperature,
         maxTokens = maxTokens,
         numberOfChoices = numberOfChoices,
@@ -116,17 +95,14 @@ public class DeepSeekParams(
         toolChoice = toolChoice,
         user = user,
         additionalProperties = additionalProperties,
-        frequencyPenalty = frequencyPenalty,
-        presencePenalty = presencePenalty,
-        logprobs = logprobs,
-        stop = stop,
-        topLogprobs = topLogprobs,
         topP = topP,
+        topK = topK,
+        thinkingConfig = thinkingConfig,
     )
 
     override fun equals(other: Any?): Boolean = when {
         this === other -> true
-        other !is DeepSeekParams -> false
+        other !is GoogleParams -> false
         else ->
             temperature == other.temperature &&
                 maxTokens == other.maxTokens &&
@@ -136,25 +112,21 @@ public class DeepSeekParams(
                 toolChoice == other.toolChoice &&
                 user == other.user &&
                 additionalProperties == other.additionalProperties &&
-                frequencyPenalty == other.frequencyPenalty &&
-                presencePenalty == other.presencePenalty &&
-                logprobs == other.logprobs &&
-                stop == other.stop &&
-                topLogprobs == other.topLogprobs &&
-                topP == other.topP
+                topP == other.topP &&
+                topK == other.topK &&
+                thinkingConfig == other.thinkingConfig
     }
 
     override fun hashCode(): Int = listOf(
         temperature, maxTokens, numberOfChoices,
         speculation, schema, toolChoice, user,
-        additionalProperties, frequencyPenalty, presencePenalty,
-        logprobs, stop, topLogprobs, topP,
+        additionalProperties, topP, topK, thinkingConfig
     ).fold(0) { acc, element ->
         31 * acc + (element?.hashCode() ?: 0)
     }
 
     override fun toString(): String = buildString {
-        append("DeepSeekParams(")
+        append("GoogleParams(")
         append("temperature=$temperature")
         append(", maxTokens=$maxTokens")
         append(", numberOfChoices=$numberOfChoices")
@@ -163,12 +135,9 @@ public class DeepSeekParams(
         append(", toolChoice=$toolChoice")
         append(", user=$user")
         append(", additionalProperties=$additionalProperties")
-        append(", frequencyPenalty=$frequencyPenalty")
-        append(", presencePenalty=$presencePenalty")
-        append(", logprobs=$logprobs")
-        append(", stop=$stop")
-        append(", topLogprobs=$topLogprobs")
         append(", topP=$topP")
+        append(", topK=$topK")
+        append(", thinkingConfig=$thinkingConfig")
         append(")")
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/models/GoogleGenerateContent.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/models/GoogleGenerateContent.kt
@@ -1,4 +1,4 @@
-package ai.koog.prompt.executor.clients.google
+package ai.koog.prompt.executor.clients.google.models
 
 import ai.koog.prompt.executor.clients.serialization.AdditionalPropertiesFlatteningSerializer
 import ai.koog.utils.serializers.ByteArrayAsBase64Serializer
@@ -325,7 +325,7 @@ internal class GoogleToolConfig(
  * API reference: https://ai.google.dev/gemini-api/docs/thinking#set-budget
  */
 @Serializable
-internal data class GoogleThinkingConfig(
+public data class GoogleThinkingConfig(
     val includeThoughts: Boolean? = null,
     val thinkingBudget: Int? = null
 )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleSerializationTest.kt
@@ -1,5 +1,7 @@
 package ai.koog.prompt.executor.clients.google
 
+import ai.koog.prompt.executor.clients.google.models.GoogleGenerationConfig
+import ai.koog.prompt.executor.clients.google.models.GoogleRequest
 import ai.koog.test.utils.verifyDeserialization
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/ThinkingConfigTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/ThinkingConfigTest.kt
@@ -1,5 +1,7 @@
 package ai.koog.prompt.executor.clients.google
 
+import ai.koog.prompt.executor.clients.google.models.GoogleGenerationConfig
+import ai.koog.prompt.executor.clients.google.models.GoogleThinkingConfig
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertTrue
 import kotlin.test.Test

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIParams.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIParams.kt
@@ -4,6 +4,7 @@ import ai.koog.prompt.executor.clients.openai.base.models.OpenAIAudioConfig
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIWebSearchOptions
 import ai.koog.prompt.executor.clients.openai.base.models.ReasoningEffort
 import ai.koog.prompt.executor.clients.openai.base.models.ServiceTier
+import ai.koog.prompt.executor.clients.openai.models.OpenAIInclude
 import ai.koog.prompt.executor.clients.openai.models.ReasoningConfig
 import ai.koog.prompt.executor.clients.openai.models.Truncation
 import ai.koog.prompt.params.LLMParams
@@ -307,7 +308,7 @@ public class OpenAIResponsesParams(
     user: String? = null,
     additionalProperties: Map<String, JsonElement>? = null,
     public val background: Boolean? = null,
-    public val include: List<String>? = null,
+    public val include: List<OpenAIInclude>? = null,
     public val maxToolCalls: Int? = null,
     public val parallelToolCalls: Boolean? = null,
     public val reasoning: ReasoningConfig? = null,
@@ -358,7 +359,6 @@ public class OpenAIResponsesParams(
         // include validations
         if (include != null) {
             require(include.isNotEmpty()) { "include must not be empty when provided." }
-            require(include.all { it.isNotBlank() }) { "include entries must be non-blank" }
         }
 
         // maxToolCalls bounds
@@ -380,7 +380,7 @@ public class OpenAIResponsesParams(
         user: String? = this.user,
         additionalProperties: Map<String, JsonElement>? = this.additionalProperties,
         background: Boolean? = this.background,
-        include: List<String>? = this.include,
+        include: List<OpenAIInclude>? = this.include,
         maxToolCalls: Int? = this.maxToolCalls,
         parallelToolCalls: Boolean? = this.parallelToolCalls,
         reasoning: ReasoningConfig? = this.reasoning,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIParams.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIParams.kt
@@ -22,7 +22,6 @@ internal fun LLMParams.toOpenAIChatParams(): OpenAIChatParams {
         schema = schema,
         toolChoice = toolChoice,
         user = user,
-        includeThoughts = includeThoughts,
         additionalProperties = additionalProperties,
     )
 }
@@ -37,7 +36,6 @@ internal fun LLMParams.toOpenAIResponsesParams(): OpenAIResponsesParams {
         schema = schema,
         toolChoice = toolChoice,
         user = user,
-        includeThoughts = includeThoughts,
         additionalProperties = additionalProperties,
     )
 }
@@ -59,8 +57,6 @@ internal fun LLMParams.toOpenAIResponsesParams(): OpenAIResponsesParams {
  * @property toolChoice Controls if/which tool must be called (`none`/`auto`/`required`/specific).
  * @property user (**Deprecated**) legacy stable end-user identifier; prefer [safetyIdentifier]
  *   and [promptCacheKey] to preserve caching and safety benefits.
- * @property includeThoughts Request inclusion of model “thoughts”/reasoning traces (model-dependent).
- * @property thinkingBudget Soft cap on tokens spent on internal reasoning (reasoning models).
  * @property additionalProperties Additional properties that can be used to store custom parameters.
  * @property frequencyPenalty Number in [-2.0, 2.0]—penalizes frequent tokens to reduce repetition.
  * @property presencePenalty Number in [-2.0, 2.0]—encourages an introduction of new tokens/topics.
@@ -86,8 +82,6 @@ public class OpenAIChatParams(
     schema: Schema? = null,
     toolChoice: ToolChoice? = null,
     user: String? = null,
-    includeThoughts: Boolean? = null,
-    thinkingBudget: Int? = null,
     additionalProperties: Map<String, JsonElement>? = null,
     public val frequencyPenalty: Double? = null,
     public val presencePenalty: Double? = null,
@@ -104,9 +98,14 @@ public class OpenAIChatParams(
     public val topP: Double? = null,
     public val webSearchOptions: OpenAIWebSearchOptions? = null
 ) : LLMParams(
-    temperature, maxTokens, numberOfChoices,
-    speculation, schema, toolChoice,
-    user, includeThoughts, thinkingBudget, additionalProperties
+    temperature,
+    maxTokens,
+    numberOfChoices,
+    speculation,
+    schema,
+    toolChoice,
+    user,
+    additionalProperties
 ),
     OpenAIParams {
     init {
@@ -156,8 +155,6 @@ public class OpenAIChatParams(
         schema: Schema? = this.schema,
         toolChoice: ToolChoice? = this.toolChoice,
         user: String? = this.user,
-        includeThoughts: Boolean? = this.includeThoughts,
-        thinkingBudget: Int? = this.thinkingBudget,
         additionalProperties: Map<String, JsonElement>? = this.additionalProperties,
         frequencyPenalty: Double? = this.frequencyPenalty,
         presencePenalty: Double? = this.presencePenalty,
@@ -181,8 +178,6 @@ public class OpenAIChatParams(
         schema = schema,
         toolChoice = toolChoice,
         user = user,
-        includeThoughts = includeThoughts,
-        thinkingBudget = thinkingBudget,
         additionalProperties = additionalProperties,
         frequencyPenalty = frequencyPenalty,
         presencePenalty = presencePenalty,
@@ -211,8 +206,6 @@ public class OpenAIChatParams(
                 schema == other.schema &&
                 toolChoice == other.toolChoice &&
                 user == other.user &&
-                includeThoughts == other.includeThoughts &&
-                thinkingBudget == other.thinkingBudget &&
                 additionalProperties == other.additionalProperties &&
                 frequencyPenalty == other.frequencyPenalty &&
                 presencePenalty == other.presencePenalty &&
@@ -232,8 +225,7 @@ public class OpenAIChatParams(
 
     override fun hashCode(): Int = listOf(
         temperature, maxTokens, numberOfChoices,
-        speculation, schema, toolChoice,
-        user, includeThoughts, thinkingBudget,
+        speculation, schema, toolChoice, user,
         additionalProperties, frequencyPenalty, presencePenalty,
         parallelToolCalls, promptCacheKey,
         safetyIdentifier, serviceTier,
@@ -253,8 +245,6 @@ public class OpenAIChatParams(
         append(", schema=$schema")
         append(", toolChoice=$toolChoice")
         append(", user=$user")
-        append(", includeThoughts=$includeThoughts")
-        append(", thinkingBudget=$thinkingBudget")
         append(", additionalProperties=$additionalProperties")
         append(", frequencyPenalty=$frequencyPenalty")
         append(", presencePenalty=$presencePenalty")
@@ -291,8 +281,6 @@ public class OpenAIChatParams(
  * @property toolChoice Controls if/which tool(s) may be called (`none` / `auto` / `required` / specific).
  * @property user (**Deprecated**) legacy stable end-user identifier; prefer [safetyIdentifier] and
  *   [promptCacheKey] to preserve caching and safety benefits.
- * @property includeThoughts Request inclusion of model “thoughts”/reasoning traces (model-dependent).
- * @property thinkingBudget Soft cap on tokens spent on internal reasoning (reasoning models).
  * @property additionalProperties Additional properties that can be used to store custom parameters.
  * @property background Run the response in the background (non-blocking).
  * @property include Additional output sections to include (see the list above).
@@ -317,8 +305,6 @@ public class OpenAIResponsesParams(
     schema: Schema? = null,
     toolChoice: ToolChoice? = null,
     user: String? = null,
-    includeThoughts: Boolean? = null,
-    thinkingBudget: Int? = null,
     additionalProperties: Map<String, JsonElement>? = null,
     public val background: Boolean? = null,
     public val include: List<String>? = null,
@@ -334,9 +320,14 @@ public class OpenAIResponsesParams(
     public val topLogprobs: Int? = null,
     public val topP: Double? = null,
 ) : LLMParams(
-    temperature, maxTokens, numberOfChoices,
-    speculation, schema, toolChoice,
-    user, includeThoughts, thinkingBudget, additionalProperties
+    temperature,
+    maxTokens,
+    numberOfChoices,
+    speculation,
+    schema,
+    toolChoice,
+    user,
+    additionalProperties
 ),
     OpenAIParams {
     init {
@@ -387,8 +378,6 @@ public class OpenAIResponsesParams(
         schema: Schema? = this.schema,
         toolChoice: ToolChoice? = this.toolChoice,
         user: String? = this.user,
-        includeThoughts: Boolean? = this.includeThoughts,
-        thinkingBudget: Int? = this.thinkingBudget,
         additionalProperties: Map<String, JsonElement>? = this.additionalProperties,
         background: Boolean? = this.background,
         include: List<String>? = this.include,
@@ -411,8 +400,6 @@ public class OpenAIResponsesParams(
         schema = schema,
         toolChoice = toolChoice,
         user = user,
-        includeThoughts = includeThoughts,
-        thinkingBudget = thinkingBudget,
         additionalProperties = additionalProperties,
         background = background,
         include = include,
@@ -440,8 +427,6 @@ public class OpenAIResponsesParams(
                 schema == other.schema &&
                 toolChoice == other.toolChoice &&
                 user == other.user &&
-                includeThoughts == other.includeThoughts &&
-                thinkingBudget == other.thinkingBudget &&
                 additionalProperties == other.additionalProperties &&
                 background == other.background &&
                 include == other.include &&
@@ -460,8 +445,7 @@ public class OpenAIResponsesParams(
 
     override fun hashCode(): Int = listOf(
         temperature, maxTokens, numberOfChoices,
-        speculation, schema, toolChoice,
-        user, includeThoughts, thinkingBudget,
+        speculation, schema, toolChoice, user,
         additionalProperties, background, include, maxToolCalls,
         parallelToolCalls, reasoning,
         truncation, promptCacheKey, safetyIdentifier,
@@ -479,8 +463,6 @@ public class OpenAIResponsesParams(
         append(", schema=$schema")
         append(", toolChoice=$toolChoice")
         append(", user=$user")
-        append(", includeThoughts=$includeThoughts")
-        append(", thinkingBudget=$thinkingBudget")
         append(", additionalProperties=$additionalProperties")
         append(", background=$background")
         append(", include=$include")

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPI.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPI.kt
@@ -119,7 +119,7 @@ import kotlin.jvm.JvmInline
 @Serializable
 internal class OpenAIResponsesAPIRequest(
     val background: Boolean? = null,
-    val include: List<String>? = null,
+    val include: List<OpenAIInclude>? = null,
     val input: List<Item>? = null,
     val instructions: String? = null,
     val maxOutputTokens: Int? = null,
@@ -147,6 +147,36 @@ internal class OpenAIResponsesAPIRequest(
     val user: String? = null,
     val additionalProperties: Map<String, JsonElement>? = null,
 ) : OpenAIBaseLLMRequest
+
+/**
+ * Specify additional output data to include in the model response. Currently supported values are:
+ *
+ * web_search_call.action.sources: Include the sources of the web search tool call.
+ * code_interpreter_call.outputs: Includes the outputs of python code execution in code interpreter tool call items.
+ * computer_call_output.output.image_url: Include image urls from the computer call output.
+ * file_search_call.results: Include the search results of the file search tool call.
+ * message.input_image.image_url: Include image urls from the input message.
+ * message.output_text.logprobs: Include logprobs with assistant messages.
+ * reasoning.encrypted_content: Includes an encrypted version of reasoning tokens in reasoning item outputs. This enables reasoning items to be used in multi-turn conversations when using the Responses API statelessly (like when the store parameter is set to false, or when an organization is enrolled in the zero data retention program).
+ */
+@Serializable
+public enum class OpenAIInclude {
+    @SerialName("web_search_call.action.sources")
+    WEB_SEARCH_CALL_ACTION_SOURCES,
+    @SerialName("code_interpreter_call.outputs")
+    CODE_INTERPRETER_CALL_OUTPUTS,
+    @SerialName("computer_call_output.output.image_url")
+    COMPUTER_CALL_OUTPUT_IMAGE_URL,
+    @SerialName("file_search_call.results")
+    FILE_SEARCH_CALL_RESULTS,
+    @SerialName("message.input_image.image_url")
+    INPUT_IMAGE_URL,
+    @SerialName("message.output_text.logprobs")
+    OUTPUT_TEXT_LOGPROBS,
+    @SerialName("reasoning.encrypted_content")
+    REASONING_ENCRYPTED_CONTENT,
+    ;
+}
 
 @Serializable(with = ItemPolymorphicSerializer::class)
 internal sealed interface Item {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPI.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPI.kt
@@ -163,19 +163,24 @@ internal class OpenAIResponsesAPIRequest(
 public enum class OpenAIInclude {
     @SerialName("web_search_call.action.sources")
     WEB_SEARCH_CALL_ACTION_SOURCES,
+
     @SerialName("code_interpreter_call.outputs")
     CODE_INTERPRETER_CALL_OUTPUTS,
+
     @SerialName("computer_call_output.output.image_url")
     COMPUTER_CALL_OUTPUT_IMAGE_URL,
+
     @SerialName("file_search_call.results")
     FILE_SEARCH_CALL_RESULTS,
+
     @SerialName("message.input_image.image_url")
     INPUT_IMAGE_URL,
+
     @SerialName("message.output_text.logprobs")
     OUTPUT_TEXT_LOGPROBS,
+
     @SerialName("reasoning.encrypted_content")
     REASONING_ENCRYPTED_CONTENT,
-    ;
 }
 
 @Serializable(with = ItemPolymorphicSerializer::class)

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIChatParamsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIChatParamsTest.kt
@@ -68,7 +68,6 @@ class OpenAIChatParamsTest {
             numberOfChoices = 2,
             speculation = "spec",
             user = "user-id",
-            includeThoughts = true,
             additionalProperties = mapOf("foo" to JsonPrimitive("bar"))
         )
 
@@ -79,7 +78,6 @@ class OpenAIChatParamsTest {
         assertEquals(base.numberOfChoices, chat.numberOfChoices)
         assertEquals(base.speculation, chat.speculation)
         assertEquals(base.user, chat.user)
-        assertEquals(base.includeThoughts, chat.includeThoughts)
         assertEquals(base.additionalProperties, chat.additionalProperties)
     }
 
@@ -119,8 +117,6 @@ class OpenAIChatParamsTest {
             schema = LLMParams.Schema.JSON.Basic("test", JsonObject(mapOf())),
             toolChoice = LLMParams.ToolChoice.Required,
             user = "user-id",
-            includeThoughts = true,
-            thinkingBudget = 1231,
             additionalProperties = mapOf("foo" to JsonPrimitive("bar")),
             frequencyPenalty = 0.43,
             presencePenalty = 0.523,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIResponsesParamsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIResponsesParamsTest.kt
@@ -71,7 +71,6 @@ class OpenAIResponsesParamsTest {
             numberOfChoices = 2,
             speculation = "spec",
             user = "user-id",
-            includeThoughts = true,
         )
 
         val resp = base.toOpenAIResponsesParams()
@@ -81,7 +80,6 @@ class OpenAIResponsesParamsTest {
         assertEquals(base.numberOfChoices, resp.numberOfChoices)
         assertEquals(base.speculation, resp.speculation)
         assertEquals(base.user, resp.user)
-        assertEquals(base.includeThoughts, resp.includeThoughts)
         assertEquals(base.additionalProperties, resp.additionalProperties)
     }
 
@@ -140,8 +138,6 @@ class OpenAIResponsesParamsTest {
             schema = LLMParams.Schema.JSON.Basic("test", JsonObject(mapOf())),
             toolChoice = LLMParams.ToolChoice.Required,
             user = "user-id",
-            includeThoughts = true,
-            thinkingBudget = 123,
             additionalProperties = mapOf("foo" to JsonPrimitive("bar")),
             background = true,
             include = listOf("a", "b", "c"),

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIResponsesParamsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIResponsesParamsTest.kt
@@ -2,6 +2,7 @@ package ai.koog.prompt.executor.clients.openai
 
 import ai.koog.prompt.executor.clients.openai.base.models.ReasoningEffort
 import ai.koog.prompt.executor.clients.openai.base.models.ServiceTier
+import ai.koog.prompt.executor.clients.openai.models.OpenAIInclude
 import ai.koog.prompt.executor.clients.openai.models.ReasoningConfig
 import ai.koog.prompt.executor.clients.openai.models.ReasoningSummary
 import ai.koog.prompt.executor.clients.openai.models.Truncation
@@ -115,17 +116,11 @@ class OpenAIResponsesParamsTest {
                 include = emptyList()
             )
         }
-        assertThrows<IllegalArgumentException>("Responses: include entries must be non-blank") {
-            OpenAIResponsesParams(
-                include = listOf("")
-            )
-        }
         assertThrows<IllegalArgumentException>("Responses: maxToolCalls must be >= 0") {
             OpenAIResponsesParams(
                 maxToolCalls = -1
             )
         }
-        OpenAIResponsesParams(include = listOf("output_text"), maxToolCalls = 0)
     }
 
     @Test
@@ -140,7 +135,7 @@ class OpenAIResponsesParamsTest {
             user = "user-id",
             additionalProperties = mapOf("foo" to JsonPrimitive("bar")),
             background = true,
-            include = listOf("a", "b", "c"),
+            include = listOf(OpenAIInclude.REASONING_ENCRYPTED_CONTENT, OpenAIInclude.OUTPUT_TEXT_LOGPROBS),
             maxToolCalls = 10,
             parallelToolCalls = true,
             reasoning = ReasoningConfig(effort = ReasoningEffort.HIGH, summary = ReasoningSummary.DETAILED),

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterParams.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterParams.kt
@@ -14,7 +14,6 @@ internal fun LLMParams.toOpenRouterParams(): OpenRouterParams {
         schema = schema,
         toolChoice = toolChoice,
         user = user,
-        includeThoughts = includeThoughts,
         additionalProperties = additionalProperties,
     )
 }
@@ -30,8 +29,6 @@ internal fun LLMParams.toOpenRouterParams(): OpenRouterParams {
  * @property schema JSON Schema to constrain model output (validated when supported).
  * @property toolChoice Controls if/which tool must be called (`none`/`auto`/`required`/specific).
  * @property user stable end-user identifier
- * @property includeThoughts Request inclusion of model “thoughts”/reasoning traces (model-dependent).
- * @property thinkingBudget Soft cap on tokens spent on internal reasoning (reasoning models).
  * @property additionalProperties Additional properties that can be used to store custom parameters.
  * @property frequencyPenalty Number in [-2.0, 2.0]—penalizes frequent tokens to reduce repetition.
  * @property presencePenalty Number in [-2.0, 2.0]—encourages introduction of new tokens/topics.
@@ -59,8 +56,6 @@ public open class OpenRouterParams(
     schema: Schema? = null,
     toolChoice: ToolChoice? = null,
     user: String? = null,
-    includeThoughts: Boolean? = null,
-    thinkingBudget: Int? = null,
     additionalProperties: Map<String, JsonElement>? = null,
     public val frequencyPenalty: Double? = null,
     public val presencePenalty: Double? = null,
@@ -77,9 +72,14 @@ public open class OpenRouterParams(
     public val route: String? = null,
     public val provider: ProviderPreferences? = null,
 ) : LLMParams(
-    temperature, maxTokens, numberOfChoices,
-    speculation, schema, toolChoice,
-    user, includeThoughts, thinkingBudget, additionalProperties
+    temperature,
+    maxTokens,
+    numberOfChoices,
+    speculation,
+    schema,
+    toolChoice,
+    user,
+    additionalProperties
 ) {
     init {
         require(topP == null || topP in 0.0..1.0) {
@@ -131,8 +131,6 @@ public open class OpenRouterParams(
         schema: Schema? = this.schema,
         toolChoice: ToolChoice? = this.toolChoice,
         user: String? = this.user,
-        includeThoughts: Boolean? = this.includeThoughts,
-        thinkingBudget: Int? = this.thinkingBudget,
         additionalProperties: Map<String, JsonElement>? = this.additionalProperties,
         frequencyPenalty: Double? = this.frequencyPenalty,
         presencePenalty: Double? = this.presencePenalty,
@@ -156,8 +154,6 @@ public open class OpenRouterParams(
         schema = schema,
         toolChoice = toolChoice,
         user = user,
-        includeThoughts = includeThoughts,
-        thinkingBudget = thinkingBudget,
         additionalProperties = additionalProperties,
         frequencyPenalty = frequencyPenalty,
         presencePenalty = presencePenalty,
@@ -186,8 +182,6 @@ public open class OpenRouterParams(
                 schema == other.schema &&
                 toolChoice == other.toolChoice &&
                 user == other.user &&
-                includeThoughts == other.includeThoughts &&
-                thinkingBudget == other.thinkingBudget &&
                 additionalProperties == other.additionalProperties &&
                 frequencyPenalty == other.frequencyPenalty &&
                 presencePenalty == other.presencePenalty &&
@@ -207,8 +201,7 @@ public open class OpenRouterParams(
 
     override fun hashCode(): Int = listOf(
         temperature, maxTokens, numberOfChoices,
-        speculation, schema, toolChoice,
-        user, includeThoughts, thinkingBudget,
+        speculation, schema, toolChoice, user,
         additionalProperties, frequencyPenalty, presencePenalty,
         logprobs, stop, topLogprobs, topP,
         topK, repetitionPenalty, minP,
@@ -226,8 +219,6 @@ public open class OpenRouterParams(
         append(", schema=$schema")
         append(", toolChoice=$toolChoice")
         append(", user=$user")
-        append(", includeThoughts=$includeThoughts")
-        append(", thinkingBudget=$thinkingBudget")
         append(", additionalProperties=$additionalProperties")
         append(", frequencyPenalty=$frequencyPenalty")
         append(", presencePenalty=$presencePenalty")

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterParamsValidationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterParamsValidationTest.kt
@@ -44,7 +44,6 @@ class OpenRouterParamsValidationTest {
             numberOfChoices = 1,
             speculation = "router",
             user = "user",
-            includeThoughts = true,
         )
         val or = base.toOpenRouterParams()
         assert(base.temperature == or.temperature)
@@ -52,7 +51,6 @@ class OpenRouterParamsValidationTest {
         assert(base.numberOfChoices == or.numberOfChoices)
         assert(base.speculation == or.speculation)
         assert(base.user == or.user)
-        assert(base.includeThoughts == or.includeThoughts)
     }
 
     @Test
@@ -63,7 +61,6 @@ class OpenRouterParamsValidationTest {
             numberOfChoices = 1,
             speculation = "copy",
             user = "user",
-            includeThoughts = true,
             additionalProperties = mapOf("foo" to JsonPrimitive("bar")),
             topP = 1.0,
             topK = 3,
@@ -78,7 +75,6 @@ class OpenRouterParamsValidationTest {
     fun `Should create from LLMParams`() {
         val source = LLMParams(
             additionalProperties = mapOf("foo" to JsonPrimitive("bar")),
-            includeThoughts = true,
             maxTokens = 321,
             numberOfChoices = 54,
             speculation = "copy",
@@ -92,7 +88,6 @@ class OpenRouterParamsValidationTest {
 
         // then
         target.additionalProperties shouldBe source.additionalProperties
-        target.includeThoughts shouldBe source.includeThoughts
         target.maxTokens shouldBe source.maxTokens
         target.numberOfChoices shouldBe source.numberOfChoices
         target.speculation shouldBe source.speculation

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/Prompt.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/Prompt.kt
@@ -140,12 +140,6 @@ public data class Prompt @JvmOverloads constructor(
      * @property user An optional user identifier that can be used for tracking or personalization purposes. This property
      * is mutable to allow updates to the user context.
      *
-     * @property includeThoughts If `true`, requests the model to add reasoning blocks to the response. Defaults to `null`.
-     * When set to `true`, responses may include detailed reasoning steps.
-     * When `false` or `null`, responses are typically shorter and faster.
-     *
-     * @property thinkingBudget Hard cap for reasoning tokens. Ignored by models that don't support budgets.
-     * This can be used to limit the amount of tokens used for reasoning when `includeThoughts` is enabled.
      */
     public class LLMParamsUpdateContext internal constructor(
         public var temperature: Double?,
@@ -153,8 +147,6 @@ public data class Prompt @JvmOverloads constructor(
         public var schema: Schema?,
         public var toolChoice: ToolChoice?,
         public var user: String? = null,
-        public var includeThoughts: Boolean? = null,
-        public var thinkingBudget: Int? = null,
     ) {
         /**
          * Secondary constructor for `LLMParamsUpdateContext` that initializes the context using an
@@ -169,8 +161,6 @@ public data class Prompt @JvmOverloads constructor(
             params.schema,
             params.toolChoice,
             params.user,
-            params.includeThoughts,
-            params.thinkingBudget
         )
 
         /**
@@ -184,9 +174,7 @@ public data class Prompt @JvmOverloads constructor(
             speculation = speculation,
             schema = schema,
             toolChoice = toolChoice,
-            user = user,
-            includeThoughts = includeThoughts,
-            thinkingBudget = thinkingBudget
+            user = user
         )
     }
 

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/params/LLMParams.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/params/LLMParams.kt
@@ -23,13 +23,6 @@ import kotlinx.serialization.json.JsonPrimitive
  * @property schema Defines the structure for the model's structured response format.
  * @property toolChoice Used to switch tool calling behavior of LLM.
  * @property user An optional identifier for the user making the request, which can be used for tracking purposes.
- * @property includeThoughts If `true`, requests the model to add reasoning blocks to the response.
- * Defaults to `null`.
- * When set to `true`, responses may include detailed reasoning steps.
- * When `false` or `null`, responses are typically shorter and faster.
- * @property thinkingBudget Hard cap for reasoning tokens.
- * Ignored by models that don't support budgets.
- * This can be used to limit the amount of tokens used for reasoning when `includeThoughts` is enabled.
  * @property additionalProperties Additional properties that can be used to store custom parameters.
  */
 @Serializable
@@ -42,8 +35,6 @@ public open class LLMParams(
     public val schema: Schema? = null,
     public val toolChoice: ToolChoice? = null,
     public val user: String? = null,
-    public val includeThoughts: Boolean? = null,
-    public val thinkingBudget: Int? = null,
     public val additionalProperties: Map<String, JsonElement>? = null,
 ) {
     init {
@@ -82,8 +73,6 @@ public open class LLMParams(
         schema = schema ?: default.schema,
         toolChoice = toolChoice ?: default.toolChoice,
         user = user ?: default.user,
-        includeThoughts = includeThoughts ?: default.includeThoughts,
-        thinkingBudget = thinkingBudget ?: default.thinkingBudget,
         additionalProperties = additionalProperties ?: default.additionalProperties,
     )
 
@@ -98,8 +87,6 @@ public open class LLMParams(
         schema: Schema? = this.schema,
         toolChoice: ToolChoice? = this.toolChoice,
         user: String? = this.user,
-        includeThoughts: Boolean? = this.includeThoughts,
-        thinkingBudget: Int? = this.thinkingBudget,
         additionalProperties: Map<String, JsonElement>? = this.additionalProperties,
     ): LLMParams = LLMParams(
         temperature = temperature,
@@ -109,8 +96,6 @@ public open class LLMParams(
         schema = schema,
         toolChoice = toolChoice,
         user = user,
-        includeThoughts = includeThoughts,
-        thinkingBudget = thinkingBudget,
         additionalProperties = additionalProperties,
     )
 
@@ -164,20 +149,6 @@ public open class LLMParams(
      */
     public operator fun component7(): String? = user
 
-    /**
-     * Retrieves the eighth component of the data class, typically used for destructuring declarations.
-     *
-     * @return A Boolean value or null representing the state of the eighth component.
-     */
-    public operator fun component8(): Boolean? = includeThoughts
-
-    /**
-     * Provides the ninth component of a destructured object, specifically the thinking budget.
-     *
-     * @return The value of the `thinkingBudget` as an optional integer, or null if not set.
-     */
-    public operator fun component9(): Int? = thinkingBudget
-
     @Suppress("MissingKDocForPublicAPI")
     public operator fun component10(): Map<String, JsonElement>? = additionalProperties
 
@@ -192,15 +163,17 @@ public open class LLMParams(
                 schema == other.schema &&
                 toolChoice == other.toolChoice &&
                 user == other.user &&
-                includeThoughts == other.includeThoughts &&
-                thinkingBudget == other.thinkingBudget &&
                 additionalProperties == other.additionalProperties
     }
 
     override fun hashCode(): Int = listOf(
-        temperature, maxTokens, numberOfChoices,
-        speculation, schema, toolChoice,
-        user, includeThoughts, thinkingBudget
+        temperature,
+        maxTokens,
+        numberOfChoices,
+        speculation,
+        schema,
+        toolChoice,
+        user
     ).fold(0) { acc, element ->
         31 * acc + (element?.hashCode() ?: 0)
     }
@@ -214,8 +187,6 @@ public open class LLMParams(
         append(", schema=$schema")
         append(", toolChoice=$toolChoice")
         append(", user=$user")
-        append(", includeThoughts=$includeThoughts")
-        append(", thinkingBudget=$thinkingBudget")
         append(", additionalProperties=$additionalProperties")
         append(")")
     }

--- a/prompt/prompt-model/src/jvmTest/kotlin/ai/koog/prompt/params/LLMParamsTest.kt
+++ b/prompt/prompt-model/src/jvmTest/kotlin/ai/koog/prompt/params/LLMParamsTest.kt
@@ -266,8 +266,6 @@ class LLMParamsTest {
             schema = originalSchema,
             toolChoice = originalToolChoice,
             user = TEST_USER,
-            includeThoughts = true,
-            thinkingBudget = 50,
             additionalProperties = mapOf("foo" to JsonPrimitive("bar"))
         )
 


### PR DESCRIPTION
[KG-453](https://youtrack.jetbrains.com/issue/KG-453) Add specific params for non-OpenAI compatible clients

- add Anthropic Params
- add Google Params
- refactor LLMParams

## Motivation and Context
To be able to configure LLM requests more precisely and improvement of the API

## Breaking Changes
Yes,
two properties have been removed from `LLMParams` that were used exclusively by `GoogleLLMClient`.
These parameters were not suitable for all clients.
Instead, such parameters are now passed through specialized classes like `OpenAIParams`, `GoogleParams`, and others.

---

#### Type of the changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [x] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [x] Docs have been added / updated
