### PR TITLE
fix: Resolve error using MCPTool - `No tag in stack for requested element`

### DIFF
--- a/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/McpToolSerializationTest.kt
+++ b/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/McpToolSerializationTest.kt
@@ -1,0 +1,51 @@
+package ai.koog.agents.mcp
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import io.modelcontextprotocol.kotlin.sdk.Implementation
+import io.modelcontextprotocol.kotlin.sdk.TextContent
+import io.modelcontextprotocol.kotlin.sdk.client.Client
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class McpToolSerializationTest {
+    private fun randomMcpTool(): McpTool = McpTool(
+        mcpClient = Client(
+            clientInfo = Implementation(
+                name = "Test",
+                version = "1.0"
+            )
+        ),
+        descriptor = ToolDescriptor(
+            name = "test-tool",
+            description = "A test tool"
+        ),
+    )
+
+    @Test
+    fun `test encode result`() {
+        val result = McpTool.Result(
+            promptMessageContents = listOf(TextContent("Hello world"))
+        )
+
+        val expected = buildJsonObject {
+            put("promptMessageContents", "Hello world")
+        }
+
+        assertEquals(expected, randomMcpTool().encodeResult(result))
+    }
+
+    @Test
+    fun `test decode result`() {
+        val expected = McpTool.Result(
+            promptMessageContents = listOf(TextContent("Hello world"))
+        )
+
+        val json = buildJsonObject {
+            put("promptMessageContents", "Hello world")
+        }
+
+        assertEquals(expected.textForLLM(), randomMcpTool().decodeResult(json).textForLLM())
+    }
+}

--- a/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/McpToolTest.kt
+++ b/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/McpToolTest.kt
@@ -4,7 +4,9 @@ import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
+import io.modelcontextprotocol.kotlin.sdk.Implementation
 import io.modelcontextprotocol.kotlin.sdk.TextContent
+import io.modelcontextprotocol.kotlin.sdk.client.Client
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
@@ -31,6 +33,19 @@ class McpToolTest {
     fun tearDown() {
         testServer.stop()
     }
+
+    private fun randomMcpTool(): McpTool = McpTool(
+        mcpClient = Client(
+            clientInfo = Implementation(
+                name = "Test",
+                version = "1.0"
+            )
+        ),
+        descriptor = ToolDescriptor(
+            name = "test-tool",
+            description = "A test tool"
+        ),
+    )
 
     @OptIn(InternalAgentToolsApi::class)
     @Test
@@ -114,5 +129,18 @@ class McpToolTest {
     fun `test McpTool with empty result`() {
         val result = McpTool.Result(promptMessageContents = listOf(TextContent("")))
         assertEquals("", result.textForLLM())
+    }
+
+    @Test
+    fun `test encode result`() {
+        val result = McpTool.Result(
+            promptMessageContents = listOf(TextContent("Hello world"))
+        )
+
+        val expected = buildJsonObject {
+            put("promptMessageContents", "Hello world")
+        }
+
+        assertEquals(expected, randomMcpTool().encodeResult(result))
     }
 }

--- a/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/McpToolTest.kt
+++ b/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/McpToolTest.kt
@@ -4,9 +4,7 @@ import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
-import io.modelcontextprotocol.kotlin.sdk.Implementation
 import io.modelcontextprotocol.kotlin.sdk.TextContent
-import io.modelcontextprotocol.kotlin.sdk.client.Client
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
@@ -33,19 +31,6 @@ class McpToolTest {
     fun tearDown() {
         testServer.stop()
     }
-
-    private fun randomMcpTool(): McpTool = McpTool(
-        mcpClient = Client(
-            clientInfo = Implementation(
-                name = "Test",
-                version = "1.0"
-            )
-        ),
-        descriptor = ToolDescriptor(
-            name = "test-tool",
-            description = "A test tool"
-        ),
-    )
 
     @OptIn(InternalAgentToolsApi::class)
     @Test
@@ -129,31 +114,5 @@ class McpToolTest {
     fun `test McpTool with empty result`() {
         val result = McpTool.Result(promptMessageContents = listOf(TextContent("")))
         assertEquals("", result.textForLLM())
-    }
-
-    @Test
-    fun `test encode result`() {
-        val result = McpTool.Result(
-            promptMessageContents = listOf(TextContent("Hello world"))
-        )
-
-        val expected = buildJsonObject {
-            put("promptMessageContents", "Hello world")
-        }
-
-        assertEquals(expected, randomMcpTool().encodeResult(result))
-    }
-
-    @Test
-    fun `test decode result`() {
-        val expected = McpTool.Result(
-            promptMessageContents = listOf(TextContent("Hello world"))
-        )
-
-        val json = buildJsonObject {
-            put("promptMessageContents", "Hello world")
-        }
-
-        assertEquals(expected.textForLLM(), randomMcpTool().decodeResult(json).textForLLM())
     }
 }

--- a/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/McpToolTest.kt
+++ b/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/McpToolTest.kt
@@ -143,4 +143,17 @@ class McpToolTest {
 
         assertEquals(expected, randomMcpTool().encodeResult(result))
     }
+
+    @Test
+    fun `test decode result`() {
+        val expected = McpTool.Result(
+            promptMessageContents = listOf(TextContent("Hello world"))
+        )
+
+        val json = buildJsonObject {
+            put("promptMessageContents", "Hello world")
+        }
+
+        assertEquals(expected.textForLLM(), randomMcpTool().decodeResult(json).textForLLM())
+    }
 }

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolResult.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolResult.kt
@@ -6,6 +6,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
 import kotlin.jvm.JvmInline
 
 /**
@@ -182,7 +186,38 @@ public interface ToolResult {
          * @return The deserialized object of type T.
          */
         override fun deserialize(decoder: Decoder): T {
-            return valueSerializer.deserialize(decoder)
+            // Read the structure and extract the string value from the first element
+            val composite = decoder.beginStructure(descriptor)
+            val textValue = composite.decodeStringElement(descriptor, 0)
+            composite.endStructure(descriptor)
+
+            // Now reconstruct the object from the text by creating a JSON structure
+            // where the first field contains the text value wrapped appropriately
+            if (decoder is JsonDecoder) {
+                val json = decoder.json
+                val firstFieldName = descriptor.getElementName(0)
+
+                // Create a JSON structure with the text value wrapped in an array with TextContent structure
+                // This assumes the first field is a List and each element has a "text" field
+                val jsonObject = buildJsonObject {
+                    put(
+                        firstFieldName,
+                        buildJsonArray {
+                            add(
+                                buildJsonObject {
+                                    put("type", JsonPrimitive("text"))
+                                    put("text", JsonPrimitive(textValue))
+                                }
+                            )
+                        }
+                    )
+                }
+                return json.decodeFromJsonElement(valueSerializer, jsonObject)
+            } else {
+                // For non-JSON decoders, we can't easily reconstruct the structure
+                // so we fall back to the value serializer
+                return valueSerializer.deserialize(decoder)
+            }
         }
     }
 

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolResult.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolResult.kt
@@ -169,7 +169,10 @@ public interface ToolResult {
          * @param value The object of type `T` to be serialized.
          */
         override fun serialize(encoder: Encoder, value: T) {
-            encoder.encodeString(value.textForLLM())
+            with(encoder.beginStructure(descriptor)) {
+                encodeStringElement(descriptor, 0, value.textForLLM())
+                endStructure(descriptor)
+            }
         }
 
         /**


### PR DESCRIPTION
## Motivation and Context
This PR addresses the issue where MCPTool throw `No tag in stack for requested element` handling the result

Fixes #1111

## Breaking Changes
No

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed