### PR TITLE
KG-622. Configure OTel with batch span exporter by default

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/README.md
+++ b/agents/agents-features/agents-features-opentelemetry/README.md
@@ -65,25 +65,27 @@ The example includes the following configuration methods:
 
 Please see below the full list of available configuration properties:
 
-| Name               | Data type          | Default value | Description                                                                  |
-|--------------------|--------------------|---------------|------------------------------------------------------------------------------|
-| `serviceName`      | `String`           | `ai.koog`     | The name of the service being instrumented.                                  |
-| `serviceVersion`   | `String`           | `0.0.0`       | The version of the service being instrumented.                               |
-| `sdk`              | `OpenTelemetrySdk` |               | The OpenTelemetry SDK instance to use for telemetry collection.              |
-| `isVerbose`        | `Boolean`          | `false`       | Whether to enable verbose logging for debugging OpenTelemetry configuration. |
-| `tracer`           | `Tracer`           |               | The OpenTelemetry tracer instance used for creating spans.                   |
+| Name                     | Data type          | Default value | Description                                                                  |
+|--------------------------|--------------------|---------------|------------------------------------------------------------------------------|
+| `serviceName`            | `String`           | `ai.koog`     | The name of the service being instrumented.                                  |
+| `serviceVersion`         | `String`           | `0.0.0`       | The version of the service being instrumented.                               |
+| `sdk`                    | `OpenTelemetrySdk` |               | The OpenTelemetry SDK instance to use for telemetry collection.              |
+| `isVerbose`              | `Boolean`          | `false`       | Whether to enable verbose logging for debugging OpenTelemetry configuration. |
+| `tracer`                 | `Tracer`           |               | The OpenTelemetry tracer instance used for creating spans.                   |
+| `spansForceFlushTimeout` | `Duration`         | `2.seconds`   | The timeout duration for forcing a final flush of spans when agent finishes. |
 
 Configuration API:
 
-| Name                    | Arguments                                           | Description                                                                       |
-|-------------------------|-----------------------------------------------------|-----------------------------------------------------------------------------------|
-| `setServiceInfo`        | `serviceName: String, serviceVersion: String`       | Sets the service information including name and version.                          |
-| `addSpanExporter`       | `exporter: SpanExporter`                            | Adds a span exporter to send telemetry data to external systems.                  |
-| `addSpanProcessor`      | `processor: (SpanExporter) -> SpanProcessor`        | Adds a span processor creator function to process spans before they are exported. |
-| `addResourceAttributes` | `attributes: Map<AttributeKey<T>, T> where T : Any` | Adds resource attributes to provide additional context about the service.         |
-| `setSampler`            | `sampler: Sampler`                                  | Sets the sampling strategy to control which spans are collected.                  |
-| `setVerbose`            | `verbose: Boolean`                                  | Enables or disables verbose logging for debugging OpenTelemetry configuration.    |
-| `setSdk`                | `sdk: OpenTelemetrySdk`                             | Injects a custom OpenTelemetry SDK instance for advanced configuration control.   |
+| Name                       | Arguments                                           | Description                                                                       |
+|----------------------------|-----------------------------------------------------|-----------------------------------------------------------------------------------|
+| `setServiceInfo`           | `serviceName: String, serviceVersion: String`       | Sets the service information including name and version.                          |
+| `addSpanExporter`          | `exporter: SpanExporter`                            | Adds a span exporter to send telemetry data to external systems.                  |
+| `addSpanProcessor`         | `processor: (SpanExporter) -> SpanProcessor`        | Adds a span processor creator function to process spans before they are exported. |
+| `addResourceAttributes`    | `attributes: Map<AttributeKey<T>, T> where T : Any` | Adds resource attributes to provide additional context about the service.         |
+| `setSampler`               | `sampler: Sampler`                                  | Sets the sampling strategy to control which spans are collected.                  |
+| `setVerbose`               | `verbose: Boolean`                                  | Enables or disables verbose logging for debugging OpenTelemetry configuration.    |
+| `setSdk`                   | `sdk: OpenTelemetrySdk`                             | Injects a custom OpenTelemetry SDK instance for advanced configuration control.   |
+| `setSpansForceFlushTimeout`| `timeout: Duration`                                 | Sets the timeout for flushing spans when agent finishes (default: 2 seconds).     |
 
 
 ### Advanced configuration

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
@@ -30,6 +30,7 @@ import ai.koog.agents.utils.HiddenString
 import ai.koog.prompt.message.Message
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.opentelemetry.api.trace.StatusCode
+import java.util.concurrent.TimeUnit
 import kotlin.reflect.KType
 
 /**
@@ -167,6 +168,11 @@ public class OpenTelemetry {
 
                 spanAdapter?.onBeforeSpanFinished(agentSpan)
                 spanProcessor.endSpan(span = agentSpan)
+
+                // Force flush all spans and wait for the operation to finish.
+                spanProcessor.endUnfinishedSpans()
+                config.sdk.sdkTracerProvider.forceFlush()
+                    .join(config.spansForceFlushTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
             }
 
             //endregion Agent

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestAPI.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestAPI.kt
@@ -32,6 +32,7 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.params.LLMParams
 import ai.koog.utils.io.use
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
@@ -167,6 +168,10 @@ internal object OpenTelemetryTestAPI {
             ) {
                 install(OpenTelemetry) {
                     addSpanExporter(mockExporter)
+                    // Export on every span end event
+                    addSpanProcessor { exporter ->
+                        BatchSpanProcessor.builder(exporter).setMaxExportBatchSize(1).build()
+                    }
                     setVerbose(verbose)
                 }
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/mock/MockSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/mock/MockSpan.kt
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit
 /**
  * A mock implementation of Open Telemetry Span for testing.
  */
-class MockSpan() : Span {
+class MockSpan : Span {
 
     var isStarted = true
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/mock/MockTracer.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/mock/MockTracer.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit
  * A mock implementation of the OpenTelemetry Tracer interface for testing.
  * This class creates MockSpanBuilder instances that can create MockSpan instances.
  */
-class MockTracer() : Tracer {
+class MockTracer : Tracer {
     val createdSpans = mutableListOf<MockSpan>()
 
     override fun spanBuilder(spanName: String): SpanBuilder {


### PR DESCRIPTION
[KG-622](https://youtrack.jetbrains.com/issue/KG-622/Configure-ability-to-flush-spans-on-every-span-end). 

- Change the default span processor for OTel from Simple to Batch span processor implementation;
- Add logic to wait for flushing all spans when agent is finished;
- Update tests.

## Motivation and Context
Update the default span processor for open telemetry to follow the common standards.

## Breaking Changes
No

---

#### Type of the changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [x] The change was discussed and approved in the issue
- [x] Docs have been added / updated
