### PR TITLE
KG-185 Validate name and description in ToolDescriptor

### DIFF
--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/FunctionalAIAgentTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/FunctionalAIAgentTest.kt
@@ -183,6 +183,7 @@ class FunctionalAIAgentTest {
     )
 
     @Serializable
+    @LLMDescription("Architecture")
     data class Architecture(
         val name: String,
         val schema: SchemaDescriptor,
@@ -196,6 +197,7 @@ class FunctionalAIAgentTest {
     enum class ComponentStatus { DESIGNED, BUILT, TESTED, QUALIFIED }
 
     @Serializable
+    @LLMDescription("Engine")
     data class Engine(
         val name: String,
         val model: String = "X-1",
@@ -208,6 +210,7 @@ class FunctionalAIAgentTest {
     )
 
     @Serializable
+    @LLMDescription("Body")
     data class Body(
         val name: String,
         val hullMaterial: Material = Material.ALUMINUM_LITHIUM,
@@ -237,6 +240,7 @@ class FunctionalAIAgentTest {
     }
 
     @Serializable
+    @LLMDescription("Spacecraft")
     data class Spacecraft(
         val engine: Engine,
         val body: Body,
@@ -254,6 +258,7 @@ class FunctionalAIAgentTest {
     }
 
     @Serializable
+    @LLMDescription("FullQAReport")
     data class FullQAReport(
         @property:LLMDescription("The report for the engine component.")
         val engineReport: QAReport,
@@ -266,6 +271,7 @@ class FunctionalAIAgentTest {
     }
 
     @Serializable
+    @LLMDescription("SimpleOut")
     data class SimpleOut(val value: String)
 
     object QATools {

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolDescriptors.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolDescriptors.kt
@@ -8,17 +8,23 @@ import kotlin.enums.EnumEntries
  *
  * This class is annotated with @Serializable to support serialization/deserialization using kotlinx.serialization.
  *
- * @property name The name of the tool.
- * @property description The description of the tool.
+ * @property name The name of the tool. Must not be blank.
+ * @property description The description of the tool. Must not be blank.
  * @property requiredParameters A list of ToolParameterDescriptor representing the required parameters for the tool.
  * @property optionalParameters A list of ToolParameterDescriptor representing the optional parameters for the tool.
+ * @throws IllegalArgumentException if [name] or [description] is blank.
  */
 public data class ToolDescriptor(
     val name: String,
     val description: String,
     val requiredParameters: List<ToolParameterDescriptor> = emptyList(),
     val optionalParameters: List<ToolParameterDescriptor> = emptyList(),
-)
+) {
+    init {
+        require(name.isNotBlank()) { "Tool name cannot be blank." }
+        require(description.isNotBlank()) { "Tool description cannot be blank." }
+    }
+}
 
 /**
  * Represents a descriptor for a tool parameter.

--- a/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/SerialToToolDescriptionTest.kt
+++ b/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/SerialToToolDescriptionTest.kt
@@ -34,12 +34,15 @@ class SerialToToolDescriptionTest {
     )
 
     @Serializable
+    @LLMDescription("Color value")
     enum class Color { RED, GREEN, BLUE }
 
     @Serializable
+    @LLMDescription("Singleton")
     object Singleton
 
     @Serializable
+    @LLMDescription("Holder")
     data class FreeFormHolder(
         // contextual => free-form property mapping
         @Contextual val meta: Any? = null
@@ -57,47 +60,47 @@ class SerialToToolDescriptionTest {
 
         // String
         assertValueParam(
-            descriptor = String.serializer().descriptor.asToolDescriptor("str"),
+            descriptor = String.serializer().descriptor.asToolDescriptor("str", toolDescription = "str"),
             expectedType = ToolParameterType.String
         )
 
         // Char -> String
         assertValueParam(
-            descriptor = Char.serializer().descriptor.asToolDescriptor("char"),
+            descriptor = Char.serializer().descriptor.asToolDescriptor("char", toolDescription = "char"),
             expectedType = ToolParameterType.String
         )
 
         // Boolean
         assertValueParam(
-            descriptor = Boolean.serializer().descriptor.asToolDescriptor("bool"),
+            descriptor = Boolean.serializer().descriptor.asToolDescriptor("bool", toolDescription = "bool"),
             expectedType = ToolParameterType.Boolean
         )
 
         // Integer family
         assertValueParam(
-            descriptor = Int.serializer().descriptor.asToolDescriptor("int"),
+            descriptor = Int.serializer().descriptor.asToolDescriptor("int", toolDescription = "int"),
             expectedType = ToolParameterType.Integer
         )
         assertValueParam(
-            descriptor = Long.serializer().descriptor.asToolDescriptor("long"),
+            descriptor = Long.serializer().descriptor.asToolDescriptor("long", toolDescription = "long"),
             expectedType = ToolParameterType.Integer
         )
         assertValueParam(
-            descriptor = Short.serializer().descriptor.asToolDescriptor("short"),
+            descriptor = Short.serializer().descriptor.asToolDescriptor("short", toolDescription = "short"),
             expectedType = ToolParameterType.Integer
         )
         assertValueParam(
-            descriptor = Byte.serializer().descriptor.asToolDescriptor("byte"),
+            descriptor = Byte.serializer().descriptor.asToolDescriptor("byte", toolDescription = "byte"),
             expectedType = ToolParameterType.Integer
         )
 
         // Float family
         assertValueParam(
-            descriptor = Float.serializer().descriptor.asToolDescriptor("float"),
+            descriptor = Float.serializer().descriptor.asToolDescriptor("float", toolDescription = "float"),
             expectedType = ToolParameterType.Float
         )
         assertValueParam(
-            descriptor = Double.serializer().descriptor.asToolDescriptor("double"),
+            descriptor = Double.serializer().descriptor.asToolDescriptor("double", toolDescription = "double"),
             expectedType = ToolParameterType.Float
         )
     }
@@ -105,13 +108,16 @@ class SerialToToolDescriptionTest {
     @Test
     fun list_and_nested_list_mappings() {
         // List<Int>
-        val listOfInt = ListSerializer(Int.serializer()).descriptor.asToolDescriptor("ints")
+        val listOfInt = ListSerializer(Int.serializer()).descriptor.asToolDescriptor("ints", toolDescription = "ints")
         val listType = listOfInt.requiredParameters.single().type
         assertIs<ToolParameterType.List>(listType)
         assertEquals(ToolParameterType.Integer, (listType as ToolParameterType.List).itemsType)
 
         // List<List<String>>
-        val nested = ListSerializer(ListSerializer(String.serializer())).descriptor.asToolDescriptor("nested")
+        val nested = ListSerializer(ListSerializer(String.serializer())).descriptor.asToolDescriptor(
+            "nested",
+            toolDescription = "nested"
+        )
         val nestedType = nested.requiredParameters.single().type
         val outer = assertIs<ToolParameterType.List>(nestedType)
         val inner = assertIs<ToolParameterType.List>(outer.itemsType)
@@ -160,15 +166,17 @@ class SerialToToolDescriptionTest {
         // Object
         val objectDesc = Singleton.serializer().descriptor.asToolDescriptor("singleton")
         assertEquals("singleton", objectDesc.name)
-        // description is empty since Singleton has no LLMDescription
-        assertEquals("", objectDesc.description)
+        assertEquals("Singleton", objectDesc.description)
         assertTrue(objectDesc.requiredParameters.isEmpty())
         assertTrue(objectDesc.optionalParameters.isEmpty())
 
         // Map
-        val mapDesc = MapSerializer(String.serializer(), Int.serializer()).descriptor.asToolDescriptor("map")
+        val mapDesc = MapSerializer(String.serializer(), Int.serializer()).descriptor.asToolDescriptor(
+            "map",
+            toolDescription = "map"
+        )
         assertEquals("map", mapDesc.name)
-        assertEquals("", mapDesc.description)
+        assertEquals("map", mapDesc.description)
         assertTrue(mapDesc.requiredParameters.isEmpty())
         assertTrue(mapDesc.optionalParameters.isEmpty())
     }

--- a/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/ToolDescriptorTest.kt
+++ b/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/ToolDescriptorTest.kt
@@ -1,0 +1,24 @@
+package ai.koog.agents.core.tools
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class ToolDescriptorValidationTest {
+
+    @Test
+    fun `creating ToolDescriptor with empty name throws IllegalArgumentException`() {
+        val exception = assertFailsWith<IllegalArgumentException> {
+            ToolDescriptor(name = "", description = "A valid description")
+        }
+        assertEquals("Tool name cannot be blank.", exception.message)
+    }
+
+    @Test
+    fun `creating ToolDescriptor with empty description throws IllegalArgumentException`() {
+        val exception = assertFailsWith<IllegalArgumentException> {
+            ToolDescriptor(name = "a_valid_name", description = "")
+        }
+        assertEquals("Tool description cannot be blank.", exception.message)
+    }
+}


### PR DESCRIPTION
Related to: [KG-185](https://youtrack.jetbrains.com/issue/KG-185)

## Motivation and Context
This change addresses an issue where `ToolDescriptor` could be instantiated with an empty `description`. 

Following the discussion in the original issue, this PR introduces validation directly into the `ToolDescriptor` constructor to enforce the "fail-fast" principle. Now, any attempt to create a tool with a blank name or description will immediately throw an `IllegalArgumentException`, providing clear and early feedback to the developer.

This fix also includes updated KDoc to reflect the new constructor behavior and adds a new, focused test class (`ToolDescriptorValidationTest.kt`) to verify the validation logic.

## Breaking Changes
Yes, this is a breaking change.

Code that previously created `ToolDescriptor` instances with an empty or blank `description` will now throw an `IllegalArgumentException` upon object creation. While the likelihood of developers intentionally providing empty descriptions is low, any such existing code will now fail at runtime. 

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [x] The change was discussed and approved in the issue
- [x] Docs have been added / updated