### PR TITLE
[examples] Add CI checks for code agent examples

### DIFF
--- a/.github/workflows/code-agent-examples.yml
+++ b/.github/workflows/code-agent-examples.yml
@@ -1,0 +1,62 @@
+name: Code Agent Examples
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main", "develop" ]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Cancel only when the run is not on main or develop
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
+
+env:
+  JAVA_VERSION: 17
+  JAVA_DISTRIBUTION: 'corretto'
+
+jobs:
+  compilation:
+    name: Compile ${{ matrix.step }}
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        step:
+          - step-01-minimal-agent
+          - step-02-add-execution-tool
+          - step-03-add-observability
+          - step-04-add-subagent
+
+    steps:
+      - name: Configure Git
+        run: |
+          git config --global core.autocrlf input
+      - uses: actions/checkout@v5
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          cache: gradle
+
+      # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
+      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          # Cache downloaded JDKs/konan in addition to the default directories.
+          gradle-home-cache-includes: |
+            caches
+            notifications
+            jdks
+            ~/.konan/**
+
+      - name: Compile
+        working-directory: ./examples/code-agent/${{ matrix.step }}
+        run: ./gradlew assemble testClasses --stacktrace
+        env:
+          JAVA_OPTS: "-Xmx8g -Dfile.encoding=UTF-8 -Djava.awt.headless=true -Dkotlin.daemon.jvm.options=-Xmx6g"


### PR DESCRIPTION
Since Code Agent examples depend on the actual Koog sources using Gradle's composite builds (just like `simple-examples`), changes in Koog might break these examples. Added a new CI configuration to check Code Agent compilation on PRs and pushes to `develop`