### PR TITLE
KG-549 Add handler for JsonElement in JsonSchemaGenerator

### DIFF
--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/generator/JsonSchemaGenerator.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/generator/JsonSchemaGenerator.kt
@@ -123,6 +123,7 @@ public abstract class JsonSchemaGenerator {
     protected abstract fun processObject(context: GenerationContext): JsonObject
     protected abstract fun processPolymorphic(context: GenerationContext): JsonObject
     protected abstract fun processClassDiscriminator(context: GenerationContext): JsonObject
+    protected abstract fun processJsonElement(context: GenerationContext): JsonObject
 }
 
 /**

--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/generator/StandardJsonSchemaGenerator.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/generator/StandardJsonSchemaGenerator.kt
@@ -2,6 +2,7 @@ package ai.koog.prompt.structure.json.generator
 
 import ai.koog.prompt.params.LLMParams
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.descriptors.PolymorphicKind
 import kotlinx.serialization.descriptors.StructureKind
 import kotlinx.serialization.json.ClassDiscriminatorMode
@@ -200,7 +201,7 @@ public open class StandardJsonSchemaGenerator : GenericJsonSchemaGenerator() {
     override fun processPolymorphic(context: GenerationContext): JsonObject {
         // Check for the special case of JsonElement. Its descriptor doesn't follow the
         // standard polymorphic pattern and must be handled separately.
-        if (context.descriptor.serialName == JSON_ELEMENT_SERIAL_NAME) {
+        if (context.descriptor.serialName in JSON_ELEMENT_SERIAL_NAMES) {
             return processJsonElement(context)
         }
 
@@ -295,4 +296,10 @@ public open class StandardJsonSchemaGenerator : GenericJsonSchemaGenerator() {
     }
 }
 
-private val JSON_ELEMENT_SERIAL_NAME = serializer<JsonElement>().descriptor.serialName
+private val JSON_ELEMENT_SERIAL_NAMES: Set<String> by lazy {
+    val elementSerializer = serializer<JsonElement>()
+    setOf(
+        elementSerializer.descriptor.serialName,
+        elementSerializer.nullable.descriptor.serialName
+    )
+}

--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/generator/StandardJsonSchemaGenerator.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/generator/StandardJsonSchemaGenerator.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.descriptors.StructureKind
 import kotlinx.serialization.json.ClassDiscriminatorMode
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
@@ -14,6 +15,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
+import kotlinx.serialization.serializer
 
 /**
  * Full implementation of [GenericJsonSchemaGenerator] to generate advanced generic [LLMParams.Schema.JSON.Standard].
@@ -195,73 +197,103 @@ public open class StandardJsonSchemaGenerator : GenericJsonSchemaGenerator() {
         putDescription(context.currentDescription)
     }
 
-    override fun processPolymorphic(context: GenerationContext): JsonObject = buildJsonObject {
-        val classDiscriminatorMode = context.json.configuration.classDiscriminatorMode
-        val classDiscriminator = context.json.configuration.classDiscriminator
+    override fun processPolymorphic(context: GenerationContext): JsonObject {
 
-        // Provide an array of all possible schemas for polymorphic types
-        put(
-            JsonSchemaConsts.Keys.ONE_OF,
-            buildJsonArray {
-                context.descriptor
-                    .getPolymorphicDescriptors(context.json)
-                    .forEach { polymorphicDescriptor ->
-                        processObject(context.copy(descriptor = polymorphicDescriptor))
+        // Check for the special case of JsonElement. Its descriptor doesn't follow the
+        // standard polymorphic pattern and must be handled separately.
+        if (context.descriptor.serialName == JSON_ELEMENT_SERIAL_NAME) {
+            return processJsonElement(context)
+        }
 
-                        // Modify polymorphic subtypes, if already processed
-                        context.processedTypeDefs[polymorphicDescriptor]?.toMutableMap()?.let { schema ->
-                            // Add class discriminators, if enabled
-                            if (classDiscriminatorMode in listOf(
-                                    ClassDiscriminatorMode.ALL_JSON_OBJECTS,
-                                    ClassDiscriminatorMode.POLYMORPHIC
-                                )
-                            ) {
-                                val updatedProperties =
-                                    schema.getValue(JsonSchemaConsts.Keys.PROPERTIES).jsonObject.toMutableMap()
+        return buildJsonObject {
+            val classDiscriminatorMode = context.json.configuration.classDiscriminatorMode
+            val classDiscriminator = context.json.configuration.classDiscriminator
 
-                                updatedProperties[classDiscriminator] =
-                                    processClassDiscriminator(context.copy(descriptor = polymorphicDescriptor))
+            // Provide an array of all possible schemas for polymorphic types
+            put(
+                JsonSchemaConsts.Keys.ONE_OF,
+                buildJsonArray {
+                    context.descriptor
+                        .getPolymorphicDescriptors(context.json)
+                        .forEach { polymorphicDescriptor ->
+                            processObject(context.copy(descriptor = polymorphicDescriptor))
 
-                                schema[JsonSchemaConsts.Keys.PROPERTIES] = JsonObject(updatedProperties)
+                            // Modify polymorphic subtypes, if already processed
+                            context.processedTypeDefs[polymorphicDescriptor]?.toMutableMap()?.let { schema ->
+                                // Add class discriminators, if enabled
+                                if (classDiscriminatorMode in listOf(
+                                        ClassDiscriminatorMode.ALL_JSON_OBJECTS,
+                                        ClassDiscriminatorMode.POLYMORPHIC
+                                    )
+                                ) {
+                                    val updatedProperties =
+                                        schema.getValue(JsonSchemaConsts.Keys.PROPERTIES).jsonObject.toMutableMap()
 
-                                schema[JsonSchemaConsts.Keys.REQUIRED] = JsonArray(
-                                    (
-                                        schema.getValue(JsonSchemaConsts.Keys.REQUIRED).jsonArray.toList() +
-                                            JsonPrimitive(classDiscriminator)
-                                        ).distinct()
-                                )
+                                    updatedProperties[classDiscriminator] =
+                                        processClassDiscriminator(context.copy(descriptor = polymorphicDescriptor))
+
+                                    schema[JsonSchemaConsts.Keys.PROPERTIES] = JsonObject(updatedProperties)
+
+                                    schema[JsonSchemaConsts.Keys.REQUIRED] = JsonArray(
+                                        (
+                                                schema.getValue(JsonSchemaConsts.Keys.REQUIRED).jsonArray.toList() +
+                                                        JsonPrimitive(classDiscriminator)
+                                                ).distinct()
+                                    )
+                                }
+
+                                context.processedTypeDefs[polymorphicDescriptor] = JsonObject(schema)
                             }
 
-                            context.processedTypeDefs[polymorphicDescriptor] = JsonObject(schema)
+                            // Add ref to subtype
+                            add(
+                                buildJsonObject {
+                                    put(
+                                        JsonSchemaConsts.Keys.REF,
+                                        "${JsonSchemaConsts.Keys.REF_PREFIX}${polymorphicDescriptor.serialName}"
+                                    )
+                                }
+                            )
                         }
 
-                        // Add ref to subtype
+                    // If this object property is nullable, add additional "null" type
+                    if (context.descriptor.isNullable) {
                         add(
                             buildJsonObject {
-                                put(
-                                    JsonSchemaConsts.Keys.REF,
-                                    "${JsonSchemaConsts.Keys.REF_PREFIX}${polymorphicDescriptor.serialName}"
-                                )
+                                put(JsonSchemaConsts.Keys.TYPE, JsonPrimitive(JsonSchemaConsts.Types.NULL))
                             }
                         )
                     }
-
-                // If this object property is nullable, add additional "null" type
-                if (context.descriptor.isNullable) {
-                    add(
-                        buildJsonObject {
-                            put(JsonSchemaConsts.Keys.TYPE, JsonPrimitive(JsonSchemaConsts.Types.NULL))
-                        }
-                    )
                 }
-            }
-        )
+            )
 
-        // Add description for this property
-        putDescription(context.currentDescription)
+            // Add description for this property
+            putDescription(context.currentDescription)
+        }
     }
 
     override fun processClassDiscriminator(context: GenerationContext): JsonObject = buildJsonObject {
         put(JsonSchemaConsts.Keys.CONST, context.descriptor.serialName)
     }
+
+    private fun processJsonElement(context: GenerationContext): JsonObject {
+        return if (context.descriptor.isNullable) {
+            buildJsonObject {
+                put(
+                    JsonSchemaConsts.Keys.ONE_OF,
+                    buildJsonArray {
+                        add(buildJsonObject { /* empty schema for "any type" */ })
+                        add(buildJsonObject { put(JsonSchemaConsts.Keys.TYPE, JsonSchemaConsts.Types.NULL) })
+                    }
+                )
+                putDescription(context.currentDescription)
+            }
+        } else {
+            buildJsonObject {
+                putDescription(context.currentDescription)
+            }
+        }
+    }
 }
+
+private val JSON_ELEMENT_SERIAL_NAME = serializer<JsonElement>().descriptor.serialName

--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/generator/StandardJsonSchemaGenerator.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/generator/StandardJsonSchemaGenerator.kt
@@ -2,13 +2,11 @@ package ai.koog.prompt.structure.json.generator
 
 import ai.koog.prompt.params.LLMParams
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.descriptors.PolymorphicKind
 import kotlinx.serialization.descriptors.StructureKind
 import kotlinx.serialization.json.ClassDiscriminatorMode
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
@@ -16,7 +14,6 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
-import kotlinx.serialization.serializer
 
 /**
  * Full implementation of [GenericJsonSchemaGenerator] to generate advanced generic [LLMParams.Schema.JSON.Standard].
@@ -198,85 +195,77 @@ public open class StandardJsonSchemaGenerator : GenericJsonSchemaGenerator() {
         putDescription(context.currentDescription)
     }
 
-    override fun processPolymorphic(context: GenerationContext): JsonObject {
-        // Check for the special case of JsonElement. Its descriptor doesn't follow the
-        // standard polymorphic pattern and must be handled separately.
-        if (context.descriptor.serialName in JSON_ELEMENT_SERIAL_NAMES) {
-            return processJsonElement(context)
-        }
+    override fun processPolymorphic(context: GenerationContext): JsonObject = buildJsonObject {
+        val classDiscriminatorMode = context.json.configuration.classDiscriminatorMode
+        val classDiscriminator = context.json.configuration.classDiscriminator
 
-        return buildJsonObject {
-            val classDiscriminatorMode = context.json.configuration.classDiscriminatorMode
-            val classDiscriminator = context.json.configuration.classDiscriminator
+        // Provide an array of all possible schemas for polymorphic types
+        put(
+            JsonSchemaConsts.Keys.ONE_OF,
+            buildJsonArray {
+                context.descriptor
+                    .getPolymorphicDescriptors(context.json)
+                    .forEach { polymorphicDescriptor ->
+                        processObject(context.copy(descriptor = polymorphicDescriptor))
 
-            // Provide an array of all possible schemas for polymorphic types
-            put(
-                JsonSchemaConsts.Keys.ONE_OF,
-                buildJsonArray {
-                    context.descriptor
-                        .getPolymorphicDescriptors(context.json)
-                        .forEach { polymorphicDescriptor ->
-                            processObject(context.copy(descriptor = polymorphicDescriptor))
+                        // Modify polymorphic subtypes, if already processed
+                        context.processedTypeDefs[polymorphicDescriptor]?.toMutableMap()?.let { schema ->
+                            // Add class discriminators, if enabled
+                            if (classDiscriminatorMode in listOf(
+                                    ClassDiscriminatorMode.ALL_JSON_OBJECTS,
+                                    ClassDiscriminatorMode.POLYMORPHIC
+                                )
+                            ) {
+                                val updatedProperties =
+                                    schema.getValue(JsonSchemaConsts.Keys.PROPERTIES).jsonObject.toMutableMap()
 
-                            // Modify polymorphic subtypes, if already processed
-                            context.processedTypeDefs[polymorphicDescriptor]?.toMutableMap()?.let { schema ->
-                                // Add class discriminators, if enabled
-                                if (classDiscriminatorMode in listOf(
-                                        ClassDiscriminatorMode.ALL_JSON_OBJECTS,
-                                        ClassDiscriminatorMode.POLYMORPHIC
-                                    )
-                                ) {
-                                    val updatedProperties =
-                                        schema.getValue(JsonSchemaConsts.Keys.PROPERTIES).jsonObject.toMutableMap()
+                                updatedProperties[classDiscriminator] =
+                                    processClassDiscriminator(context.copy(descriptor = polymorphicDescriptor))
 
-                                    updatedProperties[classDiscriminator] =
-                                        processClassDiscriminator(context.copy(descriptor = polymorphicDescriptor))
+                                schema[JsonSchemaConsts.Keys.PROPERTIES] = JsonObject(updatedProperties)
 
-                                    schema[JsonSchemaConsts.Keys.PROPERTIES] = JsonObject(updatedProperties)
-
-                                    schema[JsonSchemaConsts.Keys.REQUIRED] = JsonArray(
-                                        (
-                                            schema.getValue(JsonSchemaConsts.Keys.REQUIRED).jsonArray.toList() +
-                                                JsonPrimitive(classDiscriminator)
-                                            ).distinct()
-                                    )
-                                }
-
-                                context.processedTypeDefs[polymorphicDescriptor] = JsonObject(schema)
+                                schema[JsonSchemaConsts.Keys.REQUIRED] = JsonArray(
+                                    (
+                                        schema.getValue(JsonSchemaConsts.Keys.REQUIRED).jsonArray.toList() +
+                                            JsonPrimitive(classDiscriminator)
+                                        ).distinct()
+                                )
                             }
 
-                            // Add ref to subtype
-                            add(
-                                buildJsonObject {
-                                    put(
-                                        JsonSchemaConsts.Keys.REF,
-                                        "${JsonSchemaConsts.Keys.REF_PREFIX}${polymorphicDescriptor.serialName}"
-                                    )
-                                }
-                            )
+                            context.processedTypeDefs[polymorphicDescriptor] = JsonObject(schema)
                         }
 
-                    // If this object property is nullable, add additional "null" type
-                    if (context.descriptor.isNullable) {
+                        // Add ref to subtype
                         add(
                             buildJsonObject {
-                                put(JsonSchemaConsts.Keys.TYPE, JsonPrimitive(JsonSchemaConsts.Types.NULL))
+                                put(
+                                    JsonSchemaConsts.Keys.REF,
+                                    "${JsonSchemaConsts.Keys.REF_PREFIX}${polymorphicDescriptor.serialName}"
+                                )
                             }
                         )
                     }
-                }
-            )
 
-            // Add description for this property
-            putDescription(context.currentDescription)
-        }
+                // If this object property is nullable, add additional "null" type
+                if (context.descriptor.isNullable) {
+                    add(
+                        buildJsonObject {
+                            put(JsonSchemaConsts.Keys.TYPE, JsonPrimitive(JsonSchemaConsts.Types.NULL))
+                        }
+                    )
+                }
+            }
+        )
+
+        // Add description for this property
+        putDescription(context.currentDescription)
     }
 
     override fun processClassDiscriminator(context: GenerationContext): JsonObject = buildJsonObject {
         put(JsonSchemaConsts.Keys.CONST, context.descriptor.serialName)
     }
 
-    private fun processJsonElement(context: GenerationContext): JsonObject {
+    override fun processJsonElement(context: GenerationContext): JsonObject {
         return if (context.descriptor.isNullable) {
             buildJsonObject {
                 put(
@@ -290,16 +279,9 @@ public open class StandardJsonSchemaGenerator : GenericJsonSchemaGenerator() {
             }
         } else {
             buildJsonObject {
+                // Empty object represents "any type" in JSON schema
                 putDescription(context.currentDescription)
             }
         }
     }
-}
-
-private val JSON_ELEMENT_SERIAL_NAMES: Set<String> by lazy {
-    val elementSerializer = serializer<JsonElement>()
-    setOf(
-        elementSerializer.descriptor.serialName,
-        elementSerializer.nullable.descriptor.serialName
-    )
 }

--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/generator/StandardJsonSchemaGenerator.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/generator/StandardJsonSchemaGenerator.kt
@@ -198,7 +198,6 @@ public open class StandardJsonSchemaGenerator : GenericJsonSchemaGenerator() {
     }
 
     override fun processPolymorphic(context: GenerationContext): JsonObject {
-
         // Check for the special case of JsonElement. Its descriptor doesn't follow the
         // standard polymorphic pattern and must be handled separately.
         if (context.descriptor.serialName == JSON_ELEMENT_SERIAL_NAME) {
@@ -236,9 +235,9 @@ public open class StandardJsonSchemaGenerator : GenericJsonSchemaGenerator() {
 
                                     schema[JsonSchemaConsts.Keys.REQUIRED] = JsonArray(
                                         (
-                                                schema.getValue(JsonSchemaConsts.Keys.REQUIRED).jsonArray.toList() +
-                                                        JsonPrimitive(classDiscriminator)
-                                                ).distinct()
+                                            schema.getValue(JsonSchemaConsts.Keys.REQUIRED).jsonArray.toList() +
+                                                JsonPrimitive(classDiscriminator)
+                                            ).distinct()
                                     )
                                 }
 

--- a/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/StructureFixingParserTest.kt
+++ b/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/StructureFixingParserTest.kt
@@ -6,15 +6,25 @@ import ai.koog.prompt.structure.json.JsonStructure
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class StructureFixingParserTest {
     @Serializable
     private data class TestData(
         val a: String,
         val b: Int,
+    )
+
+    @Serializable
+    private data class DataWithWildcard(
+        val id: String,
+        val payload: JsonElement
     )
 
     private val testData = TestData("test", 42)
@@ -74,5 +84,47 @@ class StructureFixingParserTest {
         assertFailsWith<LLMStructuredParsingError> {
             parser.parse(mockExecutor, testStructure, invalidContent)
         }
+    }
+
+    @Test
+    fun testFixInvalidJsonElementContent() = runTest {
+        val parser = StructureFixingParser(
+            model = OpenAIModels.CostOptimized.GPT4oMini,
+            retries = 2,
+        )
+
+        val structure = JsonStructure.create<DataWithWildcard>()
+
+        val invalidContent = """
+            {
+                "id": "test-id",
+                "payload": { 
+                    unquotedKey: "someValue",
+                    brokenArray: [1, 2 
+                }
+            }
+        """.trimIndent()
+
+        val fixedContent = """
+            {
+                "id": "test-id",
+                "payload": { 
+                    "unquotedKey": "someValue",
+                    "brokenArray": [1, 2] 
+                }
+            }
+        """.trimIndent()
+
+        val mockExecutor = getMockExecutor {
+            mockLLMAnswer(fixedContent) onRequestContains "unquotedKey"
+        }
+
+        val result = parser.parse(mockExecutor, structure, invalidContent)
+
+        assertEquals("test-id", result.id)
+        assertTrue(result.payload is JsonObject)
+
+        val payloadObj = result.payload
+        assertEquals(JsonPrimitive("someValue"), payloadObj["unquotedKey"])
     }
 }

--- a/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/StructureFixingParserTest.kt
+++ b/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/StructureFixingParserTest.kt
@@ -89,7 +89,7 @@ class StructureFixingParserTest {
     @Test
     fun testFixInvalidJsonElementContent() = runTest {
         val parser = StructureFixingParser(
-            model = OpenAIModels.CostOptimized.GPT4oMini,
+            model = OpenAIModels.Chat.GPT4oMini,
             retries = 2,
         )
 


### PR DESCRIPTION
Related to: [KG-549](https://youtrack.jetbrains.com/issue/KG-549)

## Motivation and Context
The `StandardJsonSchemaGenerator` fails with an `IllegalArgumentException` when attempting to generate a schema for any serializable class containing a `JsonElement` property.

This occurs because the `processPolymorphic` method relies on an internal structural assumption about `kotlinx.serialization`. For a typical user-defined `sealed class`, the library generates a wrapper object in JSON containing a discriminator (e.g., `"type": "SubclassName"`) and a content field (e.g., `"value": {...}`).

The `SerialDescriptor` for such a class mirrors this structure, presenting its elements as a `(type, value)` pair. The generator's current implementation hardcodes a check for this second `"value"` element to find the subtype definitions.

However, `JsonElement` is a special-cased, primitive polymorphic type. It is not serialized within a wrapper; it serializes directly to its raw JSON representation. Consequently, its `SerialDescriptor` does not have the `(type, value)` structure. Instead, its elements are a direct list of its possible subtypes (`JsonObject`, `JsonArray`, etc.). This structural mismatch causes the generator's hardcoded check to fail, resulting in the `IllegalArgumentException`.

This change introduces a special case to detect `JsonElement` and generates a permissive, empty schema (`{}`), which is the correct JSON Schema representation for "any valid JSON value". The fix is implemented in a type-safe manner and correctly handles both nullable (`JsonElement?`) and non-nullable properties.

## Breaking Changes
None. This is a non-breaking bug fix that enables previously unsupported functionality.

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [x] The change was discussed and approved in the issue
- [ ] Docs have been added / updated