### PR TITLE
KG-256 merge response message parts in ExecutorIntegrationTestBase.kt…

### DIFF
--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
@@ -44,6 +44,7 @@ import ai.koog.prompt.markdown.markdown
 import ai.koog.prompt.message.AttachmentContent
 import ai.koog.prompt.message.ContentPart
 import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.params.LLMParams.ToolChoice
 import ai.koog.prompt.streaming.StreamFrame
@@ -362,7 +363,7 @@ abstract class ExecutorIntegrationTestBase {
 
             withRetry {
                 try {
-                    with(getExecutor(model).execute(prompt, model).single()) {
+                    with(getExecutor(model).execute(prompt, model).toSingleMessage()) {
                         when (scenario) {
                             MarkdownTestScenario.MALFORMED_SYNTAX,
                             MarkdownTestScenario.MATH_NOTATION,
@@ -920,5 +921,15 @@ abstract class ExecutorIntegrationTestBase {
         withClue("Models list should not be empty") {
             getLLMClientForProvider(provider).models().shouldNotBeEmpty()
         }
+    }
+
+    private fun List<Message>.toSingleMessage(): Message.Assistant {
+        if (this.isEmpty()) {
+            return Message.Assistant(parts = emptyList(), metaInfo = ResponseMetaInfo.Empty)
+        }
+
+        val allParts = this.flatMap { it.parts }
+
+        return Message.Assistant(parts = allParts, metaInfo = ResponseMetaInfo.Empty)
     }
 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
@@ -363,12 +363,13 @@ abstract class ExecutorIntegrationTestBase {
 
             withRetry {
                 try {
-                    with(getExecutor(model).execute(prompt, model).toSingleMessage()) {
+                    with(
+                        getExecutor(model).execute(prompt, model)
+                            .filterIsInstance<Message.Assistant>()
+                            .toSingleMessage()
+                    ) {
                         when (scenario) {
-                            MarkdownTestScenario.MALFORMED_SYNTAX,
-                            MarkdownTestScenario.MATH_NOTATION,
-                            MarkdownTestScenario.BROKEN_LINKS,
-                            MarkdownTestScenario.IRREGULAR_TABLES -> {
+                            MarkdownTestScenario.MALFORMED_SYNTAX, MarkdownTestScenario.MATH_NOTATION, MarkdownTestScenario.BROKEN_LINKS, MarkdownTestScenario.IRREGULAR_TABLES -> {
                                 checkResponseBasic(this)
                             }
 
@@ -923,6 +924,6 @@ abstract class ExecutorIntegrationTestBase {
         }
     }
 
-    private fun List<Message>.toSingleMessage(): Message.Assistant =
+    private fun List<Message.Assistant>.toSingleMessage(): Message.Assistant =
         Message.Assistant(parts = flatMap { it.parts }, metaInfo = ResponseMetaInfo.Empty)
 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
@@ -923,13 +923,6 @@ abstract class ExecutorIntegrationTestBase {
         }
     }
 
-    private fun List<Message>.toSingleMessage(): Message.Assistant {
-        if (this.isEmpty()) {
-            return Message.Assistant(parts = emptyList(), metaInfo = ResponseMetaInfo.Empty)
-        }
-
-        val allParts = this.flatMap { it.parts }
-
-        return Message.Assistant(parts = allParts, metaInfo = ResponseMetaInfo.Empty)
-    }
+    private fun List<Message>.toSingleMessage(): Message.Assistant =
+        Message.Assistant(parts = flatMap { it.parts }, metaInfo = ResponseMetaInfo.Empty)
 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/MediaTestScenarios.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/MediaTestScenarios.kt
@@ -62,7 +62,7 @@ object MediaTestScenarios {
 
     val models = listOf(
         AnthropicModels.Sonnet_4_5,
-        GoogleModels.Gemini2_5Flash, // see KG-256
+        GoogleModels.Gemini2_5Pro,
         OpenAIModels.Chat.GPT5,
     )
 


### PR DESCRIPTION
YouTrack link: https://youtrack.jetbrains.com/issue/KG-256

## Motivation and Context
This PR fixes a failing test case in `SingleLLMPromptExecutorIntegrationTest` and `MultipleLLMPromptExecutorIntegrationTest` when running against `GoogleModels.Gemini2_5Pro`. The Gemini API can return a response containing multiple parts, which our client currently interprets as multiple Assistant Messages. The test's use of the `.single()` extension function on this list caused an `IllegalArgumentException`, preventing validation.

This change introduces a workaround directly within the test. Instead of attempting to force the list to a single element, the test now:
1.  Receives the `List<Message>` from the executor.
2.  Calls a new `response.toSingleMessage()` extension function (as proposed in the issue discussion) to merge the multiple messages into a single `Message.Assistant`.
3.  Performs the existing validation checks on this newly created single message.

This approach allows the test for Gemini 2.5 Pro to pass without altering the core behavior of the `GoogleLLMClient`. Following this fix, `Gemini2_5Pro` has replaced `Gemini2_5Flash` in the list of models for this test.

## Breaking Changes
None. This change is confined to a test class and does not affect the public API.

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added (The change is a fix to an existing, failing test)
- [x] All new and existing tests passed