### PR TITLE
Add multiplatform `SystemConfigReader` interface with JVM-specific implementation

### DIFF
--- a/utils/src/androidMain/kotlin/ai/koog/utils/system/SystemConfigReader.android.kt
+++ b/utils/src/androidMain/kotlin/ai/koog/utils/system/SystemConfigReader.android.kt
@@ -1,0 +1,5 @@
+package ai.koog.utils.system
+
+public actual fun systemConfigReader(): SystemConfigReader {
+    throw NotImplementedError("SystemConfigReader is not yet supported on Android platform")
+}

--- a/utils/src/androidMain/kotlin/ai/koog/utils/system/SystemSecretsReader.android.kt
+++ b/utils/src/androidMain/kotlin/ai/koog/utils/system/SystemSecretsReader.android.kt
@@ -1,0 +1,5 @@
+package ai.koog.utils.system
+
+public actual fun systemSecretsReader(): SystemSecretsReader {
+    throw NotImplementedError("SystemSecretsReader is not yet supported on Android platform")
+}

--- a/utils/src/appleMain/kotlin/ai/koog/utils/system/SystemConfigReader.apple.kt
+++ b/utils/src/appleMain/kotlin/ai/koog/utils/system/SystemConfigReader.apple.kt
@@ -1,0 +1,5 @@
+package ai.koog.utils.system
+
+public actual fun systemConfigReader(): SystemConfigReader {
+    throw NotImplementedError("SystemConfigReader is not yet supported on Apple platforms")
+}

--- a/utils/src/appleMain/kotlin/ai/koog/utils/system/SystemSecretsReader.apple.kt
+++ b/utils/src/appleMain/kotlin/ai/koog/utils/system/SystemSecretsReader.apple.kt
@@ -1,0 +1,5 @@
+package ai.koog.utils.system
+
+public actual fun systemSecretsReader(): SystemSecretsReader {
+    throw NotImplementedError("SystemSecretsReader is not yet supported on Apple platforms")
+}

--- a/utils/src/commonMain/kotlin/ai/koog/utils/system/SystemConfigReader.kt
+++ b/utils/src/commonMain/kotlin/ai/koog/utils/system/SystemConfigReader.kt
@@ -1,0 +1,30 @@
+package ai.koog.utils.system
+
+/**
+ * An interface for reading system configuration properties.
+ *
+ * This interface provides a method to retrieve system configuration values by their names.
+ * Implementations can vary based on the operating system or platform being used.
+ */
+public interface SystemConfigReader {
+
+    /**
+     * Retrieves the value of a system configuration property by its name.
+     *
+     * @param name The name of the system configuration property to retrieve.
+     * @return The value of the configuration property if it exists, or null if not found.
+     */
+    public fun getConfigVariable(name: String): String?
+}
+
+/**
+ * Provides an implementation of the [SystemConfigReader] interface for the current platform.
+ *
+ * This function returns an instance of [SystemConfigReader] that allows access
+ * to system-level configuration properties based on platform-specific implementations.
+ * On unsupported platforms, this function will throw a [NotImplementedError].
+ *
+ * @return An instance of [SystemConfigReader] for accessing system configuration properties.
+ * @throws NotImplementedError if [SystemConfigReader] is not supported on this platform.
+ */
+public expect fun systemConfigReader(): SystemConfigReader

--- a/utils/src/commonMain/kotlin/ai/koog/utils/system/SystemSecretsReader.kt
+++ b/utils/src/commonMain/kotlin/ai/koog/utils/system/SystemSecretsReader.kt
@@ -1,0 +1,46 @@
+package ai.koog.utils.system
+
+/**
+ * An interface for reading secrets.
+ *
+ * This interface provides a method to retrieve secret values by their names.
+ * Implementations can vary based on the operating system or platform being used.
+ */
+public interface SystemSecretsReader {
+
+    /**
+     * Retrieves a secret value from environment variables.
+     *
+     * **SECURITY NOTICE**:
+     * Secrets are returned as Strings because the underlying OS APIs
+     * (environment variables, system properties) return Strings.
+     * The String cannot be cleared from memory.
+     *
+     * **Best practices**:
+     * - Use platform-specific secure storage when possible (Keychain, KeyStore)
+     * - Use short-lived tokens instead of long-lived secrets
+     * - Rotate secrets regularly
+     * - Don't log or print secret values
+     *
+     * For maximum security, consider using:
+     * - Secrets management services (HashiCorp Vault, AWS Secrets Manager)
+     * - Platform secure storage APIs
+     * - Memory-mapped files with OS-level protection
+     *
+     * @param name The secret key
+     * @return The secret value, or null if not found
+     */
+    public fun getSecret(name: String): String?
+}
+
+/**
+ * Provides an implementation of the [SystemSecretsReader] interface for the current platform.
+ *
+ * This function returns an instance of [SystemSecretsReader] that allows access
+ * to secrets based on platform-specific implementations.
+ * On unsupported platforms, this function will throw a [NotImplementedError].
+ *
+ * @return An instance of [SystemSecretsReader] for accessing system configuration properties.
+ * @throws NotImplementedError if [SystemSecretsReader] is not supported on this platform.
+ */
+public expect fun systemSecretsReader(): SystemSecretsReader

--- a/utils/src/jsMain/kotlin/ai/koog/utils/system/SystemConfigReader.js.kt
+++ b/utils/src/jsMain/kotlin/ai/koog/utils/system/SystemConfigReader.js.kt
@@ -1,0 +1,5 @@
+package ai.koog.utils.system
+
+public actual fun systemConfigReader(): SystemConfigReader {
+    throw NotImplementedError("SystemConfigReader is not yet supported on JS platform")
+}

--- a/utils/src/jsMain/kotlin/ai/koog/utils/system/SystemSecretsReader.js.kt
+++ b/utils/src/jsMain/kotlin/ai/koog/utils/system/SystemSecretsReader.js.kt
@@ -1,0 +1,5 @@
+package ai.koog.utils.system
+
+public actual fun systemSecretsReader(): SystemSecretsReader {
+    throw NotImplementedError("SystemSecretsReader is not yet supported on JS platform")
+}

--- a/utils/src/jvmMain/kotlin/ai/koog/utils/system/EnvSystemSecretsReader.kt
+++ b/utils/src/jvmMain/kotlin/ai/koog/utils/system/EnvSystemSecretsReader.kt
@@ -1,0 +1,22 @@
+package ai.koog.utils.system
+
+/**
+ * Reads secrets from environment variables in a JVM environment.
+ *
+ * EnvSystemSecretsReader retrieves secret values from environment variables only.
+ * It does not check system properties for security reasons, as system properties
+ * are JVM-wide and more easily accessible than environment variables.
+ *
+ * Implements:
+ * - SystemSecretsReader: Provides the ability to retrieve secrets.
+ */
+public object EnvSystemSecretsReader : SystemSecretsReader {
+
+    /**
+     * Retrieves a secret value by its name from the specified environment variable.
+     *
+     * @param name the name of the environment variable to retrieve.
+     * @return the value of the environment variable as a String, or null if the variable is not found.
+     */
+    override fun getSecret(name: String): String? = System.getenv(name)
+}

--- a/utils/src/jvmMain/kotlin/ai/koog/utils/system/JvmSystemConfigReader.kt
+++ b/utils/src/jvmMain/kotlin/ai/koog/utils/system/JvmSystemConfigReader.kt
@@ -1,0 +1,48 @@
+package ai.koog.utils.system
+
+/**
+ * Reads system configuration properties in a JVM environment.
+ *
+ * JvmSystemConfigReader is responsible for retrieving the values of system configuration
+ * properties using both environment variables and system properties.
+ *
+ * The property name provided is automatically converted to a format compatible with
+ * system environment variable conventions by transforming the name to lowercase and
+ * replacing underscores with dots. It attempts to fetch the value from both the original
+ * name and the transformed format.
+ *
+ * Implements:
+ * - SystemConfigReader: Provides the ability to retrieve configuration properties.
+ */
+public object JvmSystemConfigReader : SystemConfigReader {
+
+    /**
+     * Retrieves the value of the specified environment variable or system property.
+     *
+     * The method first attempts to retrieve the value from the environment variables.
+     * If it is not found, it then attempts to retrieve the value from the system properties.
+     * When checking system properties, the name is converted to lowercase and underscores
+     * are replaced with dots.
+     *
+     * @param name the name of the environment variable or system property to retrieve
+     * @return the value of the environment variable or system property, or null if not found
+     */
+    override fun getConfigVariable(name: String): String? {
+        return System.getenv(name)
+            ?: System.getProperty(name)
+            ?: System.getProperty(normalizePropertyName(name))
+    }
+
+    /**
+     * Normalizes a property name by converting it to lowercase and replacing underscores with dots.
+     *
+     * This transformation ensures compatibility with system property naming conventions
+     * and is typically used to access properties that might exist in different formats.
+     *
+     * @param name the original property name to normalize
+     * @return the normalized property name
+     */
+    private fun normalizePropertyName(name: String): String {
+        return name.lowercase().replace('_', '.')
+    }
+}

--- a/utils/src/jvmMain/kotlin/ai/koog/utils/system/SystemConfigReader.jvm.kt
+++ b/utils/src/jvmMain/kotlin/ai/koog/utils/system/SystemConfigReader.jvm.kt
@@ -1,0 +1,3 @@
+package ai.koog.utils.system
+
+public actual fun systemConfigReader(): SystemConfigReader = JvmSystemConfigReader

--- a/utils/src/jvmMain/kotlin/ai/koog/utils/system/SystemSecretsReader.jvm.kt
+++ b/utils/src/jvmMain/kotlin/ai/koog/utils/system/SystemSecretsReader.jvm.kt
@@ -1,0 +1,3 @@
+package ai.koog.utils.system
+
+public actual fun systemSecretsReader(): SystemSecretsReader = EnvSystemSecretsReader

--- a/utils/src/jvmTest/kotlin/ai/koog/utils/system/EnvSystemSecretsReaderTest.kt
+++ b/utils/src/jvmTest/kotlin/ai/koog/utils/system/EnvSystemSecretsReaderTest.kt
@@ -1,0 +1,19 @@
+package ai.koog.utils.system
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class EnvSystemSecretsReaderTest {
+
+    private val subject = systemSecretsReader()
+
+    @Test
+    fun `getSecret should read from env`() {
+        subject.getSecret("HOME") shouldBe System.getenv("HOME")
+    }
+
+    @Test
+    fun `getSecret should skip unknown entry`() {
+        subject.getSecret("ZELIBOBA") shouldBe null
+    }
+}

--- a/utils/src/jvmTest/kotlin/ai/koog/utils/system/JvmSystemConfigReaderTest.kt
+++ b/utils/src/jvmTest/kotlin/ai/koog/utils/system/JvmSystemConfigReaderTest.kt
@@ -1,0 +1,36 @@
+package ai.koog.utils.system
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class JvmSystemConfigReaderTest {
+
+    companion object {
+        init {
+            System.setProperty("FOO_PROP", "42")
+            System.setProperty("bar.prop", "43")
+        }
+    }
+
+    private val subject = systemConfigReader()
+
+    @Test
+    fun `getConfig should read from env`() {
+        subject.getConfigVariable("HOME") shouldBe System.getenv("HOME")
+    }
+
+    @Test
+    fun `getConfig should read from system property`() {
+        subject.getConfigVariable("FOO_PROP") shouldBe "42"
+    }
+
+    @Test
+    fun `getConfig should read from normalized system property`() {
+        subject.getConfigVariable("BAR_PROP") shouldBe "43"
+    }
+
+    @Test
+    fun `getConfig should skip unknown entry`() {
+        subject.getConfigVariable("ZELIBOBA") shouldBe null
+    }
+}

--- a/utils/src/wasmJsMain/kotlin/ai/koog/utils/system/SystemConfigReader.wasmJs.kt
+++ b/utils/src/wasmJsMain/kotlin/ai/koog/utils/system/SystemConfigReader.wasmJs.kt
@@ -1,0 +1,5 @@
+package ai.koog.utils.system
+
+public actual fun systemConfigReader(): SystemConfigReader {
+    throw NotImplementedError("SystemConfigReader not yet supported on WasmJS platform")
+}

--- a/utils/src/wasmJsMain/kotlin/ai/koog/utils/system/SystemSecretsReader.wasmJs.kt
+++ b/utils/src/wasmJsMain/kotlin/ai/koog/utils/system/SystemSecretsReader.wasmJs.kt
@@ -1,0 +1,5 @@
+package ai.koog.utils.system
+
+public actual fun systemSecretsReader(): SystemSecretsReader {
+    throw NotImplementedError("SystemSecretsReader not yet supported on WasmJS platform")
+}


### PR DESCRIPTION
# Add multiplatform system configuration and secrets readers with JVM-specific implementation

Introduce `SystemConfigReader` and `SystemSecretsReader` interfaces to standardize access to configuration values and secrets across different platforms. This change utilizes the `expect`/`actual` mechanism to define common contracts with specific platform implementations.

*   Implement fully functional readers for the JVM target: the configuration reader resolves values from environment variables and system properties (supports name normalization), while the secrets reader strictly uses environment variables for security.
*   Add stub implementations for Android, Apple, JS, and WasmJS platforms that currently throw a `NotImplementedError` when accessed.
*   Define the common interfaces and factory functions to allow retrieval of configuration strings and secrets.

## Motivation and Context
Should be used in Debugger Config and LLM Clients

See also #1231 

## Breaking Changes
No


#### Type of the changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
