### PR TITLE
[http-client] Make junit5 dependency from http-test compileOnly to fix IntelliJ project import breaking with "could not resolve"

### DIFF
--- a/http-client/http-client-test/build.gradle.kts
+++ b/http-client/http-client-test/build.gradle.kts
@@ -13,6 +13,6 @@ dependencies {
     api(libs.kotlinx.coroutines.test)
     api(libs.kotlinx.serialization.json)
     api(kotlin("test"))
+    compileOnly(kotlin("test-junit5")) // must be provided by the dependent modules
     implementation(libs.kotlinx.coroutines.core)
-    implementation(kotlin("test-junit5"))
 }


### PR DESCRIPTION
When `implementation` configuration is used with this test framework dependency, it breaks IntelliJ project import. Updated it to `compileOnly`, since it is provided explicitly by the dependent modules anyway.
