### PR TITLE
KG-565 Cover missing OpenAIResponsesAPI fields/methods

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIChatParamsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIChatParamsTest.kt
@@ -8,14 +8,14 @@ import ai.koog.prompt.executor.clients.openai.base.models.OpenAIWebSearchOptions
 import ai.koog.prompt.executor.clients.openai.base.models.ReasoningEffort
 import ai.koog.prompt.executor.clients.openai.base.models.ServiceTier
 import ai.koog.prompt.params.LLMParams
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import kotlin.test.assertEquals
 
 class OpenAIChatParamsTest {
 
@@ -29,7 +29,9 @@ class OpenAIChatParamsTest {
     @ValueSource(doubles = [-0.1, 1.1])
     fun `OpenAIChatParams invalid topP`(value: Double) {
         val expected = if (value < 0) "TopP must be positive" else "TopP must be <= 1"
-        assertThrows<IllegalArgumentException>(expected) { OpenAIChatParams(topP = value) }
+        shouldThrow<IllegalArgumentException> {
+            OpenAIChatParams(topP = value)
+        }.message shouldBe expected
     }
 
     @Test
@@ -41,7 +43,7 @@ class OpenAIChatParamsTest {
 
     @Test
     fun `OpenAIChatParams topLogprobs requires logprobs=true`() {
-        assertThrows<IllegalArgumentException> {
+        shouldThrow<IllegalArgumentException> {
             OpenAIChatParams(
                 logprobs = false,
                 topLogprobs = 1
@@ -52,12 +54,12 @@ class OpenAIChatParamsTest {
     @ParameterizedTest
     @ValueSource(ints = [-1, 21])
     fun `OpenAIChatParams invalid topLogprobs values when logprobs=true`(value: Int) {
-        assertThrows<IllegalArgumentException>("Chat: `topLogprobs` must be in [0, 20]") {
+        shouldThrow<IllegalArgumentException> {
             OpenAIChatParams(
                 logprobs = true,
                 topLogprobs = value
             )
-        }
+        }.message shouldBe "`topLogprobs` must be in [0, 20], but was $value"
     }
 
     @Test
@@ -73,36 +75,37 @@ class OpenAIChatParamsTest {
 
         val chat = base.toOpenAIChatParams()
 
-        assertEquals(base.temperature, chat.temperature)
-        assertEquals(base.maxTokens, chat.maxTokens)
-        assertEquals(base.numberOfChoices, chat.numberOfChoices)
-        assertEquals(base.speculation, chat.speculation)
-        assertEquals(base.user, chat.user)
-        assertEquals(base.additionalProperties, chat.additionalProperties)
+        chat.temperature shouldBe base.temperature
+        chat.maxTokens shouldBe base.maxTokens
+        chat.numberOfChoices shouldBe base.numberOfChoices
+        chat.speculation shouldBe base.speculation
+        chat.user shouldBe base.user
+        chat.additionalProperties shouldBe base.additionalProperties
     }
 
     @Test
     fun `temperature and topP are mutually exclusive in Chat`() {
-        assertThrows<IllegalArgumentException>("Chat: temperature and topP are mutually exclusive") {
+        shouldThrow<IllegalArgumentException> {
             OpenAIChatParams(
                 temperature = 0.5,
                 topP = 0.5
             )
-        }
+        }.message shouldBe "temperature and topP are mutually exclusive"
     }
 
     @Test
     fun `non-blank identifiers validated`() {
-        assertThrows<IllegalArgumentException>("Chat: promptCacheKey must be non-blank") {
+        shouldThrow<IllegalArgumentException> {
             OpenAIChatParams(
                 promptCacheKey = " "
             )
-        }
-        assertThrows<IllegalArgumentException>("Chat: safetyIdentifier must be non-blank") {
+        }.message shouldBe "promptCacheKey must be non-blank"
+
+        shouldThrow<IllegalArgumentException> {
             OpenAIChatParams(
                 safetyIdentifier = ""
             )
-        }
+        }.message shouldBe "safetyIdentifier must be non-blank"
 
         OpenAIChatParams(promptCacheKey = "key", safetyIdentifier = "sid")
     }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClientTest.kt
@@ -2,13 +2,13 @@ package ai.koog.prompt.executor.clients.openai
 
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.params.LLMParams
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 import kotlin.reflect.KClass
-import kotlin.test.assertEquals
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OpenAILLMClientTest {
@@ -50,6 +50,6 @@ class OpenAILLMClientTest {
             model = model,
         )
 
-        assertEquals(expectedClass, result::class)
+        result::class shouldBe expectedClass
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIModelsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIModelsTest.kt
@@ -2,8 +2,8 @@ package ai.koog.prompt.executor.clients.openai
 
 import ai.koog.prompt.executor.clients.list
 import ai.koog.prompt.llm.LLMProvider
+import io.kotest.matchers.shouldBe
 import kotlin.test.Test
-import kotlin.test.assertSame
 
 class OpenAIModelsTest {
 
@@ -12,11 +12,7 @@ class OpenAIModelsTest {
         val models = OpenAIModels.list()
 
         models.forEach { model ->
-            assertSame(
-                expected = LLMProvider.OpenAI,
-                actual = model.provider,
-                message = "OpenAI model ${model.id} doesn't have OpenAI provider but ${model.provider}."
-            )
+            model.provider shouldBe LLMProvider.OpenAI
         }
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIResponsesParamsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIResponsesParamsTest.kt
@@ -7,43 +7,43 @@ import ai.koog.prompt.executor.clients.openai.models.ReasoningConfig
 import ai.koog.prompt.executor.clients.openai.models.ReasoningSummary
 import ai.koog.prompt.executor.clients.openai.models.Truncation
 import ai.koog.prompt.params.LLMParams
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.NullSource
 import org.junit.jupiter.params.provider.ValueSource
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
 class OpenAIResponsesParamsTest {
 
     @ParameterizedTest
     @ValueSource(doubles = [0.1, 1.0])
     fun `OpenAIResponsesParams topP bounds`(value: Double) {
-        assertNotNull(OpenAIResponsesParams(topP = value))
+        OpenAIResponsesParams(topP = value).shouldNotBeNull()
     }
 
     @ParameterizedTest
     @ValueSource(doubles = [-0.1, 1.1])
     fun `OpenAIResponsesParams invalid topP`(value: Double) {
-        assertThrows<IllegalArgumentException>("Responses: topP must be in (0.0, 1.0]") {
+        shouldThrow<IllegalArgumentException> {
             OpenAIResponsesParams(topP = value)
-        }
+        }.message shouldBe "topP must be in (0.0, 1.0], but was $value"
     }
 
     @ParameterizedTest
     @NullSource
     @ValueSource(booleans = [false])
     fun `OpenAIResponsesParams topLogprobs requires logprobs=true`(logprobsValue: Boolean?) {
-        assertThrows<IllegalArgumentException>("Responses: `topLogprobs` requires `logprobs=true`.") {
+        shouldThrow<IllegalArgumentException> {
             OpenAIResponsesParams(
                 logprobs = logprobsValue,
                 topLogprobs = 1
             )
-        }
+        }.message shouldBe "`topLogprobs` requires `logprobs=true`."
     }
 
     @ParameterizedTest
@@ -56,12 +56,12 @@ class OpenAIResponsesParamsTest {
     @ParameterizedTest
     @ValueSource(ints = [-1, 21])
     fun `OpenAIResponsesParams invalid topLogprobs values when logprobs=true`(value: Int) {
-        assertThrows<IllegalArgumentException>("Responses: `topLogprobs` must be in [0, 20]") {
+        shouldThrow<IllegalArgumentException> {
             OpenAIResponsesParams(
                 logprobs = true,
                 topLogprobs = value
             )
-        }
+        }.message shouldBe "`topLogprobs` must be in [0, 20], but was $value"
     }
 
     @Test
@@ -74,53 +74,56 @@ class OpenAIResponsesParamsTest {
             user = "user-id",
         )
 
-        val resp = base.toOpenAIResponsesParams()
-
-        assertEquals(base.temperature, resp.temperature)
-        assertEquals(base.maxTokens, resp.maxTokens)
-        assertEquals(base.numberOfChoices, resp.numberOfChoices)
-        assertEquals(base.speculation, resp.speculation)
-        assertEquals(base.user, resp.user)
-        assertEquals(base.additionalProperties, resp.additionalProperties)
+        base.toOpenAIResponsesParams().shouldNotBeNull {
+            temperature shouldBe base.temperature
+            maxTokens shouldBe base.maxTokens
+            numberOfChoices shouldBe base.numberOfChoices
+            speculation shouldBe base.speculation
+            user shouldBe base.user
+            additionalProperties shouldBe base.additionalProperties
+        }
     }
 
     @Test
     fun `temperature and topP are mutually exclusive in Responses`() {
-        assertThrows<IllegalArgumentException>("Responses: temperature and topP are mutually exclusive") {
+        shouldThrow<IllegalArgumentException> {
             OpenAIResponsesParams(
                 temperature = 0.5,
                 topP = 0.5
             )
-        }
+        }.message shouldBe "temperature and topP are mutually exclusive"
     }
 
     @Test
     fun `non-blank identifiers validated`() {
-        assertThrows<IllegalArgumentException>("Responses: promptCacheKey must be non-blank") {
+        shouldThrow<IllegalArgumentException> {
             OpenAIResponsesParams(
                 promptCacheKey = " "
             )
-        }
-        assertThrows<IllegalArgumentException>("Responses: safetyIdentifier must be non-blank") {
+        }.message shouldBe "promptCacheKey must be non-blank"
+
+        shouldThrow<IllegalArgumentException> {
             OpenAIResponsesParams(
                 safetyIdentifier = ""
             )
-        }
+        }.message shouldBe "safetyIdentifier must be non-blank"
+
         OpenAIChatParams(promptCacheKey = "key", safetyIdentifier = "sid")
     }
 
     @Test
     fun `responses include and maxToolCalls validations`() {
-        assertThrows<IllegalArgumentException>("Responses: include must not be empty when provided.") {
+        shouldThrow<IllegalArgumentException> {
             OpenAIResponsesParams(
                 include = emptyList()
             )
-        }
-        assertThrows<IllegalArgumentException>("Responses: maxToolCalls must be >= 0") {
+        }.message shouldBe "include must not be empty when provided."
+
+        shouldThrow<IllegalArgumentException> {
             OpenAIResponsesParams(
                 maxToolCalls = -1
             )
-        }
+        }.message shouldBe "maxToolCalls must be >= 0"
     }
 
     @Test

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIResponsesParamsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIResponsesParamsTest.kt
@@ -7,6 +7,7 @@ import ai.koog.prompt.executor.clients.openai.models.ReasoningConfig
 import ai.koog.prompt.executor.clients.openai.models.ReasoningSummary
 import ai.koog.prompt.executor.clients.openai.models.Truncation
 import ai.koog.prompt.params.LLMParams
+import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.equality.shouldBeEqualToComparingFields
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -75,12 +76,14 @@ class OpenAIResponsesParamsTest {
         )
 
         base.toOpenAIResponsesParams().shouldNotBeNull {
-            temperature shouldBe base.temperature
-            maxTokens shouldBe base.maxTokens
-            numberOfChoices shouldBe base.numberOfChoices
-            speculation shouldBe base.speculation
-            user shouldBe base.user
-            additionalProperties shouldBe base.additionalProperties
+            assertSoftly {
+                temperature shouldBe base.temperature
+                maxTokens shouldBe base.maxTokens
+                numberOfChoices shouldBe base.numberOfChoices
+                speculation shouldBe base.speculation
+                user shouldBe base.user
+                additionalProperties shouldBe base.additionalProperties
+            }
         }
     }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIChatCompletionRequestSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIChatCompletionRequestSerializationTest.kt
@@ -2,7 +2,12 @@ package ai.koog.prompt.executor.clients.openai.models
 
 import ai.koog.prompt.executor.clients.openai.base.models.Content
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIMessage
-import kotlinx.serialization.json.Json
+import ai.koog.test.utils.runWithBothJsonConfigurations
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.addJsonObject
@@ -10,168 +15,146 @@ import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.intOrNull
-import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
-import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
+import kotlin.test.Test
 
 class OpenAIChatCompletionRequestSerializationTest {
 
-    private val json = Json {
-        ignoreUnknownKeys = false
-        explicitNulls = false
-    }
-
     @Test
-    fun `test serialization without additionalProperties`() {
-        val request = OpenAIChatCompletionRequest(
-            model = "gpt-4",
-            messages = listOf(OpenAIMessage.User(content = Content.Text("Hello"))),
-            temperature = 0.7,
-            maxTokens = 1000
-        )
-
-        val jsonElement = json.encodeToJsonElement(OpenAIChatCompletionRequestSerializer, request)
-        val jsonObject = jsonElement.jsonObject
-
-        assertEquals(
-            "gpt-4",
-            jsonObject["model"]?.jsonPrimitive?.contentOrNull
-        )
-        assertEquals(0.7, jsonObject["temperature"]?.jsonPrimitive?.doubleOrNull)
-        assertEquals(1000, jsonObject["maxTokens"]?.jsonPrimitive?.intOrNull)
-        assertNull(jsonObject["customProperty"])
-    }
-
-    @Test
-    fun `test serialization with additionalProperties`() {
-        val additionalProperties = mapOf<String, JsonElement>(
-            "customProperty" to JsonPrimitive("customValue"),
-            "customNumber" to JsonPrimitive(42),
-            "customBoolean" to JsonPrimitive(true)
-        )
-
-        val request = OpenAIChatCompletionRequest(
-            model = "gpt-4",
-            messages = listOf(OpenAIMessage.User(content = Content.Text("Hello"))),
-            temperature = 0.7,
-            additionalProperties = additionalProperties
-        )
-
-        val jsonElement = json.encodeToJsonElement(OpenAIChatCompletionRequestSerializer, request)
-        val jsonObject = jsonElement.jsonObject
-
-        // Standard properties should be present
-        assertEquals("gpt-4", jsonObject["model"]?.jsonPrimitive?.contentOrNull)
-        assertEquals(0.7, jsonObject["temperature"]?.jsonPrimitive?.doubleOrNull)
-
-        // Additional properties should be flattened to root level
-        assertEquals("customValue", jsonObject["customProperty"]?.jsonPrimitive?.contentOrNull)
-        assertEquals(42, jsonObject["customNumber"]?.jsonPrimitive?.intOrNull)
-        assertEquals(true, jsonObject["customBoolean"]?.jsonPrimitive?.booleanOrNull)
-
-        // additionalProperties field itself should not be present in serialized JSON
-        assertNull(jsonObject["additionalProperties"])
-    }
-
-    @Test
-    fun `test deserialization without additional properties`() {
-        val jsonInput = buildJsonObject {
-            put("model", JsonPrimitive("gpt-4"))
-            put(
-                "messages",
-                buildJsonArray {
-                    addJsonObject {
-                        put("role", "user")
-                        put("content", "Hello")
-                    }
-                }
-            )
-            put("temperature", JsonPrimitive(0.7))
-            put("maxTokens", JsonPrimitive(1000))
+    fun `test serialization without additionalProperties`() =
+        runWithBothJsonConfigurations("serialization without additionalProperties") { json ->
+            json.encodeToString(
+                OpenAIChatCompletionRequestSerializer,
+                OpenAIChatCompletionRequest(
+                    model = "gpt-4",
+                    messages = listOf(OpenAIMessage.User(content = Content.Text("Hello"))),
+                    temperature = 0.7,
+                    maxTokens = 1000
+                )
+            ) shouldEqualJson """
+            {
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "temperature": 0.7,
+                "maxTokens": 1000
+            }
+            """.trimIndent()
         }
 
-        val request = json.decodeFromJsonElement(OpenAIChatCompletionRequestSerializer, jsonInput)
-
-        assertEquals("gpt-4", request.model)
-        assertEquals(0.7, request.temperature)
-        assertEquals(1000, request.maxTokens)
-        assertNull(request.additionalProperties)
-    }
-
     @Test
-    fun `test deserialization with additional properties`() {
-        val jsonInput = buildJsonObject {
-            put("model", JsonPrimitive("gpt-4"))
-            put(
-                "messages",
-                buildJsonArray {
-                    addJsonObject {
-                        put("role", "user")
-                        put("content", "Hello")
-                    }
-                }
-            )
-            put("temperature", JsonPrimitive(0.7))
-            put("customProperty", JsonPrimitive("customValue"))
-            put("customNumber", JsonPrimitive(42))
-            put("customBoolean", JsonPrimitive(true))
+    fun `test serialization with additionalProperties`() =
+        runWithBothJsonConfigurations("serialization with additionalProperties") { json ->
+            json.encodeToString(
+                OpenAIChatCompletionRequestSerializer,
+                OpenAIChatCompletionRequest(
+                    model = "gpt-4",
+                    messages = listOf(OpenAIMessage.User(content = Content.Text("Hello"))),
+                    temperature = 0.7,
+                    additionalProperties = mapOf<String, JsonElement>(
+                        "customProperty" to JsonPrimitive("customValue"),
+                        "customNumber" to JsonPrimitive(42),
+                        "customBoolean" to JsonPrimitive(true)
+                    )
+                )
+            ) shouldEqualJson """
+            {
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "temperature": 0.7,
+                "customProperty": "customValue",
+                "customNumber": 42,
+                "customBoolean": true
+            }
+            """.trimIndent()
         }
 
-        val request = json.decodeFromJsonElement(OpenAIChatCompletionRequestSerializer, jsonInput)
+    @Test
+    fun `test deserialization without additional properties`() =
+        runWithBothJsonConfigurations("deserialization without additional properties") { json ->
+            val jsonInput = buildJsonObject {
+                put("model", JsonPrimitive("gpt-4"))
+                put(
+                    "messages",
+                    buildJsonArray {
+                        addJsonObject {
+                            put("role", "user")
+                            put("content", "Hello")
+                        }
+                    }
+                )
+                put("temperature", JsonPrimitive(0.7))
+                put("maxTokens", JsonPrimitive(1000))
+            }
 
-        assertEquals("gpt-4", request.model)
-        assertEquals(0.7, request.temperature)
-
-        assertNotNull(request.additionalProperties)
-        val additionalProps = request.additionalProperties
-        assertEquals(3, additionalProps.size)
-        assertEquals("customValue", additionalProps["customProperty"]?.jsonPrimitive?.contentOrNull)
-        assertEquals(42, additionalProps["customNumber"]?.jsonPrimitive?.intOrNull)
-        assertEquals(true, additionalProps["customBoolean"]?.jsonPrimitive?.booleanOrNull)
-    }
+            json.decodeFromJsonElement(OpenAIChatCompletionRequestSerializer, jsonInput).shouldNotBeNull {
+                model shouldBe "gpt-4"
+                temperature shouldBe 0.7
+                maxTokens shouldBe 1000
+                additionalProperties.shouldBeNull()
+            }
+        }
 
     @Test
-    fun `test round trip serialization with additionalProperties`() {
-        val originalAdditionalProperties = mapOf<String, JsonElement>(
-            "customProperty" to JsonPrimitive("customValue"),
-            "customNumber" to JsonPrimitive(42)
-        )
+    fun `test deserialization with additional properties`() =
+        runWithBothJsonConfigurations("deserialization with additional properties") { json ->
+            val jsonInput = buildJsonObject {
+                put("model", JsonPrimitive("gpt-4"))
+                put(
+                    "messages",
+                    buildJsonArray {
+                        addJsonObject {
+                            put("role", "user")
+                            put("content", "Hello")
+                        }
+                    }
+                )
+                put("temperature", JsonPrimitive(0.7))
+                put("customProperty", JsonPrimitive("customValue"))
+                put("customNumber", JsonPrimitive(42))
+                put("customBoolean", JsonPrimitive(true))
+            }
 
-        val originalRequest = OpenAIChatCompletionRequest(
-            model = "gpt-4",
-            messages = listOf(OpenAIMessage.User(content = Content.Text("Hello"))),
-            temperature = 0.7,
-            additionalProperties = originalAdditionalProperties
-        )
+            json.decodeFromJsonElement(OpenAIChatCompletionRequestSerializer, jsonInput).shouldNotBeNull {
+                model shouldBe "gpt-4"
+                temperature shouldBe 0.7
+                additionalProperties.shouldNotBeNull {
+                    size shouldBe 3
+                    this["customProperty"]?.jsonPrimitive?.contentOrNull shouldBe "customValue"
+                    this["customNumber"]?.jsonPrimitive?.intOrNull shouldBe 42
+                    this["customBoolean"]?.jsonPrimitive?.booleanOrNull shouldBe true
+                }
+            }
+        }
 
-        // Serialize to JSON string
-        val jsonString = json.encodeToString(OpenAIChatCompletionRequestSerializer, originalRequest)
+    @Test
+    fun `test round trip serialization with additionalProperties`() =
+        runWithBothJsonConfigurations("round trip serialization with additionalProperties") { json ->
+            val originalAdditionalProperties = mapOf<String, JsonElement>(
+                "customProperty" to JsonPrimitive("customValue"),
+                "customNumber" to JsonPrimitive(42)
+            )
 
-        // Deserialize back to object
-        val deserializedRequest = json.decodeFromString(OpenAIChatCompletionRequestSerializer, jsonString)
+            val originalRequest = OpenAIChatCompletionRequest(
+                model = "gpt-4",
+                messages = listOf(OpenAIMessage.User(content = Content.Text("Hello"))),
+                temperature = 0.7,
+                additionalProperties = originalAdditionalProperties
+            )
 
-        // Verify standard properties
-        assertEquals(originalRequest.model, deserializedRequest.model)
-        assertEquals(originalRequest.temperature, deserializedRequest.temperature)
-        assertEquals(originalRequest.messages.size, deserializedRequest.messages.size)
-
-        // Verify additional properties were preserved
-        assertNotNull(deserializedRequest.additionalProperties)
-        val deserializedAdditionalProps = deserializedRequest.additionalProperties
-        assertEquals(originalAdditionalProperties.size, deserializedAdditionalProps.size)
-        assertEquals(
-            originalAdditionalProperties["customProperty"]?.jsonPrimitive?.contentOrNull,
-            deserializedAdditionalProps["customProperty"]?.jsonPrimitive?.contentOrNull
-        )
-        assertEquals(
-            originalAdditionalProperties["customNumber"]?.jsonPrimitive?.intOrNull,
-            deserializedAdditionalProps["customNumber"]?.jsonPrimitive?.intOrNull
-        )
-    }
+            json.decodeFromString(
+                OpenAIChatCompletionRequestSerializer,
+                json.encodeToString(OpenAIChatCompletionRequestSerializer, originalRequest)
+            ).shouldNotBeNull {
+                model shouldBe originalRequest.model
+                temperature shouldBe originalRequest.temperature
+                messages shouldHaveSize originalRequest.messages.size
+                additionalProperties.shouldNotBeNull {
+                    size shouldBe originalAdditionalProperties.size
+                    this["customProperty"]?.jsonPrimitive?.contentOrNull shouldBe "customValue"
+                    this["customNumber"]?.jsonPrimitive?.intOrNull shouldBe 42
+                }
+            }
+        }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIContentTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIContentTest.kt
@@ -1,0 +1,371 @@
+package ai.koog.prompt.executor.clients.openai.models
+
+import ai.koog.prompt.executor.clients.openai.base.models.OpenAIChoiceLogProbs
+import ai.koog.test.utils.runWithBothJsonConfigurations
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlin.test.Test
+
+class OpenAIContentTest {
+
+    @Test
+    fun `test InputContent_Text serialization`() =
+        runWithBothJsonConfigurations("InputContent.Text serialization") { json ->
+            json.encodeToString(InputContent.Text("Hello World")) shouldEqualJson """
+            {
+                "text": "Hello World"
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `test InputContent_Text deserialization`() =
+        runWithBothJsonConfigurations("InputContent.Text deserialization") { json ->
+            val jsonInput = buildJsonObject {
+                put("type", JsonPrimitive("input_text"))
+                put("text", JsonPrimitive("Hello World"))
+            }
+
+            (json.decodeFromJsonElement<InputContent>(jsonInput) as InputContent.Text).text shouldBe "Hello World"
+        }
+
+    @Test
+    fun `test InputContent_Image serialization with fileId`() =
+        runWithBothJsonConfigurations("InputContent.Image with fileId") { json ->
+            json.encodeToString(
+                InputContent.Image(
+                    detail = "high",
+                    fileId = "file_123",
+                    imageUrl = null
+                )
+            ) shouldEqualJson """
+            {
+                "detail": "high",
+                "fileId": "file_123"
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `test InputContent_Image serialization with imageUrl`() =
+        runWithBothJsonConfigurations("InputContent.Image with imageUrl") { json ->
+            json.encodeToString(
+                InputContent.Image(
+                    detail = "low",
+                    fileId = null,
+                    imageUrl = "https://example.com/image.png"
+                )
+            ) shouldEqualJson """
+            {
+                "detail": "low",
+                "imageUrl": "https://example.com/image.png"
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `test InputContent_Image deserialization`() =
+        runWithBothJsonConfigurations("InputContent.Image deserialization") { json ->
+            val jsonInput = buildJsonObject {
+                put("type", JsonPrimitive("input_image"))
+                put("detail", JsonPrimitive("auto"))
+                put("fileId", JsonPrimitive("file_456"))
+                put("imageUrl", JsonPrimitive("https://example.com/image.jpg"))
+            }
+
+            (json.decodeFromJsonElement<InputContent>(jsonInput) as InputContent.Image).shouldNotBeNull {
+                detail shouldBe "auto"
+                fileId shouldBe "file_456"
+                imageUrl shouldBe "https://example.com/image.jpg"
+            }
+        }
+
+    @Test
+    fun `test InputContent_File serialization with all fields`() =
+        runWithBothJsonConfigurations("InputContent.File with all fields") { json ->
+            json.encodeToString(
+                InputContent.File(
+                    fileData = "base64data==",
+                    fileId = "file_789",
+                    fileUrl = "https://example.com/file.pdf",
+                    filename = "document.pdf"
+                )
+            ) shouldEqualJson """
+            {
+                "fileData": "base64data==",
+                "fileId": "file_789",
+                "fileUrl": "https://example.com/file.pdf",
+                "filename": "document.pdf"
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `test InputContent_File serialization with minimal fields`() =
+        runWithBothJsonConfigurations("InputContent.File with minimal fields") { json ->
+            json.encodeToString(
+                InputContent.File(
+                    fileId = "file_minimal"
+                )
+            ) shouldEqualJson """
+            {
+                "fileId": "file_minimal"
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `test InputContent_File deserialization`() =
+        runWithBothJsonConfigurations("InputContent.File deserialization") { json ->
+            val jsonInput = buildJsonObject {
+                put("type", JsonPrimitive("input_file"))
+                put("filename", JsonPrimitive("test.txt"))
+                put("fileUrl", JsonPrimitive("https://example.com/test.txt"))
+            }
+
+            (json.decodeFromJsonElement<InputContent>(jsonInput) as InputContent.File).shouldNotBeNull {
+                filename shouldBe "test.txt"
+                fileUrl shouldBe "https://example.com/test.txt"
+                fileId shouldBe null
+                fileData shouldBe null
+            }
+        }
+
+    @Test
+    fun `test OutputContent_Text serialization without logprobs`() =
+        runWithBothJsonConfigurations("OutputContent.Text without logprobs") { json ->
+            json.encodeToString(
+                OutputContent.Text(
+                    annotations = listOf(
+                        OpenAIAnnotations.FileCitation("file_123", "document.pdf", 0)
+                    ),
+                    text = "This is the response text",
+                    logprobs = null
+                )
+            ) shouldEqualJson """
+            {
+                "annotations": [{
+                    "type": "file_citation",
+                    "fileId": "file_123",
+                    "filename": "document.pdf",
+                    "index": 0
+                }],
+                "text": "This is the response text"
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `test OutputContent_Text serialization with logprobs`() =
+        runWithBothJsonConfigurations("OutputContent.Text with logprobs") { json ->
+            val jsonString = json.encodeToString(
+                OutputContent.Text(
+                    annotations = emptyList(),
+                    text = "Hello",
+                    logprobs = listOf(
+                        OpenAIChoiceLogProbs.ContentLogProbs(
+                            token = "Hello",
+                            logprob = -0.5,
+                            bytes = listOf(72, 101, 108, 108, 111),
+                            topLogprobs = listOf(
+                                OpenAIChoiceLogProbs.ContentTopLogProbs(
+                                    token = "Hello",
+                                    logprob = -0.5,
+                                    bytes = listOf(72, 101, 108, 108, 111)
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+
+            json.decodeFromString<OutputContent.Text>(jsonString).shouldNotBeNull {
+                text shouldBe "Hello"
+                logprobs?.shouldHaveSize(1)
+                logprobs?.first()?.token shouldBe "Hello"
+                logprobs?.first()?.logprob shouldBe -0.5
+            }
+        }
+
+    @Test
+    fun `test OutputContent_Text deserialization`() =
+        runWithBothJsonConfigurations("OutputContent.Text deserialization") { json ->
+            val jsonInput = buildJsonObject {
+                put("type", JsonPrimitive("output_text"))
+                put("annotations", buildJsonArray { })
+                put("text", JsonPrimitive("Response text"))
+            }
+
+            (json.decodeFromJsonElement<OutputContent>(jsonInput) as OutputContent.Text).shouldNotBeNull {
+                text shouldBe "Response text"
+                annotations shouldHaveSize 0
+                logprobs shouldBe null
+            }
+        }
+
+    @Test
+    fun `test OutputContent_Refusal serialization`() =
+        runWithBothJsonConfigurations("OutputContent.Refusal serialization") { json ->
+            json.encodeToString(
+                OutputContent.Refusal("I cannot help with that request")
+            ) shouldEqualJson """
+            {
+                "refusal": "I cannot help with that request"
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `test OutputContent_Refusal deserialization`() =
+        runWithBothJsonConfigurations("OutputContent.Refusal deserialization") { json ->
+            val text = "Sorry, I cannot assist with that"
+            val jsonInput = buildJsonObject {
+                put("type", JsonPrimitive("refusal"))
+                put("refusal", JsonPrimitive(text))
+            }
+
+            (json.decodeFromJsonElement<OutputContent>(jsonInput) as OutputContent.Refusal).refusal shouldBe text
+        }
+
+    @Test
+    fun `test OpenAIAnnotations_FileCitation serialization`() =
+        runWithBothJsonConfigurations("OpenAIAnnotations.FileCitation") { json ->
+            json.encodeToString(
+                OpenAIAnnotations.FileCitation(
+                    fileId = "file_123",
+                    filename = "report.pdf",
+                    index = 2
+                )
+            ) shouldEqualJson """
+            {
+                "fileId": "file_123",
+                "filename": "report.pdf",
+                "index": 2
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `test OpenAIAnnotations_UrlCitation serialization`() =
+        runWithBothJsonConfigurations("OpenAIAnnotations.UrlCitation") { json ->
+            json.encodeToString(
+                OpenAIAnnotations.UrlCitation(
+                    endIndex = 50,
+                    startIndex = 10,
+                    title = "Example Article",
+                    url = "https://example.com/article"
+                )
+            ) shouldEqualJson """
+            {
+                "endIndex": 50,
+                "startIndex": 10,
+                "title": "Example Article",
+                "url": "https://example.com/article"
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `test OpenAIAnnotations_ContainerFileCitation serialization`() =
+        runWithBothJsonConfigurations("OpenAIAnnotations.ContainerFileCitation") { json ->
+            json.encodeToString(
+                OpenAIAnnotations.ContainerFileCitation(
+                    containerId = "container_123",
+                    endIndex = 100,
+                    fileId = "file_456",
+                    filename = "data.csv",
+                    startIndex = 20
+                )
+            ) shouldEqualJson """
+            {
+                "containerId": "container_123",
+                "endIndex": 100,
+                "fileId": "file_456",
+                "filename": "data.csv",
+                "startIndex": 20
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `test OpenAIAnnotations_FilePath serialization`() =
+        runWithBothJsonConfigurations("OpenAIAnnotations.FilePath") { json ->
+            json.encodeToString(
+                OpenAIAnnotations.FilePath(
+                    fileId = "file_789",
+                    index = 1
+                )
+            ) shouldEqualJson """
+            {
+                "fileId": "file_789",
+                "index": 1
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `test all OpenAIAnnotations deserialization`() =
+        runWithBothJsonConfigurations("all OpenAIAnnotations deserialization") { json ->
+            val fileCitationJson = buildJsonObject {
+                put("type", JsonPrimitive("file_citation"))
+                put("fileId", JsonPrimitive("file_123"))
+                put("filename", JsonPrimitive("test.pdf"))
+                put("index", JsonPrimitive(0))
+            }
+
+            val urlCitationJson = buildJsonObject {
+                put("type", JsonPrimitive("url_citation"))
+                put("endIndex", JsonPrimitive(50))
+                put("startIndex", JsonPrimitive(10))
+                put("title", JsonPrimitive("Test Article"))
+                put("url", JsonPrimitive("https://test.com"))
+            }
+
+            val containerCitationJson = buildJsonObject {
+                put("type", JsonPrimitive("container_file_citation"))
+                put("containerId", JsonPrimitive("container_456"))
+                put("endIndex", JsonPrimitive(75))
+                put("fileId", JsonPrimitive("file_789"))
+                put("filename", JsonPrimitive("container.tar"))
+                put("startIndex", JsonPrimitive(25))
+            }
+
+            val filePathJson = buildJsonObject {
+                put("type", JsonPrimitive("file_path"))
+                put("fileId", JsonPrimitive("file_999"))
+                put("index", JsonPrimitive(3))
+            }
+
+            (json.decodeFromJsonElement<OpenAIAnnotations>(fileCitationJson) as OpenAIAnnotations.FileCitation).shouldNotBeNull {
+                fileId shouldBe "file_123"
+                filename shouldBe "test.pdf"
+                index shouldBe 0
+            }
+
+            (json.decodeFromJsonElement<OpenAIAnnotations>(urlCitationJson) as OpenAIAnnotations.UrlCitation).shouldNotBeNull {
+                endIndex shouldBe 50
+                startIndex shouldBe 10
+                title shouldBe "Test Article"
+                url shouldBe "https://test.com"
+            }
+
+            (json.decodeFromJsonElement<OpenAIAnnotations>(containerCitationJson) as OpenAIAnnotations.ContainerFileCitation).shouldNotBeNull {
+                containerId shouldBe "container_456"
+                endIndex shouldBe 75
+                fileId shouldBe "file_789"
+                filename shouldBe "container.tar"
+                startIndex shouldBe 25
+            }
+
+            (json.decodeFromJsonElement<OpenAIAnnotations>(filePathJson) as OpenAIAnnotations.FilePath).shouldNotBeNull {
+                fileId shouldBe "file_999"
+                index shouldBe 3
+            }
+        }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPIItemsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPIItemsTest.kt
@@ -1,0 +1,477 @@
+package ai.koog.prompt.executor.clients.openai.models
+
+import ai.koog.test.utils.runWithBothJsonConfigurations
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.test.Test
+
+class OpenAIResponsesAPIItemsTest {
+
+    @Test
+    fun `test Item_Text serialization`() = runWithBothJsonConfigurations("Item.Text serialization") { json ->
+        json.encodeToString<Item>(ItemPolymorphicSerializer, Item.Text("Hello world")) shouldEqualJson "\"Hello world\""
+    }
+
+    @Test
+    fun `test Item_Text deserialization`() = runWithBothJsonConfigurations("Item.Text deserialization") { json ->
+        json.decodeFromJsonElement(
+            ItemPolymorphicSerializer,
+            JsonPrimitive("Hello world")
+        ) shouldBe Item.Text("Hello world")
+    }
+
+    @Test
+    fun `test Item_InputMessage serialization`() =
+        runWithBothJsonConfigurations("Item.InputMessage serialization") { json ->
+            json.encodeToString(
+                ItemPolymorphicSerializer,
+                Item.InputMessage(
+                    content = listOf(InputContent.Text("Test message")),
+                    role = "user",
+                    status = OpenAIInputStatus.COMPLETED
+                )
+            ) shouldEqualJson """
+            {
+                "type": "message",
+                "content": [{"type": "input_text", "text": "Test message"}],
+                "role": "user",
+                "status": "completed"
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `test Item_InputMessage deserialization`() =
+        runWithBothJsonConfigurations("Item.InputMessage deserialization") { json ->
+            val jsonInput = buildJsonObject {
+                put("type", JsonPrimitive("message"))
+                put(
+                    "content",
+                    buildJsonArray {
+                        add(
+                            buildJsonObject {
+                                put("type", JsonPrimitive("input_text"))
+                                put("text", JsonPrimitive("Test message"))
+                            }
+                        )
+                    }
+                )
+                put("role", JsonPrimitive("user"))
+                put("status", JsonPrimitive("completed"))
+            }
+
+            (json.decodeFromJsonElement(ItemPolymorphicSerializer, jsonInput) as Item.InputMessage).shouldNotBeNull {
+                role shouldBe "user"
+                status shouldBe OpenAIInputStatus.COMPLETED
+                type shouldBe "message"
+                content shouldHaveSize 1
+                content.first() shouldBeEqualToComparingFields InputContent.Text("Test message")
+            }
+        }
+
+    @Test
+    fun `test Item_OutputMessage serialization`() =
+        runWithBothJsonConfigurations("Item.OutputMessage serialization") { json ->
+            json.encodeToString(
+                ItemPolymorphicSerializer,
+                Item.OutputMessage(
+                    content = listOf(
+                        OutputContent.Text(
+                            annotations = emptyList(),
+                            text = "Response text"
+                        )
+                    ),
+                    id = "msg-123",
+                    role = "assistant",
+                    status = OpenAIInputStatus.COMPLETED
+                )
+            ) shouldEqualJson """
+            {
+                "type": "message",
+                "content": [{"type": "output_text", "annotations": [], "text": "Response text"}],
+                "id": "msg-123",
+                "role": "assistant",
+                "status": "completed"
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `test Item_OutputMessage text() method`() {
+        Item.OutputMessage(
+            content = listOf(
+                OutputContent.Text(annotations = emptyList(), text = "Hello"),
+                OutputContent.Text(annotations = emptyList(), text = "World"),
+                OutputContent.Refusal("Sorry, I can't help with that")
+            )
+        ).text() shouldBe "Hello World Sorry, I can't help with that"
+    }
+
+    @Test
+    fun `test Item_FunctionToolCall serialization`() =
+        runWithBothJsonConfigurations("Item.FunctionToolCall serialization") { json ->
+            json.encodeToString(
+                ItemPolymorphicSerializer,
+                Item.FunctionToolCall(
+                    arguments = """{"param": "value"}""",
+                    callId = "call_123",
+                    name = "test_function",
+                    id = "func_456",
+                    status = OpenAIInputStatus.IN_PROGRESS
+                )
+            ) shouldEqualJson """
+            {
+                "type": "function_call",
+                "arguments": "{\"param\": \"value\"}",
+                "callId": "call_123",
+                "name": "test_function",
+                "id": "func_456",
+                "status": "in_progress"
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `test Item_FunctionToolCallOutput serialization`() =
+        runWithBothJsonConfigurations("Item.FunctionToolCallOutput serialization") { json ->
+            json.encodeToString(
+                ItemPolymorphicSerializer,
+                Item.FunctionToolCallOutput(
+                    callId = "call_123",
+                    output = """{"result": "success"}""",
+                    id = "output_456",
+                    status = OpenAIInputStatus.COMPLETED
+                )
+            ) shouldEqualJson """
+            {
+                "type": "function_call_output",
+                "callId": "call_123",
+                "output": "{\"result\": \"success\"}",
+                "id": "output_456",
+                "status": "completed"
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `test Item_FileSearchToolCall serialization`() =
+        runWithBothJsonConfigurations("Item.FileSearchToolCall serialization") { json ->
+            json.encodeToString(
+                ItemPolymorphicSerializer,
+                Item.FileSearchToolCall(
+                    id = "search_123",
+                    queries = listOf("test query", "another query"),
+                    status = "searching",
+                    results = listOf(
+                        Item.FileSearchToolCall.FileSearchToolResult(
+                            fileId = "file_123",
+                            filename = "test.txt",
+                            score = 0.95,
+                            text = "Found text",
+                            attributes = mapOf("category" to "document")
+                        )
+                    )
+                )
+            ) shouldEqualJson """
+            {
+                "type": "file_search_call",
+                "id": "search_123",
+                "queries": ["test query", "another query"],
+                "status": "searching",
+                "results": [{
+                    "fileId": "file_123",
+                    "filename": "test.txt",
+                    "score": 0.95,
+                    "text": "Found text",
+                    "attributes": {"category": "document"}
+                }]
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `test Item_ComputerToolCall serialization`() =
+        runWithBothJsonConfigurations("Item.ComputerToolCall serialization") { json ->
+            json.encodeToString(
+                ItemPolymorphicSerializer,
+                Item.ComputerToolCall(
+                    action = Item.ComputerToolCall.Action.Click("left", 100, 200),
+                    callId = "comp_123",
+                    id = "call_456",
+                    pendingSafetyChecks = listOf(
+                        Item.ComputerToolCall.PendingSafetyCheck("safety_001", "check_123", "Safety check message")
+                    ),
+                    status = "in_progress"
+                )
+            ) shouldEqualJson """
+            {
+                "type": "computer_call",
+                "action": {"type": "click", "button": "left", "x": 100, "y": 200},
+                "callId": "comp_123",
+                "id": "call_456",
+                "pendingSafetyChecks": [{
+                    "code": "safety_001",
+                    "id": "check_123",
+                    "message": "Safety check message"
+                }],
+                "status": "in_progress"
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `test ComputerToolCall Actions serialization`() =
+        runWithBothJsonConfigurations("ComputerToolCall Actions") { json ->
+            val actions = listOf(
+                Item.ComputerToolCall.Action.Click("right", 50, 75),
+                Item.ComputerToolCall.Action.DoubleClick(10, 20),
+                Item.ComputerToolCall.Action.Drag(
+                    listOf(
+                        Item.ComputerToolCall.Action.Coordinates(0, 0),
+                        Item.ComputerToolCall.Action.Coordinates(10, 10)
+                    )
+                ),
+                Item.ComputerToolCall.Action.KeyPress(listOf("ctrl", "c")),
+                Item.ComputerToolCall.Action.Move(30, 40),
+                Item.ComputerToolCall.Action.Screenshot(),
+                Item.ComputerToolCall.Action.Scroll(5, 10, 100, 200),
+                Item.ComputerToolCall.Action.Type("Hello World"),
+                Item.ComputerToolCall.Action.Wait()
+            )
+
+            actions.forEachIndexed { index, action ->
+                val jsonString = json.encodeToString(action)
+                when (index) {
+                    0 -> jsonString shouldEqualJson """{"type":"click","button":"right","x":50,"y":75}"""
+                    1 -> jsonString shouldEqualJson """{"type":"double_click","x":10,"y":20}"""
+                    2 -> jsonString shouldEqualJson """{"type":"drag","path":[{"x":0,"y":0},{"x":10,"y":10}]}"""
+                    3 -> jsonString shouldEqualJson """{"type":"keypress","keys":["ctrl","c"]}"""
+                    4 -> jsonString shouldEqualJson """{"type":"move","x":30,"y":40}"""
+                    5 -> jsonString shouldEqualJson """{"type":"screenshot"}"""
+                    6 -> jsonString shouldEqualJson """{"type":"scroll","scrollX":5,"scrollY":10,"x":100,"y":200}"""
+                    7 -> jsonString shouldEqualJson """{"type":"type","text":"Hello World"}"""
+                    8 -> jsonString shouldEqualJson """{"type":"wait"}"""
+                }
+            }
+        }
+
+    @Test
+    fun `test Item_WebSearchToolCall serialization`() =
+        runWithBothJsonConfigurations("Item.WebSearchToolCall serialization") { json ->
+            json.encodeToString(
+                ItemPolymorphicSerializer,
+                Item.WebSearchToolCall(
+                    action = Item.WebSearchToolCall.Action.Search("test query"),
+                    id = "web_123",
+                    status = "in_progress"
+                )
+            ) shouldEqualJson """
+            {
+                "type": "web_search_call",
+                "action": {"type": "search", "query": "test query"},
+                "id": "web_123",
+                "status": "in_progress"
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `test WebSearchToolCall Actions serialization`() =
+        runWithBothJsonConfigurations("WebSearchToolCall Actions") { json ->
+            json.encodeToString(
+                Item.WebSearchToolCall.Action.Search("machine learning")
+            ) shouldEqualJson """{"query":"machine learning"}"""
+            json.encodeToString(
+                Item.WebSearchToolCall.Action.OpenPage("https://example.com")
+            ) shouldEqualJson """{"url":"https://example.com"}"""
+            json.encodeToString(
+                Item.WebSearchToolCall.Action.Find(
+                    "pattern",
+                    "https://example.com"
+                )
+            ) shouldEqualJson """{"pattern":"pattern","url":"https://example.com"}"""
+        }
+
+    @Test
+    fun `test Item_CodeInterpreterToolCall serialization`() =
+        runWithBothJsonConfigurations("Item.CodeInterpreterToolCall serialization") { json ->
+            json.encodeToString(
+                ItemPolymorphicSerializer,
+                Item.CodeInterpreterToolCall(
+                    code = "print('Hello World')",
+                    containerId = "container_123",
+                    id = "code_456",
+                    outputs = listOf(
+                        Item.CodeInterpreterToolCall.Output.Logs("Hello World\n"),
+                        Item.CodeInterpreterToolCall.Output.Image("https://example.com/image.png")
+                    ),
+                    status = OpenAIInputStatus.COMPLETED
+                )
+            ) shouldEqualJson """
+            {
+                "type": "code_interpreter_call",
+                "code": "print('Hello World')",
+                "containerId": "container_123",
+                "id": "code_456",
+                "outputs": [
+                    {"type": "logs", "logs": "Hello World\n"},
+                    {"type": "image", "url": "https://example.com/image.png"}
+                ],
+                "status": "completed"
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `test Item_Reasoning serialization`() = runWithBothJsonConfigurations("Item.Reasoning serialization") { json ->
+        json.encodeToString(
+            ItemPolymorphicSerializer,
+            Item.Reasoning(
+                id = "reasoning_123",
+                summary = listOf(
+                    Item.Reasoning.Summary("This is a summary of the reasoning")
+                ),
+                content = listOf(
+                    Item.Reasoning.Content("Detailed reasoning content")
+                ),
+                encryptedContent = "encrypted_content_here",
+                status = OpenAIInputStatus.COMPLETED
+            )
+        ) shouldEqualJson """
+            {
+                "type": "reasoning",
+                "id": "reasoning_123",
+                "summary": [{"type": "summary_text", "text": "This is a summary of the reasoning"}],
+                "content": [{"type": "reasoning_text", "text": "Detailed reasoning content"}],
+                "encryptedContent": "encrypted_content_here",
+                "status": "completed"
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `test Item_LocalShellCall serialization`() =
+        runWithBothJsonConfigurations("Item.LocalShellCall serialization") { json ->
+            json.encodeToString(
+                ItemPolymorphicSerializer,
+                Item.LocalShellCall(
+                    action = Item.LocalShellCall.Action(
+                        command = listOf("echo", "hello"),
+                        end = buildJsonObject { put("PATH", JsonPrimitive("/usr/bin")) },
+                        timeoutMs = 5000,
+                        user = "testuser",
+                        workingDirectory = "/tmp"
+                    ),
+                    callId = "shell_123",
+                    id = "call_456",
+                    status = "in_progress"
+                )
+            ) shouldEqualJson """
+            {
+                "type": "local_shell_call",
+                "action": {
+                    "type": "exec",
+                    "command": ["echo", "hello"],
+                    "end": {"PATH": "/usr/bin"},
+                    "timeoutMs": 5000,
+                    "user": "testuser",
+                    "workingDirectory": "/tmp"
+                },
+                "callId": "shell_123",
+                "id": "call_456",
+                "status": "in_progress"
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `test Item_ItemReference serialization`() =
+        runWithBothJsonConfigurations("Item.ItemReference serialization") { json ->
+            json.encodeToString(
+                ItemPolymorphicSerializer,
+                Item.ItemReference("ref_123")
+            ) shouldEqualJson """
+            {
+                "type": "item_reference",
+                "id": "ref_123"
+            }
+            """.trimIndent()
+        }
+
+    @Test
+    fun `test OpenAIInclude enum serialization`() =
+        runWithBothJsonConfigurations("OpenAIInclude enum serialization") { json ->
+            val includes = listOf(
+                OpenAIInclude.WEB_SEARCH_CALL_ACTION_SOURCES,
+                OpenAIInclude.CODE_INTERPRETER_CALL_OUTPUTS,
+                OpenAIInclude.COMPUTER_CALL_OUTPUT_IMAGE_URL,
+                OpenAIInclude.FILE_SEARCH_CALL_RESULTS,
+                OpenAIInclude.INPUT_IMAGE_URL,
+                OpenAIInclude.OUTPUT_TEXT_LOGPROBS,
+                OpenAIInclude.REASONING_ENCRYPTED_CONTENT
+            )
+
+            val expectedSerializations = listOf(
+                "\"web_search_call.action.sources\"",
+                "\"code_interpreter_call.outputs\"",
+                "\"computer_call_output.output.image_url\"",
+                "\"file_search_call.results\"",
+                "\"message.input_image.image_url\"",
+                "\"message.output_text.logprobs\"",
+                "\"reasoning.encrypted_content\""
+            )
+
+            includes.zip(expectedSerializations).forEach { (include, expected) ->
+                json.encodeToString(include) shouldEqualJson expected
+            }
+        }
+
+    @Test
+    fun `test OpenAIInputStatus enum serialization`() =
+        runWithBothJsonConfigurations("OpenAIInputStatus enum serialization") { json ->
+            val statuses = OpenAIInputStatus.entries
+            val expectedSerializations = listOf(
+                "\"in_progress\"",
+                "\"completed\"",
+                "\"searching\"",
+                "\"failed\"",
+                "\"interpreting\"",
+                "\"incomplete\"",
+                "\"cancelled\"",
+                "\"queued\""
+            )
+
+            statuses.zip(expectedSerializations).forEach { (status, expected) ->
+                json.encodeToString(status) shouldEqualJson expected
+            }
+        }
+
+    @Test
+    fun `test Truncation enum serialization`() =
+        runWithBothJsonConfigurations("Truncation enum serialization") { json ->
+            json.encodeToString(Truncation.AUTO) shouldEqualJson "\"auto\""
+            json.encodeToString(Truncation.DISABLED) shouldEqualJson "\"disabled\""
+        }
+
+    @Test
+    fun `test ReasoningSummary enum serialization`() =
+        runWithBothJsonConfigurations("ReasoningSummary enum serialization") { json ->
+            json.encodeToString(ReasoningSummary.AUTO) shouldEqualJson "\"auto\""
+            json.encodeToString(ReasoningSummary.CONCISE) shouldEqualJson "\"concise\""
+            json.encodeToString(ReasoningSummary.DETAILED) shouldEqualJson "\"detailed\""
+        }
+
+    @Test
+    fun `test TextVerbosity enum serialization`() =
+        runWithBothJsonConfigurations("TextVerbosity enum serialization") { json ->
+            json.encodeToString(TextVerbosity.LOW) shouldEqualJson "\"low\""
+            json.encodeToString(TextVerbosity.MEDIUM) shouldEqualJson "\"medium\""
+            json.encodeToString(TextVerbosity.HIGH) shouldEqualJson "\"high\""
+        }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPIRequestSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPIRequestSerializationTest.kt
@@ -4,8 +4,8 @@ import ai.koog.prompt.executor.clients.openai.base.models.ReasoningEffort
 import ai.koog.prompt.executor.clients.openai.base.models.ServiceTier
 import ai.koog.test.utils.runWithBothJsonConfigurations
 import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
@@ -20,17 +20,16 @@ class OpenAIResponsesAPIRequestSerializationTest {
     @Test
     fun `test serialization without additionalProperties`() =
         runWithBothJsonConfigurations("serialization without additionalProperties") { json ->
-            val request = OpenAIResponsesAPIRequest(
-                model = "gpt-4o",
-                instructions = "Please help with this task",
-                temperature = 0.7,
-                maxOutputTokens = 1000,
-                stream = false
-            )
-
-            val jsonString = json.encodeToString(OpenAIResponsesAPIRequestSerializer, request)
-
-            jsonString shouldEqualJson
+            json.encodeToString(
+                OpenAIResponsesAPIRequestSerializer,
+                OpenAIResponsesAPIRequest(
+                    model = "gpt-4o",
+                    instructions = "Please help with this task",
+                    temperature = 0.7,
+                    maxOutputTokens = 1000,
+                    stream = false
+                )
+            ) shouldEqualJson
                 // language=json
                 """
             {
@@ -52,16 +51,15 @@ class OpenAIResponsesAPIRequestSerializationTest {
                 "customBoolean" to JsonPrimitive(true)
             )
 
-            val request = OpenAIResponsesAPIRequest(
-                model = "gpt-4o",
-                instructions = "Please help with this task",
-                temperature = 0.7,
-                additionalProperties = additionalProperties
-            )
-
-            val jsonString = json.encodeToString(OpenAIResponsesAPIRequestSerializer, request)
-
-            jsonString shouldEqualJson
+            json.encodeToString(
+                OpenAIResponsesAPIRequestSerializer,
+                OpenAIResponsesAPIRequest(
+                    model = "gpt-4o",
+                    instructions = "Please help with this task",
+                    temperature = 0.7,
+                    additionalProperties = additionalProperties
+                )
+            ) shouldEqualJson
                 // language=json
                 """
             {
@@ -86,14 +84,14 @@ class OpenAIResponsesAPIRequestSerializationTest {
                 put("stream", JsonPrimitive(false))
             }
 
-            val request = json.decodeFromJsonElement(OpenAIResponsesAPIRequestSerializer, jsonInput)
-
-            request.model shouldBe "gpt-4o"
-            request.instructions shouldBe "Please help with this task"
-            request.temperature shouldBe 0.7
-            request.maxOutputTokens shouldBe 1000
-            request.stream shouldBe false
-            request.additionalProperties shouldBe null
+            json.decodeFromJsonElement(OpenAIResponsesAPIRequestSerializer, jsonInput).shouldNotBeNull {
+                model shouldBe "gpt-4o"
+                instructions shouldBe "Please help with this task"
+                temperature shouldBe 0.7
+                maxOutputTokens shouldBe 1000
+                stream shouldBe false
+                additionalProperties shouldBe null
+            }
         }
 
     @Test
@@ -108,48 +106,46 @@ class OpenAIResponsesAPIRequestSerializationTest {
                 put("customBoolean", JsonPrimitive(true))
             }
 
-            val request = json.decodeFromJsonElement(OpenAIResponsesAPIRequestSerializer, jsonInput)
-
-            request.model shouldBe "gpt-4o"
-            request.instructions shouldBe "Please help with this task"
-            request.temperature shouldBe 0.7
-
-            request.additionalProperties shouldNotBe null
-            val additionalProps = request.additionalProperties!!
-            additionalProps.size shouldBe 3
-            additionalProps["customProperty"]?.jsonPrimitive?.contentOrNull shouldBe "customValue"
-            additionalProps["customNumber"]?.jsonPrimitive?.intOrNull shouldBe 42
-            additionalProps["customBoolean"]?.jsonPrimitive?.booleanOrNull shouldBe true
+            json.decodeFromJsonElement(OpenAIResponsesAPIRequestSerializer, jsonInput).shouldNotBeNull {
+                model shouldBe "gpt-4o"
+                instructions shouldBe "Please help with this task"
+                temperature shouldBe 0.7
+                additionalProperties.shouldNotBeNull {
+                    size shouldBe 3
+                    this["customProperty"]?.jsonPrimitive?.contentOrNull shouldBe "customValue"
+                    this["customNumber"]?.jsonPrimitive?.intOrNull shouldBe 42
+                    this["customBoolean"]?.jsonPrimitive?.booleanOrNull shouldBe true
+                }
+            }
         }
 
     @Test
     fun `test full serialization of OpenAIResponsesAPIRequest fields`() =
         runWithBothJsonConfigurations("test full serialization of OpenAIResponsesAPIRequest fields") { json ->
-            val request = OpenAIResponsesAPIRequest(
-                model = "gpt-4o",
-                instructions = "sys-msg",
-                temperature = 0.5,
-                maxOutputTokens = 321,
-                stream = false,
-                background = true,
-                include = listOf(OpenAIInclude.OUTPUT_TEXT_LOGPROBS, OpenAIInclude.REASONING_ENCRYPTED_CONTENT),
-                maxToolCalls = 7,
-                parallelToolCalls = true,
-                reasoning = ReasoningConfig(effort = ReasoningEffort.HIGH, summary = ReasoningSummary.CONCISE),
-                truncation = Truncation.AUTO,
-                promptCacheKey = "pck",
-                safetyIdentifier = "sid",
-                serviceTier = ServiceTier.FLEX,
-                store = true,
-                topLogprobs = 5,
-                topP = 0.9,
-                user = "user-123",
-                additionalProperties = mapOf("extra" to JsonPrimitive("value"))
-            )
-
-            val jsonString = json.encodeToString(OpenAIResponsesAPIRequestSerializer, request)
-
-            jsonString shouldEqualJson
+            json.encodeToString(
+                OpenAIResponsesAPIRequestSerializer,
+                OpenAIResponsesAPIRequest(
+                    model = "gpt-4o",
+                    instructions = "sys-msg",
+                    temperature = 0.5,
+                    maxOutputTokens = 321,
+                    stream = false,
+                    background = true,
+                    include = listOf(OpenAIInclude.OUTPUT_TEXT_LOGPROBS, OpenAIInclude.REASONING_ENCRYPTED_CONTENT),
+                    maxToolCalls = 7,
+                    parallelToolCalls = true,
+                    reasoning = ReasoningConfig(effort = ReasoningEffort.HIGH, summary = ReasoningSummary.CONCISE),
+                    truncation = Truncation.AUTO,
+                    promptCacheKey = "pck",
+                    safetyIdentifier = "sid",
+                    serviceTier = ServiceTier.FLEX,
+                    store = true,
+                    topLogprobs = 5,
+                    topP = 0.9,
+                    user = "user-123",
+                    additionalProperties = mapOf("extra" to JsonPrimitive("value"))
+                )
+            ) shouldEqualJson
                 // language=json
                 """
             {
@@ -218,35 +214,35 @@ class OpenAIResponsesAPIRequestSerializationTest {
                 put("customNumber", JsonPrimitive(42))
             }
 
-            val decoded = json.decodeFromJsonElement(OpenAIResponsesAPIRequestSerializer, input)
-
-            decoded.model shouldBe "gpt-4o"
-            decoded.instructions shouldBe "sys-msg"
-            decoded.temperature shouldBe 0.5
-            decoded.maxOutputTokens shouldBe 321
-            decoded.stream shouldBe false
-            decoded.background shouldBe true
-            decoded.include shouldBe listOf(
-                OpenAIInclude.OUTPUT_TEXT_LOGPROBS,
-                OpenAIInclude.REASONING_ENCRYPTED_CONTENT
-            )
-            decoded.maxToolCalls shouldBe 7
-            decoded.parallelToolCalls shouldBe true
-            decoded.truncation shouldBe Truncation.AUTO
-            decoded.promptCacheKey shouldBe "pck"
-            decoded.safetyIdentifier shouldBe "sid"
-            decoded.serviceTier shouldBe ServiceTier.FLEX
-            decoded.store shouldBe true
-            decoded.topLogprobs shouldBe 5
-            decoded.topP shouldBe 0.9
-            decoded.user shouldBe "user-123"
-
-            decoded.reasoning shouldNotBe null
-            decoded.reasoning?.effort shouldBe ReasoningEffort.HIGH
-            decoded.reasoning?.summary shouldBe ReasoningSummary.CONCISE
-
-            decoded.additionalProperties shouldNotBe null
-            decoded.additionalProperties?.get("extra")?.jsonPrimitive?.content shouldBe "value"
-            decoded.additionalProperties?.get("customNumber")?.jsonPrimitive?.intOrNull shouldBe 42
+            json.decodeFromJsonElement(OpenAIResponsesAPIRequestSerializer, input).shouldNotBeNull {
+                model shouldBe "gpt-4o"
+                instructions shouldBe "sys-msg"
+                temperature shouldBe 0.5
+                maxOutputTokens shouldBe 321
+                stream shouldBe false
+                background shouldBe true
+                include shouldBe listOf(
+                    OpenAIInclude.OUTPUT_TEXT_LOGPROBS,
+                    OpenAIInclude.REASONING_ENCRYPTED_CONTENT
+                )
+                maxToolCalls shouldBe 7
+                parallelToolCalls shouldBe true
+                truncation shouldBe Truncation.AUTO
+                promptCacheKey shouldBe "pck"
+                safetyIdentifier shouldBe "sid"
+                serviceTier shouldBe ServiceTier.FLEX
+                store shouldBe true
+                topLogprobs shouldBe 5
+                topP shouldBe 0.9
+                user shouldBe "user-123"
+                reasoning.shouldNotBeNull {
+                    effort shouldBe ReasoningEffort.HIGH
+                    summary shouldBe ReasoningSummary.CONCISE
+                }
+                additionalProperties.shouldNotBeNull {
+                    this["extra"]?.jsonPrimitive?.contentOrNull shouldBe "value"
+                    this["customNumber"]?.jsonPrimitive?.intOrNull shouldBe 42
+                }
+            }
         }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPIResponseTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPIResponseTest.kt
@@ -1,0 +1,485 @@
+package ai.koog.prompt.executor.clients.openai.models
+
+import ai.koog.prompt.executor.clients.openai.base.models.ReasoningEffort
+import ai.koog.prompt.executor.clients.openai.base.models.ServiceTier
+import ai.koog.test.utils.runWithBothJsonConfigurations
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeTypeOf
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+
+class OpenAIResponsesAPIResponseTest {
+
+    @Test
+    fun `test OpenAIResponsesAPIResponse minimal serialization`() =
+        runWithBothJsonConfigurations("minimal response serialization") { json ->
+            val response = OpenAIResponsesAPIResponse(
+                created = 1699500000L,
+                id = "response_123",
+                model = "gpt-4o",
+                output = listOf(
+                    Item.OutputMessage(
+                        content = listOf(
+                            OutputContent.Text(annotations = emptyList(), text = "Hello, world!")
+                        ),
+                        id = "msg_minimal_123"
+                    )
+                ),
+                parallelToolCalls = false,
+                status = OpenAIInputStatus.COMPLETED,
+                text = OpenAITextConfig()
+            )
+
+            json.decodeFromString<OpenAIResponsesAPIResponse>(json.encodeToString(response)).shouldNotBeNull {
+                created shouldBe 1699500000L
+                id shouldBe "response_123"
+                model shouldBe "gpt-4o"
+                output shouldHaveSize 1
+                parallelToolCalls shouldBe false
+                status shouldBe OpenAIInputStatus.COMPLETED
+            }
+        }
+
+    @Test
+    fun `test OpenAIResponsesAPIResponse full serialization`() =
+        runWithBothJsonConfigurations("full response serialization") { json ->
+            val response = OpenAIResponsesAPIResponse(
+                background = true,
+                created = 1699500000L,
+                error = OpenAIResponsesAPIResponse.ResponseError("rate_limit", "Rate limit exceeded"),
+                id = "response_456",
+                incompleteDetails = OpenAIResponsesAPIResponse.IncompleteDetails("token_limit"),
+                instructions = listOf(Item.Text("System instruction")),
+                maxOutputTokens = 1000,
+                maxToolCalls = 5,
+                metadata = mapOf("session" to "abc123", "user" to "user456"),
+                model = "gpt-4o-mini",
+                output = listOf(
+                    Item.OutputMessage(
+                        content = listOf(
+                            OutputContent.Text(annotations = emptyList(), text = "Response text")
+                        ),
+                        id = "msg_123"
+                    )
+                ),
+                outputText = "Response text",
+                parallelToolCalls = true,
+                previousResponseId = "prev_response_123",
+                prompt = OpenAIPromptReference(
+                    id = "prompt_123",
+                    variables = mapOf("name" to "John"),
+                    version = "1.0"
+                ),
+                promptCacheKey = "cache_key_456",
+                reasoning = ReasoningConfig(
+                    effort = ReasoningEffort.HIGH,
+                    summary = ReasoningSummary.DETAILED
+                ),
+                safetyIdentifier = "safety_789",
+                serviceTier = ServiceTier.FLEX,
+                status = OpenAIInputStatus.COMPLETED,
+                temperature = 0.7,
+                text = OpenAITextConfig(
+                    format = OpenAIOutputFormat.JsonSchema(
+                        name = "response_schema",
+                        schema = buildJsonObject {
+                            put("type", JsonPrimitive("object"))
+                            put(
+                                "properties",
+                                buildJsonObject {
+                                    put(
+                                        "message",
+                                        buildJsonObject {
+                                            put("type", JsonPrimitive("string"))
+                                        }
+                                    )
+                                }
+                            )
+                        }
+                    ),
+                    verbosity = TextVerbosity.HIGH
+                ),
+                toolChoice = OpenAIResponsesToolChoice.Mode("auto"),
+                tools = listOf(
+                    OpenAIResponsesTool.Function(
+                        name = "test_function",
+                        parameters = buildJsonObject {
+                            put("type", JsonPrimitive("object"))
+                        }
+                    )
+                ),
+                topLogprobs = 3,
+                topP = 0.9,
+                truncation = "auto",
+                usage = OpenAIResponsesAPIResponse.Usage(
+                    inputTokens = 100,
+                    inputTokensDetails = OpenAIResponsesAPIResponse.Usage.InputTokensDetails(10),
+                    outputTokens = 200,
+                    outputTokensDetails = OpenAIResponsesAPIResponse.Usage.OutputTokensDetails(50),
+                    totalTokens = 300
+                ),
+                user = "deprecated_user"
+            )
+
+            json.decodeFromString<OpenAIResponsesAPIResponse>(json.encodeToString(response)).shouldNotBeNull {
+                background shouldBe true
+                created shouldBe 1699500000L
+                error.shouldNotBeNull {
+                    code shouldBe "rate_limit"
+                    message shouldBe "Rate limit exceeded"
+                }
+                id shouldBe "response_456"
+                incompleteDetails.shouldNotBeNull {
+                    reason shouldBe "token_limit"
+                }
+                instructions.shouldNotBeNull { shouldHaveSize(1) }
+                maxOutputTokens shouldBe 1000
+                maxToolCalls shouldBe 5
+                metadata shouldBe mapOf("session" to "abc123", "user" to "user456")
+                model shouldBe "gpt-4o-mini"
+                output.shouldNotBeNull { shouldHaveSize(1) }
+                outputText shouldBe "Response text"
+                parallelToolCalls shouldBe true
+                previousResponseId shouldBe "prev_response_123"
+                prompt.shouldNotBeNull {
+                    id shouldBe "prompt_123"
+                    variables shouldBe mapOf("name" to "John")
+                    version shouldBe "1.0"
+                }
+                promptCacheKey shouldBe "cache_key_456"
+                reasoning.shouldNotBeNull {
+                    effort shouldBe ReasoningEffort.HIGH
+                    summary shouldBe ReasoningSummary.DETAILED
+                }
+                safetyIdentifier shouldBe "safety_789"
+                serviceTier shouldBe ServiceTier.FLEX
+                status shouldBe OpenAIInputStatus.COMPLETED
+                temperature shouldBe 0.7
+                text.shouldNotBeNull {
+                    format.shouldNotBeNull()
+                    verbosity shouldBe TextVerbosity.HIGH
+                }
+                toolChoice.shouldNotBeNull()
+                tools.shouldNotBeNull { shouldHaveSize(1) }
+                topLogprobs shouldBe 3
+                topP shouldBe 0.9
+                truncation shouldBe "auto"
+                usage.shouldNotBeNull {
+                    inputTokens shouldBe 100
+                    outputTokens shouldBe 200
+                    totalTokens shouldBe 300
+                }
+                user shouldBe "deprecated_user"
+            }
+        }
+
+    @Test
+    fun `test OpenAIResponsesAPIResponse deserialization from JSON`() =
+        runWithBothJsonConfigurations("response deserialization") { json ->
+            val jsonInput = buildJsonObject {
+                put("created_at", JsonPrimitive(1699500000L))
+                put("id", JsonPrimitive("response_789"))
+                put("model", JsonPrimitive("gpt-4"))
+                put("object", JsonPrimitive("response"))
+                put(
+                    "output",
+                    buildJsonArray {
+                        add(
+                            buildJsonObject {
+                                put("type", JsonPrimitive("message"))
+                                put("id", JsonPrimitive("msg_test_123"))
+                                put(
+                                    "content",
+                                    buildJsonArray {
+                                        add(
+                                            buildJsonObject {
+                                                put("type", JsonPrimitive("output_text"))
+                                                put("annotations", buildJsonArray { })
+                                                put("text", JsonPrimitive("Test response"))
+                                            }
+                                        )
+                                    }
+                                )
+                                put("role", JsonPrimitive("assistant"))
+                            }
+                        )
+                    }
+                )
+                put("parallelToolCalls", JsonPrimitive(true))
+                put("status", JsonPrimitive("completed"))
+                put("text", buildJsonObject { })
+            }
+
+            json.decodeFromJsonElement<OpenAIResponsesAPIResponse>(jsonInput).shouldNotBeNull {
+                created shouldBe 1699500000L
+                id shouldBe "response_789"
+                model shouldBe "gpt-4"
+                objectType shouldBe "response"
+                output shouldHaveSize 1
+                parallelToolCalls shouldBe true
+                status shouldBe OpenAIInputStatus.COMPLETED
+            }
+        }
+
+    @Test
+    fun `test ResponseError serialization`() = runWithBothJsonConfigurations("ResponseError serialization") { json ->
+        val jsonString = json.encodeToString(
+            OpenAIResponsesAPIResponse.ResponseError(
+                code = "invalid_request",
+                message = "The request was invalid"
+            )
+        )
+
+        jsonString shouldEqualJson """
+            {
+                "code": "invalid_request",
+                "message": "The request was invalid"
+            }
+        """.trimIndent()
+
+        json.decodeFromString<OpenAIResponsesAPIResponse.ResponseError>(jsonString).shouldNotBeNull {
+            code shouldBe "invalid_request"
+            message shouldBe "The request was invalid"
+        }
+    }
+
+    @Test
+    fun `test IncompleteDetails serialization`() =
+        runWithBothJsonConfigurations("IncompleteDetails serialization") { json ->
+            val jsonString = json.encodeToString(OpenAIResponsesAPIResponse.IncompleteDetails("max_tokens"))
+
+            jsonString shouldEqualJson """
+            {
+                "reason": "max_tokens"
+            }
+            """.trimIndent()
+
+            json.decodeFromString<OpenAIResponsesAPIResponse.IncompleteDetails>(jsonString).reason shouldBe "max_tokens"
+        }
+
+    @Test
+    fun `test Usage serialization`() = runWithBothJsonConfigurations("Usage serialization") { json ->
+        val jsonString = json.encodeToString(
+            OpenAIResponsesAPIResponse.Usage(
+                inputTokens = 150,
+                inputTokensDetails = OpenAIResponsesAPIResponse.Usage.InputTokensDetails(25),
+                outputTokens = 300,
+                outputTokensDetails = OpenAIResponsesAPIResponse.Usage.OutputTokensDetails(100),
+                totalTokens = 450
+            )
+        )
+
+        jsonString shouldEqualJson """
+            {
+                "inputTokens": 150,
+                "inputTokensDetails": {"cachedTokens": 25},
+                "outputTokens": 300,
+                "outputTokensDetails": {"reasoningTokens": 100},
+                "totalTokens": 450
+            }
+        """.trimIndent()
+
+        json.decodeFromString<OpenAIResponsesAPIResponse.Usage>(jsonString).shouldNotBeNull {
+            inputTokens shouldBe 150
+            inputTokensDetails.cachedTokens shouldBe 25
+            outputTokens shouldBe 300
+            outputTokensDetails.reasoningTokens shouldBe 100
+            totalTokens shouldBe 450
+        }
+    }
+
+    @Test
+    fun `test OpenAIPromptReference serialization`() =
+        runWithBothJsonConfigurations("OpenAIPromptReference serialization") { json ->
+            val jsonString = json.encodeToString(
+                OpenAIPromptReference(
+                    id = "prompt_ref_123",
+                    variables = mapOf(
+                        "name" to "Alice",
+                        "age" to "30",
+                        "city" to "New York"
+                    ),
+                    version = "2.1"
+                )
+            )
+
+            jsonString shouldEqualJson """
+            {
+                "id": "prompt_ref_123",
+                "variables": {
+                    "name": "Alice",
+                    "age": "30",
+                    "city": "New York"
+                },
+                "version": "2.1"
+            }
+            """.trimIndent()
+
+            json.decodeFromString<OpenAIPromptReference>(jsonString).shouldNotBeNull {
+                id shouldBe "prompt_ref_123"
+                variables shouldBe mapOf(
+                    "name" to "Alice",
+                    "age" to "30",
+                    "city" to "New York"
+                )
+                version shouldBe "2.1"
+            }
+        }
+
+    @Test
+    fun `test ReasoningConfig serialization`() =
+        runWithBothJsonConfigurations("ReasoningConfig serialization") { json ->
+            val jsonString = json.encodeToString(
+                ReasoningConfig(
+                    effort = ReasoningEffort.MEDIUM,
+                    summary = ReasoningSummary.CONCISE
+                )
+            )
+
+            jsonString shouldEqualJson """
+            {
+                "effort": "medium",
+                "summary": "concise"
+            }
+            """.trimIndent()
+
+            json.decodeFromString<ReasoningConfig>(jsonString).shouldNotBeNull {
+                effort shouldBe ReasoningEffort.MEDIUM
+                summary shouldBe ReasoningSummary.CONCISE
+            }
+        }
+
+    @Test
+    fun `test OpenAITextConfig serialization with JsonSchema format`() =
+        runWithBothJsonConfigurations("OpenAITextConfig with JsonSchema") { json ->
+            val textConfig = OpenAITextConfig(
+                format = OpenAIOutputFormat.JsonSchema(
+                    name = "user_profile",
+                    schema = buildJsonObject {
+                        put("type", JsonPrimitive("object"))
+                        put(
+                            "properties",
+                            buildJsonObject {
+                                put(
+                                    "name",
+                                    buildJsonObject {
+                                        put("type", JsonPrimitive("string"))
+                                    }
+                                )
+                                put(
+                                    "age",
+                                    buildJsonObject {
+                                        put("type", JsonPrimitive("integer"))
+                                    }
+                                )
+                            }
+                        )
+                        put(
+                            "required",
+                            buildJsonArray {
+                                add(JsonPrimitive("name"))
+                            }
+                        )
+                    },
+                    description = "User profile schema",
+                    strict = true
+                ),
+                verbosity = TextVerbosity.MEDIUM
+            )
+
+            json.decodeFromString<OpenAITextConfig>(json.encodeToString(textConfig)).shouldNotBeNull {
+                (format as OpenAIOutputFormat.JsonSchema).shouldNotBeNull {
+                    name shouldBe "user_profile"
+                    description shouldBe "User profile schema"
+                    strict shouldBe true
+                    schema["type"]?.jsonPrimitive?.content shouldBe "object"
+                }
+                verbosity shouldBe TextVerbosity.MEDIUM
+            }
+        }
+
+    @Test
+    fun `test OpenAITextConfig with all output formats`() =
+        runWithBothJsonConfigurations("OpenAITextConfig all formats") { json ->
+            listOf(
+                OpenAITextConfig(format = OpenAIOutputFormat.Text()),
+                OpenAITextConfig(format = OpenAIOutputFormat.JsonObject()),
+                OpenAITextConfig(
+                    format = OpenAIOutputFormat.JsonSchema(
+                        name = "test_schema",
+                        schema = buildJsonObject { put("type", JsonPrimitive("object")) }
+                    )
+                )
+            ).forEach { config ->
+                val jsonString = json.encodeToString(config)
+                val decoded = json.decodeFromString<OpenAITextConfig>(jsonString)
+                decoded.format.shouldNotBeNull()
+
+                when (config.format) {
+                    is OpenAIOutputFormat.Text -> decoded.format.shouldBeTypeOf<OpenAIOutputFormat.Text>()
+                    is OpenAIOutputFormat.JsonObject -> decoded.format.shouldBeTypeOf<OpenAIOutputFormat.JsonObject>()
+                    is OpenAIOutputFormat.JsonSchema -> {
+                        val decodedSchema = decoded.format as OpenAIOutputFormat.JsonSchema
+                        decodedSchema.name shouldBe "test_schema"
+                    }
+
+                    null -> {
+                        throw AssertionError("Unexpected format: ${config.format}")
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun `test OpenAIResponsesAPIStreamOptions serialization`() =
+        runWithBothJsonConfigurations("OpenAIResponsesAPIStreamOptions") { json ->
+            val jsonString = json.encodeToString(OpenAIResponsesAPIStreamOptions(includeObfuscation = false))
+
+            jsonString shouldEqualJson """
+            {
+                "includeObfuscation": false
+            }
+            """.trimIndent()
+
+            json.decodeFromString<OpenAIResponsesAPIStreamOptions>(jsonString).includeObfuscation shouldBe false
+        }
+
+    @Test
+    fun `test McpTool serialization`() = runWithBothJsonConfigurations("McpTool serialization") { json ->
+        val mcpTool = McpTool(
+            inputSchema = buildJsonObject {
+                put("type", JsonPrimitive("object"))
+                put(
+                    "properties",
+                    buildJsonObject {
+                        put(
+                            "query",
+                            buildJsonObject {
+                                put("type", JsonPrimitive("string"))
+                            }
+                        )
+                    }
+                )
+            },
+            name = "search_tool",
+            annotations = buildJsonObject {
+                put("description", JsonPrimitive("A search tool"))
+            },
+            description = "Tool for searching content"
+        )
+
+        json.decodeFromString<McpTool>(json.encodeToString(mcpTool)).shouldNotBeNull {
+            name shouldBe "search_tool"
+            description shouldBe "Tool for searching content"
+            inputSchema["type"]?.jsonPrimitive?.content shouldBe "object"
+            annotations?.get("description")?.jsonPrimitive?.content shouldBe "A search tool"
+        }
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAISerializersTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAISerializersTest.kt
@@ -1,0 +1,436 @@
+package ai.koog.prompt.executor.clients.openai.models
+
+import ai.koog.test.utils.runWithBothJsonConfigurations
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldInclude
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.matchers.types.shouldBeTypeOf
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.test.Test
+
+class OpenAISerializersTest {
+
+    @Test
+    fun `test ItemTextSerializer serialization`() =
+        runWithBothJsonConfigurations("ItemTextSerializer serialization") { json ->
+            json.encodeToString(ItemTextSerializer, Item.Text("Hello World")) shouldBe "\"Hello World\""
+        }
+
+    @Test
+    fun `test ItemTextSerializer deserialization`() =
+        runWithBothJsonConfigurations("ItemTextSerializer deserialization") { json ->
+            json.decodeFromJsonElement(ItemTextSerializer, JsonPrimitive("Hello World")).shouldNotBeNull {
+                shouldBeTypeOf<Item.Text>()
+                value shouldBe "Hello World"
+            }
+        }
+
+    @Test
+    fun `test ItemPolymorphicSerializer with JsonPrimitive`() =
+        runWithBothJsonConfigurations("ItemPolymorphicSerializer JsonPrimitive") { json ->
+            json.decodeFromJsonElement(
+                ItemPolymorphicSerializer,
+                JsonPrimitive("Simple text")
+            ).shouldNotBeNull {
+                shouldBeInstanceOf<Item.Text>()
+                value shouldBe "Simple text"
+            }
+        }
+
+    @Test
+    fun `test ItemPolymorphicSerializer with InputMessage`() =
+        runWithBothJsonConfigurations("ItemPolymorphicSerializer InputMessage") { json ->
+            val messageJson = buildJsonObject {
+                put("type", JsonPrimitive("message"))
+                put(
+                    "content",
+                    buildJsonArray {
+                        add(
+                            buildJsonObject {
+                                put("type", JsonPrimitive("input_text"))
+                                put("text", JsonPrimitive("User message"))
+                            }
+                        )
+                    }
+                )
+                put("role", JsonPrimitive("user"))
+            }
+
+            json.decodeFromJsonElement(ItemPolymorphicSerializer, messageJson).shouldNotBeNull {
+                shouldBeInstanceOf<Item.InputMessage>()
+                role shouldBe "user"
+            }
+        }
+
+    @Test
+    fun `test ItemPolymorphicSerializer with OutputMessage`() =
+        runWithBothJsonConfigurations("ItemPolymorphicSerializer OutputMessage") { json ->
+            val messageJson = buildJsonObject {
+                put("type", JsonPrimitive("message"))
+                put("id", JsonPrimitive("msg_123")) // This makes it an OutputMessage
+                put(
+                    "content",
+                    buildJsonArray {
+                        add(
+                            buildJsonObject {
+                                put("type", JsonPrimitive("output_text"))
+                                put("annotations", buildJsonArray { })
+                                put("text", JsonPrimitive("Assistant message"))
+                            }
+                        )
+                    }
+                )
+                put("role", JsonPrimitive("assistant"))
+            }
+
+            json.decodeFromJsonElement(ItemPolymorphicSerializer, messageJson).shouldNotBeNull {
+                shouldBeInstanceOf<Item.OutputMessage>()
+                id shouldBe "msg_123"
+            }
+        }
+
+    @Test
+    fun `test ItemPolymorphicSerializer with all item types`() =
+        runWithBothJsonConfigurations("ItemPolymorphicSerializer all types") { json ->
+            val itemTypes = mapOf(
+                "file_search_call" to Item.FileSearchToolCall.serializer(),
+                "computer_call" to Item.ComputerToolCall.serializer(),
+                "computer_call_output" to Item.ComputerToolCallOutput.serializer(),
+                "web_search_call" to Item.WebSearchToolCall.serializer(),
+                "function_call" to Item.FunctionToolCall.serializer(),
+                "function_call_output" to Item.FunctionToolCallOutput.serializer(),
+                "reasoning" to Item.Reasoning.serializer(),
+                "image_generation_call" to Item.ImageGenerationCall.serializer(),
+                "code_interpreter_call" to Item.CodeInterpreterToolCall.serializer(),
+                "local_shell_call" to Item.LocalShellCall.serializer(),
+                "local_shell_call_output" to Item.LocalShellCallOutput.serializer(),
+                "mcp_list_tools" to Item.McpListTools.serializer(),
+                "mcp_approval_request" to Item.McpApprovalRequest.serializer(),
+                "mcp_approval_response" to Item.McpApprovalResponse.serializer(),
+                "mcp_call" to Item.McpToolCall.serializer(),
+                "custom_tool_call_output" to Item.CustomToolCallOutput.serializer(),
+                "custom_tool_call" to Item.CustomToolCall.serializer(),
+                "item_reference" to Item.ItemReference.serializer()
+            )
+
+            itemTypes.forEach { (type, _) ->
+                val itemJson = buildJsonObject {
+                    put("type", JsonPrimitive(type))
+                    // Add minimal required fields for each type
+                    when (type) {
+                        "file_search_call" -> {
+                            put("id", JsonPrimitive("search_123"))
+                            put("queries", buildJsonArray { add(JsonPrimitive("test")) })
+                            put("status", JsonPrimitive("completed"))
+                        }
+
+                        "computer_call" -> {
+                            put(
+                                "action",
+                                buildJsonObject {
+                                    put("type", JsonPrimitive("click"))
+                                    put("button", JsonPrimitive("left"))
+                                    put("x", JsonPrimitive(10))
+                                    put("y", JsonPrimitive(20))
+                                }
+                            )
+                            put("callId", JsonPrimitive("call_123"))
+                            put("id", JsonPrimitive("comp_123"))
+                            put("pendingSafetyChecks", buildJsonArray { })
+                            put("status", JsonPrimitive("completed"))
+                        }
+
+                        "computer_call_output" -> {
+                            put("callId", JsonPrimitive("call_123"))
+                            put(
+                                "output",
+                                buildJsonObject {
+                                    put("type", JsonPrimitive("computer_screenshot"))
+                                }
+                            )
+                        }
+
+                        "web_search_call" -> {
+                            put(
+                                "action",
+                                buildJsonObject {
+                                    put("type", JsonPrimitive("search"))
+                                    put("query", JsonPrimitive("test query"))
+                                }
+                            )
+                            put("id", JsonPrimitive("web_123"))
+                            put("status", JsonPrimitive("completed"))
+                        }
+
+                        "function_call" -> {
+                            put("arguments", JsonPrimitive("{}"))
+                            put("callId", JsonPrimitive("call_123"))
+                            put("name", JsonPrimitive("test_func"))
+                        }
+
+                        "function_call_output" -> {
+                            put("callId", JsonPrimitive("call_123"))
+                            put("output", JsonPrimitive("{}"))
+                        }
+
+                        "reasoning" -> {
+                            put("id", JsonPrimitive("reasoning_123"))
+                            put(
+                                "summary",
+                                buildJsonArray {
+                                    add(
+                                        buildJsonObject {
+                                            put("type", JsonPrimitive("summary_text"))
+                                            put("text", JsonPrimitive("Summary"))
+                                        }
+                                    )
+                                }
+                            )
+                        }
+
+                        "image_generation_call" -> {
+                            put("id", JsonPrimitive("img_123"))
+                            put("result", JsonPrimitive("base64_image"))
+                            put("status", JsonPrimitive("completed"))
+                        }
+
+                        "code_interpreter_call" -> {
+                            put("code", JsonPrimitive("print('hello')"))
+                            put("containerId", JsonPrimitive("container_123"))
+                            put("id", JsonPrimitive("code_123"))
+                            put("outputs", buildJsonArray { })
+                            put("status", JsonPrimitive("completed"))
+                        }
+
+                        "local_shell_call" -> {
+                            put(
+                                "action",
+                                buildJsonObject {
+                                    put("type", JsonPrimitive("exec"))
+                                    put("command", buildJsonArray { add(JsonPrimitive("echo")) })
+                                    put("end", buildJsonObject { })
+                                    put("timeoutMs", JsonPrimitive(5000))
+                                }
+                            )
+                            put("callId", JsonPrimitive("shell_123"))
+                            put("id", JsonPrimitive("call_123"))
+                            put("status", JsonPrimitive("completed"))
+                        }
+
+                        "local_shell_call_output" -> {
+                            put("id", JsonPrimitive("output_123"))
+                            put("output", JsonPrimitive("hello"))
+                        }
+
+                        "mcp_list_tools" -> {
+                            put("id", JsonPrimitive("list_123"))
+                            put("serverLabel", JsonPrimitive("server"))
+                            put("tools", buildJsonArray { })
+                        }
+
+                        "mcp_approval_request" -> {
+                            put("arguments", JsonPrimitive("{}"))
+                            put("id", JsonPrimitive("approval_123"))
+                            put("name", JsonPrimitive("tool"))
+                            put("serverLabel", JsonPrimitive("server"))
+                        }
+
+                        "mcp_approval_response" -> {
+                            put("approvalRequestId", JsonPrimitive("req_123"))
+                            put("approve", JsonPrimitive(true))
+                        }
+
+                        "mcp_call" -> {
+                            put("arguments", JsonPrimitive("{}"))
+                            put("id", JsonPrimitive("mcp_123"))
+                            put("name", JsonPrimitive("tool"))
+                            put("serverLabel", JsonPrimitive("server"))
+                        }
+
+                        "custom_tool_call_output" -> {
+                            put("callId", JsonPrimitive("call_123"))
+                            put("output", JsonPrimitive("result"))
+                        }
+
+                        "custom_tool_call" -> {
+                            put("callId", JsonPrimitive("call_123"))
+                            put("input", JsonPrimitive("input"))
+                            put("name", JsonPrimitive("custom"))
+                        }
+
+                        "item_reference" -> {
+                            put("id", JsonPrimitive("ref_123"))
+                        }
+                    }
+                }
+
+                json.decodeFromJsonElement(ItemPolymorphicSerializer, itemJson).shouldNotBeNull()
+            }
+        }
+
+    @Test
+    fun `test ItemPolymorphicSerializer unknown type error`() =
+        runWithBothJsonConfigurations("ItemPolymorphicSerializer unknown type") { json ->
+            shouldThrow<SerializationException> {
+                json.decodeFromJsonElement(
+                    ItemPolymorphicSerializer,
+                    buildJsonObject {
+                        put("type", JsonPrimitive("unknown_type"))
+                    }
+                )
+            }.message shouldBe "Unknown Item type: unknown_type"
+        }
+
+    @Test
+    fun `test ItemPolymorphicSerializer invalid format error`() =
+        runWithBothJsonConfigurations("ItemPolymorphicSerializer invalid format") { json ->
+            val invalidJson = JsonPrimitive(123) // Neither primitive string nor object
+
+            shouldThrow<SerializationException> {
+                json.decodeFromJsonElement(ItemPolymorphicSerializer, invalidJson)
+            }.message shouldInclude "String literal for key 'primitive' should be quoted at element"
+        }
+
+    @Test
+    fun `test OpenAIResponsesToolChoiceSerializer Mode serialization`() =
+        runWithBothJsonConfigurations("OpenAIResponsesToolChoiceSerializer Mode") { json ->
+            json.encodeToString(OpenAIResponsesToolChoiceSerializer, OpenAIResponsesToolChoice.Mode("auto"))
+                .shouldBe("\"auto\"")
+
+            json.decodeFromJsonElement(OpenAIResponsesToolChoiceSerializer, JsonPrimitive("auto"))
+                .shouldBe(OpenAIResponsesToolChoice.Mode("auto"))
+        }
+
+    @Test
+    fun `test OpenAIResponsesToolChoiceSerializer AllowedTools serialization`() =
+        runWithBothJsonConfigurations("OpenAIResponsesToolChoiceSerializer AllowedTools") { json ->
+            json.decodeFromJsonElement(
+                OpenAIResponsesToolChoiceSerializer,
+                json.parseToJsonElement(
+                    json.encodeToString(
+                        OpenAIResponsesToolChoiceSerializer,
+                        OpenAIResponsesToolChoice.AllowedTools(
+                            mode = "required",
+                            tools = listOf(buildJsonObject { put("type", JsonPrimitive("function")) })
+                        )
+                    )
+                )
+            ).shouldNotBeNull {
+                shouldBeInstanceOf<OpenAIResponsesToolChoice.AllowedTools>()
+                mode shouldBe "required"
+                tools shouldHaveSize 1
+            }
+        }
+
+    @Test
+    fun `test OpenAIResponsesToolChoiceSerializer HostedTool serialization`() =
+        runWithBothJsonConfigurations("OpenAIResponsesToolChoiceSerializer HostedTool") { json ->
+            json.decodeFromJsonElement(
+                OpenAIResponsesToolChoiceSerializer,
+                json.parseToJsonElement(
+                    json.encodeToString(
+                        OpenAIResponsesToolChoiceSerializer,
+                        OpenAIResponsesToolChoice.HostedTool("file_search")
+                    )
+                )
+            ).shouldNotBeNull {
+                shouldBeInstanceOf<OpenAIResponsesToolChoice.HostedTool>()
+                type shouldBe "file_search"
+            }
+        }
+
+    @Test
+    fun `test OpenAIResponsesToolChoiceSerializer unknown object type error`() =
+        runWithBothJsonConfigurations("OpenAIResponsesToolChoiceSerializer unknown type") { json ->
+            shouldThrow<SerializationException> {
+                json.decodeFromJsonElement(
+                    OpenAIResponsesToolChoiceSerializer,
+                    buildJsonObject {
+                        put("type", JsonPrimitive("unknown_hosted_type"))
+                    }
+                )
+            }.message shouldBe "Not recognize tool choice type: unknown_hosted_type"
+        }
+
+    @Test
+    fun `test OpenAIResponsesToolChoiceSerializer invalid array type error`() =
+        runWithBothJsonConfigurations("OpenAIResponsesToolChoiceSerializer array error") { json ->
+            shouldThrow<SerializationException> {
+                json.decodeFromJsonElement(OpenAIResponsesToolChoiceSerializer, buildJsonArray { })
+            }.message shouldBe "Tool choice must be either a string or an object"
+        }
+
+    @Test
+    fun `test OpenAIResponsesToolChoiceSerializer with number input`() =
+        runWithBothJsonConfigurations("OpenAIResponsesToolChoiceSerializer number input") { json ->
+            // Numbers are converted to string mode by the serializer
+            json.decodeFromJsonElement(
+                OpenAIResponsesToolChoiceSerializer,
+                JsonPrimitive(123)
+            ) shouldBe OpenAIResponsesToolChoice.Mode("123")
+        }
+
+    @Test
+    fun `test ItemTextSerializer with empty string`() =
+        runWithBothJsonConfigurations("ItemTextSerializer empty string") { json ->
+            json.encodeToString(ItemTextSerializer, Item.Text("")) shouldBe "\"\""
+            json.decodeFromJsonElement(ItemTextSerializer, JsonPrimitive("")).value shouldBe ""
+        }
+
+    @Test
+    fun `test ItemPolymorphicSerializer with minimal message`() =
+        runWithBothJsonConfigurations("ItemPolymorphicSerializer minimal message") { json ->
+            val minimalMessageJson = buildJsonObject {
+                put("type", JsonPrimitive("message"))
+                put("content", buildJsonArray { })
+                put("role", JsonPrimitive("user"))
+            }
+
+            val decodedMessage =
+                json.decodeFromJsonElement(ItemPolymorphicSerializer, minimalMessageJson) as Item.InputMessage
+            decodedMessage.role shouldBe "user"
+            decodedMessage.content shouldBe emptyList()
+            decodedMessage.status shouldBe null
+        }
+
+    @Test
+    fun `test complex serialization round trip`() = runWithBothJsonConfigurations("complex round trip") { json ->
+        val complexItem = Item.ComputerToolCall(
+            action = Item.ComputerToolCall.Action.Drag(
+                path = listOf(
+                    Item.ComputerToolCall.Action.Coordinates(0, 0),
+                    Item.ComputerToolCall.Action.Coordinates(100, 100)
+                )
+            ),
+            callId = "drag_call_123",
+            id = "drag_id_456",
+            pendingSafetyChecks = listOf(
+                Item.ComputerToolCall.PendingSafetyCheck("safety_001", "check_001", "Drag safety check")
+            ),
+            status = "in_progress"
+        )
+
+        json.decodeFromJsonElement(
+            ItemPolymorphicSerializer,
+            json.parseToJsonElement(json.encodeToString(ItemPolymorphicSerializer, complexItem))
+        ).shouldNotBeNull {
+            shouldBeInstanceOf<Item.ComputerToolCall>()
+            callId shouldBe "drag_call_123"
+            id shouldBe "drag_id_456"
+            status shouldBe "in_progress"
+            action.shouldNotBeNull {
+                shouldBeTypeOf<Item.ComputerToolCall.Action.Drag>()
+                path shouldHaveSize 2
+                path[0].shouldBeEqualToComparingFields(Item.ComputerToolCall.Action.Coordinates(0, 0))
+                path[1].shouldBeEqualToComparingFields(Item.ComputerToolCall.Action.Coordinates(100, 100))
+            }
+        }
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIStreamEventsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIStreamEventsTest.kt
@@ -1,0 +1,769 @@
+package ai.koog.prompt.executor.clients.openai.models
+
+import ai.koog.test.utils.runWithBothJsonConfigurations
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.test.Test
+
+class OpenAIStreamEventsTest {
+
+    @Test
+    fun `test ResponseCreated event serialization`() =
+        runWithBothJsonConfigurations("ResponseCreated serialization") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseCreated>(
+                json.encodeToString(
+                    OpenAIStreamEvent.ResponseCreated(
+                        OpenAIResponsesAPIResponse(
+                            created = 1699500000L,
+                            id = "resp_123",
+                            model = "gpt-4o",
+                            output = emptyList(),
+                            parallelToolCalls = false,
+                            status = OpenAIInputStatus.IN_PROGRESS,
+                            text = OpenAITextConfig()
+                        ),
+                        1
+                    )
+                )
+            ).shouldNotBeNull {
+                sequenceNumber shouldBe 1
+                response.id shouldBe "resp_123"
+            }
+        }
+
+    @Test
+    fun `test ResponseInProgress event serialization`() =
+        runWithBothJsonConfigurations("ResponseInProgress serialization") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseInProgress>(
+                json.encodeToString(
+                    OpenAIStreamEvent.ResponseInProgress(
+                        OpenAIResponsesAPIResponse(
+                            created = 1699500000L,
+                            id = "resp_456",
+                            model = "gpt-4o",
+                            output = emptyList(),
+                            parallelToolCalls = false,
+                            status = OpenAIInputStatus.IN_PROGRESS,
+                            text = OpenAITextConfig()
+                        ),
+                        2
+                    )
+                )
+            ).shouldNotBeNull {
+                sequenceNumber shouldBe 2
+                response.status shouldBe OpenAIInputStatus.IN_PROGRESS
+            }
+        }
+
+    @Test
+    fun `test ResponseCompleted event serialization`() =
+        runWithBothJsonConfigurations("ResponseCompleted serialization") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseCompleted>(
+                json.encodeToString(
+                    OpenAIStreamEvent.ResponseCompleted(
+                        OpenAIResponsesAPIResponse(
+                            created = 1699500000L,
+                            id = "resp_789",
+                            model = "gpt-4o",
+                            output = emptyList(),
+                            parallelToolCalls = false,
+                            status = OpenAIInputStatus.COMPLETED,
+                            text = OpenAITextConfig()
+                        ),
+                        3
+                    )
+                )
+            ).shouldNotBeNull {
+                sequenceNumber shouldBe 3
+                response.status shouldBe OpenAIInputStatus.COMPLETED
+            }
+        }
+
+    @Test
+    fun `test ResponseFailed event serialization`() =
+        runWithBothJsonConfigurations("ResponseFailed serialization") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseFailed>(
+                json.encodeToString(
+                    OpenAIStreamEvent.ResponseFailed(
+                        OpenAIResponsesAPIResponse(
+                            created = 1699500000L,
+                            id = "resp_fail",
+                            model = "gpt-4o",
+                            output = emptyList(),
+                            parallelToolCalls = false,
+                            status = OpenAIInputStatus.FAILED,
+                            text = OpenAITextConfig()
+                        ),
+                        4
+                    )
+                )
+            ).shouldNotBeNull {
+                sequenceNumber shouldBe 4
+                response.status shouldBe OpenAIInputStatus.FAILED
+            }
+        }
+
+    @Test
+    fun `test ResponseIncomplete event serialization`() =
+        runWithBothJsonConfigurations("ResponseIncomplete serialization") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseIncomplete>(
+                json.encodeToString(
+                    OpenAIStreamEvent.ResponseIncomplete(
+                        OpenAIResponsesAPIResponse(
+                            created = 1699500000L,
+                            id = "resp_incomplete",
+                            model = "gpt-4o",
+                            output = emptyList(),
+                            parallelToolCalls = false,
+                            status = OpenAIInputStatus.INCOMPLETE,
+                            text = OpenAITextConfig()
+                        ),
+                        5
+                    )
+                )
+            ).shouldNotBeNull {
+                sequenceNumber shouldBe 5
+                response.status shouldBe OpenAIInputStatus.INCOMPLETE
+            }
+        }
+
+    @Test
+    fun `test ResponseOutputItemAdded event serialization`() =
+        runWithBothJsonConfigurations("ResponseOutputItemAdded serialization") { json ->
+            val item = Item.OutputMessage(
+                content = listOf(OutputContent.Text(annotations = emptyList(), text = "Test")),
+                id = "msg_test_123"
+            )
+            json.decodeFromString<OpenAIStreamEvent.ResponseOutputItemAdded>(
+                json.encodeToString(OpenAIStreamEvent.ResponseOutputItemAdded(item, 0, 6))
+            ).shouldNotBeNull {
+                outputIndex shouldBe 0
+                sequenceNumber shouldBe 6
+                (this.item as Item.OutputMessage).content shouldHaveSize 1
+                (this.item.content[0] as OutputContent.Text).text shouldBe "Test"
+            }
+        }
+
+    @Test
+    fun `test ResponseOutputItemDone event serialization`() =
+        runWithBothJsonConfigurations("ResponseOutputItemDone serialization") { json ->
+            val item = Item.OutputMessage(
+                content = listOf(OutputContent.Text(annotations = emptyList(), text = "Done")),
+                id = "msg_done_456"
+            )
+            json.decodeFromString<OpenAIStreamEvent.ResponseOutputItemDone>(
+                json.encodeToString(OpenAIStreamEvent.ResponseOutputItemDone(item, 1, 7))
+            ).shouldNotBeNull {
+                outputIndex shouldBe 1
+                sequenceNumber shouldBe 7
+                (this.item as Item.OutputMessage).content shouldHaveSize 1
+                (this.item.content[0] as OutputContent.Text).text shouldBe "Done"
+            }
+        }
+
+    @Test
+    fun `test ResponseContentPartAdded event serialization`() =
+        runWithBothJsonConfigurations("ResponseContentPartAdded serialization") { json ->
+            val part = OutputContent.Text(annotations = emptyList(), text = "Content part")
+            json.decodeFromString<OpenAIStreamEvent.ResponseContentPartAdded>(
+                json.encodeToString(OpenAIStreamEvent.ResponseContentPartAdded("item_123", 0, 0, part, 8))
+            ).shouldNotBeNull {
+                itemId shouldBe "item_123"
+                outputIndex shouldBe 0
+                contentIndex shouldBe 0
+                sequenceNumber shouldBe 8
+                (this.part as OutputContent.Text).text shouldBe "Content part"
+                this.part.annotations shouldBe emptyList()
+            }
+        }
+
+    @Test
+    fun `test ResponseOutputTextDelta event serialization`() =
+        runWithBothJsonConfigurations("ResponseOutputTextDelta serialization") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseOutputTextDelta>(
+                json.encodeToString(
+                    OpenAIStreamEvent.ResponseOutputTextDelta(
+                        itemId = "item_456",
+                        outputIndex = 1,
+                        contentIndex = 0,
+                        delta = "Hello",
+                        logprobs = listOf(
+                            OpenAIStreamEvent.LogProbWithTop(
+                                logprob = -0.1,
+                                token = "Hello",
+                                topLogprobs = listOf(OpenAIStreamEvent.LogProb(-0.1, "Hello"))
+                            )
+                        ),
+                        sequenceNumber = 9
+                    )
+                )
+            ).shouldNotBeNull {
+                itemId shouldBe "item_456"
+                outputIndex shouldBe 1
+                contentIndex shouldBe 0
+                delta shouldBe "Hello"
+                logprobs?.size shouldBe 1
+                logprobs?.first()?.token shouldBe "Hello"
+                sequenceNumber shouldBe 9
+            }
+        }
+
+    @Test
+    fun `test ResponseOutputTextDone event serialization`() =
+        runWithBothJsonConfigurations("ResponseOutputTextDone serialization") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseOutputTextDone>(
+                json.encodeToString(
+                    OpenAIStreamEvent.ResponseOutputTextDone(
+                        itemId = "item_789",
+                        outputIndex = 2,
+                        contentIndex = 1,
+                        text = "Complete text",
+                        logprobs = null,
+                        sequenceNumber = 10
+                    )
+                )
+            ).shouldNotBeNull {
+                itemId shouldBe "item_789"
+                outputIndex shouldBe 2
+                contentIndex shouldBe 1
+                text shouldBe "Complete text"
+                logprobs shouldBe null
+                sequenceNumber shouldBe 10
+            }
+        }
+
+    @Test
+    fun `test ResponseRefusalDelta event serialization`() =
+        runWithBothJsonConfigurations("ResponseRefusalDelta serialization") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseRefusalDelta>(
+                json.encodeToString(OpenAIStreamEvent.ResponseRefusalDelta("item_ref", 0, 0, "I cannot", 11))
+            ).shouldNotBeNull {
+                itemId shouldBe "item_ref"
+                outputIndex shouldBe 0
+                contentIndex shouldBe 0
+                delta shouldBe "I cannot"
+                sequenceNumber shouldBe 11
+            }
+        }
+
+    @Test
+    fun `test ResponseRefusalDone event serialization`() =
+        runWithBothJsonConfigurations("ResponseRefusalDone serialization") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseRefusalDone>(
+                json.encodeToString(
+                    OpenAIStreamEvent.ResponseRefusalDone(
+                        "item_ref_done",
+                        0,
+                        0,
+                        "I cannot help with that",
+                        12
+                    )
+                )
+            ).shouldNotBeNull {
+                itemId shouldBe "item_ref_done"
+                outputIndex shouldBe 0
+                contentIndex shouldBe 0
+                refusal shouldBe "I cannot help with that"
+                sequenceNumber shouldBe 12
+            }
+        }
+
+    @Test
+    fun `test function call streaming events delta`() =
+        runWithBothJsonConfigurations("function call events delta") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseFunctionCallArgumentsDelta>(
+                json.encodeToString(
+                    OpenAIStreamEvent.ResponseFunctionCallArgumentsDelta(
+                        "item_func",
+                        0,
+                        """{"param":""",
+                        13
+                    )
+                )
+            ).shouldNotBeNull {
+                delta shouldBe """{"param":"""
+                sequenceNumber shouldBe 13
+            }
+        }
+
+    @Test
+    fun `test function call streaming events done`() =
+        runWithBothJsonConfigurations("function call events done") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseFunctionCallArgumentsDone>(
+                json.encodeToString(
+                    OpenAIStreamEvent.ResponseFunctionCallArgumentsDone(
+                        "item_func",
+                        0,
+                        """{"param":"value"}""",
+                        14
+                    )
+                )
+            ).shouldNotBeNull {
+                arguments shouldBe """{"param":"value"}"""
+                sequenceNumber shouldBe 14
+            }
+        }
+
+    @Test
+    fun `test file search call in progress event`() =
+        runWithBothJsonConfigurations("file search call in progress") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseFileSearchCallInProgress>(
+                json.encodeToString(OpenAIStreamEvent.ResponseFileSearchCallInProgress("search_item", 0, 15))
+            ).shouldNotBeNull {
+                itemId shouldBe "search_item"
+                outputIndex shouldBe 0
+                sequenceNumber shouldBe 15
+            }
+        }
+
+    @Test
+    fun `test file search call searching event`() =
+        runWithBothJsonConfigurations("file search call searching") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseFileSearchCallSearching>(
+                json.encodeToString(OpenAIStreamEvent.ResponseFileSearchCallSearching("search_item", 0, 16))
+            ).shouldNotBeNull {
+                itemId shouldBe "search_item"
+                outputIndex shouldBe 0
+                sequenceNumber shouldBe 16
+            }
+        }
+
+    @Test
+    fun `test file search call completed event`() =
+        runWithBothJsonConfigurations("file search call completed") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseFileSearchCallCompleted>(
+                json.encodeToString(OpenAIStreamEvent.ResponseFileSearchCallCompleted("search_item", 0, 17))
+            ).shouldNotBeNull {
+                itemId shouldBe "search_item"
+                outputIndex shouldBe 0
+                sequenceNumber shouldBe 17
+            }
+        }
+
+    @Test
+    fun `test web search call in progress event`() =
+        runWithBothJsonConfigurations("web search call in progress") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseWebSearchCallInProgress>(
+                json.encodeToString(OpenAIStreamEvent.ResponseWebSearchCallInProgress("web_item", 1, 18))
+            ).shouldNotBeNull {
+                itemId shouldBe "web_item"
+                outputIndex shouldBe 1
+                sequenceNumber shouldBe 18
+            }
+        }
+
+    @Test
+    fun `test web search call searching event`() = runWithBothJsonConfigurations("web search call searching") { json ->
+        json.decodeFromString<OpenAIStreamEvent.ResponseWebSearchCallSearching>(
+            json.encodeToString(OpenAIStreamEvent.ResponseWebSearchCallSearching("web_item", 1, 19))
+        ).shouldNotBeNull {
+            itemId shouldBe "web_item"
+            outputIndex shouldBe 1
+            sequenceNumber shouldBe 19
+        }
+    }
+
+    @Test
+    fun `test web search call completed event`() = runWithBothJsonConfigurations("web search call completed") { json ->
+        json.decodeFromString<OpenAIStreamEvent.ResponseWebSearchCallCompleted>(
+            json.encodeToString(OpenAIStreamEvent.ResponseWebSearchCallCompleted("web_item", 1, 20))
+        ).shouldNotBeNull {
+            itemId shouldBe "web_item"
+            outputIndex shouldBe 1
+            sequenceNumber shouldBe 20
+        }
+    }
+
+    @Test
+    fun `test SummaryPart serialization`() = runWithBothJsonConfigurations("SummaryPart serialization") { json ->
+        val summaryPart = OpenAIStreamEvent.SummaryPart("Summary text")
+
+        summaryPart.text shouldBe "Summary text"
+        summaryPart.type shouldBe "summary_part"
+
+        json.decodeFromString<OpenAIStreamEvent.SummaryPart>(
+            json.encodeToString(summaryPart)
+        ).shouldNotBeNull {
+            text shouldBe "Summary text"
+            type shouldBe "summary_part"
+        }
+    }
+
+    @Test
+    fun `test reasoning summary part added event`() =
+        runWithBothJsonConfigurations("reasoning summary part added") { json ->
+            val summaryPart = OpenAIStreamEvent.SummaryPart("Summary text")
+            json.decodeFromString<OpenAIStreamEvent.ResponseReasoningSummaryPartAdded>(
+                json.encodeToString(
+                    OpenAIStreamEvent.ResponseReasoningSummaryPartAdded(
+                        "reasoning_item",
+                        0,
+                        0,
+                        summaryPart,
+                        21
+                    )
+                )
+            ).shouldNotBeNull {
+                itemId shouldBe "reasoning_item"
+                part.text shouldBe "Summary text"
+                sequenceNumber shouldBe 21
+            }
+        }
+
+    @Test
+    fun `test reasoning summary part done event`() =
+        runWithBothJsonConfigurations("reasoning summary part done") { json ->
+            val summaryPart = OpenAIStreamEvent.SummaryPart("Summary text")
+            json.decodeFromString<OpenAIStreamEvent.ResponseReasoningSummaryPartDone>(
+                json.encodeToString(
+                    OpenAIStreamEvent.ResponseReasoningSummaryPartDone(
+                        "reasoning_item",
+                        0,
+                        0,
+                        summaryPart,
+                        22
+                    )
+                )
+            ).shouldNotBeNull {
+                itemId shouldBe "reasoning_item"
+                sequenceNumber shouldBe 22
+            }
+        }
+
+    @Test
+    fun `test reasoning summary text delta event`() =
+        runWithBothJsonConfigurations("reasoning summary text delta") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseReasoningSummaryTextDelta>(
+                json.encodeToString(
+                    OpenAIStreamEvent.ResponseReasoningSummaryTextDelta(
+                        "reasoning_item",
+                        0,
+                        0,
+                        "Summary",
+                        23
+                    )
+                )
+            ).shouldNotBeNull {
+                itemId shouldBe "reasoning_item"
+                delta shouldBe "Summary"
+                sequenceNumber shouldBe 23
+            }
+        }
+
+    @Test
+    fun `test reasoning summary text done event`() =
+        runWithBothJsonConfigurations("reasoning summary text done") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseReasoningSummaryTextDone>(
+                json.encodeToString(
+                    OpenAIStreamEvent.ResponseReasoningSummaryTextDone(
+                        "reasoning_item",
+                        0,
+                        0,
+                        "Summary complete",
+                        24
+                    )
+                )
+            ).shouldNotBeNull {
+                itemId shouldBe "reasoning_item"
+                text shouldBe "Summary complete"
+                sequenceNumber shouldBe 24
+            }
+        }
+
+    @Test
+    fun `test reasoning text delta event`() = runWithBothJsonConfigurations("reasoning text delta") { json ->
+        json.decodeFromString<OpenAIStreamEvent.ResponseReasoningTextDelta>(
+            json.encodeToString(
+                OpenAIStreamEvent.ResponseReasoningTextDelta(
+                    "reasoning_item",
+                    0,
+                    0,
+                    "Thinking",
+                    25
+                )
+            )
+        ).shouldNotBeNull {
+            itemId shouldBe "reasoning_item"
+            delta shouldBe "Thinking"
+            sequenceNumber shouldBe 25
+        }
+    }
+
+    @Test
+    fun `test reasoning text done event`() = runWithBothJsonConfigurations("reasoning text done") { json ->
+        json.decodeFromString<OpenAIStreamEvent.ResponseReasoningTextDone>(
+            json.encodeToString(
+                OpenAIStreamEvent.ResponseReasoningTextDone(
+                    "reasoning_item",
+                    0,
+                    0,
+                    "Thinking complete",
+                    26
+                )
+            )
+        ).shouldNotBeNull {
+            itemId shouldBe "reasoning_item"
+            text shouldBe "Thinking complete"
+            sequenceNumber shouldBe 26
+        }
+    }
+
+    @Test
+    fun `test image generation call in progress event`() =
+        runWithBothJsonConfigurations("image generation call in progress") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseImageGenerationCallInProgress>(
+                json.encodeToString(OpenAIStreamEvent.ResponseImageGenerationCallInProgress("img_item", 0, 27))
+            ).shouldNotBeNull {
+                itemId shouldBe "img_item"
+                outputIndex shouldBe 0
+                sequenceNumber shouldBe 27
+            }
+        }
+
+    @Test
+    fun `test image generation call generating event`() =
+        runWithBothJsonConfigurations("image generation call generating") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseImageGenerationCallGenerating>(
+                json.encodeToString(OpenAIStreamEvent.ResponseImageGenerationCallGenerating("img_item", 0, 28))
+            ).shouldNotBeNull {
+                itemId shouldBe "img_item"
+                outputIndex shouldBe 0
+                sequenceNumber shouldBe 28
+            }
+        }
+
+    @Test
+    fun `test image generation call partial image event`() =
+        runWithBothJsonConfigurations("image generation call partial image") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseImageGenerationCallPartialImage>(
+                json.encodeToString(
+                    OpenAIStreamEvent.ResponseImageGenerationCallPartialImage(
+                        "img_item",
+                        0,
+                        0,
+                        "base64data",
+                        29
+                    )
+                )
+            ).shouldNotBeNull {
+                itemId shouldBe "img_item"
+                outputIndex shouldBe 0
+                partialImageIndex shouldBe 0
+                partialImageB64 shouldBe "base64data"
+                sequenceNumber shouldBe 29
+            }
+        }
+
+    @Test
+    fun `test image generation call completed event`() =
+        runWithBothJsonConfigurations("image generation call completed") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseImageGenerationCallCompleted>(
+                json.encodeToString(OpenAIStreamEvent.ResponseImageGenerationCallCompleted("img_item", 0, 30))
+            ).shouldNotBeNull {
+                itemId shouldBe "img_item"
+                outputIndex shouldBe 0
+                sequenceNumber shouldBe 30
+            }
+        }
+
+    @Test
+    fun `test code interpreter call in progress event`() =
+        runWithBothJsonConfigurations("code interpreter call in progress") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseCodeInterpreterCallInProgress>(
+                json.encodeToString(OpenAIStreamEvent.ResponseCodeInterpreterCallInProgress("code_item", 0, 39))
+            ).shouldNotBeNull {
+                itemId shouldBe "code_item"
+                outputIndex shouldBe 0
+                sequenceNumber shouldBe 39
+            }
+        }
+
+    @Test
+    fun `test code interpreter call interpreting event`() =
+        runWithBothJsonConfigurations("code interpreter call interpreting") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseCodeInterpreterCallInterpreting>(
+                json.encodeToString(OpenAIStreamEvent.ResponseCodeInterpreterCallInterpreting("code_item", 0, 40))
+            ).shouldNotBeNull {
+                itemId shouldBe "code_item"
+                outputIndex shouldBe 0
+                sequenceNumber shouldBe 40
+            }
+        }
+
+    @Test
+    fun `test code interpreter call completed event`() =
+        runWithBothJsonConfigurations("code interpreter call completed") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseCodeInterpreterCallCompleted>(
+                json.encodeToString(OpenAIStreamEvent.ResponseCodeInterpreterCallCompleted("code_item", 0, 41))
+            ).shouldNotBeNull {
+                itemId shouldBe "code_item"
+                outputIndex shouldBe 0
+                sequenceNumber shouldBe 41
+            }
+        }
+
+    @Test
+    fun `test code interpreter call code delta event`() =
+        runWithBothJsonConfigurations("code interpreter call code delta") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseCodeInterpreterCallCodeDelta>(
+                json.encodeToString(
+                    OpenAIStreamEvent.ResponseCodeInterpreterCallCodeDelta(
+                        "code_item",
+                        0,
+                        "print(",
+                        42
+                    )
+                )
+            ).shouldNotBeNull {
+                itemId shouldBe "code_item"
+                outputIndex shouldBe 0
+                delta shouldBe "print("
+                sequenceNumber shouldBe 42
+            }
+        }
+
+    @Test
+    fun `test code interpreter call code done event`() =
+        runWithBothJsonConfigurations("code interpreter call code done") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseCodeInterpreterCallCodeDone>(
+                json.encodeToString(
+                    OpenAIStreamEvent.ResponseCodeInterpreterCallCodeDone(
+                        "code_item",
+                        0,
+                        "print('Hello')",
+                        43
+                    )
+                )
+            ).shouldNotBeNull {
+                itemId shouldBe "code_item"
+                outputIndex shouldBe 0
+                code shouldBe "print('Hello')"
+                sequenceNumber shouldBe 43
+            }
+        }
+
+    @Test
+    fun `test output text annotation added event`() =
+        runWithBothJsonConfigurations("output text annotation added") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseOutputTextAnnotationAdded>(
+                json.encodeToString(
+                    OpenAIStreamEvent.ResponseOutputTextAnnotationAdded(
+                        "item_anno",
+                        0,
+                        0,
+                        0,
+                        buildJsonObject { put("type", JsonPrimitive("test")) },
+                        44
+                    )
+                )
+            ).shouldNotBeNull {
+                itemId shouldBe "item_anno"
+                outputIndex shouldBe 0
+                contentIndex shouldBe 0
+                annotationIndex shouldBe 0
+                sequenceNumber shouldBe 44
+            }
+        }
+
+    @Test
+    fun `test response queued event`() = runWithBothJsonConfigurations("response queued") { json ->
+        json.decodeFromString<OpenAIStreamEvent.ResponseQueued>(
+            json.encodeToString(
+                OpenAIStreamEvent.ResponseQueued(
+                    OpenAIResponsesAPIResponse(
+                        created = 1699500000L,
+                        id = "queued_resp",
+                        model = "gpt-4o",
+                        output = emptyList(),
+                        parallelToolCalls = false,
+                        status = OpenAIInputStatus.QUEUED,
+                        text = OpenAITextConfig()
+                    ),
+                    45
+                )
+            )
+        ).shouldNotBeNull {
+            response.id shouldBe "queued_resp"
+            response.status shouldBe OpenAIInputStatus.QUEUED
+            sequenceNumber shouldBe 45
+        }
+    }
+
+    @Test
+    fun `test custom tool call input delta event`() =
+        runWithBothJsonConfigurations("custom tool call input delta") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseCustomToolCallInputDelta>(
+                json.encodeToString(OpenAIStreamEvent.ResponseCustomToolCallInputDelta("custom_item", 0, "input_", 46))
+            ).shouldNotBeNull {
+                itemId shouldBe "custom_item"
+                outputIndex shouldBe 0
+                delta shouldBe "input_"
+                sequenceNumber shouldBe 46
+            }
+        }
+
+    @Test
+    fun `test custom tool call input done event`() =
+        runWithBothJsonConfigurations("custom tool call input done") { json ->
+            json.decodeFromString<OpenAIStreamEvent.ResponseCustomToolCallInputDone>(
+                json.encodeToString(
+                    OpenAIStreamEvent.ResponseCustomToolCallInputDone(
+                        "custom_item",
+                        0,
+                        "input_data",
+                        47
+                    )
+                )
+            ).shouldNotBeNull {
+                itemId shouldBe "custom_item"
+                outputIndex shouldBe 0
+                input shouldBe "input_data"
+                sequenceNumber shouldBe 47
+            }
+        }
+
+    @Test
+    fun `test stream error event`() = runWithBothJsonConfigurations("stream error") { json ->
+        json.decodeFromString<OpenAIStreamEvent.Error>(
+            json.encodeToString(OpenAIStreamEvent.Error("invalid_request", "Bad request", "param", 48))
+        ).shouldNotBeNull {
+            code shouldBe "invalid_request"
+            message shouldBe "Bad request"
+            param shouldBe "param"
+            sequenceNumber shouldBe 48
+        }
+    }
+
+    @Test
+    fun `test LogProb and LogProbWithTop serialization`() =
+        runWithBothJsonConfigurations("LogProb serialization") { json ->
+            json.decodeFromString<OpenAIStreamEvent.LogProb>(
+                json.encodeToString(OpenAIStreamEvent.LogProb(-0.5, "token"))
+            ).shouldNotBeNull {
+                logprob shouldBe -0.5
+                token shouldBe "token"
+            }
+
+            json.decodeFromString<OpenAIStreamEvent.LogProbWithTop>(
+                json.encodeToString(
+                    OpenAIStreamEvent.LogProbWithTop(
+                        -0.3,
+                        "main_token",
+                        listOf(
+                            OpenAIStreamEvent.LogProb(-0.3, "main_token"),
+                            OpenAIStreamEvent.LogProb(-1.2, "alt_token")
+                        )
+                    )
+                )
+            ).shouldNotBeNull {
+                logprob shouldBe -0.3
+                token shouldBe "main_token"
+                topLogprobs.size shouldBe 2
+                topLogprobs[1].token shouldBe "alt_token"
+                topLogprobs[1].logprob shouldBe -1.2
+            }
+        }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIToolsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIToolsTest.kt
@@ -1,0 +1,649 @@
+package ai.koog.prompt.executor.clients.openai.models
+
+import ai.koog.test.utils.runWithBothJsonConfigurations
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+
+class OpenAIToolsTest {
+
+    @Test
+    fun `test OpenAIResponsesTool_Function serialization`() =
+        runWithBothJsonConfigurations("Function tool serialization") { json ->
+            val functionTool = OpenAIResponsesTool.Function(
+                name = "get_weather",
+                parameters = buildJsonObject {
+                    put("type", JsonPrimitive("object"))
+                    put(
+                        "properties",
+                        buildJsonObject {
+                            put(
+                                "location",
+                                buildJsonObject {
+                                    put("type", JsonPrimitive("string"))
+                                    put("description", JsonPrimitive("The city name"))
+                                }
+                            )
+                        }
+                    )
+                    put(
+                        "required",
+                        buildJsonArray {
+                            add(JsonPrimitive("location"))
+                        }
+                    )
+                },
+                strict = true,
+                description = "Get current weather for a location"
+            )
+
+            json.encodeToString(functionTool) shouldEqualJson """
+            {
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "The city name"
+                        }
+                    },
+                    "required": ["location"]
+                },
+                "strict": true,
+                "description": "Get current weather for a location"
+            }
+            """.trimIndent()
+
+            json.decodeFromString<OpenAIResponsesTool.Function>(
+                json.encodeToString(functionTool)
+            ).shouldNotBeNull {
+                name shouldBe "get_weather"
+                description shouldBe "Get current weather for a location"
+                strict shouldBe true
+                parameters["type"]?.jsonPrimitive?.content shouldBe "object"
+            }
+        }
+
+    @Test
+    fun `test OpenAIResponsesTool_FileSearch serialization`() =
+        runWithBothJsonConfigurations("FileSearch tool serialization") { json ->
+            val fileSearchTool = OpenAIResponsesTool.FileSearch(
+                vectorStoreIds = listOf("vs_123", "vs_456"),
+                filters = buildJsonObject {
+                    put("category", JsonPrimitive("documents"))
+                },
+                maxNumResults = 10,
+                rankingOptions = buildJsonObject {
+                    put("algorithm", JsonPrimitive("similarity"))
+                }
+            )
+
+            json.encodeToString(fileSearchTool) shouldEqualJson """
+            {
+                "vectorStoreIds": ["vs_123", "vs_456"],
+                "filters": {"category": "documents"},
+                "maxNumResults": 10,
+                "rankingOptions": {"algorithm": "similarity"}
+            }
+            """.trimIndent()
+
+            json.decodeFromString<OpenAIResponsesTool.FileSearch>(
+                json.encodeToString(fileSearchTool)
+            ).shouldNotBeNull {
+                vectorStoreIds shouldHaveSize 2
+                vectorStoreIds shouldBe listOf("vs_123", "vs_456")
+                maxNumResults shouldBe 10
+                filters?.get("category")?.jsonPrimitive?.content shouldBe "documents"
+            }
+        }
+
+    @Test
+    fun `test OpenAIResponsesTool_WebSearchPreview serialization`() =
+        runWithBothJsonConfigurations("WebSearchPreview tool serialization") { json ->
+            val webSearchTool = OpenAIResponsesTool.WebSearchPreview(
+                searchContextSize = "medium",
+                userLocation = OpenAIResponsesTool.WebSearchPreview.UserLocation(
+                    city = "San Francisco",
+                    country = "US",
+                    region = "California",
+                    timezone = "America/Los_Angeles"
+                )
+            )
+
+            json.decodeFromString<OpenAIResponsesTool.WebSearchPreview>(
+                json.encodeToString(webSearchTool)
+            ).shouldNotBeNull {
+                searchContextSize shouldBe "medium"
+                userLocation.shouldNotBeNull {
+                    city shouldBe "San Francisco"
+                    country shouldBe "US"
+                    region shouldBe "California"
+                    timezone shouldBe "America/Los_Angeles"
+                    type shouldBe "approximate"
+                }
+            }
+        }
+
+    @Test
+    fun `test OpenAIResponsesTool_ComputerUsePreview serialization`() =
+        runWithBothJsonConfigurations("ComputerUsePreview tool serialization") { json ->
+            val computerUseTool = OpenAIResponsesTool.ComputerUsePreview(
+                displayHeight = 1080,
+                displayWidth = 1920,
+                environment = "desktop"
+            )
+
+            json.encodeToString(computerUseTool) shouldEqualJson """
+            {
+                "displayHeight": 1080,
+                "displayWidth": 1920,
+                "environment": "desktop"
+            }
+            """.trimIndent()
+
+            json.decodeFromString<OpenAIResponsesTool.ComputerUsePreview>(
+                json.encodeToString(computerUseTool)
+            ).shouldNotBeNull {
+                displayHeight shouldBe 1080
+                displayWidth shouldBe 1920
+                environment shouldBe "desktop"
+            }
+        }
+
+    @Test
+    fun `test OpenAIResponsesTool_McpTool serialization`() =
+        runWithBothJsonConfigurations("McpTool serialization") { json ->
+            val mcpTool = OpenAIResponsesTool.McpTool(
+                serverLabel = "my_mcp_server",
+                serverUrl = "https://mcp.example.com",
+                allowedTools = listOf("search", "analyze"),
+                headers = buildJsonObject {
+                    put("Authorization", JsonPrimitive("Bearer token123"))
+                },
+                requireApproval = "all",
+                serverDescription = "External MCP server for data analysis"
+            )
+
+            json.encodeToString(mcpTool) shouldEqualJson """
+            {
+                "serverLabel": "my_mcp_server",
+                "serverUrl": "https://mcp.example.com",
+                "allowedTools": ["search", "analyze"],
+                "headers": {"Authorization": "Bearer token123"},
+                "requireApproval": "all",
+                "serverDescription": "External MCP server for data analysis"
+            }
+            """.trimIndent()
+
+            json.decodeFromString<OpenAIResponsesTool.McpTool>(
+                json.encodeToString(mcpTool)
+            ).shouldNotBeNull {
+                serverLabel shouldBe "my_mcp_server"
+                serverUrl shouldBe "https://mcp.example.com"
+                allowedTools shouldBe listOf("search", "analyze")
+                headers?.get("Authorization")?.jsonPrimitive?.content shouldBe "Bearer token123"
+                requireApproval shouldBe "all"
+                serverDescription shouldBe "External MCP server for data analysis"
+            }
+        }
+
+    @Test
+    fun `test OpenAIResponsesTool_CodeInterpreter serialization`() =
+        runWithBothJsonConfigurations("CodeInterpreter tool serialization") { json ->
+            val codeInterpreter = OpenAIResponsesTool.CodeInterpreter("container_abc123")
+
+            json.encodeToString(codeInterpreter) shouldEqualJson """
+            {
+                "container": "container_abc123"
+            }
+            """.trimIndent()
+
+            json.decodeFromString<OpenAIResponsesTool.CodeInterpreter>(
+                json.encodeToString(codeInterpreter)
+            ).shouldNotBeNull {
+                container shouldBe "container_abc123"
+            }
+        }
+
+    @Test
+    fun `test OpenAIResponsesTool_ImageGenerationTool serialization`() =
+        runWithBothJsonConfigurations("ImageGenerationTool serialization") { json ->
+            val imageGenTool = OpenAIResponsesTool.ImageGenerationTool(
+                background = "transparent",
+                inputFidelity = "high",
+                inputImageMask = buildJsonObject {
+                    put("image_url", JsonPrimitive("https://example.com/mask.png"))
+                },
+                model = "gpt-image-1",
+                moderation = "auto",
+                outputCompression = 95,
+                outputFormat = "png",
+                partialImages = 2,
+                quality = "high",
+                size = "1024x1024"
+            )
+
+            json.decodeFromString<OpenAIResponsesTool.ImageGenerationTool>(
+                json.encodeToString(imageGenTool)
+            ).shouldNotBeNull {
+                background shouldBe "transparent"
+                inputFidelity shouldBe "high"
+                model shouldBe "gpt-image-1"
+                moderation shouldBe "auto"
+                outputCompression shouldBe 95
+                outputFormat shouldBe "png"
+                partialImages shouldBe 2
+                quality shouldBe "high"
+                size shouldBe "1024x1024"
+                inputImageMask?.get("image_url")?.jsonPrimitive?.content shouldBe "https://example.com/mask.png"
+            }
+        }
+
+    @Test
+    fun `test OpenAIResponsesTool_LocalShellTool serialization`() =
+        runWithBothJsonConfigurations("LocalShellTool serialization") { json ->
+            val localShellTool = OpenAIResponsesTool.LocalShellTool()
+
+            json.encodeToString(localShellTool) shouldEqualJson """
+            {
+            }
+            """.trimIndent()
+
+            json.decodeFromString<OpenAIResponsesTool.LocalShellTool>(
+                json.encodeToString(localShellTool)
+            ).shouldNotBeNull()
+        }
+
+    @Test
+    fun `test OpenAIResponsesTool_CustomTool with text format`() =
+        runWithBothJsonConfigurations("CustomTool text format") { json ->
+            val textFormatTool = OpenAIResponsesTool.CustomTool(
+                name = "text_processor",
+                description = "Process text input",
+                format = OpenAIResponsesTool.CustomTool.Format.Text()
+            )
+
+            json.decodeFromString<OpenAIResponsesTool.CustomTool>(
+                json.encodeToString(textFormatTool)
+            ).shouldNotBeNull {
+                name shouldBe "text_processor"
+                description shouldBe "Process text input"
+                format?.javaClass shouldBe OpenAIResponsesTool.CustomTool.Format.Text::class.java
+            }
+        }
+
+    @Test
+    fun `test OpenAIResponsesTool_CustomTool with grammar format`() =
+        runWithBothJsonConfigurations("CustomTool grammar format") { json ->
+            val grammarFormatTool = OpenAIResponsesTool.CustomTool(
+                name = "grammar_parser",
+                description = "Parse with custom grammar",
+                format = OpenAIResponsesTool.CustomTool.Format.Grammar(
+                    definition = "start: expr+",
+                    syntax = "lark"
+                )
+            )
+
+            json.decodeFromString<OpenAIResponsesTool.CustomTool>(
+                json.encodeToString(grammarFormatTool)
+            ).shouldNotBeNull {
+                name shouldBe "grammar_parser"
+                description shouldBe "Parse with custom grammar"
+                val grammarFormat = format as OpenAIResponsesTool.CustomTool.Format.Grammar
+                grammarFormat.definition shouldBe "start: expr+"
+                grammarFormat.syntax shouldBe "lark"
+            }
+        }
+
+    @Test
+    fun `test OpenAIResponsesToolChoice_Mode auto serialization`() =
+        runWithBothJsonConfigurations("ToolChoice Mode auto") { json ->
+            val autoChoice = OpenAIResponsesToolChoice.Mode("auto")
+
+            json.decodeFromJsonElement(
+                OpenAIResponsesToolChoiceSerializer,
+                JsonPrimitive("auto")
+            ) shouldBe autoChoice
+        }
+
+    @Test
+    fun `test OpenAIResponsesToolChoice_Mode none serialization`() =
+        runWithBothJsonConfigurations("ToolChoice Mode none") { json ->
+            val noneChoice = OpenAIResponsesToolChoice.Mode("none")
+
+            json.decodeFromJsonElement(
+                OpenAIResponsesToolChoiceSerializer,
+                JsonPrimitive("none")
+            ) shouldBe noneChoice
+        }
+
+    @Test
+    fun `test OpenAIResponsesToolChoice_Mode required serialization`() =
+        runWithBothJsonConfigurations("ToolChoice Mode required") { json ->
+            val requiredChoice = OpenAIResponsesToolChoice.Mode("required")
+
+            json.decodeFromJsonElement(
+                OpenAIResponsesToolChoiceSerializer,
+                JsonPrimitive("required")
+            ) shouldBe requiredChoice
+        }
+
+    @Test
+    fun `test OpenAIResponsesToolChoice_AllowedTools serialization`() =
+        runWithBothJsonConfigurations("ToolChoice AllowedTools serialization") { json ->
+            val allowedTools = OpenAIResponsesToolChoice.AllowedTools(
+                mode = "auto",
+                tools = listOf(
+                    buildJsonObject {
+                        put("type", JsonPrimitive("function"))
+                        put("name", JsonPrimitive("get_weather"))
+                    },
+                    buildJsonObject {
+                        put("type", JsonPrimitive("mcp"))
+                        put("server_label", JsonPrimitive("deepwiki"))
+                    }
+                )
+            )
+
+            json.encodeToString(OpenAIResponsesToolChoiceSerializer, allowedTools) shouldEqualJson """
+            {
+                "type": "allowed_tools",
+                "mode": "auto",
+                "tools": [
+                    {"type": "function", "name": "get_weather"},
+                    {"type": "mcp", "server_label": "deepwiki"}
+                ]
+            }
+            """.trimIndent()
+
+            (
+                json.decodeFromJsonElement(
+                    OpenAIResponsesToolChoiceSerializer,
+                    json.parseToJsonElement(json.encodeToString(OpenAIResponsesToolChoiceSerializer, allowedTools))
+                ) as OpenAIResponsesToolChoice.AllowedTools
+                ).shouldNotBeNull {
+                mode shouldBe "auto"
+                tools shouldHaveSize 2
+                type shouldBe "allowed_tools"
+            }
+        }
+
+    @Test
+    fun `test OpenAIResponsesToolChoice_HostedTool file_search serialization`() =
+        runWithBothJsonConfigurations("ToolChoice HostedTool file_search") { json ->
+            val tool = OpenAIResponsesToolChoice.HostedTool("file_search")
+
+            (
+                json.decodeFromJsonElement(
+                    OpenAIResponsesToolChoiceSerializer,
+                    json.parseToJsonElement(json.encodeToString(OpenAIResponsesToolChoiceSerializer, tool))
+                ) as OpenAIResponsesToolChoice.HostedTool
+                ).type shouldBe "file_search"
+        }
+
+    @Test
+    fun `test OpenAIResponsesToolChoice_HostedTool web_search_preview serialization`() =
+        runWithBothJsonConfigurations("ToolChoice HostedTool web_search_preview") { json ->
+            val tool = OpenAIResponsesToolChoice.HostedTool("web_search_preview")
+
+            (
+                json.decodeFromJsonElement(
+                    OpenAIResponsesToolChoiceSerializer,
+                    json.parseToJsonElement(json.encodeToString(OpenAIResponsesToolChoiceSerializer, tool))
+                ) as OpenAIResponsesToolChoice.HostedTool
+                ).type shouldBe "web_search_preview"
+        }
+
+    @Test
+    fun `test OpenAIResponsesToolChoice_HostedTool computer_use_preview serialization`() =
+        runWithBothJsonConfigurations("ToolChoice HostedTool computer_use_preview") { json ->
+            val tool = OpenAIResponsesToolChoice.HostedTool("computer_use_preview")
+
+            (
+                json.decodeFromJsonElement(
+                    OpenAIResponsesToolChoiceSerializer,
+                    json.parseToJsonElement(json.encodeToString(OpenAIResponsesToolChoiceSerializer, tool))
+                ) as OpenAIResponsesToolChoice.HostedTool
+                ).type shouldBe "computer_use_preview"
+        }
+
+    @Test
+    fun `test OpenAIResponsesToolChoice_HostedTool code_interpreter serialization`() =
+        runWithBothJsonConfigurations("ToolChoice HostedTool code_interpreter") { json ->
+            val tool = OpenAIResponsesToolChoice.HostedTool("code_interpreter")
+
+            (
+                json.decodeFromJsonElement(
+                    OpenAIResponsesToolChoiceSerializer,
+                    json.parseToJsonElement(json.encodeToString(OpenAIResponsesToolChoiceSerializer, tool))
+                ) as OpenAIResponsesToolChoice.HostedTool
+                ).type shouldBe "code_interpreter"
+        }
+
+    @Test
+    fun `test OpenAIResponsesToolChoice_HostedTool image_generation serialization`() =
+        runWithBothJsonConfigurations("ToolChoice HostedTool image_generation") { json ->
+            val tool = OpenAIResponsesToolChoice.HostedTool("image_generation")
+
+            (
+                json.decodeFromJsonElement(
+                    OpenAIResponsesToolChoiceSerializer,
+                    json.parseToJsonElement(json.encodeToString(OpenAIResponsesToolChoiceSerializer, tool))
+                ) as OpenAIResponsesToolChoice.HostedTool
+                ).type shouldBe "image_generation"
+        }
+
+    @Test
+    fun `test OpenAIResponsesToolChoice_FunctionTool serialization`() =
+        runWithBothJsonConfigurations("ToolChoice FunctionTool serialization") { json ->
+            val functionTool = OpenAIResponsesToolChoice.FunctionTool("calculate_sum")
+
+            json.encodeToString(OpenAIResponsesToolChoiceSerializer, functionTool) shouldEqualJson """
+            {
+                "type": "function",
+                "name": "calculate_sum"
+            }
+            """.trimIndent()
+
+            (
+                json.decodeFromJsonElement(
+                    OpenAIResponsesToolChoiceSerializer,
+                    json.parseToJsonElement(json.encodeToString(OpenAIResponsesToolChoiceSerializer, functionTool))
+                ) as OpenAIResponsesToolChoice.FunctionTool
+                ).shouldNotBeNull {
+                name shouldBe "calculate_sum"
+                type shouldBe "function"
+            }
+        }
+
+    @Test
+    fun `test OpenAIResponsesToolChoice_McpTool with name serialization`() =
+        runWithBothJsonConfigurations("ToolChoice McpTool with name") { json ->
+            val mcpToolWithName = OpenAIResponsesToolChoice.McpTool(
+                serverLabel = "my_server",
+                name = "search_tool"
+            )
+
+            (
+                json.decodeFromJsonElement(
+                    OpenAIResponsesToolChoiceSerializer,
+                    json.parseToJsonElement(json.encodeToString(OpenAIResponsesToolChoiceSerializer, mcpToolWithName))
+                ) as OpenAIResponsesToolChoice.McpTool
+                ).shouldNotBeNull {
+                serverLabel shouldBe "my_server"
+                name shouldBe "search_tool"
+                type shouldBe "mcp"
+            }
+        }
+
+    @Test
+    fun `test OpenAIResponsesToolChoice_McpTool without name serialization`() =
+        runWithBothJsonConfigurations("ToolChoice McpTool without name") { json ->
+            val mcpToolWithoutName = OpenAIResponsesToolChoice.McpTool(
+                serverLabel = "another_server"
+            )
+
+            (
+                json.decodeFromJsonElement(
+                    OpenAIResponsesToolChoiceSerializer,
+                    json.parseToJsonElement(
+                        json.encodeToString(
+                            OpenAIResponsesToolChoiceSerializer,
+                            mcpToolWithoutName
+                        )
+                    )
+                ) as OpenAIResponsesToolChoice.McpTool
+                ).shouldNotBeNull {
+                serverLabel shouldBe "another_server"
+                name shouldBe null
+                type shouldBe "mcp"
+            }
+        }
+
+    @Test
+    fun `test OpenAIResponsesToolChoice_CustomTool serialization`() =
+        runWithBothJsonConfigurations("ToolChoice CustomTool serialization") { json ->
+            val customTool = OpenAIResponsesToolChoice.CustomTool("data_transformer")
+
+            json.encodeToString(OpenAIResponsesToolChoiceSerializer, customTool) shouldEqualJson """
+            {
+                "type": "custom",
+                "name": "data_transformer"
+            }
+            """.trimIndent()
+
+            (
+                json.decodeFromJsonElement(
+                    OpenAIResponsesToolChoiceSerializer,
+                    json.parseToJsonElement(json.encodeToString(OpenAIResponsesToolChoiceSerializer, customTool))
+                ) as OpenAIResponsesToolChoice.CustomTool
+                ).shouldNotBeNull {
+                name shouldBe "data_transformer"
+                type shouldBe "custom"
+            }
+        }
+
+    @Test
+    fun `test OpenAIResponsesTool_Function round trip serialization`() =
+        runWithBothJsonConfigurations("Function tool round trip") { json ->
+            val tool = OpenAIResponsesTool.Function(
+                name = "test_func",
+                parameters = buildJsonObject { put("type", JsonPrimitive("object")) }
+            )
+
+            json.decodeFromString<OpenAIResponsesTool.Function>(
+                json.encodeToString(tool)
+            ).shouldNotBeNull()
+        }
+
+    @Test
+    fun `test OpenAIResponsesTool_FileSearch round trip serialization`() =
+        runWithBothJsonConfigurations("FileSearch tool round trip") { json ->
+            val tool = OpenAIResponsesTool.FileSearch(vectorStoreIds = listOf("vs_1"))
+
+            json.decodeFromString<OpenAIResponsesTool.FileSearch>(
+                json.encodeToString(tool)
+            ).shouldNotBeNull()
+        }
+
+    @Test
+    fun `test OpenAIResponsesTool_WebSearchPreview round trip serialization`() =
+        runWithBothJsonConfigurations("WebSearchPreview tool round trip") { json ->
+            val tool = OpenAIResponsesTool.WebSearchPreview()
+
+            json.decodeFromString<OpenAIResponsesTool.WebSearchPreview>(
+                json.encodeToString(tool)
+            ).shouldNotBeNull()
+        }
+
+    @Test
+    fun `test OpenAIResponsesTool_ComputerUsePreview round trip serialization`() =
+        runWithBothJsonConfigurations("ComputerUsePreview tool round trip") { json ->
+            val tool = OpenAIResponsesTool.ComputerUsePreview(1080, 1920, "desktop")
+
+            json.decodeFromString<OpenAIResponsesTool.ComputerUsePreview>(
+                json.encodeToString(tool)
+            ).shouldNotBeNull()
+        }
+
+    @Test
+    fun `test OpenAIResponsesTool_McpTool round trip serialization`() =
+        runWithBothJsonConfigurations("McpTool round trip") { json ->
+            val tool = OpenAIResponsesTool.McpTool("server1", "https://server1.com")
+
+            json.decodeFromString<OpenAIResponsesTool.McpTool>(
+                json.encodeToString(tool)
+            ).shouldNotBeNull()
+        }
+
+    @Test
+    fun `test OpenAIResponsesTool_CodeInterpreter round trip serialization`() =
+        runWithBothJsonConfigurations("CodeInterpreter round trip") { json ->
+            val tool = OpenAIResponsesTool.CodeInterpreter("container1")
+
+            json.decodeFromString<OpenAIResponsesTool.CodeInterpreter>(
+                json.encodeToString(tool)
+            ).shouldNotBeNull()
+        }
+
+    @Test
+    fun `test OpenAIResponsesTool_ImageGenerationTool round trip serialization`() =
+        runWithBothJsonConfigurations("ImageGenerationTool round trip") { json ->
+            val tool = OpenAIResponsesTool.ImageGenerationTool()
+
+            json.decodeFromString<OpenAIResponsesTool.ImageGenerationTool>(
+                json.encodeToString(tool)
+            ).shouldNotBeNull()
+        }
+
+    @Test
+    fun `test OpenAIResponsesTool_LocalShellTool round trip serialization`() =
+        runWithBothJsonConfigurations("LocalShellTool round trip") { json ->
+            val tool = OpenAIResponsesTool.LocalShellTool()
+
+            json.decodeFromString<OpenAIResponsesTool.LocalShellTool>(
+                json.encodeToString(tool)
+            ).shouldNotBeNull()
+        }
+
+    @Test
+    fun `test OpenAIResponsesTool_CustomTool round trip serialization`() =
+        runWithBothJsonConfigurations("CustomTool round trip") { json ->
+            val tool = OpenAIResponsesTool.CustomTool("custom1")
+
+            json.decodeFromString<OpenAIResponsesTool.CustomTool>(
+                json.encodeToString(tool)
+            ).shouldNotBeNull()
+        }
+
+    @Test
+    fun `test tool choice serializer invalid type error`() =
+        runWithBothJsonConfigurations("tool choice invalid type") { json ->
+            val invalidJson = buildJsonObject {
+                put("type", JsonPrimitive("invalid_type"))
+            }
+
+            try {
+                json.decodeFromJsonElement(OpenAIResponsesToolChoiceSerializer, invalidJson)
+            } catch (e: Exception) {
+                e.message shouldBe "Not recognize tool choice type: invalid_type"
+            }
+        }
+
+    @Test
+    fun `test tool choice serializer invalid element type error`() =
+        runWithBothJsonConfigurations("tool choice invalid element") { json ->
+            try {
+                json.decodeFromJsonElement(OpenAIResponsesToolChoiceSerializer, buildJsonArray {})
+            } catch (e: Exception) {
+                e.message shouldBe "Tool choice must be either a string or an object"
+            }
+        }
+}


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

Please add a brief description of the proposed change here.
Also, please tick the appropriate points in the checklist below.
-->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
A part of our plan of increasing test coverage up to 100%, [KG-565](https://youtrack.jetbrains.com/issue/KG-565) Cover missing OpenAIResponsesAPI fields/methods.
- Add serialization and deserialization tests for OpenAIResponsesAPI
- Rewrite assertions in the tests in the modult to kotest ones

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tests improvement
- [x] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
