### PR TITLE
Allow agents to be reusable with context

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
@@ -266,6 +266,7 @@ public interface AIAgent<Input, Output> : Closeable {
          * @param temperature Optional model temperature, with valid values ranging typically from 0.0 to 1.0.
          * @param numberOfChoices The number of response choices to be generated, defaulting to 1.
          * @param maxIterations The maximum number of iterations the agent is allowed to perform, defaulting to 50.
+         * @param enforceSingleRun A flag indicating whether to enforce a single run of the agent. Defaults to true.
          * @param installFeatures A function to configure additional features into the agent during initialization. Defaults to an empty configuration.
          * @return An instance of [AIAgent] configured with the provided parameters.
          */
@@ -280,6 +281,7 @@ public interface AIAgent<Input, Output> : Closeable {
             temperature: Double? = null,
             numberOfChoices: Int = 1,
             maxIterations: Int = 50,
+            enforceSingleRun: Boolean = true,
             installFeatures: FeatureContext.() -> Unit = {}
         ): AIAgent<String, String> = AIAgent(
             id = id,
@@ -297,6 +299,7 @@ public interface AIAgent<Input, Output> : Closeable {
                 },
                 model = llmModel,
                 maxAgentIterations = maxIterations,
+                enforceSingleRun = enforceSingleRun
             ),
             toolRegistry = toolRegistry,
             installFeatures = installFeatures
@@ -317,6 +320,7 @@ public interface AIAgent<Input, Output> : Closeable {
          * @param temperature Optional model temperature, with valid values ranging typically from 0.0 to 1.0.
          * @param numberOfChoices The number of choices the model should generate per invocation. Defaults to `1`.
          * @param maxIterations The maximum number of iterations the agent can perform. Defaults to `50`.
+         * @param enforceSingleRun A boolean flag indicating whether to enforce a single run of the agent. Defaults to `true`.
          * @param installFeatures An extension function on `FeatureContext` to install custom features for the agent. Defaults to an empty lambda.
          * @return A configured [AIAgent] instance that can process inputs and generate outputs using the specified strategy and model.
          */
@@ -332,6 +336,7 @@ public interface AIAgent<Input, Output> : Closeable {
             temperature: Double? = null,
             numberOfChoices: Int = 1,
             maxIterations: Int = 50,
+            enforceSingleRun: Boolean = true,
             noinline installFeatures: FeatureContext.() -> Unit = {},
         ): GraphAIAgent<Input, Output> {
             return GraphAIAgent(
@@ -352,6 +357,7 @@ public interface AIAgent<Input, Output> : Closeable {
                     },
                     model = llmModel,
                     maxAgentIterations = maxIterations,
+                    enforceSingleRun = enforceSingleRun
                 ),
                 toolRegistry = toolRegistry,
                 clock = clock,
@@ -374,6 +380,7 @@ public interface AIAgent<Input, Output> : Closeable {
          * @param temperature Optional model temperature, with valid values ranging typically from 0.0 to 1.0.
          * @param numberOfChoices The number of response choices to generate when querying the language model. Default is 1.
          * @param maxIterations The maximum number of iterations the agent is allowed to perform during execution. Default is 50.
+         * @param enforceSingleRun Flag indicating whether to enforce a single run of the agent. Default is true.
          * @param installFeatures A lambda to configure and install features in the agent's context.
          * @return An AI agent instance configured with the provided parameters and ready to execute the specified strategy.
          */
@@ -387,6 +394,7 @@ public interface AIAgent<Input, Output> : Closeable {
             temperature: Double? = null,
             numberOfChoices: Int = 1,
             maxIterations: Int = 50,
+            enforceSingleRun: Boolean = true,
             installFeatures: FunctionalAIAgent.FeatureContext.() -> Unit = {},
         ): FunctionalAIAgent<Input, Output> = FunctionalAIAgent(
             promptExecutor = promptExecutor,
@@ -402,6 +410,7 @@ public interface AIAgent<Input, Output> : Closeable {
                 },
                 model = llmModel,
                 maxAgentIterations = maxIterations,
+                enforceSingleRun = enforceSingleRun
             ),
             installFeatures = installFeatures,
             toolRegistry = toolRegistry,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/FunctionalAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/FunctionalAIAgent.kt
@@ -42,8 +42,9 @@ public class FunctionalAIAgent<Input, Output>(
     public val clock: Clock = Clock.System,
     @property:InternalAgentsApi
     public val installFeatures: FeatureContext.() -> Unit = {}
-) : StatefulSingleUseAIAgent<Input, Output, AIAgentFunctionalContext>(
+) : StatefulAIAgent<Input, Output, AIAgentFunctionalContext>(
     logger = logger,
+    enforceSingleRun = agentConfig.enforceSingleRun,
     id = id,
 ) {
     private companion object {

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/GraphAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/GraphAIAgent.kt
@@ -55,8 +55,9 @@ public open class GraphAIAgent<Input, Output>(
     public val clock: Clock = Clock.System,
     @property:InternalAgentsApi
     public val installFeatures: FeatureContext.() -> Unit = {}
-) : StatefulSingleUseAIAgent<Input, Output, AIAgentGraphContextBase>(
+) : StatefulAIAgent<Input, Output, AIAgentGraphContextBase>(
     logger = logger,
+    enforceSingleRun = agentConfig.enforceSingleRun,
     id = id,
 ) {
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/StatefulAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/StatefulAIAgent.kt
@@ -18,7 +18,7 @@ import kotlin.uuid.Uuid
 /**
  * Abstract base class representing a single-use AI agent with state.
  *
- * This AI agent is designed to execute a specific long-running strategy only once and provides an API to monitor and manage its state.
+ * This AI agent is designed to execute a specific long-running strategies and provides an API to monitor and manage its state.
  *
  * It maintains internal states including its running status, whether it was started, its result (if available), and
  * the root context associated with its execution. The class enforces safe state transitions and provides
@@ -28,12 +28,14 @@ import kotlin.uuid.Uuid
  * @param Output the type of the output produced by the agent.
  * @param TContext the type of the context used during the agent's execution, extending [AIAgentContext].
  * @property logger the logger used for logging execution details and errors.
+ * @property enforceSingleRun indicates whether the agent should be restricted to a single execution run.
  * @param id the unique identifier for the agent. Random UUID will be generated if set to null.
  */
 @OptIn(ExperimentalUuidApi::class)
-public abstract class StatefulSingleUseAIAgent<Input, Output, TContext : AIAgentContext>(
+public abstract class StatefulAIAgent<Input, Output, TContext : AIAgentContext>(
     protected val logger: KLogger,
-    id: String? = null,
+    protected val enforceSingleRun: Boolean,
+    id: String? = null
 ) : AIAgent<Input, Output> {
     /**
      * A mutex used to synchronize access to the state of the agent. Ensures that only one coroutine
@@ -47,6 +49,8 @@ public abstract class StatefulSingleUseAIAgent<Input, Output, TContext : AIAgent
     final override suspend fun getState(): State<Output> = agentStateMutex.withLock { state.copy() }
 
     final override val id: String by lazy { id ?: Uuid.random().toString() }
+
+    public lateinit var context: TContext
 
     /**
      * The execution strategy defining how the agent processes input and produces output.
@@ -77,16 +81,21 @@ public abstract class StatefulSingleUseAIAgent<Input, Output, TContext : AIAgent
      */
     final override suspend fun run(agentInput: Input): Output {
         agentStateMutex.withLock {
-            if (state !is NotStarted) {
+            if (enforceSingleRun && state !is NotStarted) {
+                throw IllegalStateException("Agent was already started and is single-use.")
+            } else if (state is State.Running || state is State.Starting) {
                 throw IllegalStateException(
-                    "Agent was already started. Please use AIAgentService.createAgentAndRun(agentInput) to run an agent multiple times."
+                    "Agent is currently running or starting. Cannot run concurrently."
                 )
             }
             state = State.Starting()
         }
 
-        val runId = Uuid.random().toString()
-        val context = prepareContext(agentInput, runId)
+        if (!::context.isInitialized) {
+            context = prepareContext(agentInput, Uuid.random().toString())
+        }
+
+        val runId = context.runId
 
         return withContext(
             AgentRunInfoContextElement(
@@ -111,7 +120,7 @@ public abstract class StatefulSingleUseAIAgent<Input, Output, TContext : AIAgent
 
                 pipeline.onAgentStarting<Input, Output>(
                     runId = runId,
-                    agent = this@StatefulSingleUseAIAgent,
+                    agent = this@StatefulAIAgent,
                     context = context
                 )
 
@@ -219,18 +228,18 @@ public abstract class StatefulSingleUseAIAgent<Input, Output, TContext : AIAgent
 }
 
 /**
- * Retrieves a feature from the [StatefulSingleUseAIAgent.pipeline] associated with this agent using the specified key.
+ * Retrieves a feature from the [StatefulAIAgent.pipeline] associated with this agent using the specified key.
  *
  * @param feature A feature to fetch.
  * @return The feature associated with the provided key, or null if no matching feature is found.
  * @throws IllegalArgumentException if the specified [feature] does not correspond to a registered feature.
  */
-public inline fun <reified TFeature : Any> StatefulSingleUseAIAgent<*, *, *>.feature(
+public inline fun <reified TFeature : Any> StatefulAIAgent<*, *, *>.feature(
     feature: AIAgentFeature<*, TFeature>
 ): TFeature? = feature(TFeature::class, feature)
 
 /**
- * Retrieves a feature from the [StatefulSingleUseAIAgent.pipeline] associated with this agent using the specified key
+ * Retrieves a feature from the [StatefulAIAgent.pipeline] associated with this agent using the specified key
  * or throws an exception if it is not available.
  *
  * @param feature A feature to fetch.
@@ -238,6 +247,6 @@ public inline fun <reified TFeature : Any> StatefulSingleUseAIAgent<*, *, *>.fea
  * @throws IllegalStateException if the [TFeature] feature does not correspond to a registered feature.
  * @throws NoSuchElementException if the feature is not found.
  */
-public inline fun <reified TFeature : Any> StatefulSingleUseAIAgent<*, *, *>.featureOrThrow(
+public inline fun <reified TFeature : Any> StatefulAIAgent<*, *, *>.featureOrThrow(
     feature: AIAgentFeature<*, TFeature>
 ): TFeature = feature(feature) ?: throw NoSuchElementException("Feature ${feature.key} is not found.")

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/config/AIAgentConfig.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/config/AIAgentConfig.kt
@@ -14,6 +14,7 @@ import ai.koog.prompt.llm.LLModel
  *
  * @param prompt The initial prompt configuration for the agent, encapsulating messages, model, and parameters.
  * @param model The model to use for the agent's prompt execution
+ * @param enforceSingleRun Indicates whether the agent should be restricted to a single execution run.
  * @param maxAgentIterations The maximum number of iterations allowed for an agent during its execution to prevent infinite loops.
  * @param missingToolsConversionStrategy Strategy used to determine how tool calls,
  *        present in the prompt but lacking definitions, are handled during agent execution.
@@ -25,6 +26,7 @@ public class AIAgentConfig(
     override val prompt: Prompt,
     override val model: LLModel,
     public val maxAgentIterations: Int,
+    public val enforceSingleRun: Boolean = true,
     public val missingToolsConversionStrategy: MissingToolsConversionStrategy =
         MissingToolsConversionStrategy.Missing(ToolCallDescriber.JSON)
 ) : AIAgentConfigBase {
@@ -48,6 +50,7 @@ public class AIAgentConfig(
          * @param llm The Large Language Model (LLM) to be used for the AI agent. Defaults to OpenAIModels.Chat.GPT4o.
          * @param id The identifier for the agent configuration. Defaults to "koog-agents".
          * @param maxAgentIterations The maximum number of iterations the agent can perform to avoid infinite loops. Defaults to 3.
+         * @param enforceSingleRun Indicates whether the agent should be restricted to a single execution run. Defaults to true.
          * @return An instance of `AIAgentConfigBase` representing the AI agent configuration with the specified parameters.
          */
         public fun withSystemPrompt(
@@ -55,13 +58,15 @@ public class AIAgentConfig(
             llm: LLModel = OpenAIModels.Chat.GPT4o,
             id: String = "koog-agents",
             maxAgentIterations: Int = 3,
+            enforceSingleRun: Boolean = true
         ): AIAgentConfig =
             AIAgentConfig(
                 prompt = prompt(id) {
                     system(prompt)
                 },
                 model = llm,
-                maxAgentIterations = maxAgentIterations
+                maxAgentIterations = maxAgentIterations,
+                enforceSingleRun = enforceSingleRun
             )
     }
 }

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/FunctionalAIAgentTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/FunctionalAIAgentTest.kt
@@ -30,6 +30,7 @@ import kotlinx.serialization.builtins.serializer
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertFailsWith
 
 @OptIn(kotlin.uuid.ExperimentalUuidApi::class)
 class FunctionalAIAgentTest {
@@ -787,5 +788,57 @@ class FunctionalAIAgentTest {
             testFeatureMessageProcessor.isOpen.value,
             "Feature processors should be closed after run"
         )
+    }
+
+    @Test
+    fun multipleRuns_whenEnforceSingleRunIsFalse() = runTest {
+        val mockLLMApi = getMockExecutor {
+            mockLLMAnswer("Run 1") onRequestEquals "Run 1"
+            mockLLMAnswer("Run 2") onRequestEquals "Run 2"
+            mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            promptExecutor = mockLLMApi,
+            llmModel = OllamaModels.Meta.LLAMA_3_2,
+            strategy = functionalStrategy { input: String ->
+                llm.writeSession {
+                    appendPrompt { user(input) }
+                    requestLLM()
+                }.content
+            },
+            enforceSingleRun = false
+        )
+
+        val result1 = agent.run("Run 1")
+        assertEquals("Run 1", result1)
+
+        val result2 = agent.run("Run 2")
+        assertEquals("Run 2", result2)
+    }
+
+    @Test
+    fun multipleRuns_throwsException_byDefault() = runTest {
+        val mockLLMApi = getMockExecutor {
+            mockLLMAnswer("Run 1") onRequestEquals "Run 1"
+            mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            promptExecutor = mockLLMApi,
+            llmModel = OllamaModels.Meta.LLAMA_3_2,
+            strategy = functionalStrategy { input: String ->
+                llm.writeSession {
+                    appendPrompt { user(input) }
+                    requestLLM()
+                }.content
+            }
+        )
+
+        agent.run("Run 1")
+
+        assertFailsWith<IllegalStateException> {
+            agent.run("Run 2")
+        }
     }
 }

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/GraphAIAgentTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/GraphAIAgentTest.kt
@@ -10,7 +10,9 @@ import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import kotlinx.coroutines.test.runTest
 import kotlin.reflect.typeOf
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertFailsWith
 
 class GraphAIAgentTest {
 
@@ -48,5 +50,67 @@ class GraphAIAgentTest {
             testFeatureMessageProcessor.isOpen.value,
             "Feature message processors should be closed after the agent run"
         )
+    }
+
+    @Test
+    fun multipleRuns_whenEnforceSingleRunIsFalse() = runTest {
+        val model = OpenAIModels.Chat.GPT4o
+
+        val agentConfig = AIAgentConfig(
+            prompt = prompt(id = "test-chat") {},
+            model = model,
+            maxAgentIterations = 10,
+            enforceSingleRun = false
+        )
+
+        val strategy = strategy<String, String>("test-strategy") {
+            val uppercaseNode by node<String, String> { it.uppercase() }
+            nodeStart then uppercaseNode then nodeFinish
+        }
+
+        val agent = GraphAIAgent(
+            id = "test-agent",
+            inputType = typeOf<String>(),
+            outputType = typeOf<String>(),
+            promptExecutor = getMockExecutor { },
+            agentConfig = agentConfig,
+            strategy = strategy,
+        )
+
+        val result1 = agent.run("Run 1")
+        assertEquals("RUN 1", result1)
+
+        val result2 = agent.run("Run 2")
+        assertEquals("RUN 2", result2)
+    }
+
+    @Test
+    fun multipleRuns_throwsException_byDefault() = runTest {
+        val model = OpenAIModels.Chat.GPT4o
+
+        val agentConfig = AIAgentConfig(
+            prompt = prompt(id = "test-chat") {},
+            model = model,
+            maxAgentIterations = 10,
+        )
+
+        val strategy = strategy<String, String>("test-strategy") {
+            nodeStart then nodeFinish
+        }
+
+        val agent = GraphAIAgent(
+            id = "test-agent",
+            inputType = typeOf<String>(),
+            outputType = typeOf<String>(),
+            promptExecutor = getMockExecutor { },
+            agentConfig = agentConfig,
+            strategy = strategy,
+        )
+
+        agent.run("Run 1")
+
+        assertFailsWith<IllegalStateException> {
+            agent.run("Run 2")
+        }
     }
 }

--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/Persistency.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/Persistency.kt
@@ -1,7 +1,7 @@
 package ai.koog.agents.snapshot.feature
 
 import ai.koog.agents.core.agent.AIAgent.Companion.State.Running
-import ai.koog.agents.core.agent.StatefulSingleUseAIAgent
+import ai.koog.agents.core.agent.StatefulAIAgent
 import ai.koog.agents.core.agent.context.AIAgentContext
 import ai.koog.agents.core.agent.context.AgentContextData
 import ai.koog.agents.core.agent.context.RollbackStrategy
@@ -390,7 +390,7 @@ public suspend fun <T> AIAgentContext.withPersistence(
  * @return The [Persistence] feature instance for this agent
  * @throws IllegalStateException if the checkpoint feature is not installed
  */
-public fun StatefulSingleUseAIAgent<*, *, *>.persistence(): Persistence = featureOrThrow(Persistence)
+public fun StatefulAIAgent<*, *, *>.persistence(): Persistence = featureOrThrow(Persistence)
 
 /**
  * Executes the provided action within the context of the agent's persistence layer if the agent is in a running state.
@@ -404,7 +404,7 @@ public fun StatefulSingleUseAIAgent<*, *, *>.persistence(): Persistence = featur
  * @throws IllegalStateException If the agent is not in a running state when this function is called.
  */
 @OptIn(InternalAgentsApi::class)
-public suspend fun <T> StatefulSingleUseAIAgent<*, *, *>.withPersistence(
+public suspend fun <T> StatefulAIAgent<*, *, *>.withPersistence(
     action: suspend Persistence.(AIAgentContext) -> T
 ): T = when (val state = getState()) {
     is Running<*> -> this.persistence().action(state.rootContext)

--- a/docs/docs/basic-agents.md
+++ b/docs/docs/basic-agents.md
@@ -145,16 +145,48 @@ val agent = AIAgent(
     maxIterations = 30
 )
 ```
+
+### 7. Configure Agent Reusability
+
+By default, the agent is single-use: attempting to call `agent.run()` after the first execution (completion or failure) will throw an `IllegalStateException`.
+
+To configure the agent to be reusable (allowing it to maintain its context and state across multiple sequential interactions), use the `enforceSingleRun` parameter.
+
+`enforceSingleRun = true` (Default): The agent enforces the single-use rule and throws an error if `run()` is called after the initial execution finishes.
+
+`enforceSingleRun = false`: The agent allows sequential re-runs, and it will reuse its previously prepared context (like session history, llm context) for the next execution.
+
+<!--- INCLUDE
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.ext.tool.SayToUser
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+-->
+```kotlin
+val agent = AIAgent(
+    promptExecutor = simpleOpenAIExecutor(System.getenv("YOUR_API_KEY")),
+    systemPrompt = "You are a helpful assistant. Answer user questions concisely.",
+    llmModel = OpenAIModels.Chat.GPT4o,
+    temperature = 0.7,
+    toolRegistry = ToolRegistry {
+        tool(SayToUser)
+    },
+    maxIterations = 30,
+    enforceSingleRun = false
+)
+```
+
 <!--- KNIT example-basic-05.kt -->
 
-### 7. Handle events during agent runtime
+### 8. Handle events during agent runtime
 
 Basic agents support custom event handlers.
 While having an event handler is not required for creating an agent, it might be helpful for testing, debugging, or making hooks for chained agent interactions.
 
 For more information on how to use the `EventHandler` feature for monitoring your agent interactions, see [Event Handlers](agent-event-handlers.md).
 
-### 8. Run the agent
+### 9. Run the agent
 
 To run the agent, use the `run()` function:
 
@@ -175,7 +207,7 @@ val agent = AIAgent(
     toolRegistry = ToolRegistry {
         tool(SayToUser)
     },
-    maxIterations = 100
+    maxIterations = 30
 )
 
 fun main() = runBlocking {

--- a/docs/docs/complex-workflow-agents.md
+++ b/docs/docs/complex-workflow-agents.md
@@ -240,7 +240,7 @@ val agentConfig = AIAgentConfig.withSystemPrompt(
 ```
 <!--- KNIT example-complex-workflow-agents-07.kt -->
 
-For more advanced configuration, you can specify which LLM the agent will use and set the maximum number of iterations the agent can perform to respond:
+For more advanced configuration, you can specify which LLM the agent will use, set the maximum number of iterations the agent can perform to respond, and control the agent's reusability:
 <!--- INCLUDE
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.prompt.dsl.Prompt

--- a/koog-ktor/src/commonMain/kotlin/ai/koog/ktor/Koog.kt
+++ b/koog-ktor/src/commonMain/kotlin/ai/koog/ktor/Koog.kt
@@ -40,6 +40,7 @@ public class Koog(
             agentConfig.prompt,
             model,
             agentConfig.maxAgentIterations,
+            agentConfig.enforceSingleRun,
             agentConfig.missingToolsConversionStrategy
         )
     }

--- a/koog-ktor/src/commonMain/kotlin/ai/koog/ktor/KoogAgentsConfig.kt
+++ b/koog-ktor/src/commonMain/kotlin/ai/koog/ktor/KoogAgentsConfig.kt
@@ -360,6 +360,20 @@ public class KoogAgentsConfig(private val scope: CoroutineScope) {
         public var maxAgentIterations: Int = 50
 
         /**
+         * Indicates whether the agent is intended for single-use or can be reused for multiple interactions.
+         *
+         * When set to `true`, the agent is designed to handle a single interaction or session,
+         * after which it may be discarded or reset. This is useful for scenarios where
+         * each interaction is independent and does not require maintaining state across sessions.
+         *
+         * When set to `false`, the agent can be reused for multiple interactions,
+         * allowing it to maintain context or state between sessions.
+         *
+         * Default value is `true`.
+         */
+        public var enforceSingleRun: Boolean = true
+
+        /**
          * Defines the strategy for handling tool calls present in the prompt that do not have corresponding tool definitions
          * registered in the current context. This is used to convert missing tool information into a format suitable for
          * processing by the model.


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

Please add a brief description of the proposed change here.
Also, please tick the appropriate points in the checklist below.
-->


## Motivation and Context
Currently, the default agent types are designed to be used only once; they throws an `IllegalStateException` if you try to run it a second time. This prevents the creation of  conversational, or manual feedback based agents.

This change introduces a flag (`enforceSingleRun`) that allows the agent to be **reused** for multiple interactions. When reused, the agent keeps its context history and state across runs.

This enables the development of **conversational agents** that can remember what happened in the previous step. 

The change also updates the core run logic to ensure the agent's initial setup is only done once, guaranteeing the reuse of the context object for subsequent calls while correctly tracking the session.

Closes #1217 

Example usage:
```kt
val agent = AIAgent(
    promptExecutor = simpleGoogleAIExecutor(API_KEY),
    agentConfig = AIAgentConfig(
        prompt = Prompt.build("Simple Prompt") {
            system("You are a helpful assistant.")
        }, model = GoogleModels.Gemini2_5Flash,
        enforceSingleRun = false
    )
)

println(agent.run("What is Koog?")) // Koog is a...
println(agent.run("What was my previous message?")) // "What is Koog?"
```

## Breaking Changes
No. The default behavior of `StatefulAIAgent` remains **single-use** (by assuming `enforceSingleRun = true` if not specified), replicating current behavior and throwing the `IllegalStateException` on the second run. People wishing to enable reuse must explicitly set the new parameter to `false`.

---

#### Type of the changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update (Documentation will be updated in a follow-up PR, but the capability is included here)
- [x] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [x] Docs have been added / updated (Marked for update, likely in a separate PR)