### PR TITLE
KG-178. Introduce AgentExecutionInfo entity that contains info about agent execution

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/execution/AgentExecutionInfo.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/execution/AgentExecutionInfo.kt
@@ -1,0 +1,47 @@
+package ai.koog.agents.core.agent.execution
+
+/**
+ * Represents execution information for an agent, including a reference to a parent execution
+ * and a name identifying the specific part of the execution.
+ *
+ * @property parent A reference to the parent `AgentExecutionInfo` instance. This allows the current
+ *           object to represent a node in a hierarchical structure of executions. If null, it indicates that
+ *           the current instance is the root.
+ * @property partName A string representing the name of the current part or segment of the execution.
+ */
+public data class AgentExecutionInfo(
+    public val parent: AgentExecutionInfo?,
+    public val partName: String
+) {
+
+    /**
+     * A companion object for the `AgentExecutionInfo` class that provides utility constants.
+     */
+    public companion object {
+
+        /**
+         * The default separator used to join parts of a path.
+         */
+        public val defaultPathSeparator: CharSequence = "/"
+    }
+
+    /**
+     * Constructs a path string representing the sequence of `partName` values from the current
+     * `AgentExecutionInfo` instance to the top-most parent, joined by the specified separator.
+     *
+     * @param separator The string used to separate each part of the path. If null, a default separator is used.
+     * @return A string representing the path constructed from `partName` values.
+     */
+    public fun path(separator: String? = null): String {
+        val separator = separator ?: defaultPathSeparator
+
+        return buildList {
+            var current: AgentExecutionInfo? = this@AgentExecutionInfo
+
+            while (current != null) {
+                add(current.partName)
+                current = current.parent
+            }
+        }.reversed().joinToString(separator)
+    }
+}

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/execution/AgentExecutionInfoTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/execution/AgentExecutionInfoTest.kt
@@ -1,0 +1,78 @@
+package ai.koog.agents.core.agent.execution
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AgentExecutionInfoTest {
+
+    @Test
+    fun testRootExecutionInfo() {
+        val root = AgentExecutionInfo(parent = null, partName = "root")
+
+        assertNull(root.parent)
+        assertEquals("root", root.partName)
+        assertEquals("root", root.path())
+    }
+
+    @Test
+    fun testNestedExecutionInfo() {
+        val root = AgentExecutionInfo(parent = null, partName = "root")
+        val child = AgentExecutionInfo(parent = root, partName = "child")
+
+        assertEquals(root, child.parent)
+        assertEquals("child", child.partName)
+        assertEquals("root/child", child.path())
+    }
+
+    @Test
+    fun testPathWithDeepHierarchy() {
+        val root = AgentExecutionInfo(parent = null, partName = "root")
+        val level1 = AgentExecutionInfo(parent = root, partName = "level1")
+        val level2 = AgentExecutionInfo(parent = level1, partName = "level2")
+        val level3 = AgentExecutionInfo(parent = level2, partName = "level3")
+
+        assertEquals("root/level1/level2/level3", level3.path())
+    }
+
+    @Test
+    fun testPathWithCustomSeparator() {
+        val root = AgentExecutionInfo(parent = null, partName = "root")
+        val child = AgentExecutionInfo(parent = root, partName = "child")
+        val grandchild = AgentExecutionInfo(parent = child, partName = "grandchild")
+
+        assertEquals("root.child.grandchild", grandchild.path("."))
+        assertEquals("root child grandchild", grandchild.path(" "))
+        assertEquals("root -> child -> grandchild", grandchild.path(" -> "))
+    }
+
+    @Test
+    fun testDefaultPathSeparator() {
+        assertEquals("/", AgentExecutionInfo.defaultPathSeparator)
+    }
+
+    @Test
+    fun testPathWithDefaultSeparator() {
+        val root = AgentExecutionInfo(parent = null, partName = "root")
+        val child = AgentExecutionInfo(parent = root, partName = "child")
+
+        assertEquals("root/child", child.path(null))
+        assertEquals("root/child", child.path())
+    }
+
+    @Test
+    fun testEmptyPartName() {
+        val root = AgentExecutionInfo(parent = null, partName = "")
+        val child = AgentExecutionInfo(parent = root, partName = "child")
+
+        assertEquals("/child", child.path())
+    }
+
+    @Test
+    fun testMultipleEmptyPartName() {
+        val root = AgentExecutionInfo(parent = null, partName = "")
+        val child = AgentExecutionInfo(parent = root, partName = "")
+
+        assertEquals("/", child.path())
+    }
+}


### PR DESCRIPTION
[KG-178](https://youtrack.jetbrains.com/issue/KG-178).

- Add the `AgentExecutionInfo` entity to describe the information about an agent execution.

## Motivation and Context
Agent execution flow can have a complicated structure (node -> subgraph -> node -> llm). The information about the agent execution flow can be useful for tracking in features (Otel) or for an agent persistency.

## Breaking Changes
No

---

#### Type of the changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [x] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
