### PR TITLE
(KG-524) [http-client] Fix clients to properly rethrow cancellations and to remove exception wrapping

### DIFF
--- a/http-client/http-client-java/src/main/kotlin/ai/koog/http/client/java/JavaKoogHttpClient.kt
+++ b/http-client/http-client-java/src/main/kotlin/ai/koog/http/client/java/JavaKoogHttpClient.kt
@@ -135,9 +135,8 @@ public class JavaKoogHttpClient internal constructor(
             logger.debug { "SSE connection closed for $clientName" }
             close()
         } catch (e: Exception) {
-            val errorMessage = "Exception during streaming from $clientName: ${e.message}"
-            logger.error(e) { errorMessage }
-            close(IllegalStateException(errorMessage, e))
+            logger.error(e) { "Exception during streaming from $clientName" }
+            close(e)
         }
 
         awaitClose {

--- a/http-client/http-client-ktor/src/commonMain/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClient.kt
+++ b/http-client/http-client-ktor/src/commonMain/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClient.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
 import org.jetbrains.annotations.ApiStatus.Experimental
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.jvm.JvmOverloads
 import kotlin.reflect.KClass
 
@@ -138,9 +139,11 @@ public class KtorKoogHttpClient internal constructor(
                 logger.error(e) { errorMessage }
                 error(errorMessage)
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            logger.error { "Exception during streaming from $clientName: $e" }
-            error(e.message ?: "Unknown error during streaming from $clientName: $e")
+            logger.error(e) { "Exception during streaming from $clientName" }
+            throw e
         }
     }
 }

--- a/http-client/http-client-okhttp/src/main/kotlin/ai/koog/http/client/okhttp/OkHttpKoogHttpClient.kt
+++ b/http-client/http-client-okhttp/src/main/kotlin/ai/koog/http/client/okhttp/OkHttpKoogHttpClient.kt
@@ -128,8 +128,7 @@ public class OkHttpKoogHttpClient internal constructor(
                 }
 
                 logger.error(t) { errorMessage }
-
-                close(IllegalStateException(errorMessage, t))
+                close(t)
             }
         }
 


### PR DESCRIPTION
`KtorKoogHttpClient` swallowed cancellations, rethrowing another exception. Fixed that to make structured concurrency work. Also removed exessive exception wrapping of thrown exceptions from other HTTP clients