### PR TITLE
KG-504 Change flushTextBuilder to flush whenever textBuilder is not empty

### DIFF
--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/ContentPartsBuilder.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/ContentPartsBuilder.kt
@@ -70,7 +70,7 @@ public class ContentPartsBuilder : TextContentBuilderBase<List<ContentPart>>() {
      * Flushes the text builder and adds its content as a text part if there is any.
      */
     private fun flushTextBuilder() {
-        if (caret.offset != 0) {
+        if (textBuilder.isNotEmpty()) {
             parts.add(ContentPart.Text(textBuilder.toString()))
             textBuilder.clear()
         }

--- a/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/dsl/PromptBuilderTest.kt
+++ b/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/dsl/PromptBuilderTest.kt
@@ -918,4 +918,15 @@ class PromptBuilderTest {
         assertEquals(1, prompt.messages[1].parts.size, "Should have only text part")
         assertEquals(expectedText, prompt.messages[1].parts[0], "Should have same text")
     }
+
+    @Test
+    fun testUserMessageWithTrailingNewline() {
+        val prompt = Prompt.build("test") {
+            user {
+                +"Text\n"
+            }
+        }
+
+        assertEquals(1, prompt.messages[0].parts.size, "Prompt should have one message with one part")
+    }
 }

--- a/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/dsl/PromptBuilderTest.kt
+++ b/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/dsl/PromptBuilderTest.kt
@@ -5,6 +5,7 @@ import ai.koog.prompt.message.AttachmentContent
 import ai.koog.prompt.message.ContentPart
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.text.text
+import io.kotest.matchers.equals.shouldBeEqual
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/dsl/PromptBuilderTest.kt
+++ b/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/dsl/PromptBuilderTest.kt
@@ -927,6 +927,6 @@ class PromptBuilderTest {
             }
         }
 
-        assertEquals(1, prompt.messages[0].parts.size, "Prompt should have one message with one part")
+        prompt.messages[0].parts shouldBeEqual listOf(ContentPart.Text("Text\n"))
     }
 }


### PR DESCRIPTION
Related to: [KG-504](https://youtrack.jetbrains.com/issue/KG-504)

## Motivation and Context
The `ContentPartsBuilder` would fail to create a `ContentPart` for text that ended with `\n` or was followed by a DSL call like `br()` or `newline()`. This was because the internal `flushTextBuilder` method checked `caret.offset != 0` to detect pending text. A trailing newline can reset the offset to 0, causing the check to fail even when the `textBuilder` is not empty.

This change proposes to check `textBuilder.isNotEmpty()` instead, ensuring all content is properly flushed.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None. This is a non-breaking bug fix.

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
