### PR TITLE
Remove featurePrepareDispatcher with limitedParallelism from AIAgentPipeline

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentFunctionalPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentFunctionalPipeline.kt
@@ -11,7 +11,7 @@ import kotlinx.datetime.Clock
  * workflows or data processing tasks that do not require graph-based
  * data structures.
  *
- * @param clock The clock used for time-based operations within the pipeline
+ * @property clock The clock used for time-based operations within the pipeline
  */
 public class AIAgentFunctionalPipeline(clock: Clock = Clock.System) : AIAgentPipeline(clock) {
 


### PR DESCRIPTION
## Motivation and Context
There were two bug reports related to incompatibility of kotlinx-coroutines version: https://github.com/JetBrains/koog/issues/273 and https://github.com/JetBrains/koog/issues/678 The common cause is the method "Dispatchers.Default.limitedParallelism(5)" with different number of parameters in 1.8 (runtime) and 1.10 versions. The solution is to remove "Dispatchers.Default.limitedParallelism(5)" from AIAgentPipeline. This way we can improve the compatibility with kotlinx-coroutines 1.8 in runtime.
This PR is replacing that one https://github.com/JetBrains/koog/pull/878

## Breaking Changes
none, prepareFeatures method will use an existing CoroutineDispatcher instead of its own.

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [x] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
