### PR TITLE
KG-576. Finalise an agent resources after the agent run for the StatefulSingleUseAIAgent

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/GraphAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/GraphAIAgent.kt
@@ -16,7 +16,6 @@ import ai.koog.agents.core.feature.config.FeatureConfig
 import ai.koog.agents.core.feature.pipeline.AIAgentGraphPipeline
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.prompt.executor.model.PromptExecutor
-import ai.koog.utils.io.Closeable
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.datetime.Clock
 import kotlin.reflect.KType
@@ -59,7 +58,7 @@ public open class GraphAIAgent<Input, Output>(
 ) : StatefulSingleUseAIAgent<Input, Output, AIAgentGraphContextBase>(
     logger = logger,
     id = id,
-), Closeable {
+) {
 
     private companion object {
         private val logger = KotlinLogging.logger {}

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentFunctionalPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentFunctionalPipeline.kt
@@ -33,6 +33,6 @@ public class AIAgentFunctionalPipeline(clock: Clock = Clock.System) : AIAgentPip
             pipeline = this,
         )
 
-        registeredFeatures[feature.key] = RegisteredFeature(featureImpl, featureConfig)
+        super.install(feature.key, featureConfig, featureImpl)
     }
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
@@ -48,12 +48,12 @@ public class AIAgentGraphPipeline(clock: Clock = Clock.System) : AIAgentPipeline
      * The feature's message processors are initialized during installation.
      *
      * @param TConfig The type of the feature configuration
-     * @param TFeature The type of the feature being installed
+     * @param TFeatureImpl The type of the feature being installed
      * @param feature The feature implementation to be installed
      * @param configure A lambda to customize the feature configuration
      */
-    public fun <TConfig : FeatureConfig, TFeature : Any> install(
-        feature: AIAgentGraphFeature<TConfig, TFeature>,
+    public fun <TConfig : FeatureConfig, TFeatureImpl : Any> install(
+        feature: AIAgentGraphFeature<TConfig, TFeatureImpl>,
         configure: TConfig.() -> Unit,
     ) {
         val featureConfig = feature.createInitialConfig().apply { configure() }
@@ -62,7 +62,7 @@ public class AIAgentGraphPipeline(clock: Clock = Clock.System) : AIAgentPipeline
             pipeline = this,
         )
 
-        registeredFeatures[feature.key] = RegisteredFeature(featureImpl, featureConfig)
+        super.install(feature.key, featureConfig, featureImpl)
     }
 
     //region Trigger Node Handlers

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/GraphAIAgentTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/GraphAIAgentTest.kt
@@ -1,0 +1,52 @@
+package ai.koog.agents.core.agent
+
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.core.feature.TestFeature
+import ai.koog.agents.core.feature.mock.TestFeatureMessageProcessor
+import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import kotlinx.coroutines.test.runTest
+import kotlin.reflect.typeOf
+import kotlin.test.Test
+import kotlin.test.assertFalse
+
+class GraphAIAgentTest {
+
+    @Test
+    fun testGraphAgentFeatureProcessorsClosedAfterRun() = runTest {
+        val model = OpenAIModels.Chat.GPT4o
+
+        val agentConfig = AIAgentConfig(
+            prompt = prompt(id = "test-chat") {},
+            model = model,
+            maxAgentIterations = 10,
+        )
+
+        val strategy = strategy<String, String>("test-strategy") {
+            nodeStart then nodeFinish
+        }
+
+        val testFeatureMessageProcessor = TestFeatureMessageProcessor()
+
+        val agent = GraphAIAgent(
+            id = "test-agent",
+            inputType = typeOf<String>(),
+            outputType = typeOf<String>(),
+            promptExecutor = getMockExecutor { },
+            agentConfig = agentConfig,
+            strategy = strategy,
+        ) {
+            install(TestFeature) {
+                addMessageProcessor(testFeatureMessageProcessor)
+            }
+        }
+
+        agent.run("Test input")
+        assertFalse(
+            testFeatureMessageProcessor.isOpen.value,
+            "Feature message processors should be closed after the agent run"
+        )
+    }
+}

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/feature/AIAgentPipelineJvmTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/feature/AIAgentPipelineJvmTest.kt
@@ -86,7 +86,7 @@ class AIAgentPipelineJvmTest {
 
         // Run prepare features logic
         AIAgentGraphPipeline().use { pipeline ->
-            pipeline.prepareFeatures()
+            pipeline.prepareAllFeatures()
 
             // Check Debugger feature parameters
             val actualFeature = pipeline.feature(Debugger::class, Debugger)
@@ -110,7 +110,7 @@ class AIAgentPipelineJvmTest {
 
         // Run prepare features logic
         AIAgentGraphPipeline().use { pipeline ->
-            pipeline.prepareFeatures()
+            pipeline.prepareAllFeatures()
 
             // Check Debugger feature parameters
             val actualFeature = pipeline.feature(Debugger::class, Debugger)
@@ -173,7 +173,7 @@ class AIAgentPipelineJvmTest {
         )
 
         AIAgentGraphPipeline().use { pipeline ->
-            pipeline.prepareFeatures()
+            pipeline.prepareAllFeatures()
 
             val debuggerFeature = pipeline.feature(Debugger::class, Debugger)
             assertNull(debuggerFeature, "Debugger feature is not null")
@@ -194,7 +194,7 @@ class AIAgentPipelineJvmTest {
 
         // Run prepare features logic
         AIAgentGraphPipeline().use { pipeline ->
-            pipeline.prepareFeatures()
+            pipeline.prepareAllFeatures()
 
             // Check Debugger feature is installed
             val actualFeature = pipeline.feature(Debugger::class, Debugger)
@@ -216,7 +216,7 @@ class AIAgentPipelineJvmTest {
 
         // Run prepare features logic
         AIAgentGraphPipeline().use { pipeline ->
-            pipeline.prepareFeatures()
+            pipeline.prepareAllFeatures()
 
             // Check Debugger feature is installed
             val actualFeature = pipeline.feature(Debugger::class, Debugger)
@@ -300,6 +300,6 @@ private suspend inline fun AIAgentPipeline.use(block: suspend (AIAgentPipeline) 
     try {
         block(this)
     } finally {
-        closeFeaturesStreamProviders()
+        closeAllFeaturesMessageProcessors()
     }
 }

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerStreamingTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerStreamingTest.kt
@@ -15,7 +15,6 @@ import ai.koog.agents.core.feature.remote.client.FeatureMessageRemoteClient
 import ai.koog.agents.core.feature.remote.client.config.DefaultClientConnectionConfig
 import ai.koog.agents.core.feature.writer.FeatureMessageRemoteWriter
 import ai.koog.agents.core.system.feature.DebuggerTestAPI.HOST
-import ai.koog.agents.core.system.feature.DebuggerTestAPI.connectWithRetry
 import ai.koog.agents.core.system.feature.DebuggerTestAPI.defaultClientServerTimeout
 import ai.koog.agents.core.system.feature.DebuggerTestAPI.mockLLModel
 import ai.koog.agents.core.system.feature.DebuggerTestAPI.testBaseClient
@@ -156,7 +155,7 @@ class DebuggerStreamingTest {
                 val collectEventsJob =
                     clientEventsCollector.startCollectEvents(coroutineScope = this@launch)
 
-                client.connectWithRetry(defaultClientServerTimeout)
+                client.connect()
                 collectEventsJob.join()
 
                 val callIds = clientEventsCollector.collectedEvents.filterIsInstance<LLMStreamingStartingEvent>().map { it.callId }
@@ -347,7 +346,7 @@ class DebuggerStreamingTest {
                 val collectEventsJob =
                     clientEventsCollector.startCollectEvents(coroutineScope = this@launch)
 
-                client.connectWithRetry(defaultClientServerTimeout)
+                client.connect()
                 collectEventsJob.join()
 
                 val callIds = clientEventsCollector.collectedEvents.filterIsInstance<LLMStreamingStartingEvent>().map { it.callId }

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerSubgraphTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerSubgraphTest.kt
@@ -14,7 +14,6 @@ import ai.koog.agents.core.feature.remote.client.FeatureMessageRemoteClient
 import ai.koog.agents.core.feature.remote.client.config.DefaultClientConnectionConfig
 import ai.koog.agents.core.feature.writer.FeatureMessageRemoteWriter
 import ai.koog.agents.core.system.feature.DebuggerTestAPI.HOST
-import ai.koog.agents.core.system.feature.DebuggerTestAPI.connectWithRetry
 import ai.koog.agents.core.system.feature.DebuggerTestAPI.defaultClientServerTimeout
 import ai.koog.agents.core.system.feature.DebuggerTestAPI.mockLLModel
 import ai.koog.agents.core.system.feature.DebuggerTestAPI.testBaseClient
@@ -119,7 +118,7 @@ class DebuggerSubgraphTest {
                 val collectEventsJob =
                     clientEventsCollector.startCollectEvents(coroutineScope = this@launch)
 
-                client.connectWithRetry(defaultClientServerTimeout)
+                client.connect()
                 collectEventsJob.join()
 
                 val encodedUserInput = @OptIn(InternalAgentsApi::class)
@@ -247,7 +246,7 @@ class DebuggerSubgraphTest {
                 val collectEventsJob =
                     clientEventsCollector.startCollectEvents(coroutineScope = this@launch)
 
-                client.connectWithRetry(defaultClientServerTimeout)
+                client.connect()
                 collectEventsJob.join()
 
                 val encodedUserInput = @OptIn(InternalAgentsApi::class)

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerTest.kt
@@ -30,7 +30,6 @@ import ai.koog.agents.core.feature.remote.client.FeatureMessageRemoteClient
 import ai.koog.agents.core.feature.remote.client.config.DefaultClientConnectionConfig
 import ai.koog.agents.core.feature.writer.FeatureMessageRemoteWriter
 import ai.koog.agents.core.system.feature.DebuggerTestAPI.HOST
-import ai.koog.agents.core.system.feature.DebuggerTestAPI.connectWithRetry
 import ai.koog.agents.core.system.feature.DebuggerTestAPI.defaultClientServerTimeout
 import ai.koog.agents.core.system.feature.DebuggerTestAPI.mockLLModel
 import ai.koog.agents.core.system.feature.DebuggerTestAPI.testBaseClient
@@ -190,13 +189,12 @@ class DebuggerTest {
                 baseClient = testBaseClient,
                 scope = this
             ).use { client ->
-
                 val clientEventsCollector = ClientEventsCollector(client = client)
 
                 val collectEventsJob =
                     clientEventsCollector.startCollectEvents(coroutineScope = this@launch)
 
-                client.connectWithRetry(defaultClientServerTimeout)
+                client.connect()
                 collectEventsJob.join()
 
                 // Correct run id will be set after the 'collect events job' is finished.

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerTestAPI.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerTestAPI.kt
@@ -29,13 +29,10 @@ import ai.koog.utils.io.use
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.http.URLProtocol
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.io.IOException
 import kotlin.reflect.typeOf
@@ -51,23 +48,7 @@ internal object DebuggerTestAPI {
 
     internal const val HOST = "127.0.0.1"
 
-    internal val defaultClientServerTimeout = 1000.seconds
-
-    internal suspend fun FeatureMessageRemoteClient.connectWithRetry(timeout: Duration) {
-        withTimeout(timeout) {
-            while (true) {
-                try {
-                    connect()
-                    return@withTimeout
-                } catch (exception: Exception) {
-                    if (exception is CancellationException) {
-                        throw exception
-                    }
-                    delay(300)
-                }
-            }
-        }
-    }
+    internal val defaultClientServerTimeout = 30.seconds
 
     internal val testBaseClient: HttpClient
         get() = HttpClient {

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetrySpanTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetrySpanTest.kt
@@ -98,6 +98,7 @@ class OpenTelemetrySpanTest : OpenTelemetryTestBase() {
             val model = defaultModel
 
             val expectedSpans = listOf(
+                // First run
                 mapOf(
                     "agent.$agentId" to mapOf(
                         "attributes" to mapOf(
@@ -109,8 +110,6 @@ class OpenTelemetrySpanTest : OpenTelemetryTestBase() {
                         "events" to emptyMap()
                     )
                 ),
-
-                // First run
                 mapOf(
                     "run.${mockExporter.runIds[1]}" to mapOf(
                         "attributes" to mapOf(
@@ -158,6 +157,17 @@ class OpenTelemetrySpanTest : OpenTelemetryTestBase() {
                 ),
 
                 // Second run
+                mapOf(
+                    "agent.$agentId" to mapOf(
+                        "attributes" to mapOf(
+                            "gen_ai.operation.name" to OperationNameType.CREATE_AGENT.id,
+                            "gen_ai.system" to model.provider.id,
+                            "gen_ai.agent.id" to agentId,
+                            "gen_ai.request.model" to model.id
+                        ),
+                        "events" to emptyMap()
+                    )
+                ),
                 mapOf(
                     "run.${mockExporter.runIds[0]}" to mapOf(
                         "attributes" to mapOf(

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/mock/TestFeatureMessageWriter.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/mock/TestFeatureMessageWriter.kt
@@ -2,12 +2,13 @@ package ai.koog.agents.features.tracing.mock
 
 import ai.koog.agents.core.feature.message.FeatureMessage
 import ai.koog.agents.core.feature.message.FeatureMessageProcessor
+import ai.koog.agents.core.feature.model.events.AgentClosingEvent
 import ai.koog.agents.core.feature.model.events.AgentStartingEvent
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
-class TestFeatureMessageWriter : FeatureMessageProcessor() {
+class TestFeatureMessageWriter(private val onClose: (suspend () -> Unit)? = null) : FeatureMessageProcessor() {
 
     var runId: String = ""
 
@@ -31,10 +32,11 @@ class TestFeatureMessageWriter : FeatureMessageProcessor() {
         }
 
         _messages.add(message)
+
+        if (message is AgentClosingEvent) {
+            onClose?.invoke()
+        }
     }
 
-    override suspend fun close() {
-        logger.info { "Closing test event message writer" }
-        runId = ""
-    }
+    override suspend fun close() { }
 }


### PR DESCRIPTION
[KG-576](https://youtrack.jetbrains.com/issue/KG-576). 

- Explicitly finalise an agent resources after the `run()` method. The `StatefulSingleUseAIAgent` agent instance is not able to run multiple times. After the run, it does not make sense to keep an instance resources. It can be safe to finalise resources after the the `run()` method invocation and not wait for the close() method to be called;
- Add tests to verify the graph and Functional agent features finalisation logic.

## Motivation and Context
Maker sure agent releases feature resources after finishing the agent execution.

## Breaking Changes
No

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
