### PR TITLE
Improve naming in structured output module

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentSubgraph.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentSubgraph.kt
@@ -17,9 +17,9 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.structure.StructureFixingParser
-import ai.koog.prompt.structure.StructuredOutput
-import ai.koog.prompt.structure.StructuredOutputConfig
-import ai.koog.prompt.structure.json.JsonStructuredData
+import ai.koog.prompt.structure.StructuredRequest
+import ai.koog.prompt.structure.StructuredRequestConfig
+import ai.koog.prompt.structure.json.JsonStructure
 import ai.koog.prompt.structure.json.generator.StandardJsonSchemaGenerator
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
@@ -130,9 +130,9 @@ public open class AIAgentSubgraph<TInput, TOutput>(
             }
 
             val selectedTools = this.requestLLMStructured(
-                config = StructuredOutputConfig(
-                    default = StructuredOutput.Manual(
-                        JsonStructuredData.createJsonStructure<SelectedTools>(
+                config = StructuredRequestConfig(
+                    default = StructuredRequest.Manual(
+                        JsonStructure.create<SelectedTools>(
                             schemaGenerator = StandardJsonSchemaGenerator,
                             examples = listOf(SelectedTools(listOf()), SelectedTools(tools.map { it.name }.take(3))),
                         ),
@@ -143,7 +143,7 @@ public open class AIAgentSubgraph<TInput, TOutput>(
 
             prompt = initialPrompt
 
-            tools.filter { it.name in selectedTools.structure.tools.toSet() }
+            tools.filter { it.name in selectedTools.data.tools.toSet() }
         }
     }
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMSession.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMSession.kt
@@ -13,7 +13,7 @@ import ai.koog.prompt.message.Message
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.structure.StructureFixingParser
-import ai.koog.prompt.structure.StructuredOutputConfig
+import ai.koog.prompt.structure.StructuredRequestConfig
 import ai.koog.prompt.structure.StructuredResponse
 import ai.koog.prompt.structure.executeStructured
 import ai.koog.prompt.structure.parseResponseToStructuredResponse
@@ -263,7 +263,7 @@ public sealed class AIAgentLLMSession(
      * @see [executeStructured]
      */
     public open suspend fun <T> requestLLMStructured(
-        config: StructuredOutputConfig<T>,
+        config: StructuredRequestConfig<T>,
     ): Result<StructuredResponse<T>> {
         validateSession()
 
@@ -346,7 +346,7 @@ public sealed class AIAgentLLMSession(
      */
     public suspend fun <T> parseResponseToStructuredResponse(
         response: Message.Assistant,
-        config: StructuredOutputConfig<T>
+        config: StructuredRequestConfig<T>
     ): StructuredResponse<T> = executor.parseResponseToStructuredResponse(response, config, model)
 
     /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
@@ -15,9 +15,9 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.structure.StructureDefinition
 import ai.koog.prompt.structure.StructureFixingParser
-import ai.koog.prompt.structure.StructuredDataDefinition
-import ai.koog.prompt.structure.StructuredOutputConfig
+import ai.koog.prompt.structure.StructuredRequestConfig
 import ai.koog.prompt.structure.StructuredResponse
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapMerge
@@ -441,11 +441,9 @@ public class AIAgentLLMWriteSession internal constructor(
      * Sends a request to LLM and gets a structured response.
      *
      * @param config A configuration defining structures and behavior.
-     *
-     * @see [executeStructured]
      */
     override suspend fun <T> requestLLMStructured(
-        config: StructuredOutputConfig<T>,
+        config: StructuredRequestConfig<T>,
     ): Result<StructuredResponse<T>> {
         return super.requestLLMStructured(config).also {
             it.onSuccess { response ->
@@ -491,7 +489,7 @@ public class AIAgentLLMWriteSession internal constructor(
      * in constructing the prompt for the language model request.
      * @return a flow of `StreamingFrame` objects that streams the responses from the language model.
      */
-    public fun requestLLMStreaming(definition: StructuredDataDefinition? = null): Flow<StreamFrame> {
+    public fun requestLLMStreaming(definition: StructureDefinition? = null): Flow<StreamFrame> {
         if (definition != null) {
             val prompt = prompt(prompt, clock) {
                 user {

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentFunctionalContextExt.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentFunctionalContextExt.kt
@@ -11,8 +11,8 @@ import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolResult
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.structure.StructureDefinition
 import ai.koog.prompt.structure.StructureFixingParser
-import ai.koog.prompt.structure.StructuredDataDefinition
 import ai.koog.prompt.structure.StructuredResponse
 import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.serializer
@@ -142,9 +142,8 @@ public suspend fun AIAgentFunctionalContext.latestTokenUsage(): Int {
  * The message becomes part of the current prompt, and the LLM's response is processed to extract structured data.
  *
  * @param message The content of the message to be sent to the LLM.
- * @param structure Definition of expected output format and parsing logic.
- * @param retries Number of retry attempts for failed generations.
- * @param fixingModel LLM used for error correction.
+ * @param examples Examples of the structured output.
+ * @param fixingParser Optional parser to fix generated structured data.
  * @return Result containing the structured response if successful, or an error if parsing failed.
  */
 public suspend inline fun <reified T> AIAgentFunctionalContext.requestLLMStructured(
@@ -175,7 +174,7 @@ public suspend inline fun <reified T> AIAgentFunctionalContext.requestLLMStructu
  */
 public suspend fun AIAgentFunctionalContext.requestLLMStreaming(
     message: String,
-    structureDefinition: StructuredDataDefinition? = null
+    structureDefinition: StructureDefinition? = null
 ): Flow<StreamFrame> {
     return llm.writeSession {
         appendPrompt {

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
@@ -17,9 +17,9 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.streaming.toMessageResponses
+import ai.koog.prompt.structure.StructureDefinition
 import ai.koog.prompt.structure.StructureFixingParser
-import ai.koog.prompt.structure.StructuredDataDefinition
-import ai.koog.prompt.structure.StructuredOutputConfig
+import ai.koog.prompt.structure.StructuredRequestConfig
 import ai.koog.prompt.structure.StructuredResponse
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.toList
@@ -198,7 +198,7 @@ public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMModerateMessage(
 @AIAgentBuilderDslMarker
 public inline fun <reified T> AIAgentSubgraphBuilderBase<*, *>.nodeLLMRequestStructured(
     name: String? = null,
-    config: StructuredOutputConfig<T>,
+    config: StructuredRequestConfig<T>,
 ): AIAgentNodeDelegate<String, Result<StructuredResponse<T>>> =
     node(name) { message ->
         llm.writeSession {
@@ -254,7 +254,7 @@ public inline fun <reified T> AIAgentSubgraphBuilderBase<*, *>.nodeLLMRequestStr
 @AIAgentBuilderDslMarker
 public fun <T> AIAgentSubgraphBuilderBase<*, *>.nodeLLMRequestStreaming(
     name: String? = null,
-    structureDefinition: StructuredDataDefinition? = null,
+    structureDefinition: StructureDefinition? = null,
     transformStreamData: suspend (Flow<StreamFrame>) -> Flow<T>
 ): AIAgentNodeDelegate<String, Flow<T>> =
     node(name) { message ->
@@ -278,7 +278,7 @@ public fun <T> AIAgentSubgraphBuilderBase<*, *>.nodeLLMRequestStreaming(
 @AIAgentBuilderDslMarker
 public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMRequestStreaming(
     name: String? = null,
-    structureDefinition: StructuredDataDefinition? = null,
+    structureDefinition: StructureDefinition? = null,
 ): AIAgentNodeDelegate<String, Flow<StreamFrame>> = nodeLLMRequestStreaming(name, structureDefinition) { it }
 
 /**
@@ -357,7 +357,7 @@ public inline fun <reified T> AIAgentSubgraphBuilderBase<*, *>.nodeLLMCompressHi
 @AIAgentBuilderDslMarker
 public inline fun <reified T> AIAgentSubgraphBuilderBase<*, *>.nodeLLMRequestStreamingAndSendResults(
     name: String? = null,
-    structureDefinition: StructuredDataDefinition? = null
+    structureDefinition: StructureDefinition? = null
 ): AIAgentNodeDelegate<T, List<Message.Response>> = node(name) { input ->
     llm.writeSession {
         requestLLMStreaming(structureDefinition)
@@ -536,7 +536,7 @@ public inline fun <reified ToolArg, reified TResult> AIAgentSubgraphBuilderBase<
 @AIAgentBuilderDslMarker
 public inline fun <reified TInput, T> AIAgentSubgraphBuilderBase<*, *>.nodeSetStructuredOutput(
     name: String? = null,
-    config: StructuredOutputConfig<T>
+    config: StructuredRequestConfig<T>
 ): AIAgentNodeDelegate<TInput, TInput> =
     node(name) { message ->
         llm.writeSession {

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMSessionStructuredOutputTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMSessionStructuredOutputTest.kt
@@ -9,9 +9,9 @@ import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
-import ai.koog.prompt.structure.StructuredOutput
-import ai.koog.prompt.structure.StructuredOutputConfig
-import ai.koog.prompt.structure.json.JsonStructuredData
+import ai.koog.prompt.structure.StructuredRequest
+import ai.koog.prompt.structure.StructuredRequestConfig
+import ai.koog.prompt.structure.json.JsonStructure
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
 import kotlin.test.Test
@@ -32,9 +32,9 @@ class AIAgentLLMSessionStructuredOutputTest : AgentTestBase() {
 
     @Test
     fun testParseResponseToStructuredResponse() = runTest {
-        val structure = JsonStructuredData.createJsonStructure<TestStructure>()
-        val config = StructuredOutputConfig(
-            default = StructuredOutput.Manual(structure)
+        val structure = JsonStructure.create<TestStructure>()
+        val config = StructuredRequestConfig(
+            default = StructuredRequest.Manual(structure)
         )
 
         val mockExecutor = getMockExecutor {
@@ -77,17 +77,17 @@ class AIAgentLLMSessionStructuredOutputTest : AgentTestBase() {
         }
 
         assertNotNull(result)
-        assertEquals("John Doe", result.structure.name)
-        assertEquals(30, result.structure.age)
-        assertEquals("A test person", result.structure.description)
+        assertEquals("John Doe", result.data.name)
+        assertEquals(30, result.data.age)
+        assertEquals("A test person", result.data.description)
         assertEquals(assistantMessage, result.message)
     }
 
     @Test
     fun testParseResponseToStructuredResponseWithNullableField() = runTest {
-        val structure = JsonStructuredData.createJsonStructure<TestStructure>()
-        val config = StructuredOutputConfig(
-            default = StructuredOutput.Manual(structure)
+        val structure = JsonStructure.create<TestStructure>()
+        val config = StructuredRequestConfig(
+            default = StructuredRequest.Manual(structure)
         )
 
         val mockExecutor = getMockExecutor {
@@ -129,9 +129,9 @@ class AIAgentLLMSessionStructuredOutputTest : AgentTestBase() {
         }
 
         assertNotNull(result)
-        assertEquals("Jane Doe", result.structure.name)
-        assertEquals(25, result.structure.age)
-        assertEquals(null, result.structure.description)
+        assertEquals("Jane Doe", result.data.name)
+        assertEquals(25, result.data.age)
+        assertEquals(null, result.data.description)
         assertEquals(assistantMessage, result.message)
     }
 
@@ -155,9 +155,9 @@ class AIAgentLLMSessionStructuredOutputTest : AgentTestBase() {
             val tags: Set<String>
         )
 
-        val structure = JsonStructuredData.createJsonStructure<ComplexStructure>()
-        val config = StructuredOutputConfig(
-            default = StructuredOutput.Manual(structure)
+        val structure = JsonStructure.create<ComplexStructure>()
+        val config = StructuredRequestConfig(
+            default = StructuredRequest.Manual(structure)
         )
 
         val mockExecutor = getMockExecutor {
@@ -209,13 +209,13 @@ class AIAgentLLMSessionStructuredOutputTest : AgentTestBase() {
         }
 
         assertNotNull(result)
-        assertEquals(123, result.structure.id)
-        assertEquals(2, result.structure.addresses.size)
-        assertEquals("123 Main St", result.structure.addresses[0].street)
-        assertEquals("New York", result.structure.addresses[0].city)
-        assertEquals("456 Oak Ave", result.structure.addresses[1].street)
-        assertEquals("Los Angeles", result.structure.addresses[1].city)
-        assertEquals(setOf("vip", "premium", "verified"), result.structure.tags)
+        assertEquals(123, result.data.id)
+        assertEquals(2, result.data.addresses.size)
+        assertEquals("123 Main St", result.data.addresses[0].street)
+        assertEquals("New York", result.data.addresses[0].city)
+        assertEquals("456 Oak Ave", result.data.addresses[1].street)
+        assertEquals("Los Angeles", result.data.addresses[1].city)
+        assertEquals(setOf("vip", "premium", "verified"), result.data.tags)
         assertEquals(assistantMessage, result.message)
     }
 }

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodesTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodesTest.kt
@@ -12,9 +12,9 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.llm.OllamaModels
-import ai.koog.prompt.structure.StructuredOutput
-import ai.koog.prompt.structure.StructuredOutputConfig
-import ai.koog.prompt.structure.json.JsonStructuredData
+import ai.koog.prompt.structure.StructuredRequest
+import ai.koog.prompt.structure.StructuredRequestConfig
+import ai.koog.prompt.structure.json.JsonStructure
 import ai.koog.utils.io.use
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
@@ -154,9 +154,9 @@ class AIAgentNodesTest {
         )
 
         // Test Manual mode
-        val manualStructure = JsonStructuredData.createJsonStructure<TestOutput>()
-        val manualConfig = StructuredOutputConfig(
-            default = StructuredOutput.Manual(manualStructure)
+        val manualStructure = JsonStructure.create<TestOutput>()
+        val manualConfig = StructuredRequestConfig(
+            default = StructuredRequest.Manual(manualStructure)
         )
 
         var capturedPrompt: Prompt? = null
@@ -201,9 +201,9 @@ class AIAgentNodesTest {
         )
 
         // Test Native mode
-        val nativeStructure = JsonStructuredData.createJsonStructure<TestOutput>()
-        val nativeConfig = StructuredOutputConfig(
-            default = StructuredOutput.Native(nativeStructure)
+        val nativeStructure = JsonStructure.create<TestOutput>()
+        val nativeConfig = StructuredRequestConfig(
+            default = StructuredRequest.Native(nativeStructure)
         )
 
         val nativeStrategy = strategy<String, String>("test-native") {

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentStrategies.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentStrategies.kt
@@ -19,7 +19,7 @@ import ai.koog.agents.core.dsl.extension.onToolCall
 import ai.koog.agents.core.environment.ReceivedToolResult
 import ai.koog.agents.core.environment.result
 import ai.koog.prompt.message.Message
-import ai.koog.prompt.structure.StructuredOutputConfig
+import ai.koog.prompt.structure.StructuredRequestConfig
 
 // FIXME improve this strategy to use Message.Assistant to chat, it works better than tools
 
@@ -183,7 +183,7 @@ public fun reActStrategy(
  * @param config The configuration for structured output processing, specifying schema, providers, and optional error handling mechanisms.
  */
 public inline fun <reified Output> structuredOutputWithToolsStrategy(
-    config: StructuredOutputConfig<Output>,
+    config: StructuredRequestConfig<Output>,
     parallelTools: Boolean = false
 ): AIAgentGraphStrategy<String, Output> = structuredOutputWithToolsStrategy(
     config,
@@ -203,7 +203,7 @@ public inline fun <reified Output> structuredOutputWithToolsStrategy(
  *                that serves as the input for further processing in the structured output pipeline.
  */
 public inline fun <reified Input, reified Output> structuredOutputWithToolsStrategy(
-    config: StructuredOutputConfig<Output>,
+    config: StructuredRequestConfig<Output>,
     parallelTools: Boolean = false,
     noinline transform: suspend AIAgentGraphContextBase.(input: Input) -> String
 ): AIAgentGraphStrategy<Input, Output> = strategy<Input, Output>("structured_output_with_tools_strategy") {
@@ -214,7 +214,7 @@ public inline fun <reified Input, reified Output> structuredOutputWithToolsStrat
     val sendToolResult by nodeLLMSendMultipleToolResults()
     val transformToStructuredOutput by node<Message.Assistant, Output> { response ->
         llm.writeSession {
-            parseResponseToStructuredResponse(response, config).structure
+            parseResponseToStructuredResponse(response, config).data
         }
     }
 

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/LLMAsAJudge.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/LLMAsAJudge.kt
@@ -109,10 +109,10 @@ public inline fun <reified T> AIAgentSubgraphBuilderBase<*, *>.llmAsAJudge(
             ),
             // optional field -- recommented for reliability of the format
             fixingParser = StructureFixingParser(
-                fixingModel = OpenAIModels.CostOptimized.GPT4oMini,
+                model = OpenAIModels.CostOptimized.GPT4oMini,
                 retries = 3,
             )
-        ).getOrThrow().structure
+        ).getOrThrow().data
 
         prompt = initialPrompt
         model = initialModel

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/AIAgentStrategiesTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/AIAgentStrategiesTest.kt
@@ -1,9 +1,9 @@
 package ai.koog.agents.ext.agent
 
 import ai.koog.agents.core.tools.annotations.LLMDescription
-import ai.koog.prompt.structure.StructuredOutput
-import ai.koog.prompt.structure.StructuredOutputConfig
-import ai.koog.prompt.structure.json.JsonStructuredData
+import ai.koog.prompt.structure.StructuredRequest
+import ai.koog.prompt.structure.StructuredRequestConfig
+import ai.koog.prompt.structure.json.JsonStructure
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
 import kotlin.test.Test
@@ -58,9 +58,9 @@ class AIAgentStrategiesTest {
             val field: String
         )
 
-        val structure = JsonStructuredData.createJsonStructure<TestOutput>()
-        val config = StructuredOutputConfig(
-            default = StructuredOutput.Manual(structure)
+        val structure = JsonStructure.create<TestOutput>()
+        val config = StructuredRequestConfig(
+            default = StructuredRequest.Manual(structure)
         )
 
         val strategy = structuredOutputWithToolsStrategy<String, TestOutput>(config) { input ->
@@ -80,9 +80,9 @@ class AIAgentStrategiesTest {
             val success: Boolean
         )
 
-        val structure = JsonStructuredData.createJsonStructure<TestResult>()
-        val config = StructuredOutputConfig(
-            default = StructuredOutput.Manual(structure)
+        val structure = JsonStructure.create<TestResult>()
+        val config = StructuredRequestConfig(
+            default = StructuredRequest.Manual(structure)
         )
 
         val strategyWithParallel = structuredOutputWithToolsStrategy<String, TestResult>(
@@ -136,9 +136,9 @@ class AIAgentStrategiesTest {
             val requestType: String
         )
 
-        val structure = JsonStructuredData.createJsonStructure<ComplexOutput>()
-        val config = StructuredOutputConfig(
-            default = StructuredOutput.Manual(structure)
+        val structure = JsonStructure.create<ComplexOutput>()
+        val config = StructuredRequestConfig(
+            default = StructuredRequest.Manual(structure)
         )
 
         val strategy = structuredOutputWithToolsStrategy<ComplexInput, ComplexOutput>(config) { input ->
@@ -157,12 +157,12 @@ class AIAgentStrategiesTest {
             val value: String
         )
 
-        val manualStructure = JsonStructuredData.createJsonStructure<SimpleOutput>()
-        val nativeStructure = JsonStructuredData.createJsonStructure<SimpleOutput>()
+        val manualStructure = JsonStructure.create<SimpleOutput>()
+        val nativeStructure = JsonStructure.create<SimpleOutput>()
 
         // Test with manual mode
-        val manualConfig = StructuredOutputConfig(
-            default = StructuredOutput.Manual(manualStructure)
+        val manualConfig = StructuredRequestConfig(
+            default = StructuredRequest.Manual(manualStructure)
         )
 
         val manualStrategy = structuredOutputWithToolsStrategy<String, SimpleOutput>(manualConfig) { input ->
@@ -172,8 +172,8 @@ class AIAgentStrategiesTest {
         assertNotNull(manualStrategy)
 
         // Test with native mode
-        val nativeConfig = StructuredOutputConfig(
-            default = StructuredOutput.Native(nativeStructure)
+        val nativeConfig = StructuredRequestConfig(
+            default = StructuredRequest.Native(nativeStructure)
         )
 
         val nativeStrategy = structuredOutputWithToolsStrategy<String, SimpleOutput>(nativeConfig) { input ->
@@ -183,10 +183,10 @@ class AIAgentStrategiesTest {
         assertNotNull(nativeStrategy)
 
         // Test with both modes in config
-        val mixedConfig = StructuredOutputConfig(
-            default = StructuredOutput.Manual(manualStructure),
+        val mixedConfig = StructuredRequestConfig(
+            default = StructuredRequest.Manual(manualStructure),
             byProvider = mapOf(
-                ai.koog.prompt.llm.LLMProvider.OpenAI to StructuredOutput.Native(nativeStructure)
+                ai.koog.prompt.llm.LLMProvider.OpenAI to StructuredRequest.Native(nativeStructure)
             )
         )
 

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/StructuredOutputWithToolsIntegrationTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/StructuredOutputWithToolsIntegrationTest.kt
@@ -9,9 +9,9 @@ import ai.koog.agents.features.eventHandler.feature.EventHandler
 import ai.koog.agents.testing.tools.getMockExecutor
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.structure.StructuredOutput
-import ai.koog.prompt.structure.StructuredOutputConfig
-import ai.koog.prompt.structure.json.JsonStructuredData
+import ai.koog.prompt.structure.StructuredRequest
+import ai.koog.prompt.structure.StructuredRequestConfig
+import ai.koog.prompt.structure.json.JsonStructure
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
@@ -113,9 +113,9 @@ class StructuredOutputWithToolsIntegrationTest {
 
     @Test
     fun testStructuredOutputWithToolsIntegration() = runTest {
-        val structure = JsonStructuredData.createJsonStructure<WeatherResponse>()
-        val config = StructuredOutputConfig(
-            default = StructuredOutput.Manual(structure)
+        val structure = JsonStructure.create<WeatherResponse>()
+        val config = StructuredRequestConfig(
+            default = StructuredRequest.Manual(structure)
         )
 
         val strategy = structuredOutputWithToolsStrategy<WeatherRequest, WeatherResponse>(
@@ -189,9 +189,9 @@ class StructuredOutputWithToolsIntegrationTest {
 
     @Test
     fun testStructuredOutputWithToolsParallelExecution() = runTest {
-        val structure = JsonStructuredData.createJsonStructure<WeatherResponse>()
-        val config = StructuredOutputConfig(
-            default = StructuredOutput.Manual(structure)
+        val structure = JsonStructure.create<WeatherResponse>()
+        val config = StructuredRequestConfig(
+            default = StructuredRequest.Manual(structure)
         )
 
         val strategy = structuredOutputWithToolsStrategy<WeatherRequest, WeatherResponse>(
@@ -261,9 +261,9 @@ class StructuredOutputWithToolsIntegrationTest {
 
     @Test
     fun testStructuredOutputWithNoTools() = runTest {
-        val structure = JsonStructuredData.createJsonStructure<WeatherResponse>()
-        val config = StructuredOutputConfig(
-            default = StructuredOutput.Manual(structure)
+        val structure = JsonStructure.create<WeatherResponse>()
+        val config = StructuredRequestConfig(
+            default = StructuredRequest.Manual(structure)
         )
 
         val strategy = structuredOutputWithToolsStrategy<WeatherRequest, WeatherResponse>(

--- a/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/AgentMemory.kt
+++ b/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/AgentMemory.kt
@@ -30,9 +30,9 @@ import ai.koog.agents.memory.providers.NoMemory
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
-import ai.koog.prompt.structure.StructuredOutput
-import ai.koog.prompt.structure.StructuredOutputConfig
-import ai.koog.prompt.structure.json.JsonStructuredData
+import ai.koog.prompt.structure.StructuredRequest
+import ai.koog.prompt.structure.StructuredRequestConfig
+import ai.koog.prompt.structure.json.JsonStructure
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.datetime.Clock
 import kotlinx.serialization.Serializable
@@ -511,21 +511,21 @@ public suspend fun AIAgentLLMWriteSession.retrieveFactsFromHistory(
     val facts = when (concept.factType) {
         FactType.SINGLE -> {
             val response = requestLLMStructured(
-                config = StructuredOutputConfig(default = StructuredOutput.Manual(JsonStructuredData.createJsonStructure<FactStructure>()))
+                config = StructuredRequestConfig(default = StructuredRequest.Manual(JsonStructure.create<FactStructure>()))
             )
 
             SingleFact(
                 concept = concept,
-                value = response.getOrNull()?.structure?.fact ?: "No facts extracted",
+                value = response.getOrNull()?.data?.fact ?: "No facts extracted",
                 timestamp = timestamp
             )
         }
 
         FactType.MULTIPLE -> {
             val response = requestLLMStructured(
-                config = StructuredOutputConfig(default = StructuredOutput.Manual(JsonStructuredData.createJsonStructure<FactListStructure>()))
+                config = StructuredRequestConfig(default = StructuredRequest.Manual(JsonStructure.create<FactListStructure>()))
             )
-            val factsList = response.getOrNull()?.structure?.facts ?: emptyList()
+            val factsList = response.getOrNull()?.data?.facts ?: emptyList()
             MultipleFacts(concept = concept, values = factsList.map { it.fact }, timestamp = timestamp)
         }
     }

--- a/docs/docs/examples/Banking.md
+++ b/docs/docs/examples/Banking.md
@@ -543,7 +543,7 @@ val strategy = strategy<String, String>("banking assistant") {
                 )
             ),
             fixingParser = StructureFixingParser(
-                fixingModel = OpenAIModels.CostOptimized.GPT4oMini,
+                model = OpenAIModels.CostOptimized.GPT4oMini,
                 retries = 2,
             )
         )
@@ -557,7 +557,7 @@ val strategy = strategy<String, String>("banking assistant") {
         edge(
             requestClassification forwardTo nodeFinish
                 onCondition { it.isSuccess }
-                transformed { it.getOrThrow().structure }
+                transformed { it.getOrThrow().data }
         )
 
         edge(

--- a/docs/docs/parallel-node-execution.md
+++ b/docs/docs/parallel-node-execution.md
@@ -151,7 +151,7 @@ Selects a result based on an index returned by a selection function:
 <!--- INCLUDE
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.structure.json.JsonStructuredData
+import ai.koog.prompt.structure.json.JsonStructure
 
 typealias Input = String
 typealias Output = String
@@ -181,7 +181,7 @@ val nodeBestJoke by parallel<String, String>(
             user("Here are three jokes: ${jokes.joinToString("\n\n")}")
          }
          val response = requestLLMStructured<JokeRating>()
-         response.getOrNull()!!.structure.bestJokeIndex
+         response.getOrNull()!!.data.bestJokeIndex
       }
    }
 }
@@ -299,7 +299,7 @@ val strategy = strategy("best-joke") {
             }
 
             val response = requestLLMStructured<JokeRating>()
-            val bestJoke = response.getOrNull()!!.structure
+            val bestJoke = response.getOrNull()!!.data
             bestJoke.bestJokeIndex
          }
       }

--- a/docs/docs/streaming-api.md
+++ b/docs/docs/streaming-api.md
@@ -40,7 +40,6 @@ This is the most general approach: react to each frame kind.
 <!--- INCLUDE
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.prompt.streaming.StreamFrame
-import ai.koog.prompt.structure.markdown.MarkdownStructuredDataDefinition
 
 val strategy = strategy<String, String>("strategy_name") {
     val node by node<Unit, Unit> {
@@ -77,7 +76,7 @@ Here is a raw string stream with the Markdown definition of the output structure
 
 <!--- INCLUDE
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.prompt.structure.markdown.MarkdownStructuredDataDefinition
+import ai.koog.prompt.structure.markdown.MarkdownStructureDefinition
 
 val strategy = strategy<String, String>("strategy_name") {
     val node by node<Unit, Unit> {
@@ -87,8 +86,8 @@ val strategy = strategy<String, String>("strategy_name") {
 }
 -->
 ```kotlin
-fun markdownBookDefinition(): MarkdownStructuredDataDefinition {
-    return MarkdownStructuredDataDefinition("name", schema = { /*...*/ })
+fun markdownBookDefinition(): MarkdownStructureDefinition {
+    return MarkdownStructureDefinition("name", schema = { /*...*/ })
 }
 
 val mdDefinition = markdownBookDefinition()
@@ -144,6 +143,7 @@ import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.agent.GraphAIAgent
 import ai.koog.agents.features.eventHandler.feature.handleEvents
 import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.structure.markdown.MarkdownStructureDefinition
 
 fun GraphAIAgent.FeatureContext.installStreamingApi() {
 -->
@@ -188,7 +188,7 @@ it is often more convenient to work with [structured data](structured-output.md)
 
 The structured data approach includes the following key components:
 
-1. **MarkdownStructuredDataDefinition**: a class to help you define the schema and examples for structured data in
+1. **MarkdownStructureDefinition**: a class to help you define the schema and examples for structured data in
    Markdown format.
 2. **markdownStreamingParser**: a function to create a parser that processes a stream of Markdown chunks and emits
    events.
@@ -215,15 +215,15 @@ data class Book(
 #### 2. Define the Markdown structure
 
 Create a definition that specifies how your data should be structured in Markdown with the
-`MarkdownStructuredDataDefinition` class:
+`MarkdownStructureDefinition` class:
 
 <!--- INCLUDE
 import ai.koog.prompt.markdown.markdown
-import ai.koog.prompt.structure.markdown.MarkdownStructuredDataDefinition
+import ai.koog.prompt.structure.markdown.MarkdownStructureDefinition
 -->
 ```kotlin
-fun markdownBookDefinition(): MarkdownStructuredDataDefinition {
-    return MarkdownStructuredDataDefinition("bookList", schema = {
+fun markdownBookDefinition(): MarkdownStructureDefinition {
+    return MarkdownStructureDefinition("bookList", schema = {
         markdown {
             header(1, "title")
             bulleted {
@@ -477,7 +477,7 @@ val runner = AIAgent(
 
 1. **Define clear structures**: create clear and unambiguous markdown structures for your data.
 
-2. **Provide good examples**: include comprehensive examples in your `MarkdownStructuredDataDefinition` to guide the LLM.
+2. **Provide good examples**: include comprehensive examples in your `MarkdownStructureDefinition` to guide the LLM.
 
 3. **Handle incomplete data**: always check for null or empty values when parsing data from the stream.
 

--- a/docs/docs/structured-output.md
+++ b/docs/docs/structured-output.md
@@ -254,7 +254,7 @@ val structuredResponse = promptExecutor.executeStructured<WeatherForecast>(
         examples = exampleForecasts,
         // Optional: provide a fixing parser for error correction
         fixingParser = StructureFixingParser(
-            fixingModel = OpenAIModels.Chat.GPT4o,
+            model = OpenAIModels.Chat.GPT4o,
             retries = 3
         )
     )
@@ -298,7 +298,7 @@ val structuredResponse = llm.writeSession {
     requestLLMStructured<WeatherForecast>(
         examples = exampleForecasts,
         fixingParser = StructureFixingParser(
-            fixingModel = OpenAIModels.Chat.GPT4o,
+            model = OpenAIModels.Chat.GPT4o,
             retries = 3
         )
     )
@@ -329,7 +329,7 @@ val agentStrategy = strategy("weather-forecast") {
         val structuredResponse = llm.writeSession {
             requestLLMStructured<WeatherForecast>(
                 fixingParser = StructureFixingParser(
-                    fixingModel = OpenAIModels.Chat.GPT4o,
+                    model = OpenAIModels.Chat.GPT4o,
                     retries = 3
                 )
             )
@@ -382,7 +382,7 @@ val agentStrategy = strategy("weather-forecast") {
         name = "forecast-node",
         examples = exampleForecasts,
         fixingParser = StructureFixingParser(
-            fixingModel = OpenAIModels.Chat.GPT4o,
+            model = OpenAIModels.Chat.GPT4o,
             retries = 3
         )
     )
@@ -390,7 +390,7 @@ val agentStrategy = strategy("weather-forecast") {
     val processResult by node<Result<StructuredResponse<WeatherForecast>>, String> { result ->
         when {
             result.isSuccess -> {
-                val forecast = result.getOrNull()?.structure
+                val forecast = result.getOrNull()?.data
                 "Weather forecast: $forecast"
             }
             result.isFailure -> {
@@ -425,7 +425,7 @@ import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.structure.json.generator.BasicJsonSchemaGenerator
-import ai.koog.prompt.structure.json.JsonStructuredData
+import ai.koog.prompt.structure.json.JsonStructure
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -462,7 +462,7 @@ fun main(): Unit = runBlocking {
     )
 
     // Generate JSON Schema
-    val forecastStructure = JsonStructuredData.createJsonStructure<SimpleWeatherForecast>(
+    val forecastStructure = JsonStructure.create<SimpleWeatherForecast>(
         schemaGenerator = BasicJsonSchemaGenerator.Default,
         examples = exampleForecasts
     )
@@ -521,9 +521,9 @@ For more control over the structured output process, you can use the advanced AP
 
 ### Manual schema creation and configuration
 
-Instead of relying on automatic schema generation, you can create schemas explicitly using `JsonStructuredData.createJsonStructure` and configure structured output behavior manually via the `StructuredOutput` class.
+Instead of relying on automatic schema generation, you can create schemas explicitly using `JsonStructure.create` and configure structured output behavior manually via the `StructuredOutput` class.
 
-The key difference is that instead of passing simple parameters like `examples` and `fixingParser`, you create a `StructuredOutputConfig` object that allows fine-grained control over:
+The key difference is that instead of passing simple parameters like `examples` and `fixingParser`, you create a `StructuredRequestConfig` object that allows fine-grained control over:
 
 - **Schema generation**: Choose specific generators (Standard, Basic, or Provider-specific)
 - **Output modes**: Native structured output support vs Manual prompting
@@ -538,14 +538,14 @@ import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
 import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
 import ai.koog.prompt.structure.executeStructured
-import ai.koog.prompt.structure.StructuredOutput
-import ai.koog.prompt.structure.StructuredOutputConfig
+import ai.koog.prompt.structure.StructuredRequest
 import ai.koog.prompt.structure.StructureFixingParser
-import ai.koog.prompt.structure.json.JsonStructuredData
+import ai.koog.prompt.structure.json.JsonStructure
 import ai.koog.prompt.structure.json.generator.StandardJsonSchemaGenerator
 import ai.koog.prompt.executor.clients.openai.base.structure.OpenAIBasicJsonSchemaGenerator
 import ai.koog.prompt.llm.LLMProvider
 import kotlinx.coroutines.runBlocking
+import ai.koog.prompt.structure.StructuredRequestConfig
 
 fun main() {
     runBlocking {
@@ -556,32 +556,32 @@ fun main() {
 -->
 ```kotlin
 // Create different schema structures with different generators
-val genericStructure = JsonStructuredData.createJsonStructure<WeatherForecast>(
+val genericStructure = JsonStructure.create<WeatherForecast>(
     schemaGenerator = StandardJsonSchemaGenerator,
     examples = exampleForecasts
 )
 
-val openAiStructure = JsonStructuredData.createJsonStructure<WeatherForecast>(
+val openAiStructure = JsonStructure.create<WeatherForecast>(
     schemaGenerator = OpenAIBasicJsonSchemaGenerator,
     examples = exampleForecasts
 )
 
 val promptExecutor = simpleOpenAIExecutor(System.getenv("OPENAI_KEY"))
 
-// The advanced API uses StructuredOutputConfig instead of simple parameters
+// The advanced API uses StructuredRequestConfig instead of simple parameters
 val structuredResponse = promptExecutor.executeStructured(
     prompt = prompt("structured-data") {
         system("You are a weather forecasting assistant.")
         user("What is the weather forecast for Amsterdam?")
     },
     model = OpenAIModels.CostOptimized.GPT4oMini,
-    config = StructuredOutputConfig(
+    config = StructuredRequestConfig(
         byProvider = mapOf(
-            LLMProvider.OpenAI to StructuredOutput.Native(openAiStructure),
+            LLMProvider.OpenAI to StructuredRequest.Native(openAiStructure),
         ),
-        default = StructuredOutput.Manual(genericStructure),
+        default = StructuredRequest.Manual(genericStructure),
         fixingParser = StructureFixingParser(
-            fixingModel = AnthropicModels.Haiku_3_5,
+            model = AnthropicModels.Haiku_3_5,
             retries = 2
         )
     )
@@ -601,9 +601,9 @@ Different schema generators are available depending on your needs:
 
 The advanced configuration works consistently across all three layers of the API. The method names remain the same, only the parameter changes from simple arguments to the more advanced `StructuredOutputConfig`:
 
-- **Prompt executor**: `executeStructured(prompt, model, config: StructuredOutputConfig<T>)`
-- **Agent LLM context**: `requestLLMStructured(config: StructuredOutputConfig<T>)`
-- **Node layer**: `nodeLLMRequestStructured(config: StructuredOutputConfig<T>)`
+- **Prompt executor**: `executeStructured(prompt, model, config: StructuredRequestConfig<T>)`
+- **Agent LLM context**: `requestLLMStructured(config: StructuredRequestConfig<T>)`
+- **Node layer**: `nodeLLMRequestStructured(config: StructuredRequestConfig<T>)`
 
 The simplified API (using just `examples` and `fixingParser` parameters) is recommended for most use cases, while the advanced API provides additional control when needed.
 

--- a/examples/notebooks/Banking.ipynb
+++ b/examples/notebooks/Banking.ipynb
@@ -713,7 +713,7 @@
     "                )\n",
     "            ),\n",
     "            fixingParser = StructureFixingParser(\n",
-    "                fixingModel = OpenAIModels.CostOptimized.GPT4oMini,\n",
+    "                model = OpenAIModels.CostOptimized.GPT4oMini,\n",
     "                retries = 2,\n",
     "            )\n",
     "        )\n",

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/a2a/advancedjoke/JokeWriterAgentExecutor.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/a2a/advancedjoke/JokeWriterAgentExecutor.kt
@@ -36,7 +36,6 @@ import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.message.Message
-import ai.koog.prompt.text.text
 import ai.koog.prompt.xml.xml
 import kotlinx.datetime.Clock
 import kotlinx.serialization.SerialName
@@ -321,13 +320,13 @@ private fun jokeWriterStrategy() = strategy<A2AMessage, Unit>("joke-writer") {
     // New request classification: If not a joke request, decline politely
     edge(
         classifyNewRequest forwardTo respondFallbackMessage
-            transformed { it.getOrThrow().structure }
+            transformed { it.getOrThrow().data }
             onCondition { !it.isJokeRequest }
     )
     // New request classification: If joke request, create a task
     edge(
         classifyNewRequest forwardTo createTask
-            transformed { it.getOrThrow().structure }
+            transformed { it.getOrThrow().data }
             onCondition { it.isJokeRequest }
     )
 

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/banking/routing/RoutingViaGraph.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/banking/routing/RoutingViaGraph.kt
@@ -47,7 +47,7 @@ suspend fun main() {
                     )
                 ),
                 fixingParser = StructureFixingParser(
-                    fixingModel = OpenAIModels.CostOptimized.GPT4oMini,
+                    model = OpenAIModels.CostOptimized.GPT4oMini,
                     retries = 2,
                 )
             )
@@ -59,7 +59,7 @@ suspend fun main() {
             edge(
                 requestClassification forwardTo nodeFinish
                     onCondition { it.isSuccess }
-                    transformed { it.getOrThrow().structure }
+                    transformed { it.getOrThrow().data }
             )
             edge(
                 requestClassification forwardTo callLLM

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/parallelexecution/BestJokeAgent.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/parallelexecution/BestJokeAgent.kt
@@ -164,6 +164,6 @@ private suspend fun AIAgentContext.findTheBestJoke(
     }
 
     val response = requestLLMStructured<JokeWinner>()
-    val bestJoke = response.getOrNull()!!.structure
+    val bestJoke = response.getOrNull()!!.data
     bestJoke.index
 }

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/structuredoutput/AdvancedWithStandardSchema.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/structuredoutput/AdvancedWithStandardSchema.kt
@@ -20,9 +20,9 @@ import ai.koog.prompt.executor.clients.openai.base.structure.OpenAIStandardJsonS
 import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.structure.StructureFixingParser
-import ai.koog.prompt.structure.StructuredOutput
-import ai.koog.prompt.structure.StructuredOutputConfig
-import ai.koog.prompt.structure.json.JsonStructuredData
+import ai.koog.prompt.structure.StructuredRequest
+import ai.koog.prompt.structure.StructuredRequestConfig
+import ai.koog.prompt.structure.json.JsonStructure
 import ai.koog.prompt.structure.json.generator.StandardJsonSchemaGenerator
 import ai.koog.prompt.text.text
 import kotlinx.serialization.json.Json
@@ -37,7 +37,7 @@ suspend fun main() {
      But to use native structured output support in different LLM providers you might need to use custom JSON schema generators
      that would produce the schema these providers expect.
      */
-    val genericWeatherStructure = JsonStructuredData.createJsonStructure<FullWeatherForecast>(
+    val genericWeatherStructure = JsonStructure.create<FullWeatherForecast>(
         // Some models might not work well with json schema, so you may try simple, but it has more limitations (no polymorphism!)
         schemaGenerator = StandardJsonSchemaGenerator,
         examples = FullWeatherForecast.exampleForecasts,
@@ -49,12 +49,12 @@ suspend fun main() {
      structured output.
      */
 
-    val openAiWeatherStructure = JsonStructuredData.createJsonStructure<FullWeatherForecast>(
+    val openAiWeatherStructure = JsonStructure.create<FullWeatherForecast>(
         schemaGenerator = OpenAIStandardJsonSchemaGenerator,
         examples = FullWeatherForecast.exampleForecasts,
     )
 
-    val googleWeatherStructure = JsonStructuredData.createJsonStructure<FullWeatherForecast>(
+    val googleWeatherStructure = JsonStructure.create<FullWeatherForecast>(
         schemaGenerator = GoogleStandardJsonSchemaGenerator,
         examples = FullWeatherForecast.exampleForecasts,
     )
@@ -70,28 +70,28 @@ suspend fun main() {
 
         @Suppress("DuplicatedCode")
         val getStructuredForecast by nodeLLMRequestStructured(
-            config = StructuredOutputConfig(
+            config = StructuredRequestConfig(
                 byProvider = mapOf(
                     // Native modes leveraging native structured output support in models, with custom definitions for LLM providers that might have different format.
-                    LLMProvider.OpenAI to StructuredOutput.Native(openAiWeatherStructure),
-                    LLMProvider.Google to StructuredOutput.Native(googleWeatherStructure),
+                    LLMProvider.OpenAI to StructuredRequest.Native(openAiWeatherStructure),
+                    LLMProvider.Google to StructuredRequest.Native(googleWeatherStructure),
                     // Anthropic does not support native structured output yet.
-                    LLMProvider.Anthropic to StructuredOutput.Manual(genericWeatherStructure),
+                    LLMProvider.Anthropic to StructuredRequest.Manual(genericWeatherStructure),
                 ),
 
                 // Fallback manual structured output mode, via explicit prompting with additional message, not native model support
-                default = StructuredOutput.Manual(genericWeatherStructure),
+                default = StructuredRequest.Manual(genericWeatherStructure),
 
                 // Helper parser to attempt a fix if a malformed output is produced.
                 fixingParser = StructureFixingParser(
-                    fixingModel = AnthropicModels.Haiku_3_5,
+                    model = AnthropicModels.Haiku_3_5,
                     retries = 2,
                 ),
             )
         )
 
         nodeStart then prepareRequest then getStructuredForecast
-        edge(getStructuredForecast forwardTo nodeFinish transformed { it.getOrThrow().structure })
+        edge(getStructuredForecast forwardTo nodeFinish transformed { it.getOrThrow().data })
     }
 
     val agentConfig = AIAgentConfig(

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/structuredoutput/AdvancedWithStandardSchemaAndTools.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/structuredoutput/AdvancedWithStandardSchemaAndTools.kt
@@ -21,13 +21,12 @@ import ai.koog.prompt.executor.clients.openai.base.structure.OpenAIStandardJsonS
 import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.structure.StructureFixingParser
-import ai.koog.prompt.structure.StructuredOutput
-import ai.koog.prompt.structure.StructuredOutputConfig
-import ai.koog.prompt.structure.json.JsonStructuredData
+import ai.koog.prompt.structure.StructuredRequest
+import ai.koog.prompt.structure.StructuredRequestConfig
+import ai.koog.prompt.structure.json.JsonStructure
 import ai.koog.prompt.structure.json.generator.StandardJsonSchemaGenerator
 import ai.koog.prompt.text.text
 import kotlinx.serialization.json.Json
-import kotlin.io.println
 
 private val json = Json {
     prettyPrint = true
@@ -39,7 +38,7 @@ suspend fun main() {
      But to use native structured output support in different LLM providers you might need to use custom JSON schema generators
      that would produce the schema these providers expect.
      */
-    val genericWeatherStructure = JsonStructuredData.createJsonStructure<FullWeatherForecast>(
+    val genericWeatherStructure = JsonStructure.create<FullWeatherForecast>(
         // Some models might not work well with json schema, so you may try simple, but it has more limitations (no polymorphism!)
         schemaGenerator = StandardJsonSchemaGenerator,
         examples = FullWeatherForecast.exampleForecasts,
@@ -51,31 +50,31 @@ suspend fun main() {
      structured output.
      */
 
-    val openAiWeatherStructure = JsonStructuredData.createJsonStructure<FullWeatherForecast>(
+    val openAiWeatherStructure = JsonStructure.create<FullWeatherForecast>(
         schemaGenerator = OpenAIStandardJsonSchemaGenerator,
         examples = FullWeatherForecast.exampleForecasts,
     )
 
-    val googleWeatherStructure = JsonStructuredData.createJsonStructure<FullWeatherForecast>(
+    val googleWeatherStructure = JsonStructure.create<FullWeatherForecast>(
         schemaGenerator = GoogleStandardJsonSchemaGenerator,
         examples = FullWeatherForecast.exampleForecasts,
     )
 
-    val config = StructuredOutputConfig(
+    val config = StructuredRequestConfig(
         byProvider = mapOf(
             // Native modes leveraging native structured output support in models, with custom definitions for LLM providers that might have different format.
-            LLMProvider.OpenAI to StructuredOutput.Native(openAiWeatherStructure),
-            LLMProvider.Google to StructuredOutput.Native(googleWeatherStructure),
+            LLMProvider.OpenAI to StructuredRequest.Native(openAiWeatherStructure),
+            LLMProvider.Google to StructuredRequest.Native(googleWeatherStructure),
             // Anthropic does not support native structured output yet.
-            LLMProvider.Anthropic to StructuredOutput.Manual(genericWeatherStructure),
+            LLMProvider.Anthropic to StructuredRequest.Manual(genericWeatherStructure),
         ),
 
         // Fallback manual structured output mode, via explicit prompting with additional message, not native model support
-        default = StructuredOutput.Manual(genericWeatherStructure),
+        default = StructuredRequest.Manual(genericWeatherStructure),
 
         // Helper parser to attempt a fix if a malformed output is produced.
         fixingParser = StructureFixingParser(
-            fixingModel = AnthropicModels.Haiku_3_5,
+            model = AnthropicModels.Haiku_3_5,
             retries = 2,
         ),
     )

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/structuredoutput/SimpleExample.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/structuredoutput/SimpleExample.kt
@@ -194,13 +194,13 @@ suspend fun main() {
          parser to attempt to fix malformed output.
              */
             fixingParser = StructureFixingParser(
-                fixingModel = OpenAIModels.CostOptimized.GPT4oMini,
+                model = OpenAIModels.CostOptimized.GPT4oMini,
                 retries = 2
             )
         )
 
         nodeStart then prepareRequest then getStructuredForecast
-        edge(getStructuredForecast forwardTo nodeFinish transformed { it.getOrThrow().structure })
+        edge(getStructuredForecast forwardTo nodeFinish transformed { it.getOrThrow().data })
     }
 
     val agentConfig = AIAgentConfig(

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/structuredoutput/markdown/BookMdStructure.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/structuredoutput/markdown/BookMdStructure.kt
@@ -2,7 +2,7 @@ package ai.koog.agents.example.structuredoutput.markdown
 
 import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.prompt.markdown.markdown
-import ai.koog.prompt.structure.markdown.MarkdownStructuredDataDefinition
+import ai.koog.prompt.structure.markdown.MarkdownStructureDefinition
 import ai.koog.prompt.structure.markdown.markdownStreamingParser
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -74,8 +74,8 @@ fun parseMarkdownStreamToBooks(markdownStream: Flow<String>): Flow<Book> {
     }
 }
 
-fun markdownBookDefinition(): MarkdownStructuredDataDefinition {
-    return MarkdownStructuredDataDefinition("bookList", schema = {
+fun markdownBookDefinition(): MarkdownStructureDefinition {
+    return MarkdownStructureDefinition("bookList", schema = {
         markdown {
             header(1, "bookName")
             bulleted {

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/structuredOutput/WeatherReport.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/structuredOutput/WeatherReport.kt
@@ -5,11 +5,11 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.structure.RegisteredStandardJsonSchemaGenerators
 import ai.koog.prompt.structure.StructureFixingParser
-import ai.koog.prompt.structure.StructuredOutput
-import ai.koog.prompt.structure.StructuredOutputConfig
+import ai.koog.prompt.structure.StructuredRequest
+import ai.koog.prompt.structure.StructuredRequestConfig
 import ai.koog.prompt.structure.StructuredResponse
 import ai.koog.prompt.structure.annotations.InternalStructuredOutputApi
-import ai.koog.prompt.structure.json.JsonStructuredData
+import ai.koog.prompt.structure.json.JsonStructure
 import ai.koog.prompt.structure.json.generator.StandardJsonSchemaGenerator
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -33,7 +33,7 @@ data class WeatherReport(
 )
 
 @OptIn(InternalStructuredOutputApi::class)
-fun getStructure(model: LLModel) = JsonStructuredData.createJsonStructure<WeatherReport>(
+fun getStructure(model: LLModel) = JsonStructure.create<WeatherReport>(
     json = Json,
     schemaGenerator = RegisteredStandardJsonSchemaGenerators[model.provider] ?: StandardJsonSchemaGenerator,
     descriptionOverrides = mapOf(
@@ -46,23 +46,23 @@ fun getStructure(model: LLModel) = JsonStructuredData.createJsonStructure<Weathe
 )
 
 fun getConfigNoFixingParserNative(model: LLModel) =
-    StructuredOutputConfig(default = StructuredOutput.Native(getStructure(model)))
+    StructuredRequestConfig(default = StructuredRequest.Native(getStructure(model)))
 
-fun getConfigFixingParserNative(model: LLModel) = StructuredOutputConfig(
-    default = StructuredOutput.Native(getStructure(model)),
+fun getConfigFixingParserNative(model: LLModel) = StructuredRequestConfig(
+    default = StructuredRequest.Native(getStructure(model)),
     fixingParser = StructureFixingParser(
-        fixingModel = model,
+        model = model,
         retries = 3
     )
 )
 
 fun getConfigNoFixingParserManual(model: LLModel) =
-    StructuredOutputConfig(default = StructuredOutput.Manual(getStructure(model)))
+    StructuredRequestConfig(default = StructuredRequest.Manual(getStructure(model)))
 
-fun getConfigFixingParserManual(model: LLModel) = StructuredOutputConfig(
-    default = StructuredOutput.Manual(getStructure(model)),
+fun getConfigFixingParserManual(model: LLModel) = StructuredRequestConfig(
+    default = StructuredRequest.Manual(getStructure(model)),
     fixingParser = StructureFixingParser(
-        fixingModel = model,
+        model = model,
         retries = 3
     )
 )
@@ -79,7 +79,7 @@ val weatherStructuredOutputPrompt = Prompt.build("test-structured-json") {
 
 // Asserts weather report fields are valid
 fun checkWeatherStructuredOutputResponse(result: Result<StructuredResponse<WeatherReport>>) {
-    val response = result.getOrThrow().structure
+    val response = result.getOrThrow().data
     assertNotNull(response)
 
     assertEquals("London", response.city, "City should be London, got: ${response.city}")

--- a/prompt/prompt-structure/Module.md
+++ b/prompt/prompt-structure/Module.md
@@ -10,11 +10,11 @@ The prompt-structure module provides a framework for handling structured data wi
 
 ```kotlin
 // Define a structured data type for a person
-class PersonData(
+class PersonStructure(
     id: String,
     examples: List<Person>,
     schema: LLMParams.Schema
-) : StructuredData<Person>(id, examples, schema) {
+) : Structure<Person>(id, examples, schema) {
     override fun parse(text: String): Person {
         // Parse JSON text into a Person object
         val json = Json.parseToJsonElement(text).jsonObject
@@ -40,7 +40,7 @@ class PersonData(
 }
 
 // Create an instance with examples
-val personData = PersonData(
+val personStructure = PersonStructure(
     id = "person",
     examples = listOf(
         Person("John Doe", 30, listOf("Programming", "Design")),
@@ -64,8 +64,8 @@ val personData = PersonData(
 
 // Parse text into a Person object
 val personText = """{"name":"Alice","age":25,"skills":["Writing","Research"]}"""
-val person = personData.parse(personText)
+val person = personStructure.parse(personText)
 
 // Format a Person object as a pretty string
-val prettyOutput = personData.pretty(person)
+val prettyOutput = personStructure.pretty(person)
 ```

--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/PromptExecutorExtensions.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/PromptExecutorExtensions.kt
@@ -9,7 +9,7 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.markdown.markdown
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.structure.annotations.InternalStructuredOutputApi
-import ai.koog.prompt.structure.json.JsonStructuredData
+import ai.koog.prompt.structure.json.JsonStructure
 import ai.koog.prompt.structure.json.generator.BasicJsonSchemaGenerator
 import ai.koog.prompt.structure.json.generator.JsonSchemaGenerator
 import ai.koog.prompt.structure.json.generator.StandardJsonSchemaGenerator
@@ -18,35 +18,40 @@ import kotlinx.serialization.serializer
 import kotlin.reflect.KType
 
 /**
- * Represents a container for structured data parsed from response message.
+ * Represents a container for structured data parsed from a response message.
  *
  * This class is designed to encapsulate both the parsed structured output and the original raw
  * text as returned from a processing step, such as a language model execution.
  *
  * @param T The type of the structured data contained within this response.
- * @property structure The parsed structured data corresponding to the specific schema.
+ * @property data The parsed structured data corresponding to the specific schema.
+ * @property structure The structure used for the response.
  * @property message The original assistant message from which the structure was parsed.
  */
-public data class StructuredResponse<T>(val structure: T, val message: Message.Assistant)
+public data class StructuredResponse<T>(
+    val data: T,
+    val structure: Structure<T, *>,
+    val message: Message.Assistant
+)
 
 /**
  * Configures structured output behavior.
  * Defines which structures in which modes should be used for each provider when requesting a structured output.
  *
- * @property default Fallback [StructuredOutput] to be used when there's no suitable structure found in [byProvider]
+ * @property default Fallback [StructuredRequest] to be used when there's no suitable structure found in [byProvider]
  * for a requested [LLMProvider]. Defaults to `null`, meaning structured output would fail with error in such a case.
  *
- * @property byProvider A map matching [LLMProvider] to compatible [StructuredOutput] definitions. Each provider may
- * require different schema formats. E.g. for [JsonStructuredData] this means you have to use the appropriate
- * [JsonSchemaGenerator] implementation for each provider for [StructuredOutput.Native], or fallback to [StructuredOutput.Manual]
+ * @property byProvider A map matching [LLMProvider] to compatible [StructuredRequest] definitions. Each provider may
+ * require different schema formats. E.g. for [JsonStructure] this means you have to use the appropriate
+ * [JsonSchemaGenerator] implementation for each provider for [StructuredRequest.Native], or fallback to [StructuredRequest.Manual]
  *
  * @property fixingParser Optional parser that handles malformed responses by using an auxiliary LLM to
  * intelligently fix parsing errors. When specified, parsing errors trigger additional
  * LLM calls with error context to attempt correction of the structure format.
  */
-public data class StructuredOutputConfig<T>(
-    public val default: StructuredOutput<T>? = null,
-    public val byProvider: Map<LLMProvider, StructuredOutput<T>> = emptyMap(),
+public data class StructuredRequestConfig<T>(
+    public val default: StructuredRequest<T>? = null,
+    public val byProvider: Map<LLMProvider, StructuredRequest<T>> = emptyMap(),
     public val fixingParser: StructureFixingParser? = null
 ) {
     /**
@@ -58,9 +63,9 @@ public data class StructuredOutputConfig<T>(
      * @return A new prompt reflecting the updated structured output configuration.
      */
     public fun updatePrompt(model: LLModel, prompt: Prompt): Prompt {
-        return when (val mode = structuredOutput(model)) {
+        return when (val mode = structuredRequest(model)) {
             // Don't set schema parameter in prompt and coerce the model manually with user message to provide a structured response.
-            is StructuredOutput.Manual -> {
+            is StructuredRequest.Manual -> {
                 prompt(prompt) {
                     user(
                         markdown {
@@ -71,7 +76,7 @@ public data class StructuredOutputConfig<T>(
             }
 
             // Rely on built-in model capabilities to provide structured response.
-            is StructuredOutput.Native -> {
+            is StructuredRequest.Native -> {
                 prompt.withUpdatedParams { schema = mode.structure.schema }
             }
         }
@@ -86,8 +91,8 @@ public data class StructuredOutputConfig<T>(
      * @param model The large language model (LLM) instance used to identify the structured data configuration.
      * @return The structured data configuration represented as a `StructuredData` instance.
      */
-    public fun structure(model: LLModel): StructuredData<T, *> {
-        return structuredOutput(model).structure
+    public fun structure(model: LLModel): Structure<T, *> {
+        return structuredRequest(model).structure
     }
 
     /**
@@ -101,7 +106,7 @@ public data class StructuredOutputConfig<T>(
      * @return An instance of `StructuredOutput` that represents the structured output configuration for the model.
      * @throws IllegalArgumentException if no configuration is found for the provider and no default configuration is set.
      */
-    private fun structuredOutput(model: LLModel): StructuredOutput<T> {
+    private fun structuredRequest(model: LLModel): StructuredRequest<T> {
         return byProvider[model.provider]
             ?: default
             ?: throw IllegalArgumentException("No structure found for provider ${model.provider}")
@@ -111,37 +116,37 @@ public data class StructuredOutputConfig<T>(
 /**
  * Defines how structured outputs should be generated.
  *
- * Can be [StructuredOutput.Manual] or [StructuredOutput.Native]
+ * Can be [StructuredRequest.Manual] or [StructuredRequest.Native]
  *
  * @param T The type of structured data.
  */
-public sealed interface StructuredOutput<T> {
+public sealed interface StructuredRequest<T> {
     /**
      * The definition of a structure.
      */
-    public val structure: StructuredData<T, *>
+    public val structure: Structure<T, *>
 
     /**
      * Instructs the model to produce structured output through explicit prompting.
      *
-     * Uses an additional user message containing [StructuredData.definition] to guide
+     * Uses an additional user message containing [Structure.definition] to guide
      * the model in generating correctly formatted responses.
      *
      * @property structure The structure definition to be used in output generation.
      */
-    public data class Manual<T>(override val structure: StructuredData<T, *>) : StructuredOutput<T>
+    public data class Manual<T>(override val structure: Structure<T, *>) : StructuredRequest<T>
 
     /**
      * Leverages a model's built-in structured output capabilities.
      *
-     * Uses [StructuredData.schema] to define the expected response format through the model's
+     * Uses [Structure.schema] to define the expected response format through the model's
      * native structured output functionality.
      *
-     * Note: [StructuredData.examples] are not used with this mode, only the schema is sent via parameters.
+     * Note: [Structure.examples] are not used with this mode, only the schema is sent via parameters.
      *
      * @property structure The structure definition to be used in output generation.
      */
-    public data class Native<T>(override val structure: StructuredData<T, *>) : StructuredOutput<T>
+    public data class Native<T>(override val structure: Structure<T, *>) : StructuredRequest<T>
 }
 
 /**
@@ -162,7 +167,7 @@ public sealed interface StructuredOutput<T> {
 public suspend fun <T> PromptExecutor.executeStructured(
     prompt: Prompt,
     model: LLModel,
-    config: StructuredOutputConfig<T>,
+    config: StructuredRequestConfig<T>,
 ): Result<StructuredResponse<T>> {
     val updatedPrompt = config.updatePrompt(model, prompt)
     val response = this.execute(prompt = updatedPrompt, model = model).single()
@@ -178,7 +183,7 @@ public suspend fun <T> PromptExecutor.executeStructured(
  * Registered mapping of providers to their respective known simple JSON schema format generators.
  * The registration is supposed to be done by the LLM clients when they are loaded, to communicate their custom formats.
  *
- * Used to attempt to get a proper generator implicitly in the simple version of [executeStructured] (that does not accept [StructuredOutput] explicitly)
+ * Used to attempt to get a proper generator implicitly in the simple version of [executeStructured] (that does not accept [StructuredRequest] explicitly)
  * to attempt to generate an appropriate schema for the passed [KType].
  */
 @InternalStructuredOutputApi
@@ -188,7 +193,7 @@ public val RegisteredBasicJsonSchemaGenerators: MutableMap<LLMProvider, BasicJso
  * Registered mapping of providers to their respective known full JSON schema format generators.
  * The registration is supposed to be done by the LLM clients on their initialization, to communicate their custom formats.
  *
- * Used to attempt to get a proper generator implicitly in the simple version of [executeStructured] (that does not accept [StructuredOutput] explicitly)
+ * Used to attempt to get a proper generator implicitly in the simple version of [executeStructured] (that does not accept [StructuredRequest] explicitly)
  * to attempt to generate an appropriate schema for the passed [KType].
  */
 @InternalStructuredOutputApi
@@ -226,25 +231,25 @@ public suspend fun <T> PromptExecutor.executeStructured(
     @Suppress("UNCHECKED_CAST")
     val id = serializer.descriptor.serialName.substringAfterLast(".")
 
-    val structuredOutput = when {
-        LLMCapability.Schema.JSON.Standard in model.capabilities -> StructuredOutput.Native(
-            JsonStructuredData.createJsonStructure(
+    val structuredRequest = when {
+        LLMCapability.Schema.JSON.Standard in model.capabilities -> StructuredRequest.Native(
+            JsonStructure.create(
                 id = id,
                 serializer = serializer,
                 schemaGenerator = RegisteredStandardJsonSchemaGenerators[model.provider] ?: StandardJsonSchemaGenerator
             )
         )
 
-        LLMCapability.Schema.JSON.Basic in model.capabilities -> StructuredOutput.Native(
-            JsonStructuredData.createJsonStructure(
+        LLMCapability.Schema.JSON.Basic in model.capabilities -> StructuredRequest.Native(
+            JsonStructure.create(
                 id = id,
                 serializer = serializer,
                 schemaGenerator = RegisteredBasicJsonSchemaGenerators[model.provider] ?: BasicJsonSchemaGenerator
             )
         )
 
-        else -> StructuredOutput.Manual(
-            JsonStructuredData.createJsonStructure(
+        else -> StructuredRequest.Manual(
+            JsonStructure.create(
                 id = id,
                 serializer = serializer,
                 schemaGenerator = StandardJsonSchemaGenerator,
@@ -256,8 +261,8 @@ public suspend fun <T> PromptExecutor.executeStructured(
     return executeStructured(
         prompt = prompt,
         model = model,
-        config = StructuredOutputConfig(
-            default = structuredOutput,
+        config = StructuredRequestConfig(
+            default = structuredRequest,
             fixingParser = fixingParser,
         )
     )
@@ -312,7 +317,7 @@ public suspend inline fun <reified T> PromptExecutor.executeStructured(
  */
 public suspend fun <T> PromptExecutor.parseResponseToStructuredResponse(
     response: Message.Assistant,
-    config: StructuredOutputConfig<T>,
+    config: StructuredRequestConfig<T>,
     model: LLModel
 ): StructuredResponse<T> {
     // Use fixingParser if provided, otherwise parse directly
@@ -322,7 +327,8 @@ public suspend fun <T> PromptExecutor.parseResponseToStructuredResponse(
         ?: structure.parse(response.content)
 
     return StructuredResponse(
-        structure = structureResponse,
+        data = structureResponse,
+        structure = structure,
         message = response
     )
 }

--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/Structure.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/Structure.kt
@@ -14,11 +14,11 @@ import ai.koog.prompt.params.LLMParams
  * @property schema The schema that defines the structure and validation rules for the data.
  * @property examples A collection of example instances of the structured data type.
  */
-public abstract class StructuredData<TStruct, TSchema : LLMParams.Schema>(
+public abstract class Structure<TStruct, TSchema : LLMParams.Schema>(
     public val id: String,
     public val schema: TSchema,
     public val examples: List<TStruct>,
-) : StructuredDataDefinition {
+) : StructureDefinition {
     /**
      * Parses the given text into a structured data representation.
      *

--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/StructureDefinition.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/StructureDefinition.kt
@@ -10,7 +10,7 @@ import ai.koog.prompt.text.TextContentBuilderBase
  * which facilitates the creation and management of text content. Implementations of this interface
  * can define how structured content should be constructed, supporting a fluent API for content generation.
  */
-public interface StructuredDataDefinition {
+public interface StructureDefinition {
     /**
      * Defines the structure of textual content using the provided [TextContentBuilder].
      *

--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/StructuredPrompts.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/StructuredPrompts.kt
@@ -12,7 +12,7 @@ public object StructuredOutputPrompts {
      *
      * @param structure The StructuredData instance containing the format ID and definition for the output.
      */
-    public fun outputInstructionPrompt(builder: TextContentBuilderBase<*>, structure: StructuredData<*, *>): TextContentBuilderBase<*> = builder.apply {
+    public fun outputInstructionPrompt(builder: TextContentBuilderBase<*>, structure: Structure<*, *>): TextContentBuilderBase<*> = builder.apply {
         markdown {
             h2("NEXT MESSAGE OUTPUT FORMAT")
             +"The output in the next message MUST ADHERE TO ${structure.id} format."

--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/TextContentBuilderBaseExtensions.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/TextContentBuilderBaseExtensions.kt
@@ -8,6 +8,6 @@ import ai.koog.prompt.text.TextContentBuilderBase
  * @param structure The structure definition
  * @param value The value to be serialized and added to the builder.
  */
-public fun <T> TextContentBuilderBase<*>.structure(structure: StructuredData<T, *>, value: T) {
+public fun <T> TextContentBuilderBase<*>.structure(structure: Structure<T, *>, value: T) {
     +structure.pretty(value)
 }

--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/markdown/MarkdownStructureDefinition.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/markdown/MarkdownStructureDefinition.kt
@@ -1,7 +1,7 @@
 package ai.koog.prompt.structure.markdown
 
 import ai.koog.prompt.markdown.markdown
-import ai.koog.prompt.structure.StructuredDataDefinition
+import ai.koog.prompt.structure.StructureDefinition
 import ai.koog.prompt.text.TextContentBuilder
 import ai.koog.prompt.text.TextContentBuilderBase
 
@@ -17,28 +17,28 @@ import ai.koog.prompt.text.TextContentBuilderBase
  * structured data, applied to a [TextContentBuilder].
  * @property definitionPrompt Prompt with definition, explaining the structure to the LLM.
  */
-public class MarkdownStructuredDataDefinition(
+public class MarkdownStructureDefinition(
     public val id: String,
     public val schema: TextContentBuilder.() -> Unit,
     public val examples: (TextContentBuilder.() -> Unit)? = null,
     private val definitionPrompt: (
         builder: TextContentBuilderBase<*>,
-        structureDefinition: MarkdownStructuredDataDefinition
+        structureDefinition: MarkdownStructureDefinition
     ) -> TextContentBuilderBase<*> = ::defaultDefinitionPrompt,
-) : StructuredDataDefinition {
+) : StructureDefinition {
 
     override fun definition(builder: TextContentBuilderBase<*>): TextContentBuilderBase<*> = definitionPrompt(builder, this)
 
     /**
-     * Companion object for [MarkdownStructuredDataDefinition] class, providing utility methods.
+     * Companion object for [MarkdownStructureDefinition] class, providing utility methods.
      */
     public companion object {
         /**
-         * Default prompt explaining the structure definition of [MarkdownStructuredDataDefinition] to the LLM.
+         * Default prompt explaining the structure definition of [MarkdownStructureDefinition] to the LLM.
          */
         public fun defaultDefinitionPrompt(
             builder: TextContentBuilderBase<*>,
-            structureDefinition: MarkdownStructuredDataDefinition
+            structureDefinition: MarkdownStructureDefinition
         ): TextContentBuilderBase<*> = builder.apply {
             with(structureDefinition) {
                 +"DEFINITION OF $id"

--- a/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/StructureFixingParserTest.kt
+++ b/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/StructureFixingParserTest.kt
@@ -2,7 +2,7 @@ package ai.koog.prompt.structure
 
 import ai.koog.agents.testing.tools.getMockExecutor
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.structure.json.JsonStructuredData
+import ai.koog.prompt.structure.json.JsonStructure
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -19,12 +19,12 @@ class StructureFixingParserTest {
 
     private val testData = TestData("test", 42)
     private val testDataJson = Json.encodeToString(testData)
-    private val testStructure = JsonStructuredData.createJsonStructure<TestData>()
+    private val testStructure = JsonStructure.create<TestData>()
 
     @Test
     fun testParseValidContentWithoutFixing() = runTest {
         val parser = StructureFixingParser(
-            fixingModel = OpenAIModels.CostOptimized.GPT4oMini,
+            model = OpenAIModels.CostOptimized.GPT4oMini,
             retries = 2,
         )
         val mockExecutor = getMockExecutor {}
@@ -36,7 +36,7 @@ class StructureFixingParserTest {
     @Test
     fun testFixInvalidContentInMultipleSteps() = runTest {
         val parser = StructureFixingParser(
-            fixingModel = OpenAIModels.CostOptimized.GPT4oMini,
+            model = OpenAIModels.CostOptimized.GPT4oMini,
             retries = 2,
         )
 
@@ -59,7 +59,7 @@ class StructureFixingParserTest {
     @Test
     fun testFailToParseWhenFixingRetriesExceeded() = runTest {
         val parser = StructureFixingParser(
-            fixingModel = OpenAIModels.CostOptimized.GPT4oMini,
+            model = OpenAIModels.CostOptimized.GPT4oMini,
             retries = 2,
         )
 

--- a/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/json/JsonStructureTest.kt
+++ b/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/json/JsonStructureTest.kt
@@ -18,7 +18,7 @@ import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
-class JsonStructuredDataTest {
+class JsonStructureTest {
 
     val weatherInfoName = "WeatherInfo"
 

--- a/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/json/JsonStructuredDataTest.kt
+++ b/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/json/JsonStructuredDataTest.kt
@@ -3,8 +3,8 @@ package ai.koog.prompt.structure.json
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.params.LLMParams
-import ai.koog.prompt.structure.StructuredOutput
-import ai.koog.prompt.structure.StructuredOutputConfig
+import ai.koog.prompt.structure.StructuredRequest
+import ai.koog.prompt.structure.StructuredRequestConfig
 import ai.koog.prompt.structure.json.generator.BasicJsonSchemaGenerator
 import ai.koog.prompt.structure.json.generator.StandardJsonSchemaGenerator
 import ai.koog.prompt.text.text
@@ -57,7 +57,7 @@ class JsonStructuredDataTest {
 
     @Test
     fun testInlineJsonStructureCreation() {
-        val structure = JsonStructuredData.createJsonStructure<WeatherInfo>()
+        val structure = JsonStructure.create<WeatherInfo>()
         assertEquals(weatherInfoName, structure.id)
         assertEquals(serializer<WeatherInfo>(), structure.serializer)
         assertNotNull(structure.schema)
@@ -65,7 +65,7 @@ class JsonStructuredDataTest {
 
     @Test
     fun testCreateJsonStructureWithStandardGenerator() {
-        val structure = JsonStructuredData.createJsonStructure<WeatherInfo>(
+        val structure = JsonStructure.create<WeatherInfo>(
             schemaGenerator = StandardJsonSchemaGenerator.Default
         )
 
@@ -77,7 +77,7 @@ class JsonStructuredDataTest {
 
     @Test
     fun testCreateJsonStructureWithBasicGenerator() {
-        val structure = JsonStructuredData.createJsonStructure<WeatherInfo>(
+        val structure = JsonStructure.create<WeatherInfo>(
             schemaGenerator = BasicJsonSchemaGenerator.Default
         )
 
@@ -94,7 +94,7 @@ class JsonStructuredDataTest {
             "WeatherInfo.temperature" to "Temperature in Celsius (custom)"
         )
 
-        val structure = JsonStructuredData.createJsonStructure<WeatherInfo>(
+        val structure = JsonStructure.create<WeatherInfo>(
             schemaGenerator = StandardJsonSchemaGenerator.Default,
             descriptionOverrides = descriptionOverrides
         )
@@ -111,7 +111,7 @@ class JsonStructuredDataTest {
             WeatherInfo("Paris", 22, "Sunny", 65)
         )
 
-        val structure = JsonStructuredData.createJsonStructure<WeatherInfo>(
+        val structure = JsonStructure.create<WeatherInfo>(
             examples = examples
         )
 
@@ -122,7 +122,7 @@ class JsonStructuredDataTest {
 
     @Test
     fun testJsonStructureParsing() {
-        val structure = JsonStructuredData.createJsonStructure<WeatherInfo>()
+        val structure = JsonStructure.create<WeatherInfo>()
         val jsonString = """{"city": "Tokyo", "temperature": 25, "description": "Clear", "humidity": 60}"""
 
         val parsed = structure.parse(jsonString)
@@ -135,7 +135,7 @@ class JsonStructuredDataTest {
 
     @Test
     fun testJsonStructureSerialization() {
-        val structure = JsonStructuredData.createJsonStructure<WeatherInfo>()
+        val structure = JsonStructure.create<WeatherInfo>()
         val data = WeatherInfo("Berlin", 20, "Cloudy", 70)
 
         val serialized = structure.pretty(data)
@@ -148,7 +148,7 @@ class JsonStructuredDataTest {
 
     @Test
     fun testComplexJsonStructure() {
-        val structure = JsonStructuredData.createJsonStructure<ComplexData>(
+        val structure = JsonStructure.create<ComplexData>(
             schemaGenerator = StandardJsonSchemaGenerator.Default
         )
 
@@ -173,7 +173,7 @@ class JsonStructuredDataTest {
 
     @Test
     fun testJsonStructureWithNullableFieldsParseNullable() {
-        val structure = JsonStructuredData.createJsonStructure<WeatherInfo>()
+        val structure = JsonStructure.create<WeatherInfo>()
 
         val jsonWithNull = """{"city": "Amsterdam", "temperature": 15, "description": "Overcast"}"""
         val parsedWithNull = structure.parse(jsonWithNull)
@@ -182,7 +182,7 @@ class JsonStructuredDataTest {
 
     @Test
     fun testJsonStructureWithAllFieldsParseNullable() {
-        val structure = JsonStructuredData.createJsonStructure<WeatherInfo>()
+        val structure = JsonStructure.create<WeatherInfo>()
         val jsonWithHumidity = """{"city": "Amsterdam", "temperature": 15, "description": "Overcast", "humidity": 75}"""
         val parsedWithHumidity = structure.parse(jsonWithHumidity)
         assertEquals(75, parsedWithHumidity.humidity)
@@ -190,7 +190,7 @@ class JsonStructuredDataTest {
 
     @Test
     fun testJsonStructureDefinitionContent() {
-        val structure = JsonStructuredData.createJsonStructure<WeatherInfo>(
+        val structure = JsonStructure.create<WeatherInfo>(
             examples = listOf(WeatherInfo("Example", 20, "Example weather", 50))
         )
 
@@ -207,22 +207,22 @@ class JsonStructuredDataTest {
 
     @Test
     fun testStructuredOutputModes() {
-        val structure = JsonStructuredData.createJsonStructure<WeatherInfo>()
+        val structure = JsonStructure.create<WeatherInfo>()
 
-        val nativeMode = StructuredOutput.Native(structure)
+        val nativeMode = StructuredRequest.Native(structure)
         assertEquals(structure, nativeMode.structure)
 
-        val manualMode = StructuredOutput.Manual(structure)
+        val manualMode = StructuredRequest.Manual(structure)
         assertEquals(structure, manualMode.structure)
     }
 
     @Test
     fun testStructuredOutputConfig() {
-        val structure = JsonStructuredData.createJsonStructure<WeatherInfo>()
-        val nativeOutput = StructuredOutput.Native(structure)
-        val manualOutput = StructuredOutput.Manual(structure)
+        val structure = JsonStructure.create<WeatherInfo>()
+        val nativeOutput = StructuredRequest.Native(structure)
+        val manualOutput = StructuredRequest.Manual(structure)
 
-        val config = StructuredOutputConfig(
+        val config = StructuredRequestConfig(
             default = manualOutput,
             byProvider = mapOf(
                 LLMProvider.OpenAI to nativeOutput
@@ -235,7 +235,7 @@ class JsonStructuredDataTest {
 
     @Test
     fun testJsonWithMarkdownBlockParsing() {
-        val structure = JsonStructuredData.createJsonStructure<WeatherInfo>()
+        val structure = JsonStructure.create<WeatherInfo>()
         val jsonString =
             """```
             {
@@ -257,7 +257,7 @@ class JsonStructuredDataTest {
 
     @Test
     fun testJsonWithMarkdownLanguageBlockParsing() {
-        val structure = JsonStructuredData.createJsonStructure<WeatherInfo>()
+        val structure = JsonStructure.create<WeatherInfo>()
         val jsonString =
             """```json
             {
@@ -279,7 +279,7 @@ class JsonStructuredDataTest {
 
     @Test
     fun testJsonWithSingleLineMarkdownParsing() {
-        val structure = JsonStructuredData.createJsonStructure<WeatherInfo>()
+        val structure = JsonStructure.create<WeatherInfo>()
         val jsonString = """`{"city": "Dublin","temperature": 12,"description": "Rainy","humidity": 90}`""".trimMargin()
 
         val parsed = structure.parse(jsonString)

--- a/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/markdown/MarkdownStructureDefinitionTest.kt
+++ b/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/markdown/MarkdownStructureDefinitionTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-class MarkdownStructuredDataDefinitionTest {
+class MarkdownStructureDefinitionTest {
 
     @Test
     fun testDefinitionWithSchemaOnly() {

--- a/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/markdown/MarkdownStructuredDataDefinitionTest.kt
+++ b/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/markdown/MarkdownStructuredDataDefinitionTest.kt
@@ -10,7 +10,7 @@ class MarkdownStructuredDataDefinitionTest {
     @Test
     fun testDefinitionWithSchemaOnly() {
         // Create a MarkdownStructuredDataDefinition with schema only
-        val definition = MarkdownStructuredDataDefinition(
+        val definition = MarkdownStructureDefinition(
             id = "test_format",
             schema = {
                 +"# Header"
@@ -37,7 +37,7 @@ class MarkdownStructuredDataDefinitionTest {
     @Test
     fun testDefinitionWithSchemaAndExamples() {
         // Create a MarkdownStructuredDataDefinition with schema and examples
-        val definition = MarkdownStructuredDataDefinition(
+        val definition = MarkdownStructureDefinition(
             id = "test_format",
             schema = {
                 +"# Header"
@@ -70,7 +70,7 @@ class MarkdownStructuredDataDefinitionTest {
     @Test
     fun testDefinitionStructure() {
         // Create a MarkdownStructuredDataDefinition with schema and examples
-        val definition = MarkdownStructuredDataDefinition(
+        val definition = MarkdownStructureDefinition(
             id = "test_format",
             schema = {
                 +"# Schema Header"


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

Please add a brief description of the proposed change here.
Also, please tick the appropriate points in the checklist below.
-->
Before structural refactoring of the whole structured output pipeline, it's important to make some renaming

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Renaming done:
* `StructuredOutput` -> `StructuredRequest` (Because it can be messaged up with `StructuredResponce`, but it should be opposite to)
* `StructuredData`-> `Structure` (Because there is no data in there, this entity just defines the structure and parsing)
* `JsonStructuredData` -> `JsonStructure`, `MarkdownStructuredDataDefinition` -> `MarkdownStructureDefinition` as prev
* Add `structure: Structure` into `StructuredResponse` to be able to turn in back to string
## Breaking Changes
<!-- Will users need to update their code or configurations? -->

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [x] Refactoring

#### Checklist
- [ ] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [ ] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
