### PR TITLE
Fix AdditionalPropertiesFlatteningSerializer act abnormal when json use JsonNamingStrategy.SnakeCase namingStrategy

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
@@ -6,6 +6,7 @@ import ai.koog.prompt.dsl.ModerationResult
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
 import ai.koog.prompt.executor.clients.LLMClient
+import ai.koog.prompt.executor.clients.serialization.RemainSerialNameJsonNamingStrategyWrapper
 import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
@@ -100,7 +101,7 @@ public open class AnthropicLLMClient(
         isLenient = true
         encodeDefaults = true // Ensure default values are included in serialization
         explicitNulls = false
-        namingStrategy = JsonNamingStrategy.SnakeCase
+        namingStrategy = RemainSerialNameJsonNamingStrategyWrapper(JsonNamingStrategy.SnakeCase)
     }
 
     private val httpClient = baseClient.config {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/DataModel.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/DataModel.kt
@@ -1,7 +1,8 @@
 package ai.koog.prompt.executor.clients.anthropic
 
 import ai.koog.prompt.executor.clients.InternalLLMClientApi
-import ai.koog.prompt.executor.clients.serialization.AdditionalPropertiesFlatteningSerializer
+import ai.koog.prompt.executor.clients.serialization.AdditionalPropertiesSerializer
+import ai.koog.prompt.executor.clients.serialization.RemainSerialName
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.EncodeDefault.Mode.ALWAYS
 import kotlinx.serialization.SerialName
@@ -39,6 +40,8 @@ public data class AnthropicMessageRequest(
     val stream: Boolean = false,
     @SerialName("tool_choice")
     val toolChoice: AnthropicToolChoice? = null,
+    @RemainSerialName
+    @SerialName("additionalProperties")
     val additionalProperties: Map<String, JsonElement>? = null,
 ) {
     init {
@@ -487,4 +490,4 @@ public sealed interface AnthropicToolChoice {
 }
 
 internal object AnthropicMessageRequestSerializer :
-    AdditionalPropertiesFlatteningSerializer<AnthropicMessageRequest>(AnthropicMessageRequest.serializer())
+    AdditionalPropertiesSerializer<AnthropicMessageRequest>(AnthropicMessageRequest.serializer())

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonTest/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonTest/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicSerializationTest.kt
@@ -1,9 +1,11 @@
 package ai.koog.prompt.executor.clients.anthropic
 
+import ai.koog.prompt.executor.clients.serialization.RemainSerialNameJsonNamingStrategyWrapper
 import ai.koog.test.utils.verifyDeserialization
 import io.kotest.assertions.json.shouldEqualJson
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNamingStrategy
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
@@ -22,6 +24,7 @@ class AnthropicSerializationTest {
         isLenient = true
         encodeDefaults = true // Ensure default values are included in serialization
         explicitNulls = false
+        namingStrategy = RemainSerialNameJsonNamingStrategyWrapper(JsonNamingStrategy.SnakeCase)
     }
 
     @Test

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/dashscope/models/DashscopeChatCompletion.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/dashscope/models/DashscopeChatCompletion.kt
@@ -11,7 +11,8 @@ import ai.koog.prompt.executor.clients.openai.base.models.OpenAIStreamOptions
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAITool
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIToolChoice
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIUsage
-import ai.koog.prompt.executor.clients.serialization.AdditionalPropertiesFlatteningSerializer
+import ai.koog.prompt.executor.clients.serialization.AdditionalPropertiesSerializer
+import ai.koog.prompt.executor.clients.serialization.RemainSerialName
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
@@ -53,6 +54,8 @@ internal class DashscopeChatCompletionRequest(
     val streamOptions: OpenAIStreamOptions? = null,
     val parallelToolCalls: Boolean? = null,
     val enableSearch: Boolean? = null,
+    @RemainSerialName
+    @SerialName("additionalProperties")
     val additionalProperties: Map<String, JsonElement>? = null,
 ) : OpenAIBaseLLMRequest
 
@@ -87,4 +90,4 @@ public class DashscopeChatCompletionStreamResponse(
 ) : OpenAIBaseLLMStreamResponse
 
 internal object DashscopeChatCompletionRequestSerializer :
-    AdditionalPropertiesFlatteningSerializer<DashscopeChatCompletionRequest>(DashscopeChatCompletionRequest.serializer())
+    AdditionalPropertiesSerializer<DashscopeChatCompletionRequest>(DashscopeChatCompletionRequest.serializer())

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/models/DeepSeekChatCompletion.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/models/DeepSeekChatCompletion.kt
@@ -11,7 +11,8 @@ import ai.koog.prompt.executor.clients.openai.base.models.OpenAIStreamOptions
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAITool
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIToolChoice
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIUsage
-import ai.koog.prompt.executor.clients.serialization.AdditionalPropertiesFlatteningSerializer
+import ai.koog.prompt.executor.clients.serialization.AdditionalPropertiesSerializer
+import ai.koog.prompt.executor.clients.serialization.RemainSerialName
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
@@ -79,6 +80,8 @@ internal class DeepSeekChatCompletionRequest(
     val stop: List<String>? = null,
     val logprobs: Boolean? = null,
     val streamOptions: OpenAIStreamOptions? = null,
+    @RemainSerialName
+    @SerialName("additionalProperties")
     val additionalProperties: Map<String, JsonElement>? = null,
 ) : OpenAIBaseLLMRequest
 
@@ -114,4 +117,4 @@ public class DeepSeekChatCompletionStreamResponse(
 ) : OpenAIBaseLLMStreamResponse
 
 internal object DeepSeekChatCompletionRequestSerializer :
-    AdditionalPropertiesFlatteningSerializer<DeepSeekChatCompletionRequest>(DeepSeekChatCompletionRequest.serializer())
+    AdditionalPropertiesSerializer<DeepSeekChatCompletionRequest>(DeepSeekChatCompletionRequest.serializer())

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/deepseek/models/DeepSeekSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/deepseek/models/DeepSeekSerializationTest.kt
@@ -2,8 +2,10 @@ package ai.koog.prompt.executor.clients.deepseek.models
 
 import ai.koog.prompt.executor.clients.openai.base.models.Content
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIMessage
+import ai.koog.prompt.executor.clients.serialization.RemainSerialNameJsonNamingStrategyWrapper
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNamingStrategy
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.booleanOrNull
@@ -25,6 +27,7 @@ class DeepSeekSerializationTest {
     private val json = Json {
         ignoreUnknownKeys = false
         explicitNulls = false
+        namingStrategy = RemainSerialNameJsonNamingStrategyWrapper(JsonNamingStrategy.SnakeCase)
     }
 
     @Test
@@ -42,7 +45,7 @@ class DeepSeekSerializationTest {
 
         assertEquals("deepseek-chat", jsonObject["model"]?.jsonPrimitive?.contentOrNull)
         assertEquals(0.7, jsonObject["temperature"]?.jsonPrimitive?.doubleOrNull)
-        assertEquals(1000, jsonObject["maxTokens"]?.jsonPrimitive?.intOrNull)
+        assertEquals(1000, jsonObject["max_tokens"]?.jsonPrimitive?.intOrNull)
         assertEquals(false, jsonObject["stream"]?.jsonPrimitive?.booleanOrNull)
         assertNull(jsonObject["customProperty"])
     }
@@ -92,7 +95,7 @@ class DeepSeekSerializationTest {
                 }
             )
             put("temperature", JsonPrimitive(0.7))
-            put("maxTokens", JsonPrimitive(1000))
+            put("max_tokens", JsonPrimitive(1000))
             put("stream", JsonPrimitive(false))
         }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/DataModel.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/DataModel.kt
@@ -1,6 +1,10 @@
 package ai.koog.prompt.executor.clients.google
 
-import ai.koog.prompt.executor.clients.serialization.AdditionalPropertiesFlatteningSerializer
+import ai.koog.prompt.executor.clients.google.GoogleFunctionCallingMode.ANY
+import ai.koog.prompt.executor.clients.google.GoogleFunctionCallingMode.AUTO
+import ai.koog.prompt.executor.clients.google.GoogleFunctionCallingMode.NONE
+import ai.koog.prompt.executor.clients.serialization.AdditionalPropertiesSerializer
+import ai.koog.prompt.executor.clients.serialization.RemainSerialName
 import ai.koog.utils.serializers.ByteArrayAsBase64Serializer
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerialName
@@ -301,6 +305,8 @@ internal class GoogleGenerationConfig(
     val topP: Double? = null,
     val topK: Int? = null,
     val thinkingConfig: GoogleThinkingConfig? = null,
+    @RemainSerialName
+    @SerialName("additionalProperties")
     val additionalProperties: Map<String, JsonElement>? = null,
 )
 
@@ -490,4 +496,4 @@ internal object GooglePartSerializer : JsonContentPolymorphicSerializer<GooglePa
  * `GoogleGenerationConfig`'s structure to manage known and unknown properties.
  */
 internal object GoogleGenerationConfigSerializer :
-    AdditionalPropertiesFlatteningSerializer<GoogleGenerationConfig>(GoogleGenerationConfig.serializer())
+    AdditionalPropertiesSerializer<GoogleGenerationConfig>(GoogleGenerationConfig.serializer())

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaModels.kt
@@ -1,6 +1,7 @@
 package ai.koog.prompt.executor.ollama.client.dto
 
-import ai.koog.prompt.executor.clients.serialization.AdditionalPropertiesFlatteningSerializer
+import ai.koog.prompt.executor.clients.serialization.AdditionalPropertiesSerializer
+import ai.koog.prompt.executor.clients.serialization.RemainSerialName
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
@@ -64,6 +65,8 @@ internal data class OllamaChatRequestDTO(
     val options: Options? = null,
     val stream: Boolean,
     @SerialName("keep_alive") val keepAlive: String? = null,
+    @RemainSerialName
+    @SerialName("additionalProperties")
     val additionalProperties: Map<String, JsonElement>? = null,
 ) {
     /**
@@ -125,4 +128,4 @@ internal data class EmbeddingResponseDTO(
 )
 
 internal object OllamaChatRequestDTOSerializer :
-    AdditionalPropertiesFlatteningSerializer<OllamaChatRequestDTO>(OllamaChatRequestDTO.serializer())
+    AdditionalPropertiesSerializer<OllamaChatRequestDTO>(OllamaChatRequestDTO.serializer())

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
@@ -24,6 +24,7 @@ import ai.koog.prompt.executor.clients.openai.base.models.OpenAIToolFunction
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIUsage
 import ai.koog.prompt.executor.clients.openai.base.structure.OpenAIBasicJsonSchemaGenerator
 import ai.koog.prompt.executor.clients.openai.base.structure.OpenAIStandardJsonSchemaGenerator
+import ai.koog.prompt.executor.clients.serialization.RemainSerialNameJsonNamingStrategyWrapper
 import ai.koog.prompt.executor.model.LLMChoice
 import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLMProvider
@@ -116,7 +117,7 @@ public abstract class AbstractOpenAILLMClient<TResponse : OpenAIBaseLLMResponse,
         isLenient = true
         encodeDefaults = true
         explicitNulls = false
-        namingStrategy = JsonNamingStrategy.SnakeCase
+        namingStrategy = RemainSerialNameJsonNamingStrategyWrapper(JsonNamingStrategy.SnakeCase)
     }
 
     protected val httpClient: KoogHttpClient = KoogHttpClient.fromKtorClient(

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIChatCompletion.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIChatCompletion.kt
@@ -17,11 +17,11 @@ import ai.koog.prompt.executor.clients.openai.base.models.OpenAIUsage
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIWebSearchOptions
 import ai.koog.prompt.executor.clients.openai.base.models.ReasoningEffort
 import ai.koog.prompt.executor.clients.openai.base.models.ServiceTier
-import ai.koog.prompt.executor.clients.serialization.AdditionalPropertiesFlatteningSerializer
+import ai.koog.prompt.executor.clients.serialization.AdditionalPropertiesSerializer
+import ai.koog.prompt.executor.clients.serialization.RemainSerialName
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
-import kotlin.collections.List
 
 /**
  * Chat completion request.
@@ -191,6 +191,8 @@ internal class OpenAIChatCompletionRequest(
     override val topP: Double? = null,
     val user: String? = null,
     val webSearchOptions: OpenAIWebSearchOptions? = null,
+    @RemainSerialName
+    @SerialName("additionalProperties")
     val additionalProperties: Map<String, JsonElement>? = null,
 ) : OpenAIBaseLLMRequest
 
@@ -305,4 +307,4 @@ public class OpenAIChatCompletionStreamResponse(
 ) : OpenAIBaseLLMStreamResponse
 
 internal object OpenAIChatCompletionRequestSerializer :
-    AdditionalPropertiesFlatteningSerializer<OpenAIChatCompletionRequest>(OpenAIChatCompletionRequest.serializer())
+    AdditionalPropertiesSerializer<OpenAIChatCompletionRequest>(OpenAIChatCompletionRequest.serializer())

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPI.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPI.kt
@@ -5,7 +5,8 @@ import ai.koog.prompt.executor.clients.openai.base.models.OpenAIBaseLLMResponse
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIChoiceLogProbs
 import ai.koog.prompt.executor.clients.openai.base.models.ReasoningEffort
 import ai.koog.prompt.executor.clients.openai.base.models.ServiceTier
-import ai.koog.prompt.executor.clients.serialization.AdditionalPropertiesFlatteningSerializer
+import ai.koog.prompt.executor.clients.serialization.AdditionalPropertiesSerializer
+import ai.koog.prompt.executor.clients.serialization.RemainSerialName
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.KSerializer
@@ -145,6 +146,8 @@ internal class OpenAIResponsesAPIRequest(
     val truncation: Truncation? = null,
     @Deprecated("Use safetyIdentifier and promptCacheKey instead")
     val user: String? = null,
+    @RemainSerialName
+    @SerialName("additionalProperties")
     val additionalProperties: Map<String, JsonElement>? = null,
 ) : OpenAIBaseLLMRequest
 
@@ -2363,4 +2366,4 @@ internal object OpenAIResponsesToolChoiceSerializer : KSerializer<OpenAIResponse
 }
 
 internal object OpenAIResponsesAPIRequestSerializer :
-    AdditionalPropertiesFlatteningSerializer<OpenAIResponsesAPIRequest>(OpenAIResponsesAPIRequest.serializer())
+    AdditionalPropertiesSerializer<OpenAIResponsesAPIRequest>(OpenAIResponsesAPIRequest.serializer())

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/models/OpenRouterChatCompletion.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/models/OpenRouterChatCompletion.kt
@@ -10,7 +10,8 @@ import ai.koog.prompt.executor.clients.openai.base.models.OpenAITool
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIToolCall
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIToolChoice
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIUsage
-import ai.koog.prompt.executor.clients.serialization.AdditionalPropertiesFlatteningSerializer
+import ai.koog.prompt.executor.clients.serialization.AdditionalPropertiesSerializer
+import ai.koog.prompt.executor.clients.serialization.RemainSerialName
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
@@ -49,6 +50,8 @@ internal class OpenRouterChatCompletionRequest(
     val route: String? = null,
     val provider: ProviderPreferences? = null,
     val user: String? = null,
+    @RemainSerialName
+    @SerialName("additionalProperties")
     val additionalProperties: Map<String, JsonElement>? = null,
 ) : OpenAIBaseLLMRequest
 
@@ -182,4 +185,4 @@ public class OpenRouterChatCompletionStreamResponse(
 ) : OpenAIBaseLLMStreamResponse
 
 internal object OpenRouterChatCompletionRequestSerializer :
-    AdditionalPropertiesFlatteningSerializer<OpenRouterChatCompletionRequest>(OpenRouterChatCompletionRequest.serializer())
+    AdditionalPropertiesSerializer<OpenRouterChatCompletionRequest>(OpenRouterChatCompletionRequest.serializer())

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/serialization/AdditionalPropertiesFlatteningSerializer.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/serialization/AdditionalPropertiesFlatteningSerializer.kt
@@ -1,8 +1,14 @@
 package ai.koog.prompt.executor.clients.serialization
 
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.elementNames
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonEncoder
 import kotlinx.serialization.json.JsonTransformingSerializer
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
@@ -15,12 +21,22 @@ import kotlinx.serialization.json.jsonObject
  *
  * @param knownProperties Set of known property names for the type
  */
-public abstract class AdditionalPropertiesFlatteningSerializer<T>(tSerializer: KSerializer<T>) :
+private class AdditionalPropertiesFlatteningSerializer<T>(
+    tSerializer: KSerializer<T>,
+    private val json: Json
+) :
     JsonTransformingSerializer<T>(tSerializer) {
 
     private val additionalPropertiesField = "additionalProperties"
 
-    private val knownProperties = tSerializer.descriptor.elementNames
+    private val knownProperties =
+        if (json.configuration.namingStrategy == null) {
+            tSerializer.descriptor.elementNames
+        } else {
+            tSerializer.descriptor.elementNames.mapIndexed { index, string ->
+                json.configuration.namingStrategy!!.serialNameForJson(tSerializer.descriptor, index, string)
+            }
+        }
 
     override fun transformSerialize(element: JsonElement): JsonElement {
         val obj = element.jsonObject
@@ -58,3 +74,35 @@ public abstract class AdditionalPropertiesFlatteningSerializer<T>(tSerializer: K
         }
     }
 }
+
+/**
+ * Wrap AdditionalPropertiesFlatteningSerializer
+ */
+public open class AdditionalPropertiesSerializer<T>(
+    private val baseSerializer: KSerializer<T>
+): KSerializer<T> {
+    override val descriptor: SerialDescriptor
+        get() = baseSerializer.descriptor
+
+    override fun serialize(encoder: Encoder, value: T) {
+        if (encoder is JsonEncoder) {
+            val json = encoder.json
+            val delegate = AdditionalPropertiesFlatteningSerializer(baseSerializer, json)
+            delegate.serialize(encoder, value)
+        } else {
+            baseSerializer.serialize(encoder, value)
+        }
+    }
+
+    override fun deserialize(decoder: Decoder): T {
+        if (decoder is JsonDecoder) {
+            val json = decoder.json
+            val delegate = AdditionalPropertiesFlatteningSerializer(baseSerializer, json)
+            return delegate.deserialize(decoder)
+        }
+        return baseSerializer.deserialize(decoder)
+    }
+
+}
+
+

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/serialization/util.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/serialization/util.kt
@@ -1,0 +1,32 @@
+package ai.koog.prompt.executor.clients.serialization
+
+import kotlinx.serialization.SerialInfo
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.json.JsonNamingStrategy
+
+/**
+ * Marker attributes are not affected by JsonNamingStrategy during serialization
+ * Takes effect when used with RemainSerialNameJsonNamingStrategyWrapper
+ */
+@SerialInfo
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.PROPERTY)
+public annotation class RemainSerialName
+
+/**
+ * Retain the original serialization name of properties annotated with {@link RemainSerialName},
+ * otherwise use the delegated naming strategy to determine the JSON name.
+ */
+public class RemainSerialNameJsonNamingStrategyWrapper(private val jsonNamingStrategy: JsonNamingStrategy): JsonNamingStrategy {
+    override fun serialNameForJson(
+        descriptor: SerialDescriptor,
+        elementIndex: Int,
+        serialName: String
+    ): String {
+        return if (descriptor.getElementAnnotations(elementIndex).any { it is RemainSerialName }) {
+            serialName
+        } else {
+            jsonNamingStrategy.serialNameForJson(descriptor, elementIndex, serialName)
+        }
+    }
+}


### PR DESCRIPTION
1. when `json` use `JsonNamingStrategy.SnakeCase` namingStrategy, `additionalProperties` will be converted to `additional_properties` when encoding. Considering that `AdditionalPropertiesFlatteningSerializer` uses `additionalProperties` for detection and not all clients use `JsonNamingStrategy.SnakeCase` namingStrategy, I think it would be a good solution to keep `additionalProperties` unchanged during serialization (even when namingStrategy is specified).
2. Currently, there's an issue with obtaining `knownProperties` in `AdditionalPropertiesFlatteningSerializer` where the name of a `JsonElement` for a property may not correspond to `tSerializer.descriptor.elementName` when a namingStrategy is specified. I attempted to add a json parameter to resolve this issue.

welcome your comments on my ideas or implementation issues.


## Motivation and Context
I encountered a problem when using OpenAILLMClient and specifying additionalProperties

## Breaking Changes
No

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
