### PR TITLE
(KG-481) [prompt] Fix StructureFixingParser to do the right number of retires, add tests

### DIFF
--- a/prompt/prompt-structure/build.gradle.kts
+++ b/prompt/prompt-structure/build.gradle.kts
@@ -25,6 +25,7 @@ kotlin {
             dependencies {
                 implementation(kotlin("test"))
                 implementation(libs.kotlinx.coroutines.test)
+                implementation(project(":agents:agents-test"))
             }
         }
 

--- a/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/StructureFixingParserTest.kt
+++ b/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/StructureFixingParserTest.kt
@@ -1,0 +1,78 @@
+package ai.koog.prompt.structure
+
+import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import ai.koog.prompt.structure.json.JsonStructuredData
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class StructureFixingParserTest {
+    @Serializable
+    private data class TestData(
+        val a: String,
+        val b: Int,
+    )
+
+    private val testData = TestData("test", 42)
+    private val testDataJson = Json.encodeToString(testData)
+    private val testStructure = JsonStructuredData.createJsonStructure<TestData>()
+
+    @Test
+    fun testParseValidContentWithoutFixing() = runTest {
+        val parser = StructureFixingParser(
+            fixingModel = OpenAIModels.CostOptimized.GPT4oMini,
+            retries = 2,
+        )
+        val mockExecutor = getMockExecutor {}
+
+        val result = parser.parse(mockExecutor, testStructure, testDataJson)
+        assertEquals(testData, result)
+    }
+
+    @Test
+    fun testFixInvalidContentInMultipleSteps() = runTest {
+        val parser = StructureFixingParser(
+            fixingModel = OpenAIModels.CostOptimized.GPT4oMini,
+            retries = 2,
+        )
+
+        val invalidContent = testDataJson
+            .replace("\"a\"\\s*:".toRegex(), "")
+            .replace("\"b\"\\s*:".toRegex(), "")
+
+        val firstResponse = testDataJson
+            .replace("\"a\"\\s*:".toRegex(), "")
+
+        val mockExecutor = getMockExecutor {
+            mockLLMAnswer(firstResponse) onRequestContains invalidContent
+            mockLLMAnswer(testDataJson) onRequestContains firstResponse
+        }
+
+        val result = parser.parse(mockExecutor, testStructure, invalidContent)
+        assertEquals(testData, result)
+    }
+
+    @Test
+    fun testFailToParseWhenFixingRetriesExceeded() = runTest {
+        val parser = StructureFixingParser(
+            fixingModel = OpenAIModels.CostOptimized.GPT4oMini,
+            retries = 2,
+        )
+
+        val invalidContent = testDataJson
+            .replace("\"a\"\\s*:".toRegex(), "")
+            .replace("\"b\"\\s*:".toRegex(), "")
+
+        val mockExecutor = getMockExecutor {
+            mockLLMAnswer(invalidContent).asDefaultResponse
+        }
+
+        assertFailsWith<LLMStructuredParsingError> {
+            parser.parse(mockExecutor, testStructure, invalidContent)
+        }
+    }
+}


### PR DESCRIPTION
Fixes [KG-481](https://youtrack.jetbrains.com/issue/KG-481) by correcting fixing retries behavior. Also added tests for this fixing parser