### PR TITLE
Add global inference profile prefix support to Bedrock models

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModels.kt
@@ -85,6 +85,7 @@ public enum class BedrockRegions(public val regionCode: String) {
  */
 @Serializable
 public enum class BedrockInferencePrefixes(public val prefix: String) {
+    GLOBAL("global"),
     US("us"),
     CA("ca"),
     MX("mx"),

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClientTest.kt
@@ -78,21 +78,39 @@ class BedrockLLMClientTest {
     fun `can create BedrockModel with custom inference prefix`() {
         val originalModel = BedrockModels.AnthropicClaude4Sonnet
 
+        val globalModel = originalModel.withInferenceProfile(BedrockInferencePrefixes.GLOBAL.prefix)
         val euModel = originalModel.withInferenceProfile(BedrockInferencePrefixes.EU.prefix)
         val apModel = originalModel.withInferenceProfile(BedrockInferencePrefixes.AP.prefix)
 
         assertTrue(originalModel.id.startsWith(BedrockInferencePrefixes.US.prefix))
         assertTrue(originalModel.id.contains("us.anthropic"))
 
+        assertTrue(globalModel.id.startsWith(BedrockInferencePrefixes.GLOBAL.prefix))
+        assertFalse(globalModel.id.contains("us.anthropic"))
+
         assertTrue(euModel.id.startsWith(BedrockInferencePrefixes.EU.prefix))
         assertFalse(euModel.id.contains("us.anthropic"))
+
         assertTrue(apModel.id.startsWith(BedrockInferencePrefixes.AP.prefix))
         assertFalse(apModel.id.contains("us.anthropic"))
 
+        // Verify global model properties
+        assertEquals(originalModel.provider, globalModel.provider)
+        assertEquals(originalModel.capabilities, globalModel.capabilities)
+        assertEquals(originalModel.contextLength, globalModel.contextLength)
+        assertEquals(originalModel.maxOutputTokens, globalModel.maxOutputTokens)
+
+        // Verify EU model properties
         assertEquals(originalModel.provider, euModel.provider)
         assertEquals(originalModel.capabilities, euModel.capabilities)
         assertEquals(originalModel.contextLength, euModel.contextLength)
         assertEquals(originalModel.maxOutputTokens, euModel.maxOutputTokens)
+
+        // Verify AP model properties
+        assertEquals(originalModel.provider, apModel.provider)
+        assertEquals(originalModel.capabilities, apModel.capabilities)
+        assertEquals(originalModel.contextLength, apModel.contextLength)
+        assertEquals(originalModel.maxOutputTokens, apModel.maxOutputTokens)
     }
 
     @Test


### PR DESCRIPTION
## Motivation and Context

AWS Bedrock now supports a `global` inference profile prefix that routes requests to the most suitable available region for improved availability and latency.

## Breaking Changes

None. This is a backwards-compatible addition that extends existing functionality.

---
#### Type of the changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
