### PR TITLE
KG-508 Update Tool API to fix name and descriptor discrepancy and make it more robust

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/GenericAgentEnvironment.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/GenericAgentEnvironment.kt
@@ -58,7 +58,7 @@ internal class GenericAgentEnvironment(
                 )
             }
 
-        val toolDescription = tool.description
+        val toolDescription = tool.descriptor.description
 
         // Tool Args
         val toolArgs = try {

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/CalculatorTools.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/CalculatorTools.kt
@@ -2,16 +2,20 @@ package ai.koog.agents.core
 
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.annotations.LLMDescription
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
 object CalculatorTools {
 
     abstract class CalculatorTool(
-        override val name: String,
-        override val description: String,
-    ) : Tool<CalculatorTool.Args, CalculatorTool.Result>() {
+        name: String,
+        description: String,
+    ) : Tool<CalculatorTool.Args, CalculatorTool.Result>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = Result.serializer(),
+        name = name,
+        description = description
+    ) {
         @Serializable
         data class Args(
             @property:LLMDescription("First number")
@@ -23,9 +27,6 @@ object CalculatorTools {
         @Serializable
         @JvmInline
         value class Result(val result: Float)
-
-        final override val argsSerializer = Args.serializer()
-        override val resultSerializer: KSerializer<Result> = Result.serializer()
     }
 
     object PlusTool : CalculatorTool(

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/DummyTools.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/DummyTools.kt
@@ -5,24 +5,23 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
 
-object DummyTool : SimpleTool<Unit>() {
-    override val argsSerializer = Unit.serializer()
-
-    override val description: String = "Dummy tool for testing"
-
-    override suspend fun doExecute(args: Unit): String = "Dummy result"
+object DummyTool : SimpleTool<Unit>(
+    argsSerializer = Unit.serializer(),
+    name = "dummy_tool",
+    description = "Dummy tool for testing"
+) {
+    override suspend fun execute(args: Unit): String = "Dummy result"
 }
 
-object CreateTool : SimpleTool<CreateTool.Args>() {
+object CreateTool : SimpleTool<CreateTool.Args>(
+    argsSerializer = Args.serializer(),
+    name = "create",
+    description = "Create something"
+) {
     @Serializable
     data class Args(
         @property:LLMDescription("Name of the entity to create") val name: String
     )
 
-    override val argsSerializer = Args.serializer()
-
-    override val name: String = "create"
-    override val description: String = "Create something"
-
-    override suspend fun doExecute(args: Args): String = "created"
+    override suspend fun execute(args: Args): String = "created"
 }

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/FunctionalAIAgentTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/FunctionalAIAgentTest.kt
@@ -24,7 +24,6 @@ import ai.koog.prompt.executor.clients.google.GoogleModels
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.llm.OllamaModels
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
 import kotlin.test.Test
@@ -272,28 +271,28 @@ class FunctionalAIAgentTest {
     data class SimpleOut(val value: String)
 
     object QATools {
-        object TestEngine : SimpleTool<Spacecraft>() {
-            override val argsSerializer: KSerializer<Spacecraft> = Spacecraft.serializer()
-
-            override val description: String = "Performs testing of the spacecraft engine."
-
-            override suspend fun doExecute(args: Spacecraft): String = "Engine is good"
+        object TestEngine : SimpleTool<Spacecraft>(
+            argsSerializer = Spacecraft.serializer(),
+            name = "test_engine",
+            description = "Performs testing of the spacecraft engine."
+        ) {
+            override suspend fun execute(args: Spacecraft): String = "Engine is good"
         }
 
-        object TestBody : SimpleTool<Spacecraft>() {
-            override val argsSerializer: KSerializer<Spacecraft> = Spacecraft.serializer()
-
-            override val description: String = "Performs testing of the spacecraft bofy."
-
-            override suspend fun doExecute(args: Spacecraft): String = "Body is good"
+        object TestBody : SimpleTool<Spacecraft>(
+            argsSerializer = Spacecraft.serializer(),
+            name = "test_body",
+            description = "Performs testing of the spacecraft bofy."
+        ) {
+            override suspend fun execute(args: Spacecraft): String = "Body is good"
         }
 
-        object TestBuild : SimpleTool<Spacecraft>() {
-            override val argsSerializer: KSerializer<Spacecraft> = Spacecraft.serializer()
-
-            override val description: String = "Tests how spacecraft is built."
-
-            override suspend fun doExecute(args: Spacecraft): String =
+        object TestBuild : SimpleTool<Spacecraft>(
+            argsSerializer = Spacecraft.serializer(),
+            name = "test_build",
+            description = "Tests how spacecraft is built."
+        ) {
+            override suspend fun execute(args: Spacecraft): String =
                 "Spacecraft is built badly... Engine is too big for the body"
         }
 
@@ -302,65 +301,81 @@ class FunctionalAIAgentTest {
 
     // Define sample tools for subtasks, similar in spirit to QATools so tool lists are not empty
     object ArchitectureTools {
-        object AnalyzeRequirements : SimpleTool<String>() {
-            override val argsSerializer: KSerializer<String> = String.serializer()
-            override val description: String = "Analyzes high-level mission requirements."
-            override suspend fun doExecute(args: String): String = "Requirements analyzed: $args"
+        object AnalyzeRequirements : SimpleTool<String>(
+            argsSerializer = String.serializer(),
+            name = "analyze_requirements",
+            description = "Analyzes high-level mission requirements."
+        ) {
+            override suspend fun execute(args: String): String = "Requirements analyzed: $args"
         }
 
-        object DraftArchitecture : SimpleTool<Architecture>() {
-            override val argsSerializer: KSerializer<Architecture> = Architecture.serializer()
-            override val description: String = "Drafts an initial spacecraft architecture proposal."
-            override suspend fun doExecute(args: Architecture): String = "Drafted architecture: ${'$'}{args.name}"
+        object DraftArchitecture : SimpleTool<Architecture>(
+            argsSerializer = Architecture.serializer(),
+            name = "draft_architecture",
+            description = "Drafts an initial spacecraft architecture proposal."
+        ) {
+            override suspend fun execute(args: Architecture): String = "Drafted architecture: ${'$'}{args.name}"
         }
 
         val tools: List<Tool<*, *>> = listOf(AnalyzeRequirements, DraftArchitecture)
     }
 
     object BuildEngineTools {
-        object EstimateThrust : SimpleTool<Architecture>() {
-            override val argsSerializer: KSerializer<Architecture> = Architecture.serializer()
-            override val description: String = "Estimates required thrust for the given architecture."
-            override suspend fun doExecute(args: Architecture): String = "Estimated thrust for ${'$'}{args.name}"
+        object EstimateThrust : SimpleTool<Architecture>(
+            argsSerializer = Architecture.serializer(),
+            name = "estimate_thrust",
+            description = "Estimates required thrust for the given architecture."
+        ) {
+            override suspend fun execute(args: Architecture): String = "Estimated thrust for ${'$'}{args.name}"
         }
 
-        object SelectFuelType : SimpleTool<Architecture>() {
-            override val argsSerializer: KSerializer<Architecture> = Architecture.serializer()
-            override val description: String = "Selects suitable fuel type based on mission profile and constraints."
-            override suspend fun doExecute(args: Architecture): String = "Fuel selected for ${'$'}{args.name}"
+        object SelectFuelType : SimpleTool<Architecture>(
+            argsSerializer = Architecture.serializer(),
+            name = "select_fuel_type",
+            description = "Selects suitable fuel type based on mission profile and constraints."
+        ) {
+            override suspend fun execute(args: Architecture): String = "Fuel selected for ${'$'}{args.name}"
         }
 
         val tools: List<Tool<*, *>> = listOf(EstimateThrust, SelectFuelType)
     }
 
     object BuildBodyTools {
-        object ComputeMassBudget : SimpleTool<Architecture>() {
-            override val argsSerializer: KSerializer<Architecture> = Architecture.serializer()
-            override val description: String = "Computes mass budget for the spacecraft body."
-            override suspend fun doExecute(args: Architecture): String = "Mass budget computed for ${'$'}{args.name}"
+        object ComputeMassBudget : SimpleTool<Architecture>(
+            argsSerializer = Architecture.serializer(),
+            name = "compute_mass_budget",
+            description = "Computes mass budget for the spacecraft body."
+        ) {
+            override suspend fun execute(args: Architecture): String = "Mass budget computed for ${'$'}{args.name}"
         }
 
-        object ChooseMaterial : SimpleTool<Architecture>() {
-            override val argsSerializer: KSerializer<Architecture> = Architecture.serializer()
-            override val description: String = "Chooses hull material given constraints."
-            override suspend fun doExecute(args: Architecture): String = "Material chosen for ${'$'}{args.name}"
+        object ChooseMaterial : SimpleTool<Architecture>(
+            argsSerializer = Architecture.serializer(),
+            name = "choose_material",
+            description = "Chooses hull material given constraints."
+        ) {
+            override suspend fun execute(args: Architecture): String = "Material chosen for ${'$'}{args.name}"
         }
 
         val tools: List<Tool<*, *>> = listOf(ComputeMassBudget, ChooseMaterial)
     }
 
     object AssemblyTools {
-        object CheckInterfaces : SimpleTool<Assembly>() {
-            override val argsSerializer: KSerializer<Assembly> = Assembly.serializer()
-            override val description: String = "Checks mechanical, power, and data interfaces between components."
-            override suspend fun doExecute(args: Assembly): String =
+        object CheckInterfaces : SimpleTool<Assembly>(
+            argsSerializer = Assembly.serializer(),
+            name = "check_interfaces",
+            description = "Checks mechanical, power, and data interfaces between components."
+        ) {
+            override suspend fun execute(args: Assembly): String =
                 "Interfaces check passed for engine ${'$'}{args.engine.name} and body ${'$'}{args.body.name}"
         }
 
-        object ComputeDryMass : SimpleTool<Assembly>() {
-            override val argsSerializer: KSerializer<Assembly> = Assembly.serializer()
-            override val description: String = "Computes total dry mass of the assembly."
-            override suspend fun doExecute(args: Assembly): String = "Dry mass: ${'$'}{args.totalDryMassKg} kg"
+        object ComputeDryMass : SimpleTool<Assembly>(
+            argsSerializer = Assembly.serializer(),
+            name = "compute_dry_mass",
+            description = "Computes total dry mass of the assembly."
+        ) {
+            override suspend fun execute(args: Assembly): String = "Dry mass: ${'$'}{args.totalDryMassKg} kg"
         }
 
         val tools: List<Tool<*, *>> = listOf(CheckInterfaces, ComputeDryMass)

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContextTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContextTest.kt
@@ -174,13 +174,12 @@ class AIAgentLLMContextTest : AgentTestBase() {
         val input: String
     )
 
-    private class TestTool : SimpleTool<TestToolArgs>() {
-        override val argsSerializer = TestToolArgs.serializer()
-
-        override val name: String = "test-tool"
-        override val description: String = "A test tool for testing"
-
-        override suspend fun doExecute(args: TestToolArgs): String {
+    private class TestTool : SimpleTool<TestToolArgs>(
+        argsSerializer = TestToolArgs.serializer(),
+        name = "test-tool",
+        description = "A test tool for testing"
+    ) {
+        override suspend fun execute(args: TestToolArgs): String {
             return "Processed: ${args.input}"
         }
     }

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionTest.kt
@@ -25,7 +25,6 @@ import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.processor.ResponseProcessor
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -62,40 +61,26 @@ class AIAgentLLMWriteSessionTest {
         }
     }
 
-    class TestTool : SimpleTool<TestTool.Args>() {
+    class TestTool : SimpleTool<TestTool.Args>(
+        argsSerializer = Args.serializer(),
+        name = "test-tool",
+        description = "A test tool"
+    ) {
         @Serializable
         data class Args(
             @property:LLMDescription("Input parameter")
             val input: String
         )
 
-        override val argsSerializer: KSerializer<Args> = Args.serializer()
-
-        override val name: String = "test-tool"
-        override val description: String = "A test tool"
-
-        override suspend fun doExecute(args: Args): String {
+        override suspend fun execute(args: Args): String {
             return "Processed: ${args.input}"
         }
     }
 
-    class CustomTool : Tool<CustomTool.Args, CustomTool.Result>() {
-        @Serializable
-        data class Args(val input: String)
-
-        @Serializable
-        data class Result(
-            @property:LLMDescription("Input parameter")
-            val output: String
-        )
-
-        override val argsSerializer: KSerializer<Args> = Args.serializer()
-        override val resultSerializer: KSerializer<Result> = Result.serializer()
-
-        override val name: String = "custom-tool"
-        override val description: String = "A custom tool"
-
-        override val descriptor: ToolDescriptor = ToolDescriptor(
+    class CustomTool : Tool<CustomTool.Args, CustomTool.Result>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = Result.serializer(),
+        descriptor = ToolDescriptor(
             name = "custom-tool",
             description = "A custom tool",
             requiredParameters = listOf(
@@ -105,6 +90,15 @@ class AIAgentLLMWriteSessionTest {
                     type = ToolParameterType.String
                 )
             )
+        )
+    ) {
+        @Serializable
+        data class Args(val input: String)
+
+        @Serializable
+        data class Result(
+            @property:LLMDescription("Input parameter")
+            val output: String
         )
 
         override suspend fun execute(args: Args): Result {

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContextConcurrencyTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContextConcurrencyTest.kt
@@ -145,13 +145,12 @@ class AIAgentLLMContextConcurrencyTest {
         val input: String
     )
 
-    private class TestTool : SimpleTool<TestToolArgs>() {
-        override val argsSerializer = TestToolArgs.serializer()
-
-        override val name: String = "test-tool"
-        override val description: String = "A test tool for testing"
-
-        override suspend fun doExecute(args: TestToolArgs): String {
+    private class TestTool : SimpleTool<TestToolArgs>(
+        argsSerializer = TestToolArgs.serializer(),
+        name = "test-tool",
+        description = "A test tool for testing"
+    ) {
+        override suspend fun execute(args: TestToolArgs): String {
             return "Processed: ${args.input}"
         }
     }

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/environment/SafeToolTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/environment/SafeToolTest.kt
@@ -3,7 +3,6 @@ package ai.koog.agents.core.environment
 import ai.koog.agents.core.CalculatorChatExecutor.testClock
 import ai.koog.agents.core.feature.model.toAgentError
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
-import ai.koog.agents.core.tools.asToolDescriptorSerializer
 import ai.koog.prompt.message.Message
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
@@ -90,7 +89,7 @@ class SafeToolTest {
                     toolDescription = null,
                     content = resultContent,
                     resultKind = ToolResultKind.Success,
-                    result = json.encodeToJsonElement(serializer<String>().asToolDescriptorSerializer(), TEST_RESULT)
+                    result = json.encodeToJsonElement(serializer<String>(), TEST_RESULT)
                 )
             } else {
                 ReceivedToolResult(
@@ -298,7 +297,7 @@ class SafeToolTest {
                     )
 
                     val result = testFunctionWithComplexArgs("direct-test", listOf(10, 11, 12), complexData)
-                    val resultSerializer = serializer<String>().asToolDescriptorSerializer()
+                    val resultSerializer = serializer<String>()
 
                     ReceivedToolResult(
                         id = toolCall.id,

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerTest.kt
@@ -347,7 +347,7 @@ class DebuggerTest {
                         toolCallId = "0",
                         toolName = dummyTool.name,
                         toolArgs = dummyTool.encodeArgs(DummyTool.Args("test")),
-                        toolDescription = dummyTool.description,
+                        toolDescription = dummyTool.descriptor.description,
                         result = dummyTool.encodeResult(dummyTool.result),
                         timestamp = AIAgentFeatureTestAPI.testClock.now().toEpochMilliseconds()
                     ),
@@ -364,7 +364,7 @@ class DebuggerTest {
                                 id = "0",
                                 tool = dummyTool.name,
                                 toolArgs = dummyTool.encodeArgs(DummyTool.Args("test")),
-                                toolDescription = dummyTool.description,
+                                toolDescription = dummyTool.descriptor.description,
                                 content = dummyTool.result,
                                 resultKind = ToolResultKind.Success,
                                 result = dummyTool.encodeResult(dummyTool.result)
@@ -381,7 +381,7 @@ class DebuggerTest {
                                 id = "0",
                                 tool = dummyTool.name,
                                 toolArgs = dummyTool.encodeArgs(DummyTool.Args("test")),
-                                toolDescription = dummyTool.description,
+                                toolDescription = dummyTool.descriptor.description,
                                 content = dummyTool.result,
                                 resultKind = ToolResultKind.Success,
                                 result = dummyTool.encodeResult(dummyTool.result)
@@ -414,7 +414,7 @@ class DebuggerTest {
                                 id = "0",
                                 tool = dummyTool.name,
                                 toolArgs = dummyTool.encodeArgs(DummyTool.Args("test")),
-                                toolDescription = dummyTool.description,
+                                toolDescription = dummyTool.descriptor.description,
                                 content = dummyTool.result,
                                 resultKind = ToolResultKind.Success,
                                 result = dummyTool.encodeResult(dummyTool.result)

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/AskUser.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/AskUser.kt
@@ -2,14 +2,17 @@ package ai.koog.agents.ext.tool
 
 import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.annotations.LLMDescription
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 
 /**
  * Object representation of a tool that provides an interface for agent-user interaction.
  * It allows the agent to ask the user for input (via `stdout`/`stdin`).
  */
-public object AskUser : SimpleTool<AskUser.Args>() {
+public object AskUser : SimpleTool<AskUser.Args>(
+    argsSerializer = Args.serializer(),
+    name = "__ask_user__",
+    description = "Service tool, used by the agent to talk with user"
+) {
     /**
      * Represents the arguments for the [AskUser] tool
      *
@@ -21,11 +24,7 @@ public object AskUser : SimpleTool<AskUser.Args>() {
         val message: String
     )
 
-    override val name: String = "__ask_user__"
-    override val description: String = "Service tool, used by the agent to talk with user"
-    override val argsSerializer: KSerializer<Args> = Args.serializer()
-
-    override suspend fun doExecute(args: Args): String {
+    override suspend fun execute(args: Args): String {
         println(args.message)
         return readln()
     }

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/ExitTool.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/ExitTool.kt
@@ -2,7 +2,6 @@ package ai.koog.agents.ext.tool
 
 import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.annotations.LLMDescription
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 
 /**
@@ -15,7 +14,11 @@ import kotlinx.serialization.Serializable
  *
  * The descriptor defines the tool's metadata including its name, description, and required parameters.
  */
-public object ExitTool : SimpleTool<ExitTool.Args>() {
+public object ExitTool : SimpleTool<ExitTool.Args>(
+    argsSerializer = Args.serializer(),
+    name = "__exit__",
+    description = "Service tool, used by the agent to end conversation on user request or agent decision"
+) {
     /**
      * Represents the arguments for the [ExitTool] tool
      *
@@ -27,13 +30,7 @@ public object ExitTool : SimpleTool<ExitTool.Args>() {
         val message: String
     )
 
-    override suspend fun doExecute(args: Args): String {
+    override suspend fun execute(args: Args): String {
         return "DONE"
     }
-
-    override val argsSerializer: KSerializer<Args>
-        get() = Args.serializer()
-
-    override val name: String = "__exit__"
-    override val description: String = "Service tool, used by the agent to end conversation on user request or agent decision"
 }

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/SayToUser.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/SayToUser.kt
@@ -2,13 +2,16 @@ package ai.koog.agents.ext.tool
 
 import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.annotations.LLMDescription
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 
 /**
  * The `SayToUser` allows agent to say something to the output (via `println`).
  */
-public object SayToUser : SimpleTool<SayToUser.Args>() {
+public object SayToUser : SimpleTool<SayToUser.Args>(
+    argsSerializer = Args.serializer(),
+    name = "say_to_user",
+    description = "Service tool, used by the agent to talk."
+) {
     /**
      * Represents the arguments for the [SayToUser] tool
      *
@@ -21,11 +24,7 @@ public object SayToUser : SimpleTool<SayToUser.Args>() {
         val message: String
     )
 
-    override val argsSerializer: KSerializer<Args> = Args.serializer()
-    override val name: String = "say_to_user"
-    override val description: String = "Service tool, used by the agent to talk."
-
-    override suspend fun doExecute(args: Args): String {
+    override suspend fun execute(args: Args): String {
         println("Agent says: ${args.message}")
         return "DONE"
     }

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/EditFileTool.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/EditFileTool.kt
@@ -15,7 +15,6 @@ import ai.koog.rag.base.files.FileSystemProvider
 import ai.koog.rag.base.files.readText
 import ai.koog.rag.base.files.writeText
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 
 /**
@@ -28,7 +27,11 @@ import kotlinx.serialization.Serializable
  */
 public class EditFileTool<Path>(
     private val fs: FileSystemProvider.ReadWrite<Path>
-) : Tool<EditFileTool.Args, EditFileTool.Result>() {
+) : Tool<EditFileTool.Args, EditFileTool.Result>(
+    argsSerializer = Args.serializer(),
+    resultSerializer = Result.serializer(),
+    descriptor = descriptor
+) {
 
     /**
      * Arguments required to perform a single edit operation on a file.
@@ -201,15 +204,6 @@ public class EditFileTool<Path>(
             )
         )
     }
-
-    override val argsSerializer: KSerializer<Args> = Args.serializer()
-    override val resultSerializer: KSerializer<Result> = Result.serializer()
-
-    override val name: String = EditFileTool.toolName
-
-    override val description: String = EditFileTool.toolDescription
-
-    override val descriptor: ToolDescriptor = EditFileTool.descriptor
 
     override suspend fun execute(args: Args): Result {
         val path = fs.fromAbsolutePathString(args.path)

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/ListDirectoryTool.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/ListDirectoryTool.kt
@@ -11,7 +11,6 @@ import ai.koog.agents.ext.tool.file.render.folder
 import ai.koog.prompt.text.text
 import ai.koog.rag.base.files.FileMetadata
 import ai.koog.rag.base.files.FileSystemProvider
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 
 /**
@@ -22,7 +21,21 @@ import kotlinx.serialization.Serializable
  * @property fs read-only filesystem provider for accessing directories
  */
 public class ListDirectoryTool<Path>(private val fs: FileSystemProvider.ReadOnly<Path>) :
-    Tool<ListDirectoryTool.Args, ListDirectoryTool.Result>() {
+    Tool<ListDirectoryTool.Args, ListDirectoryTool.Result>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = Result.serializer(),
+        name = "__list_directory__",
+        description = """
+            Lists files and subdirectories in a directory. READ-ONLY - never modifies anything.
+
+            Use this to:
+            - See what files exist before reading or creating
+            - Understand project structure
+            - Find specific files with patterns
+
+            Returns a tree showing all contents with sizes and metadata.
+        """.trimIndent()
+    ) {
 
     /**
      * Specifies which directory to list and how to traverse its contents.
@@ -52,21 +65,6 @@ public class ListDirectoryTool<Path>(private val fs: FileSystemProvider.ReadOnly
      */
     @Serializable
     public data class Result(val root: FileSystemEntry.Folder)
-
-    override val argsSerializer: KSerializer<Args> = Args.serializer()
-    override val resultSerializer: KSerializer<Result> = Result.serializer()
-
-    override val name: String = "__list_directory__"
-    override val description: String = """
-        Lists files and subdirectories in a directory. READ-ONLY - never modifies anything.
-        
-        Use this to:
-        - See what files exist before reading or creating
-        - Understand project structure
-        - Find specific files with patterns
-        
-        Returns a tree showing all contents with sizes and metadata.
-    """.trimIndent()
 
     /**
      * Lists directory contents from the filesystem with optional depth and pattern filtering.

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/ReadFileTool.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/ReadFileTool.kt
@@ -10,7 +10,6 @@ import ai.koog.agents.ext.tool.file.render.file
 import ai.koog.prompt.text.text
 import ai.koog.rag.base.files.FileMetadata
 import ai.koog.rag.base.files.FileSystemProvider
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 
 /**
@@ -21,7 +20,21 @@ import kotlinx.serialization.Serializable
  * @property fs read-only filesystem provider for accessing files
  */
 public class ReadFileTool<Path>(private val fs: FileSystemProvider.ReadOnly<Path>) :
-    Tool<ReadFileTool.Args, ReadFileTool.Result>() {
+    Tool<ReadFileTool.Args, ReadFileTool.Result>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = Result.serializer(),
+        name = "__read_file__",
+        description = """
+            Reads a text file (throws if non-text) with optional line range selection. TEXT-ONLY - never reads binary files.
+
+            Use this to:
+            - Read entire text files or specific line ranges
+            - Get file content along with metadata
+            - Extract portions of files using 0-based line indexing
+
+            Returns file content and metadata (name, extension, path, hidden, size, contentType).
+        """.trimIndent()
+    ) {
 
     /**
      * Specifies which file to read and what portion of its content to extract.
@@ -55,21 +68,6 @@ public class ReadFileTool<Path>(private val fs: FileSystemProvider.ReadOnly<Path
         val file: FileSystemEntry.File,
         val warningMessage: String? = null,
     )
-
-    override val argsSerializer: KSerializer<Args> = Args.serializer()
-    override val resultSerializer: KSerializer<Result> = Result.serializer()
-
-    override val name: String = "__read_file__"
-    override val description: String = """
-        Reads a text file (throws if non-text) with optional line range selection. TEXT-ONLY - never reads binary files.
-        
-        Use this to:
-        - Read entire text files or specific line ranges
-        - Get file content along with metadata
-        - Extract portions of files using 0-based line indexing
-        
-        Returns file content and metadata (name, extension, path, hidden, size, contentType).
-    """.trimIndent()
 
     /**
      * Reads file content from the filesystem with optional line range filtering.

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/WriteFileTool.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/WriteFileTool.kt
@@ -12,7 +12,6 @@ import ai.koog.prompt.text.text
 import ai.koog.rag.base.files.FileMetadata
 import ai.koog.rag.base.files.FileSystemProvider
 import ai.koog.rag.base.files.writeText
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 
 /**
@@ -23,7 +22,20 @@ import kotlinx.serialization.Serializable
  * @property fs read/write filesystem provider for accessing and modifying files
  */
 public class WriteFileTool<Path>(private val fs: FileSystemProvider.ReadWrite<Path>) :
-    Tool<WriteFileTool.Args, WriteFileTool.Result>() {
+    Tool<WriteFileTool.Args, WriteFileTool.Result>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = Result.serializer(),
+        name = "__write_file__",
+        description = """
+            Writes text content to a file at an absolute path. Creates parent directories if needed and overwrites existing content.
+
+            Use this to:
+            - Create new text files with content
+            - Replace entire content of existing files
+
+            Returns file metadata (name, extension, path, hidden, size, contentType).
+        """.trimIndent()
+    ) {
 
     /**
      * Specifies which file to write and what text content to put into it.
@@ -50,20 +62,6 @@ public class WriteFileTool<Path>(private val fs: FileSystemProvider.ReadWrite<Pa
      */
     @Serializable
     public data class Result(val file: FileSystemEntry.File)
-
-    override val resultSerializer: KSerializer<Result> = Result.serializer()
-    override val argsSerializer: KSerializer<Args> = Args.serializer()
-
-    override val name: String = "__write_file__"
-    override val description: String = """
-        Writes text content to a file at an absolute path. Creates parent directories if needed and overwrites existing content.
-        
-        Use this to:
-        - Create new text files with content
-        - Replace entire content of existing files
-        
-        Returns file metadata (name, extension, path, hidden, size, contentType).
-    """.trimIndent()
 
     /**
      * Writes text content to the filesystem at the specified absolute path.

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/shell/ExecuteShellCommandTool.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/shell/ExecuteShellCommandTool.kt
@@ -2,7 +2,6 @@ package ai.koog.agents.ext.tool.shell
 
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.annotations.LLMDescription
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -18,7 +17,17 @@ import kotlin.coroutines.cancellation.CancellationException
 public class ExecuteShellCommandTool(
     private val executor: ShellCommandExecutor,
     private val confirmationHandler: ShellCommandConfirmationHandler
-) : Tool<ExecuteShellCommandTool.Args, ExecuteShellCommandTool.Result>() {
+) : Tool<ExecuteShellCommandTool.Args, ExecuteShellCommandTool.Result>(
+    argsSerializer = Args.serializer(),
+    resultSerializer = Result.serializer(),
+    name = "__execute_shell_command__",
+    description = """
+        Executes a shell command.
+        Depending on configuration, the command may run immediately or ask the user before running.
+        A working directory and timeout can be provided. If a timeout is reached, any available output is included.
+        Returns everything the command printed and the exit code, or a message if it was not run or did not finish.
+    """.trimIndent()
+) {
 
     /**
      * Parameters for running a shell command.
@@ -63,16 +72,6 @@ public class ExecuteShellCommandTool(
         val exitCode: Int?,
         val output: String
     )
-
-    override val argsSerializer: KSerializer<Args> = Args.serializer()
-    override val resultSerializer: KSerializer<Result> = Result.serializer()
-    override val name: String = "__execute_shell_command__"
-    override val description: String = """
-        Executes a shell command.  
-        Depending on configuration, the command may run immediately or ask the user before running.  
-        A working directory and timeout can be provided. If a timeout is reached, any available output is included.  
-        Returns everything the command printed and the exit code, or a message if it was not run or did not finish.
-    """.trimIndent()
 
     /**
      * Runs a command after asking the user for permission.

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/StructuredOutputWithToolsIntegrationTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/StructuredOutputWithToolsIntegrationTest.kt
@@ -13,7 +13,6 @@ import ai.koog.prompt.structure.StructuredRequest
 import ai.koog.prompt.structure.StructuredRequestConfig
 import ai.koog.prompt.structure.json.JsonStructure
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -39,7 +38,11 @@ class StructuredOutputWithToolsIntegrationTest {
         val humidity: Int
     )
 
-    object GetTemperatureTool : SimpleTool<GetTemperatureTool.Args>() {
+    object GetTemperatureTool : SimpleTool<GetTemperatureTool.Args>(
+        argsSerializer = Args.serializer(),
+        name = "get_temperature",
+        description = "Get current temperature for a city"
+    ) {
         @Serializable
         data class Args(
             @property:LLMDescription("City name")
@@ -48,16 +51,15 @@ class StructuredOutputWithToolsIntegrationTest {
             val country: String
         )
 
-        override val argsSerializer: KSerializer<Args> = Args.serializer()
-
-        override val name: String = "get_temperature"
-        override val description: String = "Get current temperature for a city"
-
-        override suspend fun doExecute(args: Args): String =
+        override suspend fun execute(args: Args): String =
             "Temperature in ${args.city}, ${args.country}: 22°C"
     }
 
-    object GetWeatherConditionsTool : SimpleTool<GetWeatherConditionsTool.Args>() {
+    object GetWeatherConditionsTool : SimpleTool<GetWeatherConditionsTool.Args>(
+        argsSerializer = Args.serializer(),
+        name = "get_weather_conditions",
+        description = "Get current weather conditions for a city"
+    ) {
         @Serializable
         data class Args(
             @property:LLMDescription("City name")
@@ -66,16 +68,15 @@ class StructuredOutputWithToolsIntegrationTest {
             val country: String
         )
 
-        override val argsSerializer: KSerializer<Args> = Args.serializer()
-
-        override val name: String = "get_weather_conditions"
-        override val description: String = "Get current weather conditions for a city"
-
-        override suspend fun doExecute(args: Args): String =
+        override suspend fun execute(args: Args): String =
             "Weather conditions in ${args.city}, ${args.country}: Partly Cloudy"
     }
 
-    object GetWindSpeedTool : SimpleTool<GetWindSpeedTool.Args>() {
+    object GetWindSpeedTool : SimpleTool<GetWindSpeedTool.Args>(
+        argsSerializer = Args.serializer(),
+        name = "get_wind_speed",
+        description = "Get current wind speed for a city"
+    ) {
         @Serializable
         data class Args(
             @property:LLMDescription("City name")
@@ -84,16 +85,15 @@ class StructuredOutputWithToolsIntegrationTest {
             val country: String
         )
 
-        override val argsSerializer: KSerializer<Args> = Args.serializer()
-
-        override val name: String = "get_wind_speed"
-        override val description: String = "Get current wind speed for a city"
-
-        override suspend fun doExecute(args: Args): String =
+        override suspend fun execute(args: Args): String =
             "Wind speed in ${args.city}, ${args.country}: 15.5 km/h"
     }
 
-    object GetHumidityTool : SimpleTool<GetHumidityTool.Args>() {
+    object GetHumidityTool : SimpleTool<GetHumidityTool.Args>(
+        argsSerializer = Args.serializer(),
+        name = "get_humidity",
+        description = "Get current humidity for a city"
+    ) {
         @Serializable
         data class Args(
             @property:LLMDescription("City name")
@@ -102,12 +102,7 @@ class StructuredOutputWithToolsIntegrationTest {
             val country: String
         )
 
-        override val argsSerializer: KSerializer<Args> = Args.serializer()
-
-        override val name: String = "get_humidity"
-        override val description: String = "Get current humidity for a city"
-
-        override suspend fun doExecute(args: Args): String =
+        override suspend fun execute(args: Args): String =
             "Humidity in ${args.city}, ${args.country}: 65%"
     }
 

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerTest.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerTest.kt
@@ -208,7 +208,7 @@ class EventHandlerTest {
 
         val runId = eventsCollector.runId
         val dummyToolName = dummyTool.name
-        val dummyToolDescription = dummyTool.description
+        val dummyToolDescription = dummyTool.descriptor.description
         val dummyToolArgsEncoded = dummyTool.encodeArgs(DummyTool.Args("test"))
         val dummyToolResultEncoded = dummyTool.encodeResult(dummyTool.result)
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryExecuteToolSpanTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryExecuteToolSpanTest.kt
@@ -48,7 +48,7 @@ class OpenTelemetryExecuteToolSpanTest : OpenTelemetryTestBase() {
                         "gen_ai.tool.name" to TestGetWeatherTool.name,
                         "gen_ai.tool.call.id" to mockToolCallResponse.toolCallId,
                         "gen_ai.operation.name" to OperationNameType.EXECUTE_TOOL.id,
-                        "gen_ai.tool.description" to TestGetWeatherTool.description,
+                        "gen_ai.tool.description" to TestGetWeatherTool.descriptor.description,
                     ),
                     "events" to mapOf()
                 )
@@ -91,7 +91,7 @@ class OpenTelemetryExecuteToolSpanTest : OpenTelemetryTestBase() {
                         "gen_ai.tool.name" to TestGetWeatherTool.name,
                         "gen_ai.tool.call.id" to mockToolCallResponse.toolCallId,
                         "gen_ai.operation.name" to OperationNameType.EXECUTE_TOOL.id,
-                        "gen_ai.tool.description" to TestGetWeatherTool.description,
+                        "gen_ai.tool.description" to TestGetWeatherTool.descriptor.description,
                     ),
                     "events" to mapOf()
                 )

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/mock/TestToolGetWeather.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/mock/TestToolGetWeather.kt
@@ -2,11 +2,13 @@ package ai.koog.agents.features.opentelemetry.mock
 
 import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.annotations.LLMDescription
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 
-internal object TestGetWeatherTool : SimpleTool<TestGetWeatherTool.Args>() {
-
+internal object TestGetWeatherTool : SimpleTool<TestGetWeatherTool.Args>(
+    argsSerializer = Args.serializer(),
+    name = "Get whether",
+    description = "The test tool to get a whether based on provided location."
+) {
     const val DEFAULT_PARIS_RESULT: String = "rainy, 57°F"
     const val DEFAULT_LONDON_RESULT: String = "cloudy, 62°F"
 
@@ -16,12 +18,7 @@ internal object TestGetWeatherTool : SimpleTool<TestGetWeatherTool.Args>() {
         val location: String
     )
 
-    override val argsSerializer: KSerializer<Args> = Args.serializer()
-
-    override val name: String = "Get whether"
-    override val description: String = "The test tool to get a whether based on provided location."
-
-    override suspend fun doExecute(args: Args): String =
+    override suspend fun execute(args: Args): String =
         if (args.location.contains("Paris")) {
             DEFAULT_PARIS_RESULT
         } else if (args.location.contains("London")) {

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/CheckpointsTests.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/CheckpointsTests.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonPrimitive
@@ -145,20 +144,24 @@ class CheckpointsTests {
     @Serializable
     data class WriteArgs(val key: String, val value: String)
 
-    object WriteKVTool : Tool<WriteArgs, String>() {
-        override val argsSerializer: KSerializer<WriteArgs> = WriteArgs.serializer()
-        override val resultSerializer: KSerializer<String> = String.serializer()
-        override val description: String = "Writes a key-value pair (simulated)"
+    object WriteKVTool : Tool<WriteArgs, String>(
+        argsSerializer = WriteArgs.serializer(),
+        resultSerializer = String.serializer(),
+        name = "write_kv",
+        description = "Writes a key-value pair (simulated)"
+    ) {
         override suspend fun execute(args: WriteArgs): String {
             databaseMap[args.key] = args.value
             return "ok"
         }
     }
 
-    object DeleteKVTool : Tool<WriteArgs, String>() {
-        override val argsSerializer: KSerializer<WriteArgs> = WriteArgs.serializer()
-        override val resultSerializer: KSerializer<String> = String.serializer()
-        override val description: String = "Deletes a key-value pair (rollback)"
+    object DeleteKVTool : Tool<WriteArgs, String>(
+        argsSerializer = WriteArgs.serializer(),
+        resultSerializer = String.serializer(),
+        name = "delete_kv",
+        description = "Deletes a key-value pair (rollback)"
+    ) {
         var calls: MutableList<WriteArgs> = mutableListOf()
         override suspend fun execute(args: WriteArgs): String {
             databaseMap.remove(args.key)

--- a/agents/agents-features/agents-features-tokenizer/src/jvmTest/kotlin/ai/koog/agents/features/tokenizer/feature/TestTools.kt
+++ b/agents/agents-features/agents-features-tokenizer/src/jvmTest/kotlin/ai/koog/agents/features/tokenizer/feature/TestTools.kt
@@ -2,21 +2,20 @@ package ai.koog.agents.features.tokenizer.feature
 
 import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.annotations.LLMDescription
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 
-abstract class TestTool(override val name: String) : SimpleTool<TestTool.Args>() {
+abstract class TestTool(name: String) : SimpleTool<TestTool.Args>(
+    argsSerializer = Args.serializer(),
+    name = name,
+    description = "$name description"
+) {
     @Serializable
     data class Args(
         @property:LLMDescription("question description")
         val question: String
     )
 
-    override val argsSerializer: KSerializer<Args> = Args.serializer()
-
-    override val description: String = "$name description"
-
-    override suspend fun doExecute(args: Args): String {
+    override suspend fun execute(args: Args): String {
         return "Answer to ${args.question} from tool `$name`"
     }
 }

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/mock/TestTools.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/mock/TestTools.kt
@@ -7,17 +7,15 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.OllamaModels
 import kotlinx.serialization.Serializable
 
-internal class TestTool(private val executor: PromptExecutor) : SimpleTool<TestTool.Args>() {
-
+internal class TestTool(private val executor: PromptExecutor) : SimpleTool<TestTool.Args>(
+    argsSerializer = Args.serializer(),
+    name = "test-tool",
+    description = "Test tool"
+) {
     @Serializable
     data class Args(val dummy: String = "")
 
-    override val argsSerializer = Args.serializer()
-
-    override val name: String = "test-tool"
-    override val description: String = "Test tool"
-
-    override suspend fun doExecute(args: Args): String {
+    override suspend fun execute(args: Args): String {
         val prompt = Prompt.build("test") {
             system("You are a helpful assistant that uses tools.")
             user("Set the color to blue")
@@ -30,34 +28,30 @@ internal class TestTool(private val executor: PromptExecutor) : SimpleTool<TestT
     }
 }
 
-internal class RecursiveTool : SimpleTool<RecursiveTool.Args>() {
-
+internal class RecursiveTool : SimpleTool<RecursiveTool.Args>(
+    argsSerializer = Args.serializer(),
+    name = "recursive",
+    description = "Recursive tool for testing"
+) {
     @Serializable
     data class Args(val dummy: String = "")
 
-    override val argsSerializer = Args.serializer()
-
-    override val name: String = "recursive"
-    override val description: String = "Recursive tool for testing"
-
-    override suspend fun doExecute(args: Args): String {
-        return "Dummy tool result: ${DummyTool().doExecute(DummyTool.Args())}"
+    override suspend fun execute(args: Args): String {
+        return "Dummy tool result: ${DummyTool().execute(DummyTool.Args())}"
     }
 }
 
-internal class LLMCallTool : SimpleTool<LLMCallTool.Args>() {
-
+internal class LLMCallTool : SimpleTool<LLMCallTool.Args>(
+    argsSerializer = Args.serializer(),
+    name = "recursive",
+    description = "Recursive tool for testing"
+) {
     @Serializable
     data class Args(val dummy: String = "")
 
     val executor = MockLLMExecutor()
 
-    override val argsSerializer = Args.serializer()
-
-    override val name: String = "recursive"
-    override val description: String = "Recursive tool for testing"
-
-    override suspend fun doExecute(args: Args): String {
+    override suspend fun execute(args: Args): String {
         val prompt = Prompt.build("test") {
             system("You are a helpful assistant that uses tools.")
             user("Set the color to blue")

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageFileWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageFileWriterTest.kt
@@ -164,7 +164,7 @@ class TraceFeatureMessageFileWriterTest {
             val dummyToolArgsEncoded = dummyTool.encodeArgs(DummyTool.Args("test"))
             val dummyToolResultEncoded = dummyTool.encodeResult(dummyTool.result)
             val dummyToolName = dummyTool.name
-            val dummyToolDescription = dummyTool.description
+            val dummyToolDescription = dummyTool.descriptor.description
 
             val dummyReceivedToolResultEncoded = @OptIn(InternalAgentsApi::class)
             SerializationUtils.encodeDataToJsonElementOrNull(
@@ -523,7 +523,7 @@ class TraceFeatureMessageFileWriterTest {
             val dummyToolArgsEncoded = dummyTool.encodeArgs(DummyTool.Args("test"))
             val dummyToolResultEncoded = dummyTool.encodeResult(dummyTool.result)
             val dummyToolName = dummyTool.name
-            val dummyToolDescription = dummyTool.description
+            val dummyToolDescription = dummyTool.descriptor.description
 
             val expectedMessages = listOf(
                 "${LLMCallStartingEvent::class.simpleName} (run id: $runId, prompt: ${

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageLogWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageLogWriterTest.kt
@@ -149,7 +149,7 @@ class TraceFeatureMessageLogWriterTest {
             val dummyToolArgsEncoded = dummyTool.encodeArgs(DummyTool.Args("test"))
             val dummyToolResultEncoded = dummyTool.encodeResult(dummyTool.result)
             val dummyToolName = dummyTool.name
-            val dummyToolDescription = dummyTool.description
+            val dummyToolDescription = dummyTool.descriptor.description
 
             val dummyReceivedToolResultEncoded = @OptIn(InternalAgentsApi::class)
             SerializationUtils.encodeDataToJsonElementOrNull(
@@ -233,7 +233,7 @@ class TraceFeatureMessageLogWriterTest {
                                 toolCallId = "0",
                                 toolName = dummyTool.name,
                                 toolArgs = dummyTool.encodeArgs(DummyTool.Args("test")),
-                                toolDescription = dummyTool.description,
+                                toolDescription = dummyTool.descriptor.description,
                                 content = dummyTool.result,
                                 result = dummyTool.encodeResult(dummyTool.result)
                             ).toMessage(clock = testClock)
@@ -249,7 +249,7 @@ class TraceFeatureMessageLogWriterTest {
                                 toolCallId = "0",
                                 toolName = dummyTool.name,
                                 toolArgs = dummyTool.encodeArgs(DummyTool.Args("test")),
-                                toolDescription = dummyTool.description,
+                                toolDescription = dummyTool.descriptor.description,
                                 content = dummyTool.result,
                                 result = dummyTool.encodeResult(dummyTool.result)
                             ).toMessage(clock = testClock)
@@ -493,7 +493,7 @@ class TraceFeatureMessageLogWriterTest {
             val dummyToolArgsEncoded = dummyTool.encodeArgs(DummyTool.Args("test"))
             val dummyToolResultEncoded = dummyTool.encodeResult(dummyTool.result)
             val dummyToolName = dummyTool.name
-            val dummyToolDescription = dummyTool.description
+            val dummyToolDescription = dummyTool.descriptor.description
 
             val expectedLogMessages = listOf(
                 "[INFO] Received feature message [event]: ${LLMCallStartingEvent::class.simpleName} (run id: $runId, prompt: ${
@@ -519,7 +519,7 @@ class TraceFeatureMessageLogWriterTest {
                                 toolCallId = "0",
                                 toolName = dummyTool.name,
                                 toolArgs = dummyTool.encodeArgs(DummyTool.Args("test")),
-                                toolDescription = dummyTool.description,
+                                toolDescription = dummyTool.descriptor.description,
                                 content = dummyTool.result,
                                 result = dummyTool.encodeResult(dummyTool.result)
                             ).toMessage(clock = testClock)
@@ -535,7 +535,7 @@ class TraceFeatureMessageLogWriterTest {
                                 toolCallId = "0",
                                 toolName = dummyTool.name,
                                 toolArgs = dummyTool.encodeArgs(DummyTool.Args("test")),
-                                toolDescription = dummyTool.description,
+                                toolDescription = dummyTool.descriptor.description,
                                 content = dummyTool.result,
                                 result = dummyTool.encodeResult(dummyTool.result)
                             ).toMessage(clock = testClock)

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageRemoteWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageRemoteWriterTest.kt
@@ -199,7 +199,7 @@ class TraceFeatureMessageRemoteWriterTest {
         val dummyToolArgsEncoded = dummyTool.encodeArgs(DummyTool.Args("test"))
         val dummyToolResultEncoded = dummyTool.encodeResult(dummyTool.result)
         val dummyToolName = dummyTool.name
-        val dummyToolDescription = dummyTool.description
+        val dummyToolDescription = dummyTool.descriptor.description
 
         val dummyReceivedToolResultEncoded = @OptIn(InternalAgentsApi::class)
         SerializationUtils.encodeDataToJsonElementOrNull(
@@ -222,7 +222,7 @@ class TraceFeatureMessageRemoteWriterTest {
                     toolCallId = "0",
                     toolName = dummyTool.name,
                     toolArgs = dummyTool.encodeArgs(DummyTool.Args("test")),
-                    toolDescription = dummyTool.description,
+                    toolDescription = dummyTool.descriptor.description,
                     content = dummyTool.encodeResultToString(dummyTool.result),
                     result = dummyTool.encodeResult(dummyTool.result)
                 ).toMessage(clock = testClock)
@@ -327,7 +327,7 @@ class TraceFeatureMessageRemoteWriterTest {
                 val dummyToolArgsEncoded = dummyTool.encodeArgs(DummyTool.Args("test"))
                 val dummyToolResultEncoded = dummyTool.encodeResult(dummyTool.result)
                 val dummyToolName = dummyTool.name
-                val dummyToolDescription = dummyTool.description
+                val dummyToolDescription = dummyTool.descriptor.description
 
                 val dummyReceivedToolResultEncoded = @OptIn(InternalAgentsApi::class)
                 SerializationUtils.encodeDataToJsonElementOrNull(
@@ -465,7 +465,7 @@ class TraceFeatureMessageRemoteWriterTest {
                         toolCallId = "0",
                         toolName = dummyTool.name,
                         toolArgs = dummyTool.encodeArgs(DummyTool.Args("test")),
-                        toolDescription = dummyTool.description,
+                        toolDescription = dummyTool.descriptor.description,
                         result = dummyTool.encodeResult(dummyTool.result),
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
@@ -724,7 +724,7 @@ class TraceFeatureMessageRemoteWriterTest {
         val dummyToolArgsEncoded = dummyTool.encodeArgs(DummyTool.Args("test"))
         val dummyToolResultEncoded = dummyTool.encodeResult(dummyTool.result)
         val dummyToolName = dummyTool.name
-        val dummyToolDescription = dummyTool.description
+        val dummyToolDescription = dummyTool.descriptor.description
 
         val dummyReceivedToolResultEncoded = @OptIn(InternalAgentsApi::class)
         SerializationUtils.encodeDataToJsonElementOrNull(
@@ -747,7 +747,7 @@ class TraceFeatureMessageRemoteWriterTest {
                     toolCallId = "0",
                     toolName = dummyTool.name,
                     toolArgs = dummyTool.encodeArgs(DummyTool.Args("test")),
-                    toolDescription = dummyTool.description,
+                    toolDescription = dummyTool.descriptor.description,
                     content = dummyTool.encodeResultToString(dummyTool.result),
                     result = dummyTool.encodeResult(dummyTool.result)
                 ).toMessage(clock = testClock)

--- a/agents/agents-mcp-server/src/jvmTest/kotlin/ai/koog/agents/mcp/server/ThrowingExceptionTool.kt
+++ b/agents/agents-mcp-server/src/jvmTest/kotlin/ai/koog/agents/mcp/server/ThrowingExceptionTool.kt
@@ -4,20 +4,18 @@ import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.testing.tools.RandomNumberTool
 import kotlinx.io.IOException
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.serializer
 
-internal class ThrowingExceptionTool : Tool<RandomNumberTool.Args, Int>() {
-
+internal class ThrowingExceptionTool : Tool<RandomNumberTool.Args, Int>(
+    argsSerializer = RandomNumberTool.Args.serializer(),
+    resultSerializer = Int.serializer(),
+    name = RandomNumberTool().name,
+    description = RandomNumberTool().descriptor.description
+) {
     private val tool = RandomNumberTool()
 
     var last: Result<Int>? = null
     var throwing: Boolean = false
-
-    override val argsSerializer: KSerializer<RandomNumberTool.Args> = RandomNumberTool.Args.serializer()
-    override val resultSerializer: KSerializer<Int> = Int.serializer()
-    override val name = tool.name
-    override val description: String = tool.description
 
     @OptIn(InternalAgentToolsApi::class)
     override suspend fun execute(args: RandomNumberTool.Args): Int {

--- a/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpTool.kt
+++ b/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpTool.kt
@@ -4,7 +4,6 @@ import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolDescriptor
 import io.modelcontextprotocol.kotlin.sdk.client.Client
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
@@ -22,13 +21,12 @@ import kotlinx.serialization.json.jsonObject
  */
 public class McpTool(
     private val mcpClient: Client,
-    override val descriptor: ToolDescriptor,
-) : Tool<JsonObject, CallToolResult?>() {
-    override val name: String = descriptor.name
-    override val description: String = descriptor.description
-
-    override val argsSerializer: KSerializer<JsonObject> = JsonObject.serializer()
-    override val resultSerializer: KSerializer<CallToolResult?> = CallToolResult.serializer().nullable
+    descriptor: ToolDescriptor,
+) : Tool<JsonObject, CallToolResult?>(
+    argsSerializer = JsonObject.serializer(),
+    resultSerializer = CallToolResult.serializer().nullable,
+    descriptor = descriptor
+) {
 
     /**
      * Executes the MCP tool with the given arguments.

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/feature/TestingFeature.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/feature/TestingFeature.kt
@@ -1209,7 +1209,7 @@ public fun <TArgs, TResult> toolResult(tool: Tool<TArgs, TResult>, args: TArgs, 
         id = null,
         tool = tool.name,
         toolArgs = tool.encodeArgs(args),
-        toolDescription = tool.description,
+        toolDescription = tool.descriptor.description,
         content = tool.encodeResultToString(result),
         resultKind = ToolResultKind.Success,
         result = tool.encodeResult(result)
@@ -1241,7 +1241,7 @@ public fun <TArgs> toolResult(tool: SimpleTool<TArgs>, args: TArgs, result: Stri
         id = null,
         tool = tool.name,
         toolArgs = tool.encodeArgs(args),
-        toolDescription = tool.description,
+        toolDescription = tool.descriptor.description,
         content = tool.encodeResultToString(result),
         resultKind = ToolResultKind.Success,
         result = tool.encodeResult(result)

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/DummyTool.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/DummyTool.kt
@@ -2,14 +2,17 @@ package ai.koog.agents.testing.tools
 
 import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.annotations.LLMDescription
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 
 /**
  * Simple tool implementation for testing purposes.
  * This tool accepts a placeholder parameter and returns a constant result.
  */
-public class DummyTool : SimpleTool<DummyTool.Args>() {
+public class DummyTool : SimpleTool<DummyTool.Args>(
+    argsSerializer = Args.serializer(),
+    name = "dummy",
+    description = "Dummy tool for testing"
+) {
 
     /**
      * A constant value representing the default result returned by the DummyTool.
@@ -27,10 +30,5 @@ public class DummyTool : SimpleTool<DummyTool.Args>() {
         val dummy: String = ""
     )
 
-    override val argsSerializer: KSerializer<Args> = Args.serializer()
-
-    override val name: String = "dummy"
-    override val description: String = "Dummy tool for testing"
-
-    override suspend fun doExecute(args: Args): String = result
+    override suspend fun execute(args: Args): String = result
 }

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockEnvironment.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockEnvironment.kt
@@ -86,7 +86,7 @@ public class MockEnvironment(
                         id = toolCall.id,
                         tool = toolCall.tool,
                         toolArgs = toolCall.contentJson,
-                        toolDescription = tool.description,
+                        toolDescription = tool.descriptor.description,
                         content = content,
                         resultKind = ToolResultKind.Success,
                         result = tool.encodeResultUnsafe(result)
@@ -103,7 +103,7 @@ public class MockEnvironment(
             id = toolCall.id,
             tool = toolCall.tool,
             toolArgs = toolCall.contentJson,
-            toolDescription = tool.description,
+            toolDescription = tool.descriptor.description,
             content = tool.encodeResultToStringUnsafe(result),
             resultKind = ToolResultKind.Success,
             result = tool.encodeResultUnsafe(result)

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/RandomNumberTool.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/RandomNumberTool.kt
@@ -3,7 +3,6 @@ package ai.koog.agents.testing.tools
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
 import kotlin.random.Random
@@ -11,7 +10,12 @@ import kotlin.random.Random
 /**
  * A tool that provides a random number using the passed seed.
  */
-public class RandomNumberTool : Tool<RandomNumberTool.Args, Int>() {
+public class RandomNumberTool : Tool<RandomNumberTool.Args, Int>(
+    argsSerializer = Args.serializer(),
+    resultSerializer = Int.serializer(),
+    name = "random_number",
+    description = "Generates a random number"
+) {
 
     /**
      * The last generated random number.
@@ -30,10 +34,6 @@ public class RandomNumberTool : Tool<RandomNumberTool.Args, Int>() {
         @property:LLMDescription("The seed for the random number generator")
         val seed: Int? = null
     )
-
-    override val argsSerializer: KSerializer<Args> = Args.serializer()
-    override val resultSerializer: KSerializer<Int> = Int.serializer()
-    override val description: String = "Generates a random number"
 
     override suspend fun execute(args: Args): Int {
         val seed = args.seed

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/TestBlankTool.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/TestBlankTool.kt
@@ -2,7 +2,6 @@ package ai.koog.agents.testing.tools
 
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.annotations.LLMDescription
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializer
 
@@ -12,7 +11,12 @@ import kotlinx.serialization.serializer
  *
  * @param name An optional name for the tool. If not provided, it defaults to "blank-tool".
  */
-public class TestBlankTool(name: String? = null) : Tool<TestBlankTool.Args, String>() {
+public class TestBlankTool(name: String? = null) : Tool<TestBlankTool.Args, String>(
+    argsSerializer = serializer<Args>(),
+    resultSerializer = serializer<String>(),
+    name = name ?: "blank-tool",
+    description = "test-finish-tool"
+) {
 
     /**
      * Represents the arguments for the `TestBlankTool`.
@@ -23,14 +27,6 @@ public class TestBlankTool(name: String? = null) : Tool<TestBlankTool.Args, Stri
     public data class Args(
         @property:LLMDescription("Blank parameter") val args: String = ""
     )
-
-    override val name: String = name ?: "blank-tool"
-
-    override val argsSerializer: KSerializer<Args> = serializer<Args>()
-
-    override val resultSerializer: KSerializer<String> = serializer<String>()
-
-    override val description: String = "test-finish-tool"
 
     override suspend fun execute(args: Args): String {
         return args.args

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/TestFinishTool.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/TestFinishTool.kt
@@ -2,7 +2,6 @@ package ai.koog.agents.testing.tools
 
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.annotations.LLMDescription
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializer
 
@@ -10,7 +9,12 @@ import kotlinx.serialization.serializer
  * A simple implementation of the Tool class designed to handle string arguments and return string results.
  * The tool is used for testing purposes only.
  */
-public object TestFinishTool : Tool<TestFinishTool.Args, String>() {
+public object TestFinishTool : Tool<TestFinishTool.Args, String>(
+    argsSerializer = serializer<Args>(),
+    resultSerializer = serializer<String>(),
+    name = "test_finish_tool",
+    description = "test-finish-tool"
+) {
 
     /**
      * Represents the arguments for a tool or function, typically used in serialization and description contexts.
@@ -21,12 +25,6 @@ public object TestFinishTool : Tool<TestFinishTool.Args, String>() {
     public data class Args(
         @property:LLMDescription("Finish output") val output: String = ""
     )
-
-    override val argsSerializer: KSerializer<Args> = serializer<Args>()
-
-    override val resultSerializer: KSerializer<String> = serializer<String>()
-
-    override val description: String = "test-finish-tool"
 
     override suspend fun execute(args: Args): String {
         return args.output

--- a/agents/agents-test/src/commonTest/kotlin/ai/koog/agents/testing/feature/Tools.kt
+++ b/agents/agents-test/src/commonTest/kotlin/ai/koog/agents/testing/feature/Tools.kt
@@ -5,40 +5,37 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
 
-object DummyTool : SimpleTool<Unit>() {
-    override val argsSerializer = Unit.serializer()
-
-    override val name: String = "dummy"
-    override val description: String = "Dummy tool for testing"
-
-    override suspend fun doExecute(args: Unit): String = "Dummy result"
+object DummyTool : SimpleTool<Unit>(
+    argsSerializer = Unit.serializer(),
+    name = "dummy",
+    description = "Dummy tool for testing"
+) {
+    override suspend fun execute(args: Unit): String = "Dummy result"
 }
 
-object CreateTool : SimpleTool<CreateTool.Args>() {
+object CreateTool : SimpleTool<CreateTool.Args>(
+    argsSerializer = Args.serializer(),
+    name = "create",
+    description = "Create something"
+) {
     @Serializable
     data class Args(
         @property:LLMDescription("Name of the entity to create") val name: String
     )
 
-    override val argsSerializer = Args.serializer()
-
-    override val name: String = "create"
-    override val description: String = "Create something"
-
-    override suspend fun doExecute(args: Args): String = "created"
+    override suspend fun execute(args: Args): String = "created"
 }
 
-object SolveTool : SimpleTool<SolveTool.Args>() {
+object SolveTool : SimpleTool<SolveTool.Args>(
+    argsSerializer = Args.serializer(),
+    name = "solve",
+    description = "Solve something"
+) {
     @Serializable
     data class Args(
         @property:LLMDescription("Name of the entity to create")
         val name: String
     )
 
-    override val argsSerializer = Args.serializer()
-
-    override val name: String = "solve"
-    override val description: String = "Solve something"
-
-    override suspend fun doExecute(args: Args): String = "solved"
+    override suspend fun execute(args: Args): String = "solved"
 }

--- a/agents/agents-test/src/commonTest/kotlin/ai/koog/agents/testing/tools/MockLLMBuilderTests.kt
+++ b/agents/agents-test/src/commonTest/kotlin/ai/koog/agents/testing/tools/MockLLMBuilderTests.kt
@@ -6,7 +6,6 @@ import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.llm.OllamaModels
 import ai.koog.prompt.message.Message
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializer
 import kotlin.test.Test
@@ -18,15 +17,14 @@ import kotlin.test.assertTrue
 class MockLLMBuilderTests {
 
     // Sample tool for testing
-    private object TestTool : Tool<TestTool.Args, String>() {
+    private object TestTool : Tool<TestTool.Args, String>(
+        argsSerializer = serializer<Args>(),
+        resultSerializer = serializer<String>(),
+        name = "test_tool",
+        description = "A test tool for testing"
+    ) {
         @Serializable
         data class Args(val input: String)
-
-        override val argsSerializer: KSerializer<Args> = serializer()
-        override val resultSerializer: KSerializer<String> = serializer()
-
-        override val name: String = "test_tool"
-        override val description: String = "A test tool for testing"
 
         override suspend fun execute(args: Args): String =
             "Executed with: ${args.input}"

--- a/agents/agents-test/src/jvmTest/kotlin/ai/koog/agents/test/SimpleAgentMockedTest.kt
+++ b/agents/agents-test/src/jvmTest/kotlin/ai/koog/agents/test/SimpleAgentMockedTest.kt
@@ -16,7 +16,6 @@ import ai.koog.agents.testing.tools.getMockExecutor
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.message.Message
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -117,36 +116,34 @@ class SimpleAgentMockedTest {
         llmRequestedTools.clear()
     }
 
-    object ErrorTool : SimpleTool<ErrorTool.Args>() {
+    object ErrorTool : SimpleTool<ErrorTool.Args>(
+        argsSerializer = Args.serializer(),
+        name = "error_tool",
+        description = "A tool that always throws an exception"
+    ) {
         @Serializable
         data class Args(
             @property:LLMDescription("Message for the error")
             val message: String
         )
 
-        override val argsSerializer: KSerializer<Args> = Args.serializer()
-
-        override val name: String = "error_tool"
-        override val description: String = "A tool that always throws an exception"
-
-        override suspend fun doExecute(args: Args): String {
+        override suspend fun execute(args: Args): String {
             throw ToolException.ValidationFailure("This tool always fails")
         }
     }
 
-    object ConditionalTool : SimpleTool<ConditionalTool.Args>() {
+    object ConditionalTool : SimpleTool<ConditionalTool.Args>(
+        argsSerializer = Args.serializer(),
+        name = "conditional_tool",
+        description = "A tool that conditionally throws an exception"
+    ) {
         @Serializable
         data class Args(
             @property:LLMDescription("Condition that determines if the tool will succeed or fail")
             val condition: String
         )
 
-        override val argsSerializer: KSerializer<Args> = Args.serializer()
-
-        override val name: String = "conditional_tool"
-        override val description: String = "A tool that conditionally throws an exception"
-
-        override suspend fun doExecute(args: Args): String {
+        override suspend fun execute(args: Args): String {
             if (args.condition == "error") {
                 throw ToolException.ValidationFailure("Conditional failure triggered")
             }

--- a/agents/agents-test/src/jvmTest/kotlin/ai/koog/agents/test/TokenCountTest.kt
+++ b/agents/agents-test/src/jvmTest/kotlin/ai/koog/agents/test/TokenCountTest.kt
@@ -17,7 +17,6 @@ import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.nulls.shouldNotBeNull
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import org.junit.jupiter.api.Disabled
 import kotlin.test.AfterTest
@@ -45,18 +44,18 @@ class TokenCountTest {
         }
     }
 
-    object TestTool : SimpleTool<TestTool.Args>() {
+    object TestTool : SimpleTool<TestTool.Args>(
+        argsSerializer = Args.serializer(),
+        name = "test_tool",
+        description = "A test tool for token counting"
+    ) {
         @Serializable
         data class Args(
             @property:LLMDescription("Test message")
             val message: String
         )
 
-        override val argsSerializer: KSerializer<Args> = Args.serializer()
-        override val name: String = "test_tool"
-        override val description: String = "A test tool for token counting"
-
-        override suspend fun doExecute(args: Args): String {
+        override suspend fun execute(args: Args): String {
             return "Test tool executed with: ${args.message}"
         }
     }

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/SimpleTool.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/SimpleTool.kt
@@ -8,23 +8,15 @@ import kotlinx.serialization.builtins.serializer
  *
  * @param TArgs The type of arguments the tool accepts.
  */
-public abstract class SimpleTool<TArgs> : Tool<TArgs, String>() {
+public abstract class SimpleTool<TArgs>(
+    argsSerializer: KSerializer<TArgs>,
+    name: String,
+    description: String,
+) : Tool<TArgs, String>(
+    argsSerializer = argsSerializer,
+    resultSerializer = String.serializer(),
+    name = name,
+    description = description,
+) {
     override fun encodeResultToString(result: String): String = result
-
-    /**
-     * Deprecated in favor of `String`.
-     */
-    @Deprecated("Please use the `encodeResultToString(result: String): String` API instead")
-    public fun encodeResultToString(result: ToolResult.Text): String = result.text
-    override val resultSerializer: KSerializer<String> = String.serializer()
-
-    final override suspend fun execute(args: TArgs): String = doExecute(args)
-
-    /**
-     * Executes the tool's main functionality using the provided arguments and produces a textual result.
-     *
-     * @param args The arguments of type [TArgs] required to perform the execution.
-     * @return A string representing the result of the execution.
-     */
-    public abstract suspend fun doExecute(args: TArgs): String
 }

--- a/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/serialization/SampleTool.kt
+++ b/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/serialization/SampleTool.kt
@@ -4,7 +4,11 @@ import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import kotlinx.serialization.Serializable
 
-internal class SampleTool(name: String) : SimpleTool<SampleTool.Args>() {
+internal class SampleTool(name: String) : SimpleTool<SampleTool.Args>(
+    argsSerializer = Args.serializer(),
+    name = name,
+    description = "First tool description",
+) {
     @Serializable
     data class Args(
         @property:LLMDescription("First tool argument 1")
@@ -12,11 +16,5 @@ internal class SampleTool(name: String) : SimpleTool<SampleTool.Args>() {
         val arg2: Int
     )
 
-    override val argsSerializer = Args.serializer()
-
-    override val name = name
-
-    override val description: String = "First tool description"
-
-    override suspend fun doExecute(args: Args): String = "Do nothing $args"
+    override suspend fun execute(args: Args): String = "Do nothing $args"
 }

--- a/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/serialization/ToolDescriptorGenerationTest.kt
+++ b/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/serialization/ToolDescriptorGenerationTest.kt
@@ -58,14 +58,12 @@ data class ComplexNestedToolArgs(
     val profile: UserProfile
 )
 
-object ComplexNestedTool : SimpleTool<ComplexNestedToolArgs>() {
-    override val argsSerializer = ComplexNestedToolArgs.serializer()
-
-    override val name = "complex_nested_tool"
-
-    override val description = "A tool that processes user profiles with complex nested structures."
-
-    override suspend fun doExecute(args: ComplexNestedToolArgs): String {
+object ComplexNestedTool : SimpleTool<ComplexNestedToolArgs>(
+    argsSerializer = ComplexNestedToolArgs.serializer(),
+    name = "complex_nested_tool",
+    description = "A tool that processes user profiles with complex nested structures.",
+) {
+    override suspend fun execute(args: ComplexNestedToolArgs): String {
         return ""
     }
 }

--- a/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/serialization/ToolParameterTypesTest.kt
+++ b/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/serialization/ToolParameterTypesTest.kt
@@ -4,7 +4,6 @@ import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonNull
@@ -466,33 +465,36 @@ class ToolParameterTypesTest {
     }
     // endregion
 
-    private object PrimitiveTypesTool : Tool<String, String>() {
-        override val argsSerializer = String.serializer()
-        override val resultSerializer = String.serializer()
-
-        override val name = "primitive_types_tool"
-        override val description = "Tool with primitive types parameter"
-
+    private object PrimitiveTypesTool : Tool<String, String>(
+        argsSerializer = String.serializer(),
+        resultSerializer = String.serializer(),
+        name = "primitive_types_tool",
+        description = "Tool with primitive types parameter",
+    ) {
         override suspend fun execute(args: String): String =
             "input: $args"
     }
 
-    private object ValueClassTool : Tool<ValueClassTool.Args, String>() {
-        override val argsSerializer = Args.serializer()
-        override val resultSerializer = String.serializer()
-
+    private object ValueClassTool : Tool<ValueClassTool.Args, String>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = String.serializer(),
+        name = "value_class_tool",
+        description = "Tool with value class parameter",
+    ) {
         @Serializable
         @JvmInline
         value class Args(val value: String)
-
-        override val name = "value_class_tool"
-        override val description: String = "Tool with value class parameter"
 
         override suspend fun execute(args: Args): String =
             "input: ${args.value}"
     }
 
-    private object NestedListsTool : Tool<NestedListsTool.Args, NestedListsTool.Result>() {
+    private object NestedListsTool : Tool<NestedListsTool.Args, NestedListsTool.Result>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = Result.serializer(),
+        name = "nested_lists_tool",
+        description = "Tool with nested lists parameter",
+    ) {
         @Serializable
         data class Args(
             @property:LLMDescription("A nested list of integers")
@@ -502,16 +504,15 @@ class ToolParameterTypesTest {
         @Serializable
         data class Result(val nestedList: List<List<Int>>)
 
-        override val argsSerializer = Args.serializer()
-        override val resultSerializer: KSerializer<Result> = Result.serializer()
-
-        override val name = "nested_lists_tool"
-        override val description: String = "Tool with nested lists parameter"
-
         override suspend fun execute(args: Args): Result = Result(args.nestedList)
     }
 
-    private object ListOfEnumsTool : Tool<ListOfEnumsTool.Args, ListOfEnumsTool.Result>() {
+    private object ListOfEnumsTool : Tool<ListOfEnumsTool.Args, ListOfEnumsTool.Result>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = Result.serializer(),
+        name = "list_of_enums_tool",
+        description = "Tool with list of enums parameter",
+    ) {
         @Serializable
         enum class Color { RED, GREEN, BLUE }
 
@@ -531,16 +532,15 @@ class ToolParameterTypesTest {
         @Serializable
         data class Result(val colors: List<Color>, val names: List<Name>, val optional: List<Color>?)
 
-        override val argsSerializer = Args.serializer()
-        override val resultSerializer: KSerializer<Result> = Result.serializer()
-
-        override val name = "list_of_enums_tool"
-        override val description: String = "Tool with list of enums parameter"
-
         override suspend fun execute(args: Args): Result = Result(args.colors, args.names, args.optional)
     }
 
-    private object ObjectTool : Tool<ObjectTool.Args, ObjectTool.Result>() {
+    private object ObjectTool : Tool<ObjectTool.Args, ObjectTool.Result>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = Result.serializer(),
+        name = "object_tool",
+        description = "Tool with object parameter",
+    ) {
         @Serializable
         data class Address(
             @property:LLMDescription("Street address")
@@ -568,16 +568,15 @@ class ToolParameterTypesTest {
         @Serializable
         data class Result(val person: Person)
 
-        override val argsSerializer = Args.serializer()
-        override val resultSerializer: KSerializer<Result> = Result.serializer()
-
-        override val name = "object_tool"
-        override val description: String = "Tool with object parameter"
-
         override suspend fun execute(args: Args): Result = Result(args.person)
     }
 
-    private object ListOfObjectsTool : Tool<ListOfObjectsTool.Args, ListOfObjectsTool.Result>() {
+    private object ListOfObjectsTool : Tool<ListOfObjectsTool.Args, ListOfObjectsTool.Result>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = Result.serializer(),
+        name = "list_of_objects_tool",
+        description = "Tool with list of objects parameter",
+    ) {
         @Serializable
         data class Person(
             @property:LLMDescription("Person's name")
@@ -595,17 +594,16 @@ class ToolParameterTypesTest {
         @Serializable
         data class Result(val people: List<Person>)
 
-        override val argsSerializer = Args.serializer()
-        override val resultSerializer: KSerializer<Result> = Result.serializer()
-
-        override val name = "list_of_objects_tool"
-        override val description: String = "Tool with list of objects parameter"
-
         override suspend fun execute(args: Args): Result = Result(args.people)
     }
 
     private object ObjectWithAdditionalPropertiesTool :
-        Tool<ObjectWithAdditionalPropertiesTool.Args, ObjectWithAdditionalPropertiesTool.Result>() {
+        Tool<ObjectWithAdditionalPropertiesTool.Args, ObjectWithAdditionalPropertiesTool.Result>(
+            argsSerializer = Args.serializer(),
+            resultSerializer = Result.serializer(),
+            name = "object_with_additional_properties_tool",
+            description = "Tool with object with additional properties parameter",
+        ) {
 
         @Serializable
         data class Config(
@@ -632,12 +630,6 @@ class ToolParameterTypesTest {
 
         @Serializable
         data class Result(val config: Config)
-
-        override val argsSerializer = Args.serializer()
-        override val resultSerializer: KSerializer<Result> = Result.serializer()
-
-        override val name = "object_with_additional_properties_tool"
-        override val description: String = "Tool with object with additional properties parameter"
 
         override suspend fun execute(args: Args): Result = Result(args.config)
     }

--- a/agents/agents-tools/src/jvmMain/kotlin/ai/koog/agents/core/tools/reflect/ToolFromCallable.kt
+++ b/agents/agents-tools/src/jvmMain/kotlin/ai/koog/agents/core/tools/reflect/ToolFromCallable.kt
@@ -38,10 +38,14 @@ private const val nonSerializableParameterPrefix = "__##nonSerializableParameter
 public class ToolFromCallable(
     private val callable: KCallable<*>,
     private val thisRef: Any? = null,
-    override val descriptor: ToolDescriptor,
+    descriptor: ToolDescriptor,
     override val json: Json = ToolJson,
-    override val resultSerializer: KSerializer<Any?>,
-) : Tool<ToolFromCallable.VarArgs, Any?>() {
+    resultSerializer: KSerializer<Any?>,
+) : Tool<ToolFromCallable.VarArgs, Any?>(
+    argsSerializer = VarArgsSerializer(callable),
+    resultSerializer = resultSerializer,
+    descriptor = descriptor,
+) {
 
     /**
      * Represents a data structure to hold arguments conforming to the Args interface.
@@ -105,12 +109,6 @@ public class ToolFromCallable(
         }
         return callable.callSuspendBy(argsMap)
     }
-
-    override val argsSerializer: KSerializer<VarArgs>
-        get() = VarArgsSerializer(callable)
-
-    override val name: String = descriptor.name
-    override val description: String = descriptor.description
 
     /**
      * A serializer for the `VarArgs` class, enabling Kotlin serialization for arguments provided dynamically

--- a/docs/docs/class-based-tools.md
+++ b/docs/docs/class-based-tools.md
@@ -54,8 +54,13 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 -->
 ```kotlin
 // Implement a simple calculator tool that adds two digits
-object CalculatorTool : Tool<CalculatorTool.Args, Int>() {
-    
+object CalculatorTool : Tool<CalculatorTool.Args, Int>(
+    argsSerializer = Args.serializer(),
+    resultSerializer = Int.serializer(),
+    name = "calculator",
+    description = "A simple calculator that can add two digits (0-9)."
+) {
+
     // Arguments for the calculator tool
     @Serializable
     data class Args(
@@ -69,15 +74,6 @@ object CalculatorTool : Tool<CalculatorTool.Args, Int>() {
             require(digit2 in 0..9) { "digit2 must be a single digit (0-9)" }
         }
     }
-
-    // Serializer for the Args class
-    override val argsSerializer = Args.serializer()
-    override val resultSerializer = Int.serializer()
-    
-    // Name of the tool, visible to LLM (by default will be derrived from the class name)
-    override val name = "calculator"
-    // Description of the tool, visible to LLM. Required
-    override val description = "A simple calculator that can add two digits (0-9)."
 
     // Function to add two digits
     override suspend fun execute(args: Args): Int = args.digit1 + args.digit2
@@ -117,7 +113,11 @@ import kotlinx.serialization.Serializable
 -->
 ```kotlin
 // Create a tool that casts a string expression to a double value
-object CastToDoubleTool : SimpleTool<CastToDoubleTool.Args>() {
+object CastToDoubleTool : SimpleTool<CastToDoubleTool.Args>(
+    argsSerializer = Args.serializer(),
+    name = "cast_to_double",
+    description = "casts the passed expression to double or returns 0.0 if the expression is not castable"
+) {
     // Define tool arguments
     @Serializable
     data class Args(
@@ -127,17 +127,11 @@ object CastToDoubleTool : SimpleTool<CastToDoubleTool.Args>() {
         val comment: String
     )
 
-    // Serializer for the Args class
-    override val argsSerializer = Args.serializer()
-
-    // Description of the tool, visible to LLM
-    override val description = "casts the passed expression to double or returns 0.0 if the expression is not castable"
-    
     // Function that executes the tool with the provided arguments
-    override suspend fun doExecute(args: Args): String {
+    override suspend fun execute(args: Args): String {
         return "Result: ${castToDouble(args.expression)}, " + "the comment was: ${args.comment}"
     }
-    
+
     // Function to cast a string expression to a double value
     private fun castToDouble(expression: String): Double {
         return expression.toDoubleOrNull() ?: 0.0
@@ -165,7 +159,12 @@ import ai.koog.prompt.markdown.markdown
 -->
 ```kotlin
 // A tool that edits file
-object EditFile : Tool<EditFile.Args, EditFile.Result>() {
+object EditFile : Tool<EditFile.Args, EditFile.Result>(
+    argsSerializer = Args.serializer(),
+    resultSerializer = Result.serializer(),
+    name = "edit_file",
+    description = "Edits the given file"
+) {
     // Define tool arguments
     @Serializable
     public data class Args(
@@ -205,13 +204,6 @@ object EditFile : Tool<EditFile.Args, EditFile.Result>() {
 
         override fun toString(): String = textForLLM()
     }
-
-    // Serializers for the args and Result class
-    override val argsSerializer = Args.serializer()
-    override val resultSerializer = Result.serializer()
-
-    // Description of the tool, visible to LLM
-    override val description = "Edits the given file"
 
     // Function that executes the tool with the provided arguments
     override suspend fun execute(args: Args): Result {

--- a/docs/docs/custom-subgraphs.md
+++ b/docs/docs/custom-subgraphs.md
@@ -258,41 +258,41 @@ import ai.koog.prompt.dsl.prompt
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 
-class WebSearchTool: SimpleTool<WebSearchTool.Args>() {
+class WebSearchTool: SimpleTool<WebSearchTool.Args>(
+    argsSerializer = Args.serializer(),
+    name = "web_search",
+    description = "Search on the web"
+) {
     @Serializable
     class Args(val query: String)
 
-    override val argsSerializer: KSerializer<Args> = Args.serializer()
-
-    override val description = "Search on the web"
-
-    override suspend fun doExecute(args: Args): String {
+    override suspend fun execute(args: Args): String {
         return "Searching for ${args.query} on the web..."
     }
 }
 
-class DoAction: SimpleTool<DoAction.Args>() {
+class DoAction: SimpleTool<DoAction.Args>(
+    argsSerializer = Args.serializer(),
+    name = "do_action",
+    description = "Do something"
+) {
     @Serializable
     class Args(val action: String)
 
-    override val argsSerializer: KSerializer<Args> = Args.serializer()
-
-    override val description = "Do something"
-
-    override suspend fun doExecute(args: Args): String {
+    override suspend fun execute(args: Args): String {
         return "Doing action..."
     }
 }
 
-class DoAnotherAction: SimpleTool<DoAnotherAction.Args>() {
+class DoAnotherAction: SimpleTool<DoAnotherAction.Args>(
+    argsSerializer = Args.serializer(),
+    name = "do_another_action",
+    description = "Do something other"
+) {
     @Serializable
     class Args(val action: String)
 
-    override val argsSerializer: KSerializer<Args> = Args.serializer()
-
-    override val description = "Do something other"
-
-    override suspend fun doExecute(args: Args): String {
+    override suspend fun execute(args: Args): String {
         return "Doing another action..."
     }
 }

--- a/docs/docs/examples/Chess.md
+++ b/docs/docs/examples/Chess.md
@@ -248,13 +248,9 @@ The `moveNotation` string provides clear documentation for the AI agent on accep
 ```kotlin
 import kotlinx.serialization.Serializable
 
-class Move(val game: ChessGame) : SimpleTool<Move.Args>() {
-    @Serializable
-    data class Args(val notation: String) : ToolArgs
-
-    override val argsSerializer = Args.serializer()
-
-    override val descriptor = ToolDescriptor(
+class Move(val game: ChessGame) : SimpleTool<Move.Args>(
+    argsSerializer = Args.serializer(),
+    descriptor = ToolDescriptor(
         name = "move",
         description = "Moves a piece according to the notation:\n${game.moveNotation}",
         requiredParameters = listOf(
@@ -265,8 +261,11 @@ class Move(val game: ChessGame) : SimpleTool<Move.Args>() {
             )
         )
     )
+) {
+    @Serializable
+    data class Args(val notation: String) : ToolArgs
 
-    override suspend fun doExecute(args: Args): String {
+    override suspend fun execute(args: Args): String {
         game.move(args.notation)
         println(game.getBoard())
         println("-----------------")
@@ -280,7 +279,8 @@ The `Move` tool demonstrates the Koog framework's tool integration pattern:
 1. **Extends SimpleTool**: Inherits the basic tool functionality with type-safe argument handling
 2. **Serializable Arguments**: Uses Kotlin serialization to define the tool's input parameters
 3. **Rich Documentation**: The `ToolDescriptor` provides the LLM with detailed information about the tool's purpose and parameters
-4. **Execution Logic**: The `doExecute` method handles the actual move execution and provides formatted feedback
+4. **Constructor Parameters**: Passes `argsSerializer` and `descriptor` to the constructor
+5. **Execution Logic**: The `execute` method handles the actual move execution and provides formatted feedback
 
 Key design aspects:
 - **Context Injection**: The tool receives the `ChessGame` instance, allowing it to modify game state

--- a/docs/docs/streaming-api.md
+++ b/docs/docs/streaming-api.md
@@ -388,20 +388,18 @@ data class Book(
    val description: String
 )
 
-class BookTool(): SimpleTool<Book>() {
-    
+class BookTool(): SimpleTool<Book>(
+    argsSerializer = Book.serializer(),
+    name = NAME,
+    description = "A tool to parse book information from Markdown"
+) {
+
     companion object { const val NAME = "book" }
 
-    override suspend fun doExecute(args: Book): String {
+    override suspend fun execute(args: Book): String {
         println("${args.title} by ${args.author}:\n ${args.description}")
         return "Done"
     }
-
-    override val argsSerializer: KSerializer<Book>
-        get() = Book.serializer()
-
-    override val name: String = NAME
-    override val description: String = "A tool to parse book information from Markdown"
 }
 ```
 <!--- KNIT example-streaming-api-08.kt -->

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -72,7 +72,12 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
 import ai.koog.agents.core.tools.annotations.LLMDescription
 
-public object CreateTool : Tool<CreateTool.Args, String>() {
+public object CreateTool : Tool<CreateTool.Args, String>(
+    argsSerializer = Args.serializer(),
+    resultSerializer = String.serializer(),
+    name = "message",
+    description = "Service tool, used by the agent to talk with user"
+) {
     /**
     * Represents the arguments for the [AskUser] tool
     *
@@ -84,16 +89,15 @@ public object CreateTool : Tool<CreateTool.Args, String>() {
         val message: String
     )
 
-    override val argsSerializer: KSerializer<Args> = Args.serializer()
-    override val resultSerializer: KSerializer<String> = String.serializer()
-
-    override val name = "message"
-    override val description = "Service tool, used by the agent to talk with user"
-
     override suspend fun execute(args: Args): String = args.message
 }
 
-public object SearchTool : Tool<SearchTool.Args, String>() {
+public object SearchTool : Tool<SearchTool.Args, String>(
+    argsSerializer = Args.serializer(),
+    resultSerializer = String.serializer(),
+    name = "message",
+    description = "Service tool, used by the agent to talk with user"
+) {
     /**
     * Represents the arguments for the [AskUser] tool
     *
@@ -104,18 +108,17 @@ public object SearchTool : Tool<SearchTool.Args, String>() {
         @property:LLMDescription("Message from the agent")
         val query: String
     )
-
-    override val argsSerializer: KSerializer<Args> = Args.serializer()
-    override val resultSerializer: KSerializer<String> = String.serializer()
-
-    override val name = "message"
-    override val description = "Service tool, used by the agent to talk with user"
 
     override suspend fun execute(args: Args): String = args.query
 }
 
 
-public object AnalyzeTool : Tool<AnalyzeTool.Args, String>() {
+public object AnalyzeTool : Tool<AnalyzeTool.Args, String>(
+    argsSerializer = Args.serializer(),
+    resultSerializer = String.serializer(),
+    name = "message",
+    description = "Service tool, used by the agent to talk with user"
+) {
     /**
     * Represents the arguments for the [AskUser] tool
     *
@@ -126,12 +129,6 @@ public object AnalyzeTool : Tool<AnalyzeTool.Args, String>() {
         @property:LLMDescription("Message from the agent")
         val query: String
     )
-
-    override val argsSerializer: KSerializer<Args> = Args.serializer()
-    override val resultSerializer: KSerializer<String> = String.serializer()
-
-    override val name = "message"
-    override val description = "Service tool, used by the agent to talk with user"
 
     override suspend fun execute(args: Args): String = args.query
 }
@@ -354,19 +351,18 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import ai.koog.agents.core.tools.annotations.LLMDescription
 
-object SolveTool : SimpleTool<SolveTool.Args>() {
+object SolveTool : SimpleTool<SolveTool.Args>(
+    argsSerializer = Args.serializer(),
+    name = "message",
+    description = "Service tool, used by the agent to talk with user"
+) {
     @Serializable
     data class Args(
         @property:LLMDescription("Message from the agent")
         val message: String
     )
 
-    override val argsSerializer: KSerializer<Args> = Args.serializer()
- 
-    override val name = "message"
-    override val description = "Service tool, used by the agent to talk with user"
-
-    override suspend fun doExecute(args: Args): String {
+    override suspend fun execute(args: Args): String {
         return args.message
     }
 }
@@ -424,7 +420,12 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
 import ai.koog.agents.core.tools.annotations.LLMDescription
 
-object AnalyzeTool : Tool<AnalyzeTool.Args, String>() {
+object AnalyzeTool : Tool<AnalyzeTool.Args, String>(
+    argsSerializer = Args.serializer(),
+    resultSerializer = String.serializer(),
+    name = "message",
+    description = "Service tool, used by the agent to talk with user"
+) {
 
     @Serializable
     data class Args(
@@ -432,12 +433,6 @@ object AnalyzeTool : Tool<AnalyzeTool.Args, String>() {
         val query: String,
         val depth: Int
     )
-
-    override val argsSerializer: KSerializer<Args> = Args.serializer()
-    override val resultSerializer: KSerializer<String> = String.serializer()
- 
-    override val name = "message"
-    override val description = "Service tool, used by the agent to talk with user"
 
     override suspend fun execute(args: Args): String = args.query
 }
@@ -493,7 +488,12 @@ import ai.koog.prompt.message.Message
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 
-object AnalyzeTool : Tool<AnalyzeTool.Args, AnalyzeTool.Result>() {
+object AnalyzeTool : Tool<AnalyzeTool.Args, AnalyzeTool.Result>(
+    argsSerializer = Args.serializer(),
+    resultSerializer = Result.serializer(),
+    name = "message",
+    description = "Service tool, used by the agent to talk with user"
+) {
     @Serializable
     data class Args(
         val query: String,
@@ -506,12 +506,6 @@ object AnalyzeTool : Tool<AnalyzeTool.Args, AnalyzeTool.Result>() {
         val confidence: Double,
         val metadata: Map<String, String> = mapOf()
     )
-
-    override val argsSerializer: KSerializer<Args> = Args.serializer()
-    override val resultSerializer: KSerializer<Result> = Result.serializer()
- 
-    override val name = "message"
-    override val description = "Service tool, used by the agent to talk with user"
 
     override suspend fun execute(args: Args): Result {
         return Result(

--- a/docs/docs/tools-overview.md
+++ b/docs/docs/tools-overview.md
@@ -131,21 +131,19 @@ data class Book(
     val description: String
 )
 
-class BookTool() : SimpleTool<Book>() {
+class BookTool() : SimpleTool<Book>(
+    argsSerializer = Book.serializer(),
+    name = NAME,
+    description = "A tool to parse book information from Markdown"
+) {
     companion object {
         const val NAME = "book"
     }
 
-    override suspend fun doExecute(args: Book): String {
+    override suspend fun execute(args: Book): String {
         println("${args.title} by ${args.author}:\n ${args.description}")
         return "Done"
     }
-
-    override val argsSerializer: KSerializer<Book>
-        get() = Book.serializer()
-
-    override val name = NAME
-    override val description = "A tool to parse book information from Markdown"
 }
 
 val strategy = strategy<Unit, Unit>("strategy-name") {

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/chess/ChessGameTools.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/chess/ChessGameTools.kt
@@ -4,19 +4,18 @@ import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import kotlinx.serialization.Serializable
 
-class Move(val game: ChessGame) : SimpleTool<Move.Args>() {
+class Move(val game: ChessGame) : SimpleTool<Move.Args>(
+    argsSerializer = Args.serializer(),
+    name = "move",
+    description = "Moves a piece according to the notation:\n${game.moveNotation}"
+) {
     @Serializable
     data class Args(
         @property:LLMDescription("The notation of the piece to move")
         val notation: String
     )
 
-    override val argsSerializer = Args.serializer()
-
-    override val name: String = "move"
-    override val description: String = "Moves a piece according to the notation:\n${game.moveNotation}"
-
-    override suspend fun doExecute(args: Args): String {
+    override suspend fun execute(args: Args): String {
         game.move(args.notation)
         println(game.getBoard())
         return "Current state of the game:\n${game.getBoard()}\n${game.currentPlayer()} to move! Make the move!"

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/guesser/GuesserTools.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/guesser/GuesserTools.kt
@@ -6,14 +6,13 @@ import kotlinx.serialization.Serializable
 abstract class GuesserTool(
     toolName: String,
     toolDescription: String,
-) : SimpleTool<GuesserTool.Args>() {
+) : SimpleTool<GuesserTool.Args>(
+    argsSerializer = Args.serializer(),
+    name = toolName,
+    description = toolDescription
+) {
     @Serializable
     data class Args(val value: Int)
-
-    final override val argsSerializer = Args.serializer()
-
-    final override val name: String = toolName
-    final override val description: String = toolDescription
 
     protected fun ask(question: String, value: Int): String {
         print("$question [Y/n]: ")
@@ -37,7 +36,7 @@ object LessThanTool : GuesserTool(
     toolName = "less_than",
     toolDescription = "Asks the user if his number is STRICTLY less than a given value.",
 ) {
-    override suspend fun doExecute(args: Args): String {
+    override suspend fun execute(args: Args): String {
         return ask("Is your number less than ${args.value}?", args.value)
     }
 }
@@ -46,7 +45,7 @@ object GreaterThanTool : GuesserTool(
     toolName = "greater_than",
     toolDescription = "Asks the user if his number is STRICTLY greater than a given value.",
 ) {
-    override suspend fun doExecute(args: Args): String {
+    override suspend fun execute(args: Args): String {
         return ask("Is your number greater than ${args.value}?", args.value)
     }
 }
@@ -55,7 +54,7 @@ object ProposeNumberTool : GuesserTool(
     toolName = "propose_number",
     toolDescription = "Asks the user if his number is EXACTLY equal to the given number. Only use this tool once you've narrowed down your answer.",
 ) {
-    override suspend fun doExecute(args: Args): String {
+    override suspend fun execute(args: Args): String {
         return ask("Is your number equal to ${args.value}?", args.value)
     }
 }

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/structuredoutput/markdown/BookMdStructure.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/structuredoutput/markdown/BookMdStructure.kt
@@ -19,21 +19,19 @@ data class Book(
     val description: String
 )
 
-class BookTool() : SimpleTool<Book>() {
+class BookTool() : SimpleTool<Book>(
+    argsSerializer = Book.serializer(),
+    name = "book",
+    description = "A tool to parse book information from markdown"
+) {
     companion object {
         const val NAME = "book"
     }
 
-    override val name: String = "book"
-    override val description: String = "A tool to parse book information from markdown"
-
-    override suspend fun doExecute(args: Book): String {
+    override suspend fun execute(args: Book): String {
         println("${args.bookName} by ${args.author}:\n ${args.description}")
         return "Done"
     }
-
-    override val argsSerializer: KSerializer<Book>
-        get() = Book.serializer()
 }
 
 /**

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/subgraphwithtask/ProjectGeneratorTools.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/subgraphwithtask/ProjectGeneratorTools.kt
@@ -10,7 +10,12 @@ import java.util.concurrent.TimeUnit
 import kotlin.io.path.pathString
 
 object ProjectGeneratorTools {
-    class CreateFileTool(val rootProjectPath: Path) : Tool<CreateFileTool.Args, CreateFileTool.Result>() {
+    class CreateFileTool(val rootProjectPath: Path) : Tool<CreateFileTool.Args, CreateFileTool.Result>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = Result.serializer(),
+        name = "create_file",
+        description = "Creates a file under the provided relative path, with the specified content"
+    ) {
         @Serializable
         data class Args(
             @property:LLMDescription("Path to the file")
@@ -21,13 +26,6 @@ object ProjectGeneratorTools {
 
         @Serializable
         data class Result(val successful: Boolean, val comment: String? = null)
-
-        override val argsSerializer: KSerializer<Args> = Args.serializer()
-        override val resultSerializer: KSerializer<Result> = Result.serializer()
-
-        override val name: String = "create_file"
-        override val description: String =
-            "Creates a file under the provided relative path, with the specified content"
 
         override suspend fun execute(args: Args): Result {
             val path = rootProjectPath.resolve(args.path).normalize()
@@ -45,7 +43,12 @@ object ProjectGeneratorTools {
         }
     }
 
-    class ReadFileTool(val rootProjectPath: Path) : Tool<ReadFileTool.Args, ReadFileTool.Result>() {
+    class ReadFileTool(val rootProjectPath: Path) : Tool<ReadFileTool.Args, ReadFileTool.Result>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = Result.serializer(),
+        name = "read_file",
+        description = "Reads a file under the provided RELATIVE path, with the specified content"
+    ) {
         @Serializable
         data class Args(
             @property:LLMDescription("Path to the file")
@@ -58,13 +61,6 @@ object ProjectGeneratorTools {
             val fileContent: String? = null,
             val comment: String? = null
         )
-
-        override val argsSerializer: KSerializer<Args> = Args.serializer()
-        override val resultSerializer: KSerializer<Result> = Result.serializer()
-
-        override val name: String = "read_file"
-        override val description: String =
-            "Reads a file under the provided RELATIVE path, with the specified content"
 
         override suspend fun execute(args: Args): Result {
             val path = rootProjectPath.resolve(args.path).normalize()
@@ -95,7 +91,12 @@ object ProjectGeneratorTools {
         }
     }
 
-    class LSDirectoriesTool(val rootProjectPath: Path) : Tool<LSDirectoriesTool.Args, LSDirectoriesTool.Result>() {
+    class LSDirectoriesTool(val rootProjectPath: Path) : Tool<LSDirectoriesTool.Args, LSDirectoriesTool.Result>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = Result.serializer(),
+        name = "ls_directory",
+        description = "Lists all the files and directories under the provided RELATIVE path"
+    ) {
         @Serializable
         data class Args(
             @property:LLMDescription("Path to the directory")
@@ -108,12 +109,6 @@ object ProjectGeneratorTools {
             val comment: String? = null,
             val content: List<String>? = null,
         )
-
-        override val argsSerializer: KSerializer<Args> = Args.serializer()
-        override val resultSerializer: KSerializer<Result> = Result.serializer()
-
-        override val name: String = "ls_directory"
-        override val description: String = "Lists all the files and directories under the provided RELATIVE path"
 
         override suspend fun execute(args: Args): Result {
             val path = rootProjectPath.resolve(args.path).normalize()
@@ -145,7 +140,12 @@ object ProjectGeneratorTools {
     }
 
     class CreateDirectoryTool(val rootProjectPath: Path) :
-        Tool<CreateDirectoryTool.Args, CreateDirectoryTool.Result>() {
+        Tool<CreateDirectoryTool.Args, CreateDirectoryTool.Result>(
+            argsSerializer = Args.serializer(),
+            resultSerializer = Result.serializer(),
+            name = "create_directory",
+            description = "Creates a directory under the provided relative path"
+        ) {
         @Serializable
         data class Args(
             @property:LLMDescription("Path to the file")
@@ -154,12 +154,6 @@ object ProjectGeneratorTools {
 
         @Serializable
         data class Result(val successful: Boolean, val comment: String? = null)
-
-        override val argsSerializer: KSerializer<Args> = Args.serializer()
-        override val resultSerializer: KSerializer<Result> = Result.serializer()
-
-        override val name: String = "create_directory"
-        override val description: String = "Creates a directory under the provided relative path"
 
         override suspend fun execute(args: Args): Result {
             val path = rootProjectPath.resolve(args.path).normalize()
@@ -176,7 +170,12 @@ object ProjectGeneratorTools {
     }
 
     class DeleteDirectoryTool(val rootProjectPath: Path) :
-        Tool<DeleteDirectoryTool.Args, DeleteDirectoryTool.Result>() {
+        Tool<DeleteDirectoryTool.Args, DeleteDirectoryTool.Result>(
+            argsSerializer = Args.serializer(),
+            resultSerializer = Result.serializer(),
+            name = "delete_directory",
+            description = "Removes a directory under the provided relative path"
+        ) {
         @Serializable
         data class Args(
             @property:LLMDescription("Path to the directory to remove")
@@ -185,12 +184,6 @@ object ProjectGeneratorTools {
 
         @Serializable
         data class Result(val successful: Boolean, val comment: String? = null)
-
-        override val argsSerializer: KSerializer<Args> = Args.serializer()
-        override val resultSerializer: KSerializer<Result> = Result.serializer()
-
-        override val name: String = "delete_directory"
-        override val description: String = "Removes a directory under the provided relative path"
 
         override suspend fun execute(args: Args): Result {
             val path = rootProjectPath.resolve(args.path).normalize()
@@ -212,7 +205,12 @@ object ProjectGeneratorTools {
         }
     }
 
-    class DeleteFileTool(val rootProjectPath: Path) : Tool<DeleteFileTool.Args, DeleteFileTool.Result>() {
+    class DeleteFileTool(val rootProjectPath: Path) : Tool<DeleteFileTool.Args, DeleteFileTool.Result>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = Result.serializer(),
+        name = "delete_file",
+        description = "Deletes a file under the provided relative path"
+    ) {
         @Serializable
         data class Args(
             @property:LLMDescription("Path to the file to delete")
@@ -221,12 +219,6 @@ object ProjectGeneratorTools {
 
         @Serializable
         data class Result(val successful: Boolean, val comment: String? = null)
-
-        override val argsSerializer: KSerializer<Args> = Args.serializer()
-        override val resultSerializer: KSerializer<Result> = Result.serializer()
-
-        override val name: String = "delete_file"
-        override val description: String = "Deletes a file under the provided relative path"
 
         override suspend fun execute(args: Args): Result {
             val path = rootProjectPath.resolve(args.path).normalize()
@@ -246,7 +238,12 @@ object ProjectGeneratorTools {
         }
     }
 
-    class RunCommand(val rootProjectPath: Path) : Tool<RunCommand.Args, RunCommand.Result>() {
+    class RunCommand(val rootProjectPath: Path) : Tool<RunCommand.Args, RunCommand.Result>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = Result.serializer(),
+        name = "run_bash_command",
+        description = "Runs the provided bash command in the project root directory"
+    ) {
         @Serializable
         data class Args(
             @property:LLMDescription("Command to run\"")
@@ -255,12 +252,6 @@ object ProjectGeneratorTools {
 
         @Serializable
         data class Result(val successful: Boolean, val comment: String? = null)
-
-        override val argsSerializer: KSerializer<Args> = Args.serializer()
-        override val resultSerializer: KSerializer<Result> = Result.serializer()
-
-        override val name: String = "run_bash_command"
-        override val description: String = "Runs the provided bash command in the project root directory"
 
         override suspend fun execute(args: Args): Result {
             if (args.bashCommand.isBlank()) {

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/tone/ToneTools.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/tone/ToneTools.kt
@@ -15,19 +15,21 @@ object ToneTools {
      * Base class for tone analysis tools.
      */
     abstract class ToneTool(
-        override val name: String,
-        override val description: String,
+        name: String,
+        description: String,
         private val toneType: String
-    ) : SimpleTool<ToneTool.Args>() {
+    ) : SimpleTool<ToneTool.Args>(
+        argsSerializer = Args.serializer(),
+        name = name,
+        description = description
+    ) {
         @Serializable
         data class Args(
             @property:LLMDescription("The text to analyze for tone.")
             val text: String
         )
 
-        override val argsSerializer = Args.serializer()
-
-        override suspend fun doExecute(args: Args): String {
+        override suspend fun execute(args: Args): String {
             val executor: PromptExecutor = simpleOpenAIExecutor(ApiKeyService.openAIApiKey)
 
             // Create a prompt to analyze the tone

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/userpaystatus/PaymentStatusTool.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/userpaystatus/PaymentStatusTool.kt
@@ -20,7 +20,11 @@ private val payments = listOf(
     Payment("T1005", "C001", 210.20, "2021-10-08", "Pending")
 )
 
-class PaymentStatusTool : SimpleTool<PaymentStatusTool.Args>() {
+class PaymentStatusTool : SimpleTool<PaymentStatusTool.Args>(
+    argsSerializer = Args.serializer(),
+    name = "payment_status",
+    description = "Get payment status of a transaction"
+) {
 
     @Serializable
     data class Args(
@@ -28,11 +32,7 @@ class PaymentStatusTool : SimpleTool<PaymentStatusTool.Args>() {
         val transactionId: String
     )
 
-    override val description: String = "Get payment status of a transaction"
-
-    override val argsSerializer = Args.serializer()
-
-    override suspend fun doExecute(args: Args): String {
+    override suspend fun execute(args: Args): String {
         val transaction = payments.firstOrNull { it.transactionId == args.transactionId }
         return when {
             transaction != null -> "Current state of the payment is :\n${transaction.paymentStatus}"

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ToolDescriptorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ToolDescriptorIntegrationTest.kt
@@ -149,171 +149,160 @@ class ToolDescriptorIntegrationTest {
         }
     }
 
-    abstract class TestTool<T, R> : Tool<T, R>() {
-        abstract val toolName: ToolName
-        override val name: String get() = toolName.value
+    abstract class TestTool<T, R>(
+        argsSerializer: KSerializer<T>,
+        resultSerializer: KSerializer<R>,
+        val toolName: ToolName,
+    ) : Tool<T, R>(
+        argsSerializer = argsSerializer,
+        resultSerializer = resultSerializer,
+        name = toolName.value,
+        description = toolName.value
+    ) {
         override fun toString(): String = toolName.displayName
     }
 
-    class IntToStringTool : TestTool<Int, String>() {
-        override val toolName = ToolName.INT_TO_STRING
-        override val argsSerializer: KSerializer<Int> = Int.serializer()
-        override val resultSerializer: KSerializer<String> = String.serializer()
-        override val description: String = "Converts an integer to its string representation"
-
+    class IntToStringTool : TestTool<Int, String>(
+        argsSerializer = Int.serializer(),
+        resultSerializer = String.serializer(),
+        toolName = ToolName.INT_TO_STRING,
+    ) {
         override suspend fun execute(args: Int): String = "Number: $args"
     }
 
-    class StringToIntTool : TestTool<String, Int>() {
-        override val toolName = ToolName.STRING_TO_INT
-        override val argsSerializer: KSerializer<String> = String.serializer()
-        override val resultSerializer: KSerializer<Int> = Int.serializer()
-        override val description: String = "Converts a string to an integer"
-
+    class StringToIntTool : TestTool<String, Int>(
+        argsSerializer = String.serializer(),
+        resultSerializer = Int.serializer(),
+        toolName = ToolName.STRING_TO_INT,
+    ) {
         override suspend fun execute(args: String): Int = args.length
     }
 
-    class IntToIntTool : TestTool<Int, Int>() {
-        override val toolName = ToolName.INT_TO_INT
-        override val argsSerializer: KSerializer<Int> = Int.serializer()
-        override val resultSerializer: KSerializer<Int> = Int.serializer()
-        override val description: String = "Doubles an integer value"
-
+    class IntToIntTool : TestTool<Int, Int>(
+        argsSerializer = Int.serializer(),
+        resultSerializer = Int.serializer(),
+        toolName = ToolName.INT_TO_INT,
+    ) {
         override suspend fun execute(args: Int): Int = args * 2
     }
 
-    class StringToStringTool : TestTool<String, String>() {
-        override val toolName = ToolName.STRING_TO_STRING
-        override val argsSerializer: KSerializer<String> = String.serializer()
-        override val resultSerializer: KSerializer<String> = String.serializer()
-        override val description: String = "Converts string to uppercase"
-
+    class StringToStringTool : TestTool<String, String>(
+        argsSerializer = String.serializer(),
+        resultSerializer = String.serializer(),
+        toolName = ToolName.STRING_TO_STRING,
+    ) {
         override suspend fun execute(args: String): String = args.uppercase()
     }
 
-    class BooleanToStringTool : TestTool<Boolean, String>() {
-        override val toolName = ToolName.BOOLEAN_TO_STRING
-        override val argsSerializer: KSerializer<Boolean> = Boolean.serializer()
-        override val resultSerializer: KSerializer<String> = String.serializer()
-        override val description: String = "Converts boolean to descriptive string"
-
+    class BooleanToStringTool : TestTool<Boolean, String>(
+        argsSerializer = Boolean.serializer(),
+        resultSerializer = String.serializer(),
+        toolName = ToolName.BOOLEAN_TO_STRING,
+    ) {
         override suspend fun execute(args: Boolean): String = if (args) "TRUE_VALUE" else "FALSE_VALUE"
     }
 
-    class DoubleToIntTool : TestTool<Double, Int>() {
-        override val toolName = ToolName.DOUBLE_TO_INT
-        override val argsSerializer: KSerializer<Double> = Double.serializer()
-        override val resultSerializer: KSerializer<Int> = Int.serializer()
-        override val description: String = "Converts double to integer by rounding"
-
+    class DoubleToIntTool : TestTool<Double, Int>(
+        argsSerializer = Double.serializer(),
+        resultSerializer = Int.serializer(),
+        toolName = ToolName.DOUBLE_TO_INT,
+    ) {
         override suspend fun execute(args: Double): Int = args.toInt()
     }
 
-    class LongToDoubleTool : TestTool<Long, Double>() {
-        override val toolName = ToolName.LONG_TO_DOUBLE
-        override val argsSerializer: KSerializer<Long> = Long.serializer()
-        override val resultSerializer: KSerializer<Double> = Double.serializer()
-        override val description: String = "Converts long to double with decimal places"
-
+    class LongToDoubleTool : TestTool<Long, Double>(
+        argsSerializer = Long.serializer(),
+        resultSerializer = Double.serializer(),
+        toolName = ToolName.LONG_TO_DOUBLE,
+    ) {
         override suspend fun execute(args: Long): Double = args + 0.5
     }
 
-    class FloatToBooleanTool : TestTool<Float, Boolean>() {
-        override val toolName = ToolName.FLOAT_TO_BOOLEAN
-        override val argsSerializer: KSerializer<Float> = Float.serializer()
-        override val resultSerializer: KSerializer<Boolean> = Boolean.serializer()
-        override val description: String = "Converts float to boolean (positive = true)"
-
+    class FloatToBooleanTool : TestTool<Float, Boolean>(
+        argsSerializer = Float.serializer(),
+        resultSerializer = Boolean.serializer(),
+        toolName = ToolName.FLOAT_TO_BOOLEAN,
+    ) {
         override suspend fun execute(args: Float): Boolean = args > 0f
     }
 
-    class StringToBooleanTool : TestTool<String, Boolean>() {
-        override val toolName = ToolName.STRING_TO_BOOLEAN
-        override val argsSerializer: KSerializer<String> = String.serializer()
-        override val resultSerializer: KSerializer<Boolean> = Boolean.serializer()
-        override val description: String = "Converts string to boolean ('true' = true, others = false)"
-
+    class StringToBooleanTool : TestTool<String, Boolean>(
+        argsSerializer = String.serializer(),
+        resultSerializer = Boolean.serializer(),
+        toolName = ToolName.STRING_TO_BOOLEAN,
+    ) {
         override suspend fun execute(args: String): Boolean = args.equals("true", ignoreCase = true)
     }
 
-    class IntToDoubleTool : TestTool<Int, Double>() {
-        override val toolName = ToolName.INT_TO_DOUBLE
-        override val argsSerializer: KSerializer<Int> = Int.serializer()
-        override val resultSerializer: KSerializer<Double> = Double.serializer()
-        override val description: String = "Converts integer to double"
-
+    class IntToDoubleTool : TestTool<Int, Double>(
+        argsSerializer = Int.serializer(),
+        resultSerializer = Double.serializer(),
+        toolName = ToolName.INT_TO_DOUBLE,
+    ) {
         override suspend fun execute(args: Int): Double = args.toDouble()
     }
 
-    class DoubleToLongTool : TestTool<Double, Long>() {
-        override val toolName = ToolName.DOUBLE_TO_LONG
-        override val argsSerializer: KSerializer<Double> = Double.serializer()
-        override val resultSerializer: KSerializer<Long> = Long.serializer()
-        override val description: String = "Converts double to long by rounding"
-
+    class DoubleToLongTool : TestTool<Double, Long>(
+        argsSerializer = Double.serializer(),
+        resultSerializer = Long.serializer(),
+        toolName = ToolName.DOUBLE_TO_LONG,
+    ) {
         override suspend fun execute(args: Double): Long = args.toLong()
     }
 
-    class BooleanToFloatTool : TestTool<Boolean, Float>() {
-        override val toolName = ToolName.BOOLEAN_TO_FLOAT
-        override val argsSerializer: KSerializer<Boolean> = Boolean.serializer()
-        override val resultSerializer: KSerializer<Float> = Float.serializer()
-        override val description: String = "Converts boolean to float (true = 1.0f, false = 0.0f)"
-
+    class BooleanToFloatTool : TestTool<Boolean, Float>(
+        argsSerializer = Boolean.serializer(),
+        resultSerializer = Float.serializer(),
+        toolName = ToolName.BOOLEAN_TO_FLOAT,
+    ) {
         override suspend fun execute(args: Boolean): Float = if (args) 1.0f else 0.0f
     }
 
-    class LongToIntTool : TestTool<Long, Int>() {
-        override val toolName = ToolName.LONG_TO_INT
-        override val argsSerializer: KSerializer<Long> = Long.serializer()
-        override val resultSerializer: KSerializer<Int> = Int.serializer()
-        override val description: String = "Converts long to integer"
-
+    class LongToIntTool : TestTool<Long, Int>(
+        argsSerializer = Long.serializer(),
+        resultSerializer = Int.serializer(),
+        toolName = ToolName.LONG_TO_INT,
+    ) {
         override suspend fun execute(args: Long): Int = args.toInt()
     }
 
-    class IntToLongTool : TestTool<Int, Long>() {
-        override val toolName = ToolName.INT_TO_LONG
-        override val argsSerializer: KSerializer<Int> = Int.serializer()
-        override val resultSerializer: KSerializer<Long> = Long.serializer()
-        override val description: String = "Converts integer to long"
-
+    class IntToLongTool : TestTool<Int, Long>(
+        argsSerializer = Int.serializer(),
+        resultSerializer = Long.serializer(),
+        toolName = ToolName.INT_TO_LONG,
+    ) {
         override suspend fun execute(args: Int): Long = args.toLong()
     }
 
-    class FloatToStringTool : TestTool<Float, String>() {
-        override val toolName = ToolName.FLOAT_TO_STRING
-        override val argsSerializer: KSerializer<Float> = Float.serializer()
-        override val resultSerializer: KSerializer<String> = String.serializer()
-        override val description: String = "Converts float to string"
-
+    class FloatToStringTool : TestTool<Float, String>(
+        argsSerializer = Float.serializer(),
+        resultSerializer = String.serializer(),
+        toolName = ToolName.FLOAT_TO_STRING,
+    ) {
         override suspend fun execute(args: Float): String = "Float: $args"
     }
 
-    class StringToFloatTool : TestTool<String, Float>() {
-        override val toolName = ToolName.STRING_TO_FLOAT
-        override val argsSerializer: KSerializer<String> = String.serializer()
-        override val resultSerializer: KSerializer<Float> = Float.serializer()
-        override val description: String = "Converts string length to float"
-
+    class StringToFloatTool : TestTool<String, Float>(
+        argsSerializer = String.serializer(),
+        resultSerializer = Float.serializer(),
+        toolName = ToolName.STRING_TO_FLOAT,
+    ) {
         override suspend fun execute(args: String): Float = args.length.toFloat()
     }
 
-    class DoubleToStringTool : TestTool<Double, String>() {
-        override val toolName = ToolName.DOUBLE_TO_STRING
-        override val argsSerializer: KSerializer<Double> = Double.serializer()
-        override val resultSerializer: KSerializer<String> = String.serializer()
-        override val description: String = "Converts double to string"
-
+    class DoubleToStringTool : TestTool<Double, String>(
+        argsSerializer = Double.serializer(),
+        resultSerializer = String.serializer(),
+        toolName = ToolName.DOUBLE_TO_STRING,
+    ) {
         override suspend fun execute(args: Double): String = "Double: $args"
     }
 
-    class StringToDoubleTool : TestTool<String, Double>() {
-        override val toolName = ToolName.STRING_TO_DOUBLE
-        override val argsSerializer: KSerializer<String> = String.serializer()
-        override val resultSerializer: KSerializer<Double> = Double.serializer()
-        override val description: String = "Converts string length to double"
-
+    class StringToDoubleTool : TestTool<String, Double>(
+        argsSerializer = String.serializer(),
+        resultSerializer = Double.serializer(),
+        toolName = ToolName.STRING_TO_DOUBLE,
+    ) {
         override suspend fun execute(args: String): Double = args.length.toDouble()
     }
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/AnswerVerificationTool.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/AnswerVerificationTool.kt
@@ -4,7 +4,11 @@ import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import kotlinx.serialization.Serializable
 
-object AnswerVerificationTool : SimpleTool<AnswerVerificationTool.Args>() {
+object AnswerVerificationTool : SimpleTool<AnswerVerificationTool.Args>(
+    argsSerializer = Args.serializer(),
+    name = "answer_verification_tool",
+    description = "A tool for verifying the correctness of answers with optional confidence rating"
+) {
     @Serializable
     data class Args(
         @property:LLMDescription("The answer text to verify for correctness")
@@ -13,11 +17,7 @@ object AnswerVerificationTool : SimpleTool<AnswerVerificationTool.Args>() {
         val confidence: Int? = null
     )
 
-    override val argsSerializer = Args.serializer()
-    override val name: String = "answer_verification_tool"
-    override val description: String = "A tool for verifying the correctness of answers with optional confidence rating"
-
-    override suspend fun doExecute(args: Args): String {
+    override suspend fun execute(args: Args): String {
         return "Answer verification completed for: '${args.answer}', confidence level: ${args.confidence ?: "not specified"}"
     }
 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/CalculatorTools.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/CalculatorTools.kt
@@ -6,7 +6,6 @@ import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.prompt.dsl.Prompt
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
 
@@ -28,27 +27,22 @@ data class SimpleCalculatorArgs(
     val b: Int
 )
 
-@Serializable
-object CalculatorToolNoArgs : SimpleTool<Unit>() {
-    override val argsSerializer = Unit.serializer()
-
-    override val name: String = "calculator"
-    override val description: String =
-        "A simple calculator that performs basic calculations. No parameters needed."
-
-    override suspend fun doExecute(args: Unit): String {
+object CalculatorToolNoArgs : SimpleTool<Unit>(
+    argsSerializer = Unit.serializer(),
+    name = "calculator",
+    description = "A simple calculator that performs basic calculations. No parameters needed."
+) {
+    override suspend fun execute(args: Unit): String {
         return "The result of 123 + 456 is 579"
     }
 }
 
-object SimpleCalculatorTool : SimpleTool<SimpleCalculatorArgs>() {
-    override val argsSerializer = SimpleCalculatorArgs.serializer()
-
-    override val name: String = "calculator"
-    override val description: String =
-        "A simple calculator that can add, subtract, multiply, and divide two integers."
-
-    override suspend fun doExecute(args: SimpleCalculatorArgs): String {
+object SimpleCalculatorTool : SimpleTool<SimpleCalculatorArgs>(
+    argsSerializer = SimpleCalculatorArgs.serializer(),
+    name = "calculator",
+    description = "A simple calculator that can add, subtract, multiply, and divide two integers."
+) {
+    override suspend fun execute(args: SimpleCalculatorArgs): String {
         return when (args.operation) {
             CalculatorOperation.ADD -> (args.a + args.b).toString()
             CalculatorOperation.SUBTRACT -> (args.a - args.b).toString()
@@ -64,14 +58,12 @@ object SimpleCalculatorTool : SimpleTool<SimpleCalculatorArgs>() {
     }
 }
 
-object CalculatorTool : Tool<SimpleCalculatorArgs, Int>() {
-    override val argsSerializer = SimpleCalculatorArgs.serializer()
-    override val resultSerializer: KSerializer<Int> = Int.serializer()
-
-    override val name: String = "calculator"
-    override val description: String =
-        "A simple calculator that can add, subtract, multiply, and divide two integers."
-
+object CalculatorTool : Tool<SimpleCalculatorArgs, Int>(
+    argsSerializer = SimpleCalculatorArgs.serializer(),
+    resultSerializer = Int.serializer(),
+    name = "calculator",
+    description = "A simple calculator that can add, subtract, multiply, and divide two integers."
+) {
     override suspend fun execute(args: SimpleCalculatorArgs): Int = when (args.operation) {
         CalculatorOperation.ADD -> args.a + args.b
         CalculatorOperation.SUBTRACT -> args.a - args.b
@@ -86,13 +78,12 @@ data class CalculateSumArgs(
     val amounts: List<Double>
 )
 
-object CalculateSumTool : SimpleTool<CalculateSumArgs>() {
-    override val argsSerializer = CalculateSumArgs.serializer()
-
-    override val name: String = "calculate_sum"
-    override val description: String = "Calculate the sum of a list of amounts"
-
-    override suspend fun doExecute(args: CalculateSumArgs): String {
+object CalculateSumTool : SimpleTool<CalculateSumArgs>(
+    argsSerializer = CalculateSumArgs.serializer(),
+    name = "calculate_sum",
+    description = "Calculate the sum of a list of amounts"
+) {
+    override suspend fun execute(args: CalculateSumArgs): String {
         val sum = args.amounts.sum()
         return sum.toString()
     }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/ColorTools.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/ColorTools.kt
@@ -21,12 +21,12 @@ enum class Colors {
 /**
  * Use to test tool with empty arguments
  */
-object PickColorTool : Tool<Unit, Colors>() {
-    override val name = "pick_color"
-    override val description = "Picks a random color"
-    override val argsSerializer = Unit.serializer()
-    override val resultSerializer = Colors.serializer()
-
+object PickColorTool : Tool<Unit, Colors>(
+    argsSerializer = Unit.serializer(),
+    resultSerializer = Colors.serializer(),
+    name = "pick_color",
+    description = "Picks a random color"
+) {
     override suspend fun execute(args: Unit): Colors {
         return Colors.entries.toTypedArray().random()
     }
@@ -35,12 +35,12 @@ object PickColorTool : Tool<Unit, Colors>() {
 /**
  * Use to test tool with a list of enum arguments
  */
-object PickColorFromListTool : Tool<List<Colors>, Colors>() {
-    override val name = "pick_color"
-    override val description = "Picks a random color from a given list of colors"
-    override val argsSerializer = ListSerializer(Colors.serializer())
-    override val resultSerializer = Colors.serializer()
-
+object PickColorFromListTool : Tool<List<Colors>, Colors>(
+    argsSerializer = ListSerializer(Colors.serializer()),
+    resultSerializer = Colors.serializer(),
+    name = "pick_color",
+    description = "Picks a random color from a given list of colors"
+) {
     override suspend fun execute(args: List<Colors>): Colors {
         return args.random()
     }
@@ -49,12 +49,12 @@ object PickColorFromListTool : Tool<List<Colors>, Colors>() {
 /**
  * Use to test tool with enum arguments
  */
-object PaintTool : Tool<Colors, Unit>() {
-    override val name = "paint"
-    override val description = "Paints the picture with selected color"
-    override val argsSerializer = Colors.serializer()
-    override val resultSerializer = Unit.serializer()
-
+object PaintTool : Tool<Colors, Unit>(
+    argsSerializer = Colors.serializer(),
+    resultSerializer = Unit.serializer(),
+    name = "paint",
+    description = "Paints the picture with selected color"
+) {
     override suspend fun execute(args: Colors) {
         println("Painting with color: $args")
     }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/ComplexNestedTool.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/ComplexNestedTool.kt
@@ -58,14 +58,12 @@ data class ComplexNestedToolArgs(
  * This tool has parameters with complex nested structures that would trigger
  * the error in the Anthropic API before the fix.
  */
-object ComplexNestedTool : SimpleTool<ComplexNestedToolArgs>() {
-    override val argsSerializer = ComplexNestedToolArgs.serializer()
-
-    override val name = "complex_nested_tool"
-
-    override val description = "A tool that processes user profiles with complex nested structures."
-
-    override suspend fun doExecute(args: ComplexNestedToolArgs): String {
+object ComplexNestedTool : SimpleTool<ComplexNestedToolArgs>(
+    argsSerializer = ComplexNestedToolArgs.serializer(),
+    name = "complex_nested_tool",
+    description = "A tool that processes user profiles with complex nested structures."
+) {
+    override suspend fun execute(args: ComplexNestedToolArgs): String {
         // Process the user profile
         val profile = args.profile
         val addressesInfo = profile.addresses.joinToString("\n") { address ->

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/DelayTool.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/DelayTool.kt
@@ -13,13 +13,12 @@ data class DelayArgs(
     val milliseconds: Int = DELAY_MILLIS.toInt()
 )
 
-object DelayTool : SimpleTool<DelayArgs>() {
-    override val argsSerializer = DelayArgs.serializer()
-
-    override val name = "delay"
-    override val description = "A tool that introduces a delay to simulate a time-consuming operation."
-
-    override suspend fun doExecute(args: DelayArgs): String {
+object DelayTool : SimpleTool<DelayArgs>(
+    argsSerializer = DelayArgs.serializer(),
+    name = "delay",
+    description = "A tool that introduces a delay to simulate a time-consuming operation."
+) {
+    override suspend fun execute(args: DelayArgs): String {
         delay(args.milliseconds.toLong())
         return "Delayed for ${args.milliseconds} milliseconds"
     }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/FileOperationsTools.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/FileOperationsTools.kt
@@ -10,32 +10,34 @@ class FileOperationsTools {
     val readFileContentTool = ReadFileContent(this)
 
     class CreateNewFileWithText(private val fileOperationsTools: FileOperationsTools) :
-        SimpleTool<CreateNewFileWithText.Args>() {
+        SimpleTool<CreateNewFileWithText.Args>(
+            argsSerializer = Args.serializer(),
+            name = "create_new_file_with_text",
+            description = "Creates a new file at the specified path with the provided text content"
+        ) {
         @Serializable
         data class Args(
             val pathInProject: String,
             val text: String
         )
 
-        override val argsSerializer = Args.serializer()
-        override val description = "Creates a new file at the specified path with the provided text content"
-
-        override suspend fun doExecute(args: Args): String {
+        override suspend fun execute(args: Args): String {
             return fileOperationsTools.createNewFileWithText(args.pathInProject, args.text)
         }
     }
 
-    class ReadFileContent(private val fileOperationsTools: FileOperationsTools) : SimpleTool<ReadFileContent.Args>() {
+    class ReadFileContent(private val fileOperationsTools: FileOperationsTools) :
+        SimpleTool<ReadFileContent.Args>(
+            argsSerializer = Args.serializer(),
+            name = "read_file_content",
+            description = "Reads the content of a file at the specified path"
+        ) {
         @Serializable
         data class Args(
             val pathInProject: String
         )
 
-        override val argsSerializer = Args.serializer()
-
-        override val description = "Reads the content of a file at the specified path"
-
-        override suspend fun doExecute(args: Args): String {
+        override suspend fun execute(args: Args): String {
             return fileOperationsTools.readFileContent(args.pathInProject)
         }
     }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/GenericParameterTool.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/GenericParameterTool.kt
@@ -4,7 +4,11 @@ import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import kotlinx.serialization.Serializable
 
-object GenericParameterTool : SimpleTool<GenericParameterTool.Args>() {
+object GenericParameterTool : SimpleTool<GenericParameterTool.Args>(
+    argsSerializer = Args.serializer(),
+    name = "generic_parameter_tool",
+    description = "A tool that demonstrates handling of required and optional parameters"
+) {
     @Serializable
     data class Args(
         @property:LLMDescription("A required string parameter that must be provided")
@@ -13,12 +17,7 @@ object GenericParameterTool : SimpleTool<GenericParameterTool.Args>() {
         val optionalArg: String? = null
     )
 
-    override val argsSerializer = Args.serializer()
-
-    override val name: String = "generic_parameter_tool"
-    override val description: String = "A tool that demonstrates handling of required and optional parameters"
-
-    override suspend fun doExecute(args: Args): String {
+    override suspend fun execute(args: Args): String {
         return "Generic parameter tool executed with requiredArg: ${args.requiredArg}, optionalArg: ${args.optionalArg ?: "not provided"}"
     }
 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/GeographyQueryTool.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/GeographyQueryTool.kt
@@ -4,7 +4,11 @@ import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import kotlinx.serialization.Serializable
 
-object GeographyQueryTool : SimpleTool<GeographyQueryTool.Args>() {
+object GeographyQueryTool : SimpleTool<GeographyQueryTool.Args>(
+    argsSerializer = Args.serializer(),
+    name = "geography_query_tool",
+    description = "A tool for retrieving geographical information such as capitals of countries"
+) {
     @Serializable
     data class Args(
         @property:LLMDescription("The geographical query (e.g., 'capital of France')")
@@ -13,12 +17,7 @@ object GeographyQueryTool : SimpleTool<GeographyQueryTool.Args>() {
         val language: String? = null
     )
 
-    override val argsSerializer = Args.serializer()
-
-    override val name: String = "geography_query_tool"
-    override val description: String = "A tool for retrieving geographical information such as capitals of countries"
-
-    override suspend fun doExecute(args: Args): String {
+    override suspend fun execute(args: Args): String {
         return "Geography query processed: ${args.query}, language: ${args.language ?: "not specified"}"
     }
 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/GetTransactionsTool.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/GetTransactionsTool.kt
@@ -12,13 +12,12 @@ data class GetTransactionsArgs(
     val endDate: String
 )
 
-object GetTransactionsTool : SimpleTool<GetTransactionsArgs>() {
-    override val argsSerializer = GetTransactionsArgs.serializer()
-
-    override val name: String = "get_transactions"
-    override val description: String = "Get all transactions between two dates"
-
-    override suspend fun doExecute(args: GetTransactionsArgs): String {
+object GetTransactionsTool : SimpleTool<GetTransactionsArgs>(
+    argsSerializer = GetTransactionsArgs.serializer(),
+    name = "get_transactions",
+    description = "Get all transactions between two dates"
+) {
+    override suspend fun execute(args: GetTransactionsArgs): String {
         // Simulate returning transactions
         return """
             [

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/LotteryTool.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/LotteryTool.kt
@@ -7,18 +7,13 @@ import ai.koog.agents.core.tools.ToolParameterType
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
 
-object LotteryTool : Tool<List<List<Int>>, List<Int>>() {
-    override val name = "lottery_picker"
-    override val description =
-        "A tool that by lottery tickets (list of 5 number from 1 to 100) picks the ids of winning tickets. " +
-            "Winning ticket is the ticket which contains a winning number."
-
-    override val argsSerializer = ListSerializer(ListSerializer(Int.serializer()))
-    override val resultSerializer = ListSerializer(Int.serializer())
-
-    override val descriptor = ToolDescriptor(
-        name = name,
-        description = description,
+object LotteryTool : Tool<List<List<Int>>, List<Int>>(
+    argsSerializer = ListSerializer(ListSerializer(Int.serializer())),
+    resultSerializer = ListSerializer(Int.serializer()),
+    descriptor = ToolDescriptor(
+        name = "lottery_picker",
+        description = "A tool that by lottery tickets (list of 5 number from 1 to 100) picks the ids of winning tickets. " +
+            "Winning ticket is the ticket which contains a winning number.",
         requiredParameters = listOf(
             ToolParameterDescriptor(
                 name = "numbers",
@@ -27,7 +22,7 @@ object LotteryTool : Tool<List<List<Int>>, List<Int>>() {
             )
         )
     )
-
+) {
     override suspend fun execute(args: List<List<Int>>): List<Int> {
         val winnerValue = (1..100).random()
         return args.mapIndexedNotNull { index, values ->

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/PriceTool.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/PriceTool.kt
@@ -36,22 +36,12 @@ object DoubleOrStringSerializer : KSerializer<Double> {
 /**
  * Use to test tool with anyOf arguments
  */
-object PriceCalculatorTool : Tool<PriceCalculatorTool.Args, Double>() {
-    @Serializable
-    data class Args(
-        val tokens: Int,
-        @Serializable(with = DoubleOrStringSerializer::class) @SerialName("price_per_token") val pricePerToken: Double,
-        val discount: Double? = null
-    )
-
-    override val name: String = "price_calculator"
-    override val description: String = "A tool for calculating the price for LLM tokens"
-    override val argsSerializer = Args.serializer()
-    override val resultSerializer: KSerializer<Double> = Double.serializer()
-
-    override val descriptor = ToolDescriptor(
-        name = name,
-        description = description,
+object PriceCalculatorTool : Tool<PriceCalculatorTool.Args, Double>(
+    argsSerializer = Args.serializer(),
+    resultSerializer = Double.serializer(),
+    descriptor = ToolDescriptor(
+        name = "price_calculator",
+        description = "A tool for calculating the price for LLM tokens",
         requiredParameters = listOf(
             ToolParameterDescriptor(
                 name = "tokens",
@@ -85,6 +75,13 @@ object PriceCalculatorTool : Tool<PriceCalculatorTool.Args, Double>() {
             )
         ),
     )
+) {
+    @Serializable
+    data class Args(
+        val tokens: Int,
+        @Serializable(with = DoubleOrStringSerializer::class) @SerialName("price_per_token") val pricePerToken: Double,
+        val discount: Double? = null
+    )
 
     override suspend fun execute(args: Args): Double {
         return args.tokens * args.pricePerToken * (args.discount ?: 1.0)
@@ -109,22 +106,12 @@ object DoubleOrNullSerializer : KSerializer<Double?> {
 /**
  * Use to test tool with nullable arguments
  */
-object SimplePriceCalculatorTool : Tool<SimplePriceCalculatorTool.Args, Double>() {
-    @Serializable
-    data class Args(
-        val tokens: Int,
-        @Serializable(with = DoubleOrStringSerializer::class) @SerialName("price_per_token") val pricePerToken: Double,
-        @Serializable(with = DoubleOrNullSerializer::class) val discount: Double?,
-    )
-
-    override val name: String = "price_calculator"
-    override val description: String = "A tool for calculating the price for LLM tokens"
-    override val argsSerializer = Args.serializer()
-    override val resultSerializer: KSerializer<Double> = Double.serializer()
-
-    override val descriptor = ToolDescriptor(
-        name = name,
-        description = description,
+object SimplePriceCalculatorTool : Tool<SimplePriceCalculatorTool.Args, Double>(
+    argsSerializer = Args.serializer(),
+    resultSerializer = Double.serializer(),
+    descriptor = ToolDescriptor(
+        name = "price_calculator",
+        description = "A tool for calculating the price for LLM tokens",
         requiredParameters = listOf(
             ToolParameterDescriptor(
                 name = "tokens",
@@ -155,6 +142,13 @@ object SimplePriceCalculatorTool : Tool<SimplePriceCalculatorTool.Args, Double>(
                 )
             ),
         )
+    )
+) {
+    @Serializable
+    data class Args(
+        val tokens: Int,
+        @Serializable(with = DoubleOrStringSerializer::class) @SerialName("price_per_token") val pricePerToken: Double,
+        @Serializable(with = DoubleOrNullSerializer::class) val discount: Double?,
     )
 
     override suspend fun execute(args: Args): Double {

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/files/CreateFile.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/files/CreateFile.kt
@@ -2,10 +2,14 @@ package ai.koog.integration.tests.utils.tools.files
 
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.annotations.LLMDescription
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 
-class CreateFile(private val fs: MockFileSystem) : Tool<CreateFile.Args, CreateFile.Result>() {
+class CreateFile(private val fs: MockFileSystem) : Tool<CreateFile.Args, CreateFile.Result>(
+    argsSerializer = Args.serializer(),
+    resultSerializer = Result.serializer(),
+    name = "create_file",
+    description = "Create a file and writes the given text content to it"
+) {
     @Serializable
     data class Args(
         @property:LLMDescription("The path to create the file")
@@ -16,13 +20,6 @@ class CreateFile(private val fs: MockFileSystem) : Tool<CreateFile.Args, CreateF
 
     @Serializable
     data class Result(val successful: Boolean, val message: String? = null)
-
-    override val argsSerializer = Args.serializer()
-    override val resultSerializer: KSerializer<Result> = Result.serializer()
-
-    override val name: String = "create_file"
-    override val description: String =
-        "Create a file and writes the given text content to it"
 
     override suspend fun execute(args: Args): Result {
         return when (val res = fs.create(args.path, args.content)) {

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/files/DeleteFile.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/files/DeleteFile.kt
@@ -2,10 +2,14 @@ package ai.koog.integration.tests.utils.tools.files
 
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.annotations.LLMDescription
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 
-class DeleteFile(private val fs: MockFileSystem) : Tool<DeleteFile.Args, DeleteFile.Result>() {
+class DeleteFile(private val fs: MockFileSystem) : Tool<DeleteFile.Args, DeleteFile.Result>(
+    argsSerializer = Args.serializer(),
+    resultSerializer = Result.serializer(),
+    name = "delete_file",
+    description = "Deletes a file"
+) {
     @Serializable
     data class Args(
         @property:LLMDescription("The path of the file to be deleted")
@@ -14,12 +18,6 @@ class DeleteFile(private val fs: MockFileSystem) : Tool<DeleteFile.Args, DeleteF
 
     @Serializable
     data class Result(val successful: Boolean, val message: String? = null)
-
-    override val argsSerializer = Args.serializer()
-    override val resultSerializer: KSerializer<Result> = Result.serializer()
-
-    override val name: String = "delete_file"
-    override val description: String = "Deletes a file"
 
     override suspend fun execute(args: Args): Result {
         return when (val res = fs.delete(args.path)) {

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/files/ListFiles.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/files/ListFiles.kt
@@ -2,10 +2,14 @@ package ai.koog.integration.tests.utils.tools.files
 
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.annotations.LLMDescription
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 
-class ListFiles(private val fs: MockFileSystem) : Tool<ListFiles.Args, ListFiles.Result>() {
+class ListFiles(private val fs: MockFileSystem) : Tool<ListFiles.Args, ListFiles.Result>(
+    argsSerializer = Args.serializer(),
+    resultSerializer = Result.serializer(),
+    name = "list_files",
+    description = "List all files inside the given path of the directory"
+) {
     @Serializable
     data class Args(
         @property:LLMDescription("The path of the directory")
@@ -18,12 +22,6 @@ class ListFiles(private val fs: MockFileSystem) : Tool<ListFiles.Args, ListFiles
         val message: String? = null,
         val children: List<String>? = null
     )
-
-    override val argsSerializer = Args.serializer()
-    override val resultSerializer: KSerializer<Result> = Result.serializer()
-
-    override val name: String = "list_files"
-    override val description: String = "List all files inside the given path of the directory"
 
     override suspend fun execute(args: Args): Result {
         return when (val res = fs.ls(args.path)) {

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/files/ReadFile.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/tools/files/ReadFile.kt
@@ -2,10 +2,14 @@ package ai.koog.integration.tests.utils.tools.files
 
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.annotations.LLMDescription
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 
-class ReadFile(private val fs: MockFileSystem) : Tool<ReadFile.Args, ReadFile.Result>() {
+class ReadFile(private val fs: MockFileSystem) : Tool<ReadFile.Args, ReadFile.Result>(
+    argsSerializer = Args.serializer(),
+    resultSerializer = Result.serializer(),
+    name = "read_file",
+    description = "Reads a file"
+) {
     @Serializable
     data class Args(
         @property:LLMDescription("The path of the file to read")
@@ -18,12 +22,6 @@ class ReadFile(private val fs: MockFileSystem) : Tool<ReadFile.Args, ReadFile.Re
         val message: String? = null,
         val content: String? = null
     )
-
-    override val argsSerializer = Args.serializer()
-    override val resultSerializer: KSerializer<Result> = Result.serializer()
-
-    override val name: String = "read_file"
-    override val description: String = "Reads a file"
 
     override suspend fun execute(args: Args): Result {
         return when (val res = fs.read(args.path)) {

--- a/prompt/prompt-processor/src/commonTest/kotlin/ai/koog/prompt/processor/Tools.kt
+++ b/prompt/prompt-processor/src/commonTest/kotlin/ai/koog/prompt/processor/Tools.kt
@@ -6,15 +6,16 @@ import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.annotations.LLMDescription
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
 object Tools {
-    object PlusTool : Tool<PlusTool.Args, PlusTool.Result>() {
-        override val description: String = "Adds a and b"
-        override val name: String = "plus"
-
+    object PlusTool : Tool<PlusTool.Args, PlusTool.Result>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = Result.serializer(),
+        name = "plus",
+        description = "Adds a and b"
+    ) {
         @Serializable
         data class Args(
             @property:LLMDescription("First number")
@@ -27,33 +28,15 @@ object Tools {
         @JvmInline
         value class Result(val result: Float)
 
-        override val argsSerializer = Args.serializer()
-        override val resultSerializer: KSerializer<Result> = Result.serializer()
-
         override suspend fun execute(args: Args): Result {
             return Result(args.a + args.b)
         }
     }
 
-    object StringTool : Tool<StringTool.Args, StringTool.Result>() {
-        @Serializable
-        data class Args(
-            @property:LLMDescription("First string")
-            val text1: String,
-            @property:LLMDescription("Second string")
-            val text2: String
-        )
-
-        @Serializable
-        @JvmInline
-        value class Result(val result: String)
-
-        override val name: String = "string_tool"
-        override val description: String = "A tool that takes string parameters"
-        override val argsSerializer = Args.serializer()
-        override val resultSerializer: KSerializer<Result> = Result.serializer()
-
-        override val descriptor = ToolDescriptor(
+    object StringTool : Tool<StringTool.Args, StringTool.Result>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = Result.serializer(),
+        descriptor = ToolDescriptor(
             name = "string_tool",
             description = "A tool that takes string parameters",
             requiredParameters = listOf(
@@ -69,6 +52,18 @@ object Tools {
                 )
             )
         )
+    ) {
+        @Serializable
+        data class Args(
+            @property:LLMDescription("First string")
+            val text1: String,
+            @property:LLMDescription("Second string")
+            val text2: String
+        )
+
+        @Serializable
+        @JvmInline
+        value class Result(val result: String)
 
         override suspend fun execute(args: Args): Result {
             return Result(args.text1 + " " + args.text2)


### PR DESCRIPTION
**This PR introduces breaking changes in Tool API**

Currently `argsSerializer`, `resultSerializer`, `name`, `description` and `descriptor` are meant to be overriden to provide your own values. Since we can also generate `descriptor` automatically now, it introduces a discrepancy between property values and the actual state of things. It's described in [KG-508](https://youtrack.jetbrains.com/issue/KG-508). So current version makes for unstable and somewhat confusing API.

In this PR, I've moved these configurable tool properties to the constructors instead. This avoids confusion, since now the ways in which you can configure the tool are visible more explicitly - either provide your own `descriptor`, or opt for an automatic generation and only provide `name` and `description`. Updated API also looks a bit more concise and fluent, IMHO, since you have to write less `override` now. Compare these:
```kt
// Before
object DummyTool : SimpleTool<Unit>() {
    override val argsSerializer = Unit.serializer()

    override val name: String = "dummy"
    override val description: String = "Dummy tool for testing"

    override suspend fun doExecute(args: Unit): String = "Dummy result"
}

// After
object DummyTool : SimpleTool<Unit>(
    argsSerializer = Unit.serializer(),
    name = "dummy",
    description = "Dummy tool for testing"
) {
    override suspend fun execute(args: Unit): String = "Dummy result"
}
```

Also, another breaking change, as you have already seen from the example above, is `doExecute` removal. It is not needed anymore, since tools support primitive types now, so you can just use a regular `execute`