### PR TITLE
Pass jsonObject as responseFormat for DeepSeek

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
@@ -13,6 +13,7 @@ import ai.koog.prompt.executor.clients.openai.base.AbstractOpenAILLMClient
 import ai.koog.prompt.executor.clients.openai.base.OpenAIBaseSettings
 import ai.koog.prompt.executor.clients.openai.base.OpenAICompatibleToolDescriptorSchemaGenerator
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIMessage
+import ai.koog.prompt.executor.clients.openai.base.models.OpenAIResponseFormat
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAITool
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIToolChoice
 import ai.koog.prompt.llm.LLMProvider
@@ -140,6 +141,17 @@ public class DeepSeekLLMClient(
                 upsertToolCall(index, id, name, arguments)
             }
             choice.finishReason?.let { emitEnd(it, createMetaInfo(chunk.usage)) }
+        }
+    }
+
+    override fun createResponseFormat(schema: LLMParams.Schema?, model: LLModel): OpenAIResponseFormat? {
+        return schema?.let {
+            require(it.capability in model.capabilities) {
+                "Model ${model.id} does not support structured output schema ${it.name}"
+            }
+            when (it) {
+                is LLMParams.Schema.JSON -> OpenAIResponseFormat.JsonObject()
+            }
         }
     }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/jvmTest/kotlin/deepseek/DeepSeekLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/jvmTest/kotlin/deepseek/DeepSeekLLMClientTest.kt
@@ -20,8 +20,6 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
-import kotlinx.serialization.json.putJsonObject
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -199,13 +197,7 @@ class DeepSeekLLMClientTest {
         }
         val http = HttpClient(engine) {}
         val client = DeepSeekLLMClient(apiKey = key, baseClient = http, clock = FixedClock)
-        val schemaJson = buildJsonObject {
-            put(
-                "type",
-                "object"
-            )
-            putJsonObject("properties") { putJsonObject("name") { put("type", "string") } }
-        }
+        val schemaJson = buildJsonObject { }
 
         val schema = LLMParams.Schema.JSON.Basic("Person", schemaJson)
 
@@ -221,7 +213,7 @@ class DeepSeekLLMClientTest {
         assertEquals(1, responses.size, "Response should have one choice")
         assertNotNull(capturedBody, "Captured body should not be null")
         assertTrue(capturedBody.contains("\"response_format\""), "Response body should contain response_format")
-        assertTrue(capturedBody.contains("\"json_schema\""), "Response body should contain json_schema")
+        assertTrue(capturedBody.contains("\"json_object\""), "Response body should contain json_schema")
         assertTrue(
             responses.first().content.contains("{\"name\":\"Alice\"}"),
             "Response should contain JSON string [{\"name\":\"Alice\"}]"

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
@@ -486,7 +486,7 @@ public abstract class AbstractOpenAILLMClient<TResponse : OpenAIBaseLLMResponse,
         outputTokensCount = usage?.completionTokens
     )
 
-    protected fun createResponseFormat(schema: LLMParams.Schema?, model: LLModel): OpenAIResponseFormat? {
+    protected open fun createResponseFormat(schema: LLMParams.Schema?, model: LLModel): OpenAIResponseFormat? {
         return schema?.let {
             require(it.capability in model.capabilities) {
                 "Model ${model.id} does not support structured output schema ${it.name}"


### PR DESCRIPTION
[KG-537](https://youtrack.jetbrains.com/issue/KG-537) Deepseek's JSON mode request body is incorrect
#1076 Deepseek's JSON mode request body is incorrect

## Breaking Changes
None

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [ ] The pull request has a description of the proposed change
- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [ ] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed
