### PR TITLE
[agents] Remove `DirectToolCallEnabler` interface to allow calling tools with `execute` direclty.

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/GenericAgentEnvironment.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/GenericAgentEnvironment.kt
@@ -8,7 +8,6 @@ import ai.koog.agents.core.model.message.AgentToolCallToEnvironmentContent
 import ai.koog.agents.core.model.message.AgentToolCallsToEnvironmentMessage
 import ai.koog.agents.core.model.message.EnvironmentToolResultMultipleToAgentMessage
 import ai.koog.agents.core.model.message.EnvironmentToolResultToAgentContent
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolException
 import ai.koog.agents.core.tools.ToolRegistry
@@ -19,16 +18,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.supervisorScope
-
-@OptIn(InternalAgentToolsApi::class)
-private class DirectToolCallsEnablerImpl : DirectToolCallsEnabler
-
-@OptIn(InternalAgentToolsApi::class)
-private class AllowDirectToolCallsContext(val toolEnabler: DirectToolCallsEnabler)
-
-@OptIn(InternalAgentToolsApi::class)
-private suspend inline fun <T> allowToolCalls(block: suspend AllowDirectToolCallsContext.() -> T) =
-    AllowDirectToolCallsContext(DirectToolCallsEnablerImpl()).block()
 
 internal class GenericAgentEnvironment(
     private val agentId: String,
@@ -100,64 +89,63 @@ internal class GenericAgentEnvironment(
     @OptIn(InternalAgentToolsApi::class)
     private suspend fun processToolCall(
         content: AgentToolCallToEnvironmentContent
-    ): EnvironmentToolResultToAgentContent =
-        allowToolCalls {
-            logger.debug { "Handling tool call sent by server..." }
-            val tool = toolRegistry.getTool(content.toolName)
-            val toolArgs = try {
-                tool.decodeArgs(content.toolArgs)
-            } catch (e: Exception) {
-                logger.error(e) { "Tool \"${tool.name}\" failed to parse arguments: ${content.toolArgs}" }
-                return toolResult(
-                    message = "Tool \"${tool.name}\" failed to parse arguments because of ${e.message}!",
-                    toolCallId = content.toolCallId,
-                    toolName = content.toolName,
-                    agentId = agentId,
-                    result = null
-                )
-            }
+    ): EnvironmentToolResultToAgentContent {
+        logger.debug { "Handling tool call sent by server..." }
+        val tool = toolRegistry.getTool(content.toolName)
+        val toolArgs = try {
+            tool.decodeArgs(content.toolArgs)
+        } catch (e: Exception) {
+            logger.error(e) { "Tool \"${tool.name}\" failed to parse arguments: ${content.toolArgs}" }
+            return toolResult(
+                message = "Tool \"${tool.name}\" failed to parse arguments because of ${e.message}!",
+                toolCallId = content.toolCallId,
+                toolName = content.toolName,
+                agentId = agentId,
+                result = null
+            )
+        }
 
-            pipeline.onToolCallStarting(content.runId, content.toolCallId, tool, toolArgs)
+        pipeline.onToolCallStarting(content.runId, content.toolCallId, tool, toolArgs)
 
-            val toolResult = try {
-                @Suppress("UNCHECKED_CAST")
-                (tool as Tool<Any?, Any?>).execute(toolArgs, toolEnabler)
-            } catch (e: ToolException) {
-                pipeline.onToolValidationFailed(content.runId, content.toolCallId, tool, toolArgs, e.message)
-
-                return toolResult(
-                    message = e.message,
-                    toolCallId = content.toolCallId,
-                    toolName = content.toolName,
-                    agentId = strategyId,
-                    result = null
-                )
-            } catch (e: Exception) {
-                logger.error(e) { "Tool \"${tool.name}\" failed to execute with arguments: ${content.toolArgs}" }
-
-                pipeline.onToolCallFailed(content.runId, content.toolCallId, tool, toolArgs, e)
-
-                return toolResult(
-                    message = "Tool \"${tool.name}\" failed to execute because of ${e.message}!",
-                    toolCallId = content.toolCallId,
-                    toolName = content.toolName,
-                    agentId = strategyId,
-                    result = null
-                )
-            }
-
-            pipeline.onToolCallCompleted(content.runId, content.toolCallId, tool, toolArgs, toolResult)
-
-            logger.trace { "Completed execution of ${content.toolName} with result: $toolResult" }
+        val toolResult = try {
+            @Suppress("UNCHECKED_CAST")
+            (tool as Tool<Any?, Any?>).execute(toolArgs)
+        } catch (e: ToolException) {
+            pipeline.onToolValidationFailed(content.runId, content.toolCallId, tool, toolArgs, e.message)
 
             return toolResult(
+                message = e.message,
                 toolCallId = content.toolCallId,
                 toolName = content.toolName,
                 agentId = strategyId,
-                message = tool.encodeResultToStringUnsafe(toolResult),
-                result = toolResult
+                result = null
+            )
+        } catch (e: Exception) {
+            logger.error(e) { "Tool \"${tool.name}\" failed to execute with arguments: ${content.toolArgs}" }
+
+            pipeline.onToolCallFailed(content.runId, content.toolCallId, tool, toolArgs, e)
+
+            return toolResult(
+                message = "Tool \"${tool.name}\" failed to execute because of ${e.message}!",
+                toolCallId = content.toolCallId,
+                toolName = content.toolName,
+                agentId = strategyId,
+                result = null
             )
         }
+
+        pipeline.onToolCallCompleted(content.runId, content.toolCallId, tool, toolArgs, toolResult)
+
+        logger.trace { "Completed execution of ${content.toolName} with result: $toolResult" }
+
+        return toolResult(
+            toolCallId = content.toolCallId,
+            toolName = content.toolName,
+            agentId = strategyId,
+            message = tool.encodeResultToStringUnsafe(toolResult),
+            result = toolResult
+        )
+    }
 
     private suspend fun processToolCallMultiple(
         message: AgentToolCallsToEnvironmentMessage

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/AIAgentToolTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/AIAgentToolTest.kt
@@ -3,7 +3,6 @@ package ai.koog.agents.core.agent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.ToolParameterType
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.testing.tools.getMockExecutor
@@ -19,9 +18,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-
-@OptIn(InternalAgentToolsApi::class)
-object Enabler : DirectToolCallsEnabler
 
 class AIAgentToolTest {
 
@@ -96,7 +92,7 @@ class AIAgentToolTest {
     @Test
     fun testAsToolExecution() = runTest {
         val args = tool.decodeArgs(argsJson)
-        val result = tool.execute(args, Enabler)
+        val result = tool.execute(args)
 
         assertTrue(result.successful)
         assertEquals(RESPONSE, result.result?.jsonPrimitive?.content)
@@ -117,7 +113,7 @@ class AIAgentToolTest {
         )
 
         val args = tool.decodeArgs(argsJson)
-        val result = tool.execute(args, Enabler)
+        val result = tool.execute(args)
 
         assertEquals(false, result.successful)
         assertEquals(null, result.result)
@@ -140,7 +136,7 @@ class AIAgentToolTest {
         )
 
         val args = tool.decodeArgs(argsJson)
-        val result = tool.execute(args, Enabler)
+        val result = tool.execute(args)
 
         assertEquals(
             AIAgentTool.AgentToolResult(

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionTest.kt
@@ -4,7 +4,6 @@ import ai.koog.agents.core.CalculatorChatExecutor.testClock
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.environment.AIAgentEnvironment
 import ai.koog.agents.core.environment.ReceivedToolResult
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolDescriptor
@@ -37,15 +36,13 @@ class AIAgentLLMWriteSessionTest {
     private fun userMessage(content: String) = Message.User(content, RequestMetaInfo.create(testClock))
     private fun assistantMessage(content: String) = Message.Assistant(content, ResponseMetaInfo.create(testClock))
 
-    private object TestToolsEnabler : DirectToolCallsEnabler
-
     private class TestEnvironment(private val toolRegistry: ToolRegistry) : AIAgentEnvironment {
         @OptIn(InternalAgentToolsApi::class)
         override suspend fun executeTools(toolCalls: List<Message.Tool.Call>): List<ReceivedToolResult> {
             return toolCalls.map { toolCall ->
                 val tool = toolRegistry.getTool(toolCall.tool)
                 val args = tool.decodeArgs(toolCall.contentJson)
-                val result = tool.executeUnsafe(args, TestToolsEnabler)
+                val result = tool.executeUnsafe(args)
 
                 ReceivedToolResult(
                     id = toolCall.id,

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
@@ -17,7 +17,6 @@ import ai.koog.agents.core.dsl.extension.setToolChoiceRequired
 import ai.koog.agents.core.environment.ReceivedToolResult
 import ai.koog.agents.core.environment.executeTool
 import ai.koog.agents.core.environment.toSafeResult
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
@@ -402,8 +401,7 @@ public inline fun <reified Input, reified Output, reified OutputTransformed> AIA
             )
 
             val toolResult = finishTool.execute(
-                args = toolArgs,
-                enabler = object : DirectToolCallsEnabler {}
+                args = toolArgs
             )
 
             // Append a final tool call result to the prompt for further LLM calls

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/EditFileToolCoreTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/EditFileToolCoreTest.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.ext.tool.file
 
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.ext.utils.InMemoryFS
 import ai.koog.rag.base.files.readText
@@ -29,7 +28,7 @@ class EditFileToolCoreTest {
             original = "World",
             replacement = "Koog"
         )
-        tool.execute(args, object : DirectToolCallsEnabler {})
+        tool.execute(args)
 
         // Then
         val updated = mockedFS.readText(path)
@@ -51,7 +50,7 @@ class EditFileToolCoreTest {
             original = "World",
             replacement = "Koog"
         )
-        val result = tool.execute(args, object : DirectToolCallsEnabler {})
+        val result = tool.execute(args)
 
         // Then
         val markdownReport = result.textForLLM()
@@ -80,7 +79,7 @@ class EditFileToolCoreTest {
             original = "world", // different case than in file
             replacement = "Koog"
         )
-        tool.execute(args, object : DirectToolCallsEnabler {})
+        tool.execute(args)
 
         // Then
         val updated = mockedFS.readText(path)
@@ -115,7 +114,7 @@ class EditFileToolCoreTest {
             original = "Hello    World", // more spaces than in file
             replacement = "Hello Koog"
         )
-        tool.execute(args, object : DirectToolCallsEnabler {})
+        tool.execute(args)
 
         // Then
         val updated = mockedFS.readText(path)
@@ -150,7 +149,7 @@ class EditFileToolCoreTest {
             original = "Hello World", // less spaces than in file
             replacement = "Hello Koog"
         )
-        tool.execute(args, object : DirectToolCallsEnabler {})
+        tool.execute(args)
 
         // Then
         val updated = mockedFS.readText(path)
@@ -185,7 +184,7 @@ class EditFileToolCoreTest {
             original = "Hello World\n",
             replacement = ""
         )
-        tool.execute(args, object : DirectToolCallsEnabler {})
+        tool.execute(args)
 
         // Then
         val updated = mockedFS.readText(path)
@@ -213,7 +212,7 @@ class EditFileToolCoreTest {
             original = "",
             replacement = newContent
         )
-        tool.execute(args, object : DirectToolCallsEnabler {})
+        tool.execute(args)
 
         // Then
         assertEquals(true, mockedFS.exists(path))
@@ -245,7 +244,7 @@ class EditFileToolCoreTest {
             original = "",
             replacement = replacementContent
         )
-        tool.execute(args, object : DirectToolCallsEnabler {})
+        tool.execute(args)
 
         // Then
         val updated = mockedFS.readText(path)
@@ -275,7 +274,7 @@ class EditFileToolCoreTest {
             original = "Delta", // does not exist in file
             replacement = "Omega"
         )
-        val result = tool.execute(args, object : DirectToolCallsEnabler {})
+        val result = tool.execute(args)
 
         // Then
         val markdownReport = result.textForLLM()

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/EditFileToolDifferentFileTypesTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/EditFileToolDifferentFileTypesTest.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.ext.tool.file
 
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.ext.utils.InMemoryFS
 import ai.koog.rag.base.files.readText
@@ -34,7 +33,7 @@ class EditFileToolDifferentFileTypesTest {
             original = "print(\"debug\")\n    ",
             replacement = ""
         )
-        tool.execute(args, object : DirectToolCallsEnabler {})
+        tool.execute(args)
 
         // Then
         val updated = mockedFS.readText(path)
@@ -62,7 +61,7 @@ class EditFileToolDifferentFileTypesTest {
             original = "\"value\"",
             replacement = "\"newValue\""
         )
-        tool.execute(args, object : DirectToolCallsEnabler {})
+        tool.execute(args)
 
         // Then
         val updated = mockedFS.readText(path)
@@ -83,7 +82,7 @@ class EditFileToolDifferentFileTypesTest {
             original = "<item>value</item>",
             replacement = "<item>newValue</item>"
         )
-        tool.execute(args, object : DirectToolCallsEnabler {})
+        tool.execute(args)
 
         // Then
         val updated = mockedFS.readText(path)

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/EditFileToolFormattingEdgeCasesTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/EditFileToolFormattingEdgeCasesTest.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.ext.tool.file
 
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.ext.utils.InMemoryFS
 import ai.koog.rag.base.files.readText
@@ -35,7 +34,7 @@ class EditFileToolFormattingEdgeCasesTest {
             original = "        return 42",
             replacement = "\t    return 43"
         )
-        tool.execute(args, object : DirectToolCallsEnabler {})
+        tool.execute(args)
 
         // Then
         val updated = mockedFS.readText(path)
@@ -66,7 +65,7 @@ class EditFileToolFormattingEdgeCasesTest {
             original = "line2\nline3",
             replacement = "newline\nline3"
         )
-        tool.execute(args, object : DirectToolCallsEnabler {})
+        tool.execute(args)
 
         // Then
         val updated = mockedFS.readText(path)

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/EditFileToolMultilineContentTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/EditFileToolMultilineContentTest.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.ext.tool.file
 
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.ext.utils.InMemoryFS
 import ai.koog.rag.base.files.readText
@@ -44,8 +43,7 @@ class EditFileToolMultilineContentTest {
             |    }
         """.trimMargin()
         tool.execute(
-            EditFileTool.Args(path = path, original = original, replacement = replacement),
-            object : DirectToolCallsEnabler {}
+            EditFileTool.Args(path = path, original = original, replacement = replacement)
         )
 
         // Then
@@ -78,7 +76,7 @@ class EditFileToolMultilineContentTest {
 
         // When
         val args = EditFileTool.Args(path = path, original = "const target = 42", replacement = "const target = 43")
-        tool.execute(args, object : DirectToolCallsEnabler {})
+        tool.execute(args)
 
         // Then
         val updated = mockedFS.readText(path)
@@ -94,7 +92,7 @@ class EditFileToolMultilineContentTest {
         mockedFS.writeText(path, "const x = 42\nrest of code")
 
         // When
-        tool.execute(EditFileTool.Args(path = path, original = "const x", replacement = "let x"), object : DirectToolCallsEnabler {})
+        tool.execute(EditFileTool.Args(path = path, original = "const x", replacement = "let x"))
 
         // Then
         val updated = mockedFS.readText(path)
@@ -110,7 +108,7 @@ class EditFileToolMultilineContentTest {
         mockedFS.writeText(path, "code;\nreturn 42")
 
         // When
-        tool.execute(EditFileTool.Args(path = path, original = "return 42", replacement = "return 43"), object : DirectToolCallsEnabler {})
+        tool.execute(EditFileTool.Args(path = path, original = "return 42", replacement = "return 43"))
 
         // Then
         val updated = mockedFS.readText(path)
@@ -127,13 +125,11 @@ class EditFileToolMultilineContentTest {
 
         // When
         tool.execute(
-            EditFileTool.Args(path = path, original = "const x = 42", replacement = "const x = 142"),
-            object : DirectToolCallsEnabler {}
+            EditFileTool.Args(path = path, original = "const x = 42", replacement = "const x = 142")
         )
 
         tool.execute(
-            EditFileTool.Args(path = path, original = "const y = 43", replacement = "const y = 143"),
-            object : DirectToolCallsEnabler {}
+            EditFileTool.Args(path = path, original = "const y = 43", replacement = "const y = 143")
         )
 
         // Then

--- a/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/ListDirectoryToolJvmTest.kt
+++ b/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/ListDirectoryToolJvmTest.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.ext.tool.file
 
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.ToolException
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.ext.tool.file.render.norm
@@ -21,9 +20,6 @@ import kotlin.test.assertTrue
 class ListDirectoryToolJvmTest {
 
     private val fs = JVMFileSystemProvider.ReadOnly
-
-    @OptIn(InternalAgentToolsApi::class)
-    private val enabler = object : DirectToolCallsEnabler {}
     private val tool = ListDirectoryTool(fs)
 
     @TempDir
@@ -32,7 +28,7 @@ class ListDirectoryToolJvmTest {
     private fun createDir(name: String): Path = tempDir.resolve(name).createDirectories()
 
     private suspend fun list(path: Path, depth: Int = 1, filter: String? = null): ListDirectoryTool.Result =
-        tool.execute(ListDirectoryTool.Args(path.toString(), depth, filter), enabler)
+        tool.execute(ListDirectoryTool.Args(path.toString(), depth, filter))
 
     @Test
     fun `Args uses correct defaults`() {

--- a/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/ReadFileToolJvmTest.kt
+++ b/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/ReadFileToolJvmTest.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.ext.tool.file
 
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.ToolException
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.ext.tool.file.render.norm
@@ -21,7 +20,6 @@ import kotlin.test.assertEquals
 class ReadFileToolJvmTest {
 
     private val fs = JVMFileSystemProvider.ReadOnly
-    private val enabler = object : DirectToolCallsEnabler {}
     private val tool = ReadFileTool(fs)
 
     @TempDir
@@ -31,7 +29,7 @@ class ReadFileToolJvmTest {
         tempDir.resolve(name).createFile().apply { writeText(content) }
 
     private suspend fun readFile(path: Path, startLine: Int = 0, endLine: Int = -1): ReadFileTool.Result =
-        tool.execute(ReadFileTool.Args(path.toString(), startLine, endLine), enabler)
+        tool.execute(ReadFileTool.Args(path.toString(), startLine, endLine))
 
     @Test
     fun `Args uses correct defaults`() {

--- a/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/WriteFileToolJvmTest.kt
+++ b/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/WriteFileToolJvmTest.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.ext.tool.file
 
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.ToolException
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.ext.tool.file.render.norm
@@ -20,14 +19,13 @@ import kotlin.test.assertTrue
 class WriteFileToolJvmTest {
 
     private val fs = JVMFileSystemProvider.ReadWrite
-    private val enabler = object : DirectToolCallsEnabler {}
     private val tool = WriteFileTool(fs)
 
     @TempDir
     lateinit var tempDir: Path
 
     private suspend fun write(path: Path, content: String): WriteFileTool.Result =
-        tool.execute(WriteFileTool.Args(path.toString(), content), enabler)
+        tool.execute(WriteFileTool.Args(path.toString(), content))
 
     @Test
     fun `descriptor is configured correctly`() {

--- a/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/shell/ExecuteShellCommandToolJvmTest.kt
+++ b/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/shell/ExecuteShellCommandToolJvmTest.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.ext.tool.shell
 
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
@@ -24,9 +23,6 @@ import kotlin.test.fail
 @OptIn(InternalAgentToolsApi::class)
 class ExecuteShellCommandToolJvmTest {
 
-    @OptIn(InternalAgentToolsApi::class)
-    private val enabler = object : DirectToolCallsEnabler {}
-
     private val executor = JvmShellCommandExecutor()
 
     @TempDir
@@ -39,8 +35,7 @@ class ExecuteShellCommandToolJvmTest {
         confirmationHandler: ShellCommandConfirmationHandler = BraveModeConfirmationHandler()
     ): ExecuteShellCommandTool.Result {
         return ExecuteShellCommandTool(executor, confirmationHandler).execute(
-            ExecuteShellCommandTool.Args(command, timeoutSeconds, workingDirectory),
-            enabler
+            ExecuteShellCommandTool.Args(command, timeoutSeconds, workingDirectory)
         )
     }
 

--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/Persistency.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/Persistency.kt
@@ -14,7 +14,6 @@ import ai.koog.agents.core.agent.featureOrThrow
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.feature.AIAgentGraphFeature
 import ai.koog.agents.core.feature.pipeline.AIAgentGraphPipeline
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.core.utils.SerializationUtil
 import ai.koog.agents.snapshot.providers.PersistenceStorageProvider
@@ -309,7 +308,7 @@ public class Persistence(
                             rollbackToolRegistry.getRollbackTool(toolCall.tool)?.let { rollbackTool ->
                                 val toolArgs = rollbackTool.decodeArgs(toolCall.contentJson)
 
-                                rollbackTool.executeUnsafe(toolArgs, object : DirectToolCallsEnabler {})
+                                rollbackTool.executeUnsafe(toolArgs)
                             }
                         }
                 }

--- a/agents/agents-mcp-server/src/commonMain/kotlin/ai/koog/agents/mcp/server/McpServer.kt
+++ b/agents/agents-mcp-server/src/commonMain/kotlin/ai/koog/agents/mcp/server/McpServer.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.mcp.server
 
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor
@@ -96,8 +95,6 @@ public fun configureMcpServer(
     tools: ToolRegistry,
     implementation: Implementation = Implementation("MCP Server with Koog-based tools", "dev")
 ): Server {
-    val enabler = object : DirectToolCallsEnabler {}
-
     val server = Server(
         serverInfo = implementation,
         options = ServerOptions(
@@ -108,7 +105,7 @@ public fun configureMcpServer(
     )
 
     tools.tools.forEach { tool ->
-        server.addTool(tool, enabler)
+        server.addTool(tool)
     }
 
     return server
@@ -120,11 +117,10 @@ public fun configureMcpServer(
 @OptIn(InternalAgentToolsApi::class)
 public fun Server.addTool(
     tool: Tool<*, *>,
-    enabler: DirectToolCallsEnabler = object : DirectToolCallsEnabler {},
 ) {
     addTool(tool.descriptor.asSdkTool()) { request ->
         val args = tool.decodeArgs(request.arguments)
-        val result = tool.executeUnsafe(args, enabler)
+        val result = tool.executeUnsafe(args)
 
         CallToolResult(
             content = listOf(TextContent(tool.encodeResultToStringUnsafe(result)))

--- a/agents/agents-mcp-server/src/jvmTest/kotlin/ai/koog/agents/mcp/server/KoogToolAsMcpToolTest.kt
+++ b/agents/agents-mcp-server/src/jvmTest/kotlin/ai/koog/agents/mcp/server/KoogToolAsMcpToolTest.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.mcp.server
 
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
@@ -38,7 +37,7 @@ class KoogToolAsMcpToolTest {
 
         val result = withContext(Dispatchers.Default.limitedParallelism(1)) {
             withTimeout(20.seconds) {
-                mcpTool.execute(args, object : DirectToolCallsEnabler {})
+                mcpTool.execute(args)
             }
         }
 
@@ -55,7 +54,7 @@ class KoogToolAsMcpToolTest {
 
         val result = withContext(Dispatchers.Default.limitedParallelism(1)) {
             withTimeout(20.seconds) {
-                mcpTool.execute(args, object : DirectToolCallsEnabler {})
+                mcpTool.execute(args)
             }
         }
 
@@ -73,7 +72,7 @@ class KoogToolAsMcpToolTest {
 
             withContext(Dispatchers.Default.limitedParallelism(1)) {
                 withTimeout(20.seconds) {
-                    mcpTool.execute(args, object : DirectToolCallsEnabler {})
+                    mcpTool.execute(args)
                 }
             }
         }
@@ -85,7 +84,7 @@ class KoogToolAsMcpToolTest {
 
             val result = withContext(Dispatchers.Default.limitedParallelism(1)) {
                 withTimeout(20.seconds) {
-                    mcpTool.execute(args, object : DirectToolCallsEnabler {})
+                    mcpTool.execute(args)
                 }
             }
 
@@ -109,7 +108,7 @@ class KoogToolAsMcpToolTest {
 
                 withContext(Dispatchers.Default.limitedParallelism(1)) {
                     withTimeout(20.seconds) {
-                        mcpTool.execute(args, object : DirectToolCallsEnabler {})
+                        mcpTool.execute(args)
                     }
                 }
 
@@ -126,7 +125,7 @@ class KoogToolAsMcpToolTest {
 
                 val result = withContext(Dispatchers.Default.limitedParallelism(1)) {
                     withTimeout(20.seconds) {
-                        mcpTool.execute(args, object : DirectToolCallsEnabler {})
+                        mcpTool.execute(args)
                     }
                 }
 

--- a/agents/agents-mcp-server/src/jvmTest/kotlin/ai/koog/agents/mcp/server/ThrowingExceptionTool.kt
+++ b/agents/agents-mcp-server/src/jvmTest/kotlin/ai/koog/agents/mcp/server/ThrowingExceptionTool.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.mcp.server
 
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.testing.tools.RandomNumberTool
@@ -26,7 +25,7 @@ internal class ThrowingExceptionTool : Tool<RandomNumberTool.Args, Int>() {
             if (throwing) {
                 throw IOException("Can not do something during IO")
             } else {
-                tool.execute(args, object : DirectToolCallsEnabler {})
+                tool.execute(args)
             }
         }
             .also { last = it }

--- a/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/McpToolTest.kt
+++ b/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/McpToolTest.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.mcp
 
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
@@ -18,9 +17,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
-
-@OptIn(InternalAgentToolsApi::class)
-object TestToolEnabler : DirectToolCallsEnabler
 
 class McpToolTest {
     private val testPort = 3001
@@ -82,7 +78,7 @@ class McpToolTest {
 
         val result = withContext(Dispatchers.Default.limitedParallelism(1)) {
             withTimeout(1.minutes) {
-                greetingTool.execute(args, TestToolEnabler)
+                greetingTool.execute(args)
             }
         }
 
@@ -97,7 +93,7 @@ class McpToolTest {
         )
         val resultWithTitle = withContext(Dispatchers.Default.limitedParallelism(1)) {
             withTimeout(1.minutes) {
-                greetingTool.execute(argsWithTitle, TestToolEnabler)
+                greetingTool.execute(argsWithTitle)
             }
         }
 

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockEnvironment.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockEnvironment.kt
@@ -2,18 +2,10 @@ package ai.koog.agents.testing.tools
 
 import ai.koog.agents.core.environment.AIAgentEnvironment
 import ai.koog.agents.core.environment.ReceivedToolResult
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.message.Message
-
-/**
- * A mock implementation of [DirectToolCallsEnabler] used for testing purposes.
- * This enables direct tool calls without requiring additional authorization.
- */
-@OptIn(InternalAgentToolsApi::class)
-private object MockToolsEnabler : DirectToolCallsEnabler
 
 /**
  * A mock implementation of [AIAgentEnvironment] used for testing agent behavior.
@@ -98,7 +90,7 @@ public class MockEnvironment(
         val tool = toolRegistry.getTool(functionCall.tool)
 
         val args = tool.decodeArgs(functionCall.contentJson)
-        val result = tool.executeUnsafe(args, MockToolsEnabler)
+        val result = tool.executeUnsafe(args)
 
         return ReceivedToolResult(
             id = functionCall.id,

--- a/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/serialization/ToolComplexParameterTypesTest.kt
+++ b/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/serialization/ToolComplexParameterTypesTest.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.core.tools.serialization
 
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.core.tools.annotations.LLMDescription
@@ -19,9 +18,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
-
-@OptIn(InternalAgentToolsApi::class)
-object ToolParameterTypeTestEnabler : DirectToolCallsEnabler
 
 // Complex tool params = objects, lists of enums, nested lists.
 @OptIn(InternalAgentToolsApi::class)
@@ -42,8 +38,7 @@ class ToolComplexParameterTypesTest {
                         }
                     }
                 }
-            ),
-            ToolParameterTypeTestEnabler
+            )
         )
 
         assertEquals("John", result.person.name)
@@ -135,8 +130,7 @@ class ToolComplexParameterTypesTest {
                         put("custom2", "value2")
                     }
                 }
-            ),
-            ToolParameterTypeTestEnabler
+            )
         )
 
         assertEquals("MyConfig", result.config.name)
@@ -177,8 +171,7 @@ class ToolComplexParameterTypesTest {
                         }
                     }
                 }
-            ),
-            ToolParameterTypeTestEnabler
+            )
         )
 
         assertEquals(2, result.people.size)
@@ -195,8 +188,7 @@ class ToolComplexParameterTypesTest {
                 buildJsonObject {
                     putJsonArray("people") {}
                 }
-            ),
-            ToolParameterTypeTestEnabler
+            )
         )
 
         assertEquals(0, result.people.size)
@@ -234,8 +226,7 @@ class ToolComplexParameterTypesTest {
                         add("RED")
                     }
                 }
-            ),
-            ToolParameterTypeTestEnabler
+            )
         )
 
         assertEquals(3, result.colors.size)
@@ -264,8 +255,7 @@ class ToolComplexParameterTypesTest {
                         add("JOHN")
                     }
                 }
-            ),
-            ToolParameterTypeTestEnabler
+            )
         )
 
         assertEquals(3, result.colors.size)
@@ -294,8 +284,7 @@ class ToolComplexParameterTypesTest {
                     }
                     putJsonArray("optional") {}
                 }
-            ),
-            ToolParameterTypeTestEnabler
+            )
         )
 
         assertEquals(3, result.colors.size)
@@ -331,8 +320,7 @@ class ToolComplexParameterTypesTest {
                     putJsonArray("colors") {}
                     putJsonArray("names") {}
                 }
-            ),
-            ToolParameterTypeTestEnabler
+            )
         )
 
         assertEquals(0, result.colors.size)
@@ -396,8 +384,7 @@ class ToolComplexParameterTypesTest {
                         }
                     }
                 }
-            ),
-            ToolParameterTypeTestEnabler
+            )
         )
 
         assertEquals(2, result.nestedList.size)
@@ -418,8 +405,7 @@ class ToolComplexParameterTypesTest {
                 buildJsonObject {
                     putJsonArray("nestedList") {}
                 }
-            ),
-            ToolParameterTypeTestEnabler
+            )
         )
 
         assertEquals(0, result.nestedList.size)

--- a/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/serialization/ToolTest.kt
+++ b/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/serialization/ToolTest.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.core.tools.serialization
 
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolResult
@@ -20,9 +19,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @OptIn(InternalAgentToolsApi::class)
-object Enabler : DirectToolCallsEnabler
-
-@OptIn(InternalAgentToolsApi::class)
 class ToolTest {
     // Unstructured tool
 
@@ -38,7 +34,7 @@ class ToolTest {
     @Test
     fun testSimpleUnstructuredToolSerialization() = runTest {
         val args = JsonObject(emptyMap())
-        val result = UnstructuredTool.execute(UnstructuredTool.decodeArgs(args), Enabler)
+        val result = UnstructuredTool.execute(UnstructuredTool.decodeArgs(args))
 
         assertEquals("Simple result", result)
     }
@@ -67,7 +63,7 @@ class ToolTest {
             put("arg1", "argument")
             put("arg2", 15)
         }
-        val result = SampleStructuredTool.execute(SampleStructuredTool.decodeArgs(args), Enabler)
+        val result = SampleStructuredTool.execute(SampleStructuredTool.decodeArgs(args))
 
         assertEquals(
             //language=JSON
@@ -112,7 +108,7 @@ class ToolTest {
     @Test
     fun testCustomFormatToolSerialization() = runTest {
         val args = JsonObject(emptyMap())
-        val result = CustomFormatTool.execute(CustomFormatTool.decodeArgs(args), Enabler)
+        val result = CustomFormatTool.execute(CustomFormatTool.decodeArgs(args))
         assertEquals("Foo: first result | Bar: second result", result.toStringDefault())
     }
 }

--- a/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/core/tools/reflect/ReflectionArgsSerializerTest.kt
+++ b/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/core/tools/reflect/ReflectionArgsSerializerTest.kt
@@ -6,7 +6,6 @@ import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.core.tools.annotations.Tool
 import ai.koog.agents.core.tools.reflect.ToolFromCallable.VarArgsSerializer
-import ai.koog.agents.core.tools.reflect.ToolsFromCallableTest.Companion.ToolsEnabler
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -108,7 +107,7 @@ class ReflectionArgsSerializerTest {
             "Specific tool called with 42",
             runBlocking {
                 val args = tool.decodeArgs(buildJsonObject { put("argLong", JsonPrimitive(42)) })
-                tool.execute(args, ToolsEnabler)
+                tool.execute(args)
             },
         )
     }
@@ -122,7 +121,7 @@ class ReflectionArgsSerializerTest {
             "Specific tool called with 42.0",
             runBlocking {
                 val args = tool.decodeArgs(buildJsonObject { put("argDouble", JsonPrimitive(42.0)) })
-                tool.execute(args, ToolsEnabler)
+                tool.execute(args)
             },
         )
     }
@@ -138,7 +137,7 @@ class ReflectionArgsSerializerTest {
             "Specific tool called with 42.0",
             runBlocking {
                 val args = tool.decodeArgs(buildJsonObject { put("argDouble", JsonPrimitive(42.0)) })
-                tool.execute(args, ToolsEnabler)
+                tool.execute(args)
             },
         )
     }
@@ -170,7 +169,7 @@ class ReflectionArgsSerializerTest {
                             )
                         }
                     )
-                tool.execute(args, ToolsEnabler)
+                tool.execute(args)
             }
         )
     }
@@ -205,7 +204,7 @@ class ReflectionArgsSerializerTest {
                             )
                         }
                     )
-                tool.execute(args, ToolsEnabler)
+                tool.execute(args)
             }
         )
     }

--- a/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/core/tools/reflect/ToolSetAsToolsTest.kt
+++ b/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/core/tools/reflect/ToolSetAsToolsTest.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.core.tools.reflect
 
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.core.tools.annotations.Tool
@@ -14,9 +13,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-
-@OptIn(InternalAgentToolsApi::class)
-object TestToolsEnabler : DirectToolCallsEnabler
 
 interface MathToolsInterface : ToolSet {
     @Tool
@@ -133,7 +129,7 @@ class ToolSetAsToolsTest {
             put("b", JsonPrimitive(3))
         }
 
-        val addResult = addTool.execute(addTool.decodeArgs(addArgs), TestToolsEnabler)
+        val addResult = addTool.execute(addTool.decodeArgs(addArgs))
         assertEquals("8", addTool.encodeResultToStringUnsafe(addResult), "Add tool should return 8")
 
         val multiplyTool = tools.find { it.descriptor.name == "multiply" }
@@ -144,7 +140,7 @@ class ToolSetAsToolsTest {
             put("b", JsonPrimitive(7))
         }
 
-        val multiplyResult = multiplyTool.execute(multiplyTool.decodeArgs(multiplyArgs), TestToolsEnabler)
+        val multiplyResult = multiplyTool.execute(multiplyTool.decodeArgs(multiplyArgs))
         assertEquals("28", multiplyTool.encodeResultToStringUnsafe(multiplyResult), "Multiply tool should return 28")
     }
 
@@ -164,7 +160,7 @@ class ToolSetAsToolsTest {
             put("exponent", JsonPrimitive(3))
         }
 
-        val powerResult = powerTool.execute(powerTool.decodeArgs(powerArgs), TestToolsEnabler)
+        val powerResult = powerTool.execute(powerTool.decodeArgs(powerArgs))
         assertEquals("8", powerTool.encodeResultToStringUnsafe(powerResult), "Power tool should return 8")
     }
 
@@ -184,7 +180,7 @@ class ToolSetAsToolsTest {
             put("b", JsonPrimitive(4))
         }
 
-        val subtractResult = subtractTool.execute(subtractTool.decodeArgs(subtractArgs), TestToolsEnabler)
+        val subtractResult = subtractTool.execute(subtractTool.decodeArgs(subtractArgs))
         assertEquals("6", subtractTool.encodeResultToStringUnsafe(subtractResult), "Subtract tool should return 6")
     }
 
@@ -204,7 +200,7 @@ class ToolSetAsToolsTest {
             put("b", JsonPrimitive("World!"))
         }
 
-        val concatResult = concatTool.execute(concatTool.decodeArgs(concatArgs), TestToolsEnabler)
+        val concatResult = concatTool.execute(concatTool.decodeArgs(concatArgs))
         assertEquals("\"Hello, World!\"", concatTool.encodeResultToStringUnsafe(concatResult), "Concat tool should return \"Hello, World!\"")
     }
 
@@ -223,7 +219,7 @@ class ToolSetAsToolsTest {
         }
 
         val createPersonResult =
-            createPersonTool.execute(createPersonTool.decodeArgs(createPersonArgs), TestToolsEnabler)
+            createPersonTool.execute(createPersonTool.decodeArgs(createPersonArgs))
         val personJson = createPersonTool.encodeResultToStringUnsafe(createPersonResult)
         assertTrue(personJson.contains("\"name\":\"John\""), "Person JSON should contain name")
         assertTrue(personJson.contains("\"age\":30"), "Person JSON should contain age")
@@ -236,7 +232,7 @@ class ToolSetAsToolsTest {
         }
 
         val formatPersonResult =
-            formatPersonTool.execute(formatPersonTool.decodeArgs(formatPersonArgs), TestToolsEnabler)
+            formatPersonTool.execute(formatPersonTool.decodeArgs(formatPersonArgs))
         assertEquals(
             "\"John is 30 years old\"",
             formatPersonTool.encodeResultToStringUnsafe(formatPersonResult),

--- a/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/core/tools/reflect/ToolsFromCallableTest.kt
+++ b/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/core/tools/reflect/ToolsFromCallableTest.kt
@@ -2,7 +2,6 @@
 
 package ai.koog.agents.core.tools.reflect
 
-import ai.koog.agents.core.tools.DirectToolCallsEnabler
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.core.tools.annotations.Tool
@@ -206,8 +205,6 @@ class MyTools : Tools {
 @OptIn(InternalAgentToolsApi::class)
 class ToolsFromCallableTest {
     companion object {
-        object ToolsEnabler : DirectToolCallsEnabler
-
         val tools = MyTools()
         val json = Json
 
@@ -311,7 +308,7 @@ class ToolsFromCallableTest {
         val tool = callable.asTool(json)
         val args = tool.decodeArgs(argumentJson)
         val result = runBlocking {
-            tool.execute(args, ToolsEnabler)
+            tool.execute(args)
         }
         assertEquals(
             expectedResult,


### PR DESCRIPTION
Remove `DirectToolCallEnabler` interface to allow calling tools with `execute` direclty. This is helpful to test that your code actually works as expected outside of context of AI agent.