### PR TITLE
Improve Bedrock moderation implementation

### DIFF
--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/AnthropicSchemaValidationIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/AnthropicSchemaValidationIntegrationTest.kt
@@ -3,7 +3,7 @@ package ai.koog.integration.tests
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.features.eventHandler.feature.EventHandler
-import ai.koog.integration.tests.utils.APIKeys.readTestAnthropicKeyFromEnv
+import ai.koog.integration.tests.utils.TestCredentials.readTestAnthropicKeyFromEnv
 import ai.koog.integration.tests.utils.annotations.Retry
 import ai.koog.integration.tests.utils.tools.ComplexNestedTool
 import ai.koog.prompt.executor.clients.anthropic.AnthropicModels

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
@@ -6,8 +6,8 @@ import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.features.eventHandler.feature.EventHandler
 import ai.koog.agents.features.eventHandler.feature.EventHandlerConfig
 import ai.koog.integration.tests.agent.AIAgentTestBase.ReportingLLMClient.Event
-import ai.koog.integration.tests.utils.APIKeys.readTestAnthropicKeyFromEnv
-import ai.koog.integration.tests.utils.APIKeys.readTestOpenAIKeyFromEnv
+import ai.koog.integration.tests.utils.TestCredentials.readTestAnthropicKeyFromEnv
+import ai.koog.integration.tests.utils.TestCredentials.readTestOpenAIKeyFromEnv
 import ai.koog.integration.tests.utils.Models
 import ai.koog.integration.tests.utils.RetryUtils.withRetry
 import ai.koog.integration.tests.utils.annotations.Retry

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
@@ -6,10 +6,10 @@ import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.features.eventHandler.feature.EventHandler
 import ai.koog.agents.features.eventHandler.feature.EventHandlerConfig
 import ai.koog.integration.tests.agent.AIAgentTestBase.ReportingLLMClient.Event
-import ai.koog.integration.tests.utils.TestCredentials.readTestAnthropicKeyFromEnv
-import ai.koog.integration.tests.utils.TestCredentials.readTestOpenAIKeyFromEnv
 import ai.koog.integration.tests.utils.Models
 import ai.koog.integration.tests.utils.RetryUtils.withRetry
+import ai.koog.integration.tests.utils.TestCredentials.readTestAnthropicKeyFromEnv
+import ai.koog.integration.tests.utils.TestCredentials.readTestOpenAIKeyFromEnv
 import ai.koog.integration.tests.utils.annotations.Retry
 import ai.koog.integration.tests.utils.tools.CalculatorTool
 import ai.koog.integration.tests.utils.tools.files.CreateFile

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentTestBase.kt
@@ -16,8 +16,8 @@ import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.ext.agent.subgraphWithTask
 import ai.koog.agents.features.eventHandler.feature.EventHandler
 import ai.koog.agents.features.eventHandler.feature.EventHandlerConfig
-import ai.koog.integration.tests.utils.APIKeys.readTestAnthropicKeyFromEnv
-import ai.koog.integration.tests.utils.APIKeys.readTestOpenAIKeyFromEnv
+import ai.koog.integration.tests.utils.TestCredentials.readTestAnthropicKeyFromEnv
+import ai.koog.integration.tests.utils.TestCredentials.readTestOpenAIKeyFromEnv
 import ai.koog.integration.tests.utils.Models
 import ai.koog.integration.tests.utils.getLLMClientForProvider
 import ai.koog.integration.tests.utils.tools.files.CreateFile

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentTestBase.kt
@@ -16,9 +16,9 @@ import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.ext.agent.subgraphWithTask
 import ai.koog.agents.features.eventHandler.feature.EventHandler
 import ai.koog.agents.features.eventHandler.feature.EventHandlerConfig
+import ai.koog.integration.tests.utils.Models
 import ai.koog.integration.tests.utils.TestCredentials.readTestAnthropicKeyFromEnv
 import ai.koog.integration.tests.utils.TestCredentials.readTestOpenAIKeyFromEnv
-import ai.koog.integration.tests.utils.Models
 import ai.koog.integration.tests.utils.getLLMClientForProvider
 import ai.koog.integration.tests.utils.tools.files.CreateFile
 import ai.koog.integration.tests.utils.tools.files.DeleteFile

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/capabilities/ModelCapabilitiesIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/capabilities/ModelCapabilitiesIntegrationTest.kt
@@ -1,8 +1,8 @@
 package ai.koog.integration.tests.capabilities
 
-import ai.koog.integration.tests.utils.APIKeys.readTestAnthropicKeyFromEnv
-import ai.koog.integration.tests.utils.APIKeys.readTestGoogleAIKeyFromEnv
-import ai.koog.integration.tests.utils.APIKeys.readTestOpenAIKeyFromEnv
+import ai.koog.integration.tests.utils.TestCredentials.readTestAnthropicKeyFromEnv
+import ai.koog.integration.tests.utils.TestCredentials.readTestGoogleAIKeyFromEnv
+import ai.koog.integration.tests.utils.TestCredentials.readTestOpenAIKeyFromEnv
 import ai.koog.integration.tests.utils.MediaTestScenarios
 import ai.koog.integration.tests.utils.MediaTestUtils.createAudioFileForScenario
 import ai.koog.integration.tests.utils.MediaTestUtils.createTextFileForScenario

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/capabilities/ModelCapabilitiesIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/capabilities/ModelCapabilitiesIntegrationTest.kt
@@ -1,8 +1,5 @@
 package ai.koog.integration.tests.capabilities
 
-import ai.koog.integration.tests.utils.TestCredentials.readTestAnthropicKeyFromEnv
-import ai.koog.integration.tests.utils.TestCredentials.readTestGoogleAIKeyFromEnv
-import ai.koog.integration.tests.utils.TestCredentials.readTestOpenAIKeyFromEnv
 import ai.koog.integration.tests.utils.MediaTestScenarios
 import ai.koog.integration.tests.utils.MediaTestUtils.createAudioFileForScenario
 import ai.koog.integration.tests.utils.MediaTestUtils.createTextFileForScenario
@@ -10,6 +7,9 @@ import ai.koog.integration.tests.utils.MediaTestUtils.createVideoFileForScenario
 import ai.koog.integration.tests.utils.MediaTestUtils.getImageFileForScenario
 import ai.koog.integration.tests.utils.Models
 import ai.koog.integration.tests.utils.RetryUtils.withRetry
+import ai.koog.integration.tests.utils.TestCredentials.readTestAnthropicKeyFromEnv
+import ai.koog.integration.tests.utils.TestCredentials.readTestGoogleAIKeyFromEnv
+import ai.koog.integration.tests.utils.TestCredentials.readTestOpenAIKeyFromEnv
 import ai.koog.integration.tests.utils.TestUtils.assertExceptionMessageContains
 import ai.koog.integration.tests.utils.TestUtils.isValidJson
 import ai.koog.integration.tests.utils.TestUtils.singlePropertyObjectSchema

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
@@ -832,12 +832,10 @@ abstract class ExecutorIntegrationTestBase {
 
     open fun integration_testSingleMessageModeration(model: LLModel) = runTest(timeout = 300.seconds) {
         // For Bedrock, moderation is done via guardrails at the client level, not model capabilities
-        if (model.provider != LLMProvider.Bedrock) {
-            assumeTrue(
-                model.capabilities.contains(LLMCapability.Moderation),
-                "Model $model does not support moderation"
-            )
-        }
+        assumeTrue(
+            model.provider == LLMProvider.Bedrock || model.capabilities.contains(LLMCapability.Moderation),
+            "Model $model does not support moderation"
+        )
         val client = getLLMClient(model)
 
         val prompt = prompt("test-harmful-content") {
@@ -858,12 +856,10 @@ abstract class ExecutorIntegrationTestBase {
 
     open fun integration_testMultipleMessagesModeration(model: LLModel) = runTest(timeout = 300.seconds) {
         // For Bedrock, moderation is done via guardrails at the client level, not model capabilities
-        if (model.provider != LLMProvider.Bedrock) {
-            assumeTrue(
-                model.capabilities.contains(LLMCapability.Moderation),
-                "Model $model does not support moderation"
-            )
-        }
+        assumeTrue(
+            model.provider == LLMProvider.Bedrock || model.capabilities.contains(LLMCapability.Moderation),
+            "Model $model does not support moderation"
+        )
         val client = getLLMClient(model)
 
         // Not harmful (without the answer)

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
@@ -831,10 +831,13 @@ abstract class ExecutorIntegrationTestBase {
     }
 
     open fun integration_testSingleMessageModeration(model: LLModel) = runTest(timeout = 300.seconds) {
-        assumeTrue(
-            model.capabilities.contains(LLMCapability.Moderation),
-            "Model $model does not support moderation"
-        )
+        // For Bedrock, moderation is done via guardrails at the client level, not model capabilities
+        if (model.provider != LLMProvider.Bedrock) {
+            assumeTrue(
+                model.capabilities.contains(LLMCapability.Moderation),
+                "Model $model does not support moderation"
+            )
+        }
         val client = getLLMClient(model)
 
         val prompt = prompt("test-harmful-content") {
@@ -854,10 +857,13 @@ abstract class ExecutorIntegrationTestBase {
     }
 
     open fun integration_testMultipleMessagesModeration(model: LLModel) = runTest(timeout = 300.seconds) {
-        assumeTrue(
-            model.capabilities.contains(LLMCapability.Moderation),
-            "Model $model does not support moderation"
-        )
+        // For Bedrock, moderation is done via guardrails at the client level, not model capabilities
+        if (model.provider != LLMProvider.Bedrock) {
+            assumeTrue(
+                model.capabilities.contains(LLMCapability.Moderation),
+                "Model $model does not support moderation"
+            )
+        }
         val client = getLLMClient(model)
 
         // Not harmful (without the answer)

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/LLMClients.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/LLMClients.kt
@@ -1,16 +1,19 @@
 package ai.koog.integration.tests.utils
 
-import ai.koog.integration.tests.utils.APIKeys.readAwsAccessKeyIdFromEnv
-import ai.koog.integration.tests.utils.APIKeys.readAwsSecretAccessKeyFromEnv
-import ai.koog.integration.tests.utils.APIKeys.readAwsSessionTokenFromEnv
-import ai.koog.integration.tests.utils.APIKeys.readTestAnthropicKeyFromEnv
-import ai.koog.integration.tests.utils.APIKeys.readTestGoogleAIKeyFromEnv
-import ai.koog.integration.tests.utils.APIKeys.readTestMistralAiKeyFromEnv
-import ai.koog.integration.tests.utils.APIKeys.readTestOpenAIKeyFromEnv
-import ai.koog.integration.tests.utils.APIKeys.readTestOpenRouterKeyFromEnv
+import ai.koog.integration.tests.utils.TestCredentials.readAwsAccessKeyIdFromEnv
+import ai.koog.integration.tests.utils.TestCredentials.readAwsBedrockGuardrailIdFromEnv
+import ai.koog.integration.tests.utils.TestCredentials.readAwsBedrockGuardrailVersionFromEnv
+import ai.koog.integration.tests.utils.TestCredentials.readAwsSecretAccessKeyFromEnv
+import ai.koog.integration.tests.utils.TestCredentials.readAwsSessionTokenFromEnv
+import ai.koog.integration.tests.utils.TestCredentials.readTestAnthropicKeyFromEnv
+import ai.koog.integration.tests.utils.TestCredentials.readTestGoogleAIKeyFromEnv
+import ai.koog.integration.tests.utils.TestCredentials.readTestMistralAiKeyFromEnv
+import ai.koog.integration.tests.utils.TestCredentials.readTestOpenAIKeyFromEnv
+import ai.koog.integration.tests.utils.TestCredentials.readTestOpenRouterKeyFromEnv
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
 import ai.koog.prompt.executor.clients.bedrock.BedrockClientSettings
+import ai.koog.prompt.executor.clients.bedrock.BedrockGuardrailsSettings
 import ai.koog.prompt.executor.clients.bedrock.BedrockLLMClient
 import ai.koog.prompt.executor.clients.google.GoogleLLMClient
 import ai.koog.prompt.executor.clients.mistralai.MistralAILLMClient
@@ -42,7 +45,12 @@ fun getLLMClientForProvider(provider: LLMProvider): LLMClient {
                 this.secretAccessKey = readAwsSecretAccessKeyFromEnv()
                 readAwsSessionTokenFromEnv()?.let { this.sessionToken = it }
             },
-            settings = BedrockClientSettings()
+            settings = BedrockClientSettings(
+                moderationGuardrailsSettings = BedrockGuardrailsSettings(
+                    guardrailIdentifier = readAwsBedrockGuardrailIdFromEnv(),
+                    guardrailVersion = readAwsBedrockGuardrailVersionFromEnv()
+                )
+            )
         )
 
         LLMProvider.Google -> GoogleLLMClient(

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
@@ -68,11 +68,22 @@ object Models {
         )
     }
 
+    /**
+     * Returns models that support content moderation capabilities.
+     *
+     * Note: For Bedrock, the model returned here is not actually used by the moderation API.
+     * AWS Bedrock Guardrails are model-independent and configured at the client level.
+     * However, we need to provide a Bedrock model here so that the integration tests can
+     * instantiate a [ai.koog.prompt.executor.clients.bedrock.BedrockLLMClient] with the appropriate provider and guardrail settings.
+     * The actual moderation behavior is determined by the guardrail configuration
+     * in [getLLMClientForProvider], not by the model's capabilities.
+     */
     @JvmStatic
     fun moderationModels(): Stream<LLModel> {
         return Stream.of(
             OpenAIModels.Moderation.Omni,
             MistralAIModels.Moderation.MistralModeration,
+            BedrockModels.AnthropicClaude4_5Haiku
         )
     }
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/TestCredentials.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/TestCredentials.kt
@@ -1,6 +1,6 @@
 package ai.koog.integration.tests.utils
 
-object APIKeys {
+object TestCredentials {
     fun readTestAnthropicKeyFromEnv(): String {
         return System.getenv("ANTHROPIC_API_TEST_KEY")
             ?: error("ERROR: environment variable `ANTHROPIC_API_TEST_KEY` is not set")
@@ -36,10 +36,25 @@ object APIKeys {
             ?: error("ERROR: environment variable `AWS_SECRET_ACCESS_KEY` is not set")
     }
 
+    fun readAwsBedrockBearerTokenFromEnv(): String {
+        return System.getenv("AWS_BEARER_TOKEN_BEDROCK")
+            ?: error("ERROR: environment variable `AWS_BEARER_TOKEN_BEDROCK` is not set")
+    }
+
     fun readAwsSessionTokenFromEnv(): String? {
         return System.getenv("AWS_SESSION_TOKEN")
             ?: null.also {
                 println("WARNING: environment variable `AWS_SESSION_TOKEN` is not set, using default session token")
             }
+    }
+
+    fun readAwsBedrockGuardrailIdFromEnv(): String {
+        return System.getenv("AWS_BEDROCK_GUARDRAIL_ID")
+            ?: error("ERROR: environment variable `AWS_BEDROCK_GUARDRAIL_ID` is not set")
+    }
+
+    fun readAwsBedrockGuardrailVersionFromEnv(): String {
+        return System.getenv("AWS_BEDROCK_GUARDRAIL_VERSION")
+            ?: error("ERROR: environment variable `AWS_BEDROCK_GUARDRAIL_VERSION` is not set")
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
@@ -551,14 +551,16 @@ public class BedrockLLMClient(
                                         "png", "PNG" -> GuardrailImageFormat.Png
                                         else -> GuardrailImageFormat.SdkUnknown(part.format)
                                     }
-
-                                    when (val imageContent = part.content) {
-                                        is AttachmentContent.Binary.Base64 -> source = Bytes(imageContent.asBytes())
-                                        is AttachmentContent.Binary.Bytes -> source = Bytes(imageContent.data)
+                                    source = when (val imageContent = part.content) {
+                                        is AttachmentContent.Binary.Base64 -> Bytes(imageContent.asBytes())
+                                        is AttachmentContent.Binary.Bytes -> Bytes(imageContent.data)
                                         is AttachmentContent.PlainText ->
-                                            source = Bytes(imageContent.text.encodeToByteArray())
+                                            Bytes(imageContent.text.encodeToByteArray())
                                         else -> {
-                                            logger.warn { "Unknown image content type: ${imageContent::class.simpleName}" }
+                                            throw IllegalArgumentException(
+                                                "Unsupported image content type: ${imageContent::class.simpleName}. " +
+                                                    "Bedrock Guardrails only supports Binary.Base64, Binary.Bytes, or PlainText content."
+                                            )
                                         }
                                     }
                                 }
@@ -570,11 +572,8 @@ public class BedrockLLMClient(
                         }
                     }
 
-                    // Only add non-null blocks
-                    contentBlock.let {
-                        add(it)
-                        logger.debug { "Added content block ${this.size} to list" }
-                    }
+                    add(contentBlock)
+                    logger.debug { "Added content block ${this.size} to list" }
                 }
             }
         }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
@@ -400,19 +400,31 @@ public class BedrockLLMClient(
     }
 
     /**
-     * Moderates the provided prompt using specified moderation guardrails settings.
-     * The method evaluates both input and output of the prompt against guardrails
-     * and determines if either is harmful, returning a corresponding result.
+     * Moderates the provided prompt using AWS Bedrock Guardrails.
      *
-     * Requires [moderationGuardrailsSettings] to be set for this [BedrockLLMClient]
+     * Unlike other LLM operations, moderation in Bedrock uses the Guardrails API which is
+     * **model-independent**. The guardrails are configured at the client level via
+     * [moderationGuardrailsSettings] and evaluate content based on those guardrail rules,
+     * not based on any specific model's capabilities.
      *
-     * Note: [model] parameter is unused here
+     * This means:
+     * - The [model] parameter is **not used** in this implementation
+     * - Any Bedrock model can be passed, but it won't affect the moderation result
+     * - The moderation behavior is determined entirely by the guardrail configuration
      *
-     * @param prompt the input text/content to be evaluated.
-     * @param model the language learning model to be used for evaluation.
-     * @return a [ModerationResult] indicating whether the content is harmful and
-     * a map of categorized moderation results.
-     * @throws IllegalArgumentException if moderation guardrails settings are not provided.
+     * The method evaluates both input (user messages) and output (assistant responses)
+     * against the configured guardrails and determines if either is harmful.
+     *
+     * Requires [moderationGuardrailsSettings] to be configured when creating this [BedrockLLMClient].
+     *
+     * @param prompt The prompt containing messages to be evaluated for harmful content.
+     * @param model The language model (unused in Bedrock - moderation is model-independent).
+     * @return A [ModerationResult] indicating whether the content is harmful and
+     *         a map of categorized moderation results based on the guardrail filters.
+     * @throws IllegalArgumentException if moderation guardrails settings are not provided
+     *         or if the prompt is empty.
+     *
+     * @see [AWS Bedrock Guardrails Documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-use-independent-api.html)
      */
     override suspend fun moderate(
         prompt: Prompt,
@@ -425,29 +437,38 @@ public class BedrockLLMClient(
                     "See https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-use-independent-api.html for more information."
             )
         }
-
         require(prompt.messages.isNotEmpty()) {
             "Can't moderate an empty prompt"
         }
 
-        val inputGuardrailResponse = requestGuardrails<Message.Request>(
-            moderationGuardrailsSettings,
-            prompt,
-            GuardrailContentSource.Input
-        )
+        val requestMessages = prompt.messages.filterIsInstance<Message.Request>()
+        val responseMessages = prompt.messages.filterIsInstance<Message.Response>()
+        logger.debug { "Moderating prompt with ${requestMessages.size} request messages and ${responseMessages.size} response messages" }
 
-        val outputGuardrailResponse = requestGuardrails<Message.Response>(
-            moderationGuardrailsSettings,
-            prompt,
-            GuardrailContentSource.Output
-        )
+        val inputGuardrailResponse = if (requestMessages.isNotEmpty()) {
+            requestGuardrails<Message.Request>(
+                moderationGuardrailsSettings,
+                prompt,
+                GuardrailContentSource.Input
+            )
+        } else {
+            null
+        }
+        val outputGuardrailResponse = if (responseMessages.isNotEmpty()) {
+            requestGuardrails<Message.Response>(
+                moderationGuardrailsSettings,
+                prompt,
+                GuardrailContentSource.Output
+            )
+        } else {
+            null
+        }
 
-        val inputIsHarmful = inputGuardrailResponse.action is GuardrailAction.GuardrailIntervened
-        val outputIsHarmful = inputGuardrailResponse.action is GuardrailAction.GuardrailIntervened
-
+        val inputIsHarmful = inputGuardrailResponse?.action is GuardrailAction.GuardrailIntervened
+        val outputIsHarmful = outputGuardrailResponse?.action is GuardrailAction.GuardrailIntervened
         val categories = buildMap {
-            fillCategoriesMap(inputGuardrailResponse)
-            fillCategoriesMap(outputGuardrailResponse)
+            inputGuardrailResponse?.let { fillCategoriesMap(it) }
+            outputGuardrailResponse?.let { fillCategoriesMap(it) }
         }
 
         return ModerationResult(inputIsHarmful || outputIsHarmful, categories)
@@ -500,21 +521,29 @@ public class BedrockLLMClient(
         moderationGuardrailsSettings: BedrockGuardrailsSettings,
         prompt: Prompt,
         sourceType: GuardrailContentSource
-    ): ApplyGuardrailResponse = bedrockClient.applyGuardrail {
-        guardrailIdentifier = moderationGuardrailsSettings.guardrailIdentifier
-        guardrailVersion = moderationGuardrailsSettings.guardrailVersion
+    ): ApplyGuardrailResponse {
+        // Filter messages by type
+        val filteredMessages = prompt.messages.filterIsInstance<MessageType>()
 
-        source = sourceType
+        logger.debug {
+            "Requesting guardrails for ${filteredMessages.size} messages of type ${MessageType::class.simpleName} with source $sourceType"
+        }
 
-        content = buildList {
-            prompt.messages.filterIsInstance<MessageType>().forEach { message ->
-                message.parts.forEach { part ->
-                    when (part) {
+        val contentBlocks = buildList {
+            filteredMessages.forEachIndexed { messageIndex, message ->
+                logger.debug { "Processing message $messageIndex with ${message.parts.size} parts" }
+
+                message.parts.forEachIndexed { partIndex, part ->
+                    logger.debug { "Processing part $partIndex of type ${part::class.simpleName}" }
+
+                    val contentBlock = when (part) {
                         is ContentPart.Text -> {
-                            add(GuardrailContentBlock.Text(GuardrailTextBlock { text = part.text }))
+                            logger.debug { "Creating text block with ${part.text.length} characters" }
+                            GuardrailContentBlock.Text(GuardrailTextBlock { text = part.text })
                         }
 
                         is ContentPart.Image -> {
+                            logger.debug { "Creating image block with format ${part.format}" }
                             GuardrailContentBlock.Image(
                                 GuardrailImageBlock {
                                     format = when (part.format) {
@@ -527,19 +556,41 @@ public class BedrockLLMClient(
                                         is AttachmentContent.Binary.Base64 -> source = Bytes(imageContent.asBytes())
                                         is AttachmentContent.Binary.Bytes -> source = Bytes(imageContent.data)
                                         is AttachmentContent.PlainText ->
-                                            source =
-                                                Bytes(imageContent.text.encodeToByteArray())
-
-                                        else -> {}
+                                            source = Bytes(imageContent.text.encodeToByteArray())
+                                        else -> {
+                                            logger.warn { "Unknown image content type: ${imageContent::class.simpleName}" }
+                                        }
                                     }
                                 }
                             )
                         }
 
-                        else -> throw IllegalArgumentException("Unsupported attachment type: $this")
+                        else -> {
+                            throw IllegalArgumentException("Unsupported attachment type: ${part::class.simpleName}")
+                        }
+                    }
+
+                    // Only add non-null blocks
+                    contentBlock.let {
+                        add(it)
+                        logger.debug { "Added content block ${this.size} to list" }
                     }
                 }
             }
+        }
+
+        logger.debug { "Built ${contentBlocks.size} content blocks for guardrails request" }
+
+        // Validate we have content
+        require(contentBlocks.isNotEmpty()) {
+            "Cannot send guardrails request with empty content. Filtered ${filteredMessages.size} messages but produced no valid content blocks."
+        }
+
+        return bedrockClient.applyGuardrail {
+            guardrailIdentifier = moderationGuardrailsSettings.guardrailIdentifier
+            guardrailVersion = moderationGuardrailsSettings.guardrailVersion
+            source = sourceType
+            content = contentBlocks
         }
     }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModels.kt
@@ -99,8 +99,7 @@ public enum class BedrockInferencePrefixes(public val prefix: String) {
 }
 
 /**
- * Bedrock models
- * Models available through the AWS Bedrock API
+ * Bedrock models available through the AWS Bedrock API
  */
 public object BedrockModels : LLModelDefinitions {
     // Basic capabilities for text-only models

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClientTest.kt
@@ -246,47 +246,32 @@ class BedrockLLMClientTest {
                 }
             }
 
-            override val config: BedrockRuntimeClient.Config get() = TODO("Not yet implemented")
-            override suspend fun converse(input: ConverseRequest): ConverseResponse {
-                TODO("Not yet implemented")
-            }
+            override val config: BedrockRuntimeClient.Config
+                get() = throw UnsupportedOperationException("config not implemented in mock client")
 
-            override suspend fun <T> converseStream(
-                input: ConverseStreamRequest,
-                block: suspend (ConverseStreamResponse) -> T
-            ): T {
-                TODO("Not yet implemented")
-            }
+            override suspend fun converse(input: ConverseRequest): ConverseResponse =
+                throw UnsupportedOperationException("converse not implemented in mock client")
 
-            override suspend fun getAsyncInvoke(input: GetAsyncInvokeRequest): GetAsyncInvokeResponse {
-                TODO("Not yet implemented")
-            }
+            override suspend fun <T> converseStream(input: ConverseStreamRequest, block: suspend (ConverseStreamResponse) -> T): T =
+                throw UnsupportedOperationException("converseStream not implemented in mock client")
 
-            override suspend fun invokeModel(input: InvokeModelRequest): InvokeModelResponse {
-                TODO("Not yet implemented")
-            }
+            override suspend fun getAsyncInvoke(input: GetAsyncInvokeRequest): GetAsyncInvokeResponse =
+                throw UnsupportedOperationException("getAsyncInvoke not implemented in mock client")
 
-            override suspend fun <T> invokeModelWithBidirectionalStream(
-                input: InvokeModelWithBidirectionalStreamRequest,
-                block: suspend (InvokeModelWithBidirectionalStreamResponse) -> T
-            ): T {
-                TODO("Not yet implemented")
-            }
+            override suspend fun invokeModel(input: InvokeModelRequest): InvokeModelResponse =
+                throw UnsupportedOperationException("invokeModel not implemented in mock client")
 
-            override suspend fun <T> invokeModelWithResponseStream(
-                input: InvokeModelWithResponseStreamRequest,
-                block: suspend (InvokeModelWithResponseStreamResponse) -> T
-            ): T {
-                TODO("Not yet implemented")
-            }
+            override suspend fun <T> invokeModelWithBidirectionalStream(input: InvokeModelWithBidirectionalStreamRequest, block: suspend (InvokeModelWithBidirectionalStreamResponse) -> T): T =
+                throw UnsupportedOperationException("invokeModelWithBidirectionalStream not implemented in mock client")
 
-            override suspend fun listAsyncInvokes(input: ListAsyncInvokesRequest): ListAsyncInvokesResponse {
-                TODO("Not yet implemented")
-            }
+            override suspend fun <T> invokeModelWithResponseStream(input: InvokeModelWithResponseStreamRequest, block: suspend (InvokeModelWithResponseStreamResponse) -> T): T =
+                throw UnsupportedOperationException("invokeModelWithResponseStream not implemented in mock client")
 
-            override suspend fun startAsyncInvoke(input: StartAsyncInvokeRequest): StartAsyncInvokeResponse {
-                TODO("Not yet implemented")
-            }
+            override suspend fun listAsyncInvokes(input: ListAsyncInvokesRequest): ListAsyncInvokesResponse =
+                throw UnsupportedOperationException("listAsyncInvokes not implemented in mock client")
+
+            override suspend fun startAsyncInvoke(input: StartAsyncInvokeRequest): StartAsyncInvokeResponse =
+                throw UnsupportedOperationException("startAsyncInvoke not implemented in mock client")
 
             override fun close() {
                 print("closing")
@@ -447,15 +432,34 @@ class BedrockLLMClientTest {
                     outputs = emptyList()
                 }
             }
-            override val config: BedrockRuntimeClient.Config get() = TODO("Not used in test")
-            override suspend fun converse(input: ConverseRequest): ConverseResponse = TODO("Not used in test")
-            override suspend fun <T> converseStream(input: ConverseStreamRequest, block: suspend (ConverseStreamResponse) -> T): T = TODO("Not used in test")
-            override suspend fun getAsyncInvoke(input: GetAsyncInvokeRequest): GetAsyncInvokeResponse = TODO("Not used in test")
-            override suspend fun invokeModel(input: InvokeModelRequest): InvokeModelResponse = TODO("Not used in test")
-            override suspend fun <T> invokeModelWithBidirectionalStream(input: InvokeModelWithBidirectionalStreamRequest, block: suspend (InvokeModelWithBidirectionalStreamResponse) -> T): T = TODO("Not used in test")
-            override suspend fun <T> invokeModelWithResponseStream(input: InvokeModelWithResponseStreamRequest, block: suspend (InvokeModelWithResponseStreamResponse) -> T): T = TODO("Not used in test")
-            override suspend fun listAsyncInvokes(input: ListAsyncInvokesRequest): ListAsyncInvokesResponse = TODO("Not used in test")
-            override suspend fun startAsyncInvoke(input: StartAsyncInvokeRequest): StartAsyncInvokeResponse = TODO("Not used in test")
+
+            override val config: BedrockRuntimeClient.Config
+                get() = throw UnsupportedOperationException("config not implemented in mock client")
+
+            override suspend fun converse(input: ConverseRequest): ConverseResponse =
+                throw UnsupportedOperationException("converse not implemented in mock client")
+
+            override suspend fun <T> converseStream(input: ConverseStreamRequest, block: suspend (ConverseStreamResponse) -> T): T =
+                throw UnsupportedOperationException("converseStream not implemented in mock client")
+
+            override suspend fun getAsyncInvoke(input: GetAsyncInvokeRequest): GetAsyncInvokeResponse =
+                throw UnsupportedOperationException("getAsyncInvoke not implemented in mock client")
+
+            override suspend fun invokeModel(input: InvokeModelRequest): InvokeModelResponse =
+                throw UnsupportedOperationException("invokeModel not implemented in mock client")
+
+            override suspend fun <T> invokeModelWithBidirectionalStream(input: InvokeModelWithBidirectionalStreamRequest, block: suspend (InvokeModelWithBidirectionalStreamResponse) -> T): T =
+                throw UnsupportedOperationException("invokeModelWithBidirectionalStream not implemented in mock client")
+
+            override suspend fun <T> invokeModelWithResponseStream(input: InvokeModelWithResponseStreamRequest, block: suspend (InvokeModelWithResponseStreamResponse) -> T): T =
+                throw UnsupportedOperationException("invokeModelWithResponseStream not implemented in mock client")
+
+            override suspend fun listAsyncInvokes(input: ListAsyncInvokesRequest): ListAsyncInvokesResponse =
+                throw UnsupportedOperationException("listAsyncInvokes not implemented in mock client")
+
+            override suspend fun startAsyncInvoke(input: StartAsyncInvokeRequest): StartAsyncInvokeResponse =
+                throw UnsupportedOperationException("startAsyncInvoke not implemented in mock client")
+
             override fun close() {
                 print("closing")
             }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClientTest.kt
@@ -204,8 +204,6 @@ class BedrockLLMClientTest {
         }
     }
 
-
-
     @Execution(ExecutionMode.SAME_THREAD)
     @Test
     fun `can create BedrockLLMClient with moderation guardrails settings`() = runTest {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClientTest.kt
@@ -39,6 +39,8 @@ import aws.sdk.kotlin.services.bedrockruntime.model.StartAsyncInvokeResponse
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
@@ -202,6 +204,9 @@ class BedrockLLMClientTest {
         }
     }
 
+
+
+    @Execution(ExecutionMode.SAME_THREAD)
     @Test
     fun `can create BedrockLLMClient with moderation guardrails settings`() = runTest {
         val guardrailsSettings = BedrockGuardrailsSettings(
@@ -286,7 +291,7 @@ class BedrockLLMClientTest {
             }
 
             override fun close() {
-                TODO("Not yet implemented")
+                print("closing")
             }
         }
 
@@ -295,18 +300,22 @@ class BedrockLLMClientTest {
             moderationGuardrailsSettings = guardrailsSettings
         )
 
-        val prompt = Prompt.build("test") {
-            user("This is a test prompt")
-        }
-        val model = BedrockModels.AnthropicClaude3Sonnet
+        try {
+            val prompt = Prompt.build("test") {
+                user("This is a test prompt")
+            }
+            val model = BedrockModels.AnthropicClaude3Sonnet
 
-        val moderationResult = client.moderate(prompt, model)
-        assertEquals(true, moderationResult.isHarmful)
-        assertEquals(true, moderationResult.violatesCategory(ModerationCategory.Hate))
-        assertEquals(true, moderationResult.violatesCategory(ModerationCategory.Sexual))
-        assertEquals(true, moderationResult.violatesCategory(ModerationCategory.Misconduct))
-        assertEquals(false, moderationResult.violatesCategory(ModerationCategory.Illicit))
-        assertEquals(null, moderationResult.categories[ModerationCategory.Illicit])
+            val moderationResult = client.moderate(prompt, model)
+            assertEquals(true, moderationResult.isHarmful)
+            assertEquals(true, moderationResult.violatesCategory(ModerationCategory.Hate))
+            assertEquals(true, moderationResult.violatesCategory(ModerationCategory.Sexual))
+            assertEquals(true, moderationResult.violatesCategory(ModerationCategory.Misconduct))
+            assertEquals(false, moderationResult.violatesCategory(ModerationCategory.Illicit))
+            assertEquals(null, moderationResult.categories[ModerationCategory.Illicit])
+        } finally {
+            client.close()
+        }
     }
 
     @Test
@@ -329,6 +338,129 @@ class BedrockLLMClientTest {
         // Verify that moderate method throws an exception because moderationGuardrailsSettings wasn't provided
         assertFailsWith<IllegalArgumentException> {
             client.moderate(prompt, model)
+        }
+    }
+
+    @Execution(ExecutionMode.SAME_THREAD)
+    @Test
+    fun `moderate calls guardrails once for Request-only prompts`() = runTest {
+        val guardrailsSettings = BedrockGuardrailsSettings(
+            guardrailIdentifier = "test-guardrail",
+            guardrailVersion = "1.0"
+        )
+
+        var applyGuardrailCallCount = 0
+
+        val mockClient = createCountingMockClient { applyGuardrailCallCount++ }
+
+        val client = BedrockLLMClient(
+            mockClient,
+            moderationGuardrailsSettings = guardrailsSettings
+        )
+
+        try {
+            // Prompt with only User (Request) message
+            val prompt = Prompt.build("test") {
+                user("hi")
+            }
+            val model = BedrockModels.AnthropicClaude3Sonnet
+
+            client.moderate(prompt, model)
+
+            assertEquals(1, applyGuardrailCallCount, "Should call applyGuardrail exactly once for Request-only prompts")
+        } finally {
+            client.close()
+        }
+    }
+
+    @Execution(ExecutionMode.SAME_THREAD)
+    @Test
+    fun `moderate calls guardrails twice for prompts with both Request and Response`() = runTest {
+        val guardrailsSettings = BedrockGuardrailsSettings(
+            guardrailIdentifier = "test-guardrail",
+            guardrailVersion = "1.0"
+        )
+
+        var applyGuardrailCallCount = 0
+
+        val mockClient = createCountingMockClient { applyGuardrailCallCount++ }
+
+        val client = BedrockLLMClient(
+            mockClient,
+            moderationGuardrailsSettings = guardrailsSettings
+        )
+
+        try {
+            // Prompt with both User (Request) and Assistant (Response) messages
+            val prompt = Prompt.build("test") {
+                user("What is 2+2?")
+                assistant("2+2 equals 4")
+            }
+            val model = BedrockModels.AnthropicClaude3Sonnet
+
+            client.moderate(prompt, model)
+
+            assertEquals(2, applyGuardrailCallCount, "Should call applyGuardrail exactly twice for prompts with both Request and Response")
+        } finally {
+            client.close()
+        }
+    }
+
+    @Execution(ExecutionMode.SAME_THREAD)
+    @Test
+    fun `moderate calls guardrails once for Response-only prompts`() = runTest {
+        val guardrailsSettings = BedrockGuardrailsSettings(
+            guardrailIdentifier = "test-guardrail",
+            guardrailVersion = "1.0"
+        )
+
+        var applyGuardrailCallCount = 0
+
+        val mockClient = createCountingMockClient { applyGuardrailCallCount++ }
+
+        val client = BedrockLLMClient(
+            mockClient,
+            moderationGuardrailsSettings = guardrailsSettings
+        )
+
+        try {
+            // Prompt with only Assistant (Response) message
+            val prompt = Prompt.build("test") {
+                assistant("Hello, how can I help?")
+            }
+            val model = BedrockModels.AnthropicClaude3Sonnet
+
+            client.moderate(prompt, model)
+
+            assertEquals(1, applyGuardrailCallCount, "Should call applyGuardrail exactly once for Response-only prompts")
+        } finally {
+            client.close()
+        }
+    }
+
+    // Helper function to create a counting mock client
+    private fun createCountingMockClient(onApplyGuardrail: () -> Unit): BedrockRuntimeClient {
+        return object : BedrockRuntimeClient {
+            override suspend fun applyGuardrail(input: ApplyGuardrailRequest): ApplyGuardrailResponse {
+                onApplyGuardrail()
+                return ApplyGuardrailResponse {
+                    action = GuardrailAction.None
+                    assessments = emptyList()
+                    outputs = emptyList()
+                }
+            }
+            override val config: BedrockRuntimeClient.Config get() = TODO("Not used in test")
+            override suspend fun converse(input: ConverseRequest): ConverseResponse = TODO("Not used in test")
+            override suspend fun <T> converseStream(input: ConverseStreamRequest, block: suspend (ConverseStreamResponse) -> T): T = TODO("Not used in test")
+            override suspend fun getAsyncInvoke(input: GetAsyncInvokeRequest): GetAsyncInvokeResponse = TODO("Not used in test")
+            override suspend fun invokeModel(input: InvokeModelRequest): InvokeModelResponse = TODO("Not used in test")
+            override suspend fun <T> invokeModelWithBidirectionalStream(input: InvokeModelWithBidirectionalStreamRequest, block: suspend (InvokeModelWithBidirectionalStreamResponse) -> T): T = TODO("Not used in test")
+            override suspend fun <T> invokeModelWithResponseStream(input: InvokeModelWithResponseStreamRequest, block: suspend (InvokeModelWithResponseStreamResponse) -> T): T = TODO("Not used in test")
+            override suspend fun listAsyncInvokes(input: ListAsyncInvokesRequest): ListAsyncInvokesResponse = TODO("Not used in test")
+            override suspend fun startAsyncInvoke(input: StartAsyncInvokeRequest): StartAsyncInvokeResponse = TODO("Not used in test")
+            override fun close() {
+                print("closing")
+            }
         }
     }
 


### PR DESCRIPTION
Enhance `BedrockLLMClient.moderate()` to conditionally call guardrails API based on message types present in the prompt. Previously, the function would always call both input and output guardrails regardless of whether Request or Response messages existed, which was inefficient and a confusing pattern.

Changes:
- Conditionally call `requestGuardrails()` only when corresponding message types exist in the prompt
- Refactor `requestGuardrails()` with extracted variables and improved logging for better debuggability
- Fix Image content block not being added to content list
- Enhance KDoc to clarify Bedrock's model-independent moderation approach

Testing:
- Add unit tests for Request-only, Response-only, and mixed message scenarios
- Add integration test support with bearer token authentication
- Refactor APIKeys to TestCredentials with guardrail configuration helpers
- Add environment variable support for guardrail ID and version

This refactoring improves code clarity, reduces unnecessary API calls, and provides better debugging support for Bedrock moderation workflows.

---

#### Type of the changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
