### PR TITLE
Fix itemize notation in A2AServer documentation

### DIFF
--- a/docs/docs/a2a-server.md
+++ b/docs/docs/a2a-server.md
@@ -36,6 +36,7 @@ The main server class implementing the complete A2A protocol. It serves as the c
 - **Handles** all protocol operations: message sending, task querying, cancellation, push notifications
 
 The `A2AServer` accepts two required parameters:
+
 * `AgentExecutor` which defines business logic implementation of the agent
 * `AgentCard` which defines agent capabilities and metadata
 
@@ -71,6 +72,7 @@ The `RequestContext` provides rich information about the current request,
 including the `contextId` and `taskId` of the current session, the `message` sent, and the `params` of the request.
 
 The `SessionEventProcessor` communicates with clients:
+
 - **`sendMessage(message)`**: Send immediate responses (chat-style interactions)
 - **`sendTaskEvent(event)`**: Send task-related updates (long-running operations)
 


### PR DESCRIPTION

<!--
Thank you for opening a pull request!

Please add a brief description of the proposed change here.
Also, please tick the appropriate points in the checklist below.
-->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

itemizes seem rendered incorrectly on `docs.koog.ai` due to missing empty lines between sentences and itemizes

<img width="1266" height="800" alt="image" src="https://github.com/user-attachments/assets/b20f0be5-eff1-4cc3-9eb1-3110affee039" />

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

N/A
just documentation update

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
    - Contributing Guidelines says that we should create PRs for docs to koog-docs repo, but it is already public archive
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
