### PR TITLE
Fix KG-478 Binary files are misclassified as text

### DIFF
--- a/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
+++ b/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
@@ -219,24 +219,43 @@ public object JVMFileSystemProvider {
         /**
          * Determines if the beginning of a file's content is text-based, as opposed to binary.
          * This method reads a specified amount of data from the start of the file,
-         * attempts decoding with a list of provided character sets, and checks if any succeed.
+         * checks for null bytes, and attempts decoding with a list of provided character sets.
          *
-         * @param headMaxSize The maximum number of bytes to read from the start of the file. Defaults to 1024 bytes.
+         * @param headMaxSize The maximum number of bytes to read from the start of the file. Defaults to 8000 bytes.
          * @param charsetsToTry A list of character sets to attempt decoding the file's content. Defaults to a list containing UTF-8.
-         * @return True if the file's head data is successfully decoded with one of the given character sets, otherwise false.
+         * @return True if the file's head data contains no null bytes and is successfully decoded with one of the given character sets,
+         * otherwise false.
          */
         private fun Path.isFileHeadTextBased(
-            headMaxSize: Int = 1024,
+            headMaxSize: Int = 8000,
             charsetsToTry: List<Charset> = listOf(
                 Charsets.UTF_8,
             )
         ): Boolean {
             return runCatching {
-                val headData = inputStream().use { stream ->
+                val bytes = inputStream().use { stream ->
                     val buffer = ByteArray(headMaxSize)
-                    stream.read(buffer, 0, headMaxSize).let { ByteBuffer.wrap(buffer.copyOf(it)) }
+                    val bytesRead = stream.read(buffer, 0, headMaxSize)
+                    if (bytesRead <= 0) return true
+                    buffer.copyOf(bytesRead)
                 }
-                charsetsToTry.any { runCatching { it.newDecoder().decode(headData) }.isSuccess }
+
+                val bytesToCheck = bytes.size
+
+                // check for null bytes
+                for (i in 0 until bytesToCheck) {
+                    if (bytes[i] == 0.toByte()) {
+                        return false
+                    }
+                }
+
+                val headData = ByteBuffer.wrap(bytes, 0, bytesToCheck)
+                charsetsToTry.any { charset ->
+                    runCatching {
+                        charset.newDecoder().decode(headData.duplicate())
+                        true
+                    }.getOrElse { false }
+                }
             }.getOrElse { false }
         }
 

--- a/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
+++ b/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
@@ -236,7 +236,7 @@ public object JVMFileSystemProvider {
                 val bytes = inputStream().use { stream ->
                     val buffer = ByteArray(headMaxSize)
                     val bytesRead = stream.read(buffer, 0, headMaxSize)
-                    if (bytesRead <= 0) return true
+                    if (bytesRead <= 0) return false
                     buffer.copyOf(bytesRead)
                 }
 

--- a/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
+++ b/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
@@ -249,7 +249,6 @@ public object JVMFileSystemProvider {
                 charsetsToTry.any { charset ->
                     runCatching {
                         charset.newDecoder().decode(headData.duplicate())
-                        true
                     }.isSuccess
                 }
             }.getOrElse { false }

--- a/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
+++ b/rag/rag-base/src/jvmMain/kotlin/ai/koog/rag/base/files/JVMFileSystemProvider.kt
@@ -240,21 +240,17 @@ public object JVMFileSystemProvider {
                     buffer.copyOf(bytesRead)
                 }
 
-                val bytesToCheck = bytes.size
-
                 // check for null bytes
-                for (i in 0 until bytesToCheck) {
-                    if (bytes[i] == 0.toByte()) {
-                        return false
-                    }
+                if (bytes.any { it == 0.toByte() }) {
+                    return false
                 }
 
-                val headData = ByteBuffer.wrap(bytes, 0, bytesToCheck)
+                val headData = ByteBuffer.wrap(bytes)
                 charsetsToTry.any { charset ->
                     runCatching {
                         charset.newDecoder().decode(headData.duplicate())
                         true
-                    }.getOrElse { false }
+                    }.isSuccess
                 }
             }.getOrElse { false }
         }


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

Please add a brief description of the proposed change here.
Also, please tick the appropriate points in the checklist below.
-->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
PR contains the fix for [KG-478](https://youtrack.jetbrains.com/issue/KG-478) where `getFileContentType` fails to detect binary file as binary.
Since the new approach doesn't load the whole file into memory, I decided to increase `headMaxSize` to 8000 as it's done for [JBAI-15086](https://youtrack.jetbrains.com/issue/JBAI-15086), but it's not a strong opinion and we can revert it back to 1024.
## Breaking Changes
<!-- Will users need to update their code or configurations? -->

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [x] Docs have been added / updated
