### PR TITLE
Preserve `LLMParams` fields after `Prompt.withUpdatedParams`

### DIFF
--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/Prompt.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/Prompt.kt
@@ -176,6 +176,20 @@ public data class Prompt @JvmOverloads constructor(
             toolChoice = toolChoice,
             user = user
         )
+
+        /**
+         * Updates the given [LLMParams] instance with the current context's configuration.
+         *
+         * @param params The original instance of [LLMParams] to which the updates are applied.
+         * @return A new instance of [LLMParams] with updated values.
+         */
+        public fun applyToParams(params: LLMParams): LLMParams = params.copy(
+            temperature = temperature,
+            speculation = speculation,
+            schema = schema,
+            toolChoice = toolChoice,
+            user = user,
+        )
     }
 
     /**
@@ -189,5 +203,5 @@ public data class Prompt @JvmOverloads constructor(
      * @return A new `Prompt` instance with the updated parameters.
      */
     public fun withUpdatedParams(update: LLMParamsUpdateContext.() -> Unit): Prompt =
-        copy(params = LLMParamsUpdateContext(params).apply { update() }.toParams())
+        copy(params = LLMParamsUpdateContext(params).apply { update() }.applyToParams(params))
 }

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/Prompt.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/Prompt.kt
@@ -183,7 +183,7 @@ public data class Prompt @JvmOverloads constructor(
          * @param params The original instance of [LLMParams] to which the updates are applied.
          * @return A new instance of [LLMParams] with updated values.
          */
-        public fun applyToParams(params: LLMParams): LLMParams = params.copy(
+        internal fun applyToParams(params: LLMParams): LLMParams = params.copy(
             temperature = temperature,
             speculation = speculation,
             schema = schema,

--- a/prompt/prompt-model/src/jvmTest/kotlin/ai/koog/prompt/PromptTest.kt
+++ b/prompt/prompt-model/src/jvmTest/kotlin/ai/koog/prompt/PromptTest.kt
@@ -8,6 +8,7 @@ import ai.koog.prompt.params.LLMParams
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.junit.jupiter.api.Assertions.assertNull
@@ -626,7 +627,13 @@ class PromptTest {
 
     @Test
     fun testWithUpdatedParamsFunction() {
-        val originalPrompt = Prompt.build("test") {
+        val originalParams = LLMParams(
+            temperature = 0.7,
+            speculation = "test speculation",
+            user = "test_user",
+            additionalProperties = mapOf("test_property_name" to JsonPrimitive("test_property_value")),
+        )
+        val originalPrompt = Prompt.build("test", originalParams) {
             system("You are a helpful assistant")
         }
 
@@ -637,6 +644,9 @@ class PromptTest {
 
         assertNotEquals(originalPrompt, tempUpdatedPrompt)
         assertEquals(0.8, tempUpdatedPrompt.params.temperature)
+        assertEquals(originalParams.speculation, tempUpdatedPrompt.params.speculation)
+        assertEquals(originalParams.user, tempUpdatedPrompt.params.user)
+        assertEquals(originalParams.additionalProperties, tempUpdatedPrompt.params.additionalProperties)
 
         // Test updating multiple parameters
         val multiUpdatedPrompt = originalPrompt.withUpdatedParams {


### PR DESCRIPTION
## Motivation and Context
Preserves all `LLMParams` fields that were not updated during `Prompt.withUpdatedParams`, including subtype of LLMParams instance. The biggest impact of this change is on `PromptExecutor.executeStructured`, where it erases all the properties that were not updated by the method for Native structured completion requests.

## Breaking Changes
No breaking changes.

## Solution
I used `.copy` method from `LLMParams` that is properly overwritten by its children instead of `LLMParamsUpdateContext.toParams`

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [x] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed (checked jvmTest for `prompt.*` package, agent tests are red on my machine even before the PR)
