### PR TITLE
[agents] Fix and simplify McpTool to properly support updated Tool serialization

### DIFF
--- a/agents/agents-mcp-server/src/jvmTest/kotlin/ai/koog/agents/mcp/server/KoogToolAsMcpToolTest.kt
+++ b/agents/agents-mcp-server/src/jvmTest/kotlin/ai/koog/agents/mcp/server/KoogToolAsMcpToolTest.kt
@@ -9,6 +9,7 @@ import ai.koog.agents.testing.network.NetUtil.isPortAvailable
 import ai.koog.agents.testing.tools.RandomNumberTool
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.server.cio.CIO
+import io.modelcontextprotocol.kotlin.sdk.EmptyJsonObject
 import io.modelcontextprotocol.kotlin.sdk.TextContent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -33,7 +34,7 @@ class KoogToolAsMcpToolTest {
     @OptIn(InternalAgentToolsApi::class)
     @Test
     fun testKoogToolAsMcpTool() = testMcpTool(RandomNumberTool()) { mcpTool, origin ->
-        val args = McpTool.Args(buildJsonObject { put("seed", "42") })
+        val args = buildJsonObject { put("seed", "42") }
 
         val result = withContext(Dispatchers.Default.limitedParallelism(1)) {
             withTimeout(20.seconds) {
@@ -43,14 +44,14 @@ class KoogToolAsMcpToolTest {
 
         logger.info { "Result: ${mcpTool.encodeResultToString(result)}" }
 
-        val content = result.promptMessageContents.first() as TextContent
+        val content = result?.content?.first() as TextContent
         assertEquals("${origin.last}", content.text)
     }
 
     @OptIn(InternalAgentToolsApi::class)
     @Test
     fun testKoogToolAsMcpToolWithoutOptionalArguments() = testMcpTool(RandomNumberTool()) { mcpTool, origin ->
-        val args = McpTool.Args(buildJsonObject { })
+        val args = EmptyJsonObject
 
         val result = withContext(Dispatchers.Default.limitedParallelism(1)) {
             withTimeout(20.seconds) {
@@ -60,7 +61,7 @@ class KoogToolAsMcpToolTest {
 
         logger.info { "Result: ${mcpTool.encodeResultToString(result)}" }
 
-        val content = result.promptMessageContents.first() as TextContent
+        val content = result?.content?.first() as TextContent
         assertEquals("${origin.last}", content.text)
     }
 
@@ -68,7 +69,7 @@ class KoogToolAsMcpToolTest {
     @Test
     fun testKoogToolAsMcpToolWithInvalidArguments() = testMcpTool(RandomNumberTool()) { mcpTool, origin ->
         assertFailsWith<IllegalStateException> {
-            val args = McpTool.Args(buildJsonObject { put("seed", "forty-two") })
+            val args = buildJsonObject { put("seed", "forty-two") }
 
             withContext(Dispatchers.Default.limitedParallelism(1)) {
                 withTimeout(20.seconds) {
@@ -80,7 +81,7 @@ class KoogToolAsMcpToolTest {
         run {
             // check that the server is still working
 
-            val args = McpTool.Args(buildJsonObject { put("seed", "42") })
+            val args = buildJsonObject { put("seed", "42") }
 
             val result = withContext(Dispatchers.Default.limitedParallelism(1)) {
                 withTimeout(20.seconds) {
@@ -90,7 +91,7 @@ class KoogToolAsMcpToolTest {
 
             logger.info { "Result: ${mcpTool.encodeResultToString(result)}" }
 
-            val content = result.promptMessageContents.first() as TextContent
+            val content = result?.content?.first() as TextContent
             assertEquals("${origin.last}", content.text)
         }
     }
@@ -104,7 +105,7 @@ class KoogToolAsMcpToolTest {
             tool.throwing = true
 
             assertFailsWith<IllegalStateException> {
-                val args = McpTool.Args(buildJsonObject { })
+                val args = EmptyJsonObject
 
                 withContext(Dispatchers.Default.limitedParallelism(1)) {
                     withTimeout(20.seconds) {
@@ -121,7 +122,7 @@ class KoogToolAsMcpToolTest {
                 // check that the server is still working
                 tool.throwing = false
 
-                val args = McpTool.Args(buildJsonObject { })
+                val args = EmptyJsonObject
 
                 val result = withContext(Dispatchers.Default.limitedParallelism(1)) {
                     withTimeout(20.seconds) {
@@ -131,7 +132,7 @@ class KoogToolAsMcpToolTest {
 
                 logger.info { "Result: ${mcpTool.encodeResultToString(result)}" }
 
-                val content = result.promptMessageContents.first() as TextContent
+                val content = result?.content?.first() as TextContent
                 assertEquals("${origin.last?.getOrNull()}", content.text)
             }
         }

--- a/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/McpToolTest.kt
+++ b/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/McpToolTest.kt
@@ -3,39 +3,48 @@ package ai.koog.agents.mcp
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
+import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
+import io.modelcontextprotocol.kotlin.sdk.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.EmptyJsonObject
+import io.modelcontextprotocol.kotlin.sdk.Implementation
 import io.modelcontextprotocol.kotlin.sdk.TextContent
+import io.modelcontextprotocol.kotlin.sdk.client.Client
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
+@Execution(ExecutionMode.SAME_THREAD)
 class McpToolTest {
-    private val testPort = 3001
-    private val testServer = TestMcpServer(testPort)
+    companion object {
+        private const val testPort = 3001
+        private val testServer = TestMcpServer(testPort)
 
-    @BeforeTest
-    fun setup() {
-        testServer.start()
+        @BeforeAll
+        @JvmStatic
+        fun setup() {
+            testServer.start()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun tearDown() {
+            testServer.stop()
+        }
     }
 
-    @AfterTest
-    fun tearDown() {
-        testServer.stop()
-    }
-
-    @OptIn(InternalAgentToolsApi::class)
-    @Test
-    fun `test McpTool with SSE transport`() = runTest(timeout = 30.seconds) {
-        // Create a tool registry using McpToolRegistryProvider.fromTransport
+    private suspend fun testMcpTools(action: suspend (toolRegistry: ToolRegistry) -> Unit) {
         val toolRegistry = withContext(Dispatchers.Default.limitedParallelism(1)) {
             withTimeout(1.minutes) {
                 McpToolRegistryProvider.fromTransport(
@@ -46,73 +55,143 @@ class McpToolTest {
             }
         }
 
-        // A list of tools that the server is expected to provide
-        val expectedToolDescriptors = listOf(
-            ToolDescriptor(
-                name = "greeting",
-                description = "A simple greeting tool",
-                requiredParameters = listOf(
-                    ToolParameterDescriptor(
-                        name = "name",
-                        type = ToolParameterType.String,
-                        description = "A name to greet",
+        action(toolRegistry)
+    }
+
+    @Test
+    fun `test McpToolRegistry provides all tools`() = runTest(timeout = 30.seconds) {
+        testMcpTools { toolRegistry ->
+            val expectedToolDescriptors = listOf(
+                ToolDescriptor(
+                    name = "greeting",
+                    description = "A simple greeting tool",
+                    requiredParameters = listOf(
+                        ToolParameterDescriptor(
+                            name = "name",
+                            type = ToolParameterType.String,
+                            description = "A name to greet",
+                        )
+                    ),
+                    optionalParameters = listOf(
+                        ToolParameterDescriptor(
+                            name = "title",
+                            type = ToolParameterType.String,
+                            description = "Title to use in the greeting",
+                        )
                     )
                 ),
-                optionalParameters = listOf(
-                    ToolParameterDescriptor(
-                        name = "title",
-                        type = ToolParameterType.String,
-                        description = "Title to use in the greeting",
-                    )
+                ToolDescriptor(
+                    name = "empty",
+                    description = "An empty tool",
                 )
             )
-        )
 
-        // Actual list of tools provided
-        val actualToolDescriptor = toolRegistry.tools.map { it.descriptor }
-        assertEquals(expectedToolDescriptors, actualToolDescriptor)
-
-        // Now test the actual tool
-        val greetingTool = toolRegistry.getTool("greeting") as McpTool
-        val args = McpTool.Args(buildJsonObject { put("name", "Test") })
-
-        val result = withContext(Dispatchers.Default.limitedParallelism(1)) {
-            withTimeout(1.minutes) {
-                greetingTool.execute(args)
-            }
+            // Actual list of tools provided
+            val actualToolDescriptor = toolRegistry.tools.map { it.descriptor }
+            assertEquals(expectedToolDescriptors, actualToolDescriptor)
         }
+    }
 
-        val content = result.promptMessageContents.first() as TextContent
-        assertEquals("Hello, Test!", content.text)
+    @OptIn(InternalAgentToolsApi::class)
+    @Test
+    fun `test greeting tool`() = runTest(timeout = 30.seconds) {
+        testMcpTools { toolRegistry ->
+            val greetingTool = toolRegistry.getTool("greeting") as McpTool
+            val args = buildJsonObject { put("name", "Test") }
 
-        val argsWithTitle = McpTool.Args(
-            buildJsonObject {
+            val result = withContext(Dispatchers.Default.limitedParallelism(1)) {
+                withTimeout(1.minutes) {
+                    greetingTool.execute(args)
+                }
+            }
+
+            val content = result?.content?.first() as TextContent
+            assertEquals("Hello, Test!", content.text)
+
+            val argsWithTitle = buildJsonObject {
                 put("name", "Test")
                 put("title", "Mr.")
             }
-        )
-        val resultWithTitle = withContext(Dispatchers.Default.limitedParallelism(1)) {
-            withTimeout(1.minutes) {
-                greetingTool.execute(argsWithTitle)
+            val resultWithTitle = withContext(Dispatchers.Default.limitedParallelism(1)) {
+                withTimeout(1.minutes) {
+                    greetingTool.execute(argsWithTitle)
+                }
             }
+
+            val contentWithTitle = resultWithTitle?.content?.first() as TextContent
+            assertEquals("Hello, Mr. Test!", contentWithTitle.text)
+
+            val encodedResult = greetingTool.encodeResultToString(result)
+            assertEquals(
+                //language=Json
+                expected = """{"content":[{"text":"Hello, Test!","type":"text"}],"isError":false}""",
+                actual = encodedResult
+            )
         }
-
-        val contentWithTitle = resultWithTitle.promptMessageContents.first() as TextContent
-        assertEquals("Hello, Mr. Test!", contentWithTitle.text)
-
-        val textForLLM = resultWithTitle.textForLLM()
-        assertEquals("Hello, Mr. Test!", textForLLM)
     }
 
     @Test
-    fun `test McpTool with empty content`() {
-        val result = McpTool.Result(promptMessageContents = emptyList())
-        assertEquals("[No content]", result.textForLLM())
+    fun `test empty tool`() = runTest(timeout = 30.seconds) {
+        testMcpTools { toolRegistry ->
+            val emptyTool = toolRegistry.getTool("empty") as McpTool
+            val args = EmptyJsonObject
+
+            val result = withContext(Dispatchers.Default.limitedParallelism(1)) {
+                withTimeout(1.minutes) {
+                    emptyTool.execute(args)
+                }
+            }
+            assertEquals(emptyList(), result?.content.orEmpty())
+
+            val encodedResult = emptyTool.encodeResultToString(result)
+            assertEquals(
+                //language=Json
+                expected = """{"content":[],"isError":false}""",
+                actual = encodedResult
+            )
+        }
     }
 
     @Test
-    fun `test McpTool with empty result`() {
-        val result = McpTool.Result(promptMessageContents = listOf(TextContent("")))
-        assertEquals("", result.textForLLM())
+    fun `test encode result`() {
+        val result = CallToolResult(listOf(TextContent("Hello world")))
+        val toolDescriptor = ToolDescriptor(
+            name = "test-tool",
+            description = "A test tool",
+            requiredParameters = emptyList(),
+            optionalParameters = emptyList()
+        )
+        val mcpTool = McpTool(
+            mcpClient = Client(clientInfo = Implementation(name = "Test", version = "1.0")),
+            descriptor = toolDescriptor,
+        )
+        val encodedResult = mcpTool.encodeResultToString(result)
+
+        assertEquals(
+            //language=Json
+            expected = """{"content":[{"text":"Hello world","type":"text"}],"isError":false}""",
+            actual = encodedResult
+        )
+    }
+
+    @Test
+    fun `test encode null result`() {
+        val result: CallToolResult? = null
+        val toolDescriptor = ToolDescriptor(
+            name = "test-tool",
+            description = "A test tool",
+            requiredParameters = emptyList(),
+            optionalParameters = emptyList()
+        )
+        val mcpTool = McpTool(
+            mcpClient = Client(clientInfo = Implementation(name = "Test", version = "1.0")),
+            descriptor = toolDescriptor,
+        )
+        val encodedResult = mcpTool.encodeResultToString(result)
+
+        assertEquals(
+            expected = "null",
+            actual = encodedResult
+        )
     }
 }

--- a/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/TestMcpServer.kt
+++ b/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/TestMcpServer.kt
@@ -80,6 +80,15 @@ class TestMcpServer(private val port: Int) {
             )
         }
 
+        // A completely empty tool that accepts nothing and returns nothing
+        server.addTool(
+            name = "empty",
+            description = "An empty tool",
+            inputSchema = Tool.Input()
+        ) {
+            CallToolResult(content = emptyList())
+        }
+
         return server
     }
 

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/Tool.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/Tool.kt
@@ -4,7 +4,7 @@ import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.core.tools.serialization.ToolJson
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.StringFormat
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
@@ -46,10 +46,10 @@ public abstract class Tool<TArgs, TResult> {
     public abstract val resultSerializer: KSerializer<TResult>
 
     /**
-     * The [StringFormat] used to encode and decode the arguments and results of the tool.
-     * This property is used to serialize and deserialize the tool arguments and results.
+     * The [Json] used to encode and decode the arguments and results of the tool.
      */
-    protected open val format: StringFormat = ToolJson
+    @OptIn(InternalAgentToolsApi::class)
+    protected open val json: Json = ToolJson
 
     /**
      * The name of the tool.
@@ -119,7 +119,7 @@ public abstract class Tool<TArgs, TResult> {
      * @param rawArgs the raw JSON object that contains the encoded arguments
      * @return the decoded arguments of type TArgs
      */
-    public fun decodeArgs(rawArgs: JsonObject): TArgs = ToolJson.decodeFromJsonElement(actualArgsSerializer, rawArgs)
+    public fun decodeArgs(rawArgs: JsonObject): TArgs = json.decodeFromJsonElement(actualArgsSerializer, rawArgs)
 
     /**
      * Decodes the provided raw JSON element into an instance of the specified result type.
@@ -128,7 +128,7 @@ public abstract class Tool<TArgs, TResult> {
      * @return The decoded result of type TResult.
      */
     public fun decodeResult(rawResult: JsonElement): TResult =
-        ToolJson.decodeFromJsonElement(actualResultSerializer, rawResult)
+        json.decodeFromJsonElement(actualResultSerializer, rawResult)
 
     /**
      * Encodes the given arguments into a JSON representation.
@@ -136,7 +136,7 @@ public abstract class Tool<TArgs, TResult> {
      * @param args The arguments to be encoded.
      * @return A JsonObject representing the encoded arguments.
      */
-    public fun encodeArgs(args: TArgs): JsonObject = ToolJson.encodeToJsonElement(actualArgsSerializer, args).jsonObject
+    public fun encodeArgs(args: TArgs): JsonObject = json.encodeToJsonElement(actualArgsSerializer, args).jsonObject
 
     /**
      * Encodes the given arguments into a JSON representation without type safety checks.
@@ -152,7 +152,7 @@ public abstract class Tool<TArgs, TResult> {
      */
     public fun encodeArgsUnsafe(args: Any?): JsonObject {
         @Suppress("UNCHECKED_CAST")
-        return ToolJson.encodeToJsonElement(actualArgsSerializer, args as TArgs).jsonObject
+        return json.encodeToJsonElement(actualArgsSerializer, args as TArgs).jsonObject
     }
 
     /**
@@ -162,7 +162,7 @@ public abstract class Tool<TArgs, TResult> {
      * @return A JsonObject representing the encoded result.
      */
     public fun encodeResult(result: TResult): JsonElement =
-        ToolJson.encodeToJsonElement(actualResultSerializer, result)
+        json.encodeToJsonElement(actualResultSerializer, result)
 
     /**
      * Encodes the given result object into a JSON representation without type safety checks.
@@ -185,7 +185,7 @@ public abstract class Tool<TArgs, TResult> {
      * @param args the arguments to be encoded into a JSON string
      * @return the JSON string representation of the provided arguments
      */
-    public fun encodeArgsToString(args: TArgs): String = ToolJson.encodeToString(actualArgsSerializer, args)
+    public fun encodeArgsToString(args: TArgs): String = json.encodeToString(actualArgsSerializer, args)
 
     /**
      * Encodes the provided arguments into a JSON string representation without type safety checks.
@@ -209,7 +209,7 @@ public abstract class Tool<TArgs, TResult> {
      * @param result The result object of type TResult to be encoded into a string.
      * @return The string representation of the given result.
      */
-    public open fun encodeResultToString(result: TResult): String = format.encodeToString(resultSerializer, result)
+    public open fun encodeResultToString(result: TResult): String = json.encodeToString(resultSerializer, result)
 
     /**
      * Encodes the provided result object into a JSON string representation without type safety checks.

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/serialization/ToolSerialization.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/serialization/ToolSerialization.kt
@@ -3,11 +3,14 @@ package ai.koog.agents.core.tools.serialization
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
+import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
-internal val ToolJson = Json {
+@InternalAgentToolsApi
+@Suppress("MissingKDocForPublicAPI")
+public val ToolJson: Json = Json {
     ignoreUnknownKeys = true
     encodeDefaults = true
     explicitNulls = false
@@ -47,6 +50,7 @@ internal data class ToolArrayItemTypeModel(
  *
  * @param toolDescriptors List of [ToolDescriptor]
  */
+@OptIn(InternalAgentToolsApi::class)
 public fun serializeToolDescriptorsToJsonString(toolDescriptors: List<ToolDescriptor>): String {
     val toolModels = toolDescriptors.map {
         ToolModel(

--- a/agents/agents-tools/src/jvmMain/kotlin/ai/koog/agents/core/tools/reflect/ToolFromCallable.kt
+++ b/agents/agents-tools/src/jvmMain/kotlin/ai/koog/agents/core/tools/reflect/ToolFromCallable.kt
@@ -3,6 +3,7 @@ package ai.koog.agents.core.tools.reflect
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
+import ai.koog.agents.core.tools.serialization.ToolJson
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
@@ -38,7 +39,7 @@ public class ToolFromCallable(
     private val callable: KCallable<*>,
     private val thisRef: Any? = null,
     override val descriptor: ToolDescriptor,
-    private val json: Json = Json,
+    override val json: Json = ToolJson,
     override val resultSerializer: KSerializer<Any?>,
 ) : Tool<ToolFromCallable.VarArgs, Any?>() {
 
@@ -58,8 +59,7 @@ public class ToolFromCallable(
          */
         public fun asNamedValues(): List<Pair<String, Any?>> = args.mapNotNull { (parameter, value) ->
             parameter.name?.let {
-                it to
-                    value
+                it to value
             }
         }
     }

--- a/agents/agents-tools/src/jvmMain/kotlin/ai/koog/agents/core/tools/reflect/util.kt
+++ b/agents/agents-tools/src/jvmMain/kotlin/ai/koog/agents/core/tools/reflect/util.kt
@@ -4,8 +4,10 @@ import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
 import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.core.tools.annotations.Tool
+import ai.koog.agents.core.tools.serialization.ToolJson
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
 import kotlin.reflect.KClass
@@ -52,7 +54,8 @@ import ai.koog.agents.core.tools.Tool as ToolType
  * val tools = myToolset.asTools()
  * ```
  */
-public fun ToolSet.asTools(json: Json = Json): List<ToolType<ToolFromCallable.VarArgs, *>> {
+@OptIn(InternalAgentToolsApi::class)
+public fun ToolSet.asTools(json: Json = ToolJson): List<ToolType<ToolFromCallable.VarArgs, *>> {
     return this::class.asTools(json = json, thisRef = this)
 }
 
@@ -89,7 +92,8 @@ public fun ToolSet.asTools(json: Json = Json): List<ToolType<ToolFromCallable.Va
  * val tools = myToolset.asToolsByInterface<MyToolsetInterface>() // only interface methods will be added
  * ```
  */
-public inline fun <reified T : ToolSet> T.asToolsByInterface(json: Json = Json): List<ToolType<ToolFromCallable.VarArgs, *>> {
+@OptIn(InternalAgentToolsApi::class)
+public inline fun <reified T : ToolSet> T.asToolsByInterface(json: Json = ToolJson): List<ToolType<ToolFromCallable.VarArgs, *>> {
     return T::class.asTools(json = json, thisRef = this)
 }
 
@@ -102,9 +106,10 @@ public inline fun <reified T : ToolSet> T.asToolsByInterface(json: Json = Json):
  * @param toolSet The [ToolSet] containing the tools to be registered.
  * @param json The Json instance to use for serialization. Defaults to a standard `Json` instance if not provided.
  */
+@OptIn(InternalAgentToolsApi::class)
 public fun ToolRegistry.Builder.tools(
     toolSet: ToolSet,
-    json: Json = Json
+    json: Json = ToolJson
 ) {
     tools(toolSet.asTools(json = json))
 }
@@ -117,8 +122,9 @@ public fun ToolRegistry.Builder.tools(
 
  * @see [asTool]
  */
+@OptIn(InternalAgentToolsApi::class)
 public fun <T : ToolSet> KClass<out T>.asTools(
-    json: Json = Json,
+    json: Json = ToolJson,
     thisRef: T? = null
 ): List<ToolType<ToolFromCallable.VarArgs, *>> {
     return this.functions.filter { m ->
@@ -180,8 +186,9 @@ public fun <T : ToolSet> KClass<out T>.asTools(
  * val tool = MyTools::my_best_tool.asTool(json = Json, thisRef = myTools)
  * ```
  */
+@OptIn(InternalAgentToolsApi::class)
 public fun <A> KFunction<A>.asTool(
-    json: Json = Json,
+    json: Json = ToolJson,
     thisRef: Any? = null,
     name: String? = null,
     description: String? = null
@@ -215,9 +222,10 @@ public fun <A> KFunction<A>.asTool(
  * @param name An optional name to uniquely identify the tool in the registry. If `null`, a default name derived from the function will be used.
  * @param description An optional description of the tool functionality. Useful for documentation and explanatory purposes.
  */
+@OptIn(InternalAgentToolsApi::class)
 public fun ToolRegistry.Builder.tool(
     toolFunction: KFunction<*>,
-    json: Json = Json,
+    json: Json = ToolJson,
     thisRef: Any? = null,
     name: String? = null,
     description: String? = null

--- a/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/core/tools/reflect/ToolsFromCallableTest.kt
+++ b/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/core/tools/reflect/ToolsFromCallableTest.kt
@@ -5,9 +5,9 @@ package ai.koog.agents.core.tools.reflect
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.core.tools.annotations.Tool
+import ai.koog.agents.core.tools.serialization.ToolJson
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -206,7 +206,7 @@ class MyTools : Tools {
 class ToolsFromCallableTest {
     companion object {
         val tools = MyTools()
-        val json = Json
+        val json = ToolJson
 
         @JvmStatic
         fun testVariants(): Array<Arguments> {


### PR DESCRIPTION
Simplify and refactor `McpTool` implementation and some related parts, to properly support updated `Tool` serialization mechanism and make the implementaiton shorter and more straightforward.

Fixes #1111, #1127