### PR TITLE
[agents] Make a2aClients property in A2AAgentClient.Config actually configurable

### DIFF
--- a/agents/agents-features/agents-features-a2a-client/src/commonMain/kotlin/ai/koog/agents/a2a/client/feature/A2AAgentClient.kt
+++ b/agents/agents-features/agents-features-a2a-client/src/commonMain/kotlin/ai/koog/agents/a2a/client/feature/A2AAgentClient.kt
@@ -43,7 +43,7 @@ public class A2AAgentClient(
         /**
          * Map of [A2AClient] instances keyed by agent ID for accessing remote A2A agents.
          */
-        public val a2aClients: Map<String, A2AClient> = mapOf()
+        public var a2aClients: Map<String, A2AClient> = mapOf()
     }
 
     public companion object Feature :


### PR DESCRIPTION
Fix `A2AAgentClient` feature, make `a2aClients` map var in config to make it actually possible to configure