### PR TITLE
Stripping markdown code block fences before parsing string as json output

### DIFF
--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/JsonStructuredData.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/JsonStructuredData.kt
@@ -36,11 +36,19 @@ public class JsonStructuredData<TStruct>(
     ) -> TextContentBuilderBase<*> = ::defaultDefinitionPrompt
 ) : StructuredData<TStruct, LLMParams.Schema.JSON>(id, schema, examples) {
 
-    override fun parse(text: String): TStruct = json.decodeFromString(serializer, text)
+    override fun parse(text: String): TStruct = json.decodeFromString(serializer, text.trim().stripMarkdown())
 
     override fun pretty(value: TStruct): String = json.encodeToString(serializer, value)
 
     override fun definition(builder: TextContentBuilderBase<*>): TextContentBuilderBase<*> = definitionPrompt(builder, this)
+
+    // LLMs often enclose JSON output in Markdown code blocks.
+    // Stripping them saves extra LLM call which would be required to fix the string.
+    private fun String.stripMarkdown() = when {
+        startsWith("```json") -> removePrefix("```json").removeSuffix("```").trim()
+        startsWith("```") -> removePrefix("```").removeSuffix("```").trim()
+        else -> this
+    }
 
     /**
      * Companion object for the [JsonStructuredData] class, providing utility methods to facilitate the

--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/JsonStructuredData.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/JsonStructuredData.kt
@@ -45,8 +45,11 @@ public class JsonStructuredData<TStruct>(
     // LLMs often enclose JSON output in Markdown code blocks.
     // Stripping them saves extra LLM call which would be required to fix the string.
     private fun String.stripMarkdown() = when {
-        startsWith("```json") -> removePrefix("```json").removeSuffix("```").trim()
-        startsWith("```") -> removePrefix("```").removeSuffix("```").trim()
+        startsWith("```json") -> removePrefix("```json").removeSuffix("```")
+        startsWith("```") -> removePrefix("```").removeSuffix("```")
+        startsWith("`") -> removePrefix("`").removeSuffix("`")
+        startsWith("~~~json") -> removePrefix("~~~json").removeSuffix("~~~").trim()
+        startsWith("~~~") -> removePrefix("~~~").removeSuffix("~~~").trim()
         else -> this
     }
 

--- a/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/json/JsonStructuredDataTest.kt
+++ b/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/json/JsonStructuredDataTest.kt
@@ -244,7 +244,8 @@ class JsonStructuredDataTest {
                 "description": "Cloudy",
                 "humidity": 80
             }
-            ```""".trimMargin()
+            ```
+            """.trimMargin()
 
         val parsed = structure.parse(jsonString)
 
@@ -265,7 +266,8 @@ class JsonStructuredDataTest {
                 "description": "Cloudy",
                 "humidity": 80
             }
-            ```""".trimMargin()
+            ```
+            """.trimMargin()
 
         val parsed = structure.parse(jsonString)
 
@@ -278,7 +280,7 @@ class JsonStructuredDataTest {
     @Test
     fun testJsonWithSingleLineMarkdownParsing() {
         val structure = JsonStructuredData.createJsonStructure<WeatherInfo>()
-        val jsonString ="""`{"city": "Dublin","temperature": 12,"description": "Rainy","humidity": 90}`""".trimMargin()
+        val jsonString = """`{"city": "Dublin","temperature": 12,"description": "Rainy","humidity": 90}`""".trimMargin()
 
         val parsed = structure.parse(jsonString)
 
@@ -287,5 +289,4 @@ class JsonStructuredDataTest {
         assertEquals("Rainy", parsed.description)
         assertEquals(90, parsed.humidity)
     }
-
 }

--- a/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/json/JsonStructuredDataTest.kt
+++ b/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/json/JsonStructuredDataTest.kt
@@ -234,11 +234,16 @@ class JsonStructuredDataTest {
     }
 
     @Test
-    fun testJsonWithMarkdownFencesParsing() {
+    fun testJsonWithMarkdownBlockParsing() {
         val structure = JsonStructuredData.createJsonStructure<WeatherInfo>()
         val jsonString =
-            """```json
-            {"city": "London", "temperature": 15, "description": "Cloudy", "humidity": 80
+            """```
+            {
+                "city": "London",
+                "temperature": 15,
+                "description": "Cloudy",
+                "humidity": 80
+            }
             ```""".trimMargin()
 
         val parsed = structure.parse(jsonString)
@@ -248,4 +253,39 @@ class JsonStructuredDataTest {
         assertEquals("Cloudy", parsed.description)
         assertEquals(80, parsed.humidity)
     }
+
+    @Test
+    fun testJsonWithMarkdownLanguageBlockParsing() {
+        val structure = JsonStructuredData.createJsonStructure<WeatherInfo>()
+        val jsonString =
+            """```json
+            {
+                "city": "London",
+                "temperature": 15,
+                "description": "Cloudy",
+                "humidity": 80
+            }
+            ```""".trimMargin()
+
+        val parsed = structure.parse(jsonString)
+
+        assertEquals("London", parsed.city)
+        assertEquals(15, parsed.temperature)
+        assertEquals("Cloudy", parsed.description)
+        assertEquals(80, parsed.humidity)
+    }
+
+    @Test
+    fun testJsonWithSingleLineMarkdownParsing() {
+        val structure = JsonStructuredData.createJsonStructure<WeatherInfo>()
+        val jsonString ="""`{"city": "Dublin","temperature": 12,"description": "Rainy","humidity": 90}`""".trimMargin()
+
+        val parsed = structure.parse(jsonString)
+
+        assertEquals("Dublin", parsed.city)
+        assertEquals(12, parsed.temperature)
+        assertEquals("Rainy", parsed.description)
+        assertEquals(90, parsed.humidity)
+    }
+
 }

--- a/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/json/JsonStructuredDataTest.kt
+++ b/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/json/JsonStructuredDataTest.kt
@@ -232,4 +232,20 @@ class JsonStructuredDataTest {
         assertEquals(manualOutput, config.default)
         assertEquals(nativeOutput, config.byProvider[LLMProvider.OpenAI])
     }
+
+    @Test
+    fun testJsonWithMarkdownFencesParsing() {
+        val structure = JsonStructuredData.createJsonStructure<WeatherInfo>()
+        val jsonString =
+            """```json
+            {"city": "London", "temperature": 15, "description": "Cloudy", "humidity": 80
+            ```""".trimMargin()
+
+        val parsed = structure.parse(jsonString)
+
+        assertEquals("London", parsed.city)
+        assertEquals(15, parsed.temperature)
+        assertEquals("Cloudy", parsed.description)
+        assertEquals(80, parsed.humidity)
+    }
 }


### PR DESCRIPTION
## Motivation and Context

LLMs often enclose JSON output in Markdown code blocks. Current implementation fails to parse it and sends the whole output into LLM again to fix the schema. Fixing LLM call is pretty slow and maybe not successful. Stripping markdown saves time and makes it more predictable.

The change doesn't require any adjustments in client's code.

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed
