### PR TITLE
Clamp `endLine` to file length and add warnings for overflow(KG-534 )

### DIFF
--- a/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/ReadFileToolJvmTest.kt
+++ b/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/ReadFileToolJvmTest.kt
@@ -303,4 +303,21 @@ class ReadFileToolJvmTest {
             runBlocking { readFile(f, startLine = 0, endLine = -2) }
         }
     }
+
+    @Test
+    fun `includes warning when endLine exceeds file length`() = runBlocking {
+        val f = createTestFile("short.txt", "line1\nline2\nline3")
+
+        val result = readFile(f, startLine = 0, endLine = 200)
+
+        val expected = """
+            Warning: endLine=200 exceeds file length (3 lines). Clamped to available lines 0-3.
+            ${"${f.toAbsolutePath().toString().norm()} (<0.1 KiB, 3 lines)"}
+            Content:
+            line1
+            line2
+            line3
+        """.trimIndent()
+        assertEquals(expected, result.textForLLM())
+    }
 }


### PR DESCRIPTION
When endLine exceeds the actual file length, `ReadFileTool` throws an error like "endLine=200 must be <= lineCount=50 or -1". Instead of failing, it should return all available lines with a warning.

https://youtrack.jetbrains.com/issue/KG-534

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [x] The change was discussed and approved in the issue
- [x] Docs have been added / updated
