### PR TITLE
Add `subtask` extension for non-graph agents similar to `subgraphWithTask`

### DIFF
--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/FunctionalAIAgentTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/FunctionalAIAgentTest.kt
@@ -1,16 +1,30 @@
 package ai.koog.agents.core.agent
 
+import ai.koog.agents.core.agent.context.AIAgentFunctionalContext
+import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.dsl.extension.asAssistantMessage
 import ai.koog.agents.core.dsl.extension.containsToolCalls
 import ai.koog.agents.core.dsl.extension.executeMultipleTools
 import ai.koog.agents.core.dsl.extension.extractToolCalls
 import ai.koog.agents.core.dsl.extension.requestLLMMultiple
 import ai.koog.agents.core.dsl.extension.sendMultipleToolResults
+import ai.koog.agents.core.tools.SimpleTool
+import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.agents.ext.agent.SubgraphWithTaskUtils
+import ai.koog.agents.ext.agent.subtask
+import ai.koog.agents.ext.agent.subtaskWithVerification
 import ai.koog.agents.features.eventHandler.feature.EventHandler
 import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
+import ai.koog.prompt.executor.clients.google.GoogleModels
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.llm.OllamaModels
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.serializer
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -146,5 +160,604 @@ class FunctionalAIAgentTest {
 
         assertEquals(1, actualToolCalls.size)
         assertEquals("Tools called!", result)
+    }
+
+    enum class MissionProfile { ORBITAL, LUNAR, INTERPLANETARY, LANDER }
+
+    @Serializable
+    data class SchemaDescriptor(
+        val id: String,
+        val version: String = "1.0.0",
+        val format: String = "json",
+        val url: String? = null
+    )
+
+    @Serializable
+    data class Constraints(
+        @property:LLMDescription("The maximum amount of fuel the vehicle can carry.")
+        val maxGLoad: Double = 3.0,
+        @property:LLMDescription("Maximum radiation exposure (in Joules per second) of the vehicle.")
+        val maxRadiationSv: Double = 0.1,
+        @property:LLMDescription("Maximum operating temperature (in degrees Celsius) of the vehicle.")
+        val maxOperatingTempC: Int = 120
+    )
+
+    @Serializable
+    data class Architecture(
+        val name: String,
+        val schema: SchemaDescriptor,
+        val version: String = "1.0",
+        val missionProfile: MissionProfile = MissionProfile.ORBITAL,
+        val constraints: Constraints = Constraints()
+    )
+
+    enum class FuelType { CHEMICAL, ION, NUCLEAR, ELECTRIC }
+    enum class Material { ALUMINUM_LITHIUM, TITANIUM, CARBON_COMPOSITE, STAINLESS_STEEL }
+    enum class ComponentStatus { DESIGNED, BUILT, TESTED, QUALIFIED }
+
+    @Serializable
+    data class Engine(
+        val name: String,
+        val model: String = "X-1",
+        val fuel: FuelType = FuelType.CHEMICAL,
+        val maxThrustKN: Double = 0.0,
+        val specificImpulseS: Int = 0,
+        val massKg: Double = 0.0,
+        val powerRequirementKW: Double? = null,
+        val status: ComponentStatus = ComponentStatus.DESIGNED
+    )
+
+    @Serializable
+    data class Body(
+        val name: String,
+        val hullMaterial: Material = Material.ALUMINUM_LITHIUM,
+        val dryMassKg: Double = 0.0,
+        val maxCargoKg: Double = 0.0,
+        val crewCapacity: Int = 0,
+        val heatShieldRating: String? = null,
+        val status: ComponentStatus = ComponentStatus.DESIGNED
+    )
+
+    @Serializable
+    enum class InterfaceType { ENGINE_MOUNT, POWER_BUS, DATA_BUS }
+
+    @Serializable
+    data class InterfaceSpec(
+        val type: InterfaceType,
+        val version: String,
+        val notes: String? = null
+    )
+
+    @Serializable
+    data class Assembly(
+        val engine: Engine,
+        val body: Body
+    ) {
+        val totalDryMassKg: Double get() = engine.massKg + body.dryMassKg
+    }
+
+    @Serializable
+    data class Spacecraft(
+        val engine: Engine,
+        val body: Body,
+        val architecture: Architecture,
+        val serial: String = "<serial>",
+        val notes: String? = null
+    ) {
+        val dryMassKg: Double get() = engine.massKg + body.dryMassKg
+        val missionProfile: MissionProfile get() = architecture.missionProfile
+    }
+
+    @Serializable
+    data class QAReport(val correct: Boolean, val feedback: String) {
+        val feedbackIfIncorrect: String? = if (correct) null else feedback
+    }
+
+    @Serializable
+    data class FullQAReport(
+        @property:LLMDescription("The report for the engine component.")
+        val engineReport: QAReport,
+        @property:LLMDescription("The report for the body component.")
+        val bodyReport: QAReport,
+        @property:LLMDescription("The report about the architecture of the spacecraft.")
+        val architectureReport: QAReport
+    ) {
+        val isCorrect: Boolean = engineReport.correct && bodyReport.correct && architectureReport.correct
+    }
+
+    @Serializable
+    data class SimpleOut(val value: String)
+
+    object QATools {
+        object TestEngine : SimpleTool<Spacecraft>() {
+            override val argsSerializer: KSerializer<Spacecraft> = Spacecraft.serializer()
+
+            override val description: String = "Performs testing of the spacecraft engine."
+
+            override suspend fun doExecute(args: Spacecraft): String = "Engine is good"
+        }
+
+        object TestBody : SimpleTool<Spacecraft>() {
+            override val argsSerializer: KSerializer<Spacecraft> = Spacecraft.serializer()
+
+            override val description: String = "Performs testing of the spacecraft bofy."
+
+            override suspend fun doExecute(args: Spacecraft): String = "Body is good"
+        }
+
+        object TestBuild : SimpleTool<Spacecraft>() {
+            override val argsSerializer: KSerializer<Spacecraft> = Spacecraft.serializer()
+
+            override val description: String = "Tests how spacecraft is built."
+
+            override suspend fun doExecute(args: Spacecraft): String =
+                "Spacecraft is built badly... Engine is too big for the body"
+        }
+
+        val tools = listOf(TestEngine, TestBody, TestBuild)
+    }
+
+    // Define sample tools for subtasks, similar in spirit to QATools so tool lists are not empty
+    object ArchitectureTools {
+        object AnalyzeRequirements : SimpleTool<String>() {
+            override val argsSerializer: KSerializer<String> = String.serializer()
+            override val description: String = "Analyzes high-level mission requirements."
+            override suspend fun doExecute(args: String): String = "Requirements analyzed: $args"
+        }
+
+        object DraftArchitecture : SimpleTool<Architecture>() {
+            override val argsSerializer: KSerializer<Architecture> = Architecture.serializer()
+            override val description: String = "Drafts an initial spacecraft architecture proposal."
+            override suspend fun doExecute(args: Architecture): String = "Drafted architecture: ${'$'}{args.name}"
+        }
+
+        val tools: List<Tool<*, *>> = listOf(AnalyzeRequirements, DraftArchitecture)
+    }
+
+    object BuildEngineTools {
+        object EstimateThrust : SimpleTool<Architecture>() {
+            override val argsSerializer: KSerializer<Architecture> = Architecture.serializer()
+            override val description: String = "Estimates required thrust for the given architecture."
+            override suspend fun doExecute(args: Architecture): String = "Estimated thrust for ${'$'}{args.name}"
+        }
+
+        object SelectFuelType : SimpleTool<Architecture>() {
+            override val argsSerializer: KSerializer<Architecture> = Architecture.serializer()
+            override val description: String = "Selects suitable fuel type based on mission profile and constraints."
+            override suspend fun doExecute(args: Architecture): String = "Fuel selected for ${'$'}{args.name}"
+        }
+
+        val tools: List<Tool<*, *>> = listOf(EstimateThrust, SelectFuelType)
+    }
+
+    object BuildBodyTools {
+        object ComputeMassBudget : SimpleTool<Architecture>() {
+            override val argsSerializer: KSerializer<Architecture> = Architecture.serializer()
+            override val description: String = "Computes mass budget for the spacecraft body."
+            override suspend fun doExecute(args: Architecture): String = "Mass budget computed for ${'$'}{args.name}"
+        }
+
+        object ChooseMaterial : SimpleTool<Architecture>() {
+            override val argsSerializer: KSerializer<Architecture> = Architecture.serializer()
+            override val description: String = "Chooses hull material given constraints."
+            override suspend fun doExecute(args: Architecture): String = "Material chosen for ${'$'}{args.name}"
+        }
+
+        val tools: List<Tool<*, *>> = listOf(ComputeMassBudget, ChooseMaterial)
+    }
+
+    object AssemblyTools {
+        object CheckInterfaces : SimpleTool<Assembly>() {
+            override val argsSerializer: KSerializer<Assembly> = Assembly.serializer()
+            override val description: String = "Checks mechanical, power, and data interfaces between components."
+            override suspend fun doExecute(args: Assembly): String =
+                "Interfaces check passed for engine ${'$'}{args.engine.name} and body ${'$'}{args.body.name}"
+        }
+
+        object ComputeDryMass : SimpleTool<Assembly>() {
+            override val argsSerializer: KSerializer<Assembly> = Assembly.serializer()
+            override val description: String = "Computes total dry mass of the assembly."
+            override suspend fun doExecute(args: Assembly): String = "Dry mass: ${'$'}{args.totalDryMassKg} kg"
+        }
+
+        val tools: List<Tool<*, *>> = listOf(CheckInterfaces, ComputeDryMass)
+    }
+
+    @Test
+    fun `test_complex_subtasks_multistep_no_parallel_tools`() = runTest {
+        val actualToolCalls = mutableListOf<String>()
+
+        val testToolRegistry = ToolRegistry {
+            tools(QATools.tools)
+        }
+
+        val chosenArchitecture = Architecture(
+            name = "Starship",
+            schema = SchemaDescriptor(id = "arch-1"),
+            missionProfile = MissionProfile.ORBITAL,
+            constraints = Constraints()
+        )
+        val chosenEngine = Engine(
+            name = "Raptor",
+            model = "X-1",
+            fuel = FuelType.CHEMICAL,
+            maxThrustKN = 1000.0,
+            specificImpulseS = 330,
+            massKg = 2000.0,
+            powerRequirementKW = null,
+            status = ComponentStatus.DESIGNED
+        )
+        val chosenBody = Body(
+            name = "Hull",
+            hullMaterial = Material.STAINLESS_STEEL,
+            dryMassKg = 8000.0,
+            maxCargoKg = 100000.0,
+            crewCapacity = 0,
+            heatShieldRating = "PICA-Next",
+            status = ComponentStatus.DESIGNED
+        )
+
+        val enginePromptExact = "Create the engine for the given architecture: $chosenArchitecture"
+        val bodyPromptExact = "Create the body for the given architecture: $chosenArchitecture"
+        val productV1 = Spacecraft(
+            engine = chosenEngine,
+            body = chosenBody,
+            architecture = chosenArchitecture,
+            serial = "SN-1",
+            notes = null
+        )
+
+        var qaAttempt = 0
+
+        val mockLLMApi = getMockExecutor(handleLastAssistantMessage = false) {
+            // Design architecture subtask - match exact first request
+            mockLLMToolCall(
+                SubgraphWithTaskUtils.finishTool<Architecture>(),
+                chosenArchitecture
+            ) onRequestEquals "Create the architecture for the following machinery: Solve task"
+            // Build engine/body subtasks - match exact composed prompts
+            mockLLMToolCall(
+                SubgraphWithTaskUtils.finishTool<Engine>(),
+                chosenEngine
+            ) onRequestEquals enginePromptExact
+            mockLLMToolCall(
+                SubgraphWithTaskUtils.finishTool<Engine>(),
+                chosenEngine
+            ) onRequestContains "Create the engine for the given architecture:"
+            mockLLMToolCall(SubgraphWithTaskUtils.finishTool<Body>(), chosenBody) onRequestEquals bodyPromptExact
+            mockLLMToolCall(
+                SubgraphWithTaskUtils.finishTool<Body>(),
+                chosenBody
+            ) onRequestContains "Create the body for the given architecture:"
+            // Assembly subtask
+            mockLLMToolCall(
+                SubgraphWithTaskUtils.finishTool<Spacecraft>(),
+                productV1
+            ) onRequestContains "Assemble the product"
+            // QA subtask first attempt: not correct
+            mockLLMToolCall(
+                SubgraphWithTaskUtils.finishTool<FullQAReport>(),
+                FullQAReport(
+                    engineReport = QAReport(true, "OK"),
+                    bodyReport = QAReport(false, "Engine is too big for the body"),
+                    architectureReport = QAReport(true, "OK")
+                )
+            ) onCondition { input -> input.contains("Verify the product") && qaAttempt++ == 0 }
+            // QA subtask second attempt: correct
+            mockLLMToolCall(
+                SubgraphWithTaskUtils.finishTool<FullQAReport>(),
+                FullQAReport(
+                    engineReport = QAReport(true, "OK"),
+                    bodyReport = QAReport(true, "OK"),
+                    architectureReport = QAReport(true, "OK")
+                )
+            ) onCondition { input -> input.contains("Verify the product") && qaAttempt > 0 }
+
+            mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            systemPrompt = "You are helpful",
+            promptExecutor = mockLLMApi,
+            strategy = functionalStrategy<String, Spacecraft> { input ->
+                var qaReport: FullQAReport? = null
+                var product: Spacecraft? = null
+
+                while (qaReport?.isCorrect != true) {
+                    val architecture = designArchitecture(
+                        input = input,
+                        additionalInfo = qaReport?.architectureReport?.feedbackIfIncorrect
+                    )
+                    val engine = buildEngine(
+                        architecture = architecture,
+                        additionalInfo = qaReport?.engineReport?.feedbackIfIncorrect
+                    )
+                    val body = buildBody(
+                        architecture = architecture,
+                        additionalInfo = qaReport?.bodyReport?.feedbackIfIncorrect
+                    )
+
+                    product = subtask<Assembly, Spacecraft>(
+                        input = Assembly(engine, body),
+                        tools = AssemblyTools.tools,
+                        llmModel = OllamaModels.Meta.LLAMA_4,
+                        runMode = ToolCalls.SINGLE_RUN_SEQUENTIAL
+                    ) {
+                        "Assemble the product: $it"
+                    }
+
+                    qaReport = subtask<Spacecraft, FullQAReport>(
+                        input = product,
+                        tools = QATools.tools,
+                        runMode = ToolCalls.SINGLE_RUN_SEQUENTIAL
+                    ) {
+                        "Verify the product is built correctly: $it"
+                    }
+
+                    if (qaReport.isCorrect) break
+                }
+
+                product!!
+            },
+            llmModel = OllamaModels.Meta.LLAMA_3_2,
+            toolRegistry = testToolRegistry
+        ) {
+            install(EventHandler) {
+                onToolCallStarting { eventContext -> actualToolCalls += eventContext.toolArgs.toString() }
+            }
+        }
+
+        val result = agent.run("Solve task")
+
+        // Since finish tool calls are handled internally, no external tool executions are expected
+        assertEquals(0, actualToolCalls.size)
+        assertEquals("SN-1", result.serial)
+        assertEquals("Raptor", result.engine.name)
+        assertEquals("Hull", result.body.name)
+        assertEquals("Starship", result.architecture.name)
+    }
+
+    private suspend fun AIAgentFunctionalContext.buildBody(
+        architecture: Architecture,
+        additionalInfo: String? = null
+    ): Body = subtask<Architecture, Body>(
+        input = architecture,
+        tools = BuildBodyTools.tools,
+        llmModel = GoogleModels.Gemini2_0Flash,
+        runMode = ToolCalls.SINGLE_RUN_SEQUENTIAL
+    ) {
+        "Create the body for the given architecture: $it" +
+            (additionalInfo?.let { "Additional feedback: $additionalInfo" } ?: "")
+    }
+
+    private suspend fun AIAgentFunctionalContext.buildEngine(
+        architecture: Architecture,
+        additionalInfo: String? = null
+    ): Engine = subtask<Architecture, Engine>(
+        input = architecture,
+        tools = BuildEngineTools.tools,
+        llmModel = AnthropicModels.Sonnet_4_5,
+        runMode = ToolCalls.SINGLE_RUN_SEQUENTIAL
+    ) {
+        "Create the engine for the given architecture: $it" +
+            (additionalInfo?.let { "Additional feedback: $additionalInfo" } ?: "")
+    }
+
+    private suspend fun AIAgentFunctionalContext.designArchitecture(
+        input: String,
+        additionalInfo: String? = null
+    ): Architecture = subtask<String, Architecture>(
+        input = input,
+        tools = ArchitectureTools.tools,
+        llmModel = OpenAIModels.Chat.GPT5,
+        runMode = ToolCalls.SINGLE_RUN_SEQUENTIAL
+    ) {
+        "Create the architecture for the following machinery: $input" +
+            (additionalInfo?.let { "Additional feedback: $additionalInfo" } ?: "")
+    }
+
+    @Test
+    fun `subtask_default_sequential_finish_only`() = runTest {
+        val actualToolCalls = mutableListOf<String>()
+
+        val mockLLMApi = getMockExecutor(handleLastAssistantMessage = false) {
+            // The subtask should immediately call the finish tool in SEQUENTIAL (multi-tool) mode
+            mockLLMToolCall(
+                SubgraphWithTaskUtils.finishTool<SimpleOut>(),
+                SimpleOut("done-seq")
+            ) onRequestContains "Do simple subtask:"
+
+            mockLLMAnswer("default").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            promptExecutor = mockLLMApi,
+            llmModel = OllamaModels.Meta.LLAMA_3_2,
+            toolRegistry = ToolRegistry.EMPTY,
+            strategy = functionalStrategy<String, SimpleOut> { input ->
+                subtask<String, SimpleOut>(
+                    input = input,
+                    tools = null, // no extra tools
+                    runMode = ToolCalls.SEQUENTIAL
+                ) {
+                    "Do simple subtask: $it"
+                }
+            },
+            systemPrompt = "You are helpful"
+        ) {
+            install(EventHandler) {
+                onToolCallStarting { eventContext -> actualToolCalls += eventContext.toolArgs.toString() }
+            }
+        }
+
+        val result = agent.run("input-1")
+        assertEquals("done-seq", result.value)
+        // finish tool is executed internally, so external tool executions list should be empty
+        assertEquals(0, actualToolCalls.size)
+    }
+
+    @Test
+    fun `subtask_sequential_with_normal_tool_then_finish`() = runTest {
+        val actualToolCalls = mutableListOf<String>()
+
+        val testToolRegistry = ToolRegistry { tool(DummyTool) }
+
+        val mockLLMApi = getMockExecutor(testToolRegistry, handleLastAssistantMessage = false) {
+            // First, LLM asks to call a normal tool, then after tool results it calls finish tool
+            mockLLMToolCall(
+                listOf(
+                    DummyTool to Unit // first response: call normal tool
+                )
+            ) onRequestEquals "Compose task with tool: seed-X"
+
+            // After tool result is sent back to LLM, it should call finish tool
+            mockLLMToolCall(
+                SubgraphWithTaskUtils.finishTool<SimpleOut>(),
+                SimpleOut("final-from-finish")
+            ) onRequestContains "DO NOT CHAT WITH ME DIRECTLY! CALL TOOLS, INSTEAD."
+
+            mockLLMAnswer("default").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            systemPrompt = "You are helpful",
+            promptExecutor = mockLLMApi,
+            llmModel = OllamaModels.Meta.LLAMA_3_2,
+            strategy = functionalStrategy<String, SimpleOut> { input ->
+                subtask<String, SimpleOut>(
+                    input = input,
+                    tools = listOf(DummyTool),
+                    runMode = ToolCalls.SEQUENTIAL
+                ) {
+                    "Compose task with tool: $it"
+                }
+            },
+            toolRegistry = testToolRegistry
+        ) {
+            install(EventHandler) {
+                onToolCallStarting { eventContext -> actualToolCalls += eventContext.toolArgs.toString() }
+            }
+        }
+
+        val result = agent.run("seed-X")
+        assertEquals("final-from-finish", result.value)
+        // Only the normal tool goes through environment, finish tool is internal
+        assertEquals(1, actualToolCalls.size)
+        // Verify that DummyTool has been called once with Unit args
+        assertEquals("kotlin.Unit", actualToolCalls.first())
+    }
+
+    @Test
+    fun `subtask_parallel_finish_only`() = runTest {
+        val actualToolCalls = mutableListOf<String>()
+
+        val mockLLMApi = getMockExecutor(handleLastAssistantMessage = false) {
+            mockLLMToolCall(
+                SubgraphWithTaskUtils.finishTool<SimpleOut>(),
+                SimpleOut("done-par")
+            ) onRequestContains "Parallel subtask:"
+
+            mockLLMAnswer("default").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            systemPrompt = "You are helpful",
+            promptExecutor = mockLLMApi,
+            llmModel = OllamaModels.Meta.LLAMA_3_2,
+            strategy = functionalStrategy<String, SimpleOut> { input ->
+                subtask<String, SimpleOut>(
+                    input = input,
+                    tools = null,
+                    runMode = ToolCalls.PARALLEL
+                ) {
+                    "Parallel subtask: $it"
+                }
+            }
+        ) {
+            install(EventHandler) {
+                onToolCallStarting { eventContext -> actualToolCalls += eventContext.toolArgs.toString() }
+            }
+        }
+
+        val result = agent.run("input-2")
+        assertEquals("done-par", result.value)
+        assertEquals(0, actualToolCalls.size)
+    }
+
+    @Test
+    fun `subtask_single_run_sequential_finish_only`() = runTest {
+        val actualToolCalls = mutableListOf<String>()
+
+        val mockLLMApi = getMockExecutor(handleLastAssistantMessage = false) {
+            mockLLMToolCall(
+                SubgraphWithTaskUtils.finishTool<SimpleOut>(),
+                SimpleOut("done-single")
+            ) onRequestContains "Single-run subtask:"
+
+            mockLLMAnswer("default").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            systemPrompt = "You are helpful",
+            promptExecutor = mockLLMApi,
+            llmModel = OllamaModels.Meta.LLAMA_3_2,
+            strategy = functionalStrategy<String, SimpleOut> { input ->
+                subtask<String, SimpleOut>(
+                    input = input,
+                    tools = null,
+                    runMode = ToolCalls.SINGLE_RUN_SEQUENTIAL
+                ) {
+                    "Single-run subtask: $it"
+                }
+            }
+        ) {
+            install(EventHandler) {
+                onToolCallStarting { eventContext -> actualToolCalls += eventContext.toolArgs.toString() }
+            }
+        }
+
+        val result = agent.run("input-3")
+        assertEquals("done-single", result.value)
+        assertEquals(0, actualToolCalls.size)
+    }
+
+    @OptIn(InternalAgentsApi::class)
+    @Test
+    fun `subtask_withVerification_success`() = runTest {
+        val actualToolCalls = mutableListOf<String>()
+
+        val mockLLMApi = getMockExecutor(handleLastAssistantMessage = false) {
+            mockLLMToolCall(
+                SubgraphWithTaskUtils.finishTool<ai.koog.agents.ext.agent.CriticResultFromLLM>(),
+                ai.koog.agents.ext.agent.CriticResultFromLLM(isCorrect = true, feedback = "OK")
+            ) onRequestContains "Judge this:"
+
+            mockLLMAnswer("default").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            promptExecutor = mockLLMApi,
+            llmModel = OllamaModels.Meta.LLAMA_3_2,
+            toolRegistry = ToolRegistry.EMPTY,
+            strategy = functionalStrategy<String, ai.koog.agents.ext.agent.CriticResult<String>> { input ->
+                subtaskWithVerification(
+                    input = input,
+                    runMode = ToolCalls.SEQUENTIAL
+                ) {
+                    "Judge this: $it"
+                }
+            },
+            systemPrompt = "You are helpful"
+        ) {
+            install(EventHandler) {
+                onToolCallStarting { eventContext -> actualToolCalls += eventContext.toolArgs.toString() }
+            }
+        }
+
+        val result = agent.run("case-A")
+        assertEquals(true, result.successful)
+        assertEquals("OK", result.feedback)
+        assertEquals("case-A", result.input)
+        assertEquals(0, actualToolCalls.size)
     }
 }

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
@@ -1,5 +1,6 @@
 package ai.koog.agents.ext.agent
 
+import ai.koog.agents.core.agent.context.AIAgentContext
 import ai.koog.agents.core.agent.context.AIAgentGraphContextBase
 import ai.koog.agents.core.agent.context.DetachedPromptExecutorAPI
 import ai.koog.agents.core.agent.entity.ToolSelectionStrategy
@@ -158,19 +159,23 @@ public inline fun <reified Input, reified Output> AIAgentSubgraphBuilderBase<*, 
     llmParams = llmParams,
 ) {
     // An identity tool that provides arguments as a tool result without changes.
-    val finishTool = object : Tool<Output, Output>() {
-        override val argsSerializer: KSerializer<Output> = serializer()
-        override val resultSerializer: KSerializer<Output> = serializer()
-        override val name: String = SubgraphWithTaskUtils.FINALIZE_SUBGRAPH_TOOL_NAME
-        override val description: String = SubgraphWithTaskUtils.FINALIZE_SUBGRAPH_TOOL_DESCRIPTION
-        override suspend fun execute(args: Output): Output = args
-    }
+    val finishTool = identityTool<Output>()
 
     setupSubgraphWithTask<Input, Output, Output>(
         finishTool = finishTool,
         assistantResponseRepeatMax = assistantResponseRepeatMax,
         defineTask = defineTask
     )
+}
+
+@PublishedApi
+@OptIn(InternalAgentToolsApi::class)
+internal inline fun <reified Output> identityTool(): Tool<Output, Output> = object : Tool<Output, Output>() {
+    override val argsSerializer: KSerializer<Output> = serializer()
+    override val resultSerializer: KSerializer<Output> = serializer()
+    override val name: String = SubgraphWithTaskUtils.FINALIZE_SUBGRAPH_TOOL_NAME
+    override val description: String = SubgraphWithTaskUtils.FINALIZE_SUBGRAPH_TOOL_DESCRIPTION
+    override suspend fun execute(args: Output): Output = args
 }
 
 /**
@@ -342,7 +347,7 @@ public inline fun <reified Input : Any> AIAgentSubgraphBuilderBase<*, *>.subgrap
  * @param finishTool A descriptor for the tool that determines the condition to finalize the subgraph's operation.
  * @param defineTask A suspending lambda that defines the main task of the subgraph, producing a task description based on the input.
  */
-@OptIn(InternalAgentToolsApi::class)
+@OptIn(InternalAgentToolsApi::class, InternalAgentsApi::class)
 public inline fun <reified Input, reified Output, reified OutputTransformed> AIAgentSubgraphBuilderBase<Input, OutputTransformed>.setupSubgraphWithTask(
     finishTool: Tool<Output, OutputTransformed>,
     assistantResponseRepeatMax: Int? = null,
@@ -392,29 +397,7 @@ public inline fun <reified Input, reified Output, reified OutputTransformed> AIA
      * */
     val callToolHacked by node<Message.Tool.Call, ReceivedToolResult> { toolCall ->
         if (toolCall.tool == finishTool.name) {
-            // Execute Finish tool directly and get a result
-            val toolArgs = finishTool.decodeArgs(toolCall.contentJson)
-
-            val toolResult = finishTool.execute(
-                args = toolArgs
-            )
-
-            // Append a final tool call result to the prompt for further LLM calls
-            // to see it (otherwise they would fail)
-            llm.writeSession {
-                appendPrompt {
-                    tool {
-                        result(toolCall.id, toolCall.tool, toolCall.content)
-                    }
-                }
-            }
-
-            ReceivedToolResult(
-                id = toolCall.id,
-                tool = finishTool.name,
-                content = toolCall.content,
-                result = toolResult
-            )
+            executeFinishTool<Output, OutputTransformed>(toolCall, finishTool)
         } else {
             environment.executeTool(toolCall)
         }
@@ -479,4 +462,35 @@ public inline fun <reified Input, reified Output, reified OutputTransformed> AIA
     edge(sendToolResult forwardTo nodeDecide)
 
     edge(finalizeTask forwardTo nodeFinish)
+}
+
+@OptIn(InternalAgentToolsApi::class)
+@PublishedApi
+internal suspend inline fun <reified Output, reified OutputTransformed> AIAgentContext.executeFinishTool(
+    toolCall: Message.Tool.Call,
+    finishTool: Tool<Output, OutputTransformed>
+): ReceivedToolResult {
+    // Execute Finish tool directly and get a result
+    val toolArgs = finishTool.decodeArgs(toolCall.contentJson)
+
+    val toolResult = finishTool.execute(
+        args = toolArgs
+    )
+
+    // Append a final tool call result to the prompt for further LLM calls
+    // to see it (otherwise they would fail)
+    llm.writeSession {
+        appendPrompt {
+            tool {
+                result(toolCall.id, toolCall.tool, toolCall.content)
+            }
+        }
+    }
+
+    return ReceivedToolResult(
+        id = toolCall.id,
+        tool = finishTool.name,
+        content = toolCall.content,
+        result = toolResult
+    )
 }

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubtaskExt.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubtaskExt.kt
@@ -1,0 +1,293 @@
+package ai.koog.agents.ext.agent
+
+import ai.koog.agents.core.agent.ToolCalls
+import ai.koog.agents.core.agent.context.AIAgentFunctionalContext
+import ai.koog.agents.core.agent.context.DetachedPromptExecutorAPI
+import ai.koog.agents.core.annotation.InternalAgentsApi
+import ai.koog.agents.core.dsl.extension.containsToolCalls
+import ai.koog.agents.core.dsl.extension.extractToolCalls
+import ai.koog.agents.core.dsl.extension.requestLLM
+import ai.koog.agents.core.dsl.extension.requestLLMMultiple
+import ai.koog.agents.core.dsl.extension.sendMultipleToolResults
+import ai.koog.agents.core.dsl.extension.sendToolResult
+import ai.koog.agents.core.dsl.extension.setToolChoiceRequired
+import ai.koog.agents.core.environment.ReceivedToolResult
+import ai.koog.agents.core.environment.executeTool
+import ai.koog.agents.core.environment.toSafeResult
+import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.markdown.markdown
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.params.LLMParams
+
+/**
+ * Executes a subtask with validation and verification of the results.
+ * The method defines a subtask for the AI agent using the provided input
+ * and additional parameters and ensures that the output is evaluated
+ * based on its correctness and feedback.
+ *
+ * @param Input The type of the input provided to the subtask.
+ * @param input The input data for the subtask, which will be used to
+ * create and execute the task.
+ * @param tools An optional list of tools that can be utilized during
+ * the execution of the subtask.
+ * @param llmModel An optional parameter specifying the LLM model to be used for the subtask.
+ * @param llmParams Optional configuration parameters for the LLM, such as temperature
+ * and token limits.
+ * @param runMode The mode in which tools should be executed, either sequentially or in parallel.
+ * @param assistantResponseRepeatMax An optional parameter specifying the maximum number of
+ * retries for obtaining valid responses from the assistant.
+ * @param defineTask A suspend function that defines the subtask as a string
+ * based on the provided input.
+ * @return A [CriticResult] object containing the verification status, feedback,
+ * and the original input for the subtask.
+ */
+@OptIn(InternalAgentToolsApi::class, InternalAgentsApi::class)
+public suspend inline fun <reified Input> AIAgentFunctionalContext.subtaskWithVerification(
+    input: Input,
+    tools: List<Tool<*, *>>? = null,
+    llmModel: LLModel? = null,
+    llmParams: LLMParams? = null,
+    runMode: ToolCalls = ToolCalls.SEQUENTIAL,
+    assistantResponseRepeatMax: Int? = null,
+    defineTask: suspend AIAgentFunctionalContext.(input: Input) -> String
+): CriticResult<Input> {
+    val result = subtask<Input, CriticResultFromLLM>(
+        input,
+        tools,
+        llmModel,
+        llmParams,
+        runMode,
+        assistantResponseRepeatMax,
+        defineTask
+    )
+
+    return CriticResult(
+        successful = result.isCorrect,
+        feedback = result.feedback,
+        input = input
+    )
+}
+
+/**
+ * Executes a subtask within the larger context of an AI agent's functional operation. This method allows you to define a specific
+ * task to be performed, utilizing the given input, tools, and optional configuration parameters.
+ *
+ * @param Input The type of input provided to the subtask.
+ * @param Output The type of the output expected from the subtask.
+ * @param input The input data required for the subtask execution.
+ * @param tools A list of tools available for use within the subtask.
+ * @param llmModel The optional large language model to be used during the subtask, if different from the default one.
+ * @param llmParams The configuration parameters for the large language model, such as temperature, etc.
+ * @param runMode The mode in which tools should be executed, either sequentially or in parallel.
+ * @param assistantResponseRepeatMax The maximum number of times the assistant response can repeat. Useful to control redundant outputs.
+ * @param defineTask A suspendable lambda defining the actual task logic, which takes the provided input and produces a task description.
+ * @return The result of the subtask execution, as an instance of type Output.
+ */
+@OptIn(InternalAgentToolsApi::class)
+public suspend inline fun <reified Input, reified Output> AIAgentFunctionalContext.subtask(
+    input: Input,
+    tools: List<Tool<*, *>>? = null,
+    llmModel: LLModel? = null,
+    llmParams: LLMParams? = null,
+    runMode: ToolCalls = ToolCalls.SEQUENTIAL,
+    assistantResponseRepeatMax: Int? = null,
+    defineTask: suspend AIAgentFunctionalContext.(input: Input) -> String
+): Output {
+    val finishTool = identityTool<Output>()
+
+    return subtask(input, tools, finishTool, llmModel, llmParams, runMode, assistantResponseRepeatMax, defineTask)
+}
+
+/**
+ * Executes a subtask within the AI agent's functional context. This method enables the use of tools to
+ * accomplish a specific task based on the input provided. It defines the task using an inline function,
+ * employs tools iteratively, and attempts to complete the subtask with a designated finishing tool.
+ *
+ * @param input The input data required to define and execute the subtask.
+ * @param tools An optional list of tools that can be utilized to accomplish the task, excluding the finishing tool.
+ * @param finishTool A mandatory tool that determines the final result of the subtask by producing and transforming output.
+ * @param llmModel An optional specific language learning model (LLM) to use for executing the subtask.
+ * @param llmParams Optional parameters for configuring the behavior of the LLM during subtask execution.
+ * @param runMode The mode in which tools should be executed, either sequentially or in parallel.
+ * @param assistantResponseRepeatMax The maximum number of feedback attempts allowed from the language model if the subtask is not completed.
+ * @param defineTask A suspendable function used to define the task based on the provided input.
+ * @return The transformed final result of executing the finishing tool to complete the subtask.
+ */
+@OptIn(InternalAgentToolsApi::class, DetachedPromptExecutorAPI::class, InternalAgentsApi::class)
+public suspend inline fun <reified Input, reified Output, reified OutputTransformed> AIAgentFunctionalContext.subtask(
+    input: Input,
+    tools: List<Tool<*, *>>? = null,
+    finishTool: Tool<Output, OutputTransformed>,
+    llmModel: LLModel? = null,
+    llmParams: LLMParams? = null,
+    runMode: ToolCalls = ToolCalls.SEQUENTIAL,
+    assistantResponseRepeatMax: Int? = null,
+    defineTask: suspend AIAgentFunctionalContext.(input: Input) -> String
+): OutputTransformed {
+    val maxAssistantResponses = assistantResponseRepeatMax ?: SubgraphWithTaskUtils.ASSISTANT_RESPONSE_REPEAT_MAX
+
+    val toolsSubset = tools?.map { it.descriptor } ?: llm.readSession { this.tools.toList() }
+
+    val originalTools = llm.readSession { this.tools.toList() }
+    val originalMdel = llm.readSession { this.model }
+    val originalParams = llm.readSession { this.prompt.params }
+
+    // setup:
+    llm.writeSession {
+        if (finishTool.descriptor !in toolsSubset) {
+            this.tools = toolsSubset + finishTool.descriptor
+        }
+
+        if (llmModel != null) {
+            model = llmModel
+        }
+
+        if (llmParams != null) {
+            prompt = prompt.withParams(llmParams)
+        }
+
+        setToolChoiceRequired()
+    }
+
+    val task = defineTask(input)
+
+    val result = when (runMode) {
+        ToolCalls.SINGLE_RUN_SEQUENTIAL -> subtaskWithSingleToolMode(
+            task,
+            finishTool,
+            maxAssistantResponses
+        )
+
+        else -> subtaskWithMultiToolMode(
+            task,
+            finishTool,
+            runMode,
+            maxAssistantResponses
+        )
+    }
+
+    // rollback
+    llm.writeSession {
+        this.tools = originalTools
+        this.model = originalMdel
+        this.prompt = prompt.withParams(originalParams)
+    }
+
+    return result
+}
+
+@PublishedApi
+@OptIn(DetachedPromptExecutorAPI::class, InternalAgentsApi::class)
+internal suspend inline fun <reified Output, reified OutputTransformed> AIAgentFunctionalContext.subtaskWithMultiToolMode(
+    task: String,
+    finishTool: Tool<Output, OutputTransformed>,
+    runMode: ToolCalls,
+    maxAssistantResponses: Int
+): OutputTransformed {
+    var feedbacksCount = 0
+    var responses = requestLLMMultiple(task)
+    while (true) {
+        when {
+            responses.containsToolCalls() -> {
+                val toolCalls = extractToolCalls(responses)
+                val toolResults =
+                    executeMultipleToolsHacked(toolCalls, finishTool, parallelTools = runMode == ToolCalls.PARALLEL)
+                responses = sendMultipleToolResults(toolResults)
+
+                toolResults.firstOrNull { it.tool == finishTool.descriptor.name }
+                    ?.let { finishResult ->
+                        return finishResult.toSafeResult<OutputTransformed>().asSuccessful().result
+                    }
+            }
+
+            else -> {
+                if (feedbacksCount++ > maxAssistantResponses) {
+                    error(
+                        "Unable to finish subtask. Reason: the model '${llm.model.id}' does not support tool choice, " +
+                            "and was not able to call `${finishTool.name}` tool after " +
+                            "<$maxAssistantResponses> attempts."
+                    )
+                }
+
+                responses = requestLLMMultiple(
+                    message = markdown {
+                        h1("DO NOT CHAT WITH ME DIRECTLY! CALL TOOLS, INSTEAD.")
+                        h2("IF YOU HAVE FINISHED, CALL `${finishTool.name}` TOOL!")
+                    }
+                )
+            }
+        }
+    }
+}
+
+@PublishedApi
+@OptIn(DetachedPromptExecutorAPI::class, InternalAgentsApi::class)
+internal suspend inline fun <reified Output, reified OutputTransformed> AIAgentFunctionalContext.subtaskWithSingleToolMode(
+    task: String,
+    finishTool: Tool<Output, OutputTransformed>,
+    maxAssistantResponses: Int
+): OutputTransformed {
+    var feedbacksCount = 0
+    var response = requestLLM(task)
+    while (true) {
+        when {
+            response is Message.Tool.Call -> {
+                val toolResult = executeToolHacked(response, finishTool)
+                response = sendToolResult(toolResult)
+
+                if (toolResult.tool == finishTool.descriptor.name) {
+                    return toolResult.toSafeResult<OutputTransformed>().asSuccessful().result
+                }
+            }
+
+            else -> {
+                if (feedbacksCount++ > maxAssistantResponses) {
+                    error(
+                        "Unable to finish subtask. Reason: the model '${llm.model.id}' does not support tool choice, " +
+                            "and was not able to call `${finishTool.name}` tool after " +
+                            "<$maxAssistantResponses> attempts."
+                    )
+                }
+
+                response = requestLLM(
+                    message = markdown {
+                        h1("DO NOT CHAT WITH ME DIRECTLY! CALL TOOLS, INSTEAD.")
+                        h2("IF YOU HAVE FINISHED, CALL `${finishTool.name}` TOOL!")
+                    }
+                )
+            }
+        }
+    }
+}
+
+@OptIn(InternalAgentToolsApi::class)
+@PublishedApi
+internal suspend inline fun <reified Output, reified OutputTransformed> AIAgentFunctionalContext.executeMultipleToolsHacked(
+    toolCalls: List<Message.Tool.Call>,
+    finishTool: Tool<Output, OutputTransformed>,
+    parallelTools: Boolean = false
+): List<ReceivedToolResult> {
+    val finishTools = toolCalls.filter { it.tool == finishTool.descriptor.name }
+    val normalTools = toolCalls.filterNot { it.tool == finishTool.descriptor.name }
+
+    val finishToolResults = finishTools.map { toolCall ->
+        executeFinishTool(toolCall, finishTool)
+    }
+
+    val normalToolResults = if (parallelTools) {
+        environment.executeTools(normalTools)
+    } else {
+        normalTools.map { environment.executeTool(it) }
+    }
+
+    return finishToolResults + normalToolResults
+}
+
+@OptIn(InternalAgentToolsApi::class)
+@PublishedApi
+internal suspend inline fun <reified Output, reified OutputTransformed> AIAgentFunctionalContext.executeToolHacked(
+    toolCall: Message.Tool.Call,
+    finishTool: Tool<Output, OutputTransformed>
+): ReceivedToolResult = executeMultipleToolsHacked(listOf(toolCall), finishTool).first()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ group = "ai.koog"
 version = run {
     // our version follows the semver specification
 
-    val main = "0.5.0"
+    val main = "0.5.2"
 
     val feat = run {
         val releaseBuild = !System.getenv("BRANCH_KOOG_IS_RELEASING_FROM").isNullOrBlank()


### PR DESCRIPTION
How to use it and why: https://medium.com/@vadim.briliantov/non-graph-strategies-and-when-to-use-them-in-ai-agents-eb0cee6dba73

---

#### Type of the changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [ ] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [ ] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
