### PR TITLE
Add Bedrock support in Ktor for configuring and initializing Bedrock LLM clients.

### DIFF
--- a/koog-ktor/src/jvmMain/kotlin/ai/koog/ktor/BedrockConfig.kt
+++ b/koog-ktor/src/jvmMain/kotlin/ai/koog/ktor/BedrockConfig.kt
@@ -1,0 +1,75 @@
+package ai.koog.ktor
+
+import ai.koog.prompt.executor.clients.LLMClient
+import ai.koog.prompt.executor.clients.bedrock.BedrockGuardrailsSettings
+import ai.koog.prompt.executor.clients.bedrock.BedrockLLMClient
+import ai.koog.prompt.executor.clients.bedrock.StaticBearerTokenProvider
+import ai.koog.prompt.llm.LLMProvider
+import aws.sdk.kotlin.services.bedrockruntime.BedrockRuntimeClient
+import kotlinx.datetime.Clock
+
+/**
+ * Configuration to create a new Bedrock LLM client configured with the specified identity provider and settings.
+ */
+public class BedrockClientConfig {
+
+    /**
+     * Configure the underlying BedrockRuntimeClient from the AWS SDK.
+     */
+    public var configure: BedrockRuntimeClient.Config.Builder.() -> Unit = {}
+
+    /**
+     * Set moderation guardrails settings for Bedrock.
+     */
+    public var moderationGuardrailsSettings: BedrockGuardrailsSettings? = null
+
+    /**
+     * Override the clock used for time-based operations.
+     */
+    public var clock: Clock = Clock.System
+}
+
+/**
+ * Configures and initializes a Bedrock LLM client with optional configuration.
+ *
+ * @param apiKey The API key used for authenticating with the Bedrock API.
+ * @param clock A clock used for time-based operations
+ * @param moderationGuardrailsSettings Optional settings of the AWS bedrock Guardrails (see [AWS documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-use-independent-api.html) ) that would be used for the [LLMClient.moderate] request
+ * @param configure A lambda receiver to customize the OpenAI configuration such as base URL, timeout settings, and paths.
+ */
+public fun KoogAgentsConfig.bedrock(
+    apiKey: String,
+    clock: Clock = Clock.System,
+    moderationGuardrailsSettings: BedrockGuardrailsSettings? = null,
+    configure: BedrockRuntimeClient.Config.Builder.() -> Unit = {}
+) {
+    val client = BedrockRuntimeClient {
+        configure()
+        bearerTokenProvider = StaticBearerTokenProvider(apiKey)
+    }
+    addLLMClient(
+        LLMProvider.Bedrock,
+        BedrockLLMClient(client, moderationGuardrailsSettings, clock)
+    )
+}
+
+/**
+ * Configures and initializes a Bedrock LLM client with AWS SDK builder
+ *
+ * @param clock A clock used for time-based operations
+ * @param moderationGuardrailsSettings Optional settings of the AWS bedrock Guardrails (see [AWS documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-use-independent-api.html) ) that would be used for the [LLMClient.moderate] request
+ * @param configure A lambda receiver to customize the OpenAI configuration such as base URL, timeout settings, and paths.
+ */
+public fun KoogAgentsConfig.bedrock(
+    clock: Clock = Clock.System,
+    moderationGuardrailsSettings: BedrockGuardrailsSettings? = null,
+    configure: BedrockRuntimeClient.Config.Builder.() -> Unit
+) {
+    val client = BedrockRuntimeClient {
+        configure()
+    }
+    addLLMClient(
+        LLMProvider.Bedrock,
+        BedrockLLMClient(client, moderationGuardrailsSettings, clock)
+    )
+}


### PR DESCRIPTION
Fixes https://github.com/JetBrains/koog/issues/803

## Motivation and Context

Adds missing support for Amazon Bedrock in Ktor integration

## Breaking Changes

No

---

#### Type of the changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [x] Docs have been added / updated
