### PR TITLE
fix: tool result as text serialization

### DIFF
--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/Tool.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/Tool.kt
@@ -29,12 +29,6 @@ public abstract class Tool<TArgs, TResult> {
         argsSerializer.asToolDescriptorSerializer()
     }
 
-    // FIXME just a quickfix, more proper and thorough update is required for Tool
-    @OptIn(InternalAgentToolsApi::class)
-    private val actualResultSerializer by lazy {
-        resultSerializer.asToolDescriptorSerializer()
-    }
-
     /**
      * Serializer responsible for encoding the result of the tool execution.
      * This abstract property is used to define the specific [KSerializer] corresponding to the type of arguments
@@ -128,7 +122,7 @@ public abstract class Tool<TArgs, TResult> {
      * @return The decoded result of type TResult.
      */
     public fun decodeResult(rawResult: JsonElement): TResult =
-        json.decodeFromJsonElement(actualResultSerializer, rawResult)
+        json.decodeFromJsonElement(resultSerializer, rawResult)
 
     /**
      * Encodes the given arguments into a JSON representation.
@@ -162,7 +156,7 @@ public abstract class Tool<TArgs, TResult> {
      * @return A JsonObject representing the encoded result.
      */
     public fun encodeResult(result: TResult): JsonElement =
-        json.encodeToJsonElement(actualResultSerializer, result)
+        json.encodeToJsonElement(resultSerializer, result)
 
     /**
      * Encodes the given result object into a JSON representation without type safety checks.

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolResult.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolResult.kt
@@ -2,6 +2,8 @@ package ai.koog.agents.core.tools
 
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
@@ -158,7 +160,11 @@ public interface ToolResult {
          * This descriptor corresponds to the valueSerializer's descriptor, defining the
          * structure of the serialized data and associated information like kind and elements.
          */
-        override val descriptor: SerialDescriptor = valueSerializer.descriptor
+        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor(
+            valueSerializer.descriptor.serialName,
+            PrimitiveKind.STRING
+        )
+//        override val descriptor: SerialDescriptor = valueSerializer.descriptor
 
         /**
          * Serializes an object of type `T` into its textual representation.


### PR DESCRIPTION
After using `kotlinx.serialization` for tool result handling, `AsTextSerializer` and `TextSerializable` are broken, causing `EditFileTool`, `ReadFileTool` and `ListDirectoryTool` throw exception whenever called.

## Motivation and Context

Fix #1164 

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [ ] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added (There's no tests for `AsTextSerializer` and `TextSerializable` originally!)
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [x] Docs have been added / updated
