### PR TITLE
[examples] use Markdown renderer for agent response text in demo app

### DIFF
--- a/examples/demo-compose-app/commonApp/build.gradle.kts
+++ b/examples/demo-compose-app/commonApp/build.gradle.kts
@@ -49,6 +49,7 @@ kotlin {
             implementation(libs.koog.prompt.executor.llms.all)
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.datetime)
+            implementation(libs.markdown.renderer)
             implementation(libs.kotlinx.serialization.core)
             implementation(libs.kotlinx.serialization.json)
             implementation(project.dependencies.platform(libs.koin.bom))

--- a/examples/demo-compose-app/commonApp/src/commonMain/kotlin/com/jetbrains/example/koog/compose/screens/agentdemo/AgentDemoScreen.kt
+++ b/examples/demo-compose-app/commonApp/src/commonMain/kotlin/com/jetbrains/example/koog/compose/screens/agentdemo/AgentDemoScreen.kt
@@ -51,6 +51,9 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.jetbrains.example.koog.compose.theme.AppDimension
 import com.jetbrains.example.koog.compose.theme.AppTheme
+import com.mikepenz.markdown.m3.Markdown
+import com.mikepenz.markdown.m3.markdownColor
+import com.mikepenz.markdown.m3.markdownTypography
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
@@ -202,10 +205,10 @@ private fun AgentMessageBubble(text: String) {
                 .background(MaterialTheme.colorScheme.primaryContainer)
                 .padding(AppDimension.spacingMedium)
         ) {
-            Text(
-                text = text,
-                color = MaterialTheme.colorScheme.onPrimaryContainer,
-                style = MaterialTheme.typography.bodyLarge
+            Markdown(
+                content = text,
+                colors = markdownColor(text = MaterialTheme.colorScheme.onPrimaryContainer),
+                typography = markdownTypography(text = MaterialTheme.typography.bodyLarge)
             )
         }
     }

--- a/examples/demo-compose-app/gradle/libs.versions.toml
+++ b/examples/demo-compose-app/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ kotlinx-datetime = "0.7.1-0.6.x-compat"
 kotlinx-serialization = "1.9.0"
 ktlint = "14.0.1"
 ktor = "3.3.2"
+markdown-renderer = "0.38.1"
 
 [libraries]
 androidx-activityCompose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
@@ -36,6 +37,7 @@ ktor-client-apache5 = { module = "io.ktor:ktor-client-apache5" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin" }
 ktor-client-js = { module = "io.ktor:ktor-client-js" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp" }
+markdown-renderer = { module = "com.mikepenz:multiplatform-markdown-renderer-m3", version.ref = "markdown-renderer" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Uses https://github.com/mikepenz/multiplatform-markdown-renderer for displaying agent response text

<img width="1039" height="802" alt="Screenshot 2025-11-28 at 10 59 04" src="https://github.com/user-attachments/assets/1b5e336b-9c6d-443d-9162-cae077f53c21" />


cc @mikepenz :)