### PR TITLE
KG-480. Add backward compatibility for node event parameters

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/events/nodeExecutionEvents.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/events/nodeExecutionEvents.kt
@@ -1,6 +1,8 @@
 package ai.koog.agents.core.feature.model.events
 
+import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.feature.model.AIAgentError
+import ai.koog.agents.core.utils.SerializationUtil
 import kotlinx.datetime.Clock
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
@@ -17,7 +19,7 @@ import kotlinx.serialization.json.JsonElement
  * understanding the flow of agent execution is essential.
  *
  * @property nodeName The name of the node whose execution is starting;
- * @property input The input data being processed by the node during the execution;
+ * @property input The input data provided to the node and serialized into JSON element;
  * @property timestamp The timestamp of the event, in milliseconds since the Unix epoch.
  */
 @Serializable
@@ -26,7 +28,28 @@ public data class NodeExecutionStartingEvent(
     val nodeName: String,
     val input: JsonElement?,
     override val timestamp: Long = Clock.System.now().toEpochMilliseconds(),
-) : DefinedFeatureEvent()
+) : DefinedFeatureEvent() {
+
+    /**
+     * Creates an instance of [NodeExecutionStartingEvent].
+     *
+     * This constructor is deprecated and should be replaced with the constructor
+     * that accepts an input parameter of type [JsonElement].
+     */
+    @Deprecated("Use constructor with input parameter of type [JsonElement]")
+    public constructor(
+        runId: String,
+        nodeName: String,
+        input: String,
+        timestamp: Long = Clock.System.now().toEpochMilliseconds()
+    ) : this(
+        runId = runId,
+        nodeName = nodeName,
+        input = @OptIn(InternalAgentsApi::class)
+        SerializationUtil.tryParseToJsonElement(input),
+        timestamp = timestamp
+    )
+}
 
 /**
  * Represents an event indicating the completion of a node's execution within an AI agent.
@@ -47,7 +70,31 @@ public data class NodeExecutionCompletedEvent(
     val input: JsonElement?,
     val output: JsonElement?,
     override val timestamp: Long = Clock.System.now().toEpochMilliseconds(),
-) : DefinedFeatureEvent()
+) : DefinedFeatureEvent() {
+
+    /**
+     * Creates an instance of [NodeExecutionCompletedEvent].
+     *
+     * This constructor is deprecated and should be replaced with the constructor
+     * that accepts input and output parameters of type [JsonElement].
+     */
+    @Deprecated("Use constructor with input and output parameters of type [JsonElement]")
+    public constructor(
+        runId: String,
+        nodeName: String,
+        input: String,
+        output: String,
+        timestamp: Long = Clock.System.now().toEpochMilliseconds()
+    ) : this(
+        runId = runId,
+        nodeName = nodeName,
+        input = @OptIn(InternalAgentsApi::class)
+        SerializationUtil.tryParseToJsonElement(input),
+        output = @OptIn(InternalAgentsApi::class)
+        SerializationUtil.tryParseToJsonElement(output),
+        timestamp = timestamp
+    )
+}
 
 /**
  * Represents an event that signifies the occurrence of an error during the execution of a specific node
@@ -74,7 +121,28 @@ public data class NodeExecutionFailedEvent(
     val input: JsonElement?,
     val error: AIAgentError,
     override val timestamp: Long = Clock.System.now().toEpochMilliseconds(),
-) : DefinedFeatureEvent()
+) : DefinedFeatureEvent() {
+
+    /**
+     * Creates an instance of [NodeExecutionFailedEvent].
+     *
+     * This constructor is deprecated and should be replaced with the constructor
+     * that accepts an input parameter of type [JsonElement].
+     */
+    @Deprecated("Use constructor with input parameter of type [JsonElement]")
+    public constructor(
+        runId: String,
+        nodeName: String,
+        error: AIAgentError,
+        timestamp: Long = Clock.System.now().toEpochMilliseconds()
+    ) : this(
+        runId = runId,
+        nodeName = nodeName,
+        input = null,
+        error = error,
+        timestamp = timestamp
+    )
+}
 
 //region Deprecated
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/utils/SerializationUtil.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/utils/SerializationUtil.kt
@@ -5,6 +5,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.serializerOrNull
 import kotlin.reflect.KType
 
@@ -50,5 +51,23 @@ public object SerializationUtil {
         }
 
         return json.encodeToJsonElement(serializer, data)
+    }
+
+    /**
+     * Attempts to parse the given string into a [JsonElement]. If the parsing fails due to a
+     * [SerializationException], it falls back to returning a [JsonPrimitive] wrapping the original string.
+     *
+     * @param data The input string to be parsed into a [JsonElement].
+     * @return A [JsonElement] if parsing succeeds; otherwise, a [JsonPrimitive] containing the original string.
+     */
+    @InternalAgentsApi
+    public fun tryParseToJsonElement(data: String): JsonElement {
+        logger.debug { "Parsing data to JsonElement: $data" }
+        return try {
+            json.parseToJsonElement(data)
+        } catch (e: SerializationException) {
+            logger.debug { "Failed to parse data to JsonElement: ${e.message}. Return JsonPrimitive instance" }
+            JsonPrimitive(data)
+        }
     }
 }


### PR DESCRIPTION
[KG-480](https://youtrack.jetbrains.com/issue/KG-480). Add backward compatibility for parameters in node execution events classes.

## Motivation and Context
We need to make sure that all old types of Koog agent events are supported in the new lib version.

## Breaking Changes
No

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [x] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
