### PR TITLE
Fix system message tag in LLMAsAJudge(#980)

### DIFF
--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/LLMAsAJudge.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/LLMAsAJudge.kt
@@ -69,7 +69,7 @@ public inline fun <reified T> AIAgentSubgraphBuilderBase<*, *>.llmAsAJudge(
                 append("<previous_conversation>\n")
                 initialPrompt.messages.forEach { message ->
                     when (message) {
-                        is Message.System -> append("<user>\n${message.content}\n</user>\n")
+                        is Message.System -> append("<system>\n${message.content}\n</system>\n")
                         is Message.User -> append("<user>\n${message.content}\n</user>\n")
                         is Message.Assistant -> append("<assistant>\n${message.content}\n</assistant>\n")
                         is Message.Tool.Call -> append(

--- a/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/agent/LLMAsJudgeNodeTest.kt
+++ b/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/agent/LLMAsJudgeNodeTest.kt
@@ -30,8 +30,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
 class LLMAsJudgeNodeTest {
-    private val defaultName = "re_act"
-
     private val testClock: Clock = object : Clock {
         override fun now(): Instant = Instant.parse("2023-01-01T00:00:00Z")
     }
@@ -113,9 +111,9 @@ class LLMAsJudgeNodeTest {
 
         val expectedXMLHistory = """
             <previous_conversation>
-            <user>
+            <system>
             System message
-            </user>
+            </system>
             <user>
             User question
             </user>


### PR DESCRIPTION
## Motivation and Context
LLMAsJujudge was treating system messages as users ones, while folding message history

## Breaking Changes
No

Fixes(#980)

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
