### PR TITLE
Fix empty list condition check

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentEdges.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentEdges.kt
@@ -162,7 +162,7 @@ public infix fun <IncomingOutput, OutgoingInput> AIAgentEdgeBuilderIntermediate<
     return onIsInstance(List::class)
         .transformed { it.filterIsInstance<Message.Tool.Call>() }
         // skipping this edge in case we have list of only assistant messages
-        .onCondition { it.any() }
+        .onCondition { it.isNotEmpty() }
         .onCondition { toolCalls -> block(toolCalls) }
 }
 
@@ -178,6 +178,7 @@ public infix fun <IncomingOutput, IntermediateOutput, OutgoingInput> AIAgentEdge
 ): AIAgentEdgeBuilderIntermediate<IncomingOutput, List<ReceivedToolResult>, OutgoingInput> {
     return onIsInstance(List::class)
         .transformed { it.filterIsInstance<ReceivedToolResult>() }
+        .onCondition { it.isNotEmpty() }
         .onCondition { toolResults -> block(toolResults) }
 }
 
@@ -206,6 +207,7 @@ public infix fun <IncomingOutput, OutgoingInput> AIAgentEdgeBuilderIntermediate<
 ): AIAgentEdgeBuilderIntermediate<IncomingOutput, List<Message.Assistant>, OutgoingInput> {
     return onIsInstance(List::class)
         .transformed { it.filterIsInstance<Message.Assistant>() }
+        .onCondition { it.isNotEmpty() }
         .onCondition { toolResults -> block(toolResults) }
 }
 


### PR DESCRIPTION
Adds `isNotEmpty` condition to ensure lists are non-empty before call condition

## Motivation and Context
fix `onMultipleToolResults` and `onMultipleAssistantMessages`

## Breaking Changes
None

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed