### PR TITLE
KG-616 fix streaming + tool call issue

### DIFF
--- a/http-client/http-client-ktor/src/commonMain/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClient.kt
+++ b/http-client/http-client-ktor/src/commonMain/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClient.kt
@@ -161,10 +161,17 @@ public class KtorKoogHttpClient internal constructor(
                 }
             }
         } catch (e: SSEClientException) {
+            val errorBody = try {
+                e.response?.bodyAsText()
+            } catch (ignored: Exception) {
+                logger.debug(ignored) { "Unable to read SSE error response body (may already be consumed)" }
+                null
+            }
             throw KoogHttpClientException(
                 clientName = clientName,
                 statusCode = e.response?.status?.value,
-                errorBody = e.response?.bodyAsText(),
+                errorBody = errorBody,
+                message = e.message,
                 cause = e
             )
         } catch (e: CancellationException) {

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -17,7 +17,7 @@ kotlin {
                 implementation(libs.testcontainers)
                 implementation(libs.ktor.server.netty)
                 implementation(kotlin("test-junit5"))
-                runtimeOnly(libs.ktor.client.apache5)
+                runtimeOnly(libs.ktor.client.cio)
                 runtimeOnly(libs.slf4j.simple)
             }
         }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
@@ -23,11 +23,13 @@ import ai.koog.integration.tests.utils.structuredOutput.getConfigNoFixingParserM
 import ai.koog.integration.tests.utils.structuredOutput.getConfigNoFixingParserNative
 import ai.koog.integration.tests.utils.structuredOutput.parseMarkdownStreamToCountries
 import ai.koog.integration.tests.utils.structuredOutput.weatherStructuredOutputPrompt
+import ai.koog.integration.tests.utils.tools.CalculatorOperation
 import ai.koog.integration.tests.utils.tools.CalculatorTool
 import ai.koog.integration.tests.utils.tools.LotteryTool
 import ai.koog.integration.tests.utils.tools.PickColorFromListTool
 import ai.koog.integration.tests.utils.tools.PickColorTool
 import ai.koog.integration.tests.utils.tools.PriceCalculatorTool
+import ai.koog.integration.tests.utils.tools.SimpleCalculatorTool
 import ai.koog.integration.tests.utils.tools.SimplePriceCalculatorTool
 import ai.koog.integration.tests.utils.tools.calculatorPrompt
 import ai.koog.integration.tests.utils.tools.calculatorPromptNotRequiredOptionalParams
@@ -42,16 +44,12 @@ import ai.koog.prompt.executor.clients.anthropic.AnthropicParams
 import ai.koog.prompt.executor.clients.anthropic.models.AnthropicThinking
 import ai.koog.prompt.executor.clients.google.GoogleModels
 import ai.koog.prompt.executor.clients.google.GoogleParams
-import kotlinx.coroutines.flow.collect
 import ai.koog.prompt.executor.clients.google.models.GoogleThinkingConfig
 import ai.koog.prompt.executor.clients.google.models.GoogleThinkingLevel
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.clients.openai.OpenAIResponsesParams
 import ai.koog.prompt.executor.clients.openai.base.models.ReasoningEffort
 import ai.koog.prompt.executor.clients.openai.models.OpenAIInclude
-import ai.koog.integration.tests.utils.tools.CalculatorOperation
-import ai.koog.integration.tests.utils.tools.SimpleCalculatorTool
-import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.executor.clients.openai.models.ReasoningConfig
 import ai.koog.prompt.executor.clients.openai.models.ReasoningSummary
 import ai.koog.prompt.executor.model.PromptExecutor
@@ -66,6 +64,7 @@ import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.params.LLMParams.ToolChoice
+import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.structure.executeStructured
 import io.kotest.assertions.withClue
 import io.kotest.inspectors.shouldForAll
@@ -90,7 +89,7 @@ import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.BeforeAll
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.Base64
+import java.util.*
 import kotlin.io.path.pathString
 import kotlin.io.path.readBytes
 import kotlin.io.path.readText

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
@@ -42,12 +42,16 @@ import ai.koog.prompt.executor.clients.anthropic.AnthropicParams
 import ai.koog.prompt.executor.clients.anthropic.models.AnthropicThinking
 import ai.koog.prompt.executor.clients.google.GoogleModels
 import ai.koog.prompt.executor.clients.google.GoogleParams
+import kotlinx.coroutines.flow.collect
 import ai.koog.prompt.executor.clients.google.models.GoogleThinkingConfig
 import ai.koog.prompt.executor.clients.google.models.GoogleThinkingLevel
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.clients.openai.OpenAIResponsesParams
 import ai.koog.prompt.executor.clients.openai.base.models.ReasoningEffort
 import ai.koog.prompt.executor.clients.openai.models.OpenAIInclude
+import ai.koog.integration.tests.utils.tools.CalculatorOperation
+import ai.koog.integration.tests.utils.tools.SimpleCalculatorTool
+import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.executor.clients.openai.models.ReasoningConfig
 import ai.koog.prompt.executor.clients.openai.models.ReasoningSummary
 import ai.koog.prompt.executor.model.PromptExecutor
@@ -62,7 +66,6 @@ import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.params.LLMParams.ToolChoice
-import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.structure.executeStructured
 import io.kotest.assertions.withClue
 import io.kotest.inspectors.shouldForAll
@@ -1077,6 +1080,59 @@ abstract class ExecutorIntegrationTestBase {
             response2.shouldNotBeEmpty()
             val answer = response2.filterIsInstance<Message.Assistant>().first().content
             answer.shouldContain("20")
+        }
+    }
+
+    open fun integration_testExecuteStreamingWithTools(model: LLModel) = runTest(timeout = 300.seconds) {
+        Models.assumeAvailable(model.provider)
+        assumeTrue(model.capabilities.contains(LLMCapability.Tools), "Model $model does not support tools")
+
+        val executor = getExecutor(model)
+
+        val prompt = Prompt.build("test-streaming", LLMParams(toolChoice = ToolChoice.Required)) {
+            system("You are a helpful assistant.")
+            user("Count three times five")
+        }
+
+        withRetry(times = 3, testName = "integration_testExecuteStreamingWithTools[${model.id}]") {
+            with(StringBuilder()) {
+                val endMessages = mutableListOf<StreamFrame.End>()
+                val toolMessages = mutableListOf<StreamFrame.ToolCall>()
+
+                executor.executeStreamAndCollect(
+                    prompt = prompt,
+                    model = model,
+                    tools = listOf(SimpleCalculatorTool.descriptor),
+                    appendable = this,
+                    endMessages = endMessages,
+                    toolMessages = toolMessages
+                )
+
+                toolMessages.shouldNotBeEmpty()
+                withClue("Expected calculator tool call but got: [$toolMessages]") {
+                    toolMessages.any {
+                        it.name == SimpleCalculatorTool.name &&
+                            it.content.contains(CalculatorOperation.MULTIPLY.name, ignoreCase = true)
+                    } shouldBe true
+                }
+            }
+        }
+    }
+
+    private suspend fun PromptExecutor.executeStreamAndCollect(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>,
+        appendable: StringBuilder,
+        endMessages: MutableList<StreamFrame.End>,
+        toolMessages: MutableList<StreamFrame.ToolCall>
+    ) {
+        executeStreaming(prompt, model, tools).collect { frame ->
+            when (frame) {
+                is StreamFrame.Append -> appendable.append(frame.text)
+                is StreamFrame.ToolCall -> toolMessages.add(frame)
+                is StreamFrame.End -> endMessages.add(frame)
+            }
         }
     }
 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/MultipleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/MultipleLLMPromptExecutorIntegrationTest.kt
@@ -115,6 +115,12 @@ class MultipleLLMPromptExecutorIntegrationTest : ExecutorIntegrationTestBase() {
 
     @ParameterizedTest
     @MethodSource("allCompletionModels")
+    override fun integration_testExecuteStreamingWithTools(model: LLModel) {
+        super.integration_testExecuteStreamingWithTools(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
     override fun integration_testToolWithRequiredParams(model: LLModel) {
         super.integration_testToolWithRequiredParams(model)
     }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SingleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SingleLLMPromptExecutorIntegrationTest.kt
@@ -109,6 +109,12 @@ class SingleLLMPromptExecutorIntegrationTest : ExecutorIntegrationTestBase() {
 
     @ParameterizedTest
     @MethodSource("allCompletionModels")
+    override fun integration_testExecuteStreamingWithTools(model: LLModel) {
+        super.integration_testExecuteStreamingWithTools(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
     override fun integration_testToolWithRequiredParams(model: LLModel) {
         super.integration_testToolWithRequiredParams(model)
     }
@@ -305,11 +311,5 @@ class SingleLLMPromptExecutorIntegrationTest : ExecutorIntegrationTestBase() {
     @MethodSource("reasoningCapableModels")
     override fun integration_testReasoningMultiStep(model: LLModel) {
         super.integration_testReasoningMultiStep(model)
-    }
-    
-    @ParameterizedTest
-    @MethodSource("allCompletionModels")
-    override fun integration_testExecuteStreamingWithTools(model: LLModel) {
-        super.integration_testExecuteStreamingWithTools(model)
     }
 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SingleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SingleLLMPromptExecutorIntegrationTest.kt
@@ -306,4 +306,10 @@ class SingleLLMPromptExecutorIntegrationTest : ExecutorIntegrationTestBase() {
     override fun integration_testReasoningMultiStep(model: LLModel) {
         super.integration_testReasoningMultiStep(model)
     }
+    
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testExecuteStreamingWithTools(model: LLModel) {
+        super.integration_testExecuteStreamingWithTools(model)
+    }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -172,7 +172,7 @@ public open class GoogleLLMClient(
             "Model ${model.id} does not support chat completions"
         }
 
-        val request = createGoogleRequest(prompt, model, emptyList())
+        val request = createGoogleRequest(prompt, model, tools)
 
         try {
             httpClient.sse(


### PR DESCRIPTION
Related to [KG-616](https://youtrack.jetbrains.com/issue/KG-616)

## Motivation and Context
This PR addresses critical issues encountered with SSE streaming for both Google and OpenRouter clients, ensuring robust functionality and better error handling.

1.  **Google Client Fix:**
    *   **Problem:** The [GoogleLLMClient](cci:2://file:///Users/ku76uh/Developer/jetbrains/fork/koog/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt:98:0-797:1) was ignoring the `tools` parameter during streaming requests ([executeStreaming](cci:1://file:///Users/ku76uh/Developer/jetbrains/fork/koog/prompt/prompt-executor/prompt-executor-model/src/commonMain/kotlin/ai/koog/prompt/executor/model/PromptExecutor.kt:36:4-48:24)), explicitly passing `emptyList()` instead. This broke tool usage for streaming calls.
    *   **Solution:** We corrected this to specificially pass the `tools` parameter to [createGoogleRequest](cci:1://file:///Users/ku76uh/Developer/jetbrains/fork/koog/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt:277:4-446:5).

2.  **OpenRouter Integration Test Fix:**
    *   **Problem:** Integration tests for OpenRouter streaming were failing with `Socket is not connected` errors. This was traced back to the default `Apache5` HTTP client engine used in tests, which has known connection pooling issues with OpenRouter's non-standard Keep-Alive comments (e.g., `: OPENROUTER PROCESSING`).
    *   **Solution:** We switched the integration test runtime dependency from `ktor-client-apache5` to `ktor-client-cio`. The CIO (Coroutine-based I/O) engine handles these SSE keep-alive comments correctly, resolving the socket closure issues.

3.  **Enhanced SSE Error Handling:**
    *   **Problem:** When a `SSEClientException` occurred (e.g., due to a 400 Bad Request or streaming interruption), the error handling logic in [KtorKoogHttpClient](cci:2://file:///Users/ku76uh/Developer/jetbrains/fork/koog/http-client/http-client-ktor/src/commonMain/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClient.kt:49:0-191:1) would attempt to read `e.response?.bodyAsText()` directly. If the response body was already consumed or unavailable (common in streaming errors), this would throw a `DoubleReceiveException`, masking the original error.
    *   **Solution:** We wrapped the `bodyAsText()` call in a `try-catch` block. This allows us to successfully capture the error body for handshake failures (like 400 Bad Request) while gracefully handling cases where the body is unavailable (falling back to `null`), ensuring the original `SSEClientException` is always propagated with maximum available context.

## Breaking Changes
None. These are internal fixes and test configuration updates.

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated