### PR TITLE
KG-178. Update API for AIAgentEnvironment

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentFunctionalContextExt.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentFunctionalContextExt.kt
@@ -3,7 +3,7 @@ package ai.koog.agents.core.dsl.extension
 import ai.koog.agents.core.agent.context.AIAgentFunctionalContext
 import ai.koog.agents.core.environment.ReceivedToolResult
 import ai.koog.agents.core.environment.SafeTool
-import ai.koog.agents.core.environment.executeTool
+import ai.koog.agents.core.environment.executeTools
 import ai.koog.agents.core.environment.result
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolArgs

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
@@ -6,7 +6,7 @@ import ai.koog.agents.core.dsl.builder.AIAgentNodeDelegate
 import ai.koog.agents.core.dsl.builder.AIAgentSubgraphBuilderBase
 import ai.koog.agents.core.environment.ReceivedToolResult
 import ai.koog.agents.core.environment.SafeTool
-import ai.koog.agents.core.environment.executeTool
+import ai.koog.agents.core.environment.executeTools
 import ai.koog.agents.core.environment.result
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolDescriptor

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/AIAgentEnvironment.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/AIAgentEnvironment.kt
@@ -1,21 +1,25 @@
 package ai.koog.agents.core.environment
 
 import ai.koog.prompt.message.Message
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.supervisorScope
 
 /**
  * AIAgentEnvironment provides a mechanism for AI agents to interface with an external environment.
  * It offers methods for tool execution, error reporting, and sending termination messages.
  */
 public interface AIAgentEnvironment {
+
     /**
-     * Executes a list of tool calls and returns their corresponding results.
+     * Executes a tool call and returns its result.
      *
-     * @param toolCalls A list of tool call messages to be executed. Each message contains details about the tool,
-     * its identifier, the request content, and associated metadata.
-     * @return A list of results corresponding to the executed tool calls. Each result includes details such as
-     * the tool name, identifier, response content, and associated metadata.
+     * @param toolCall A tool call messages to be executed. A message contains details about the tool,
+     *        its identifier, the request content, and associated metadata.
+     * @return A result corresponding to the executed tool call. The result includes details such as
+     *         the tool name, identifier, response content, and associated metadata.
      */
-    public suspend fun executeTools(toolCalls: List<Message.Tool.Call>): List<ReceivedToolResult>
+    public suspend fun executeTool(toolCall: Message.Tool.Call): ReceivedToolResult
 
     /**
      * Reports a problem that occurred within the environment.
@@ -30,14 +34,24 @@ public interface AIAgentEnvironment {
 }
 
 /**
- * Executes a single tool call and retrieves the result.
+ * Executes a batch of tool calls within the AI agent environment and processes their results.
  *
- * This method sends the specified tool call to the tool execution environment, processes it,
- * and returns the result of the tool call. It internally leverages `executeTools` to handle
- * the execution and retrieves the first result from the returned list of results.
+ * This method takes a list of tool call messages, processes them by sending appropriate requests
+ * to the underlying environment, and returns a list of results corresponding to the tool calls.
  *
- * @param toolCall The tool call to be executed, represented as an instance of [Message.Tool.Call].
- * @return The result of the executed tool call, represented as [ReceivedToolResult].
+ * @param toolCalls A list of tool call messages to be executed. Each message contains details
+ *        about the tool, its identifier, the request content, and associated metadata.
+ * @return A list of results corresponding to the executed tool calls. Each result includes details
+ *         such as the tool name, identifier, response content, and metadata.
  */
-public suspend fun AIAgentEnvironment.executeTool(toolCall: Message.Tool.Call): ReceivedToolResult =
-    executeTools(listOf(toolCall)).first()
+public suspend fun AIAgentEnvironment.executeTools(toolCalls: List<Message.Tool.Call>): List<ReceivedToolResult> {
+    val results = supervisorScope {
+        toolCalls
+            .map { toolCall ->
+                async { executeTool(toolCall) }
+            }
+            .awaitAll()
+    }
+
+    return results
+}

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/AIAgentEnvironmentUtils.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/AIAgentEnvironmentUtils.kt
@@ -8,14 +8,14 @@ import ai.koog.agents.core.model.message.EnvironmentToolResultMultipleToAgentMes
 import ai.koog.agents.core.model.message.EnvironmentToolResultSingleToAgentMessage
 
 internal object AIAgentEnvironmentUtils {
-    fun EnvironmentToAgentMessage.mapToToolResult(): List<ReceivedToolResult> {
+    fun EnvironmentToAgentMessage.mapToToolResult(): ReceivedToolResult {
         return when (this) {
             is EnvironmentToolResultSingleToAgentMessage -> {
-                listOf(this.content.toResult())
+                this.content.toResult()
             }
 
             is EnvironmentToolResultMultipleToAgentMessage -> {
-                this.content.map { it.toResult() }
+                this.content.toResult()
             }
 
             is EnvironmentToAgentErrorMessage -> {

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/model/message/AgentToEnvironment.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/model/message/AgentToEnvironment.kt
@@ -57,7 +57,7 @@ public data class AgentToolCallToEnvironmentContent(
 @SerialName("ACTION_MULTIPLE")
 public data class AgentToolCallsToEnvironmentMessage(
     override val runId: String,
-    val content: List<AgentToolCallToEnvironmentContent>
+    val content: AgentToolCallToEnvironmentContent
 ) : AgentToolCallToEnvironmentMessage
 
 /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/model/message/EnvironmentToAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/model/message/EnvironmentToAgent.kt
@@ -136,7 +136,9 @@ public abstract class EnvironmentToolResultToAgentContent : EnvironmentToAgentCo
      * scope of tool-based operations in an agent's environment.
      */
     public abstract val toolName: String
+
     abstract override val agentId: String
+
     abstract override val message: String
 }
 
@@ -166,7 +168,7 @@ public data class EnvironmentToolResultSingleToAgentMessage(
 @SerialName("OBSERVATIONS_MULTIPLE")
 public data class EnvironmentToolResultMultipleToAgentMessage(
     override val runId: String,
-    val content: List<EnvironmentToolResultToAgentContent>,
+    val content: EnvironmentToolResultToAgentContent,
 ) : EnvironmentToolResultToAgentMessage
 
 /**

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/context/AgentTestBase.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/context/AgentTestBase.kt
@@ -14,6 +14,7 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.llm.OllamaModels
 import ai.koog.prompt.message.Message
+import kotlinx.serialization.json.JsonPrimitive
 import kotlin.reflect.typeOf
 
 open class AgentTestBase {
@@ -23,8 +24,13 @@ open class AgentTestBase {
 
     protected fun createTestEnvironment(id: String = "test-environment"): AIAgentEnvironment {
         return object : AIAgentEnvironment {
-            override suspend fun executeTools(toolCalls: List<Message.Tool.Call>): List<ReceivedToolResult> {
-                return emptyList()
+            override suspend fun executeTool(toolCall: Message.Tool.Call): ReceivedToolResult {
+                return ReceivedToolResult(
+                    id = toolCall.id,
+                    tool = toolCall.tool,
+                    content = toolCall.content,
+                    result = JsonPrimitive("Test result content")
+                )
             }
 
             override suspend fun reportProblem(exception: Throwable) {

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionTest.kt
@@ -39,19 +39,17 @@ class AIAgentLLMWriteSessionTest {
 
     private class TestEnvironment(private val toolRegistry: ToolRegistry) : AIAgentEnvironment {
         @OptIn(InternalAgentToolsApi::class)
-        override suspend fun executeTools(toolCalls: List<Message.Tool.Call>): List<ReceivedToolResult> {
-            return toolCalls.map { toolCall ->
-                val tool = toolRegistry.getTool(toolCall.tool)
-                val args = tool.decodeArgs(toolCall.contentJson)
-                val result = tool.executeUnsafe(args)
+        override suspend fun executeTool(toolCall: Message.Tool.Call): ReceivedToolResult {
+            val tool = toolRegistry.getTool(toolCall.tool)
+            val args = tool.decodeArgs(toolCall.contentJson)
+            val result = tool.executeUnsafe(args)
 
-                ReceivedToolResult(
-                    id = toolCall.id,
-                    tool = toolCall.tool,
-                    content = tool.encodeResultToStringUnsafe(result),
-                    result = tool.encodeResultUnsafe(result)
-                )
-            }
+            return ReceivedToolResult(
+                id = toolCall.id,
+                tool = toolCall.tool,
+                content = tool.encodeResultToStringUnsafe(result),
+                result = tool.encodeResultUnsafe(result)
+            )
         }
 
         override suspend fun reportProblem(exception: Throwable) {

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContextConcurrencyTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContextConcurrencyTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonPrimitive
 import org.junit.jupiter.api.Timeout
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
@@ -156,8 +157,13 @@ class AIAgentLLMContextConcurrencyTest {
 
     private fun createTestEnvironment(): AIAgentEnvironment {
         return object : AIAgentEnvironment {
-            override suspend fun executeTools(toolCalls: List<Message.Tool.Call>): List<ReceivedToolResult> {
-                return emptyList()
+            override suspend fun executeTool(toolCall: Message.Tool.Call): ReceivedToolResult {
+                return ReceivedToolResult(
+                    id = toolCall.id,
+                    tool = toolCall.tool,
+                    content = toolCall.content,
+                    result = JsonPrimitive("Test result content")
+                )
             }
 
             override suspend fun reportProblem(exception: Throwable) {

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/environment/SafeToolTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/environment/SafeToolTest.kt
@@ -80,23 +80,21 @@ class SafeToolTest {
         private val resultContent: String = "Success content",
     ) : AIAgentEnvironment {
         @OptIn(InternalAgentToolsApi::class)
-        override suspend fun executeTools(toolCalls: List<Message.Tool.Call>): List<ReceivedToolResult> {
-            return toolCalls.map { toolCall ->
-                if (shouldSucceed) {
-                    ReceivedToolResult(
-                        id = toolCall.id,
-                        tool = toolCall.tool,
-                        content = resultContent,
-                        result = json.encodeToJsonElement(serializer<String>().asToolDescriptorSerializer(), TEST_RESULT)
-                    )
-                } else {
-                    ReceivedToolResult(
-                        id = toolCall.id,
-                        tool = toolCall.tool,
-                        content = TEST_ERROR,
-                        result = null,
-                    )
-                }
+        override suspend fun executeTool(toolCall: Message.Tool.Call): ReceivedToolResult {
+            return if (shouldSucceed) {
+                ReceivedToolResult(
+                    id = toolCall.id,
+                    tool = toolCall.tool,
+                    content = resultContent,
+                    result = json.encodeToJsonElement(serializer<String>().asToolDescriptorSerializer(), TEST_RESULT)
+                )
+            } else {
+                ReceivedToolResult(
+                    id = toolCall.id,
+                    tool = toolCall.tool,
+                    content = TEST_ERROR,
+                    result = null,
+                )
             }
         }
 
@@ -194,25 +192,23 @@ class SafeToolTest {
     @Test
     fun testWithNullArgumentInDirectCallEnvironment() = runTest {
         val directCallEnvironment = object : AIAgentEnvironment {
-            override suspend fun executeTools(toolCalls: List<Message.Tool.Call>): List<ReceivedToolResult> {
-                return toolCalls.map { toolCall ->
-                    try {
-                        val result = testFunction("test", null as Int)
+            override suspend fun executeTool(toolCall: Message.Tool.Call): ReceivedToolResult {
+                return try {
+                    val result = testFunction("test", null as Int)
 
-                        ReceivedToolResult(
-                            id = toolCall.id,
-                            tool = toolCall.tool,
-                            content = "Success: $result",
-                            result = json.encodeToJsonElement(result).jsonObject
-                        )
-                    } catch (e: Exception) {
-                        ReceivedToolResult(
-                            id = toolCall.id,
-                            tool = toolCall.tool,
-                            content = "Error: ${e.message}",
-                            result = null
-                        )
-                    }
+                    ReceivedToolResult(
+                        id = toolCall.id,
+                        tool = toolCall.tool,
+                        content = "Success: $result",
+                        result = json.encodeToJsonElement(result).jsonObject
+                    )
+                } catch (e: Exception) {
+                    ReceivedToolResult(
+                        id = toolCall.id,
+                        tool = toolCall.tool,
+                        content = "Error: ${e.message}",
+                        result = null
+                    )
                 }
             }
 
@@ -280,33 +276,31 @@ class SafeToolTest {
     @Test
     fun testWithComplexArgumentsInDirectCallEnvironment() = runTest {
         val directCallEnvironment = object : AIAgentEnvironment {
-            override suspend fun executeTools(toolCalls: List<Message.Tool.Call>): List<ReceivedToolResult> {
-                return toolCalls.map { toolCall ->
-                    try {
-                        val complexData = ComplexDataClass(
-                            id = "direct-call-id",
-                            numbers = listOf(7, 8, 9),
-                            nested = SimpleDataClass(name = "direct-nested", value = 100),
-                            enumValue = TestEnum.THIRD
-                        )
+            override suspend fun executeTool(toolCall: Message.Tool.Call): ReceivedToolResult {
+                return try {
+                    val complexData = ComplexDataClass(
+                        id = "direct-call-id",
+                        numbers = listOf(7, 8, 9),
+                        nested = SimpleDataClass(name = "direct-nested", value = 100),
+                        enumValue = TestEnum.THIRD
+                    )
 
-                        val result = testFunctionWithComplexArgs("direct-test", listOf(10, 11, 12), complexData)
-                        val resultSerializer = serializer<String>().asToolDescriptorSerializer()
+                    val result = testFunctionWithComplexArgs("direct-test", listOf(10, 11, 12), complexData)
+                    val resultSerializer = serializer<String>().asToolDescriptorSerializer()
 
-                        ReceivedToolResult(
-                            id = toolCall.id,
-                            tool = toolCall.tool,
-                            content = "Success: $result",
-                            result = json.encodeToJsonElement(resultSerializer, result)
-                        )
-                    } catch (e: Exception) {
-                        ReceivedToolResult(
-                            id = toolCall.id,
-                            tool = toolCall.tool,
-                            content = "Error: ${e.message}",
-                            result = null
-                        )
-                    }
+                    ReceivedToolResult(
+                        id = toolCall.id,
+                        tool = toolCall.tool,
+                        content = "Success: $result",
+                        result = json.encodeToJsonElement(resultSerializer, result)
+                    )
+                } catch (e: Exception) {
+                    ReceivedToolResult(
+                        id = toolCall.id,
+                        tool = toolCall.tool,
+                        content = "Error: ${e.message}",
+                        result = null
+                    )
                 }
             }
 

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
@@ -16,7 +16,7 @@ import ai.koog.agents.core.dsl.extension.nodeLLMRequestMultiple
 import ai.koog.agents.core.dsl.extension.nodeLLMSendMultipleToolResults
 import ai.koog.agents.core.dsl.extension.setToolChoiceRequired
 import ai.koog.agents.core.environment.ReceivedToolResult
-import ai.koog.agents.core.environment.executeTool
+import ai.koog.agents.core.environment.executeTools
 import ai.koog.agents.core.environment.toSafeResult
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolDescriptor

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubtaskExt.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubtaskExt.kt
@@ -12,7 +12,7 @@ import ai.koog.agents.core.dsl.extension.sendMultipleToolResults
 import ai.koog.agents.core.dsl.extension.sendToolResult
 import ai.koog.agents.core.dsl.extension.setToolChoiceRequired
 import ai.koog.agents.core.environment.ReceivedToolResult
-import ai.koog.agents.core.environment.executeTool
+import ai.koog.agents.core.environment.executeTools
 import ai.koog.agents.core.environment.toSafeResult
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi

--- a/docs/docs/custom-nodes.md
+++ b/docs/docs/custom-nodes.md
@@ -286,7 +286,6 @@ val summarizeTextNode by node<String, String>("node_name") { input ->
 
 <!--- INCLUDE
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.environment.executeTool
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
 import kotlinx.datetime.Clock


### PR DESCRIPTION
[KG-178](https://youtrack.jetbrains.com/issue/KG-178). 

- Swap executeTool and executeTools API for agent environment to support handling tool result in the agent pipeline.

## Motivation and Context
`executeTools` agent environment API proceed with tools execution all at once in async manner. Tool execution needs to be reported by an Agent pipeline. Currently, pipeline is available as a parameter for environment. However, those two entities are unrelated. If we split them, then tool execution would need to be handled on an environment API level and would need to have a single tool call precision. So, it would be more convenient to use a single tool execution in interface and add a wrapper for a multiple async tool call as an extension instead of a current approach.

## Breaking Changes
Yes

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [x] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [x] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
