### PR TITLE
Generate API Docs for A2A modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 [![Kotlin](https://img.shields.io/badge/kotlin-2.1-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![CI status](https://img.shields.io/github/checks-status/JetBrains/koog/main)](https://github.com/JetBrains/koog/actions?query=branch%3Amain)
 [![GitHub license](https://img.shields.io/github/license/JetBrains/koog)](LICENSE.txt)
-[![docs](https://img.shields.io/badge/documentation-blue)](https://docs.koog.ai)
+[![API Docs](https://img.shields.io/badge/documentation-blue)](https://docs.koog.ai)
+[![API](https://img.shields.io/badge/API-Docs-blue)](https://api.koog.ai/)
 [![Slack channel](https://img.shields.io/badge/chat-slack-green.svg?logo=slack)](https://kotlinlang.slack.com/messages/koog-agentic-framework/)
 
 Build status:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ import java.util.Base64
 version = run {
     // our version follows the semver specification
 
-    val main = project.version
+    val baseVersion = (project.property("version") as String).removeSuffix("-SNAPSHOT")
 
     val feat = run {
         val releaseBuild = !System.getenv("BRANCH_KOOG_IS_RELEASING_FROM").isNullOrBlank()
@@ -72,7 +72,7 @@ version = run {
         }
     }
 
-    "$main$feat"
+    "$baseVersion$feat"
 }
 
 fun isCustomReleaseBranch(branchName: String): Boolean = branchName.matches(Regex("""^\d+\.\d+\.\d+$"""))
@@ -205,12 +205,6 @@ tasks {
 }
 
 dependencies {
-    dokka(project(":a2a:a2a-client"))
-    dokka(project(":a2a:a2a-core"))
-    dokka(project(":a2a:a2a-server"))
-    dokka(project(":a2a:a2a-transport:a2a-transport-client-jsonrpc-http"))
-    dokka(project(":a2a:a2a-transport:a2a-transport-core-jsonrpc"))
-    dokka(project(":a2a:a2a-transport:a2a-transport-server-jsonrpc-http"))
     dokka(project(":agents:agents-core"))
     dokka(project(":agents:agents-ext"))
     dokka(project(":agents:agents-features:agents-features-event-handler"))
@@ -234,7 +228,6 @@ dependencies {
     dokka(project(":prompt:prompt-executor:prompt-executor-clients"))
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-anthropic-client"))
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-bedrock-client"))
-    dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-dashscope-client"))
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-deepseek-client"))
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-google-client"))
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-mistralai-client"))
@@ -242,6 +235,7 @@ dependencies {
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client"))
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client-base"))
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openrouter-client"))
+    dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-dashscope-client"))
     dokka(project(":prompt:prompt-executor:prompt-executor-llms"))
     dokka(project(":prompt:prompt-executor:prompt-executor-llms-all"))
     dokka(project(":prompt:prompt-executor:prompt-executor-model"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,11 +14,10 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Base64
 
-group = "ai.koog"
 version = run {
     // our version follows the semver specification
 
-    val main = "0.5.2"
+    val main = project.version
 
     val feat = run {
         val releaseBuild = !System.getenv("BRANCH_KOOG_IS_RELEASING_FROM").isNullOrBlank()
@@ -206,6 +205,12 @@ tasks {
 }
 
 dependencies {
+    dokka(project(":a2a:a2a-client"))
+    dokka(project(":a2a:a2a-core"))
+    dokka(project(":a2a:a2a-server"))
+    dokka(project(":a2a:a2a-transport:a2a-transport-client-jsonrpc-http"))
+    dokka(project(":a2a:a2a-transport:a2a-transport-core-jsonrpc"))
+    dokka(project(":a2a:a2a-transport:a2a-transport-server-jsonrpc-http"))
     dokka(project(":agents:agents-core"))
     dokka(project(":agents:agents-ext"))
     dokka(project(":agents:agents-features:agents-features-event-handler"))
@@ -229,6 +234,7 @@ dependencies {
     dokka(project(":prompt:prompt-executor:prompt-executor-clients"))
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-anthropic-client"))
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-bedrock-client"))
+    dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-dashscope-client"))
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-deepseek-client"))
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-google-client"))
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-mistralai-client"))
@@ -236,7 +242,6 @@ dependencies {
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client"))
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client-base"))
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openrouter-client"))
-    dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-dashscope-client"))
     dokka(project(":prompt:prompt-executor:prompt-executor-llms"))
     dokka(project(":prompt:prompt-executor:prompt-executor-llms-all"))
     dokka(project(":prompt:prompt-executor:prompt-executor-model"))

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -14,10 +14,16 @@ kotlin {
 }
 
 dependencies {
+    implementation(project(":a2a:a2a-client"))
+    implementation(project(":a2a:a2a-core"))
+    implementation(project(":a2a:a2a-server"))
+    implementation(project(":a2a:a2a-transport:a2a-transport-client-jsonrpc-http"))
+    implementation(project(":a2a:a2a-transport:a2a-transport-core-jsonrpc"))
+    implementation(project(":a2a:a2a-transport:a2a-transport-server-jsonrpc-http"))
     implementation(project(":agents:agents-test"))
     implementation(project(":koog-agents"))
-    implementation(libs.opentelemetry.exporter.otlp)
     implementation(libs.opentelemetry.exporter.logging)
+    implementation(libs.opentelemetry.exporter.otlp)
 }
 
 dokka {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 
 kotlin.native.ignoreDisabledTargets=true
+
+group=ai.koog
+version=0.5.4-SNAPSHOT


### PR DESCRIPTION
Generate API Docs for A2A modules
Move version and groupId to `gradle.properties`

## Motivation and Context
A2A API documentation is missing on https://api.koog.ai/

## Breaking Changes
No

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [ ] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [ ] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] Tested with [workflow](https://github.com/JetBrains/koog/actions/runs/19336563900)

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
