### PR TITLE
Creating correlation between LLMCall events

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/PromptExecutorProxy.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/PromptExecutorProxy.kt
@@ -76,11 +76,11 @@ public class PromptExecutorProxy(
             }
             .onEach {
                 logger.debug { "Received frame from LLM streaming call: $it" }
-                pipeline.onLLMStreamingFrameReceived(runId, callId,  it)
+                pipeline.onLLMStreamingFrameReceived(runId, callId, it)
             }
             .catch { error ->
                 logger.debug(error) { "Error in LLM streaming call" }
-                pipeline.onLLMStreamingFailed(runId, callId,  error)
+                pipeline.onLLMStreamingFailed(runId, callId, error)
                 throw error
             }
             .onCompletion { error ->

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/PromptExecutorProxy.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/PromptExecutorProxy.kt
@@ -15,6 +15,8 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 /**
  * A wrapper around [ai.koog.prompt.executor.model.PromptExecutor] that allows for adding internal functionality to the executor
@@ -23,6 +25,7 @@ import kotlinx.coroutines.flow.onStart
  * @property executor The [ai.koog.prompt.executor.model.PromptExecutor] to wrap.
  * @property pipeline The [ai.koog.agents.core.feature.pipeline.AIAgentPipeline] associated with the executor.
  */
+@OptIn(ExperimentalUuidApi::class)
 public class PromptExecutorProxy(
     private val executor: PromptExecutor,
     private val pipeline: AIAgentPipeline,
@@ -34,13 +37,14 @@ public class PromptExecutorProxy(
     }
 
     override suspend fun execute(prompt: Prompt, model: LLModel, tools: List<ToolDescriptor>): List<Message.Response> {
+        val callId = Uuid.random().toString()
         logger.debug { "Executing LLM call (prompt: $prompt, tools: [${tools.joinToString { it.name }}])" }
-        pipeline.onLLMCallStarting(runId, prompt, model, tools)
+        pipeline.onLLMCallStarting(runId, callId, prompt, model, tools)
 
         val responses = executor.execute(prompt, model, tools)
 
         logger.trace { "Finished LLM call with responses: [${responses.joinToString { "${it.role}: ${it.content}" }}]" }
-        pipeline.onLLMCallCompleted(runId, prompt, model, tools, responses)
+        pipeline.onLLMCallCompleted(runId, callId, prompt, model, tools, responses)
 
         return responses
     }
@@ -64,23 +68,24 @@ public class PromptExecutorProxy(
         tools: List<ToolDescriptor>
     ): Flow<StreamFrame> {
         logger.debug { "Executing LLM streaming call (prompt: $prompt, tools: [${tools.joinToString { it.name }}])" }
+        val callId: String = Uuid.random().toString()
         return executor.executeStreaming(prompt, model, tools)
             .onStart {
                 logger.debug { "Starting LLM streaming call" }
-                pipeline.onLLMStreamingStarting(runId, prompt, model, tools)
+                pipeline.onLLMStreamingStarting(runId, callId, prompt, model, tools)
             }
             .onEach {
                 logger.debug { "Received frame from LLM streaming call: $it" }
-                pipeline.onLLMStreamingFrameReceived(runId, it)
+                pipeline.onLLMStreamingFrameReceived(runId, callId,  it)
             }
             .catch { error ->
                 logger.debug(error) { "Error in LLM streaming call" }
-                pipeline.onLLMStreamingFailed(runId, error)
+                pipeline.onLLMStreamingFailed(runId, callId,  error)
                 throw error
             }
             .onCompletion { error ->
                 logger.debug(error) { "Finished LLM streaming call" }
-                pipeline.onLLMStreamingCompleted(runId, prompt, model, tools)
+                pipeline.onLLMStreamingCompleted(runId, callId, prompt, model, tools)
             }
     }
 
@@ -115,12 +120,14 @@ public class PromptExecutorProxy(
         model: LLModel
     ): ModerationResult {
         logger.debug { "Executing moderation LLM request (prompt: $prompt)" }
-        pipeline.onLLMCallStarting(runId, prompt, model, emptyList())
+        val callId = Uuid.random().toString()
+
+        pipeline.onLLMCallStarting(runId, callId, prompt, model, emptyList())
 
         val result = executor.moderate(prompt, model)
         logger.trace { "Finished moderation LLM request with response: $result" }
 
-        pipeline.onLLMCallCompleted(runId, prompt, model, emptyList(), responses = emptyList(), moderationResponse = result)
+        pipeline.onLLMCallCompleted(runId, callId, prompt, model, emptyList(), responses = emptyList(), moderationResponse = result)
         return result
     }
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/debugger/Debugger.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/debugger/Debugger.kt
@@ -230,6 +230,7 @@ public class Debugger(public val port: Int, public val awaitInitialConnectionTim
             pipeline.interceptLLMCallStarting(this) intercept@{ eventContext ->
                 val event = LLMCallStartingEvent(
                     runId = eventContext.runId,
+                    callId = eventContext.callId,
                     prompt = eventContext.prompt,
                     model = eventContext.model.toModelInfo(),
                     tools = eventContext.tools.map { it.name },
@@ -241,6 +242,7 @@ public class Debugger(public val port: Int, public val awaitInitialConnectionTim
             pipeline.interceptLLMCallCompleted(this) intercept@{ eventContext ->
                 val event = LLMCallCompletedEvent(
                     runId = eventContext.runId,
+                    callId = eventContext.callId,
                     prompt = eventContext.prompt,
                     model = eventContext.model.toModelInfo(),
                     responses = eventContext.responses,
@@ -257,6 +259,7 @@ public class Debugger(public val port: Int, public val awaitInitialConnectionTim
             pipeline.interceptLLMStreamingStarting(this) intercept@{ eventContext ->
                 val event = LLMStreamingStartingEvent(
                     runId = eventContext.runId,
+                    callId = eventContext.callId,
                     prompt = eventContext.prompt,
                     model = eventContext.model.toModelInfo().modelIdentifierName,
                     tools = eventContext.tools.map { it.name },
@@ -268,6 +271,7 @@ public class Debugger(public val port: Int, public val awaitInitialConnectionTim
             pipeline.interceptLLMStreamingFrameReceived(this) intercept@{ eventContext ->
                 val event = LLMStreamingFrameReceivedEvent(
                     runId = eventContext.runId,
+                    callId = eventContext.callId,
                     frame = eventContext.streamFrame,
                     timestamp = pipeline.clock.now().toEpochMilliseconds()
                 )
@@ -277,6 +281,7 @@ public class Debugger(public val port: Int, public val awaitInitialConnectionTim
             pipeline.interceptLLMStreamingFailed(this) intercept@{ eventContext ->
                 val event = LLMStreamingFailedEvent(
                     runId = eventContext.runId,
+                    callId = eventContext.callId,
                     error = eventContext.error.toAgentError(),
                     timestamp = pipeline.clock.now().toEpochMilliseconds()
                 )
@@ -286,6 +291,7 @@ public class Debugger(public val port: Int, public val awaitInitialConnectionTim
             pipeline.interceptLLMStreamingCompleted(this) intercept@{ eventContext ->
                 val event = LLMStreamingCompletedEvent(
                     runId = eventContext.runId,
+                    callId = eventContext.callId,
                     prompt = eventContext.prompt,
                     model = eventContext.model.toModelInfo().modelIdentifierName,
                     tools = eventContext.tools.map { it.name },

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/llm/LLMCallEventContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/llm/LLMCallEventContext.kt
@@ -22,6 +22,7 @@ public interface LLMCallEventContext : AgentLifecycleEventContext
  */
 public data class LLMCallStartingContext(
     val runId: String,
+    val callId: String,
     val prompt: Prompt,
     val model: LLModel,
     val tools: List<ToolDescriptor>,
@@ -39,6 +40,7 @@ public data class LLMCallStartingContext(
  */
 public data class LLMCallCompletedContext(
     val runId: String,
+    val callId: String,
     val prompt: Prompt,
     val model: LLModel,
     val tools: List<ToolDescriptor>,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/streaming/LLMStreamingEventContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/streaming/LLMStreamingEventContext.kt
@@ -17,12 +17,14 @@ public interface LLMStreamingEventContext : AgentLifecycleEventContext
  * This context is provided when streaming is about to begin.
  *
  * @property runId The unique identifier for this streaming session.
+ * @property callId The unique identifier for the streaming call.
  * @property prompt The prompt that will be sent to the language model for streaming.
  * @property model The language model instance being used for streaming.
  * @property tools The list of tool descriptors available for the streaming call.
  */
 public data class LLMStreamingStartingContext(
     val runId: String,
+    val callId: String,
     val prompt: Prompt,
     val model: LLModel,
     val tools: List<ToolDescriptor>,
@@ -35,10 +37,12 @@ public data class LLMStreamingStartingContext(
  * This context is provided when stream frames are sent out during the streaming process.
  *
  * @property runId The unique identifier for this streaming session.
+ * @property callId The unique identifier for the streaming call.
  * @property streamFrame The individual stream frame containing partial response data from the LLM.
  */
 public data class LLMStreamingFrameReceivedContext(
     val runId: String,
+    val callId: String,
     val streamFrame: StreamFrame,
 ) : LLMStreamingEventContext {
     override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.LLMStreamingFrameReceived
@@ -49,10 +53,12 @@ public data class LLMStreamingFrameReceivedContext(
  * This context is provided when an error occurs during streaming.
  *
  * @property runId The unique identifier for this streaming session.
+ * @property callId The unique identifier for the streaming call.
  * @property error The exception or error that occurred during streaming.
  */
 public data class LLMStreamingFailedContext(
     val runId: String,
+    val callId: String,
     val error: Throwable
 ) : LLMStreamingEventContext {
     override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.LLMStreamingFailed
@@ -63,12 +69,14 @@ public data class LLMStreamingFailedContext(
  * This context is provided when streaming is complete.
  *
  * @property runId The unique identifier for this streaming session.
+ * @property callId The unique identifier for the streaming call.
  * @property prompt The prompt that was sent to the language model for streaming.
  * @property model The language model instance that was used for streaming.
  * @property tools The list of tool descriptors that were available for the streaming call.
  */
 public data class LLMStreamingCompletedContext(
     val runId: String,
+    val callId: String,
     val prompt: Prompt,
     val model: LLModel,
     val tools: List<ToolDescriptor>

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/events/llmCallEvents.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/events/llmCallEvents.kt
@@ -15,6 +15,7 @@ import kotlinx.serialization.Serializable
  * and serves as a specific type of event in a feature-driven framework.
  *
  * @property runId A unique identifier associated with the specific run of the LLM call.
+ * @property callId A unique identifier associated with the specific LLM call grouping.
  * @property prompt The input prompt encapsulated as a [Prompt] object. This represents the structured set of
  *                  messages and configuration parameters sent to the LLM.
  * @property model The model information including provider, model, and context details.
@@ -25,6 +26,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class LLMCallStartingEvent(
     val runId: String,
+    val callId: String,
     val prompt: Prompt,
     val model: ModelInfo,
     val tools: List<String>,
@@ -36,17 +38,18 @@ public data class LLMCallStartingEvent(
      *             LLMCallStartingEvent(runId, prompt, model, tools, timestamp)
      */
     @Deprecated(
-        message = "Please use constructor with model parameter of type [ModelInfo]: LLMCallStartingEvent(runId, prompt, model, tools, timestamp)",
-        replaceWith = ReplaceWith("LLMCallStartingEvent(runId, prompt, model, tools, timestamp)")
+        message = "Please use constructor with model parameter of type [ModelInfo]: LLMCallStartingEvent(runId, callId, prompt, model, tools, timestamp)",
+        replaceWith = ReplaceWith("LLMCallStartingEvent(runId, callId, prompt, model, tools, timestamp)")
     )
     public constructor(
         runId: String,
+        callId: String,
         prompt: Prompt,
         model: String,
         tools: List<String>,
         eventId: String = LLMCallStartingEvent::class.simpleName!!,
         timestamp: Long = Clock.System.now().toEpochMilliseconds()
-    ) : this(runId, prompt, ModelInfo.fromString(model), tools, timestamp)
+    ) : this(runId, callId, prompt, ModelInfo.fromString(model), tools, timestamp)
 
     /**
      * @deprecated Use model.eventString instead
@@ -64,6 +67,7 @@ public data class LLMCallStartingEvent(
  * and logging of LLM-related interactions.
  *
  * @property runId The unique identifier of the LLM run.
+ * @property callId The unique identifier of the LLM call grouping.
  * @property prompt The input prompt encapsulated as a [Prompt] object. This represents the structured set of
  *                  messages and configuration parameters sent to the LLM.
  * @property model The model information including provider, model, and context details.
@@ -76,6 +80,7 @@ public data class LLMCallStartingEvent(
 @Serializable
 public data class LLMCallCompletedEvent(
     val runId: String,
+    val callId: String,
     val prompt: Prompt,
     val model: ModelInfo,
     val responses: List<Message.Response>,
@@ -88,18 +93,19 @@ public data class LLMCallCompletedEvent(
      *             LLMCallCompletedEvent(runId, prompt, model, responses, moderationResponse, timestamp)
      */
     @Deprecated(
-        message = "Please use constructor with model parameter of type [ModelInfo]: LLMCallCompletedEvent(runId, prompt, model, responses, moderationResponse, timestamp)",
-        replaceWith = ReplaceWith("LLMCallCompletedEvent(runId, prompt, model, responses, moderationResponse, timestamp)")
+        message = "Please use constructor with model parameter of type [ModelInfo]: LLMCallCompletedEvent(runId, callId, prompt, model, responses, moderationResponse, timestamp)",
+        replaceWith = ReplaceWith("LLMCallCompletedEvent(runId, callId, prompt, model, responses, moderationResponse, timestamp)")
     )
     public constructor(
         runId: String,
+        callId: String,
         prompt: Prompt,
         model: String,
         responses: List<Message.Response>,
         moderationResponse: ModerationResult? = null,
         eventId: String = LLMCallCompletedEvent::class.simpleName!!,
         timestamp: Long = Clock.System.now().toEpochMilliseconds()
-    ) : this(runId, prompt, ModelInfo.fromString(model), responses, moderationResponse, timestamp)
+    ) : this(runId, callId, prompt, ModelInfo.fromString(model), responses, moderationResponse, timestamp)
 
     /**
      * @deprecated Use model.eventString instead

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/events/llmStreamingEvents.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/events/llmStreamingEvents.kt
@@ -21,6 +21,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class LLMStreamingStartingEvent(
     val runId: String,
+    val callId: String,
     val prompt: Prompt,
     val model: String,
     val tools: List<String>,
@@ -42,6 +43,7 @@ public data class LLMStreamingStartingEvent(
 @Serializable
 public data class LLMStreamingFrameReceivedEvent(
     val runId: String,
+    val callId: String,
     val frame: StreamFrame,
     override val timestamp: Long = Clock.System.now().toEpochMilliseconds(),
 ) : DefinedFeatureEvent()
@@ -61,6 +63,7 @@ public data class LLMStreamingFrameReceivedEvent(
 @Serializable
 public data class LLMStreamingFailedEvent(
     val runId: String,
+    val callId: String,
     val error: AIAgentError,
     override val timestamp: Long = Clock.System.now().toEpochMilliseconds(),
 ) : DefinedFeatureEvent()
@@ -77,6 +80,7 @@ public data class LLMStreamingFailedEvent(
 @Serializable
 public data class LLMStreamingCompletedEvent(
     val runId: String,
+    val callId: String,
     val prompt: Prompt,
     val model: String,
     val tools: List<String>,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
@@ -361,12 +361,13 @@ public abstract class AIAgentPipeline(public val clock: Clock) {
     /**
      * Notifies all registered LLM handlers before a language model call is made.
      *
+     * @param callId The unique identifier for the LLM call
      * @param prompt The prompt that will be sent to the language model
      * @param tools The list of tool descriptors available for the LLM call
      * @param model The language model instance that will process the request
      */
-    public suspend fun onLLMCallStarting(runId: String, prompt: Prompt, model: LLModel, tools: List<ToolDescriptor>) {
-        val eventContext = LLMCallStartingContext(runId, prompt, model, tools)
+    public suspend fun onLLMCallStarting(runId: String, callId: String, prompt: Prompt, model: LLModel, tools: List<ToolDescriptor>) {
+        val eventContext = LLMCallStartingContext(runId, callId, prompt, model, tools)
         llmCallEventHandlers.values.forEach { handler -> handler.llmCallStartingHandler.handle(eventContext) }
     }
 
@@ -374,6 +375,7 @@ public abstract class AIAgentPipeline(public val clock: Clock) {
      * Notifies all registered LLM handlers after a language model call has completed.
      *
      * @param runId Identifier for the current run.
+     * @param callId Identifier for the current LLM call.
      * @param prompt The prompt that was sent to the language model
      * @param tools The list of tool descriptors that were available for the LLM call
      * @param model The language model instance that processed the request
@@ -381,13 +383,14 @@ public abstract class AIAgentPipeline(public val clock: Clock) {
      */
     public suspend fun onLLMCallCompleted(
         runId: String,
+        callId: String,
         prompt: Prompt,
         model: LLModel,
         tools: List<ToolDescriptor>,
         responses: List<Message.Response>,
         moderationResponse: ModerationResult? = null,
     ) {
-        val eventContext = LLMCallCompletedContext(runId, prompt, model, tools, responses, moderationResponse)
+        val eventContext = LLMCallCompletedContext(runId, callId, prompt, model, tools, responses, moderationResponse)
         llmCallEventHandlers.values.forEach { handler -> handler.llmCallCompletedHandler.handle(eventContext) }
     }
 
@@ -476,17 +479,19 @@ public abstract class AIAgentPipeline(public val clock: Clock) {
      * allowing them to perform preprocessing or logging operations.
      *
      * @param runId The unique identifier for this streaming session
+     * @param callId The unique identifier for this LLM call
      * @param prompt The prompt being sent to the language model
      * @param model The language model being used for streaming
      * @param tools The list of available tool descriptors for this streaming session
      */
     public suspend fun onLLMStreamingStarting(
         runId: String,
+        callId: String,
         prompt: Prompt,
         model: LLModel,
         tools: List<ToolDescriptor>
     ) {
-        val eventContext = LLMStreamingStartingContext(runId, prompt, model, tools)
+        val eventContext = LLMStreamingStartingContext(runId, callId, prompt, model, tools)
         llmStreamingEventHandlers.values.forEach { handler -> handler.llmStreamingStartingHandler.handle(eventContext) }
     }
 
@@ -497,10 +502,11 @@ public abstract class AIAgentPipeline(public val clock: Clock) {
      * allowing them to process, transform, or aggregate the streaming content in real-time.
      *
      * @param runId The unique identifier for this streaming session
+     * @param callId The unique identifier for this LLM call
      * @param streamFrame The individual stream frame containing partial response data
      */
-    public suspend fun onLLMStreamingFrameReceived(runId: String, streamFrame: StreamFrame) {
-        val eventContext = LLMStreamingFrameReceivedContext(runId, streamFrame)
+    public suspend fun onLLMStreamingFrameReceived(runId: String, callId: String, streamFrame: StreamFrame) {
+        val eventContext = LLMStreamingFrameReceivedContext(runId, callId, streamFrame)
         llmStreamingEventHandlers.values.forEach { handler ->
             handler.llmStreamingFrameReceivedHandler.handle(
                 eventContext
@@ -515,10 +521,11 @@ public abstract class AIAgentPipeline(public val clock: Clock) {
      * allowing them to handle or log the error.
      *
      * @param runId The unique identifier for this streaming session
+     * @param callId The unique identifier for this LLM call
      * @param throwable The exception that occurred during streaming, if applicable
      */
-    public suspend fun onLLMStreamingFailed(runId: String, throwable: Throwable) {
-        val eventContext = LLMStreamingFailedContext(runId, throwable)
+    public suspend fun onLLMStreamingFailed(runId: String, callId: String, throwable: Throwable) {
+        val eventContext = LLMStreamingFailedContext(runId, callId, throwable)
         llmStreamingEventHandlers.values.forEach { handler -> handler.llmStreamingFailedHandler.handle(eventContext) }
     }
 
@@ -529,17 +536,19 @@ public abstract class AIAgentPipeline(public val clock: Clock) {
      * allowing them to perform post-processing, cleanup, or final logging operations.
      *
      * @param runId The unique identifier for this streaming session
+     * @param callId The unique identifier for this LLM call
      * @param prompt The prompt that was sent to the language model
      * @param model The language model that was used for streaming
      * @param tools The list of tool descriptors that were available for this streaming session
      */
     public suspend fun onLLMStreamingCompleted(
         runId: String,
+        callId: String,
         prompt: Prompt,
         model: LLModel,
         tools: List<ToolDescriptor>
     ) {
-        val eventContext = LLMStreamingCompletedContext(runId, prompt, model, tools)
+        val eventContext = LLMStreamingCompletedContext(runId, callId, prompt, model, tools)
         llmStreamingEventHandlers.values.forEach { handler -> handler.llmStreamingCompletedHandler.handle(eventContext) }
     }
 

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerTest.kt
@@ -293,7 +293,11 @@ class DebuggerTest {
                 val finishGraphNode = StrategyEventGraphNode(id = "__finish__", name = "__finish__")
 
                 val callIds = clientEventsCollector.collectedEvents.filterIsInstance<LLMCallStartingEvent>().map { it.callId }
-                assertEquals(callIds.size == 2) { "Expected 2 LLMCallStartingEvent, got ${callIds.size}" }
+                assertEquals(
+                    2,
+                    callIds.size,
+                    "Expected 2 LLMCallStartingEvent, got ${callIds.size}"
+                )
 
                 val expectedEvents = listOf(
                     AgentStartingEvent(
@@ -643,7 +647,11 @@ class DebuggerTest {
                 collectEventsJob.join()
 
                 val callIds = clientEventsCollector.collectedEvents.filterIsInstance<LLMStreamingStartingEvent>().map { it.callId }
-                assertEquals(callIds.size == 1) { "Expected 1 LLMCallStartingEvent, got ${callIds.size}" }
+                assertEquals(
+                    1,
+                    callIds.size,
+                    "Expected 1 LLMCallStartingEvent, got ${callIds.size}"
+                )
 
                 // Correct run id will be set after the 'collect events job' is finished.
                 val expectedEvents = listOf(
@@ -835,7 +843,11 @@ class DebuggerTest {
                 collectEventsJob.join()
 
                 val callIds = clientEventsCollector.collectedEvents.filterIsInstance<LLMStreamingStartingEvent>().map { it.callId }
-                assertEquals(callIds.size == 1) { "Expected 1 LLMCallStartingEvent, got ${callIds.size}" }
+                assertEquals(
+                    1,
+                    callIds.size,
+                    "Expected 1 LLMCallStartingEvent, got ${callIds.size}"
+                )
 
                 // Correct run id will be set after the 'collect events job' is finished.
                 val expectedEvents = listOf(

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerTest.kt
@@ -835,7 +835,7 @@ class DebuggerTest {
                 collectEventsJob.join()
 
                 val callIds = clientEventsCollector.collectedEvents.filterIsInstance<LLMStreamingStartingEvent>().map { it.callId }
-                require(callIds.size == 2) { "Expected 2 LLMCallStartingEvent, got ${callIds.size}" }
+                require(callIds.size == 1) { "Expected 1 LLMCallStartingEvent, got ${callIds.size}" }
 
                 // Correct run id will be set after the 'collect events job' is finished.
                 val expectedEvents = listOf(

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerTest.kt
@@ -14,7 +14,6 @@ import ai.koog.agents.core.feature.debugger.Debugger
 import ai.koog.agents.core.feature.model.AIAgentError
 import ai.koog.agents.core.feature.model.events.AgentCompletedEvent
 import ai.koog.agents.core.feature.model.events.AgentStartingEvent
-import ai.koog.agents.core.feature.model.events.DefinedFeatureEvent
 import ai.koog.agents.core.feature.model.events.GraphStrategyStartingEvent
 import ai.koog.agents.core.feature.model.events.LLMCallCompletedEvent
 import ai.koog.agents.core.feature.model.events.LLMCallStartingEvent

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerTest.kt
@@ -293,7 +293,7 @@ class DebuggerTest {
                 val finishGraphNode = StrategyEventGraphNode(id = "__finish__", name = "__finish__")
 
                 val callIds = clientEventsCollector.collectedEvents.filterIsInstance<LLMCallStartingEvent>().map { it.callId }
-                require(callIds.size == 2) { "Expected 2 LLMCallStartingEvent, got ${callIds.size}" }
+                assertEquals(callIds.size == 2) { "Expected 2 LLMCallStartingEvent, got ${callIds.size}" }
 
                 val expectedEvents = listOf(
                     AgentStartingEvent(
@@ -643,7 +643,7 @@ class DebuggerTest {
                 collectEventsJob.join()
 
                 val callIds = clientEventsCollector.collectedEvents.filterIsInstance<LLMStreamingStartingEvent>().map { it.callId }
-                require(callIds.size == 1) { "Expected 1 LLMCallStartingEvent, got ${callIds.size}" }
+                assertEquals(callIds.size == 1) { "Expected 1 LLMCallStartingEvent, got ${callIds.size}" }
 
                 // Correct run id will be set after the 'collect events job' is finished.
                 val expectedEvents = listOf(
@@ -835,7 +835,7 @@ class DebuggerTest {
                 collectEventsJob.join()
 
                 val callIds = clientEventsCollector.collectedEvents.filterIsInstance<LLMStreamingStartingEvent>().map { it.callId }
-                require(callIds.size == 1) { "Expected 1 LLMCallStartingEvent, got ${callIds.size}" }
+                assertEquals(callIds.size == 1) { "Expected 1 LLMCallStartingEvent, got ${callIds.size}" }
 
                 // Correct run id will be set after the 'collect events job' is finished.
                 val expectedEvents = listOf(

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerTest.kt
@@ -14,6 +14,7 @@ import ai.koog.agents.core.feature.debugger.Debugger
 import ai.koog.agents.core.feature.model.AIAgentError
 import ai.koog.agents.core.feature.model.events.AgentCompletedEvent
 import ai.koog.agents.core.feature.model.events.AgentStartingEvent
+import ai.koog.agents.core.feature.model.events.DefinedFeatureEvent
 import ai.koog.agents.core.feature.model.events.GraphStrategyStartingEvent
 import ai.koog.agents.core.feature.model.events.LLMCallCompletedEvent
 import ai.koog.agents.core.feature.model.events.LLMCallStartingEvent
@@ -292,6 +293,9 @@ class DebuggerTest {
                 val startGraphNode = StrategyEventGraphNode(id = "__start__", name = "__start__")
                 val finishGraphNode = StrategyEventGraphNode(id = "__finish__", name = "__finish__")
 
+                val callIds = clientEventsCollector.collectedEvents.filterIsInstance<LLMCallStartingEvent>().map { it.callId }
+                require(callIds.size == 2) { "Expected 2 LLMCallStartingEvent, got ${callIds.size}" }
+
                 val expectedEvents = listOf(
                     AgentStartingEvent(
                         agentId = agentId,
@@ -369,6 +373,7 @@ class DebuggerTest {
                     ),
                     LLMCallStartingEvent(
                         runId = clientEventsCollector.runId,
+                        callId = callIds[0],
                         prompt = expectedLLMCallPrompt,
                         model = testModel.toModelInfo(),
                         tools = listOf(dummyTool.name),
@@ -376,6 +381,7 @@ class DebuggerTest {
                     ),
                     LLMCallCompletedEvent(
                         runId = clientEventsCollector.runId,
+                        callId = callIds[0],
                         prompt = expectedLLMCallPrompt,
                         model = testModel.toModelInfo(),
                         responses = listOf(toolCallMessage(dummyTool.name, content = """{"dummy":"$requestedDummyToolArgs"}""")),
@@ -442,6 +448,7 @@ class DebuggerTest {
                     ),
                     LLMCallStartingEvent(
                         runId = clientEventsCollector.runId,
+                        callId = callIds[1],
                         prompt = expectedLLMCallWithToolsPrompt,
                         model = testModel.toModelInfo(),
                         tools = listOf(dummyTool.name),
@@ -449,6 +456,7 @@ class DebuggerTest {
                     ),
                     LLMCallCompletedEvent(
                         runId = clientEventsCollector.runId,
+                        callId = callIds[1],
                         prompt = expectedLLMCallWithToolsPrompt,
                         model = testModel.toModelInfo(),
                         responses = listOf(assistantMessage(mockResponse)),
@@ -635,10 +643,14 @@ class DebuggerTest {
                 client.connectWithRetry(defaultClientServerTimeout)
                 collectEventsJob.join()
 
+                val callIds = clientEventsCollector.collectedEvents.filterIsInstance<LLMStreamingStartingEvent>().map { it.callId }
+                require(callIds.size == 1) { "Expected 1 LLMCallStartingEvent, got ${callIds.size}" }
+
                 // Correct run id will be set after the 'collect events job' is finished.
                 val expectedEvents = listOf(
                     LLMStreamingStartingEvent(
                         runId = clientEventsCollector.runId,
+                        callId = callIds[0],
                         prompt = expectedLLMCallPrompt,
                         model = testModel.toModelInfo().modelIdentifierName,
                         tools = listOf(dummyTool.name),
@@ -646,11 +658,13 @@ class DebuggerTest {
                     ),
                     LLMStreamingFrameReceivedEvent(
                         runId = clientEventsCollector.runId,
+                        callId = callIds[0],
                         frame = StreamFrame.Append(testLLMResponse),
                         timestamp = testClock.now().toEpochMilliseconds(),
                     ),
                     LLMStreamingCompletedEvent(
                         runId = clientEventsCollector.runId,
+                        callId = callIds[0],
                         prompt = expectedLLMCallPrompt,
                         model = testModel.toModelInfo().modelIdentifierName,
                         tools = listOf(dummyTool.name),
@@ -821,10 +835,14 @@ class DebuggerTest {
                 client.connectWithRetry(defaultClientServerTimeout)
                 collectEventsJob.join()
 
+                val callIds = clientEventsCollector.collectedEvents.filterIsInstance<LLMStreamingStartingEvent>().map { it.callId }
+                require(callIds.size == 2) { "Expected 2 LLMCallStartingEvent, got ${callIds.size}" }
+
                 // Correct run id will be set after the 'collect events job' is finished.
                 val expectedEvents = listOf(
                     LLMStreamingStartingEvent(
                         runId = clientEventsCollector.runId,
+                        callId = callIds[0],
                         prompt = expectedLLMCallPrompt,
                         model = testModel.toModelInfo().modelIdentifierName,
                         tools = listOf(dummyTool.name),
@@ -832,11 +850,13 @@ class DebuggerTest {
                     ),
                     LLMStreamingFailedEvent(
                         runId = clientEventsCollector.runId,
+                        callId = callIds[0],
                         error = AIAgentError(testStreamingErrorMessage, testStreamingStackTrace),
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
                     LLMStreamingCompletedEvent(
                         runId = clientEventsCollector.runId,
+                        callId = callIds[0],
                         prompt = expectedLLMCallPrompt,
                         model = testModel.toModelInfo().modelIdentifierName,
                         tools = listOf(dummyTool.name),

--- a/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/feature/Tracing.kt
+++ b/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/feature/Tracing.kt
@@ -227,6 +227,7 @@ public class Tracing {
             pipeline.interceptLLMCallStarting(this) intercept@{ eventContext ->
                 val event = LLMCallStartingEvent(
                     runId = eventContext.runId,
+                    callId = eventContext.callId,
                     prompt = eventContext.prompt,
                     model = eventContext.model.toModelInfo(),
                     tools = eventContext.tools.map { it.name },
@@ -238,6 +239,7 @@ public class Tracing {
             pipeline.interceptLLMCallCompleted(this) intercept@{ eventContext ->
                 val event = LLMCallCompletedEvent(
                     runId = eventContext.runId,
+                    callId = eventContext.callId,
                     prompt = eventContext.prompt,
                     model = eventContext.model.toModelInfo(),
                     responses = eventContext.responses,
@@ -254,6 +256,7 @@ public class Tracing {
             pipeline.interceptLLMStreamingStarting(this) intercept@{ eventContext ->
                 val event = LLMStreamingStartingEvent(
                     runId = eventContext.runId,
+                    callId = eventContext.callId,
                     prompt = eventContext.prompt,
                     model = eventContext.model.toModelInfo().modelIdentifierName,
                     tools = eventContext.tools.map { it.name },
@@ -265,6 +268,7 @@ public class Tracing {
             pipeline.interceptLLMStreamingCompleted(this) intercept@{ eventContext ->
                 val event = LLMStreamingCompletedEvent(
                     runId = eventContext.runId,
+                    callId = eventContext.callId,
                     prompt = eventContext.prompt,
                     model = eventContext.model.toModelInfo().modelIdentifierName,
                     tools = eventContext.tools.map { it.name },
@@ -276,6 +280,7 @@ public class Tracing {
             pipeline.interceptLLMStreamingFrameReceived(this) intercept@{ eventContext ->
                 val event = LLMStreamingFrameReceivedEvent(
                     runId = eventContext.runId,
+                    callId = eventContext.callId,
                     frame = eventContext.streamFrame,
                     timestamp = pipeline.clock.now().toEpochMilliseconds()
                 )
@@ -285,6 +290,7 @@ public class Tracing {
             pipeline.interceptLLMStreamingFailed(this) intercept@{ eventContext ->
                 val event = LLMStreamingFailedEvent(
                     runId = eventContext.runId,
+                    callId = eventContext.callId,
                     error = eventContext.error.toAgentError(),
                     timestamp = pipeline.clock.now().toEpochMilliseconds()
                 )

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageRemoteWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageRemoteWriterTest.kt
@@ -673,7 +673,6 @@ class TraceFeatureMessageRemoteWriterTest {
         val isClientFinished = CompletableDeferred<Boolean>()
         val isServerStarted = CompletableDeferred<Boolean>()
 
-
         // Server
         val serverJob = launch {
             TraceFeatureMessageRemoteWriter(connectionConfig = serverConfig).use { writer ->

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageRemoteWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageRemoteWriterTest.kt
@@ -298,7 +298,11 @@ class TraceFeatureMessageRemoteWriterTest {
                 val finishGraphNode = StrategyEventGraphNode(id = "__finish__", name = "__finish__")
 
                 val callIds = actualEvents.filterIsInstance<LLMCallStartingEvent>().map { it.callId }
-                require(callIds.size == 2) { "Expected 2 LLMCallStartingEvent, got ${callIds.size}" }
+                assertEquals(
+                    2,
+                    callIds.size,
+                    "Expected 2 LLMCallStartingEvent, got ${callIds.size}"
+                )
 
                 // Correct run id will be set after the 'collect events job' is finished.
                 val expectedEvents = listOf(
@@ -754,7 +758,11 @@ class TraceFeatureMessageRemoteWriterTest {
                 collectEventsJob.join()
 
                 val callIds = actualEvents.filterIsInstance<LLMCallStartingEvent>().map { it.callId }
-                require(callIds.size == 2) { "Expected 2 LLMCallStartingEvent, got ${callIds.size}" }
+                assertEquals(
+                    2,
+                    callIds.size,
+                    "Expected 2 LLMCallStartingEvent, got ${callIds.size}"
+                )
 
                 // Correct run id will be set after the 'collect events job' is finished.
                 val expectedEvents = listOf(

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageRemoteWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageRemoteWriterTest.kt
@@ -297,6 +297,9 @@ class TraceFeatureMessageRemoteWriterTest {
                 val startGraphNode = StrategyEventGraphNode(id = "__start__", name = "__start__")
                 val finishGraphNode = StrategyEventGraphNode(id = "__finish__", name = "__finish__")
 
+                val callIds = actualEvents.filterIsInstance<LLMCallStartingEvent>().map { it.callId }
+                require(callIds.size == 2) { "Expected 2 LLMCallStartingEvent, got ${callIds.size}" }
+
                 // Correct run id will be set after the 'collect events job' is finished.
                 val expectedEvents = listOf(
                     AgentStartingEvent(
@@ -372,6 +375,7 @@ class TraceFeatureMessageRemoteWriterTest {
                     ),
                     LLMCallStartingEvent(
                         runId = runId,
+                        callId = callIds[0],
                         prompt = expectedLLMCallPrompt,
                         model = testModel.toModelInfo(),
                         tools = listOf(dummyTool.name),
@@ -379,6 +383,7 @@ class TraceFeatureMessageRemoteWriterTest {
                     ),
                     LLMCallCompletedEvent(
                         runId = runId,
+                        callId = callIds[0],
                         prompt = expectedLLMCallPrompt,
                         model = testModel.toModelInfo(),
                         responses = listOf(toolCallMessage(dummyTool.name, content = """{"dummy":"test"}""")),
@@ -442,6 +447,7 @@ class TraceFeatureMessageRemoteWriterTest {
                     ),
                     LLMCallStartingEvent(
                         runId = runId,
+                        callId = callIds[1],
                         prompt = expectedLLMCallWithToolsPrompt,
                         model = testModel.toModelInfo(),
                         tools = listOf(dummyTool.name),
@@ -449,6 +455,7 @@ class TraceFeatureMessageRemoteWriterTest {
                     ),
                     LLMCallCompletedEvent(
                         runId = runId,
+                        callId = callIds[1],
                         prompt = expectedLLMCallWithToolsPrompt,
                         model = testModel.toModelInfo(),
                         responses = listOf(assistantMessage(mockResponse)),
@@ -666,6 +673,7 @@ class TraceFeatureMessageRemoteWriterTest {
         val isClientFinished = CompletableDeferred<Boolean>()
         val isServerStarted = CompletableDeferred<Boolean>()
 
+
         // Server
         val serverJob = launch {
             TraceFeatureMessageRemoteWriter(connectionConfig = serverConfig).use { writer ->
@@ -746,10 +754,14 @@ class TraceFeatureMessageRemoteWriterTest {
                 client.connect()
                 collectEventsJob.join()
 
+                val callIds = actualEvents.filterIsInstance<LLMCallStartingEvent>().map { it.callId }
+                require(callIds.size == 2) { "Expected 2 LLMCallStartingEvent, got ${callIds.size}" }
+
                 // Correct run id will be set after the 'collect events job' is finished.
                 val expectedEvents = listOf(
                     LLMCallStartingEvent(
                         runId = runId,
+                        callId = callIds[0],
                         prompt = expectedLLMCallPrompt,
                         model = testModel.toModelInfo(),
                         tools = listOf(dummyTool.name),
@@ -757,6 +769,7 @@ class TraceFeatureMessageRemoteWriterTest {
                     ),
                     LLMCallCompletedEvent(
                         runId = runId,
+                        callId = callIds[0],
                         prompt = expectedLLMCallPrompt,
                         model = testModel.toModelInfo(),
                         responses = listOf(toolCallMessage(dummyTool.name, content = """{"dummy":"test"}""")),
@@ -764,6 +777,7 @@ class TraceFeatureMessageRemoteWriterTest {
                     ),
                     LLMCallStartingEvent(
                         runId = runId,
+                        callId = callIds[1],
                         prompt = expectedLLMCallWithToolsPrompt,
                         model = testModel.toModelInfo(),
                         tools = listOf(dummyTool.name),
@@ -771,6 +785,7 @@ class TraceFeatureMessageRemoteWriterTest {
                     ),
                     LLMCallCompletedEvent(
                         runId = runId,
+                        callId = callIds[1],
                         prompt = expectedLLMCallWithToolsPrompt,
                         model = testModel.toModelInfo(),
                         responses = listOf(assistantMessage(mockResponse)),

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
@@ -379,7 +379,11 @@ class TraceFeatureMessageTestWriterTest {
                 )
 
                 val callIds = actualEvents.filterIsInstance<LLMStreamingStartingEvent>().map { it.callId }
-                require(callIds.size == 1) { "Expected 2 LLMCallStartingEvent, got ${callIds.size}" }
+                assertEquals(
+                    1,
+                    callIds.size,
+                    "Expected 2 LLMCallStartingEvent, got ${callIds.size}"
+                )
 
                 val expectedEvents = listOf(
                     LLMStreamingStartingEvent(
@@ -498,7 +502,11 @@ class TraceFeatureMessageTestWriterTest {
                 }
 
                 val callIds = actualEvents.filterIsInstance<LLMStreamingStartingEvent>().map { it.callId }
-                require(callIds.size == 1) { "Expected 2 LLMCallStartingEvent, got ${callIds.size}" }
+                assertEquals(
+                    1,
+                    callIds.size,
+                    "Expected 2 LLMCallStartingEvent, got ${callIds.size}"
+                )
 
                 val expectedEvents = listOf(
                     LLMStreamingStartingEvent(

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
@@ -287,7 +287,6 @@ class TraceFeatureMessageTestWriterTest {
         }
 
         TestFeatureMessageWriter().use { writer ->
-
             createAgent(
                 agentId = agentId,
                 strategy = strategy

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
@@ -379,7 +379,7 @@ class TraceFeatureMessageTestWriterTest {
                     id = promptId
                 )
 
-                val callIds = actualEvents.filterIsInstance<LLMCallStartingEvent>().map { it.callId }
+                val callIds = actualEvents.filterIsInstance<LLMStreamingStartingEvent>().map { it.callId }
                 require(callIds.size == 1) { "Expected 2 LLMCallStartingEvent, got ${callIds.size}" }
 
                 val expectedEvents = listOf(

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
@@ -98,6 +98,7 @@ class TraceFeatureMessageTestWriterTest {
 
         val llmStartEvents = messageProcessor.messages.filterIsInstance<LLMCallStartingEvent>().toList()
         assertEquals(2, llmStartEvents.size)
+
         assertEquals(
             listOf("User 0", "User 1", ""),
             llmStartEvents[0].prompt.messages.filter { it.role == Message.Role.User }.map { it.content }
@@ -378,9 +379,13 @@ class TraceFeatureMessageTestWriterTest {
                     id = promptId
                 )
 
+                val callIds = actualEvents.filterIsInstance<LLMCallStartingEvent>().map { it.callId }
+                require(callIds.size == 1) { "Expected 2 LLMCallStartingEvent, got ${callIds.size}" }
+
                 val expectedEvents = listOf(
                     LLMStreamingStartingEvent(
                         runId = writer.runId,
+                        callId = callIds[0],
                         prompt = expectedPrompt,
                         model = model.toModelInfo().modelIdentifierName,
                         tools = toolRegistry.tools.map { it.name },
@@ -388,11 +393,13 @@ class TraceFeatureMessageTestWriterTest {
                     ),
                     LLMStreamingFrameReceivedEvent(
                         runId = writer.runId,
+                        callId = callIds[0],
                         frame = StreamFrame.Append(testLLMResponse),
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
                     LLMStreamingCompletedEvent(
                         runId = writer.runId,
+                        callId = callIds[0],
                         prompt = expectedPrompt,
                         model = model.toModelInfo().modelIdentifierName,
                         tools = toolRegistry.tools.map { it.name },
@@ -491,9 +498,13 @@ class TraceFeatureMessageTestWriterTest {
                         event is LLMStreamingCompletedEvent
                 }
 
+                val callIds = actualEvents.filterIsInstance<LLMStreamingStartingEvent>().map { it.callId }
+                require(callIds.size == 1) { "Expected 2 LLMCallStartingEvent, got ${callIds.size}" }
+
                 val expectedEvents = listOf(
                     LLMStreamingStartingEvent(
                         runId = writer.runId,
+                        callId = callIds[0],
                         prompt = expectedPrompt,
                         model = model.toModelInfo().modelIdentifierName,
                         tools = toolRegistry.tools.map { it.name },
@@ -501,11 +512,13 @@ class TraceFeatureMessageTestWriterTest {
                     ),
                     LLMStreamingFailedEvent(
                         runId = writer.runId,
+                        callId = callIds[0],
                         error = AIAgentError(testStreamingErrorMessage, testStreamingStackTrace),
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
                     LLMStreamingCompletedEvent(
                         runId = writer.runId,
+                        callId = callIds[0],
                         prompt = expectedPrompt,
                         model = model.toModelInfo().modelIdentifierName,
                         tools = toolRegistry.tools.map { it.name },

--- a/docs/docs/agent-events.md
+++ b/docs/docs/agent-events.md
@@ -142,12 +142,13 @@ Represents an error that occurred during a node run. Includes the following fiel
 
 Represents the start of an LLM call. Includes the following fields:
 
-| Name     | Data type          | Required | Default | Description                                                                        |
-|----------|--------------------|----------|---------|------------------------------------------------------------------------------------|
-| `runId`  | String             | Yes      |         | The unique identifier of the LLM run.                                              |
-| `prompt` | Prompt             | Yes      |         | The prompt that is sent to the model. For more information, see [Prompt](#prompt). |
-| `model`  | String             | Yes      |         | The model identifier in the format `llm_provider:model_id`.                        |
-| `tools`  | List<String>       | Yes      |         | The list of tools that the model can call.                                         |
+| Name     | Data type    | Required | Default | Description                                                                        |
+|----------|--------------|----------|---------|------------------------------------------------------------------------------------|
+| `runId`  | String       | Yes      |         | The unique identifier of the LLM run.                                              |
+| `callId` | String       | Yes      |         | The unique identifier of the LLM Call, correlating the related events.             |
+| `prompt` | Prompt       | Yes      |         | The prompt that is sent to the model. For more information, see [Prompt](#prompt). |
+| `model`  | String       | Yes      |         | The model identifier in the format `llm_provider:model_id`.                        |
+| `tools`  | List<String> | Yes      |         | The list of tools that the model can call.                                         |
 
 <a id="prompt"></a>
 The `Prompt` class represents a data structure for a prompt, consisting of a list of messages, a unique identifier, and
@@ -163,13 +164,14 @@ optional parameters for language model settings. Includes the following fields:
 
 Represents the end of an LLM call. Includes the following fields:
 
-| Name                 | Data type                      | Required | Default | Description                                               |
-|----------------------|--------------------------------|----------|---------|-----------------------------------------------------------|
-| `runId`              | String                         | Yes      |         | The unique identifier of the LLM run.                     |
-| `prompt`             | Prompt                         | Yes      |         | The prompt used in the call.                              |
-| `model`              | String                         | Yes      |         | The model identifier in the format `llm_provider:model_id`.|
-| `responses`          | List<Message.Response>         | Yes      |         | One or more responses returned by the model.              |
-| `moderationResponse` | ModerationResult               | No       | null    | The moderation response, if any.                          |
+| Name                 | Data type              | Required | Default | Description                                                            |
+|----------------------|------------------------|----------|---------|------------------------------------------------------------------------|
+| `runId`              | String                 | Yes      |         | The unique identifier of the LLM run.                                  |
+| `callId`             | String                 | Yes      |         | The unique identifier of the LLM Call, correlating the related events. |
+| `prompt`             | Prompt                 | Yes      |         | The prompt used in the call.                                           |
+| `model`              | String                 | Yes      |         | The model identifier in the format `llm_provider:model_id`.            |
+| `responses`          | List<Message.Response> | Yes      |         | One or more responses returned by the model.                           |
+| `moderationResponse` | ModerationResult       | No       | null    | The moderation response, if any.                                       |
 
 ### LLM streaming events
 
@@ -177,41 +179,45 @@ Represents the end of an LLM call. Includes the following fields:
 
 Represents the start of an LLM streaming call. Includes the following fields:
 
-| Name     | Data type    | Required | Default | Description                                                 |
-|----------|--------------|----------|---------|-------------------------------------------------------------|
-| `runId`  | String       | Yes      |         | The unique identifier of the LLM run.                       |
-| `prompt` | Prompt       | Yes      |         | The prompt that is sent to the model.                       |
-| `model`  | String       | Yes      |         | The model identifier in the format `llm_provider:model_id`. |
-| `tools`  | List<String> | Yes      |         | The list of tools that the model can call.                  |
+| Name     | Data type    | Required | Default | Description                                                            |
+|----------|--------------|----------|---------|------------------------------------------------------------------------|
+| `runId`  | String       | Yes      |         | The unique identifier of the LLM run.                                  |
+| `callId` | String       | Yes      |         | The unique identifier of the LLM Call, correlating the related events. |
+| `prompt` | Prompt       | Yes      |         | The prompt that is sent to the model.                                  |
+| `model`  | String       | Yes      |         | The model identifier in the format `llm_provider:model_id`.            |
+| `tools`  | List<String> | Yes      |         | The list of tools that the model can call.                             |
 
 #### LLMStreamingFrameReceivedEvent
 
 Represents a streaming frame received from the LLM. Includes the following fields:
 
-| Name     | Data type   | Required | Default | Description                                      |
-|----------|-------------|----------|---------|--------------------------------------------------|
-| `runId`  | String      | Yes      |         | The unique identifier of the LLM run.            |
-| `frame`  | StreamFrame | Yes      |         | The frame received from the stream.               |
+| Name    | Data type   | Required | Default | Description                                                             |
+|---------|-------------|----------|---------|-------------------------------------------------------------------------|
+| `runId` | String      | Yes      |         | The unique identifier of the LLM run.                                   |
+| `callId`| String      | Yes      |         | The unique identifier of the LLM Call, correlating the related events.  |
+| `frame` | StreamFrame | Yes      |         | The frame received from the stream.                                     |
 
 #### LLMStreamingFailedEvent
 
 Represents the occurrence of an error during an LLM streaming call. Includes the following fields:
 
-| Name    | Data type    | Required | Default | Description                                                                                                     |
-|---------|--------------|----------|---------|-----------------------------------------------------------------------------------------------------------------|
-| `runId` | String       | Yes      |         | The unique identifier of the LLM run.                                                                          |
-| `error` | AIAgentError | Yes      |         | The specific error that occurred during streaming. For more information, see [AIAgentError](#aiagenterror).     |
+| Name    | Data type    | Required | Default | Description                                                                                                 |
+|---------|--------------|----------|---------|-------------------------------------------------------------------------------------------------------------|
+| `runId` | String       | Yes      |         | The unique identifier of the LLM run.                                                                       |
+| `callId`| String       | Yes      |         | The unique identifier of the LLM Call, correlating the related events.                                      |
+| `error` | AIAgentError | Yes      |         | The specific error that occurred during streaming. For more information, see [AIAgentError](#aiagenterror). |
 
 #### LLMStreamingCompletedEvent
 
 Represents the end of an LLM streaming call. Includes the following fields:
 
-| Name     | Data type    | Required | Default | Description                                                 |
-|----------|--------------|----------|---------|-------------------------------------------------------------|
-| `runId`  | String       | Yes      |         | The unique identifier of the LLM run.                       |
-| `prompt` | Prompt       | Yes      |         | The prompt that is sent to the model.                       |
-| `model`  | String       | Yes      |         | The model identifier in the format `llm_provider:model_id`. |
-| `tools`  | List<String> | Yes      |         | The list of tools that the model can call.                  |
+| Name     | Data type    | Required | Default | Description                                                             |
+|----------|--------------|----------|---------|-------------------------------------------------------------------------|
+| `runId`  | String       | Yes      |         | The unique identifier of the LLM run.                                   |
+| `callId` | String       | Yes      |         | The unique identifier of the LLM Call, correlating the related events.  |
+| `prompt` | Prompt       | Yes      |         | The prompt that is sent to the model.                                   |
+| `model`  | String       | Yes      |         | The model identifier in the format `llm_provider:model_id`.             |
+| `tools`  | List<String> | Yes      |         | The list of tools that the model can call.                              |
 
 ### Tool execution events
 


### PR DESCRIPTION
Connect LLMCall events.  The RunId supplied covers the whole trace, however it's not currently possible to connect individual LLMCall events.  This introduces a callId to allow the connection to be made. This address the following [issue](https://github.com/JetBrains/koog/issues/1053). 

## Motivation and Context
When leveraging the tracing feature LLMCall events may need to be connected. An example is a custom tracer integrated with a product like Langfuse. If the two LLMCalls (Starting and Completed) cannot be connected, Langfuse cannot roll them up together. 

## Breaking Changes
Technically if someone was new-ing up these events this would be breaking.  However these do seem like internal events to koog.  If necessary i can default the String.

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [X] The pull request has a description of the proposed change
- [X] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [X] The pull request uses **`develop`** as the base branch
- [X] Tests for the changes have been added
- [X] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [X] An issue describing the proposed change exists
- [X] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [X] Docs have been added / updated
