### PR TITLE
Adjust endMessages size assertion based on LLM provider type

### DIFF
--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
@@ -152,7 +152,10 @@ abstract class ExecutorIntegrationTestBase {
                 }
                 length shouldNotBe (0)
                 toolMessages.shouldBeEmpty()
-                endMessages.size shouldBe 1
+                when (model.provider) {
+                    is LLMProvider.Ollama -> endMessages.size shouldBe 0
+                    else -> endMessages.size shouldBe 1
+                }
 
                 toString() shouldNotBeNull {
                     shouldContain("1")


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

Please add a brief description of the proposed change here.
Also, please tick the appropriate points in the checklist below.
-->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
We have a `ollama_testExecuteStreaming` test. Not so long ago a check for `StreamFrame.End `events in the stream was added. However, the Ollama client returns a JSON with `done=true` to indicate the end of the stream, not wrapping it into `StreamFrame.End`.
A simple and obvious option is to adjust the test not to check for `StreamFrame.End` in the case of the Ollama client. However, we can consider wrapping the end event of the Ollama stream in the `StreamFrame.End` in the furture.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None.

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
