### PR TITLE
Add tests for new tool param types and reduce models number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ docs/src/main/kotlin/*.kt
 **/.env
 .venv
 .DS_Store
-**/kotlin-js-store
+/.claude/

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
@@ -173,10 +173,10 @@ class AIAgentIntegrationTest {
                         toolChoice = ToolChoice.Auto,
                     )
                 ) {
-                    system(
-                        "You are a helpful assistant. " +
-                            "JUST CALL THE TOOLS, NO QUESTIONS ASKED."
-                    )
+                    system {
+                        +"You are a helpful assistant. "
+                        +"JUST CALL THE TOOLS, NO QUESTIONS ASKED."
+                    }
                 },
                 model = model,
                 maxAgentIterations = 10,
@@ -1261,7 +1261,11 @@ class AIAgentIntegrationTest {
 
                     assertTrue(
                         state.errors.isEmpty(),
-                        "No errors should occur during agent execution with $strategyName, got: [${state.errors.joinToString("\n")}]"
+                        "No errors should occur during agent execution with $strategyName, got: [${
+                            state.errors.joinToString(
+                                "\n"
+                            )
+                        }]"
                     )
                     assertTrue(
                         result.isNotBlank(),

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
@@ -170,13 +170,13 @@ class AIAgentIntegrationTest {
                     id = "multiple-tool-calls-agent",
                     params = LLMParams(
                         temperature = 1.0,
-                        toolChoice = ToolChoice.Auto,
+                        toolChoice = ToolChoice.Required,
                     )
                 ) {
                     system("You are a helpful assistant.")
                 },
                 model = model,
-                maxAgentIterations = 10,
+                maxAgentIterations = 30,
             ),
             toolRegistry = toolRegistry,
             installFeatures = { install(EventHandler.Feature, eventHandlerConfig) },
@@ -575,7 +575,7 @@ class AIAgentIntegrationTest {
     fun integration_AIAgentSingleRunNoParallelToolsTest(model: LLModel) = runTest(timeout = 300.seconds) {
         Models.assumeAvailable(model.provider)
         assumeTrue(model.capabilities.contains(LLMCapability.Tools), "Model $model does not support tools")
-        assumeTrue(model.id != OpenAIModels.Audio.GPT4oAudio.id, "See KG-124")
+
         assumeTrue(
             model !in listOf(
                 BedrockModels.AnthropicClaude35Haiku,
@@ -598,8 +598,8 @@ class AIAgentIntegrationTest {
                     "There should be no parallel tool calls in a Sequential single run scenario"
                 )
                 assertTrue(
-                    state.singleToolCalls.isNotEmpty(),
-                    "There should be exactly 2 single tool calls in a Sequential single run scenario"
+                    state.singleToolCalls.size >= 2,
+                    "There should be more or equal than 2 single tool calls in a Sequential single run scenario"
                 )
                 assertEquals(
                     CalculatorTool.name,

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
@@ -173,7 +173,10 @@ class AIAgentIntegrationTest {
                         toolChoice = ToolChoice.Auto,
                     )
                 ) {
-                    system("You are a helpful assistant.")
+                    system(
+                        "You are a helpful assistant. " +
+                            "YOU MUST CALL TOOLS OR I WILL CHARGE YOU."
+                    )
                 },
                 model = model,
                 maxAgentIterations = 10,
@@ -425,7 +428,7 @@ class AIAgentIntegrationTest {
 
                 val agent = AIAgent.invoke(
                     promptExecutor = executor,
-                    systemPrompt = systemPrompt + "You MUST use tools.",
+                    systemPrompt = systemPrompt + "ALWAYS USE TOOLS! THIS IS YOUR LEGAL OBLIGATION!",
                     strategy = singleRunStrategy(ToolCalls.SEQUENTIAL),
                     llmModel = model,
                     temperature = 1.0,
@@ -1036,15 +1039,6 @@ class AIAgentIntegrationTest {
     @MethodSource("openAIModels", "anthropicModels", "googleModels", "bedrockModels", "openRouterModels")
     fun integration_AgentWithToolsWithoutParamsTest(model: LLModel) = runTest(timeout = 180.seconds) {
         assumeTrue(model.capabilities.contains(LLMCapability.Tools), "Model $model does not support tools")
-        val flakyModels = listOf(
-            GoogleModels.Gemini2_0Flash.id,
-            GoogleModels.Gemini2_0Flash001.id,
-            GoogleModels.Gemini2_0FlashLite.id,
-            GoogleModels.Gemini2_0FlashLite001.id,
-            OpenAIModels.Chat.GPT5Mini.id,
-            BedrockModels.AmazonNovaLite.id,
-        )
-        assumeTrue(!flakyModels.contains(model.id), "Model $model is flaky and fails to call tools exactly once")
 
         val registry = ToolRegistry {
             tool(CalculatorToolNoArgs)

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
@@ -170,13 +170,13 @@ class AIAgentIntegrationTest {
                     id = "multiple-tool-calls-agent",
                     params = LLMParams(
                         temperature = 1.0,
-                        toolChoice = ToolChoice.Required,
+                        toolChoice = ToolChoice.Auto,
                     )
                 ) {
                     system("You are a helpful assistant.")
                 },
                 model = model,
-                maxAgentIterations = 30,
+                maxAgentIterations = 10,
             ),
             toolRegistry = toolRegistry,
             installFeatures = { install(EventHandler.Feature, eventHandlerConfig) },

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
@@ -175,7 +175,7 @@ class AIAgentIntegrationTest {
                 ) {
                     system(
                         "You are a helpful assistant. " +
-                            "YOU MUST CALL TOOLS OR I WILL CHARGE YOU."
+                            "JUST CALL THE TOOLS, NO QUESTIONS ASKED."
                     )
                 },
                 model = model,
@@ -428,7 +428,7 @@ class AIAgentIntegrationTest {
 
                 val agent = AIAgent.invoke(
                     promptExecutor = executor,
-                    systemPrompt = systemPrompt + "ALWAYS USE TOOLS! THIS IS YOUR LEGAL OBLIGATION!",
+                    systemPrompt = systemPrompt + "JUST CALL THE TOOLS, NO QUESTIONS ASKED!",
                     strategy = singleRunStrategy(ToolCalls.SEQUENTIAL),
                     llmModel = model,
                     temperature = 1.0,

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
@@ -40,14 +40,16 @@ import ai.koog.prompt.markdown.markdown
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.streaming.StreamFrame
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
@@ -92,15 +94,17 @@ internal class ReportingLLMLLMClient(
         model: LLModel,
         tools: List<ToolDescriptor>
     ): List<Message.Response> {
-        eventsChannel.trySend(
-            Event.Message(
-                llmClient = underlyingClient::class.simpleName ?: "Unknown",
-                method = "execute",
-                prompt = prompt,
-                tools = tools.map { it.name },
-                model = model
+        CoroutineScope(currentCoroutineContext()).launch {
+            eventsChannel.send(
+                Event.Message(
+                    llmClient = underlyingClient::class.simpleName ?: "null",
+                    method = "execute",
+                    prompt = prompt,
+                    tools = tools.map { it.name },
+                    model = model
+                )
             )
-        )
+        }
         return underlyingClient.execute(prompt, model, tools)
     }
 
@@ -108,17 +112,20 @@ internal class ReportingLLMLLMClient(
         prompt: Prompt,
         model: LLModel,
         tools: List<ToolDescriptor>
-    ): Flow<StreamFrame> {
-        eventsChannel.trySend(
-            Event.Message(
-                llmClient = underlyingClient::class.simpleName ?: "Unknown",
-                method = "executeStreaming",
-                prompt = prompt,
-                tools = tools.map { it.name },
-                model = model
+    ): Flow<StreamFrame> = flow {
+        coroutineScope {
+            eventsChannel.send(
+                Event.Message(
+                    llmClient = underlyingClient::class.simpleName ?: "null",
+                    method = "execute",
+                    prompt = prompt,
+                    tools = emptyList(),
+                    model = model
+                )
             )
-        )
-        return underlyingClient.executeStreaming(prompt, model, tools)
+        }
+        underlyingClient.executeStreaming(prompt, model, tools)
+            .collect(this)
     }
 
     override suspend fun moderate(
@@ -517,7 +524,7 @@ class AIAgentMultipleLLMIntegrationTest {
         val eventsChannel = Channel<Event>(Channel.UNLIMITED)
         val eventHandlerConfig: EventHandlerConfig.() -> Unit = {
             onAgentCompleted { _ ->
-                eventsChannel.trySend(Event.Termination)
+                eventsChannel.send(Event.Termination)
             }
         }
 
@@ -528,32 +535,9 @@ class AIAgentMultipleLLMIntegrationTest {
             eventsChannel = eventsChannel,
         )
 
-        val messagesDeferred = async {
-            val messages = mutableListOf<Event.Message>()
-            try {
-                for (msg in eventsChannel) {
-                    when (msg) {
-                        is Event.Message -> messages.add(msg)
-                        is Event.Termination -> break
-                    }
-                }
-            } catch (e: ClosedReceiveChannelException) {
-                // ignore
-            }
-            messages
-        }
-
-        val result = try {
-            withTimeout(8.minutes.inWholeMilliseconds) {
-                agent.run(
-                    "Generate me a project in Ktor that has a GET endpoint that returns the capital of France. Write a test"
-                )
-            }
-        } finally {
-            eventsChannel.close()
-        }
-
-        val messages = messagesDeferred.await()
+        val result = agent.run(
+            "Generate me a project in Ktor that has a GET endpoint that returns the capital of France. Write a test"
+        )
 
         assertNotNull(result)
 
@@ -561,6 +545,15 @@ class AIAgentMultipleLLMIntegrationTest {
             fs.fileCount() > 0,
             "Agent must have created at least one file"
         )
+
+        val messages = mutableListOf<Event.Message>()
+        for (msg in eventsChannel) {
+            if (msg is Event.Message) {
+                messages.add(msg)
+            } else {
+                break
+            }
+        }
 
         assertTrue(
             messages.any { it.llmClient == "AnthropicLLMClient" },

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
@@ -40,16 +40,16 @@ import ai.koog.prompt.markdown.markdown
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.streaming.StreamFrame
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
@@ -89,15 +89,16 @@ internal class ReportingLLMLLMClient(
         data object Termination : Event
     }
 
+    @OptIn(DelicateCoroutinesApi::class)
     override suspend fun execute(
         prompt: Prompt,
         model: LLModel,
         tools: List<ToolDescriptor>
     ): List<Message.Response> {
-        CoroutineScope(currentCoroutineContext()).launch {
+        if (!eventsChannel.isClosedForSend) {
             eventsChannel.send(
                 Event.Message(
-                    llmClient = underlyingClient::class.simpleName ?: "null",
+                    llmClient = underlyingClient::class.simpleName ?: "Unknown",
                     method = "execute",
                     prompt = prompt,
                     tools = tools.map { it.name },
@@ -518,7 +519,7 @@ class AIAgentMultipleLLMIntegrationTest {
     }
 
     @Test
-    fun integration_testOpenAIAnthropicAgent() = runTest(timeout = 600.seconds) {
+    fun integration_testOpenAIAnthropicAgent() = runTest(timeout = 10.minutes) {
         Models.assumeAvailable(LLMProvider.OpenAI)
         Models.assumeAvailable(LLMProvider.Anthropic)
 
@@ -527,6 +528,7 @@ class AIAgentMultipleLLMIntegrationTest {
         val eventHandlerConfig: EventHandlerConfig.() -> Unit = {
             onAgentCompleted { _ ->
                 eventsChannel.send(Event.Termination)
+                eventsChannel.close()
             }
         }
 
@@ -537,9 +539,32 @@ class AIAgentMultipleLLMIntegrationTest {
             eventsChannel = eventsChannel,
         )
 
-        val result = agent.run(
-            "Generate me a project in Ktor that has a GET endpoint that returns the capital of France. Write a test"
-        )
+        val agentJob = async {
+            agent.run(
+                "Generate me a project in Ktor that has a GET endpoint that returns the capital of France. Write a test"
+            )
+        }
+
+        val messages = mutableListOf<Event.Message>()
+
+        try {
+            withTimeout(8.minutes.inWholeMilliseconds) {
+                for (msg in eventsChannel) {
+                    if (msg is Event.Message) {
+                        messages.add(msg)
+                    } else if (msg is Event.Termination) {
+                        break
+                    }
+                }
+            }
+        } catch (e: TimeoutCancellationException) {
+            println("Warning: Event collection timed out: [${e.message}]")
+        } finally {
+            eventsChannel.close()
+        }
+
+        val result = agentJob.await()
+
 
         assertNotNull(result)
 
@@ -547,15 +572,6 @@ class AIAgentMultipleLLMIntegrationTest {
             fs.fileCount() > 0,
             "Agent must have created at least one file"
         )
-
-        val messages = mutableListOf<Event.Message>()
-        for (msg in eventsChannel) {
-            if (msg is Event.Message) {
-                messages.add(msg)
-            } else {
-                break
-            }
-        }
 
         assertTrue(
             messages.any { it.llmClient == "AnthropicLLMClient" },

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
@@ -41,12 +41,10 @@ import ai.koog.prompt.message.Message
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.streaming.StreamFrame
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
@@ -89,23 +87,20 @@ internal class ReportingLLMLLMClient(
         data object Termination : Event
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
     override suspend fun execute(
         prompt: Prompt,
         model: LLModel,
         tools: List<ToolDescriptor>
     ): List<Message.Response> {
-        if (!eventsChannel.isClosedForSend) {
-            eventsChannel.send(
-                Event.Message(
-                    llmClient = underlyingClient::class.simpleName ?: "Unknown",
-                    method = "execute",
-                    prompt = prompt,
-                    tools = tools.map { it.name },
-                    model = model
-                )
+        eventsChannel.trySend(
+            Event.Message(
+                llmClient = underlyingClient::class.simpleName ?: "Unknown",
+                method = "execute",
+                prompt = prompt,
+                tools = tools.map { it.name },
+                model = model
             )
-        }
+        )
         return underlyingClient.execute(prompt, model, tools)
     }
 
@@ -113,28 +108,23 @@ internal class ReportingLLMLLMClient(
         prompt: Prompt,
         model: LLModel,
         tools: List<ToolDescriptor>
-    ): Flow<StreamFrame> = flow {
-        coroutineScope {
-            eventsChannel.send(
-                Event.Message(
-                    llmClient = underlyingClient::class.simpleName ?: "null",
-                    method = "execute",
-                    prompt = prompt,
-                    tools = emptyList(),
-                    model = model
-                )
+    ): Flow<StreamFrame> {
+        eventsChannel.trySend(
+            Event.Message(
+                llmClient = underlyingClient::class.simpleName ?: "Unknown",
+                method = "executeStreaming",
+                prompt = prompt,
+                tools = tools.map { it.name },
+                model = model
             )
-        }
-        underlyingClient.executeStreaming(prompt, model, tools)
-            .collect(this)
+        )
+        return underlyingClient.executeStreaming(prompt, model, tools)
     }
 
     override suspend fun moderate(
         prompt: Prompt,
         model: LLModel
-    ): ModerationResult {
-        throw NotImplementedError("Moderation not needed for this test")
-    }
+    ): ModerationResult = throw NotImplementedError("Moderation not needed for this test")
 }
 
 internal fun LLMClient.reportingTo(
@@ -527,8 +517,7 @@ class AIAgentMultipleLLMIntegrationTest {
         val eventsChannel = Channel<Event>(Channel.UNLIMITED)
         val eventHandlerConfig: EventHandlerConfig.() -> Unit = {
             onAgentCompleted { _ ->
-                eventsChannel.send(Event.Termination)
-                eventsChannel.close()
+                eventsChannel.trySend(Event.Termination)
             }
         }
 
@@ -539,32 +528,32 @@ class AIAgentMultipleLLMIntegrationTest {
             eventsChannel = eventsChannel,
         )
 
-        val agentJob = async {
-            agent.run(
-                "Generate me a project in Ktor that has a GET endpoint that returns the capital of France. Write a test"
-            )
-        }
-
-        val messages = mutableListOf<Event.Message>()
-
-        try {
-            withTimeout(8.minutes.inWholeMilliseconds) {
+        val messagesDeferred = async {
+            val messages = mutableListOf<Event.Message>()
+            try {
                 for (msg in eventsChannel) {
-                    if (msg is Event.Message) {
-                        messages.add(msg)
-                    } else if (msg is Event.Termination) {
-                        break
+                    when (msg) {
+                        is Event.Message -> messages.add(msg)
+                        is Event.Termination -> break
                     }
                 }
+            } catch (e: ClosedReceiveChannelException) {
+                // ignore
             }
-        } catch (e: TimeoutCancellationException) {
-            println("Warning: Event collection timed out: [${e.message}]")
+            messages
+        }
+
+        val result = try {
+            withTimeout(8.minutes.inWholeMilliseconds) {
+                agent.run(
+                    "Generate me a project in Ktor that has a GET endpoint that returns the capital of France. Write a test"
+                )
+            }
         } finally {
             eventsChannel.close()
         }
 
-        val result = agentJob.await()
-
+        val messages = messagesDeferred.await()
 
         assertNotNull(result)
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
@@ -147,8 +147,8 @@ class AIAgentMultipleLLMIntegrationTest {
 
         @JvmStatic
         fun getModels(): Stream<LLModel> = Stream.of(
-            AnthropicModels.Sonnet_3_7,
-            OpenAIModels.Chat.GPT4o,
+            AnthropicModels.Sonnet_4_5,
+            OpenAIModels.Chat.GPT5,
         )
 
         @JvmStatic
@@ -381,7 +381,7 @@ class AIAgentMultipleLLMIntegrationTest {
             val anthropicSubgraph by subgraph<String, Unit>("anthropic") {
                 val definePromptAnthropic by node<Unit, Unit> {
                     llm.writeSession {
-                        model = AnthropicModels.Sonnet_3_7
+                        model = AnthropicModels.Sonnet_4_5
                         rewritePrompt {
                             prompt("test", params = LLMParams(toolChoice = LLMParams.ToolChoice.Auto)) {
                                 system(
@@ -410,7 +410,7 @@ class AIAgentMultipleLLMIntegrationTest {
             val openaiSubgraph by subgraph("openai") {
                 val definePromptOpenAI by node<Unit, Unit> {
                     llm.writeSession {
-                        model = OpenAIModels.Chat.GPT4o
+                        model = OpenAIModels.Chat.GPT5
                         rewritePrompt {
                             prompt("test", params = LLMParams(toolChoice = LLMParams.ToolChoice.Auto)) {
                                 system(
@@ -456,7 +456,7 @@ class AIAgentMultipleLLMIntegrationTest {
         return AIAgent(
             promptExecutor = executor,
             strategy = strategy,
-            agentConfig = AIAgentConfig(prompt, OpenAIModels.Chat.GPT4o, maxAgentIterations),
+            agentConfig = AIAgentConfig(prompt, OpenAIModels.Chat.GPT5, maxAgentIterations),
             toolRegistry = tools,
         ) {
             install(EventHandler, eventHandlerConfig)
@@ -686,7 +686,7 @@ class AIAgentMultipleLLMIntegrationTest {
     @Test
     fun integration_testAnthropicAgentEnumSerialization() {
         runBlocking {
-            val llmModel = AnthropicModels.Sonnet_3_7
+            val llmModel = AnthropicModels.Sonnet_4_5
             Models.assumeAvailable(llmModel.provider)
             val agent = AIAgent(
                 promptExecutor = simpleAnthropicExecutor(anthropicApiKey),

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
@@ -381,13 +381,12 @@ class AIAgentMultipleLLMIntegrationTest {
             val anthropicSubgraph by subgraph<String, Unit>("anthropic") {
                 val definePromptAnthropic by node<Unit, Unit> {
                     llm.writeSession {
-                        model = AnthropicModels.Sonnet_4_5
+                        model = AnthropicModels.Haiku_4_5
                         rewritePrompt {
                             prompt("test", params = LLMParams(toolChoice = LLMParams.ToolChoice.Auto)) {
                                 system(
                                     "You are a helpful assistant. You need to solve my task. " +
-                                        "CALL TOOLS!!! DO NOT SEND MESSAGES!!!!! ONLY SEND THE FINAL MESSAGE " +
-                                        "WHEN YOU ARE FINISHED AND EVERYTHING IS DONE AFTER CALLING THE TOOLS!"
+                                        "JUST CALL TOOLS. NO QUESTIONS ASKED."
                                 )
                             }
                         }
@@ -418,9 +417,7 @@ class AIAgentMultipleLLMIntegrationTest {
                                     You are a helpful assistant. You need to verify that the task is solved correctly.
                                     Please analyze the whole produced solution, and check that it is valid.
                                     Write concise verification result.
-                                    CALL TOOLS!!! DO NOT SEND MESSAGES!!!!!
-                                    ONLY SEND THE FINAL MESSAGE WHEN YOU ARE FINISHED AND EVERYTHING IS DONE
-                                    AFTER CALLING THE TOOLS! 
+                                    JUST CALL TOOLS. NO QUESTIONS ASKED.
                                     """.trimIndent()
                                 )
                             }
@@ -536,7 +533,7 @@ class AIAgentMultipleLLMIntegrationTest {
         val agent = createTestMultiLLMAgent(
             fs,
             eventHandlerConfig,
-            maxAgentIterations = 42,
+            maxAgentIterations = 50,
             eventsChannel = eventsChannel,
         )
 
@@ -780,7 +777,7 @@ class AIAgentMultipleLLMIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("modelsWithVisionCapability")
-    fun integration_testAgentWithImageCapabilityUrl(model: LLModel) = runTest(timeout = 3.minutes) {
+    fun integration_testAgentWithImageCapabilityUrl(model: LLModel) = runTest(timeout = 5.minutes) {
         Models.assumeAvailable(model.provider)
 
         val fs = MockFileSystem()
@@ -817,7 +814,7 @@ class AIAgentMultipleLLMIntegrationTest {
             val agent = createTestMultiLLMAgent(
                 fs,
                 eventHandlerConfig,
-                maxAgentIterations = 20,
+                maxAgentIterations = 50,
                 prompt = prompt,
             )
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/BedrockExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/BedrockExecutorIntegrationTest.kt
@@ -121,6 +121,18 @@ class BedrockExecutorIntegrationTest : ExecutorIntegrationTestBase() {
 
     @ParameterizedTest
     @MethodSource("bedrockCombinations")
+    fun integration_testToolsWithNullParamsBedrock(model: LLModel) {
+        integration_testToolsWithNullParams(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("bedrockCombinations")
+    fun integration_testToolsWithAnyOfParamsBedrock(model: LLModel) {
+        integration_testToolsWithAnyOfParams(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("bedrockCombinations")
     fun integration_testRawStringStreamingBedrock(model: LLModel) {
         integration_testRawStringStreaming(model)
     }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
@@ -409,11 +409,10 @@ abstract class ExecutorIntegrationTestBase {
 
         val executor = getExecutor(model)
 
-        withRetry(times = 3, testName = "integration_testToolsWithNestedListParams[${model.id}]") {
+        withRetry(times = 3, testName = "integration_testToolsWithNullParams[${model.id}]") {
             val response = executor.execute(prompt, model, listOf(nullGiverTool))
             assertTrue(response.isNotEmpty(), "Response should not be empty")
-            assertEquals(
-                true,
+            assertTrue(
                 response.first { it is Message.Tool.Call }.content.contains("null"),
                 "Tool call response should contain null"
             )
@@ -457,7 +456,7 @@ abstract class ExecutorIntegrationTestBase {
 
         val executor = getExecutor(model)
 
-        withRetry(times = 3, testName = "integration_testToolsWithNestedListParams[${model.id}]") {
+        withRetry(times = 3, testName = "integration_testToolsWithAnyOfParams[${model.id}]") {
             val response = executor.execute(prompt, model, listOf(anyOfTool))
             assertTrue(response.isNotEmpty(), "Response should not be empty")
             assertTrue(response.any { it is Message.Tool.Call })

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
@@ -386,6 +386,84 @@ abstract class ExecutorIntegrationTestBase {
         }
     }
 
+    open fun integration_testToolsWithNullParams(model: LLModel) = runTest(timeout = 300.seconds) {
+        Models.assumeAvailable(model.provider)
+        assumeTrue(model.capabilities.contains(LLMCapability.Tools), "Model $model does not support tools")
+
+        val nullGiverTool = ToolDescriptor(
+            name = "nullGiver",
+            description = "A tool that returns a null value",
+            requiredParameters = listOf(
+                ToolParameterDescriptor(
+                    name = "Null",
+                    description = "A null",
+                    type = ToolParameterType.Null
+                )
+            )
+        )
+
+        val prompt = Prompt.build("test-tools") {
+            system("You are a helpful assistant. ALWAYS CALL TOOL FIRST.")
+            user("Hi. Call a tool.")
+        }
+
+        val executor = getExecutor(model)
+
+        withRetry(times = 3, testName = "integration_testToolsWithNestedListParams[${model.id}]") {
+            val response = executor.execute(prompt, model, listOf(nullGiverTool))
+            assertTrue(response.isNotEmpty(), "Response should not be empty")
+            assertEquals(
+                true,
+                response.first { it is Message.Tool.Call }.content.contains("null"),
+                "Tool call response should contain null"
+            )
+        }
+    }
+
+    open fun integration_testToolsWithAnyOfParams(model: LLModel) = runTest(timeout = 300.seconds) {
+        Models.assumeAvailable(model.provider)
+        assumeTrue(model.provider != LLMProvider.Anthropic, "Anthropic does not support anyOf")
+        assumeTrue(model.capabilities.contains(LLMCapability.Tools), "Model $model does not support tools")
+
+        val anyOfTool = ToolDescriptor(
+            name = "stringNumberGiver",
+            description = "A tool that returns a string or number value",
+            requiredParameters = listOf(
+                ToolParameterDescriptor(
+                    name = "anyOfParam",
+                    description = "String or number parameter",
+                    type = ToolParameterType.AnyOf(
+                        types = arrayOf(
+                            ToolParameterDescriptor(
+                                name = "String",
+                                description = "String option",
+                                type = ToolParameterType.String
+                            ),
+                            ToolParameterDescriptor(
+                                name = "Number",
+                                description = "Number option",
+                                type = ToolParameterType.Float
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val prompt = Prompt.build("test-tools") {
+            system("You are a helpful assistant. ALWAYS CALL TOOL FIRST.")
+            user("Hi. Give me a word and a number.")
+        }
+
+        val executor = getExecutor(model)
+
+        withRetry(times = 3, testName = "integration_testToolsWithNestedListParams[${model.id}]") {
+            val response = executor.execute(prompt, model, listOf(anyOfTool))
+            assertTrue(response.isNotEmpty(), "Response should not be empty")
+            assertTrue(response.any { it is Message.Tool.Call })
+        }
+    }
+
     open fun integration_testStructuredDataStreaming(model: LLModel) = runTest(timeout = 300.seconds) {
         Models.assumeAvailable(model.provider)
         assumeTrue(model != OpenAIModels.CostOptimized.GPT4_1Nano, "Model $model is too small for structured streaming")

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/MultipleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/MultipleLLMPromptExecutorIntegrationTest.kt
@@ -154,6 +154,18 @@ class MultipleLLMPromptExecutorIntegrationTest : ExecutorIntegrationTestBase() {
 
     @ParameterizedTest
     @MethodSource("allModels")
+    override fun integration_testToolsWithNullParams(model: LLModel) {
+        super.integration_testToolsWithNullParams(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allModels")
+    override fun integration_testToolsWithAnyOfParams(model: LLModel) {
+        super.integration_testToolsWithAnyOfParams(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allModels")
     override fun integration_testRawStringStreaming(model: LLModel) {
         super.integration_testRawStringStreaming(model)
     }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/OllamaExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/OllamaExecutorIntegrationTest.kt
@@ -137,31 +137,31 @@ class OllamaExecutorIntegrationTest : ExecutorIntegrationTestBase() {
     @ParameterizedTest
     @MethodSource("modelParams")
     fun ollama_testRawStringStreaming(model: LLModel) {
-        super.integration_testRawStringStreaming(model)
+        integration_testRawStringStreaming(model)
     }
 
     @ParameterizedTest
     @MethodSource("modelParams")
     fun ollama_testStructuredDataStreaming(model: LLModel) {
-        super.integration_testStructuredDataStreaming(model)
+        integration_testStructuredDataStreaming(model)
     }
 
     @ParameterizedTest
     @MethodSource("modelParams")
     fun ollama_testToolChoiceRequired(model: LLModel) {
-        super.integration_testToolChoiceRequired(model)
+        integration_testToolChoiceRequired(model)
     }
 
     @ParameterizedTest
     @MethodSource("modelParams")
     fun ollama_testToolChoiceNone(model: LLModel) {
-        super.integration_testToolChoiceNone(model)
+        integration_testToolChoiceNone(model)
     }
 
     @ParameterizedTest
     @MethodSource("modelParams")
     fun ollama_testToolChoiceNamed(model: LLModel) {
-        super.integration_testToolChoiceNamed(model)
+        integration_testToolChoiceNamed(model)
     }
 
     // Ollama-specific moderation tests

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SingleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SingleLLMPromptExecutorIntegrationTest.kt
@@ -109,6 +109,18 @@ class SingleLLMPromptExecutorIntegrationTest : ExecutorIntegrationTestBase() {
 
     @ParameterizedTest
     @MethodSource("allModels")
+    override fun integration_testToolsWithNullParams(model: LLModel) {
+        super.integration_testToolsWithNullParams(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allModels")
+    override fun integration_testToolsWithAnyOfParams(model: LLModel) {
+        super.integration_testToolsWithAnyOfParams(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allModels")
     override fun integration_testRawStringStreaming(model: LLModel) {
         super.integration_testRawStringStreaming(model)
     }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ToolDescriptorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ToolDescriptorIntegrationTest.kt
@@ -108,9 +108,9 @@ class ToolDescriptorIntegrationTest {
         fun allModels(): Stream<LLModel> {
             return Stream.of(
                 OpenAIModels.CostOptimized.GPT4_1Mini,
-                AnthropicModels.Sonnet_3_7,
+                AnthropicModels.Sonnet_4_5,
                 GoogleModels.Gemini2_5Flash,
-                BedrockModels.AnthropicClaude35Haiku,
+                BedrockModels.AnthropicClaude4_5Haiku,
                 OpenRouterModels.Mistral7B,
             )
         }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/MediaTestScenarios.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/MediaTestScenarios.kt
@@ -60,14 +60,15 @@ object MediaTestScenarios {
         CORRUPTED_AUDIO
     }
 
+    val models = listOf(
+        AnthropicModels.Sonnet_4_5,
+        GoogleModels.Gemini2_5Flash, // see KG-256
+        OpenAIModels.Chat.GPT5,
+    )
+
     @JvmStatic
     fun markdownScenarioModelCombinations(): Stream<Arguments> {
         val scenarios = MarkdownTestScenario.entries.toTypedArray()
-        val models = listOf(
-            AnthropicModels.Sonnet_3_7,
-            GoogleModels.Gemini2_0Flash, // see KG-256
-            OpenAIModels.Chat.GPT4o,
-        )
         return scenarios.flatMap { scenario ->
             models.map { model ->
                 Arguments.of(scenario, model)
@@ -78,11 +79,6 @@ object MediaTestScenarios {
     @JvmStatic
     fun imageScenarioModelCombinations(): Stream<Arguments> {
         val scenarios = ImageTestScenario.entries.toTypedArray()
-        val models = listOf(
-            OpenAIModels.Chat.GPT4o,
-            AnthropicModels.Sonnet_3_7,
-            GoogleModels.Gemini2_5Pro
-        )
         return scenarios.flatMap { scenario ->
             models.map { model ->
                 Arguments.of(scenario, model)
@@ -93,11 +89,6 @@ object MediaTestScenarios {
     @JvmStatic
     fun textScenarioModelCombinations(): Stream<Arguments> {
         val scenarios = TextTestScenario.entries.toTypedArray()
-        val models = listOf(
-            OpenAIModels.Chat.GPT4o,
-            AnthropicModels.Sonnet_3_7,
-            GoogleModels.Gemini2_5Pro
-        )
         return scenarios.flatMap { scenario ->
             models.map { model ->
                 Arguments.of(scenario, model)
@@ -109,7 +100,7 @@ object MediaTestScenarios {
     fun audioScenarioModelCombinations(): Stream<Arguments> {
         val scenarios = AudioTestScenario.entries.toTypedArray()
         val models = listOf(
-            OpenAIModels.Audio.GPT4oAudio,
+            OpenAIModels.Audio.GptAudio,
             GoogleModels.Gemini2_5Pro
         )
         return scenarios.flatMap { scenario ->

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
@@ -44,7 +44,7 @@ object Models {
     fun bedrockModels(): Stream<LLModel> {
         return Stream.of(
             BedrockModels.MetaLlama3_1_70BInstruct,
-            BedrockModels.AmazonNovaPro,
+            BedrockModels.AmazonNovaPremier,
         )
     }
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
@@ -44,7 +44,7 @@ object Models {
     fun bedrockModels(): Stream<LLModel> {
         return Stream.of(
             BedrockModels.MetaLlama3_1_70BInstruct,
-            BedrockModels.AmazonNovaPremier,
+            BedrockModels.AnthropicClaude4_5Sonnet,
         )
     }
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
@@ -16,38 +16,17 @@ object Models {
     @JvmStatic
     fun openAIModels(): Stream<LLModel> {
         return Stream.of(
-            OpenAIModels.Chat.GPT4o,
-            OpenAIModels.Chat.GPT4_1,
             OpenAIModels.Chat.GPT5,
-            OpenAIModels.Chat.GPT5Mini,
-            OpenAIModels.Chat.GPT5Nano,
-            OpenAIModels.Chat.GPT5Codex,
-
-            OpenAIModels.Reasoning.O4Mini,
-            OpenAIModels.Reasoning.O3Mini,
-            OpenAIModels.Reasoning.O3,
             OpenAIModels.Reasoning.O1,
-
-            OpenAIModels.CostOptimized.GPT4_1Nano,
             OpenAIModels.CostOptimized.GPT4_1Mini,
-            OpenAIModels.CostOptimized.GPT4oMini,
         )
     }
 
     @JvmStatic
     fun anthropicModels(): Stream<LLModel> {
         return Stream.of(
-            AnthropicModels.Opus_3,
-            AnthropicModels.Opus_4,
             AnthropicModels.Opus_4_1,
-
-            AnthropicModels.Haiku_3,
-            AnthropicModels.Haiku_3_5,
             AnthropicModels.Haiku_4_5,
-
-            AnthropicModels.Sonnet_3_5,
-            AnthropicModels.Sonnet_3_7,
-            AnthropicModels.Sonnet_4,
             AnthropicModels.Sonnet_4_5,
         )
     }
@@ -56,12 +35,7 @@ object Models {
     fun googleModels(): Stream<LLModel> {
         return Stream.of(
             GoogleModels.Gemini2_5Pro,
-            GoogleModels.Gemini2_0Flash,
-            GoogleModels.Gemini2_0Flash001,
-            GoogleModels.Gemini2_0FlashLite,
-            GoogleModels.Gemini2_0FlashLite001,
             GoogleModels.Gemini2_5Flash,
-            GoogleModels.Gemini2_5FlashLite,
         )
     }
 
@@ -69,19 +43,13 @@ object Models {
     @JvmStatic
     fun bedrockModels(): Stream<LLModel> {
         return Stream.of(
-            BedrockModels.AnthropicClaude35Haiku,
-            BedrockModels.AnthropicClaude4Sonnet,
             BedrockModels.MetaLlama3_1_70BInstruct,
             BedrockModels.AmazonNovaPro,
-            BedrockModels.AmazonNovaLite,
         )
     }
 
     @JvmStatic
     fun openRouterModels(): Stream<LLModel> = Stream.of(
-        OpenRouterModels.GPT5Nano,
-        OpenRouterModels.Claude4Sonnet,
-        OpenRouterModels.Gemini2_5Flash,
         OpenRouterModels.DeepSeekV30324,
         OpenRouterModels.Qwen2_5,
     )

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
@@ -39,7 +39,6 @@ object Models {
         )
     }
 
-    // listing not all profiles but one from each LLM provider
     @JvmStatic
     fun bedrockModels(): Stream<LLModel> {
         return Stream.of(


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

Please add a brief description of the proposed change here.
Also, please tick the appropriate points in the checklist below.
-->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
1. As agreed with @skarpovdev after our discussion, we don't need to have all supported LLM profiles in test. The goal is to make sure each provider is working without issues.
2. Added tests for new tool param types – `anyOf` and `Null` (a follow-up to #953)
3. Fixed Ollama tests' naming
4. Fixed executor definition methods to include Bedrock and OpenRouter

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None
---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tests improvement
- [x] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [x] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
