### PR TITLE
Refine condition for Qodana checks and enable Gradle caching

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -152,7 +152,7 @@ jobs:
 
   qodana:
     needs: [ tests ]
-    if: github.repository == 'jetbrains/koog'
+    if: github.repository == 'jetbrains/koog' && (github.event_name == 'push' || github.event.pull_request.head.repo.fork == false)
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -171,6 +171,7 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
+          cache: gradle
 
       # Download the coverage data artifact
       - name: Download coverage data


### PR DESCRIPTION
Update GitHub Actions: refine condition for Qodana checks and enable Gradle caching

- Adjusted Qodana job condition to exclude forked repositories for pull requests.
- Enabled Gradle cache for improved build speed.

## Motivation and Context

Qodana checks are slow due to missing gradle caching. It is also do not work for PR from fork repos, so it's useless in this case

## Breaking Changes

No

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring
- [x] CI

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
