### PR TITLE
KG-480. Return JSON element for input and output in Agent events

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentNode.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentNode.kt
@@ -163,7 +163,7 @@ public open class AIAgentNode<TInput, TOutput> internal constructor(
                     executeResult
                 } catch (t: Throwable) {
                     logger.error(t) { "Error executing node (name: $name): ${t.message}" }
-                    context.pipeline.onNodeExecutionFailed(this@AIAgentNode, context, t)
+                    context.pipeline.onNodeExecutionFailed(this@AIAgentNode, context, input, inputType, t)
                     throw t
                 }
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/node/NodeExecutionEventContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/node/NodeExecutionEventContext.kt
@@ -65,6 +65,8 @@ public data class NodeExecutionCompletedContext(
 public data class NodeExecutionFailedContext(
     val node: AIAgentNodeBase<*, *>,
     val context: AIAgentContext,
+    val input: Any?,
+    val inputType: KType,
     val throwable: Throwable
 ) : NodeExecutionEventContext {
     override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.NodeExecutionFailed

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/events/nodeExecutionEvents.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/events/nodeExecutionEvents.kt
@@ -3,6 +3,7 @@ package ai.koog.agents.core.feature.model.events
 import ai.koog.agents.core.feature.model.AIAgentError
 import kotlinx.datetime.Clock
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 
 /**
  * Represents an event triggered when the execution of a specific AI agent node starts.
@@ -23,7 +24,7 @@ import kotlinx.serialization.Serializable
 public data class NodeExecutionStartingEvent(
     val runId: String,
     val nodeName: String,
-    val input: String,
+    val input: JsonElement?,
     override val timestamp: Long = Clock.System.now().toEpochMilliseconds(),
 ) : DefinedFeatureEvent()
 
@@ -43,8 +44,8 @@ public data class NodeExecutionStartingEvent(
 public data class NodeExecutionCompletedEvent(
     val runId: String,
     val nodeName: String,
-    val input: String,
-    val output: String,
+    val input: JsonElement?,
+    val output: JsonElement?,
     override val timestamp: Long = Clock.System.now().toEpochMilliseconds(),
 ) : DefinedFeatureEvent()
 
@@ -62,6 +63,7 @@ public data class NodeExecutionCompletedEvent(
  *
  * @property runId A unique identifier associated with the specific run of the AI agent;
  * @property nodeName The name of the node where the error occurred;
+ * @property input The input data provided to the node;
  * @property error An instance of `AIAgentError` containing the error details, such as a message, stack trace, and optional cause;
  * @property timestamp The timestamp of the event, in milliseconds since the Unix epoch.
  */
@@ -69,6 +71,7 @@ public data class NodeExecutionCompletedEvent(
 public data class NodeExecutionFailedEvent(
     val runId: String,
     val nodeName: String,
+    val input: JsonElement?,
     val error: AIAgentError,
     override val timestamp: Long = Clock.System.now().toEpochMilliseconds(),
 ) : DefinedFeatureEvent()

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
@@ -61,6 +61,7 @@ public class AIAgentGraphPipeline(clock: Clock = Clock.System) : AIAgentPipeline
      * @param node The node that is about to be executed
      * @param context The agent context in which the node is being executed
      * @param input The input data for the node execution
+     * @param inputType The type of the input data provided to the node
      */
     public suspend fun onNodeExecutionStarting(
         node: AIAgentNodeBase<*, *>,
@@ -78,7 +79,9 @@ public class AIAgentGraphPipeline(clock: Clock = Clock.System) : AIAgentPipeline
      * @param node The node that was executed
      * @param context The agent context in which the node was executed
      * @param input The input data that was provided to the node
+     * @param inputType The type of the input data provided to the node
      * @param output The output data produced by the node execution
+     * @param outputType The type of the output data produced by the node execution
      */
     public suspend fun onNodeExecutionCompleted(
         node: AIAgentNodeBase<*, *>,
@@ -97,14 +100,18 @@ public class AIAgentGraphPipeline(clock: Clock = Clock.System) : AIAgentPipeline
      *
      * @param node The instance of the node where the error occurred.
      * @param context The context associated with the AI agent executing the node.
+     * @param input The input data provided to the node.
+     * @param inputType The type of the input data provided to the node.
      * @param throwable The exception or error that occurred during node execution.
      */
     public suspend fun onNodeExecutionFailed(
         node: AIAgentNodeBase<*, *>,
         context: AIAgentContext,
+        input: Any?,
+        inputType: KType,
         throwable: Throwable
     ) {
-        val eventContext = NodeExecutionFailedContext(node, context, throwable)
+        val eventContext = NodeExecutionFailedContext(node, context, input, inputType, throwable)
         executeNodeHandlers.values.forEach { handler -> handler.nodeExecutionFailedHandler.handle(eventContext) }
     }
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/remote/server/FeatureMessageRemoteServer.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/remote/server/FeatureMessageRemoteServer.kt
@@ -286,7 +286,7 @@ public class FeatureMessageRemoteServer(
                         data = serverEventData,
                     )
 
-                    logger.debug { "Feature Message Remote Server. Sending SSE server event: $serverEvent" }
+                    logger.trace { "Feature Message Remote Server. Sending SSE server event: $serverEvent" }
                     send(serverEvent)
                 } catch (t: CancellationException) {
                     logger.info {

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/utils/SerializationUtil.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/utils/SerializationUtil.kt
@@ -1,0 +1,54 @@
+package ai.koog.agents.core.utils
+
+import ai.koog.agents.core.annotation.InternalAgentsApi
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.serializerOrNull
+import kotlin.reflect.KType
+
+/**
+ * Utility object for handling serialization of input data to JSON using Kotlin Serialization.
+ */
+@InternalAgentsApi
+public object SerializationUtil {
+
+    private val json = Json {
+        prettyPrint = true
+    }
+
+    private val logger = KotlinLogging.logger { }
+
+    /**
+     * Attempts to serialize the given input data using the provided data type.
+     * Returns the serialized JsonElement if successful, or null if serialization fails.
+     */
+    @InternalAgentsApi
+    public fun trySerializeDataToJsonElement(data: Any?, dataType: KType): JsonElement? =
+        try {
+            serializeDataToJsonElement(data, dataType)
+        } catch (e: SerializationException) {
+            logger.debug { "Failed to serialize data: ${e.message}" }
+            null
+        }
+
+    /**
+     * Serializes the given input data into a JSON element using the specified data type.
+     * If no serializer is found for the data type, the function returns null.
+     *
+     * @param data The object to be serialized.
+     * @param dataType The type of the object used to find the appropriate serializer.
+     * @return A JsonElement representing the serialized data, or null if serialization fails.
+     */
+    @InternalAgentsApi
+    public fun serializeDataToJsonElement(data: Any?, dataType: KType): JsonElement? {
+        val serializer = json.serializersModule.serializerOrNull(dataType)
+        if (serializer == null) {
+            logger.debug { "No serializer found for data type: $dataType" }
+            return null
+        }
+
+        return json.encodeToJsonElement(serializer, data)
+    }
+}

--- a/agents/agents-features/agents-features-debugger/src/jvmTest/kotlin/ai/koog/agents/features/debugger/feature/DebuggerTest.kt
+++ b/agents/agents-features/agents-features-debugger/src/jvmTest/kotlin/ai/koog/agents/features/debugger/feature/DebuggerTest.kt
@@ -1,5 +1,6 @@
 package ai.koog.agents.features.debugger.feature
 
+import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.nodeExecuteTool
@@ -31,6 +32,7 @@ import ai.koog.agents.core.feature.remote.client.config.DefaultClientConnectionC
 import ai.koog.agents.core.feature.remote.server.config.DefaultServerConnectionConfig
 import ai.koog.agents.core.feature.writer.FeatureMessageRemoteWriter
 import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.core.utils.SerializationUtil
 import ai.koog.agents.features.debugger.SystemVariablesReader
 import ai.koog.agents.features.debugger.mock.ClientEventsCollector
 import ai.koog.agents.features.debugger.mock.MockLLMProvider
@@ -39,7 +41,7 @@ import ai.koog.agents.features.debugger.mock.createAgent
 import ai.koog.agents.features.debugger.mock.systemMessage
 import ai.koog.agents.features.debugger.mock.testClock
 import ai.koog.agents.features.debugger.mock.toolCallMessage
-import ai.koog.agents.features.debugger.mock.toolResult
+import ai.koog.agents.features.debugger.mock.toolResultMessage
 import ai.koog.agents.features.debugger.mock.userMessage
 import ai.koog.agents.testing.network.NetUtil
 import ai.koog.agents.testing.network.NetUtil.findAvailablePort
@@ -50,6 +52,7 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.llm.toModelInfo
 import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.utils.io.use
 import io.ktor.client.HttpClient
@@ -69,10 +72,12 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.io.IOException
+import kotlinx.serialization.json.JsonPrimitive
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
+import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -135,29 +140,30 @@ class DebuggerTest {
         val nodeExecuteToolName = "test-tool-call"
         val nodeSendToolResultName = "test-node-llm-send-tool-result"
 
-        val userPrompt = "Call the dummy tool with argument: test"
+        val dummyTool = DummyTool()
+        val requestedDummyToolArgs = "test"
+
+        val userPrompt = "Call the dummy tool with argument: $requestedDummyToolArgs"
         val systemPrompt = "Test system prompt"
         val assistantPrompt = "Test assistant prompt"
-        val promptId = "Test prompt id"
 
         val mockResponse = "Return test result"
-
-        // Tools
-        val dummyTool = DummyTool()
 
         val toolRegistry = ToolRegistry {
             tool(dummyTool)
         }
 
         // Model
+        val modelId = "test-llm-id"
         val testModel = LLModel(
             provider = MockLLMProvider(),
-            id = "test-llm-id",
+            id = modelId,
             capabilities = emptyList(),
             contextLength = 1_000,
         )
 
         // Prompt
+        val promptId = "Test prompt id"
         val expectedPrompt = Prompt(
             messages = listOf(
                 systemMessage(systemPrompt),
@@ -176,8 +182,16 @@ class DebuggerTest {
         val expectedLLMCallWithToolsPrompt = expectedPrompt.copy(
             messages = expectedPrompt.messages + listOf(
                 userMessage(content = userPrompt),
-                toolCallMessage(dummyTool.name, content = """{"dummy":"test"}"""),
-                toolResult("0", dummyTool.name, dummyTool.result, dummyTool.result).toMessage(clock = testClock)
+                toolCallMessage(
+                    toolName = dummyTool.name,
+                    content = """{"dummy":"$requestedDummyToolArgs"}"""
+                ),
+                toolResultMessage(
+                    toolCallId = "0",
+                    toolName = dummyTool.name,
+                    content = dummyTool.encodeResultToString(dummyTool.result),
+                    metaInfo = RequestMetaInfo.create(testClock)
+                )
             )
         )
 
@@ -205,7 +219,7 @@ class DebuggerTest {
             val mockExecutor = getMockExecutor(clock = testClock) {
                 mockLLMToolCall(
                     tool = dummyTool,
-                    args = DummyTool.Args("test"),
+                    args = DummyTool.Args(requestedDummyToolArgs),
                     toolCallId = "0"
                 ) onRequestEquals userPrompt
                 mockLLMAnswer(mockResponse) onRequestContains dummyTool.result
@@ -309,20 +323,36 @@ class DebuggerTest {
                     NodeExecutionStartingEvent(
                         runId = clientEventsCollector.runId,
                         nodeName = "__start__",
-                        input = userPrompt,
+                        input = @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = userPrompt,
+                            dataType = typeOf<String>()
+                        ),
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
                     NodeExecutionCompletedEvent(
                         runId = clientEventsCollector.runId,
                         nodeName = "__start__",
-                        input = userPrompt,
-                        output = userPrompt,
+                        input = @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = userPrompt,
+                            dataType = typeOf<String>()
+                        ),
+                        output = @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = userPrompt,
+                            dataType = typeOf<String>()
+                        ),
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
                     NodeExecutionStartingEvent(
                         runId = clientEventsCollector.runId,
                         nodeName = "test-llm-call",
-                        input = userPrompt,
+                        input = @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = userPrompt,
+                            dataType = typeOf<String>()
+                        ),
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
                     LLMCallStartingEvent(
@@ -336,20 +366,32 @@ class DebuggerTest {
                         runId = clientEventsCollector.runId,
                         prompt = expectedLLMCallPrompt,
                         model = testModel.toModelInfo(),
-                        responses = listOf(toolCallMessage(dummyTool.name, content = """{"dummy":"test"}""")),
+                        responses = listOf(toolCallMessage(dummyTool.name, content = """{"dummy":"$requestedDummyToolArgs"}""")),
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
                     NodeExecutionCompletedEvent(
                         runId = clientEventsCollector.runId,
                         nodeName = "test-llm-call",
-                        input = userPrompt,
-                        output = toolCallMessage(dummyTool.name, content = """{"dummy":"test"}""").toString(),
+                        input = @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = userPrompt,
+                            dataType = typeOf<String>()
+                        ),
+                        output = @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = toolCallMessage(dummyTool.name, content = """{"dummy":"$requestedDummyToolArgs"}"""),
+                            dataType = typeOf<Message>()
+                        ),
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
                     NodeExecutionStartingEvent(
                         runId = clientEventsCollector.runId,
                         nodeName = "test-tool-call",
-                        input = toolCallMessage(dummyTool.name, content = """{"dummy":"test"}""").toString(),
+                        input = @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = toolCallMessage(dummyTool.name, content = """{"dummy":"$requestedDummyToolArgs"}"""),
+                            dataType = typeOf<Message.Tool.Call>()
+                        ),
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
                     ToolCallStartingEvent(
@@ -370,14 +412,20 @@ class DebuggerTest {
                     NodeExecutionCompletedEvent(
                         runId = clientEventsCollector.runId,
                         nodeName = "test-tool-call",
-                        input = toolCallMessage(dummyTool.name, content = """{"dummy":"test"}""").toString(),
-                        output = toolResult("0", dummyTool.name, dummyTool.result, dummyTool.result).toString(),
+                        input = @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = toolCallMessage(toolName = dummyTool.name, content = """{"dummy":"$requestedDummyToolArgs"}"""),
+                            dataType = typeOf<Message.Tool.Call>()
+                        ),
+                        // TODO: KG-485. Update to include serialized [ReceivedToolResult] when it became a serializable type.
+                        output = JsonPrimitive(dummyTool.result),
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
                     NodeExecutionStartingEvent(
                         runId = clientEventsCollector.runId,
                         nodeName = "test-node-llm-send-tool-result",
-                        input = toolResult("0", dummyTool.name, dummyTool.result, dummyTool.result).toString(),
+                        // TODO: KG-485. Update to include serialized [ReceivedToolResult] when it became a serializable type.
+                        input = JsonPrimitive(dummyTool.result),
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
                     LLMCallStartingEvent(
@@ -397,21 +445,38 @@ class DebuggerTest {
                     NodeExecutionCompletedEvent(
                         runId = clientEventsCollector.runId,
                         nodeName = "test-node-llm-send-tool-result",
-                        input = toolResult("0", dummyTool.name, dummyTool.result, dummyTool.result).toString(),
-                        output = assistantMessage(mockResponse).toString(),
+                        // TODO: KG-485. Update to include serialized [ReceivedToolResult] when it became a serializable type.
+                        input = JsonPrimitive(dummyTool.result),
+                        output = @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = assistantMessage(mockResponse),
+                            dataType = typeOf<Message>()
+                        ),
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
                     NodeExecutionStartingEvent(
                         runId = clientEventsCollector.runId,
                         nodeName = "__finish__",
-                        input = mockResponse,
+                        input = @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = mockResponse,
+                            dataType = typeOf<String>()
+                        ),
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
                     NodeExecutionCompletedEvent(
                         runId = clientEventsCollector.runId,
                         nodeName = "__finish__",
-                        input = mockResponse,
-                        output = mockResponse,
+                        input = @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = mockResponse,
+                            dataType = typeOf<String>()
+                        ),
+                        output = @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = mockResponse,
+                            dataType = typeOf<String>()
+                        ),
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
                     StrategyCompletedEvent(
@@ -1027,27 +1092,51 @@ class DebuggerTest {
                     NodeExecutionStartingEvent(
                         runId = clientEventsCollector.runId,
                         nodeName = "__start__",
-                        input = userPrompt,
+                        input = @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = userPrompt,
+                            dataType = typeOf<String>()
+                        ),
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
                     NodeExecutionCompletedEvent(
                         runId = clientEventsCollector.runId,
                         nodeName = "__start__",
-                        input = userPrompt,
-                        output = userPrompt,
+                        input = @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = userPrompt,
+                            dataType = typeOf<String>()
+                        ),
+                        output = @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = userPrompt,
+                            dataType = typeOf<String>()
+                        ),
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
                     NodeExecutionStartingEvent(
                         runId = clientEventsCollector.runId,
                         nodeName = "__finish__",
-                        input = userPrompt,
+                        input = @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = userPrompt,
+                            dataType = typeOf<String>()
+                        ),
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
                     NodeExecutionCompletedEvent(
                         runId = clientEventsCollector.runId,
                         nodeName = "__finish__",
-                        input = userPrompt,
-                        output = userPrompt,
+                        input = @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = userPrompt,
+                            dataType = typeOf<String>()
+                        ),
+                        output = @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = userPrompt,
+                            dataType = typeOf<String>()
+                        ),
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
                     StrategyCompletedEvent(

--- a/agents/agents-features/agents-features-debugger/src/jvmTest/kotlin/ai/koog/agents/features/debugger/mock/TestAgent.kt
+++ b/agents/agents-features/agents-features-debugger/src/jvmTest/kotlin/ai/koog/agents/features/debugger/mock/TestAgent.kt
@@ -77,12 +77,20 @@ fun toolCallMessage(toolName: String, content: String): Message.Tool.Call =
         metaInfo = ResponseMetaInfo.create(testClock)
     )
 
-fun toolResult(toolCallId: String?, toolName: String, content: String, result: String): ReceivedToolResult =
+fun receivedToolResult(toolCallId: String?, toolName: String, content: String, result: String): ReceivedToolResult =
     ReceivedToolResult(
         id = toolCallId,
         tool = toolName,
         content = content,
         result = result
+    )
+
+fun toolResultMessage(toolCallId: String?, toolName: String, content: String, metaInfo: RequestMetaInfo): Message.Tool.Result =
+    Message.Tool.Result(
+        id = toolCallId,
+        tool = toolName,
+        content = content,
+        metaInfo = metaInfo
     )
 
 /**

--- a/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/feature/Tracing.kt
+++ b/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/feature/Tracing.kt
@@ -3,6 +3,7 @@ package ai.koog.agents.features.tracing.feature
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.agent.entity.AIAgentStorageKey
 import ai.koog.agents.core.annotation.InternalAgentsApi
+import ai.koog.agents.core.environment.ReceivedToolResult
 import ai.koog.agents.core.feature.AIAgentGraphFeature
 import ai.koog.agents.core.feature.message.FeatureMessage
 import ai.koog.agents.core.feature.message.FeatureMessageProcessorUtil.onMessageForEachCatching
@@ -29,8 +30,13 @@ import ai.koog.agents.core.feature.model.events.startNodeToGraph
 import ai.koog.agents.core.feature.model.toAgentError
 import ai.koog.agents.core.feature.pipeline.AIAgentGraphPipeline
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.utils.SerializationUtil
 import ai.koog.prompt.llm.toModelInfo
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.reflect.KType
 
 /**
  * Feature that collects comprehensive tracing data during agent execution and sends it to configured feature message processors.
@@ -187,7 +193,7 @@ public class Tracing {
                 val event = NodeExecutionStartingEvent(
                     runId = eventContext.context.runId,
                     nodeName = eventContext.node.name,
-                    input = eventContext.input?.toString() ?: "",
+                    input = getNodeData(eventContext.input, eventContext.inputType),
                     timestamp = pipeline.clock.now().toEpochMilliseconds()
                 )
                 processMessage(config, event)
@@ -197,8 +203,8 @@ public class Tracing {
                 val event = NodeExecutionCompletedEvent(
                     runId = eventContext.context.runId,
                     nodeName = eventContext.node.name,
-                    input = eventContext.input?.toString() ?: "",
-                    output = eventContext.output?.toString() ?: "",
+                    input = getNodeData(eventContext.input, eventContext.inputType),
+                    output = getNodeData(eventContext.output, eventContext.outputType),
                     timestamp = pipeline.clock.now().toEpochMilliseconds()
                 )
                 processMessage(config, event)
@@ -208,6 +214,7 @@ public class Tracing {
                 val event = NodeExecutionFailedEvent(
                     runId = eventContext.context.runId,
                     nodeName = eventContext.node.name,
+                    input = getNodeData(eventContext.input, eventContext.inputType),
                     error = eventContext.throwable.toAgentError(),
                     timestamp = pipeline.clock.now().toEpochMilliseconds()
                 )
@@ -249,7 +256,7 @@ public class Tracing {
                 val event = LLMStreamingStartingEvent(
                     runId = eventContext.runId,
                     prompt = eventContext.prompt,
-                    model = eventContext.model.toModelInfo().eventString,
+                    model = eventContext.model.toModelInfo().modelIdentifierName,
                     tools = eventContext.tools.map { it.name },
                     timestamp = pipeline.clock.now().toEpochMilliseconds()
                 )
@@ -260,7 +267,7 @@ public class Tracing {
                 val event = LLMStreamingCompletedEvent(
                     runId = eventContext.runId,
                     prompt = eventContext.prompt,
-                    model = eventContext.model.toModelInfo().eventString,
+                    model = eventContext.model.toModelInfo().modelIdentifierName,
                     tools = eventContext.tools.map { it.name },
                     timestamp = pipeline.clock.now().toEpochMilliseconds()
                 )
@@ -361,6 +368,27 @@ public class Tracing {
 
         private suspend fun processMessage(config: TraceFeatureConfig, message: FeatureMessage) {
             config.messageProcessors.onMessageForEachCatching(message)
+        }
+
+        /**
+         * Retrieves the JSON representation of the given data based on its type.
+         *
+         * Note: See [KG-485](https://youtrack.jetbrains.com/issue/KG-485)
+         *       Workaround for processing non-serializable [ReceivedToolResult] type in the node input/output.
+         */
+        private fun getNodeData(data: Any?, dataType: KType): JsonElement? {
+            data ?: return null
+
+            return when (data) {
+                is ReceivedToolResult -> {
+                    runCatching { Json.parseToJsonElement(data.content) }.getOrNull()
+                        ?: JsonPrimitive(data.content)
+                }
+                else -> {
+                    @OptIn(InternalAgentsApi::class)
+                    SerializationUtil.trySerializeDataToJsonElement(data, dataType)
+                }
+            }
         }
 
         //endregion Private Methods

--- a/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/messageFormat.kt
+++ b/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/messageFormat.kt
@@ -1,7 +1,6 @@
 package ai.koog.agents.features.tracing
 
 import ai.koog.prompt.dsl.Prompt
-import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 
 /**
@@ -37,18 +36,4 @@ internal val Prompt.traceString: String
  * summary of the message content and its associated role is required.
  */
 internal val Message.Response.traceString: String
-    get() {
-        return "role: $role, message: $content"
-    }
-
-/**
- * A property that combines the provider ID and the model ID of an `LLModel` instance into a single string.
- *
- * It constructs a formatted identifier in the form of `providerId:modelId`, where:
- * - `providerId` is the unique identifier of the `LLMProvider` associated with the model.
- * - `modelId` is the unique identifier for the specific model instance.
- *
- * This property is typically used to uniquely identify an LLM instance for logging, tracing, or serialization purposes.
- */
-internal val LLModel.eventString: String
-    get() = "${this.provider.id}:${this.id}"
+    get() = "role: $role, message: $content"

--- a/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/writer/traceMessageFormat.kt
+++ b/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/writer/traceMessageFormat.kt
@@ -59,10 +59,10 @@ internal val NodeExecutionFailedEvent.nodeExecutionErrorEventFormat
     get() = "${this::class.simpleName} (run id: $runId, node: $nodeName, error: ${error.message})"
 
 internal val LLMCallStartingEvent.beforeLLMCallEventFormat
-    get() = "${this::class.simpleName} (run id: $runId, prompt: ${prompt.traceString}, model: ${model.eventString}, tools: [${tools.joinToString()}])"
+    get() = "${this::class.simpleName} (run id: $runId, prompt: ${prompt.traceString}, model: ${model.modelIdentifierName}, tools: [${tools.joinToString()}])"
 
 internal val LLMCallCompletedEvent.afterLLMCallEventFormat
-    get() = "${this::class.simpleName} (run id: $runId, prompt: ${prompt.traceString}, model: ${model.eventString}, responses: [${responses.joinToString { "{${it.traceString}}" }}])"
+    get() = "${this::class.simpleName} (run id: $runId, prompt: ${prompt.traceString}, model: ${model.modelIdentifierName}, responses: [${responses.joinToString { "{${it.traceString}}" }}])"
 
 internal val ToolCallStartingEvent.toolCallEventFormat
     get() = "${this::class.simpleName} (run id: $runId, tool: $toolName, tool args: $toolArgs)"

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/mock/TestAgent.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/mock/TestAgent.kt
@@ -76,7 +76,7 @@ fun toolCallMessage(toolName: String, content: String): Message.Tool.Call =
         metaInfo = ResponseMetaInfo.create(testClock)
     )
 
-fun toolResult(toolCallId: String?, toolName: String, content: String, result: String): ReceivedToolResult =
+fun receivedToolResult(toolCallId: String?, toolName: String, content: String, result: String): ReceivedToolResult =
     ReceivedToolResult(
         id = toolCallId,
         tool = toolName,

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageFileWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageFileWriterTest.kt
@@ -1,5 +1,6 @@
 package ai.koog.agents.features.tracing.writer
 
+import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.nodeExecuteTool
@@ -22,15 +23,15 @@ import ai.koog.agents.core.feature.model.events.StrategyCompletedEvent
 import ai.koog.agents.core.feature.model.events.ToolCallCompletedEvent
 import ai.koog.agents.core.feature.model.events.ToolCallStartingEvent
 import ai.koog.agents.core.tools.ToolRegistry
-import ai.koog.agents.features.tracing.eventString
+import ai.koog.agents.core.utils.SerializationUtil
 import ai.koog.agents.features.tracing.feature.Tracing
 import ai.koog.agents.features.tracing.mock.MockLLMProvider
 import ai.koog.agents.features.tracing.mock.assistantMessage
 import ai.koog.agents.features.tracing.mock.createAgent
+import ai.koog.agents.features.tracing.mock.receivedToolResult
 import ai.koog.agents.features.tracing.mock.systemMessage
 import ai.koog.agents.features.tracing.mock.testClock
 import ai.koog.agents.features.tracing.mock.toolCallMessage
-import ai.koog.agents.features.tracing.mock.toolResult
 import ai.koog.agents.features.tracing.mock.userMessage
 import ai.koog.agents.features.tracing.traceString
 import ai.koog.agents.testing.tools.DummyTool
@@ -38,17 +39,20 @@ import ai.koog.agents.testing.tools.getMockExecutor
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.llm.toModelInfo
+import ai.koog.prompt.message.Message
 import ai.koog.utils.io.use
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.Sink
 import kotlinx.io.buffered
 import kotlinx.io.files.SystemFileSystem
+import kotlinx.serialization.json.JsonPrimitive
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.listDirectoryEntries
 import kotlin.io.path.pathString
 import kotlin.io.path.readLines
+import kotlin.reflect.typeOf
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -122,8 +126,12 @@ class TraceFeatureMessageFileWriterTest {
             }
 
             val mockExecutor = getMockExecutor(clock = testClock) {
-                mockLLMToolCall(tool = dummyTool, args = DummyTool.Args("test"), toolCallId = "0") onRequestEquals
-                    userPrompt
+                mockLLMToolCall(
+                    tool = dummyTool,
+                    args = DummyTool.Args("test"),
+                    toolCallId = "0"
+                ) onRequestEquals userPrompt
+
                 mockLLMAnswer(mockResponse) onRequestContains dummyTool.result
             }
 
@@ -156,57 +164,78 @@ class TraceFeatureMessageFileWriterTest {
             val expectedMessages = listOf(
                 "${AgentStartingEvent::class.simpleName} (agent id: $agentId, run id: $runId)",
                 "${GraphStrategyStartingEvent::class.simpleName} (run id: $runId, strategy: $strategyName)",
-                "${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: __start__, input: $userPrompt)",
-                "${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: __start__, input: $userPrompt, output: $userPrompt)",
-                "${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: test-llm-call, input: $userPrompt)",
+                "${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: __start__, " +
+                    "input: \"$userPrompt\"" +
+                    ")",
+                "${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: __start__, " +
+                    "input: \"$userPrompt\", " +
+                    "output: \"$userPrompt\"" +
+                    ")",
+                "${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: test-llm-call, " +
+                    "input: \"$userPrompt\"" +
+                    ")",
                 "${LLMCallStartingEvent::class.simpleName} (run id: $runId, prompt: ${
                     expectedPrompt.copy(
                         messages = expectedPrompt.messages + userMessage(
                             content = userPrompt
                         )
                     ).traceString
-                }, model: ${testModel.toModelInfo().eventString}, tools: [${dummyTool.name}])",
+                }, model: ${testModel.toModelInfo().modelIdentifierName}, tools: [${dummyTool.name}])",
                 "${LLMCallCompletedEvent::class.simpleName} (run id: $runId, prompt: ${
                     expectedPrompt.copy(
                         messages = expectedPrompt.messages + userMessage(
                             content = userPrompt
                         )
                     ).traceString
-                }, model: ${testModel.toModelInfo().eventString}, responses: [{role: Tool, message: {\"dummy\":\"test\"}}])",
-                "${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: test-llm-call, input: $userPrompt, output: ${
-                    toolCallMessage(
-                        dummyTool.name,
-                        content = """{"dummy":"test"}"""
-                    )
-                })",
-                "${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: test-tool-call, input: ${
-                    toolCallMessage(
-                        dummyTool.name,
-                        content = """{"dummy":"test"}"""
-                    )
-                })",
+                }, model: ${testModel.toModelInfo().modelIdentifierName}, responses: [{role: Tool, message: {\"dummy\":\"test\"}}])",
+                "${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: test-llm-call, " +
+                    "input: \"$userPrompt\", " +
+                    "output: ${
+                        @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = toolCallMessage(
+                                toolName = dummyTool.name,
+                                content = """{"dummy":"test"}"""
+                            ),
+                            dataType = typeOf<Message>()
+                        )}" +
+                    ")",
+                "${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: test-tool-call, " +
+                    "input: ${
+                        @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = toolCallMessage(
+                                toolName = dummyTool.name,
+                                content = """{"dummy":"test"}"""
+                            ),
+                            dataType = typeOf<Message.Tool.Call>()
+                        )}" +
+                    ")",
                 "${ToolCallStartingEvent::class.simpleName} (run id: $runId, tool: ${dummyTool.name}, tool args: {\"dummy\":\"test\"})",
                 "${ToolCallCompletedEvent::class.simpleName} (run id: $runId, tool: ${dummyTool.name}, tool args: {\"dummy\":\"test\"}, result: ${dummyTool.result})",
-                "${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: test-tool-call, input: ${
-                    toolCallMessage(
-                        dummyTool.name,
-                        content = """{"dummy":"test"}"""
-                    )
-                }, output: ${toolResult("0", dummyTool.name, dummyTool.result, dummyTool.result)})",
-                "${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: test-node-llm-send-tool-result, input: ${
-                    toolResult(
-                        "0",
-                        dummyTool.name,
-                        dummyTool.result,
-                        dummyTool.result
-                    )
-                })",
+                "${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: test-tool-call, " +
+                    "input: ${
+                        @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = toolCallMessage(
+                                toolName = dummyTool.name,
+                                content = """{"dummy":"test"}"""
+                            ),
+                            dataType = typeOf<Message.Tool.Call>()
+                        )}, " +
+                    "output: ${JsonPrimitive(dummyTool.result)}" +
+                    ")",
+                "${NodeExecutionStartingEvent::class.simpleName} (" +
+                    "run id: $runId, " +
+                    "node: test-node-llm-send-tool-result, " +
+                    "input: ${JsonPrimitive(dummyTool.result)}" +
+                    ")",
                 "${LLMCallStartingEvent::class.simpleName} (run id: $runId, prompt: ${
                     expectedPrompt.copy(
                         messages = expectedPrompt.messages + listOf(
                             userMessage(content = userPrompt),
                             toolCallMessage(dummyTool.name, content = """{"dummy":"test"}"""),
-                            toolResult(
+                            receivedToolResult(
                                 "0",
                                 dummyTool.name,
                                 dummyTool.result,
@@ -214,13 +243,13 @@ class TraceFeatureMessageFileWriterTest {
                             ).toMessage(clock = testClock)
                         )
                     ).traceString
-                }, model: ${testModel.toModelInfo().eventString}, tools: [${dummyTool.name}])",
+                }, model: ${testModel.toModelInfo().modelIdentifierName}, tools: [${dummyTool.name}])",
                 "${LLMCallCompletedEvent::class.simpleName} (run id: $runId, prompt: ${
                     expectedPrompt.copy(
                         messages = expectedPrompt.messages + listOf(
                             userMessage(content = userPrompt),
                             toolCallMessage(dummyTool.name, content = """{"dummy":"test"}"""),
-                            toolResult(
+                            receivedToolResult(
                                 "0",
                                 dummyTool.name,
                                 dummyTool.result,
@@ -228,17 +257,18 @@ class TraceFeatureMessageFileWriterTest {
                             ).toMessage(clock = testClock)
                         )
                     ).traceString
-                }, model: ${testModel.eventString}, responses: [{${expectedResponse.traceString}}])",
-                "${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: test-node-llm-send-tool-result, input: ${
-                    toolResult(
-                        "0",
-                        dummyTool.name,
-                        dummyTool.result,
-                        dummyTool.result
-                    )
-                }, output: $expectedResponse)",
-                "${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: __finish__, input: $mockResponse)",
-                "${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: __finish__, input: $mockResponse, output: $mockResponse)",
+                }, model: ${testModel.toModelInfo().modelIdentifierName}, responses: [{${expectedResponse.traceString}}])",
+                "${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: test-node-llm-send-tool-result, " +
+                    "input: ${JsonPrimitive(dummyTool.result)}, " +
+                    "output: ${
+                        @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = expectedResponse,
+                            dataType = typeOf<Message>()
+                        )}" +
+                    ")",
+                "${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: __finish__, input: \"$mockResponse\")",
+                "${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: __finish__, input: \"$mockResponse\", output: \"$mockResponse\")",
                 "${StrategyCompletedEvent::class.simpleName} (run id: $runId, strategy: $strategyName, result: $mockResponse)",
                 "${AgentCompletedEvent::class.simpleName} (agent id: $agentId, run id: $runId, result: $mockResponse)",
                 "${AgentClosingEvent::class.simpleName} (agent id: $agentId)",
@@ -477,20 +507,20 @@ class TraceFeatureMessageFileWriterTest {
                             content = userPrompt
                         )
                     ).traceString
-                }, model: ${testModel.toModelInfo().eventString}, tools: [${dummyTool.name}])",
+                }, model: ${testModel.toModelInfo().modelIdentifierName}, tools: [${dummyTool.name}])",
                 "${LLMCallCompletedEvent::class.simpleName} (run id: $runId, prompt: ${
                     expectedPrompt.copy(
                         messages = expectedPrompt.messages + userMessage(
                             content = userPrompt
                         )
                     ).traceString
-                }, model: ${testModel.toModelInfo().eventString}, responses: [{role: Tool, message: {\"dummy\":\"test\"}}])",
+                }, model: ${testModel.toModelInfo().modelIdentifierName}, responses: [{role: Tool, message: {\"dummy\":\"test\"}}])",
                 "${LLMCallStartingEvent::class.simpleName} (run id: $runId, prompt: ${
                     expectedPrompt.copy(
                         messages = expectedPrompt.messages + listOf(
                             userMessage(content = userPrompt),
                             toolCallMessage(dummyTool.name, content = """{"dummy":"test"}"""),
-                            toolResult(
+                            receivedToolResult(
                                 "0",
                                 dummyTool.name,
                                 dummyTool.result,
@@ -498,13 +528,13 @@ class TraceFeatureMessageFileWriterTest {
                             ).toMessage(clock = testClock)
                         )
                     ).traceString
-                }, model: ${testModel.toModelInfo().eventString}, tools: [${dummyTool.name}])",
+                }, model: ${testModel.toModelInfo().modelIdentifierName}, tools: [${dummyTool.name}])",
                 "${LLMCallCompletedEvent::class.simpleName} (run id: $runId, prompt: ${
                     expectedPrompt.copy(
                         messages = expectedPrompt.messages + listOf(
                             userMessage(content = userPrompt),
                             toolCallMessage(dummyTool.name, content = """{"dummy":"test"}"""),
-                            toolResult(
+                            receivedToolResult(
                                 "0",
                                 dummyTool.name,
                                 dummyTool.result,
@@ -512,7 +542,7 @@ class TraceFeatureMessageFileWriterTest {
                             ).toMessage(clock = testClock)
                         )
                     ).traceString
-                }, model: ${testModel.eventString}, responses: [{${expectedResponse.traceString}}])",
+                }, model: ${testModel.toModelInfo().modelIdentifierName}, responses: [{${expectedResponse.traceString}}])",
             )
 
             val actualMessages = writer.targetPath.readLines()

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageLogWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageLogWriterTest.kt
@@ -1,5 +1,6 @@
 package ai.koog.agents.features.tracing.writer
 
+import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.nodeExecuteTool
@@ -22,24 +23,28 @@ import ai.koog.agents.core.feature.model.events.StrategyCompletedEvent
 import ai.koog.agents.core.feature.model.events.ToolCallCompletedEvent
 import ai.koog.agents.core.feature.model.events.ToolCallStartingEvent
 import ai.koog.agents.core.tools.ToolRegistry
-import ai.koog.agents.features.tracing.eventString
+import ai.koog.agents.core.utils.SerializationUtil
 import ai.koog.agents.features.tracing.feature.Tracing
 import ai.koog.agents.features.tracing.mock.MockLLMProvider
 import ai.koog.agents.features.tracing.mock.TestLogger
 import ai.koog.agents.features.tracing.mock.assistantMessage
 import ai.koog.agents.features.tracing.mock.createAgent
+import ai.koog.agents.features.tracing.mock.receivedToolResult
 import ai.koog.agents.features.tracing.mock.systemMessage
 import ai.koog.agents.features.tracing.mock.testClock
 import ai.koog.agents.features.tracing.mock.toolCallMessage
-import ai.koog.agents.features.tracing.mock.toolResult
 import ai.koog.agents.features.tracing.mock.userMessage
 import ai.koog.agents.features.tracing.traceString
 import ai.koog.agents.testing.tools.DummyTool
 import ai.koog.agents.testing.tools.getMockExecutor
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.llm.toModelInfo
+import ai.koog.prompt.message.Message
 import ai.koog.utils.io.use
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.reflect.typeOf
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -144,57 +149,69 @@ class TraceFeatureMessageLogWriterTest {
             val expectedLogMessages = listOf(
                 "[INFO] Received feature message [event]: ${AgentStartingEvent::class.simpleName} (agent id: $agentId, run id: $runId)",
                 "[INFO] Received feature message [event]: ${GraphStrategyStartingEvent::class.simpleName} (run id: $runId, strategy: $strategyName)",
-                "[INFO] Received feature message [event]: ${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: __start__, input: $userPrompt)",
-                "[INFO] Received feature message [event]: ${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: __start__, input: $userPrompt, output: $userPrompt)",
-                "[INFO] Received feature message [event]: ${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: test-llm-call, input: $userPrompt)",
+                "[INFO] Received feature message [event]: ${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: __start__, input: \"$userPrompt\")",
+                "[INFO] Received feature message [event]: ${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: __start__, input: \"$userPrompt\", output: \"$userPrompt\")",
+                "[INFO] Received feature message [event]: ${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: test-llm-call, input: \"$userPrompt\")",
                 "[INFO] Received feature message [event]: ${LLMCallStartingEvent::class.simpleName} (run id: $runId, prompt: ${
                     expectedPrompt.copy(
                         messages = expectedPrompt.messages + userMessage(
                             content = userPrompt
                         )
                     ).traceString
-                }, model: ${testModel.eventString}, tools: [${dummyTool.name}])",
+                }, model: ${testModel.toModelInfo().modelIdentifierName}, tools: [${dummyTool.name}])",
                 "[INFO] Received feature message [event]: ${LLMCallCompletedEvent::class.simpleName} (run id: $runId, prompt: ${
                     expectedPrompt.copy(
                         messages = expectedPrompt.messages + userMessage(
                             content = userPrompt
                         )
                     ).traceString
-                }, model: ${testModel.eventString}, responses: [{role: Tool, message: {\"dummy\":\"test\"}}])",
-                "[INFO] Received feature message [event]: ${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: test-llm-call, input: $userPrompt, output: ${
-                    toolCallMessage(
-                        dummyTool.name,
-                        content = """{"dummy":"test"}"""
-                    )
-                })",
-                "[INFO] Received feature message [event]: ${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: test-tool-call, input: ${
-                    toolCallMessage(
-                        dummyTool.name,
-                        content = """{"dummy":"test"}"""
-                    )
-                })",
+                }, model: ${testModel.toModelInfo().modelIdentifierName}, responses: [{role: Tool, message: {\"dummy\":\"test\"}}])",
+                "[INFO] Received feature message [event]: ${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: test-llm-call, " +
+                    "input: \"$userPrompt\", " +
+                    "output: ${
+                        @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = toolCallMessage(
+                                toolName = dummyTool.name,
+                                content = """{"dummy":"test"}"""
+                            ),
+                            dataType = typeOf<Message>()
+                        )}" +
+                    ")",
+                "[INFO] Received feature message [event]: ${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: test-tool-call, " +
+                    "input: ${
+                        @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = toolCallMessage(
+                                toolName = dummyTool.name,
+                                content = """{"dummy":"test"}"""
+                            ),
+                            dataType = typeOf<Message.Tool.Call>()
+                        )}" +
+                    ")",
                 "[INFO] Received feature message [event]: ${ToolCallStartingEvent::class.simpleName} (run id: $runId, tool: ${dummyTool.name}, tool args: {\"dummy\":\"test\"})",
                 "[INFO] Received feature message [event]: ${ToolCallCompletedEvent::class.simpleName} (run id: $runId, tool: ${dummyTool.name}, tool args: {\"dummy\":\"test\"}, result: ${dummyTool.result})",
-                "[INFO] Received feature message [event]: ${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: test-tool-call, input: ${
-                    toolCallMessage(
-                        dummyTool.name,
-                        content = """{"dummy":"test"}"""
-                    )
-                }, output: ${toolResult("0", dummyTool.name, dummyTool.result, dummyTool.result)})",
-                "[INFO] Received feature message [event]: ${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: test-node-llm-send-tool-result, input: ${
-                    toolResult(
-                        "0",
-                        dummyTool.name,
-                        dummyTool.result,
-                        dummyTool.result
-                    )
-                })",
+                "[INFO] Received feature message [event]: ${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: test-tool-call, " +
+                    "input: ${
+                        @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = toolCallMessage(
+                                toolName = dummyTool.name,
+                                content = """{"dummy":"test"}"""
+                            ),
+                            dataType = typeOf<Message.Tool.Call>()
+                        )}, " +
+                    "output: ${JsonPrimitive(dummyTool.result)}" +
+                    ")",
+                "[INFO] Received feature message [event]: ${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: test-node-llm-send-tool-result, " +
+                    "input: ${JsonPrimitive(dummyTool.result)}" +
+                    ")",
                 "[INFO] Received feature message [event]: ${LLMCallStartingEvent::class.simpleName} (run id: $runId, prompt: ${
                     expectedPrompt.copy(
                         messages = expectedPrompt.messages + listOf(
                             userMessage(content = userPrompt),
                             toolCallMessage(dummyTool.name, content = """{"dummy":"test"}"""),
-                            toolResult(
+                            receivedToolResult(
                                 "0",
                                 dummyTool.name,
                                 dummyTool.result,
@@ -202,13 +219,13 @@ class TraceFeatureMessageLogWriterTest {
                             ).toMessage(clock = testClock)
                         )
                     ).traceString
-                }, model: ${testModel.eventString}, tools: [${dummyTool.name}])",
+                }, model: ${testModel.toModelInfo().modelIdentifierName}, tools: [${dummyTool.name}])",
                 "[INFO] Received feature message [event]: ${LLMCallCompletedEvent::class.simpleName} (run id: $runId, prompt: ${
                     expectedPrompt.copy(
                         messages = expectedPrompt.messages + listOf(
                             userMessage(content = userPrompt),
                             toolCallMessage(dummyTool.name, content = """{"dummy":"test"}"""),
-                            toolResult(
+                            receivedToolResult(
                                 "0",
                                 dummyTool.name,
                                 dummyTool.result,
@@ -216,17 +233,18 @@ class TraceFeatureMessageLogWriterTest {
                             ).toMessage(clock = testClock)
                         )
                     ).traceString
-                }, model: ${testModel.eventString}, responses: [{${expectedResponse.traceString}}])",
-                "[INFO] Received feature message [event]: ${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: test-node-llm-send-tool-result, input: ${
-                    toolResult(
-                        "0",
-                        dummyTool.name,
-                        dummyTool.result,
-                        dummyTool.result
-                    )
-                }, output: $expectedResponse)",
-                "[INFO] Received feature message [event]: ${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: __finish__, input: $mockResponse)",
-                "[INFO] Received feature message [event]: ${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: __finish__, input: $mockResponse, output: $mockResponse)",
+                }, model: ${testModel.toModelInfo().modelIdentifierName}, responses: [{${expectedResponse.traceString}}])",
+                "[INFO] Received feature message [event]: ${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: test-node-llm-send-tool-result, " +
+                    "input: ${JsonPrimitive(dummyTool.result)}, " +
+                    "output: ${
+                        @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = expectedResponse,
+                            dataType = typeOf<Message>()
+                        )}" +
+                    ")",
+                "[INFO] Received feature message [event]: ${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: __finish__, input: \"$mockResponse\")",
+                "[INFO] Received feature message [event]: ${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: __finish__, input: \"$mockResponse\", output: \"$mockResponse\")",
                 "[INFO] Received feature message [event]: ${StrategyCompletedEvent::class.simpleName} (run id: $runId, strategy: $strategyName, result: $mockResponse)",
                 "[INFO] Received feature message [event]: ${AgentCompletedEvent::class.simpleName} (agent id: $agentId, run id: $runId, result: $mockResponse)",
                 "[INFO] Received feature message [event]: ${AgentClosingEvent::class.simpleName} (agent id: $agentId)",
@@ -410,8 +428,12 @@ class TraceFeatureMessageLogWriterTest {
             }
 
             val mockExecutor = getMockExecutor(clock = testClock) {
-                mockLLMToolCall(tool = dummyTool, args = DummyTool.Args("test"), toolCallId = "0") onRequestEquals
-                    userPrompt
+                mockLLMToolCall(
+                    tool = dummyTool,
+                    args = DummyTool.Args("test"),
+                    toolCallId = "0"
+                ) onRequestEquals userPrompt
+
                 mockLLMAnswer(mockResponse) onRequestContains dummyTool.result
             }
 
@@ -448,20 +470,20 @@ class TraceFeatureMessageLogWriterTest {
                             content = userPrompt
                         )
                     ).traceString
-                }, model: ${testModel.eventString}, tools: [${dummyTool.name}])",
+                }, model: ${testModel.toModelInfo().modelIdentifierName}, tools: [${dummyTool.name}])",
                 "[INFO] Received feature message [event]: ${LLMCallCompletedEvent::class.simpleName} (run id: $runId, prompt: ${
                     expectedPrompt.copy(
                         messages = expectedPrompt.messages + userMessage(
                             content = userPrompt
                         )
                     ).traceString
-                }, model: ${testModel.eventString}, responses: [{role: Tool, message: {\"dummy\":\"test\"}}])",
+                }, model: ${testModel.toModelInfo().modelIdentifierName}, responses: [{role: Tool, message: {\"dummy\":\"test\"}}])",
                 "[INFO] Received feature message [event]: ${LLMCallStartingEvent::class.simpleName} (run id: $runId, prompt: ${
                     expectedPrompt.copy(
                         messages = expectedPrompt.messages + listOf(
                             userMessage(content = userPrompt),
                             toolCallMessage(dummyTool.name, content = """{"dummy":"test"}"""),
-                            toolResult(
+                            receivedToolResult(
                                 "0",
                                 dummyTool.name,
                                 dummyTool.result,
@@ -469,13 +491,13 @@ class TraceFeatureMessageLogWriterTest {
                             ).toMessage(clock = testClock)
                         )
                     ).traceString
-                }, model: ${testModel.eventString}, tools: [${dummyTool.name}])",
+                }, model: ${testModel.toModelInfo().modelIdentifierName}, tools: [${dummyTool.name}])",
                 "[INFO] Received feature message [event]: ${LLMCallCompletedEvent::class.simpleName} (run id: $runId, prompt: ${
                     expectedPrompt.copy(
                         messages = expectedPrompt.messages + listOf(
                             userMessage(content = userPrompt),
                             toolCallMessage(dummyTool.name, content = """{"dummy":"test"}"""),
-                            toolResult(
+                            receivedToolResult(
                                 "0",
                                 dummyTool.name,
                                 dummyTool.result,
@@ -483,7 +505,7 @@ class TraceFeatureMessageLogWriterTest {
                             ).toMessage(clock = testClock)
                         )
                     ).traceString
-                }, model: ${testModel.eventString}, responses: [{${expectedResponse.traceString}}])",
+                }, model: ${testModel.toModelInfo().modelIdentifierName}, responses: [{${expectedResponse.traceString}}])",
             )
 
             val actualMessages = targetLogger.messages

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
@@ -1,5 +1,6 @@
 package ai.koog.agents.features.tracing.writer
 
+import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.nodeExecuteTool
@@ -16,7 +17,7 @@ import ai.koog.agents.core.feature.model.events.NodeExecutionFailedEvent
 import ai.koog.agents.core.feature.model.events.ToolCallCompletedEvent
 import ai.koog.agents.core.feature.model.events.ToolCallStartingEvent
 import ai.koog.agents.core.tools.ToolRegistry
-import ai.koog.agents.features.tracing.eventString
+import ai.koog.agents.core.utils.SerializationUtil
 import ai.koog.agents.features.tracing.feature.Tracing
 import ai.koog.agents.features.tracing.mock.RecursiveTool
 import ai.koog.agents.features.tracing.mock.TestFeatureMessageWriter
@@ -31,6 +32,7 @@ import ai.koog.agents.testing.tools.getMockExecutor
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.llm.toModelInfo
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.streaming.StreamFrame
@@ -40,6 +42,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
+import kotlin.reflect.typeOf
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -299,6 +302,11 @@ class TraceFeatureMessageTestWriterTest {
                     NodeExecutionFailedEvent(
                         runId = writer.runId,
                         nodeName = nodeWithErrorName,
+                        input = @OptIn(InternalAgentsApi::class)
+                        SerializationUtil.trySerializeDataToJsonElement(
+                            data = "",
+                            dataType = typeOf<String>()
+                        ),
                         error = AIAgentError(testErrorMessage, expectedStackTrace, null),
                         timestamp = testClock.now().toEpochMilliseconds()
                     )
@@ -372,7 +380,7 @@ class TraceFeatureMessageTestWriterTest {
                     LLMStreamingStartingEvent(
                         runId = writer.runId,
                         prompt = expectedPrompt,
-                        model = model.eventString,
+                        model = model.toModelInfo().modelIdentifierName,
                         tools = toolRegistry.tools.map { it.name },
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
@@ -384,7 +392,7 @@ class TraceFeatureMessageTestWriterTest {
                     LLMStreamingCompletedEvent(
                         runId = writer.runId,
                         prompt = expectedPrompt,
-                        model = model.eventString,
+                        model = model.toModelInfo().modelIdentifierName,
                         tools = toolRegistry.tools.map { it.name },
                         timestamp = testClock.now().toEpochMilliseconds()
                     )
@@ -483,7 +491,7 @@ class TraceFeatureMessageTestWriterTest {
                     LLMStreamingStartingEvent(
                         runId = writer.runId,
                         prompt = expectedPrompt,
-                        model = model.eventString,
+                        model = model.toModelInfo().modelIdentifierName,
                         tools = toolRegistry.tools.map { it.name },
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
@@ -495,7 +503,7 @@ class TraceFeatureMessageTestWriterTest {
                     LLMStreamingCompletedEvent(
                         runId = writer.runId,
                         prompt = expectedPrompt,
-                        model = model.eventString,
+                        model = model.toModelInfo().modelIdentifierName,
                         tools = toolRegistry.tools.map { it.name },
                         timestamp = testClock.now().toEpochMilliseconds()
                     )

--- a/agents/agents-utils/src/commonMain/kotlin/ai/koog/agents/utils/ModelInfo.kt
+++ b/agents/agents-utils/src/commonMain/kotlin/ai/koog/agents/utils/ModelInfo.kt
@@ -38,7 +38,12 @@ public data class ModelInfo(
      */
     public val modelIdentifierName: String get() = displayName ?: "$provider/$model"
 
+    /**
+     * Companion object for the ModelInfo class that provides utility methods and constants
+     * related to model information parsing and representation.
+     */
     public companion object {
+
         /**
          * Represents an undefined or invalid ModelInfo instance
          * Used when model information cannot be determined or parsed

--- a/docs/docs/agent-events.md
+++ b/docs/docs/agent-events.md
@@ -108,22 +108,22 @@ Represents the end of a strategy run. Includes the following fields:
 
 Represents the start of a node run. Includes the following fields:
 
-| Name       | Data type | Required | Default | Description                                      |
-|------------|-----------|----------|---------|--------------------------------------------------|
-| `runId`    | String    | Yes      |         | The unique identifier of the strategy run.       |
-| `nodeName` | String    | Yes      |         | The name of the node whose run started.          |
-| `input`    | String    | Yes      |         | The input value for the node.                    |
+| Name       | Data type   | Required | Default | Description                                      |
+|------------|-------------|----------|---------|--------------------------------------------------|
+| `runId`    | String      | Yes      |         | The unique identifier of the strategy run.       |
+| `nodeName` | String      | Yes      |         | The name of the node whose run started.          |
+| `input`    | JsonElement | No       | null    | The input value for the node.                    |
 
 #### NodeExecutionCompletedEvent
 
 Represents the end of a node run. Includes the following fields:
 
-| Name       | Data type | Required | Default | Description                                      |
-|------------|-----------|----------|---------|--------------------------------------------------|
-| `runId`    | String    | Yes      |         | The unique identifier of the strategy run.       |
-| `nodeName` | String    | Yes      |         | The name of the node whose run ended.            |
-| `input`    | String    | Yes      |         | The input value for the node.                    |
-| `output`   | String    | Yes      |         | The output value produced by the node.           |
+| Name       | Data type   | Required | Default | Description                                      |
+|------------|-------------|----------|---------|--------------------------------------------------|
+| `runId`    | String      | Yes      |         | The unique identifier of the strategy run.       |
+| `nodeName` | String      | Yes      |         | The name of the node whose run ended.            |
+| `input`    | JsonElement | No       | null    | The input value for the node.                    |
+| `output`   | JsonElement | No       | null    | The output value produced by the node.           |
 
 #### NodeExecutionFailedEvent
 
@@ -133,6 +133,7 @@ Represents an error that occurred during a node run. Includes the following fiel
 |------------|--------------|----------|---------|-----------------------------------------------------------------------------------------------------------------|
 | `runId`    | String       | Yes      |         | The unique identifier of the strategy run.                                                                      |
 | `nodeName` | String       | Yes      |         | The name of the node where the error occurred.                                                                  |
+| `input`    | JsonElement  | No       | null    | The input data provided to the node.                                                                            |
 | `error`    | AIAgentError | Yes      |         | The specific error that occurred during the node run. For more information, see [AIAgentError](#aiagenterror). |
 
 ### LLM call events


### PR DESCRIPTION
[KG-480](https://youtrack.jetbrains.com/issue/KG-480).

- Agent node execution events return String object for input and output data. It might be more convenient to pass JsonElement through events to be able to use more structured data and render it on a client side;
- Pass node input object to the NodeExecutionFailedEvent event;
- Add serialization handling for ReceivedToolResultType;
- Update Debugger and Tracing logic and tests.

## Motivation and Context
Add a structured JsonElement data for input/output properties for a node agent events. This can help to process this data on a client side.

## Breaking Changes
Yes (change input/output parameter types in agent events)

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [x] The change was discussed and approved in the issue
- [x] Docs have been added / updated
