### PR TITLE
Set JVM target to 11

### DIFF
--- a/convention-plugin-ai/src/main/kotlin/ai.kotlin.configuration.gradle.kts
+++ b/convention-plugin-ai/src/main/kotlin/ai.kotlin.configuration.gradle.kts
@@ -61,6 +61,11 @@ tasks.withType<KotlinJvmCompile>().configureEach {
     }
 }
 
+tasks.withType<JavaCompile>().configureEach {
+    sourceCompatibility = JavaVersion.VERSION_11.toString()
+    targetCompatibility = JavaVersion.VERSION_11.toString()
+}
+
 configurations.all {
     resolutionStrategy {
         eachDependency {

--- a/convention-plugin-ai/src/main/kotlin/ai.kotlin.configuration.gradle.kts
+++ b/convention-plugin-ai/src/main/kotlin/ai.kotlin.configuration.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.accessors.dm.LibrariesForLibs
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
@@ -55,6 +56,7 @@ tasks.withType<KotlinCompilationTask<*>>().configureEach {
 
 tasks.withType<KotlinJvmCompile>().configureEach {
     compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_11)
         freeCompilerArgs.add("-Xjvm-default=all")
     }
 }

--- a/koog-spring-boot-starter/build.gradle.kts
+++ b/koog-spring-boot-starter/build.gradle.kts
@@ -1,4 +1,6 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 group = rootProject.group
 version = rootProject.version
@@ -12,6 +14,18 @@ plugins {
 
 kotlin {
     explicitApi()
+}
+
+// Override JVM target to 17 for Spring Boot 3.x compatibility
+tasks.withType<KotlinJvmCompile>().configureEach {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    sourceCompatibility = JavaVersion.VERSION_17.toString()
+    targetCompatibility = JavaVersion.VERSION_17.toString()
 }
 
 dependencies {


### PR DESCRIPTION
set jvm target to 11 version

## Motivation and Context
To support older JVM versions and explicitly specify the JVM target. Previously, the target was set based on the toolchain used

Version 17 will still be used for Android.
The spring-boot-starter will also use version 17, since Spring Boot requires Java 17

## Breaking Changes
No

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [x] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed
