### PR TITLE
KG-507. Support multi-responses from LLM in the subgraphWithTask API

### DIFF
--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
@@ -1,5 +1,6 @@
 package ai.koog.agents.ext.agent
 
+import ai.koog.agents.core.agent.ToolCalls
 import ai.koog.agents.core.agent.context.AIAgentContext
 import ai.koog.agents.core.agent.context.AIAgentGraphContextBase
 import ai.koog.agents.core.agent.context.DetachedPromptExecutorAPI
@@ -10,10 +11,9 @@ import ai.koog.agents.core.dsl.builder.AIAgentBuilderDslMarker
 import ai.koog.agents.core.dsl.builder.AIAgentSubgraphBuilderBase
 import ai.koog.agents.core.dsl.builder.AIAgentSubgraphDelegate
 import ai.koog.agents.core.dsl.builder.forwardTo
-import ai.koog.agents.core.dsl.extension.nodeLLMRequest
-import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResult
-import ai.koog.agents.core.dsl.extension.onIsInstance
-import ai.koog.agents.core.dsl.extension.onToolCall
+import ai.koog.agents.core.dsl.extension.containsToolCalls
+import ai.koog.agents.core.dsl.extension.nodeLLMRequestMultiple
+import ai.koog.agents.core.dsl.extension.nodeLLMSendMultipleToolResults
 import ai.koog.agents.core.dsl.extension.setToolChoiceRequired
 import ai.koog.agents.core.environment.ReceivedToolResult
 import ai.koog.agents.core.environment.executeTool
@@ -132,42 +132,10 @@ public object SubgraphWithTaskUtils {
 }
 
 /**
- * Creates a subgraph, which performs one specific task, defined by [defineTask],
- * using the tools defined by [toolSelectionStrategy].
+ * Creates an identity tool which performs no transformations, returning the input as the output.
  *
- * Use this function if you need the agent to perform a single task which outputs a structured result.
- *
- * @param Input The input type for the task to be defined in the subgraph.
- * @param Output The output type for the subgraph's finalized result.
- * @param toolSelectionStrategy The strategy used to select tools for the subgraph operations.
- * @param llmModel Optional language model to be used within the subgraph. Defaults to null.
- * @param llmParams Optional parameters for configuring the language model behavior. Defaults to null.
- * @param defineTask A suspending lambda function that defines the task for the subgraph, taking the input as a parameter.
- * @return A delegate that represents the created subgraph, allowing input and output operations.
+ * @return An instance of a Tool that processes input of type Output and returns the same input as output.
  */
-@OptIn(InternalAgentToolsApi::class)
-@AIAgentBuilderDslMarker
-public inline fun <reified Input, reified Output> AIAgentSubgraphBuilderBase<*, *>.subgraphWithTask(
-    toolSelectionStrategy: ToolSelectionStrategy,
-    llmModel: LLModel? = null,
-    llmParams: LLMParams? = null,
-    assistantResponseRepeatMax: Int? = null,
-    noinline defineTask: suspend AIAgentGraphContextBase.(input: Input) -> String
-): AIAgentSubgraphDelegate<Input, Output> = subgraph(
-    toolSelectionStrategy = toolSelectionStrategy,
-    llmModel = llmModel,
-    llmParams = llmParams,
-) {
-    // An identity tool that provides arguments as a tool result without changes.
-    val finishTool = identityTool<Output>()
-
-    setupSubgraphWithTask<Input, Output, Output>(
-        finishTool = finishTool,
-        assistantResponseRepeatMax = assistantResponseRepeatMax,
-        defineTask = defineTask
-    )
-}
-
 @PublishedApi
 @OptIn(InternalAgentToolsApi::class)
 internal inline fun <reified Output> identityTool(): Tool<Output, Output> = object : Tool<Output, Output>() {
@@ -178,6 +146,47 @@ internal inline fun <reified Output> identityTool(): Tool<Output, Output> = obje
     override suspend fun execute(args: Output): Output = args
 }
 
+//region Subgraph With Task
+
+/**
+ * Creates a subgraph, which performs one specific task, defined by [defineTask],
+ * using the tools defined by [toolSelectionStrategy].
+ *
+ * Use this function if you need the agent to perform a single task which outputs a structured result.
+ *
+ * @param Input The input type for the task to be defined in the subgraph.
+ * @param Output The output type for the subgraph's finalized result.
+ * @param toolSelectionStrategy The strategy used to select tools for the subgraph operations.
+ * @param llmModel Optional language model to be used within the subgraph. Defaults to null.
+ * @param llmParams Optional parameters for configuring the language model behavior. Defaults to null.
+ * @param runMode The mode in which tools are executed. Defaults to sequential execution.
+ * @param defineTask A suspending lambda function that defines the task for the subgraph, taking the input as a parameter.
+ * @return A delegate that represents the created subgraph, allowing input and output operations.
+ */
+@OptIn(InternalAgentToolsApi::class, InternalAgentsApi::class)
+@AIAgentBuilderDslMarker
+public inline fun <reified Input, reified Output> AIAgentSubgraphBuilderBase<*, *>.subgraphWithTask(
+    toolSelectionStrategy: ToolSelectionStrategy,
+    llmModel: LLModel? = null,
+    llmParams: LLMParams? = null,
+    runMode: ToolCalls = ToolCalls.SEQUENTIAL,
+    assistantResponseRepeatMax: Int? = null,
+    noinline defineTask: suspend AIAgentGraphContextBase.(input: Input) -> String
+): AIAgentSubgraphDelegate<Input, Output> = subgraph(
+    toolSelectionStrategy = toolSelectionStrategy,
+    llmModel = llmModel,
+    llmParams = llmParams,
+) {
+    val finishTool = identityTool<Output>()
+
+    setupSubgraphWithTask<Input, Output, Output>(
+        finishTool = finishTool,
+        runMode = runMode,
+        assistantResponseRepeatMax = assistantResponseRepeatMax,
+        defineTask = defineTask
+    )
+}
+
 /**
  * Creates a subgraph with a task definition and specified tools. The subgraph uses the provided tools to process
  * input and execute the defined task, eventually producing a result through the provided finish tool.
@@ -185,20 +194,24 @@ internal inline fun <reified Output> identityTool(): Tool<Output, Output> = obje
  * @param tools The list of tools that are available for use within the subgraph.
  * @param llmModel An optional language model to be used in the subgraph. If not specified, a default model may be used.
  * @param llmParams Optional parameters to customize the behavior of the language model in the subgraph.
+ * @param runMode The mode in which tools are executed. Defaults to sequential execution.
  * @param defineTask A suspend function that defines the task to be executed by the subgraph based on the given input.
  * @return A delegate representing the subgraph that processes the input and produces a result through the finish tool.
  */
-@Suppress("unused")
 @AIAgentBuilderDslMarker
 public inline fun <reified Input, reified Output> AIAgentSubgraphBuilderBase<*, *>.subgraphWithTask(
     tools: List<Tool<*, *>>,
     llmModel: LLModel? = null,
     llmParams: LLMParams? = null,
+    runMode: ToolCalls = ToolCalls.SEQUENTIAL,
+    assistantResponseRepeatMax: Int? = null,
     noinline defineTask: suspend AIAgentGraphContextBase.(input: Input) -> String
 ): AIAgentSubgraphDelegate<Input, Output> = subgraphWithTask(
     toolSelectionStrategy = ToolSelectionStrategy.Tools(tools.map { it.descriptor }),
     llmModel = llmModel,
     llmParams = llmParams,
+    runMode = runMode,
+    assistantResponseRepeatMax = assistantResponseRepeatMax,
     defineTask = defineTask
 )
 
@@ -212,16 +225,19 @@ public inline fun <reified Input, reified Output> AIAgentSubgraphBuilderBase<*, 
  * @param finishTool The tool responsible for finalizing the task and producing the transformed output.
  * @param llmModel The optional language model to be used in the subgraph for processing requests.
  * @param llmParams The optional parameters to customize the behavior of the language model.
+ * @param runMode The mode in which tools are executed. Defaults to sequential execution.
+ * @param assistantResponseRepeatMax The maximum number of assistant responses allowed before determining that the task cannot be completed.
  * @param defineTask A lambda function to define the task logic, which accepts the input and returns a task description.
  * @return A delegate object representing the constructed subgraph for the specified task.
  */
-@OptIn(InternalAgentToolsApi::class)
+@OptIn(InternalAgentsApi::class)
 @AIAgentBuilderDslMarker
 public inline fun <reified Input, reified Output, reified OutputTransformed> AIAgentSubgraphBuilderBase<*, *>.subgraphWithTask(
     toolSelectionStrategy: ToolSelectionStrategy,
     finishTool: Tool<Output, OutputTransformed>,
     llmModel: LLModel? = null,
     llmParams: LLMParams? = null,
+    runMode: ToolCalls = ToolCalls.SEQUENTIAL,
     assistantResponseRepeatMax: Int? = null,
     noinline defineTask: suspend AIAgentGraphContextBase.(input: Input) -> String
 ): AIAgentSubgraphDelegate<Input, OutputTransformed> = subgraph(
@@ -231,6 +247,7 @@ public inline fun <reified Input, reified Output, reified OutputTransformed> AIA
 ) {
     setupSubgraphWithTask<Input, Output, OutputTransformed>(
         finishTool = finishTool,
+        runMode = runMode,
         assistantResponseRepeatMax = assistantResponseRepeatMax,
         defineTask = defineTask
     )
@@ -246,16 +263,19 @@ public inline fun <reified Input, reified Output, reified OutputTransformed> AIA
  * @param finishTool The tool responsible for transforming the output of the subgraph.
  * @param llmModel The language model to be used within the subgraph. Defaults to null if not provided.
  * @param llmParams Optional parameters to customize the behavior of the language model. Defaults to null if not provided.
+ * @param runMode The mode in which tools are executed. Defaults to sequential execution.
+ * @param assistantResponseRepeatMax The maximum number of assistant responses allowed before determining that the task cannot be completed.
  * @param defineTask A suspend function that defines the task to be executed in the subgraph, based on the provided input.
  * @return A subgraph delegate that handles the input and produces the transformed output for the defined task.
  */
-@OptIn(InternalAgentToolsApi::class)
+@OptIn(InternalAgentsApi::class)
 @AIAgentBuilderDslMarker
 public inline fun <reified Input, reified Output, reified OutputTransformed> AIAgentSubgraphBuilderBase<*, *>.subgraphWithTask(
     tools: List<Tool<*, *>>,
     finishTool: Tool<Output, OutputTransformed>,
     llmModel: LLModel? = null,
     llmParams: LLMParams? = null,
+    runMode: ToolCalls = ToolCalls.SEQUENTIAL,
     assistantResponseRepeatMax: Int? = null,
     noinline defineTask: suspend AIAgentGraphContextBase.(input: Input) -> String
 ): AIAgentSubgraphDelegate<Input, OutputTransformed> = subgraph(
@@ -265,10 +285,15 @@ public inline fun <reified Input, reified Output, reified OutputTransformed> AIA
 ) {
     setupSubgraphWithTask<Input, Output, OutputTransformed>(
         finishTool = finishTool,
+        runMode = runMode,
         assistantResponseRepeatMax = assistantResponseRepeatMax,
         defineTask = defineTask
     )
 }
+
+//endregion Subgraph With Task
+
+//region Subgraph With Verification
 
 /**
  * [subgraphWithTask] with [CriticResult] result.
@@ -281,6 +306,8 @@ public inline fun <reified Input : Any> AIAgentSubgraphBuilderBase<*, *>.subgrap
     toolSelectionStrategy: ToolSelectionStrategy,
     llmModel: LLModel? = null,
     llmParams: LLMParams? = null,
+    runMode: ToolCalls = ToolCalls.SEQUENTIAL,
+    assistantResponseRepeatMax: Int? = null,
     noinline defineTask: suspend AIAgentGraphContextBase.(input: Input) -> String
 ): AIAgentSubgraphDelegate<Input, CriticResult<Input>> = subgraph {
     val inputKey = createStorageKey<Input>("subgraphWithVerification-input-key")
@@ -295,6 +322,8 @@ public inline fun <reified Input : Any> AIAgentSubgraphBuilderBase<*, *>.subgrap
         toolSelectionStrategy = toolSelectionStrategy,
         llmModel = llmModel,
         llmParams = llmParams,
+        runMode = runMode,
+        assistantResponseRepeatMax = assistantResponseRepeatMax,
         defineTask = defineTask
     )
 
@@ -331,13 +360,19 @@ public inline fun <reified Input : Any> AIAgentSubgraphBuilderBase<*, *>.subgrap
     tools: List<Tool<*, *>>,
     llmModel: LLModel? = null,
     llmParams: LLMParams? = null,
+    runMode: ToolCalls = ToolCalls.SEQUENTIAL,
+    assistantResponseRepeatMax: Int? = null,
     noinline defineTask: suspend AIAgentGraphContextBase.(input: Input) -> String
 ): AIAgentSubgraphDelegate<Input, CriticResult<Input>> = subgraphWithVerification(
     toolSelectionStrategy = ToolSelectionStrategy.Tools(tools.map { it.descriptor }),
     llmModel = llmModel,
     llmParams = llmParams,
+    runMode = runMode,
+    assistantResponseRepeatMax = assistantResponseRepeatMax,
     defineTask = defineTask
 )
+
+//endregion Subgraph With Verification
 
 /**
  * Configures a subgraph within the AI agent framework, associating it with required tasks and operations.
@@ -347,9 +382,44 @@ public inline fun <reified Input : Any> AIAgentSubgraphBuilderBase<*, *>.subgrap
  * @param finishTool A descriptor for the tool that determines the condition to finalize the subgraph's operation.
  * @param defineTask A suspending lambda that defines the main task of the subgraph, producing a task description based on the input.
  */
-@OptIn(InternalAgentToolsApi::class, InternalAgentsApi::class)
+@Deprecated(
+    message = "Use setupSubgraphWithTask API that receive a runMode parameter instead.",
+    replaceWith = ReplaceWith(
+        expression = "setupSubgraphWithTask(finishTool, assistantResponseRepeatMax, runMode, defineTask)"
+    )
+)
+@InternalAgentsApi
 public inline fun <reified Input, reified Output, reified OutputTransformed> AIAgentSubgraphBuilderBase<Input, OutputTransformed>.setupSubgraphWithTask(
     finishTool: Tool<Output, OutputTransformed>,
+    assistantResponseRepeatMax: Int? = null,
+    noinline defineTask: suspend AIAgentGraphContextBase.(Input) -> String
+) {
+    return setupSubgraphWithTask(
+        finishTool = finishTool,
+        runMode = ToolCalls.SEQUENTIAL,
+        assistantResponseRepeatMax = assistantResponseRepeatMax,
+        defineTask = defineTask,
+    )
+}
+
+/**
+ * Configures and sets up a subgraph with task handling, including tool execution operations,
+ * assistant response management, and task finalization logic.
+ *
+ * @param Input the type of input data for the subgraph.
+ * @param Output the type of output data from the finish tool.
+ * @param OutputTransformed the transformed type of the output data after processing by the finish tool.
+ * @param finishTool the tool used to signify task completion and process task finalization.
+ * @param runMode the mode in which tools are executed, e.g., parallel or sequential execution.
+ * @param assistantResponseRepeatMax the maximum number of assistant responses allowed before
+ *        determining that the task cannot be completed. If not provided, a default is used.
+ * @param defineTask a suspend function defining the task description, executed within the
+ *        context of an AI agent graph and based on the given input data.
+ */
+@InternalAgentsApi
+public inline fun <reified Input, reified Output, reified OutputTransformed> AIAgentSubgraphBuilderBase<Input, OutputTransformed>.setupSubgraphWithTask(
+    finishTool: Tool<Output, OutputTransformed>,
+    runMode: ToolCalls,
     assistantResponseRepeatMax: Int? = null,
     noinline defineTask: suspend AIAgentGraphContextBase.(Input) -> String
 ) {
@@ -387,26 +457,41 @@ public inline fun <reified Input, reified Output, reified OutputTransformed> AIA
     }
 
     // Helper node to overcome problems of the current api and repeat less code when writing routing conditions
-    val nodeDecide by node<Message.Response, Message.Response> { it }
+    val nodeDecide by node<List<Message.Response>, List<Message.Response>> { it }
 
-    val nodeCallLLM by nodeLLMRequest()
+    val nodeCallLLM by nodeLLMRequestMultiple()
 
-    /**
-     * Works like a normal `nodeExecuteTool` but a bit hacked: if LLM decides to call the fake "finalize_result" tool,
-     * it doesn't execute it.
-     * */
-    val callToolHacked by node<Message.Tool.Call, ReceivedToolResult> { toolCall ->
-        if (toolCall.tool == finishTool.name) {
+    val callToolsHacked by node<List<Message.Tool.Call>, List<ReceivedToolResult>> { toolCalls ->
+        val (finishToolCalls, regularToolCalls) = toolCalls.partition { it.tool == finishTool.name }
+
+        // Execute finish tool
+        val finishToolResult = finishToolCalls.firstOrNull()?.let { toolCall ->
             executeFinishTool<Output, OutputTransformed>(toolCall, finishTool)
-        } else {
-            environment.executeTool(toolCall)
+        }
+
+        // Execute regular tools
+        val regularToolsResults = when (runMode) {
+            ToolCalls.PARALLEL -> {
+                environment.executeTools(regularToolCalls)
+            }
+            ToolCalls.SEQUENTIAL,
+            ToolCalls.SINGLE_RUN_SEQUENTIAL -> {
+                regularToolCalls.map { toolCall ->
+                    environment.executeTool(toolCall)
+                }
+            }
+        }
+
+        buildList {
+            finishToolResult?.let { add(it) }
+            addAll(regularToolsResults)
         }
     }
 
-    val sendToolResult by nodeLLMSendToolResult()
+    val sendToolsResults by nodeLLMSendMultipleToolResults()
 
     @OptIn(DetachedPromptExecutorAPI::class)
-    val handleAssistantMessage by node<Message.Assistant, Message.Response> { response ->
+    val handleAssistantMessage by node<Message.Assistant, List<Message.Response>> { response ->
         if (llm.model.capabilities.contains(LLMCapability.ToolChoice)) {
             error(
                 "Subgraph with task must always call tools, but no ${Message.Tool.Call::class.simpleName} was generated, " +
@@ -436,14 +521,24 @@ public inline fun <reified Input, reified Output, reified OutputTransformed> AIA
                 }
             }
 
-            requestLLM()
+            requestLLMMultiple()
         }
     }
 
     nodeStart then setupTask then nodeCallLLM then nodeDecide
 
-    edge(nodeDecide forwardTo callToolHacked onToolCall { true })
-    edge(nodeDecide forwardTo handleAssistantMessage onIsInstance Message.Assistant::class)
+    edge(
+        nodeDecide forwardTo callToolsHacked
+            onCondition { responses -> responses.containsToolCalls() }
+            transformed { responses -> responses.filterIsInstance<Message.Tool.Call>() }
+    )
+
+    edge(
+        nodeDecide forwardTo handleAssistantMessage
+            onCondition { responses -> responses.filterIsInstance<Message.Assistant>().isNotEmpty() }
+            transformed { responses -> responses.first() as Message.Assistant }
+    )
+
     edge(handleAssistantMessage forwardTo nodeDecide)
 
     // throw to terminate the agent early with exception
@@ -456,26 +551,28 @@ public inline fun <reified Input, reified Output, reified OutputTransformed> AIA
         }
     )
 
-    edge(callToolHacked forwardTo finalizeTask onCondition { it.tool == finishTool.name })
-    edge(callToolHacked forwardTo sendToolResult)
+    edge(
+        callToolsHacked forwardTo finalizeTask
+            onCondition { toolResults -> toolResults.firstOrNull()?.let { it.tool == finishTool.name } == true }
+            transformed { toolsResults -> toolsResults.first() }
+    )
 
-    edge(sendToolResult forwardTo nodeDecide)
+    edge(callToolsHacked forwardTo sendToolsResults)
+
+    edge(sendToolsResults forwardTo nodeDecide)
 
     edge(finalizeTask forwardTo nodeFinish)
 }
 
-@OptIn(InternalAgentToolsApi::class)
 @PublishedApi
+@InternalAgentsApi
 internal suspend inline fun <reified Output, reified OutputTransformed> AIAgentContext.executeFinishTool(
     toolCall: Message.Tool.Call,
-    finishTool: Tool<Output, OutputTransformed>
+    finishTool: Tool<Output, OutputTransformed>,
 ): ReceivedToolResult {
     // Execute Finish tool directly and get a result
-    val toolArgs = finishTool.decodeArgs(toolCall.contentJson)
-
-    val toolResult = finishTool.execute(
-        args = toolArgs
-    )
+    val args = finishTool.decodeArgs(toolCall.contentJson)
+    val toolResult = finishTool.execute(args = args)
 
     // Append a final tool call result to the prompt for further LLM calls
     // to see it (otherwise they would fail)

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubtaskExt.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubtaskExt.kt
@@ -30,14 +30,14 @@ import ai.koog.prompt.params.LLMParams
  * @param Input The type of the input provided to the subtask.
  * @param input The input data for the subtask, which will be used to
  * create and execute the task.
- * @param tools An optional list of tools that can be utilized during
+ * @param tools An optional list of tools that can be used during
  * the execution of the subtask.
  * @param llmModel An optional parameter specifying the LLM model to be used for the subtask.
  * @param llmParams Optional configuration parameters for the LLM, such as temperature
  * and token limits.
  * @param runMode The mode in which tools should be executed, either sequentially or in parallel.
  * @param assistantResponseRepeatMax An optional parameter specifying the maximum number of
- * retries for obtaining valid responses from the assistant.
+ * retries for getting valid responses from the assistant.
  * @param defineTask A suspend function that defines the subtask as a string
  * based on the provided input.
  * @return A [CriticResult] object containing the verification status, feedback,
@@ -72,7 +72,7 @@ public suspend inline fun <reified Input> AIAgentFunctionalContext.subtaskWithVe
 
 /**
  * Executes a subtask within the larger context of an AI agent's functional operation. This method allows you to define a specific
- * task to be performed, utilizing the given input, tools, and optional configuration parameters.
+ * task to be performed, using the given input, tools, and optional configuration parameters.
  *
  * @param Input The type of input provided to the subtask.
  * @param Output The type of the output expected from the subtask.
@@ -102,11 +102,11 @@ public suspend inline fun <reified Input, reified Output> AIAgentFunctionalConte
 
 /**
  * Executes a subtask within the AI agent's functional context. This method enables the use of tools to
- * accomplish a specific task based on the input provided. It defines the task using an inline function,
+ * achieve a specific task based on the input provided. It defines the task using an inline function,
  * employs tools iteratively, and attempts to complete the subtask with a designated finishing tool.
  *
  * @param input The input data required to define and execute the subtask.
- * @param tools An optional list of tools that can be utilized to accomplish the task, excluding the finishing tool.
+ * @param tools An optional list of tools that can be used to achieve the task, excluding the finishing tool.
  * @param finishTool A mandatory tool that determines the final result of the subtask by producing and transforming output.
  * @param llmModel An optional specific language learning model (LLM) to use for executing the subtask.
  * @param llmParams Optional parameters for configuring the behavior of the LLM during subtask execution.
@@ -131,7 +131,7 @@ public suspend inline fun <reified Input, reified Output, reified OutputTransfor
     val toolsSubset = tools?.map { it.descriptor } ?: llm.readSession { this.tools.toList() }
 
     val originalTools = llm.readSession { this.tools.toList() }
-    val originalMdel = llm.readSession { this.model }
+    val originalModel = llm.readSession { this.model }
     val originalParams = llm.readSession { this.prompt.params }
 
     // setup:
@@ -171,7 +171,7 @@ public suspend inline fun <reified Input, reified Output, reified OutputTransfor
     // rollback
     llm.writeSession {
         this.tools = originalTools
-        this.model = originalMdel
+        this.model = originalModel
         this.prompt = prompt.withParams(originalParams)
     }
 
@@ -262,7 +262,7 @@ internal suspend inline fun <reified Output, reified OutputTransformed> AIAgentF
     }
 }
 
-@OptIn(InternalAgentToolsApi::class)
+@OptIn(InternalAgentToolsApi::class, InternalAgentsApi::class)
 @PublishedApi
 internal suspend inline fun <reified Output, reified OutputTransformed> AIAgentFunctionalContext.executeMultipleToolsHacked(
     toolCalls: List<Message.Tool.Call>,

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/mock/MockTools.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/mock/MockTools.kt
@@ -26,12 +26,14 @@ object MockTools {
         }
     }
 
-    class BlankTool : Tool<BlankTool.Args, String>() {
+    class BlankTool(name: String? = null) : Tool<BlankTool.Args, String>() {
 
         @Serializable
         data class Args(
-            @property:LLMDescription("Dummy parameter") val args: String = ""
+            @property:LLMDescription("Blank parameter") val args: String = ""
         )
+
+        override val name: String = name ?: "blank-tool"
 
         override val argsSerializer: KSerializer<Args> = serializer<Args>()
 
@@ -43,4 +45,6 @@ object MockTools {
             return args.args
         }
     }
+
+    class TransferArgumentsTool()
 }


### PR DESCRIPTION
[KG-507](https://youtrack.jetbrains.com/issue/KG-507/Support-multi-response-from-LLM-in-subgraphWithTask-API). Support multi-responses from LLM in the subgraphWithTask API

- Unify the logic for subgraphWithTask API to be able to support multi-responses from LLM;
- Add an optional parameter 'runMode' to control the task execution flow and run tools flow;
- Deprecate old methods;
- Add tests.

## Motivation and Context
Unify the subgraphWithTask API

## Breaking Changes
No

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [x] The change was discussed and approved in the issue
- [x] Docs have been added / updated
