### PR TITLE
Pin Ollama version in CI checks to avoid accidental bugs and regressions from Ollama side

### DIFF
--- a/.github/workflows/ollama-tests.yml
+++ b/.github/workflows/ollama-tests.yml
@@ -12,6 +12,9 @@ on:
   push:
     branches: [ "main", "develop" ]
 
+env:
+  OLLAMA_VERSION: "0.12.6"
+
 jobs:
   integration-tests:
     name: ${{ matrix.job-name }}
@@ -100,7 +103,7 @@ jobs:
       - name: Install and start Ollama
         run: |
           echo "=== Installing Ollama ==="
-          curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=0.12.6 sh
+          curl -fsSL https://ollama.com/install.sh | sh
 
           echo "=== Starting Ollama in background ==="
           nohup ollama serve > /tmp/ollama.log 2>&1 &

--- a/.github/workflows/ollama-tests.yml
+++ b/.github/workflows/ollama-tests.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Install and start Ollama
         run: |
           echo "=== Installing Ollama ==="
-          curl -fsSL https://ollama.com/install.sh | sh
+          curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=0.12.6 sh
 
           echo "=== Starting Ollama in background ==="
           nohup ollama serve > /tmp/ollama.log 2>&1 &


### PR DESCRIPTION
It seems that the latest at the time of writing version of Ollama introduced some performance degradations, making our Ollama tests fail on CI with timeouts. I pinned exact version in CI config to try to fix it and to avoid similar problems in the future. 