### PR TITLE
Optimize dependencies

### DIFF
--- a/agents/agents-features/agents-features-sql/build.gradle.kts
+++ b/agents/agents-features/agents-features-sql/build.gradle.kts
@@ -35,10 +35,10 @@ kotlin {
                 api(libs.exposed.jdbc)
                 api(libs.exposed.json)
                 api(libs.exposed.kotlin.datetime)
-                api(libs.postgresql)
-                api(libs.mysql)
-                api(libs.h2)
-                api(libs.sqlite)
+                compileOnly(libs.h2)
+                compileOnly(libs.mysql)
+                compileOnly(libs.postgresql)
+                compileOnly(libs.sqlite)
                 implementation(libs.hikaricp)
             }
         }
@@ -52,6 +52,11 @@ kotlin {
                 implementation(libs.testcontainers)
                 implementation(libs.testcontainers.postgresql)
                 implementation(libs.testcontainers.mysql)
+
+                runtimeOnly(libs.postgresql)
+                runtimeOnly(libs.mysql)
+                runtimeOnly(libs.h2)
+                runtimeOnly(libs.sqlite)
             }
         }
     }

--- a/agents/agents-features/agents-features-sql/src/jvmTest/resources/logback.xml
+++ b/agents/agents-features/agents-features-sql/src/jvmTest/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="ai.koog" level="debug" />
+    <logger name="com.github.dockerjava" level="error" />
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/docs/docs/spring-boot.md
+++ b/docs/docs/spring-boot.md
@@ -19,11 +19,13 @@ ready-to-use beans for dependency injection. It supports all major LLM providers
 
 ### 1. Add Dependency
 
-Add the Spring Boot starter to your `build.gradle.kts`:
+Add the Koog Spring Boot starter and [Ktor Client Engine](https://ktor.io/docs/client-engines.html#jvm) 
+to your `build.gradle.kts` or `pom.xml`:
 
 ```kotlin
 dependencies {
     implementation("ai.koog:koog-spring-boot-starter:$koogVersion")
+    implementation("io.ktor:ktor-client-okhttp-jvm:$ktorVersion")
 }
 ```
 

--- a/koog-spring-boot-starter/build.gradle.kts
+++ b/koog-spring-boot-starter/build.gradle.kts
@@ -34,10 +34,10 @@ dependencies {
     implementation(project.dependencies.platform(libs.spring.boot.bom))
     api(libs.bundles.spring.boot.core)
     api(libs.reactor.kotlin.extensions)
-    runtimeOnly(libs.ktor.client.apache5)
 
     testImplementation(libs.spring.boot.starter.test)
     testRuntimeOnly(libs.junit.platform.launcher)
+    testRuntimeOnly(libs.ktor.client.apache5)
 }
 
 publishToMaven()


### PR DESCRIPTION
# Optimize dependencies and update project setup

## Motivation and Context

Reduce the library’s transitive footprint by making JDBC drivers and the connection pool `compileOnly`, so applications are no longer forced to pull in specific database drivers they may not use. It also stops the Spring Boot starter from implicitly choosing a Ktor client engine, requiring consumers to select the engine that best fits their environment and avoiding version and engine conflicts. The updated docs clarify these explicit dependency requirements, and the logging configuration helps keep test logs readable while still surfacing useful debug information.

- Switched optional JDBC drivers to `compileOnly` for reduced transitive dependencies.
- Added `logback.xml` to configure logging levels and prevent excessive logs.
- Exclude Ktor client engine from spring-boot transitive dependencies and updated documentation

## Breaking Changes

1. JDBC drivers dependencies are no longer included and should be explicitly configured by users.
2. Ktor client engine dependency should be configured by user when using Koog Spring Boot starter

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Dependency update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [x] Docs have been added / updated
