### PR TITLE
Persistence snapshot ordering fix

### DIFF
--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/AgentCheckpointData.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/AgentCheckpointData.kt
@@ -32,6 +32,7 @@ public data class AgentCheckpointData(
     val nodeId: String,
     val lastInput: JsonElement,
     val messageHistory: List<Message>,
+    val parentId: String?,
     val properties: Map<String, JsonElement>? = null
 )
 
@@ -43,14 +44,15 @@ public data class AgentCheckpointData(
  * @return An `AgentCheckpointData` instance with predefined properties indicating a tombstone state.
  */
 @OptIn(ExperimentalUuidApi::class)
-public fun tombstoneCheckpoint(time: Instant): AgentCheckpointData {
+public fun tombstoneCheckpoint(time: Instant, parentId: String?): AgentCheckpointData {
     return AgentCheckpointData(
         checkpointId = Uuid.random().toString(),
         createdAt = time,
         nodeId = PersistenceUtils.TOMBSTONE_CHECKPOINT_NAME,
         lastInput = JsonNull,
         messageHistory = emptyList(),
-        properties = mapOf(PersistenceUtils.TOMBSTONE_CHECKPOINT_NAME to JsonPrimitive(true))
+        properties = mapOf(PersistenceUtils.TOMBSTONE_CHECKPOINT_NAME to JsonPrimitive(true)),
+        parentId = parentId
     )
 }
 

--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/AgentCheckpointData.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/AgentCheckpointData.kt
@@ -32,7 +32,7 @@ public data class AgentCheckpointData(
     val nodeId: String,
     val lastInput: JsonElement,
     val messageHistory: List<Message>,
-    val parentId: String?,
+    val version: Long,
     val properties: Map<String, JsonElement>? = null
 )
 
@@ -44,7 +44,7 @@ public data class AgentCheckpointData(
  * @return An `AgentCheckpointData` instance with predefined properties indicating a tombstone state.
  */
 @OptIn(ExperimentalUuidApi::class)
-public fun tombstoneCheckpoint(time: Instant, parentId: String?): AgentCheckpointData {
+public fun tombstoneCheckpoint(time: Instant, version: Long): AgentCheckpointData {
     return AgentCheckpointData(
         checkpointId = Uuid.random().toString(),
         createdAt = time,
@@ -52,7 +52,7 @@ public fun tombstoneCheckpoint(time: Instant, parentId: String?): AgentCheckpoin
         lastInput = JsonNull,
         messageHistory = emptyList(),
         properties = mapOf(PersistenceUtils.TOMBSTONE_CHECKPOINT_NAME to JsonPrimitive(true)),
-        parentId = parentId
+        version = version
     )
 }
 

--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/Persistency.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/Persistency.kt
@@ -165,11 +165,13 @@ public class Persistence(
                 }
 
                 if (config.enableAutomaticPersistence) {
+                    val parent = getLatestCheckpoint(eventCtx.context.agentId)
                     createCheckpoint(
                         agentContext = eventCtx.context,
                         nodeId = eventCtx.node.id,
                         lastInput = eventCtx.input,
                         lastInputType = eventCtx.inputType,
+                        parentId = parent?.checkpointId
                     )
                 }
             }
@@ -180,7 +182,8 @@ public class Persistence(
 
             pipeline.interceptStrategyCompleted(interceptContext) { ctx ->
                 if (config.enableAutomaticPersistence && config.rollbackStrategy == RollbackStrategy.Default) {
-                    ctx.feature.createTombstoneCheckpoint(ctx.agentId, ctx.feature.clock.now())
+                    val parent = ctx.feature.getLatestCheckpoint(ctx.agentId)
+                    ctx.feature.createTombstoneCheckpoint(ctx.agentId, ctx.feature.clock.now(), parent?.checkpointId)
                 }
             }
         }
@@ -207,7 +210,8 @@ public class Persistence(
         nodeId: String,
         lastInput: Any?,
         lastInputType: KType,
-        checkpointId: String? = null
+        parentId: String?,
+        checkpointId: String? = null,
     ): AgentCheckpointData? {
         val inputJson = trySerializeInput(lastInput, lastInputType)
 
@@ -224,7 +228,8 @@ public class Persistence(
                 messageHistory = prompt.messages,
                 nodeId = nodeId,
                 lastInput = inputJson,
-                createdAt = Clock.System.now()
+                createdAt = Clock.System.now(),
+                parentId = parentId,
             )
         }
 
@@ -242,8 +247,8 @@ public class Persistence(
      * @return The created tombstone checkpoint data.
      */
     @InternalAgentsApi
-    public suspend fun createTombstoneCheckpoint(agentId: String, time: Instant): AgentCheckpointData {
-        val checkpoint = tombstoneCheckpoint(time)
+    public suspend fun createTombstoneCheckpoint(agentId: String, time: Instant, parentId: String?): AgentCheckpointData {
+        val checkpoint = tombstoneCheckpoint(time, parentId)
         saveCheckpoint(agentId, checkpoint)
         return checkpoint
     }
@@ -279,8 +284,10 @@ public class Persistence(
      * @param checkpointId The ID of the checkpoint to retrieve
      * @return The checkpoint data with the specified ID, or null if not found
      */
-    public suspend fun getCheckpointById(agentId: String, checkpointId: String): AgentCheckpointData? =
-        persistenceStorageProvider.getCheckpoints(agentId).firstOrNull { it.checkpointId == checkpointId }
+    public suspend fun getCheckpointById(agentId: String, checkpointId: String): AgentCheckpointData? {
+        val allCps = persistenceStorageProvider.getCheckpoints(agentId)
+        return allCps.firstOrNull { it.checkpointId == checkpointId }
+    }
 
     /**
      * Sets the execution point of an agent to a specific state.

--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/Persistency.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/Persistency.kt
@@ -171,7 +171,7 @@ public class Persistence(
                         nodeId = eventCtx.node.id,
                         lastInput = eventCtx.input,
                         lastInputType = eventCtx.inputType,
-                        parentId = parent?.checkpointId
+                        version = parent?.version?.plus(1) ?: 0L,
                     )
                 }
             }
@@ -183,7 +183,11 @@ public class Persistence(
             pipeline.interceptStrategyCompleted(interceptContext) { ctx ->
                 if (config.enableAutomaticPersistence && config.rollbackStrategy == RollbackStrategy.Default) {
                     val parent = ctx.feature.getLatestCheckpoint(ctx.agentId)
-                    ctx.feature.createTombstoneCheckpoint(ctx.agentId, ctx.feature.clock.now(), parent?.checkpointId)
+                    ctx.feature.createTombstoneCheckpoint(
+                        ctx.agentId,
+                        ctx.feature.clock.now(),
+                        parent?.version?.plus(1) ?: 0L
+                    )
                 }
             }
         }
@@ -210,7 +214,7 @@ public class Persistence(
         nodeId: String,
         lastInput: Any?,
         lastInputType: KType,
-        parentId: String?,
+        version: Long,
         checkpointId: String? = null,
     ): AgentCheckpointData? {
         val inputJson = trySerializeInput(lastInput, lastInputType)
@@ -229,7 +233,7 @@ public class Persistence(
                 nodeId = nodeId,
                 lastInput = inputJson,
                 createdAt = Clock.System.now(),
-                parentId = parentId,
+                version = version,
             )
         }
 
@@ -247,7 +251,7 @@ public class Persistence(
      * @return The created tombstone checkpoint data.
      */
     @InternalAgentsApi
-    public suspend fun createTombstoneCheckpoint(agentId: String, time: Instant, parentId: String?): AgentCheckpointData {
+    public suspend fun createTombstoneCheckpoint(agentId: String, time: Instant, parentId: Long): AgentCheckpointData {
         val checkpoint = tombstoneCheckpoint(time, parentId)
         saveCheckpoint(agentId, checkpoint)
         return checkpoint

--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/providers/InMemoryPersistencyStorageProvider.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/providers/InMemoryPersistencyStorageProvider.kt
@@ -35,7 +35,7 @@ public class InMemoryPersistenceStorageProvider() : PersistenceStorageProvider<A
                 return snapshotMap[agentId]?.filter { filter.check(it) }?.maxByOrNull { it.createdAt }
             }
 
-            return PersistenceUtils.latestCheckpointOf(snapshotMap[agentId] ?: emptyList())
+            return snapshotMap[agentId]?.maxBy { it.version }
         }
     }
 }

--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/providers/InMemoryPersistencyStorageProvider.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/providers/InMemoryPersistencyStorageProvider.kt
@@ -34,7 +34,8 @@ public class InMemoryPersistenceStorageProvider() : PersistenceStorageProvider<A
             if (filter != null) {
                 return snapshotMap[agentId]?.filter { filter.check(it) }?.maxByOrNull { it.createdAt }
             }
-            return snapshotMap[agentId]?.maxBy { it.createdAt }
+
+            return PersistenceUtils.latestCheckpointOf(snapshotMap[agentId] ?: emptyList())
         }
     }
 }

--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/providers/PersistenceUtils.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/providers/PersistenceUtils.kt
@@ -1,5 +1,7 @@
 package ai.koog.agents.snapshot.providers
 
+import ai.koog.agents.snapshot.feature.AgentCheckpointData
+import ai.koog.agents.snapshot.feature.isTombstone
 import kotlinx.serialization.json.Json
 
 @Deprecated(
@@ -36,4 +38,46 @@ public object PersistenceUtils {
      * or is no longer valid. This constant helps in recognizing such checkpoints during retrieval and processing.
      */
     public const val TOMBSTONE_CHECKPOINT_NAME: String = "tombstone"
+
+    /**
+     * Retrieves the latest checkpoint from a given list of agent checkpoint data.
+     * The latest checkpoint is determined based on the parent-child chain.
+     *
+     * @param checkpoints A list of `AgentCheckpointData` containing checkpoint details
+     *                    from which the latest checkpoint will be extracted.
+     * @return The `AgentCheckpointData` representing the latest checkpoint, or `null` if the list is empty.
+     */
+    public fun latestCheckpointOf(checkpoints: List<AgentCheckpointData>): AgentCheckpointData? {
+        if (checkpoints.isEmpty()) return null
+        val map = checkpoints.filter { it.parentId != null }.associateBy { it.parentId!! }
+        val roots = checkpoints.filter { it.parentId == null }
+
+        return roots.firstNotNullOfOrNull { processChain(it, map) }
+    }
+
+    private fun processChain(root: AgentCheckpointData, map: Map<String, AgentCheckpointData>): AgentCheckpointData? {
+        if (root.isTombstone()) {
+            // If the root itself is a tombstone, return null to indicate no valid checkpoint
+            return null
+        }
+
+        var current: AgentCheckpointData = root
+        while (true) {
+            val parent = current.checkpointId
+            val child = map[parent] ?: break
+            if (child == current) {
+                // Prevent potential infinite loop if there's a cycle
+                break
+            }
+
+            current = child
+        }
+
+        if (current.isTombstone()) {
+            // If the latest checkpoint is a tombstone, return null to indicate no valid checkpoint
+            return null
+        }
+
+        return current
+    }
 }

--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/providers/PersistenceUtils.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/providers/PersistenceUtils.kt
@@ -1,7 +1,5 @@
 package ai.koog.agents.snapshot.providers
 
-import ai.koog.agents.snapshot.feature.AgentCheckpointData
-import ai.koog.agents.snapshot.feature.isTombstone
 import kotlinx.serialization.json.Json
 
 @Deprecated(
@@ -38,46 +36,4 @@ public object PersistenceUtils {
      * or is no longer valid. This constant helps in recognizing such checkpoints during retrieval and processing.
      */
     public const val TOMBSTONE_CHECKPOINT_NAME: String = "tombstone"
-
-    /**
-     * Retrieves the latest checkpoint from a given list of agent checkpoint data.
-     * The latest checkpoint is determined based on the parent-child chain.
-     *
-     * @param checkpoints A list of `AgentCheckpointData` containing checkpoint details
-     *                    from which the latest checkpoint will be extracted.
-     * @return The `AgentCheckpointData` representing the latest checkpoint, or `null` if the list is empty.
-     */
-    public fun latestCheckpointOf(checkpoints: List<AgentCheckpointData>): AgentCheckpointData? {
-        if (checkpoints.isEmpty()) return null
-        val map = checkpoints.filter { it.parentId != null }.associateBy { it.parentId!! }
-        val roots = checkpoints.filter { it.parentId == null }
-
-        return roots.firstNotNullOfOrNull { processChain(it, map) }
-    }
-
-    private fun processChain(root: AgentCheckpointData, map: Map<String, AgentCheckpointData>): AgentCheckpointData? {
-        if (root.isTombstone()) {
-            // If the root itself is a tombstone, return null to indicate no valid checkpoint
-            return null
-        }
-
-        var current: AgentCheckpointData = root
-        while (true) {
-            val parent = current.checkpointId
-            val child = map[parent] ?: break
-            if (child == current) {
-                // Prevent potential infinite loop if there's a cycle
-                break
-            }
-
-            current = child
-        }
-
-        if (current.isTombstone()) {
-            // If the latest checkpoint is a tombstone, return null to indicate no valid checkpoint
-            return null
-        }
-
-        return current
-    }
 }

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/CheckpointSerializationTest.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/CheckpointSerializationTest.kt
@@ -32,7 +32,7 @@ class CheckpointSerializationTest {
             nodeId = "NodeA",
             lastInput = JsonPrimitive("last-input"),
             messageHistory = sampleMessages(now),
-            parentId = null
+            version = 0L
         )
 
         val json = PersistenceUtils.defaultCheckpointJson
@@ -91,7 +91,7 @@ class CheckpointSerializationTest {
             lastInput = JsonObject(mapOf("inputKey" to JsonPrimitive("inputVal"))),
             messageHistory = sampleMessages(now),
             properties = properties,
-            parentId = null
+            version = 0L
         )
 
         val json = PersistenceUtils.defaultCheckpointJson
@@ -104,7 +104,7 @@ class CheckpointSerializationTest {
 
     @Test
     fun `serialize and deserialize tombstone checkpoint`() {
-        val checkpoint = tombstoneCheckpoint(Clock.System.now(), null)
+        val checkpoint = tombstoneCheckpoint(Clock.System.now(), 0L)
         val json = PersistenceUtils.defaultCheckpointJson
         val serialized = json.encodeToString(AgentCheckpointData.serializer(), checkpoint)
         val restored = json.decodeFromString(AgentCheckpointData.serializer(), serialized)

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/CheckpointSerializationTest.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/CheckpointSerializationTest.kt
@@ -32,7 +32,7 @@ class CheckpointSerializationTest {
             nodeId = "NodeA",
             lastInput = JsonPrimitive("last-input"),
             messageHistory = sampleMessages(now),
-            properties = null
+            parentId = null
         )
 
         val json = PersistenceUtils.defaultCheckpointJson
@@ -90,7 +90,8 @@ class CheckpointSerializationTest {
             nodeId = "NodeB",
             lastInput = JsonObject(mapOf("inputKey" to JsonPrimitive("inputVal"))),
             messageHistory = sampleMessages(now),
-            properties = properties
+            properties = properties,
+            parentId = null
         )
 
         val json = PersistenceUtils.defaultCheckpointJson
@@ -103,7 +104,7 @@ class CheckpointSerializationTest {
 
     @Test
     fun `serialize and deserialize tombstone checkpoint`() {
-        val checkpoint = tombstoneCheckpoint(Clock.System.now())
+        val checkpoint = tombstoneCheckpoint(Clock.System.now(), null)
         val json = PersistenceUtils.defaultCheckpointJson
         val serialized = json.encodeToString(AgentCheckpointData.serializer(), checkpoint)
         val restored = json.decodeFromString(AgentCheckpointData.serializer(), serialized)

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/CheckpointsTests.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/CheckpointsTests.kt
@@ -36,7 +36,6 @@ import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
-import kotlin.time.Duration.Companion.seconds
 
 val databaseMap: MutableMap<String, String> = mutableMapOf()
 
@@ -71,11 +70,12 @@ class CheckpointsTests {
                     println("checkpoint save")
                     withPersistence { ctx ->
                         createCheckpoint(
-                            ctx,
-                            currentNodeId ?: error("currentNodeId not set"),
-                            input,
-                            typeOf<String>(),
-                            "cpt-100500"
+                            agentContext = ctx,
+                            nodeId = currentNodeId ?: error("currentNodeId not set"),
+                            lastInput = input,
+                            lastInputType = typeOf<String>(),
+                            checkpointId = "cpt-100500",
+                            parentId = null
                         )
                     }
                     input
@@ -215,7 +215,8 @@ class CheckpointsTests {
                         currentNodeId ?: error("currentNodeId not set"),
                         input,
                         typeOf<String>(),
-                        checkpointId
+                        checkpointId = checkpointId,
+                        parentId = null
                     )
                     llm.writeSession { updatePrompt { user { text("Checkpoint created with ID: $checkpointId") } } }
                 }
@@ -359,7 +360,8 @@ class CheckpointsTests {
             messageHistory = listOf(
                 Message.User("User message", metaInfo = RequestMetaInfo(time)),
                 Message.Assistant("Assistant message", metaInfo = ResponseMetaInfo(time))
-            )
+            ),
+            parentId = null
         )
 
         checkpointStorageProvider.saveCheckpoint(agentId, testCheckpoint)
@@ -392,6 +394,18 @@ class CheckpointsTests {
         val time = Clock.System.now()
         val agentId = "testAgentId"
 
+        val testCheckpoint2 = AgentCheckpointData(
+            checkpointId = "testCheckpointId",
+            createdAt = time,
+            nodeId = "Node1",
+            lastInput = JsonPrimitive("Test input"),
+            messageHistory = listOf(
+                Message.User("User message", metaInfo = RequestMetaInfo(time)),
+                Message.Assistant("Assistant message", metaInfo = ResponseMetaInfo(time))
+            ),
+            parentId = null
+        )
+
         val testCheckpoint = AgentCheckpointData(
             checkpointId = "testCheckpointId",
             createdAt = time,
@@ -400,22 +414,12 @@ class CheckpointsTests {
             messageHistory = listOf(
                 Message.User("User message", metaInfo = RequestMetaInfo(time)),
                 Message.Assistant("Assistant message", metaInfo = ResponseMetaInfo(time))
-            )
+            ),
+            parentId = testCheckpoint2.checkpointId
         )
 
-        val testCheckpoint2 = AgentCheckpointData(
-            checkpointId = "testCheckpointId",
-            createdAt = time - 10.seconds,
-            nodeId = "Node1",
-            lastInput = JsonPrimitive("Test input"),
-            messageHistory = listOf(
-                Message.User("User message", metaInfo = RequestMetaInfo(time)),
-                Message.Assistant("Assistant message", metaInfo = ResponseMetaInfo(time))
-            )
-        )
-
-        checkpointStorageProvider.saveCheckpoint(agentId, testCheckpoint)
         checkpointStorageProvider.saveCheckpoint(agentId, testCheckpoint2)
+        checkpointStorageProvider.saveCheckpoint(agentId, testCheckpoint)
 
         val agent = AIAgent(
             promptExecutor = getMockExecutor { },

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/CheckpointsTests.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/CheckpointsTests.kt
@@ -75,7 +75,7 @@ class CheckpointsTests {
                             lastInput = input,
                             lastInputType = typeOf<String>(),
                             checkpointId = "cpt-100500",
-                            parentId = null
+                            version = 0
                         )
                     }
                     input
@@ -216,7 +216,7 @@ class CheckpointsTests {
                         input,
                         typeOf<String>(),
                         checkpointId = checkpointId,
-                        parentId = null
+                        version = 0
                     )
                     llm.writeSession { updatePrompt { user { text("Checkpoint created with ID: $checkpointId") } } }
                 }
@@ -361,7 +361,7 @@ class CheckpointsTests {
                 Message.User("User message", metaInfo = RequestMetaInfo(time)),
                 Message.Assistant("Assistant message", metaInfo = ResponseMetaInfo(time))
             ),
-            parentId = null
+            version = 0
         )
 
         checkpointStorageProvider.saveCheckpoint(agentId, testCheckpoint)
@@ -403,7 +403,7 @@ class CheckpointsTests {
                 Message.User("User message", metaInfo = RequestMetaInfo(time)),
                 Message.Assistant("Assistant message", metaInfo = ResponseMetaInfo(time))
             ),
-            parentId = null
+            version = 0
         )
 
         val testCheckpoint = AgentCheckpointData(
@@ -415,7 +415,7 @@ class CheckpointsTests {
                 Message.User("User message", metaInfo = RequestMetaInfo(time)),
                 Message.Assistant("Assistant message", metaInfo = ResponseMetaInfo(time))
             ),
-            parentId = testCheckpoint2.checkpointId
+            version = testCheckpoint2.version + 1
         )
 
         checkpointStorageProvider.saveCheckpoint(agentId, testCheckpoint2)

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/CheckpointsTests.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/CheckpointsTests.kt
@@ -172,8 +172,7 @@ class CheckpointsTests {
     )
 
     private fun createGraphWithOptionalToolCallAndRollback(
-        checkpointId: String,
-        appendToolCall: Boolean
+        checkpointId: String
     ): TestRollbackableStrategy {
         val commands = Channel<String>(capacity = 100500)
         val notifications = Channel<String>(capacity = 100500)
@@ -287,7 +286,7 @@ class CheckpointsTests {
             tool(DeleteKVTool)
         }
 
-        val rollbackConfig = createGraphWithOptionalToolCallAndRollback("ckpt-1", appendToolCall = true)
+        val rollbackConfig = createGraphWithOptionalToolCallAndRollback("ckpt-1")
 
         val agentService = AIAgentService(
             promptExecutor = getMockExecutor { },
@@ -312,7 +311,7 @@ class CheckpointsTests {
 
         println("before second launch")
 
-        val task2 = launch {
+        launch {
             assertEquals("after-checkpoint", rollbackConfig.notifications.receive())
             rollbackConfig.commands.send("continue")
 

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/PersistencyRestoreStrategyTests.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/PersistencyRestoreStrategyTests.kt
@@ -29,6 +29,7 @@ class PersistenceRestoreStrategyTests {
             nodeId = "Node2",
             lastInput = JsonPrimitive("input-for-node2"),
             messageHistory = listOf(Message.Assistant("History Before", ResponseMetaInfo(Clock.System.now()))),
+            parentId = null
         )
 
         provider.saveCheckpoint(agentId, checkpoint)

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/PersistencyRestoreStrategyTests.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/PersistencyRestoreStrategyTests.kt
@@ -29,7 +29,7 @@ class PersistenceRestoreStrategyTests {
             nodeId = "Node2",
             lastInput = JsonPrimitive("input-for-node2"),
             messageHistory = listOf(Message.Assistant("History Before", ResponseMetaInfo(Clock.System.now()))),
-            parentId = null
+            version = 0L
         )
 
         provider.saveCheckpoint(agentId, checkpoint)

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/TestStrategies.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/TestStrategies.kt
@@ -132,7 +132,7 @@ private fun AIAgentSubgraphBuilderBase<*, *>.createCheckpointNode(name: String? 
     node<String, String>(name) {
         val input = it
         withPersistence { ctx ->
-            createCheckpoint(ctx, name!!, input, typeOf<String>(), null, checkpointId)
+            createCheckpoint(ctx, name!!, input, typeOf<String>(), 0L, checkpointId)
             llm.writeSession {
                 updatePrompt {
                     user {
@@ -180,7 +180,7 @@ private fun AIAgentSubgraphBuilderBase<*, *>.nodeCreateCheckpoint(
             currentNodeId ?: error("currentNodeId not set"),
             input,
             typeOf<String>(),
-            "snapshot-id"
+            0L
         )
 
         saveCheckpoint(ctx.agentId, checkpoint ?: error("Checkpoint creation failed"))

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/TestStrategies.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/TestStrategies.kt
@@ -132,7 +132,7 @@ private fun AIAgentSubgraphBuilderBase<*, *>.createCheckpointNode(name: String? 
     node<String, String>(name) {
         val input = it
         withPersistence { ctx ->
-            createCheckpoint(ctx, name!!, input, typeOf<String>(), checkpointId)
+            createCheckpoint(ctx, name!!, input, typeOf<String>(), null, checkpointId)
             llm.writeSession {
                 updatePrompt {
                     user {

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/TestStrategies.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/TestStrategies.kt
@@ -287,26 +287,6 @@ internal fun loggingGraphStrategy(collector: TestAgentLogsCollector) = strategy(
     edge(node2 forwardTo nodeFinish)
 }
 
-internal fun loggingGraphWithHistoryCollectionStrategy(collector: TestAgentLogsCollector) = strategy("logging-test") {
-    val node1 by loggingNode(
-        "Node1",
-        message = "First Step",
-        collector = collector
-    )
-
-    val node2 by loggingNode(
-        "Node2",
-        message = "Second Step",
-        collector = collector
-    )
-    val historyNode by collectHistoryNode("History Node")
-
-    edge(nodeStart forwardTo node1)
-    edge(node1 forwardTo node2)
-    edge(node2 forwardTo historyNode)
-    edge(historyNode forwardTo nodeFinish)
-}
-
 internal fun loggingGraphForRunFromSecondTry(collector: TestAgentLogsCollector) = strategy("logging-test") {
     val node1 by loggingNode(
         "Node1",

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/ai/koog/agents/snapshot/providers/file/FileAgentCheckpointStorageProviderTest.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/ai/koog/agents/snapshot/providers/file/FileAgentCheckpointStorageProviderTest.kt
@@ -51,7 +51,8 @@ class FileAgentCheckpointStorageProviderTest {
             createdAt = createdAt,
             nodeId = nodeId,
             lastInput = lastInput,
-            messageHistory = messageHistory
+            messageHistory = messageHistory,
+            parentId = null
         )
 
         val agentId = "testAgentId"
@@ -93,7 +94,8 @@ class FileAgentCheckpointStorageProviderTest {
             createdAt = laterCreatedAt,
             nodeId = nodeId,
             lastInput = lastInput,
-            messageHistory = messageHistory
+            messageHistory = messageHistory,
+            parentId = checkpoint.checkpointId
         )
 
         // Save the later checkpoint

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/ai/koog/agents/snapshot/providers/file/FileAgentCheckpointStorageProviderTest.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/ai/koog/agents/snapshot/providers/file/FileAgentCheckpointStorageProviderTest.kt
@@ -52,7 +52,7 @@ class FileAgentCheckpointStorageProviderTest {
             nodeId = nodeId,
             lastInput = lastInput,
             messageHistory = messageHistory,
-            parentId = null
+            version = 0L
         )
 
         val agentId = "testAgentId"
@@ -95,7 +95,7 @@ class FileAgentCheckpointStorageProviderTest {
             nodeId = nodeId,
             lastInput = lastInput,
             messageHistory = messageHistory,
-            parentId = checkpoint.checkpointId
+            version = checkpoint.version.plus(1)
         )
 
         // Save the later checkpoint

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/ai/koog/agents/snapshot/providers/file/FileCheckpointsTests.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/ai/koog/agents/snapshot/providers/file/FileCheckpointsTests.kt
@@ -126,7 +126,8 @@ class FileCheckpointsTests {
             messageHistory = listOf(
                 Message.User("User message", metaInfo = RequestMetaInfo(time)),
                 Message.Assistant("Assistant message", metaInfo = ResponseMetaInfo(time))
-            )
+            ),
+            parentId = null
         )
 
         provider.saveCheckpoint(agentId, testCheckpoint)
@@ -158,17 +159,6 @@ class FileCheckpointsTests {
         val time = Clock.System.now()
         val agentId = "testAgentId"
 
-        val testCheckpoint = AgentCheckpointData(
-            checkpointId = "testCheckpointId",
-            createdAt = time,
-            nodeId = "Node2",
-            lastInput = JsonPrimitive("Test input"),
-            messageHistory = listOf(
-                Message.User("User message", metaInfo = RequestMetaInfo(time)),
-                Message.Assistant("Assistant message", metaInfo = ResponseMetaInfo(time))
-            )
-        )
-
         val testCheckpoint2 = AgentCheckpointData(
             checkpointId = "testCheckpointId2",
             createdAt = time - 10.seconds,
@@ -177,7 +167,20 @@ class FileCheckpointsTests {
             messageHistory = listOf(
                 Message.User("Earlier message", metaInfo = RequestMetaInfo(time)),
                 Message.Assistant("Earlier response", metaInfo = ResponseMetaInfo(time))
-            )
+            ),
+            parentId = null
+        )
+
+        val testCheckpoint = AgentCheckpointData(
+            checkpointId = "testCheckpointId",
+            createdAt = time,
+            nodeId = "Node2",
+            lastInput = JsonPrimitive("Test input"),
+            messageHistory = listOf(
+                Message.User("User message", metaInfo = RequestMetaInfo(time)),
+                Message.Assistant("Assistant message", metaInfo = ResponseMetaInfo(time))
+            ),
+            parentId = testCheckpoint2.checkpointId
         )
 
         provider.saveCheckpoint(agentId, testCheckpoint)

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/ai/koog/agents/snapshot/providers/file/FileCheckpointsTests.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/ai/koog/agents/snapshot/providers/file/FileCheckpointsTests.kt
@@ -127,7 +127,7 @@ class FileCheckpointsTests {
                 Message.User("User message", metaInfo = RequestMetaInfo(time)),
                 Message.Assistant("Assistant message", metaInfo = ResponseMetaInfo(time))
             ),
-            parentId = null
+            version = 0L
         )
 
         provider.saveCheckpoint(agentId, testCheckpoint)
@@ -168,7 +168,7 @@ class FileCheckpointsTests {
                 Message.User("Earlier message", metaInfo = RequestMetaInfo(time)),
                 Message.Assistant("Earlier response", metaInfo = ResponseMetaInfo(time))
             ),
-            parentId = null
+            version = 0L
         )
 
         val testCheckpoint = AgentCheckpointData(
@@ -180,7 +180,7 @@ class FileCheckpointsTests {
                 Message.User("User message", metaInfo = RequestMetaInfo(time)),
                 Message.Assistant("Assistant message", metaInfo = ResponseMetaInfo(time))
             ),
-            parentId = testCheckpoint2.checkpointId
+            version = testCheckpoint2.version.plus(1)
         )
 
         provider.saveCheckpoint(agentId, testCheckpoint)

--- a/agents/agents-features/agents-features-sql/src/jvmMain/kotlin/ai/koog/agents/features/sql/providers/CheckpointsTable.kt
+++ b/agents/agents-features/agents-features-sql/src/jvmMain/kotlin/ai/koog/agents/features/sql/providers/CheckpointsTable.kt
@@ -61,10 +61,18 @@ public open class CheckpointsTable(tableName: String) : Table(tableName) {
      */
     public val ttlTimestamp: Column<Long?> = long("ttl_timestamp").nullable().index()
 
+    /**
+     * Represents the version of the checkpoint.
+     *
+     * This column stores a long integer indicating the version of the checkpoint.
+     */
+    public val version: Column<Long> = long("version")
+
     override val primaryKey: PrimaryKey = PrimaryKey(persistenceId, checkpointId)
 
     init {
         // Create composite index for efficient queries
         index(isUnique = false, persistenceId, createdAt)
+        index(isUnique = true, persistenceId, version)
     }
 }

--- a/agents/agents-features/agents-features-sql/src/jvmMain/kotlin/ai/koog/agents/features/sql/providers/CleanupConfig.kt
+++ b/agents/agents-features/agents-features-sql/src/jvmMain/kotlin/ai/koog/agents/features/sql/providers/CleanupConfig.kt
@@ -1,0 +1,32 @@
+package ai.koog.agents.features.sql.providers
+
+/**
+ * Configuration for TTL cleanup behavior
+ *
+ * @property enabled Whether TTL cleanup should be performed automatically
+ * @property intervalMs Minimum interval between cleanup operations in milliseconds (default: 1 minute)
+ */
+public data class CleanupConfig(
+    val enabled: Boolean = true,
+    val intervalMs: Long = 60_000L
+) {
+    /**
+     * Companion object for CleanupConfig providing factory methods for creating configuration instances.
+     */
+    public companion object {
+        /**
+         * Creates a default CleanupConfig instance with automatic TTL cleanup enabled
+         * and a default interval of 1 minute between cleanup operations.
+         *
+         * @return A CleanupConfig instance with default settings.
+         */
+        public fun default(): CleanupConfig = CleanupConfig()
+
+        /**
+         * Creates a CleanupConfig instance with automatic TTL cleanup disabled.
+         *
+         * @return A CleanupConfig instance with the `enabled` property set to `false`.
+         */
+        public fun disabled(): CleanupConfig = CleanupConfig(enabled = false)
+    }
+}

--- a/agents/agents-features/agents-features-sql/src/jvmMain/kotlin/ai/koog/agents/features/sql/providers/ExposedPersistencyStorageProvider.kt
+++ b/agents/agents-features/agents-features-sql/src/jvmMain/kotlin/ai/koog/agents/features/sql/providers/ExposedPersistencyStorageProvider.kt
@@ -123,7 +123,7 @@ public abstract class ExposedPersistenceStorageProvider(
                 checkpointsTable.select(checkpointsTable.checkpointJson).where {
                     (checkpointsTable.persistenceId eq agentId) and
                         ((checkpointsTable.ttlTimestamp eq null) or (checkpointsTable.ttlTimestamp greaterEq now))
-                }.orderBy(checkpointsTable.createdAt to SortOrder.ASC).mapNotNull { row ->
+                }.mapNotNull { row ->
                     runCatching {
                         json.decodeFromString<AgentCheckpointData>(row[checkpointsTable.checkpointJson])
                     }.getOrNull()
@@ -146,20 +146,35 @@ public abstract class ExposedPersistenceStorageProvider(
         val ttlTimestamp = calculateTtlTimestamp(agentCheckpointData.createdAt)
 
         transaction {
-            // Use upsert for idempotent saves
             checkpointsTable.upsert {
                 it[checkpointsTable.persistenceId] = agentId
                 it[checkpointsTable.checkpointId] = agentCheckpointData.checkpointId
                 it[checkpointsTable.createdAt] = agentCheckpointData.createdAt.toEpochMilliseconds()
                 it[checkpointsTable.checkpointJson] = checkpointJson
                 it[checkpointsTable.ttlTimestamp] = ttlTimestamp
+                it[checkpointsTable.version] = agentCheckpointData.version
             }
         }
     }
 
     override suspend fun getLatestCheckpoint(agentId: String, filter: ExposedPersistenceFilter?): AgentCheckpointData? {
         if (filter == null) {
-            return PersistenceUtils.latestCheckpointOf(getCheckpoints(agentId))
+            val now = Clock.System.now().toEpochMilliseconds()
+            return transaction {
+                checkpointsTable
+                    .select(checkpointsTable.checkpointJson)
+                    .where {
+                        (checkpointsTable.persistenceId eq agentId) and
+                            ((checkpointsTable.ttlTimestamp eq null) or (checkpointsTable.ttlTimestamp greaterEq now))
+                    }
+                    .orderBy(checkpointsTable.version to SortOrder.DESC)
+                    .limit(1)
+                    .firstNotNullOfOrNull { row ->
+                        runCatching {
+                            json.decodeFromString<AgentCheckpointData>(row[checkpointsTable.checkpointJson])
+                        }
+                    }?.getOrNull()
+            }
         }
 
         return transaction {

--- a/agents/agents-features/agents-features-sql/src/jvmMain/kotlin/ai/koog/agents/features/sql/providers/ExposedPersistencyStorageProvider.kt
+++ b/agents/agents-features/agents-features-sql/src/jvmMain/kotlin/ai/koog/agents/features/sql/providers/ExposedPersistencyStorageProvider.kt
@@ -16,37 +16,6 @@ import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.upsert
 
 /**
- * Configuration for TTL cleanup behavior
- *
- * @property enabled Whether TTL cleanup should be performed automatically
- * @property intervalMs Minimum interval between cleanup operations in milliseconds (default: 1 minute)
- */
-public data class CleanupConfig(
-    val enabled: Boolean = true,
-    val intervalMs: Long = 60_000L
-) {
-    /**
-     * Companion object for CleanupConfig providing factory methods for creating configuration instances.
-     */
-    public companion object {
-        /**
-         * Creates a default CleanupConfig instance with automatic TTL cleanup enabled
-         * and a default interval of 1 minute between cleanup operations.
-         *
-         * @return A CleanupConfig instance with default settings.
-         */
-        public fun default(): CleanupConfig = CleanupConfig()
-
-        /**
-         * Creates a CleanupConfig instance with automatic TTL cleanup disabled.
-         *
-         * @return A CleanupConfig instance with the `enabled` property set to `false`.
-         */
-        public fun disabled(): CleanupConfig = CleanupConfig(enabled = false)
-    }
-}
-
-/**
  * An abstract Exposed-based implementation of [SQLPersistenceStorageProvider] for managing
  * agent checkpoints in SQL databases using JetBrains Exposed ORM.
  *
@@ -65,7 +34,6 @@ public data class CleanupConfig(
  * - PostgreSQL: Full support including JSONB columns
  * - MySQL: JSON column support (5.7+)
  * - H2: JSON stored as TEXT with parsing
- * - SQLite: JSON stored as TEXT with parsing
  *
  * ## Performance Considerations:
  * - Uses database-specific JSON operations where available
@@ -85,7 +53,6 @@ public data class CleanupConfig(
  * @param tableName Name of the table to store checkpoints (default: "agent_checkpoints")
  * @param ttlSeconds Optional TTL for checkpoint entries in seconds (null = no expiration)
  */
-@Suppress("MissingKDocForPublicAPI")
 public abstract class ExposedPersistenceStorageProvider(
     protected val database: Database,
     tableName: String = "agent_checkpoints",
@@ -192,15 +159,7 @@ public abstract class ExposedPersistenceStorageProvider(
 
     override suspend fun getLatestCheckpoint(agentId: String, filter: ExposedPersistenceFilter?): AgentCheckpointData? {
         if (filter == null) {
-            return transaction {
-                checkpointsTable.select(checkpointsTable.checkpointJson).where {
-                    checkpointsTable.persistenceId eq agentId
-                }.orderBy(checkpointsTable.createdAt to SortOrder.DESC).limit(1).firstOrNull()?.let { row ->
-                    runCatching {
-                        json.decodeFromString<AgentCheckpointData>(row[checkpointsTable.checkpointJson])
-                    }.getOrNull()
-                }
-            }
+            return PersistenceUtils.latestCheckpointOf(getCheckpoints(agentId))
         }
 
         return transaction {

--- a/agents/agents-features/agents-features-sql/src/jvmMain/kotlin/ai/koog/agents/features/sql/providers/H2PersistencyStorageProvider.kt
+++ b/agents/agents-features/agents-features-sql/src/jvmMain/kotlin/ai/koog/agents/features/sql/providers/H2PersistencyStorageProvider.kt
@@ -126,6 +126,7 @@ public class H2PersistenceSchemaMigrator(private val database: Database, private
                 created_at BIGINT NOT NULL,
                 checkpoint_json TEXT NOT NULL,
                 ttl_timestamp BIGINT NULL,
+                version BIGINT NOT NULL,
                 
                 -- Primary key constraint
                 CONSTRAINT ${tableName}_pkey PRIMARY KEY (persistence_id, checkpoint_id)
@@ -143,6 +144,12 @@ public class H2PersistenceSchemaMigrator(private val database: Database, private
             exec(
                 """
             CREATE INDEX IF NOT EXISTS idx_${tableName}_ttl_timestamp ON $tableName (ttl_timestamp)
+                """.trimIndent()
+            )
+
+            exec(
+                """
+            CREATE UNIQUE INDEX IF NOT EXISTS ${tableName}_persistence_id_version_idx ON $tableName (persistence_id, version);
                 """.trimIndent()
             )
         }

--- a/agents/agents-features/agents-features-sql/src/jvmMain/kotlin/ai/koog/agents/features/sql/providers/MySQLPersistencyStorageProvider.kt
+++ b/agents/agents-features/agents-features-sql/src/jvmMain/kotlin/ai/koog/agents/features/sql/providers/MySQLPersistencyStorageProvider.kt
@@ -76,10 +76,12 @@ public class MySqlPersistenceSchemaMigrator(private val database: Database, priv
                 created_at BIGINT NOT NULL,
                 checkpoint_json JSON NOT NULL,
                 ttl_timestamp BIGINT NULL,
+                version BIGINT NOT NULL,
                 
                 PRIMARY KEY (persistence_id, checkpoint_id),
                 INDEX idx_${tableName}_created_at (created_at),
-                INDEX idx_${tableName}_ttl_timestamp (ttl_timestamp)
+                INDEX idx_${tableName}_ttl_timestamp (ttl_timestamp),
+                UNIQUE INDEX uniq_${tableName}_persistence_id_version (persistence_id, version)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
                 """.trimIndent()
             )

--- a/agents/agents-features/agents-features-sql/src/jvmMain/kotlin/ai/koog/agents/features/sql/providers/PostgresPersistencyStorageProvider.kt
+++ b/agents/agents-features/agents-features-sql/src/jvmMain/kotlin/ai/koog/agents/features/sql/providers/PostgresPersistencyStorageProvider.kt
@@ -64,7 +64,8 @@ public class PostgresPersistenceSchemaMigrator(private val database: Database, p
                 created_at BIGINT NOT NULL,
                 checkpoint_json TEXT NOT NULL,
                 ttl_timestamp BIGINT NULL,
-                
+                version BIGINT NOT NULL,
+
                 -- Primary key constraint
                 CONSTRAINT ${tableName}_pkey PRIMARY KEY (persistence_id, checkpoint_id)
             )
@@ -81,6 +82,12 @@ public class PostgresPersistenceSchemaMigrator(private val database: Database, p
             exec(
                 """
             CREATE INDEX IF NOT EXISTS idx_${tableName}_ttl_timestamp ON $tableName (ttl_timestamp)
+                """.trimIndent()
+            )
+
+            exec(
+                """
+            CREATE UNIQUE INDEX IF NOT EXISTS ${tableName}_persistence_id_version_idx ON $tableName (persistence_id, version);
                 """.trimIndent()
             )
         }

--- a/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/ExposedPersistenceFilterPostgresTest.kt
+++ b/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/ExposedPersistenceFilterPostgresTest.kt
@@ -73,17 +73,17 @@ class ExposedPersistenceFilterPostgresTest {
 
         val baseTime = Clock.System.now()
 
-        val checkpoint1 = createTestCheckpoint("cp-a1", baseTime - 10.seconds, parentId = null)
-        val checkpoint2 = createTestCheckpoint("cp-a2", baseTime - 5.seconds, parentId = checkpoint1.checkpointId)
-        val checkpoint3 = createTestCheckpoint("cp-a3", baseTime, parentId = checkpoint2.checkpointId)
+        val checkpoint1 = createTestCheckpoint("cp-a1", baseTime - 10.seconds, version = 0)
+        val checkpoint2 = createTestCheckpoint("cp-a2", baseTime - 5.seconds, version = checkpoint1.version.plus(1))
+        val checkpoint3 = createTestCheckpoint("cp-a3", baseTime, version = checkpoint2.version.plus(1))
 
         // Seed data: 3 for agentId, 2 for otherAgent
         p.saveCheckpoint(agentId, checkpoint1)
         p.saveCheckpoint(agentId, checkpoint2)
         p.saveCheckpoint(agentId, checkpoint3)
 
-        val checkpointB1 = createTestCheckpoint("cp-b1", baseTime - 3.seconds, parentId = null)
-        val checkpointB2 = createTestCheckpoint("cp-b2", baseTime + 2.seconds, parentId = checkpointB1.checkpointId)
+        val checkpointB1 = createTestCheckpoint("cp-b1", baseTime - 3.seconds, version = 0)
+        val checkpointB2 = createTestCheckpoint("cp-b2", baseTime + 2.seconds, version = checkpointB1.version.plus(1))
         p.saveCheckpoint(otherAgent, checkpointB1)
         p.saveCheckpoint(otherAgent, checkpointB2)
 
@@ -107,9 +107,9 @@ class ExposedPersistenceFilterPostgresTest {
         val agentId = "agent-prefix-1"
         val baseTime = Clock.System.now()
 
-        val checkpoint1 = createTestCheckpoint("order-001", baseTime - 2.seconds, parentId = null)
-        val checkpoint2 = createTestCheckpoint("order-002", baseTime - 1.seconds, parentId = checkpoint1.checkpointId)
-        val checkpoint3 = createTestCheckpoint("note-001", baseTime, parentId = checkpoint2.checkpointId)
+        val checkpoint1 = createTestCheckpoint("order-001", baseTime - 2.seconds, version = 0)
+        val checkpoint2 = createTestCheckpoint("order-002", baseTime - 1.seconds, version = checkpoint1.version.plus(1))
+        val checkpoint3 = createTestCheckpoint("note-001", baseTime, version = checkpoint2.version.plus(1))
 
         p.saveCheckpoint(agentId, checkpoint1)
         p.saveCheckpoint(agentId, checkpoint2)
@@ -125,7 +125,7 @@ class ExposedPersistenceFilterPostgresTest {
         assertEquals("order-002", latest.checkpointId)
     }
 
-    private fun createTestCheckpoint(id: String, createdAt: Instant, parentId: String?): AgentCheckpointData {
+    private fun createTestCheckpoint(id: String, createdAt: Instant, version: Long): AgentCheckpointData {
         return AgentCheckpointData(
             checkpointId = id,
             createdAt = createdAt,
@@ -136,7 +136,7 @@ class ExposedPersistenceFilterPostgresTest {
                 Message.User("Hello", RequestMetaInfo.create(Clock.System)),
                 Message.Assistant("Hi there!", ResponseMetaInfo.create(Clock.System))
             ),
-            parentId = parentId
+            version = version
         )
     }
 

--- a/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/ExposedPersistenceFilterPostgresTest.kt
+++ b/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/ExposedPersistenceFilterPostgresTest.kt
@@ -73,13 +73,19 @@ class ExposedPersistenceFilterPostgresTest {
 
         val baseTime = Clock.System.now()
 
-        // Seed data: 3 for agentId, 2 for otherAgent
-        p.saveCheckpoint(agentId, createTestCheckpoint("cp-a1", baseTime - 10.seconds))
-        p.saveCheckpoint(agentId, createTestCheckpoint("cp-a2", baseTime - 5.seconds))
-        p.saveCheckpoint(agentId, createTestCheckpoint("cp-a3", baseTime))
+        val checkpoint1 = createTestCheckpoint("cp-a1", baseTime - 10.seconds, parentId = null)
+        val checkpoint2 = createTestCheckpoint("cp-a2", baseTime - 5.seconds, parentId = checkpoint1.checkpointId)
+        val checkpoint3 = createTestCheckpoint("cp-a3", baseTime, parentId = checkpoint2.checkpointId)
 
-        p.saveCheckpoint(otherAgent, createTestCheckpoint("cp-b1", baseTime - 7.seconds))
-        p.saveCheckpoint(otherAgent, createTestCheckpoint("cp-b2", baseTime + 1.seconds))
+        // Seed data: 3 for agentId, 2 for otherAgent
+        p.saveCheckpoint(agentId, checkpoint1)
+        p.saveCheckpoint(agentId, checkpoint2)
+        p.saveCheckpoint(agentId, checkpoint3)
+
+        val checkpointB1 = createTestCheckpoint("cp-b1", baseTime - 3.seconds, parentId = null)
+        val checkpointB2 = createTestCheckpoint("cp-b2", baseTime + 2.seconds, parentId = checkpointB1.checkpointId)
+        p.saveCheckpoint(otherAgent, checkpointB1)
+        p.saveCheckpoint(otherAgent, checkpointB2)
 
         // Build filter: for agentId and createdAt >= baseTime - 5s
         val filter = CreatedAfterForAgentFilter(agentId, threshold = baseTime - 5.seconds)
@@ -101,9 +107,13 @@ class ExposedPersistenceFilterPostgresTest {
         val agentId = "agent-prefix-1"
         val baseTime = Clock.System.now()
 
-        p.saveCheckpoint(agentId, createTestCheckpoint("order-001", baseTime - 2.seconds))
-        p.saveCheckpoint(agentId, createTestCheckpoint("order-002", baseTime - 1.seconds))
-        p.saveCheckpoint(agentId, createTestCheckpoint("note-001", baseTime))
+        val checkpoint1 = createTestCheckpoint("order-001", baseTime - 2.seconds, parentId = null)
+        val checkpoint2 = createTestCheckpoint("order-002", baseTime - 1.seconds, parentId = checkpoint1.checkpointId)
+        val checkpoint3 = createTestCheckpoint("note-001", baseTime, parentId = checkpoint2.checkpointId)
+
+        p.saveCheckpoint(agentId, checkpoint1)
+        p.saveCheckpoint(agentId, checkpoint2)
+        p.saveCheckpoint(agentId, checkpoint3)
 
         val filter = CheckpointIdPrefixFilter(agentId, prefix = "order-")
 
@@ -115,7 +125,7 @@ class ExposedPersistenceFilterPostgresTest {
         assertEquals("order-002", latest.checkpointId)
     }
 
-    private fun createTestCheckpoint(id: String, createdAt: Instant): AgentCheckpointData {
+    private fun createTestCheckpoint(id: String, createdAt: Instant, parentId: String?): AgentCheckpointData {
         return AgentCheckpointData(
             checkpointId = id,
             createdAt = createdAt,
@@ -125,7 +135,8 @@ class ExposedPersistenceFilterPostgresTest {
                 Message.System("You are a test assistant", RequestMetaInfo.create(Clock.System)),
                 Message.User("Hello", RequestMetaInfo.create(Clock.System)),
                 Message.Assistant("Hi there!", ResponseMetaInfo.create(Clock.System))
-            )
+            ),
+            parentId = parentId
         )
     }
 

--- a/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/H2PersistencyStorageProviderTest.kt
+++ b/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/H2PersistencyStorageProviderTest.kt
@@ -1,10 +1,13 @@
 package ai.koog.agents.features.sql.providers
 
 import ai.koog.agents.snapshot.feature.AgentCheckpointData
+import ai.koog.agents.snapshot.feature.isTombstone
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.test.utils.DockerAvailableCondition
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Clock
@@ -14,10 +17,9 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
-@TestInstance(Lifecycle.PER_CLASS)
+@TestInstance(Lifecycle.PER_METHOD)
 @ExtendWith(DockerAvailableCondition::class)
 class H2PersistenceStorageProviderTest {
 
@@ -37,26 +39,28 @@ class H2PersistenceStorageProviderTest {
         p.migrate()
 
         // empty
-        assertNull(p.getLatestCheckpoint(agentId))
-        assertEquals(0, p.getCheckpointCount(agentId))
+        p.getLatestCheckpoint(agentId) shouldBe null
+        p.getCheckpointCount(agentId) shouldBe 0
 
         // save
-        val cp1 = createTestCheckpoint("cp-1", null)
+        val cp1 = createTestCheckpoint("cp-1", 0L)
         p.saveCheckpoint(agentId, cp1)
 
         // read
         val latest1 = p.getLatestCheckpoint(agentId)
-        assertNotNull(latest1)
-        assertEquals("cp-1", latest1.checkpointId)
-        assertEquals(1, p.getCheckpoints(agentId).size)
-        assertEquals(1, p.getCheckpointCount(agentId))
+
+        latest1 shouldNotBe null
+        latest1?.checkpointId shouldBe "cp-1"
+        latest1?.nodeId shouldBe "test-node"
+        latest1?.messageHistory?.size shouldBe 3
+        latest1?.isTombstone() shouldBe false
 
         // upsert same id should be idempotent (no duplicates due PK)
         p.saveCheckpoint(agentId, cp1)
         assertEquals(1, p.getCheckpoints(agentId).size)
 
         // insert second
-        val cp2 = createTestCheckpoint("cp-2", cp1.checkpointId)
+        val cp2 = createTestCheckpoint("cp-2", cp1.version.plus(1))
         p.saveCheckpoint(agentId, cp2)
         val all = p.getCheckpoints(agentId)
         assertEquals(listOf("cp-1", "cp-2"), all.map { it.checkpointId })
@@ -76,7 +80,7 @@ class H2PersistenceStorageProviderTest {
         val p = provider(ttlSeconds = 1)
         p.migrate()
 
-        p.saveCheckpoint(agentId, createTestCheckpoint("will-expire", null))
+        p.saveCheckpoint(agentId, createTestCheckpoint("will-expire", 0L))
         assertEquals(1, p.getCheckpointCount(agentId))
 
         // Wait slightly over 1s to ensure ttl passes
@@ -88,7 +92,7 @@ class H2PersistenceStorageProviderTest {
         assertNull(p.getLatestCheckpoint(agentId))
     }
 
-    private fun createTestCheckpoint(id: String, parentId: String?): AgentCheckpointData {
+    private fun createTestCheckpoint(id: String, version: Long): AgentCheckpointData {
         return AgentCheckpointData(
             checkpointId = id,
             createdAt = Clock.System.now(),
@@ -99,7 +103,7 @@ class H2PersistenceStorageProviderTest {
                 Message.User("Hello", RequestMetaInfo.create(Clock.System)),
                 Message.Assistant("Hi there!", ResponseMetaInfo.create(Clock.System))
             ),
-            parentId = parentId
+            version = version
         )
     }
 }

--- a/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/H2PersistencyStorageProviderTest.kt
+++ b/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/H2PersistencyStorageProviderTest.kt
@@ -41,7 +41,7 @@ class H2PersistenceStorageProviderTest {
         assertEquals(0, p.getCheckpointCount(agentId))
 
         // save
-        val cp1 = createTestCheckpoint("cp-1")
+        val cp1 = createTestCheckpoint("cp-1", null)
         p.saveCheckpoint(agentId, cp1)
 
         // read
@@ -56,7 +56,7 @@ class H2PersistenceStorageProviderTest {
         assertEquals(1, p.getCheckpoints(agentId).size)
 
         // insert second
-        val cp2 = createTestCheckpoint("cp-2")
+        val cp2 = createTestCheckpoint("cp-2", cp1.checkpointId)
         p.saveCheckpoint(agentId, cp2)
         val all = p.getCheckpoints(agentId)
         assertEquals(listOf("cp-1", "cp-2"), all.map { it.checkpointId })
@@ -76,7 +76,7 @@ class H2PersistenceStorageProviderTest {
         val p = provider(ttlSeconds = 1)
         p.migrate()
 
-        p.saveCheckpoint(agentId, createTestCheckpoint("will-expire"))
+        p.saveCheckpoint(agentId, createTestCheckpoint("will-expire", null))
         assertEquals(1, p.getCheckpointCount(agentId))
 
         // Wait slightly over 1s to ensure ttl passes
@@ -88,7 +88,7 @@ class H2PersistenceStorageProviderTest {
         assertNull(p.getLatestCheckpoint(agentId))
     }
 
-    private fun createTestCheckpoint(id: String): AgentCheckpointData {
+    private fun createTestCheckpoint(id: String, parentId: String?): AgentCheckpointData {
         return AgentCheckpointData(
             checkpointId = id,
             createdAt = Clock.System.now(),
@@ -98,7 +98,8 @@ class H2PersistenceStorageProviderTest {
                 Message.System("You are a test assistant", RequestMetaInfo.create(Clock.System)),
                 Message.User("Hello", RequestMetaInfo.create(Clock.System)),
                 Message.Assistant("Hi there!", ResponseMetaInfo.create(Clock.System))
-            )
+            ),
+            parentId = parentId
         )
     }
 }

--- a/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/MySQLPersistencyStorageProviderTest.kt
+++ b/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/MySQLPersistencyStorageProviderTest.kt
@@ -68,7 +68,7 @@ class MySQLPersistenceStorageProviderTest {
         assertEquals(0, p.getCheckpointCount(agentId))
 
         // save
-        val cp1 = createTestCheckpoint("cp-1")
+        val cp1 = createTestCheckpoint("cp-1", null)
         p.saveCheckpoint(agentId, cp1)
 
         // read
@@ -83,7 +83,7 @@ class MySQLPersistenceStorageProviderTest {
         assertEquals(1, p.getCheckpoints(agentId).size)
 
         // insert second
-        val cp2 = createTestCheckpoint("cp-2")
+        val cp2 = createTestCheckpoint("cp-2", cp1.checkpointId)
         p.saveCheckpoint(agentId, cp2)
         val all = p.getCheckpoints(agentId)
         assertEquals(listOf("cp-1", "cp-2"), all.map { it.checkpointId })
@@ -103,7 +103,7 @@ class MySQLPersistenceStorageProviderTest {
         val p = provider(ttlSeconds = 1)
         p.migrate()
 
-        p.saveCheckpoint(agentId, createTestCheckpoint("will-expire"))
+        p.saveCheckpoint(agentId, createTestCheckpoint("will-expire", null))
         assertEquals(1, p.getCheckpointCount(agentId))
 
         // Sleep slightly over 1s to ensure ttl passes
@@ -115,7 +115,7 @@ class MySQLPersistenceStorageProviderTest {
         assertNull(p.getLatestCheckpoint(agentId))
     }
 
-    private fun createTestCheckpoint(id: String): AgentCheckpointData {
+    private fun createTestCheckpoint(id: String, parentId: String?): AgentCheckpointData {
         return AgentCheckpointData(
             checkpointId = id,
             createdAt = Clock.System.now(),
@@ -125,7 +125,8 @@ class MySQLPersistenceStorageProviderTest {
                 Message.System("You are a test assistant", RequestMetaInfo.create(Clock.System)),
                 Message.User("Hello", RequestMetaInfo.create(Clock.System)),
                 Message.Assistant("Hi there!", ResponseMetaInfo.create(Clock.System))
-            )
+            ),
+            parentId = parentId
         )
     }
 }

--- a/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/MySQLPersistencyStorageProviderTest.kt
+++ b/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/MySQLPersistencyStorageProviderTest.kt
@@ -68,7 +68,7 @@ class MySQLPersistenceStorageProviderTest {
         assertEquals(0, p.getCheckpointCount(agentId))
 
         // save
-        val cp1 = createTestCheckpoint("cp-1", null)
+        val cp1 = createTestCheckpoint("cp-1", 0L)
         p.saveCheckpoint(agentId, cp1)
 
         // read
@@ -83,7 +83,7 @@ class MySQLPersistenceStorageProviderTest {
         assertEquals(1, p.getCheckpoints(agentId).size)
 
         // insert second
-        val cp2 = createTestCheckpoint("cp-2", cp1.checkpointId)
+        val cp2 = createTestCheckpoint("cp-2", cp1.version.plus(1))
         p.saveCheckpoint(agentId, cp2)
         val all = p.getCheckpoints(agentId)
         assertEquals(listOf("cp-1", "cp-2"), all.map { it.checkpointId })
@@ -103,7 +103,7 @@ class MySQLPersistenceStorageProviderTest {
         val p = provider(ttlSeconds = 1)
         p.migrate()
 
-        p.saveCheckpoint(agentId, createTestCheckpoint("will-expire", null))
+        p.saveCheckpoint(agentId, createTestCheckpoint("will-expire", 0L))
         assertEquals(1, p.getCheckpointCount(agentId))
 
         // Sleep slightly over 1s to ensure ttl passes
@@ -115,7 +115,7 @@ class MySQLPersistenceStorageProviderTest {
         assertNull(p.getLatestCheckpoint(agentId))
     }
 
-    private fun createTestCheckpoint(id: String, parentId: String?): AgentCheckpointData {
+    private fun createTestCheckpoint(id: String, version: Long): AgentCheckpointData {
         return AgentCheckpointData(
             checkpointId = id,
             createdAt = Clock.System.now(),
@@ -126,7 +126,7 @@ class MySQLPersistenceStorageProviderTest {
                 Message.User("Hello", RequestMetaInfo.create(Clock.System)),
                 Message.Assistant("Hi there!", ResponseMetaInfo.create(Clock.System))
             ),
-            parentId = parentId
+            version = version
         )
     }
 }

--- a/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/PostgresPersistenceAgentRunTest.kt
+++ b/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/PostgresPersistenceAgentRunTest.kt
@@ -1,0 +1,294 @@
+package ai.koog.agents.features.sql.providers
+
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.dsl.builder.AIAgentNodeDelegate
+import ai.koog.agents.core.dsl.builder.AIAgentSubgraphBuilderBase
+import ai.koog.agents.core.dsl.builder.forwardTo
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.snapshot.feature.AgentCheckpointData
+import ai.koog.agents.snapshot.feature.Persistence
+import ai.koog.agents.snapshot.feature.tombstoneCheckpoint
+import ai.koog.agents.snapshot.providers.InMemoryPersistenceStorageProvider
+import ai.koog.agents.snapshot.providers.PersistenceStorageProvider
+import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.llm.OllamaModels
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.RequestMetaInfo
+import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.test.utils.DockerAvailableCondition
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.JsonPrimitive
+import org.jetbrains.exposed.sql.Database
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle
+import org.junit.jupiter.api.extension.ExtendWith
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@TestInstance(Lifecycle.PER_CLASS)
+@ExtendWith(DockerAvailableCondition::class)
+class PostgresPersistenceAgentRunTest {
+
+    private lateinit var postgres: PostgreSQLContainer<*>
+
+    private val agentConfig = AIAgentConfig(
+        prompt = prompt("test") {
+            system("You are a test agent.")
+        },
+        model = OllamaModels.Meta.LLAMA_3_2,
+        maxAgentIterations = 20
+    )
+
+    @BeforeAll
+    fun setUp() {
+        postgres = PostgreSQLContainer(DockerImageName.parse("postgres:16-alpine"))
+            .withDatabaseName("testdb")
+            .withUsername("test")
+            .withPassword("test")
+        postgres.start()
+    }
+
+    @AfterAll
+    fun tearDown() {
+        postgres.stop()
+    }
+
+    private fun provider(): PostgresPersistenceStorageProvider {
+        val db: Database = Database.connect(
+            url = postgres.jdbcUrl,
+            driver = "org.postgresql.Driver",
+            user = postgres.username,
+            password = postgres.password
+        )
+        return PostgresPersistenceStorageProvider(database = db)
+    }
+
+    private fun straightForwardGraphNoCheckpoint() = strategy("straight-forward") {
+        val node1 by simpleNode(
+            name = "Node1",
+            output = "Node 1 output"
+        )
+        val node2 by simpleNode(
+            name = "Node2",
+            output = "Node 2 output"
+        )
+        val historyNode by collectHistoryNode("History Node")
+
+        edge(nodeStart forwardTo node1)
+        edge(node1 forwardTo node2)
+        edge(node2 forwardTo historyNode)
+        edge(historyNode forwardTo nodeFinish)
+    }
+
+    private fun AIAgentSubgraphBuilderBase<*, *>.simpleNode(
+        name: String? = null,
+        output: String,
+    ): AIAgentNodeDelegate<String, String> = node(name) {
+        llm.writeSession {
+            updatePrompt { user { text(output) } }
+        }
+        return@node it + "\n" + output
+    }
+
+    private fun AIAgentSubgraphBuilderBase<*, *>.collectHistoryNode(
+        name: String? = null,
+    ): AIAgentNodeDelegate<String, String> = node(name) {
+        return@node llm.readSession {
+            val history = this.prompt.messages.joinToString("\n") { it.content }
+            return@readSession "History: $history"
+        }
+    }
+
+    @Test
+    fun `postgres pre seeded valid checkpoint chain respected and agent starts fresh`() = runBlocking {
+        val pgStorage = provider()
+        pgStorage.migrate()
+        preSeedValidCheckpointChainTest(pgStorage)
+    }
+
+    @Test
+    fun `in memory pre seeded valid checkpoint chain respected and agent starts fresh`() =
+        preSeedValidCheckpointChainTest(InMemoryPersistenceStorageProvider())
+
+    @Test
+    fun `preseeded chain finished with tombstone and extra checkpoint on top is used as latest`() = runBlocking {
+        val pgStorage = provider()
+        pgStorage.migrate()
+        preSeedFinishedChainPlusUnfinishedTest(pgStorage)
+    }
+
+    @Test
+    fun `in memory preseeded chain finished with tombstone and extra checkpoint on top is used as latest`() =
+        preSeedFinishedChainPlusUnfinishedTest(InMemoryPersistenceStorageProvider())
+
+    @Test
+    fun `in memory pre seeded single checkpoint respected and agent starts fresh`() = runBlocking {
+        preSeedSingleCheckpoint(InMemoryPersistenceStorageProvider())
+    }
+
+    @Test
+    fun `postgres pre seeded single checkpoint respected and agent starts fresh`() = runBlocking {
+        val pgStorage = provider()
+        pgStorage.migrate()
+        preSeedSingleCheckpoint(pgStorage)
+    }
+
+    fun preSeedValidCheckpointChainTest(provider: PersistenceStorageProvider<*>) = runBlocking<Unit> {
+        val agentId = "pg-agent-preseed-1"
+        val time = Clock.System.now()
+
+        val cp1 = createTestCheckpoint("cp-1", parentId = null, time = time)
+        val cp2 = createTestCheckpoint("cp-2", parentId = cp1.checkpointId, time = time)
+        val tomb = tombstoneCheckpoint(time = Clock.System.now(), parentId = cp2.checkpointId)
+
+        // Save in order: cp1 -> cp2 -> tombstone
+        provider.saveCheckpoint(agentId, cp1)
+        provider.saveCheckpoint(agentId, cp2)
+        provider.saveCheckpoint(agentId, tomb)
+
+        // Pre-run assertions about the chain
+        val seeded = provider.getLatestCheckpoint(agentId)
+        assertNull(seeded, "Latest checkpoint must be null because chain ends with tombstone")
+        seeded shouldBe null
+
+        // Create agent with persistence but without automatic persistence to keep seeded chain intact
+        val agent = AIAgent(
+            promptExecutor = getMockExecutor { },
+            strategy = straightForwardGraphNoCheckpoint(),
+            agentConfig = agentConfig,
+            id = agentId
+        ) {
+            install(Persistence) {
+                storage = provider
+                enableAutomaticPersistence = false
+            }
+        }
+
+        // Act: run
+        val output = agent.run("Start the test")
+        val latest = provider.getLatestCheckpoint(agentId)
+
+        output shouldBe "History: You are a test agent.\n" +
+                "Node 1 output\n" +
+                "Node 2 output"
+
+        latest shouldBe null
+    }
+
+    fun preSeedFinishedChainPlusUnfinishedTest(provider: PersistenceStorageProvider<*>) = runBlocking<Unit> {
+        val agentId = "pg-agent-preseed-2"
+        val time = Clock.System.now()
+
+        val cp1 = createTestCheckpoint("cp-1", parentId = null, time = time)
+        val cp2 = createTestCheckpoint("cp-2", parentId = cp1.checkpointId, time = time)
+        val tomb = tombstoneCheckpoint(time = Clock.System.now(), parentId = cp2.checkpointId)
+        val cp3 = createTestCheckpoint("cp-3", parentId = tomb.checkpointId, time = time, "Node1")
+
+        // Save in order: cp1 -> cp2 -> tombstone -> cp3
+        provider.saveCheckpoint(agentId, cp1)
+        provider.saveCheckpoint(agentId, cp2)
+        provider.saveCheckpoint(agentId, tomb)
+        provider.saveCheckpoint(agentId, cp3)
+
+        // Pre-run: latest checkpoint must be cp3
+        val latestBefore = provider.getLatestCheckpoint(agentId)
+        assertEquals("cp-3", latestBefore?.checkpointId, "Latest checkpoint must be the one on top of tombstone")
+
+        // Create agent with persistence; keep auto persistence off to avoid mutating preseeded data
+        val agent = AIAgent(
+            promptExecutor = getMockExecutor { },
+            strategy = straightForwardGraphNoCheckpoint(),
+            agentConfig = agentConfig,
+            id = agentId
+        ) {
+            install(Persistence) {
+                storage = provider
+                enableAutomaticPersistence = false
+            }
+        }
+
+        // Act: run
+        val output = agent.run("Start the test")
+
+        output shouldBeEqual "History: You are a test agent.\n" +
+                "Node 1 output\n" +
+                "Node 2 output\n" +
+                "Node 1 output\n" +
+                "Node 2 output"
+
+        // Post-run: latest should still be cp3 since we did not persist new checkpoints
+        val latestAfter = provider.getLatestCheckpoint(agentId)
+
+        latestAfter?.checkpointId shouldBe "cp-3"
+    }
+
+    fun preSeedSingleCheckpoint(provider: PersistenceStorageProvider<*>) = runBlocking<Unit> {
+        val agentId = "pg-agent-preseed-3"
+        val time = Clock.System.now()
+
+        val cp1 = createTestCheckpoint("cp-1", parentId = null, time = time, nodeId = "Node1")
+
+        // Save single checkpoint
+        provider.saveCheckpoint(agentId, cp1)
+
+        // Pre-run assertions about the chain
+        val seeded = provider.getLatestCheckpoint(agentId)
+        assertEquals("cp-1", seeded?.checkpointId, "Latest checkpoint must be the single pre-seeded one")
+
+        // Create agent with persistence but without automatic persistence to keep seeded chain intact
+        val agent = AIAgent(
+            promptExecutor = getMockExecutor { },
+            strategy = straightForwardGraphNoCheckpoint(),
+            agentConfig = agentConfig,
+            id = agentId
+        ) {
+            install(Persistence) {
+                storage = provider
+                enableAutomaticPersistence = false
+            }
+        }
+
+        // Act: run
+        val output = agent.run("Start the test")
+        val latest = provider.getLatestCheckpoint(agentId)
+
+        output shouldBe "History: You are a test agent.\n" +
+                "Node 1 output\n" +
+                "Node 2 output\n" +
+                "Node 1 output\n" +
+                "Node 2 output"
+
+        latest?.checkpointId shouldBe "cp-1"
+    }
+
+    private fun createTestCheckpoint(
+        id: String,
+        parentId: String?,
+        time: Instant,
+        nodeId: String = "Node2"
+    ): AgentCheckpointData {
+        return AgentCheckpointData(
+            checkpointId = id,
+            createdAt = time,
+            nodeId = nodeId,
+            lastInput = JsonPrimitive("Test input"),
+            messageHistory = listOf(
+                Message.System("You are a test agent.", RequestMetaInfo(time)),
+                Message.User("Node 1 output", RequestMetaInfo(time)),
+                Message.Assistant("Node 2 output", ResponseMetaInfo(time))
+            ),
+            parentId = parentId
+        )
+    }
+}

--- a/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/PostgresPersistenceAgentRunTest.kt
+++ b/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/PostgresPersistenceAgentRunTest.kt
@@ -8,6 +8,7 @@ import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.snapshot.feature.AgentCheckpointData
 import ai.koog.agents.snapshot.feature.Persistence
+import ai.koog.agents.snapshot.feature.isTombstone
 import ai.koog.agents.snapshot.feature.tombstoneCheckpoint
 import ai.koog.agents.snapshot.providers.InMemoryPersistenceStorageProvider
 import ai.koog.agents.snapshot.providers.PersistenceStorageProvider
@@ -34,7 +35,6 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 @TestInstance(Lifecycle.PER_CLASS)
 @ExtendWith(DockerAvailableCondition::class)
@@ -148,9 +148,9 @@ class PostgresPersistenceAgentRunTest {
         val agentId = "pg-agent-preseed-1"
         val time = Clock.System.now()
 
-        val cp1 = createTestCheckpoint("cp-1", parentId = null, time = time)
-        val cp2 = createTestCheckpoint("cp-2", parentId = cp1.checkpointId, time = time)
-        val tomb = tombstoneCheckpoint(time = Clock.System.now(), parentId = cp2.checkpointId)
+        val cp1 = createTestCheckpoint("cp-1", time = time, version = 0)
+        val cp2 = createTestCheckpoint("cp-2", version = cp1.version + 1, time = time)
+        val tomb = tombstoneCheckpoint(time = Clock.System.now(), version = cp2.version + 1)
 
         // Save in order: cp1 -> cp2 -> tombstone
         provider.saveCheckpoint(agentId, cp1)
@@ -159,8 +159,7 @@ class PostgresPersistenceAgentRunTest {
 
         // Pre-run assertions about the chain
         val seeded = provider.getLatestCheckpoint(agentId)
-        assertNull(seeded, "Latest checkpoint must be null because chain ends with tombstone")
-        seeded shouldBe null
+        seeded?.isTombstone() shouldBe true
 
         // Create agent with persistence but without automatic persistence to keep seeded chain intact
         val agent = AIAgent(
@@ -180,20 +179,20 @@ class PostgresPersistenceAgentRunTest {
         val latest = provider.getLatestCheckpoint(agentId)
 
         output shouldBe "History: You are a test agent.\n" +
-                "Node 1 output\n" +
-                "Node 2 output"
+            "Node 1 output\n" +
+            "Node 2 output"
 
-        latest shouldBe null
+        latest?.isTombstone() shouldBe true
     }
 
     fun preSeedFinishedChainPlusUnfinishedTest(provider: PersistenceStorageProvider<*>) = runBlocking<Unit> {
         val agentId = "pg-agent-preseed-2"
         val time = Clock.System.now()
 
-        val cp1 = createTestCheckpoint("cp-1", parentId = null, time = time)
-        val cp2 = createTestCheckpoint("cp-2", parentId = cp1.checkpointId, time = time)
-        val tomb = tombstoneCheckpoint(time = Clock.System.now(), parentId = cp2.checkpointId)
-        val cp3 = createTestCheckpoint("cp-3", parentId = tomb.checkpointId, time = time, "Node1")
+        val cp1 = createTestCheckpoint("cp-1", version = 0, time = time)
+        val cp2 = createTestCheckpoint("cp-2", version = cp1.version + 1, time = time)
+        val tomb = tombstoneCheckpoint(time = Clock.System.now(), version = cp2.version + 1)
+        val cp3 = createTestCheckpoint("cp-3", version = tomb.version + 1, time = time, "Node1")
 
         // Save in order: cp1 -> cp2 -> tombstone -> cp3
         provider.saveCheckpoint(agentId, cp1)
@@ -222,10 +221,10 @@ class PostgresPersistenceAgentRunTest {
         val output = agent.run("Start the test")
 
         output shouldBeEqual "History: You are a test agent.\n" +
-                "Node 1 output\n" +
-                "Node 2 output\n" +
-                "Node 1 output\n" +
-                "Node 2 output"
+            "Node 1 output\n" +
+            "Node 2 output\n" +
+            "Node 1 output\n" +
+            "Node 2 output"
 
         // Post-run: latest should still be cp3 since we did not persist new checkpoints
         val latestAfter = provider.getLatestCheckpoint(agentId)
@@ -237,7 +236,7 @@ class PostgresPersistenceAgentRunTest {
         val agentId = "pg-agent-preseed-3"
         val time = Clock.System.now()
 
-        val cp1 = createTestCheckpoint("cp-1", parentId = null, time = time, nodeId = "Node1")
+        val cp1 = createTestCheckpoint("cp-1", version = 0, time = time, nodeId = "Node1")
 
         // Save single checkpoint
         provider.saveCheckpoint(agentId, cp1)
@@ -264,17 +263,17 @@ class PostgresPersistenceAgentRunTest {
         val latest = provider.getLatestCheckpoint(agentId)
 
         output shouldBe "History: You are a test agent.\n" +
-                "Node 1 output\n" +
-                "Node 2 output\n" +
-                "Node 1 output\n" +
-                "Node 2 output"
+            "Node 1 output\n" +
+            "Node 2 output\n" +
+            "Node 1 output\n" +
+            "Node 2 output"
 
         latest?.checkpointId shouldBe "cp-1"
     }
 
     private fun createTestCheckpoint(
         id: String,
-        parentId: String?,
+        version: Long,
         time: Instant,
         nodeId: String = "Node2"
     ): AgentCheckpointData {
@@ -288,7 +287,7 @@ class PostgresPersistenceAgentRunTest {
                 Message.User("Node 1 output", RequestMetaInfo(time)),
                 Message.Assistant("Node 2 output", ResponseMetaInfo(time))
             ),
-            parentId = parentId
+            version = version
         )
     }
 }

--- a/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/PostgresPersistencyStorageProviderTest.kt
+++ b/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/PostgresPersistencyStorageProviderTest.kt
@@ -67,7 +67,7 @@ class PostgresPersistenceStorageProviderTest {
         assertEquals(0, p.getCheckpointCount(agentId))
 
         // save
-        val cp1 = createTestCheckpoint("cp-1")
+        val cp1 = createTestCheckpoint("cp-1", null)
         p.saveCheckpoint(agentId, cp1)
 
         // read
@@ -82,7 +82,7 @@ class PostgresPersistenceStorageProviderTest {
         assertEquals(1, p.getCheckpoints(agentId).size)
 
         // insert second
-        val cp2 = createTestCheckpoint("cp-2")
+        val cp2 = createTestCheckpoint("cp-2", "cp-1")
         p.saveCheckpoint(agentId, cp2)
         val all = p.getCheckpoints(agentId)
         assertEquals(listOf("cp-1", "cp-2"), all.map { it.checkpointId })
@@ -102,7 +102,7 @@ class PostgresPersistenceStorageProviderTest {
         val p = provider(ttlSeconds = 1)
         p.migrate()
 
-        p.saveCheckpoint(agentId, createTestCheckpoint("will-expire"))
+        p.saveCheckpoint(agentId, createTestCheckpoint("will-expire", null))
         assertEquals(1, p.getCheckpointCount(agentId))
 
         // Force cleanup by calling cleanupExpired directly to avoid time-based throttle
@@ -114,7 +114,7 @@ class PostgresPersistenceStorageProviderTest {
         assertNull(p.getLatestCheckpoint(agentId))
     }
 
-    private fun createTestCheckpoint(id: String): AgentCheckpointData {
+    private fun createTestCheckpoint(id: String, parentId: String?): AgentCheckpointData {
         return AgentCheckpointData(
             checkpointId = id,
             createdAt = Clock.System.now(),
@@ -124,7 +124,8 @@ class PostgresPersistenceStorageProviderTest {
                 Message.System("You are a test assistant", RequestMetaInfo.create(Clock.System)),
                 Message.User("Hello", RequestMetaInfo.create(Clock.System)),
                 Message.Assistant("Hi there!", ResponseMetaInfo.create(Clock.System))
-            )
+            ),
+            parentId = parentId
         )
     }
 }

--- a/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/PostgresPersistencyStorageProviderTest.kt
+++ b/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/PostgresPersistencyStorageProviderTest.kt
@@ -67,7 +67,7 @@ class PostgresPersistenceStorageProviderTest {
         assertEquals(0, p.getCheckpointCount(agentId))
 
         // save
-        val cp1 = createTestCheckpoint("cp-1", null)
+        val cp1 = createTestCheckpoint("cp-1", 0L)
         p.saveCheckpoint(agentId, cp1)
 
         // read
@@ -82,7 +82,7 @@ class PostgresPersistenceStorageProviderTest {
         assertEquals(1, p.getCheckpoints(agentId).size)
 
         // insert second
-        val cp2 = createTestCheckpoint("cp-2", "cp-1")
+        val cp2 = createTestCheckpoint("cp-2", cp1.version.plus(1))
         p.saveCheckpoint(agentId, cp2)
         val all = p.getCheckpoints(agentId)
         assertEquals(listOf("cp-1", "cp-2"), all.map { it.checkpointId })
@@ -102,7 +102,7 @@ class PostgresPersistenceStorageProviderTest {
         val p = provider(ttlSeconds = 1)
         p.migrate()
 
-        p.saveCheckpoint(agentId, createTestCheckpoint("will-expire", null))
+        p.saveCheckpoint(agentId, createTestCheckpoint("will-expire", 0L))
         assertEquals(1, p.getCheckpointCount(agentId))
 
         // Force cleanup by calling cleanupExpired directly to avoid time-based throttle
@@ -114,7 +114,7 @@ class PostgresPersistenceStorageProviderTest {
         assertNull(p.getLatestCheckpoint(agentId))
     }
 
-    private fun createTestCheckpoint(id: String, parentId: String?): AgentCheckpointData {
+    private fun createTestCheckpoint(id: String, version: Long): AgentCheckpointData {
         return AgentCheckpointData(
             checkpointId = id,
             createdAt = Clock.System.now(),
@@ -125,7 +125,7 @@ class PostgresPersistenceStorageProviderTest {
                 Message.User("Hello", RequestMetaInfo.create(Clock.System)),
                 Message.Assistant("Hi there!", ResponseMetaInfo.create(Clock.System))
             ),
-            parentId = parentId
+            version = version
         )
     }
 }

--- a/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/SQLPersistenceProvidersTest.kt
+++ b/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/SQLPersistenceProvidersTest.kt
@@ -32,7 +32,7 @@ class SQLPersistenceProvidersTest {
         provider.migrate()
 
         // Create and save checkpoint
-        val checkpoint = createTestCheckpoint("test-1")
+        val checkpoint = createTestCheckpoint("test-1", null)
         provider.saveCheckpoint(agentId, checkpoint)
 
         // Retrieve and verify
@@ -53,9 +53,13 @@ class SQLPersistenceProvidersTest {
         provider.migrate()
 
         // Save multiple checkpoints
-        provider.saveCheckpoint(agentId, createTestCheckpoint("checkpoint-1"))
-        provider.saveCheckpoint(agentId, createTestCheckpoint("checkpoint-2"))
-        provider.saveCheckpoint(agentId, createTestCheckpoint("checkpoint-3"))
+        val checkpoint1 = createTestCheckpoint("checkpoint-1", null)
+        val checkpoint2 = createTestCheckpoint("checkpoint-2", checkpoint1.checkpointId)
+        val checkpoint3 = createTestCheckpoint("checkpoint-3", checkpoint2.checkpointId)
+
+        provider.saveCheckpoint(agentId, checkpoint1)
+        provider.saveCheckpoint(agentId, checkpoint2)
+        provider.saveCheckpoint(agentId, checkpoint3)
 
         // Verify count and ordering
         val allCheckpoints = provider.getCheckpoints(agentId)
@@ -84,8 +88,8 @@ class SQLPersistenceProvidersTest {
         provider2.migrate()
 
         // Save to different agents
-        provider1.saveCheckpoint(agentId, createTestCheckpoint("agent1-data"))
-        provider2.saveCheckpoint(agentId2, createTestCheckpoint("agent2-data"))
+        provider1.saveCheckpoint(agentId, createTestCheckpoint("agent1-data", null))
+        provider2.saveCheckpoint(agentId2, createTestCheckpoint("agent2-data", null))
 
         // Verify isolation
         val agent1Checkpoints = provider1.getCheckpoints(agentId)
@@ -109,7 +113,7 @@ class SQLPersistenceProvidersTest {
         provider.migrate()
 
         // Save checkpoint
-        provider.saveCheckpoint(agentId, createTestCheckpoint("expire-soon"))
+        provider.saveCheckpoint(agentId, createTestCheckpoint("expire-soon", null))
         assertEquals(1, provider.getCheckpointCount(agentId))
 
         // Wait for expiration
@@ -151,7 +155,7 @@ class SQLPersistenceProvidersTest {
         )
     }
 
-    private fun createTestCheckpoint(id: String): AgentCheckpointData {
+    private fun createTestCheckpoint(id: String, parentId: String?): AgentCheckpointData {
         return AgentCheckpointData(
             checkpointId = id,
             createdAt = Clock.System.now(),
@@ -161,7 +165,8 @@ class SQLPersistenceProvidersTest {
                 Message.System("You are a test assistant", RequestMetaInfo.create(Clock.System)),
                 Message.User("Hello", RequestMetaInfo.create(Clock.System)),
                 Message.Assistant("Hi there!", ResponseMetaInfo.create(Clock.System))
-            )
+            ),
+            parentId = parentId
         )
     }
 }

--- a/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/SQLPersistenceProvidersTest.kt
+++ b/agents/agents-features/agents-features-sql/src/jvmTest/kotlin/ai/koog/agents/features/sql/providers/SQLPersistenceProvidersTest.kt
@@ -32,7 +32,7 @@ class SQLPersistenceProvidersTest {
         provider.migrate()
 
         // Create and save checkpoint
-        val checkpoint = createTestCheckpoint("test-1", null)
+        val checkpoint = createTestCheckpoint("test-1", 0L)
         provider.saveCheckpoint(agentId, checkpoint)
 
         // Retrieve and verify
@@ -53,9 +53,9 @@ class SQLPersistenceProvidersTest {
         provider.migrate()
 
         // Save multiple checkpoints
-        val checkpoint1 = createTestCheckpoint("checkpoint-1", null)
-        val checkpoint2 = createTestCheckpoint("checkpoint-2", checkpoint1.checkpointId)
-        val checkpoint3 = createTestCheckpoint("checkpoint-3", checkpoint2.checkpointId)
+        val checkpoint1 = createTestCheckpoint("checkpoint-1", 0L)
+        val checkpoint2 = createTestCheckpoint("checkpoint-2", checkpoint1.version.plus(1))
+        val checkpoint3 = createTestCheckpoint("checkpoint-3", checkpoint2.version.plus(1))
 
         provider.saveCheckpoint(agentId, checkpoint1)
         provider.saveCheckpoint(agentId, checkpoint2)
@@ -88,8 +88,8 @@ class SQLPersistenceProvidersTest {
         provider2.migrate()
 
         // Save to different agents
-        provider1.saveCheckpoint(agentId, createTestCheckpoint("agent1-data", null))
-        provider2.saveCheckpoint(agentId2, createTestCheckpoint("agent2-data", null))
+        provider1.saveCheckpoint(agentId, createTestCheckpoint("agent1-data", 0L))
+        provider2.saveCheckpoint(agentId2, createTestCheckpoint("agent2-data", 0L))
 
         // Verify isolation
         val agent1Checkpoints = provider1.getCheckpoints(agentId)
@@ -113,7 +113,7 @@ class SQLPersistenceProvidersTest {
         provider.migrate()
 
         // Save checkpoint
-        provider.saveCheckpoint(agentId, createTestCheckpoint("expire-soon", null))
+        provider.saveCheckpoint(agentId, createTestCheckpoint("expire-soon", 0L))
         assertEquals(1, provider.getCheckpointCount(agentId))
 
         // Wait for expiration
@@ -155,7 +155,7 @@ class SQLPersistenceProvidersTest {
         )
     }
 
-    private fun createTestCheckpoint(id: String, parentId: String?): AgentCheckpointData {
+    private fun createTestCheckpoint(id: String, version: Long): AgentCheckpointData {
         return AgentCheckpointData(
             checkpointId = id,
             createdAt = Clock.System.now(),
@@ -166,7 +166,7 @@ class SQLPersistenceProvidersTest {
                 Message.User("Hello", RequestMetaInfo.create(Clock.System)),
                 Message.Assistant("Hi there!", ResponseMetaInfo.create(Clock.System))
             ),
-            parentId = parentId
+            version = version
         )
     }
 }

--- a/docs/docs/agent-persistence.md
+++ b/docs/docs/agent-persistence.md
@@ -173,6 +173,7 @@ suspend fun example(context: AIAgentContext) {
         lastInput = inputData,
         lastInputType = inputType,
         checkpointId = context.runId,
+        version = 0L
     )
 
     // The checkpoint ID can be stored for later use
@@ -287,6 +288,7 @@ suspend fun example(context: AIAgentContext) {
             lastInput = inputData,
             lastInputType = inputType,
             checkpointId = ctx.runId,
+            version = 0L
         )
     }
 }

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/snapshot/sql/SQLPersistentAgentExample.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/snapshot/sql/SQLPersistentAgentExample.kt
@@ -58,7 +58,7 @@ object SQLPersistentAgentExample {
         provider.migrate()
 
         // Create and save checkpoint
-        val checkpoint = createSampleCheckpoint("postgres-checkpoint-1")
+        val checkpoint = createSampleCheckpoint("postgres-checkpoint-1", version = 0)
         provider.saveCheckpoint(agentId = agentId, agentCheckpointData = checkpoint)
         println("Saved checkpoint: ${checkpoint.checkpointId}")
 
@@ -90,9 +90,9 @@ object SQLPersistentAgentExample {
 
         // Save multiple checkpoints
         val checkpoints = listOf(
-            createSampleCheckpoint("mysql-checkpoint-1"),
-            createSampleCheckpoint("mysql-checkpoint-2"),
-            createSampleCheckpoint("mysql-checkpoint-3")
+            createSampleCheckpoint("mysql-checkpoint-1", version = 1),
+            createSampleCheckpoint("mysql-checkpoint-2", version = 2),
+            createSampleCheckpoint("mysql-checkpoint-3", version = 3)
         )
 
         checkpoints.forEach { checkpoint ->
@@ -123,7 +123,7 @@ object SQLPersistentAgentExample {
         )
 
         inMemoryProvider.migrate()
-        val testCheckpoint = createSampleCheckpoint("h2-memory-checkpoint")
+        val testCheckpoint = createSampleCheckpoint("h2-memory-checkpoint", version = 1)
         inMemoryProvider.saveCheckpoint(agentId, testCheckpoint)
         println("   Saved to in-memory: ${testCheckpoint.checkpointId}")
 
@@ -137,7 +137,7 @@ object SQLPersistentAgentExample {
         )
 
         fileProvider.migrate()
-        val fileCheckpoint = createSampleCheckpoint("h2-file-checkpoint")
+        val fileCheckpoint = createSampleCheckpoint("h2-file-checkpoint", version = 1)
         fileProvider.saveCheckpoint(h2AgentId, fileCheckpoint)
         println("   Saved to file: ${fileCheckpoint.checkpointId}")
 
@@ -158,7 +158,7 @@ object SQLPersistentAgentExample {
         )
 
         pgCompatProvider.migrate()
-        val pgCheckpoint = createSampleCheckpoint("h2-pgcompat-checkpoint")
+        val pgCheckpoint = createSampleCheckpoint("h2-pgcompat-checkpoint", version = 2)
         pgCompatProvider.saveCheckpoint(postgresAgentId, pgCheckpoint)
         println("   Saved with PG compatibility: ${pgCheckpoint.checkpointId}")
     }
@@ -166,7 +166,7 @@ object SQLPersistentAgentExample {
     /**
      * Creates a sample checkpoint for testing
      */
-    private fun createSampleCheckpoint(checkpointId: String): AgentCheckpointData {
+    private fun createSampleCheckpoint(checkpointId: String, version: Long): AgentCheckpointData {
         return AgentCheckpointData(
             checkpointId = checkpointId,
             createdAt = Clock.System.now(),
@@ -176,7 +176,8 @@ object SQLPersistentAgentExample {
                 Message.System("You are a helpful assistant", RequestMetaInfo.create(Clock.System)),
                 Message.User("Hello, agent!", RequestMetaInfo.create(Clock.System)),
                 Message.Assistant("Hello! How can I help you today?", ResponseMetaInfo.create(Clock.System))
-            )
+            ),
+            version = version
         )
     }
 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
@@ -742,7 +742,7 @@ class AIAgentIntegrationTest {
                         nodeId = save,
                         lastInput = input,
                         lastInputType = typeOf<String>(),
-                        version = parent?.checkpointId
+                        version = parent?.version?.plus(1) ?: 0
                     )
                 }
                 savedMessage
@@ -849,7 +849,7 @@ class AIAgentIntegrationTest {
                         nodeId = save,
                         lastInput = input,
                         lastInputType = typeOf<String>(),
-                        version = parent?.checkpointId
+                        version = parent?.version?.plus(1) ?: 0
                     )
                 }
                 executionLog.append(saySaveLog)
@@ -1031,7 +1031,7 @@ class AIAgentIntegrationTest {
                         nodeId = bye,
                         lastInput = input,
                         lastInputType = typeOf<String>(),
-                        version = parent?.checkpointId
+                        version = parent?.version?.plus(1) ?: 0
                     )
                 }
                 sayBye

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
@@ -736,11 +736,13 @@ class AIAgentIntegrationTest {
             val nodeSave by node<String, String>(save) { input ->
                 // Create a checkpoint
                 withPersistence { agentContext ->
+                    val parent = getLatestCheckpoint(agentContext.agentId)
                     createCheckpoint(
                         agentContext = agentContext,
                         nodeId = save,
                         lastInput = input,
                         lastInputType = typeOf<String>(),
+                        version = parent?.checkpointId
                     )
                 }
                 savedMessage
@@ -841,11 +843,13 @@ class AIAgentIntegrationTest {
 
             val nodeSave by node<String, String>(save) { input ->
                 withPersistence { agentContext ->
+                    val parent = getLatestCheckpoint(agentContext.agentId)
                     createCheckpoint(
                         agentContext = agentContext,
                         nodeId = save,
                         lastInput = input,
                         lastInputType = typeOf<String>(),
+                        version = parent?.checkpointId
                     )
                 }
                 executionLog.append(saySaveLog)
@@ -1021,11 +1025,13 @@ class AIAgentIntegrationTest {
 
             val nodeBye by node<String, String>(bye) { input ->
                 withPersistence { agentContext ->
+                    val parent = getLatestCheckpoint(agentContext.agentId)
                     createCheckpoint(
                         agentContext = agentContext,
                         nodeId = bye,
                         lastInput = input,
                         lastInputType = typeOf<String>(),
+                        version = parent?.checkpointId
                     )
                 }
                 sayBye


### PR DESCRIPTION

## Motivation and Context
This fix is aiming to fix happens-before issue for agent checkpoint. 

Right now we're sorting it by createdAt timestamp, which is not resilient way to preserve happens-before relation between checkpoints which is essential to determine latest checkpoint.

This PR proposes pretty simple solution - each checkpoint has parent checkpoint in linked-list manner. Starting checkpoints has no parent and no bases on tombstone checkpoint. So we have chains of 

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
