### PR TITLE
Stabilize debugger and tracing remote writer tests by awaiting server readiness

### DIFF
--- a/agents/agents-features/agents-features-debugger/src/jvmTest/kotlin/ai/koog/agents/features/debugger/feature/DebuggerTest.kt
+++ b/agents/agents-features/agents-features-debugger/src/jvmTest/kotlin/ai/koog/agents/features/debugger/feature/DebuggerTest.kt
@@ -56,8 +56,10 @@ import ai.koog.utils.io.use
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.http.URLProtocol
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
@@ -65,6 +67,7 @@ import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.io.IOException
 import org.junit.jupiter.api.AfterEach
@@ -87,6 +90,22 @@ class DebuggerTest {
     companion object {
         private val defaultClientServerTimeout = 30.seconds
         private const val HOST = "127.0.0.1"
+    }
+
+    private suspend fun FeatureMessageRemoteClient.connectWithRetry(timeout: Duration) {
+        withTimeout(timeout) {
+            while (true) {
+                try {
+                    connect()
+                    return@withTimeout
+                } catch (exception: Exception) {
+                    if (exception is CancellationException) {
+                        throw exception
+                    }
+                    delay(100)
+                }
+            }
+        }
     }
 
     private val testBaseClient: HttpClient
@@ -165,7 +184,6 @@ class DebuggerTest {
         val clientConfig = DefaultClientConnectionConfig(host = HOST, port = port, protocol = URLProtocol.HTTP)
 
         val isClientFinished = CompletableDeferred<Boolean>()
-        val isServerStarted = CompletableDeferred<Boolean>()
 
         // Server
         val serverJob = launch {
@@ -205,7 +223,6 @@ class DebuggerTest {
                 install(Debugger) {
                     setPort(port)
 
-                    // A job to wait for a server to start
                     launch {
                         val messageProcessor = messageProcessors.single() as FeatureMessageRemoteWriter
                         val isServerStartedCheck = withTimeoutOrNull(defaultClientServerTimeout) {
@@ -213,7 +230,6 @@ class DebuggerTest {
                         } != null
 
                         assertTrue(isServerStartedCheck, "Server did not start in time")
-                        isServerStarted.complete(true)
                     }
                 }
             }.use { agent ->
@@ -236,8 +252,7 @@ class DebuggerTest {
                 val collectEventsJob =
                     clientEventsCollector.startCollectEvents(coroutineScope = this@launch)
 
-                isServerStarted.await()
-                client.connect()
+                client.connectWithRetry(defaultClientServerTimeout)
                 collectEventsJob.join()
 
                 // Correct run id will be set after the 'collect events job' is finished.
@@ -480,7 +495,6 @@ class DebuggerTest {
         val clientConfig = DefaultClientConnectionConfig(host = HOST, port = port, protocol = URLProtocol.HTTP)
 
         val isClientFinished = CompletableDeferred<Boolean>()
-        val isServerStarted = CompletableDeferred<Boolean>()
 
         // Server
         val serverJob = launch {
@@ -516,7 +530,6 @@ class DebuggerTest {
                         } != null
 
                         assertTrue(isServerStartedCheck, "Server did not start in time")
-                        isServerStarted.complete(true)
                     }
                 }
             }.use { agent ->
@@ -539,8 +552,7 @@ class DebuggerTest {
                 val collectEventsJob =
                     clientEventsCollector.startCollectEvents(coroutineScope = this@launch)
 
-                isServerStarted.await()
-                client.connect()
+                client.connectWithRetry(defaultClientServerTimeout)
                 collectEventsJob.join()
 
                 // Correct run id will be set after the 'collect events job' is finished.
@@ -660,7 +672,6 @@ class DebuggerTest {
         val clientConfig = DefaultClientConnectionConfig(host = HOST, port = port, protocol = URLProtocol.HTTP)
 
         val isClientFinished = CompletableDeferred<Boolean>()
-        val isServerStarted = CompletableDeferred<Boolean>()
 
         // Server
         val serverJob = launch {
@@ -696,7 +707,6 @@ class DebuggerTest {
                         } != null
 
                         assertTrue(isServerStartedCheck, "Server did not start in time")
-                        isServerStarted.complete(true)
                     }
                 }
             }.use { agent ->
@@ -725,8 +735,7 @@ class DebuggerTest {
                 val collectEventsJob =
                     clientEventsCollector.startCollectEvents(coroutineScope = this@launch)
 
-                isServerStarted.await()
-                client.connect()
+                client.connectWithRetry(defaultClientServerTimeout)
                 collectEventsJob.join()
 
                 // Correct run id will be set after the 'collect events job' is finished.

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageRemoteWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageRemoteWriterTest.kt
@@ -25,6 +25,7 @@ import ai.koog.agents.core.feature.model.events.ToolCallStartingEvent
 import ai.koog.agents.core.feature.remote.client.FeatureMessageRemoteClient
 import ai.koog.agents.core.feature.remote.client.config.DefaultClientConnectionConfig
 import ai.koog.agents.core.feature.remote.server.config.DefaultServerConnectionConfig
+import ai.koog.agents.core.feature.writer.FeatureMessageRemoteWriter
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.features.tracing.eventString
 import ai.koog.agents.features.tracing.feature.Tracing
@@ -48,9 +49,12 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.plugins.sse.SSEClientException
 import io.ktor.http.URLProtocol
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -69,6 +73,19 @@ class TraceFeatureMessageRemoteWriterTest {
         private val logger = KotlinLogging.logger { }
         private val defaultClientServerTimeout = 30.seconds
         private const val HOST = "127.0.0.1"
+    }
+
+    private fun CoroutineScope.signalServerStarted(
+        writer: FeatureMessageRemoteWriter,
+        signal: CompletableDeferred<Boolean>
+    ): Job = launch {
+        val isStarted = withTimeoutOrNull(defaultClientServerTimeout) {
+            writer.isOpen.first { it }
+        } ?: throw AssertionError("Server did not start in time")
+
+        if (!signal.isCompleted) {
+            signal.complete(isStarted)
+        }
     }
 
     @Test
@@ -93,6 +110,8 @@ class TraceFeatureMessageRemoteWriterTest {
         val serverJob = launch {
             TraceFeatureMessageRemoteWriter(connectionConfig = serverConfig).use { writer ->
 
+                val serverReadyJob = signalServerStarted(writer, isServerStarted)
+
                 val strategy = strategy<String, String>("tracing-test-strategy") {
                     val llmCallNode by nodeLLMRequest("test LLM call")
                     val llmCallWithToolsNode by nodeLLMRequest("test LLM call with tools")
@@ -102,14 +121,17 @@ class TraceFeatureMessageRemoteWriterTest {
                     edge(llmCallWithToolsNode forwardTo nodeFinish transformed { "Done" })
                 }
 
-                createAgent(strategy = strategy) {
-                    install(Tracing) {
-                        addMessageProcessor(writer)
+                try {
+                    createAgent(strategy = strategy) {
+                        install(Tracing) {
+                            addMessageProcessor(writer)
+                        }
+                    }.use { agent ->
+                        agent.run("")
+                        isClientFinished.await()
                     }
-                }.use { agent ->
-                    agent.run("")
-                    isServerStarted.complete(true)
-                    isClientFinished.await()
+                } finally {
+                    serverReadyJob.join()
                 }
             }
         }
@@ -188,6 +210,8 @@ class TraceFeatureMessageRemoteWriterTest {
         val serverJob = launch {
             TraceFeatureMessageRemoteWriter(connectionConfig = serverConfig).use { writer ->
 
+                val serverReadyJob = signalServerStarted(writer, isServerStarted)
+
                 val strategy = strategy(strategyName) {
                     val nodeSendInput by nodeLLMRequest("test-llm-call")
                     val nodeExecuteTool by nodeExecuteTool("test-tool-call")
@@ -207,24 +231,27 @@ class TraceFeatureMessageRemoteWriterTest {
                     mockLLMAnswer(mockResponse) onRequestContains dummyTool.result
                 }
 
-                createAgent(
-                    agentId = agentId,
-                    strategy = strategy,
-                    promptId = promptId,
-                    model = testModel,
-                    userPrompt = userPrompt,
-                    systemPrompt = systemPrompt,
-                    assistantPrompt = assistantPrompt,
-                    toolRegistry = toolRegistry,
-                    promptExecutor = mockExecutor
-                ) {
-                    install(Tracing) {
-                        addMessageProcessor(writer)
+                try {
+                    createAgent(
+                        agentId = agentId,
+                        strategy = strategy,
+                        promptId = promptId,
+                        model = testModel,
+                        userPrompt = userPrompt,
+                        systemPrompt = systemPrompt,
+                        assistantPrompt = assistantPrompt,
+                        toolRegistry = toolRegistry,
+                        promptExecutor = mockExecutor
+                    ) {
+                        install(Tracing) {
+                            addMessageProcessor(writer)
+                        }
+                    }.use { agent ->
+                        agent.run(userPrompt)
+                        isClientFinished.await()
                     }
-                }.use { agent ->
-                    agent.run(userPrompt)
-                    isServerStarted.complete(true)
-                    isClientFinished.await()
+                } finally {
+                    serverReadyJob.join()
                 }
             }
         }
@@ -588,6 +615,8 @@ class TraceFeatureMessageRemoteWriterTest {
         val serverJob = launch {
             TraceFeatureMessageRemoteWriter(connectionConfig = serverConfig).use { writer ->
 
+                val serverReadyJob = signalServerStarted(writer, isServerStarted)
+
                 val strategy = strategy(strategyName) {
                     val nodeSendInput by nodeLLMRequest("test-llm-call")
                     val nodeExecuteTool by nodeExecuteTool("test-tool-call")
@@ -607,27 +636,30 @@ class TraceFeatureMessageRemoteWriterTest {
                     mockLLMAnswer(mockResponse) onRequestContains dummyTool.result
                 }
 
-                createAgent(
-                    agentId = agentId,
-                    strategy = strategy,
-                    promptId = promptId,
-                    model = testModel,
-                    userPrompt = userPrompt,
-                    systemPrompt = systemPrompt,
-                    assistantPrompt = assistantPrompt,
-                    toolRegistry = toolRegistry,
-                    promptExecutor = mockExecutor
-                ) {
-                    install(Tracing) {
-                        writer.setMessageFilter { message ->
-                            message is LLMCallStartingEvent || message is LLMCallCompletedEvent
+                try {
+                    createAgent(
+                        agentId = agentId,
+                        strategy = strategy,
+                        promptId = promptId,
+                        model = testModel,
+                        userPrompt = userPrompt,
+                        systemPrompt = systemPrompt,
+                        assistantPrompt = assistantPrompt,
+                        toolRegistry = toolRegistry,
+                        promptExecutor = mockExecutor
+                    ) {
+                        install(Tracing) {
+                            writer.setMessageFilter { message ->
+                                message is LLMCallStartingEvent || message is LLMCallCompletedEvent
+                            }
+                            addMessageProcessor(writer)
                         }
-                        addMessageProcessor(writer)
+                    }.use { agent ->
+                        agent.run(userPrompt)
+                        isClientFinished.await()
                     }
-                }.use { agent ->
-                    agent.run(userPrompt)
-                    isServerStarted.complete(true)
-                    isClientFinished.await()
+                } finally {
+                    serverReadyJob.join()
                 }
             }
         }


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

Please add a brief description of the proposed change here.
Also, please tick the appropriate points in the checklist below.
-->

## Motivation and Context
Stabilize debugger and tracing remote writer tests by awaiting server readiness.

- ensure tracing tests wait on FeatureMessageRemoteWriter.isOpen so the client connects before the server times out while awaiting its first connection
- add retry-based connectWithRetry for debugger test clients so they poll until the server accepts connections, eliminating the previous handshake deadlock
- keep existing event assertions intact after reworking the synchronization

## Breaking Changes
No.

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
