### PR TITLE
Fix missing tool support in Ollama streaming client

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -168,13 +168,13 @@ public class OllamaClient(
     ): List<Message.Response> {
         require(model.provider == LLMProvider.Ollama) { "Model not supported by Ollama" }
 
-        val llmTools = tools.takeIf { it.isNotEmpty() }?.map { it.toOllamaChatTool() }
+        val ollamaTools = tools.takeIf { it.isNotEmpty() }?.map { it.toOllamaChatTool() }
         val request = ollamaJson.encodeToString(
             OllamaChatRequestDTOSerializer,
             OllamaChatRequestDTO(
                 model = model.id,
                 messages = prompt.toOllamaChatMessages(model),
-                tools = llmTools,
+                tools = ollamaTools,
                 format = prompt.extractOllamaJsonFormat(),
                 options = extractOllamaOptions(prompt, model),
                 stream = false,
@@ -261,7 +261,7 @@ public class OllamaClient(
     ): Flow<StreamFrame> = streamFrameFlow {
         require(model.provider == LLMProvider.Ollama) { "Model not supported by Ollama" }
 
-        val llmTools = tools.takeIf { it.isNotEmpty() }?.map { it.toOllamaChatTool() }
+        val ollamaTools = tools.takeIf { it.isNotEmpty() }?.map { it.toOllamaChatTool() }
         val request = ollamaJson.encodeToString(
             OllamaChatRequestDTOSerializer,
             OllamaChatRequestDTO(
@@ -270,7 +270,7 @@ public class OllamaClient(
                 options = extractOllamaOptions(prompt, model),
                 stream = true,
                 additionalProperties = prompt.params.additionalProperties,
-                tools = llmTools
+                tools = ollamaTools
             )
         )
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -267,10 +267,10 @@ public class OllamaClient(
             OllamaChatRequestDTO(
                 model = model.id,
                 messages = prompt.toOllamaChatMessages(model),
+                tools = ollamaTools,
                 options = extractOllamaOptions(prompt, model),
                 stream = true,
-                additionalProperties = prompt.params.additionalProperties,
-                tools = ollamaTools
+                additionalProperties = prompt.params.additionalProperties
             )
         )
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -168,27 +168,13 @@ public class OllamaClient(
     ): List<Message.Response> {
         require(model.provider == LLMProvider.Ollama) { "Model not supported by Ollama" }
 
-        val ollamaTools = if (tools.isNotEmpty()) {
-            tools.map {
-                OllamaToolDTO(
-                    type = "function",
-                    function = Definition(
-                        name = it.name,
-                        description = it.description,
-                        parameters = toolDescriptorConverter.generate(it)
-                    )
-                )
-            }
-        } else {
-            null
-        }
-
+        val llmTools = tools.takeIf { it.isNotEmpty() }?.map { it.toOllamaChatTool() }
         val request = ollamaJson.encodeToString(
             OllamaChatRequestDTOSerializer,
             OllamaChatRequestDTO(
                 model = model.id,
                 messages = prompt.toOllamaChatMessages(model),
-                tools = ollamaTools,
+                tools = llmTools,
                 format = prompt.extractOllamaJsonFormat(),
                 options = extractOllamaOptions(prompt, model),
                 stream = false,
@@ -275,6 +261,7 @@ public class OllamaClient(
     ): Flow<StreamFrame> = streamFrameFlow {
         require(model.provider == LLMProvider.Ollama) { "Model not supported by Ollama" }
 
+        val llmTools = tools.takeIf { it.isNotEmpty() }?.map { it.toOllamaChatTool() }
         val request = ollamaJson.encodeToString(
             OllamaChatRequestDTOSerializer,
             OllamaChatRequestDTO(
@@ -283,6 +270,7 @@ public class OllamaClient(
                 options = extractOllamaOptions(prompt, model),
                 stream = true,
                 additionalProperties = prompt.params.additionalProperties,
+                tools = llmTools
             )
         )
 
@@ -324,6 +312,15 @@ public class OllamaClient(
             numCtx = contextWindowStrategy.computeContextLength(prompt, model),
         )
     }
+
+    private fun ToolDescriptor.toOllamaChatTool(): OllamaToolDTO = OllamaToolDTO(
+        type = "function",
+        function = Definition(
+            name = name,
+            description = description,
+            parameters = toolDescriptorConverter.generate(this)
+        )
+    )
 
     /**
      * Embeds the given text using the Ollama model.


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

Please add a brief description of the proposed change here.
Also, please tick the appropriate points in the checklist below.
-->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

The streaming Ollama client was not sending the `tools` parameter, so tool calls could never be triggered in streaming mode.  
This PR adds the missing `tools` field for consistency with the non-streaming path and to support models that can use tools.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

None

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
