### PR TITLE
Parse tool usage in Bedrock Anthropic streaming

### DIFF
--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
@@ -1132,10 +1132,6 @@ abstract class ExecutorIntegrationTestBase {
             model.provider !== LLMProvider.OpenRouter,
             "KG-626 Error from OpenRouter on a streaming with a tool call"
         )
-        assumeTrue(
-            model.provider !== LLMProvider.Bedrock,
-            "KG-627 Error from Bedrock executor on a streaming with a tool call"
-        )
 
         val executor = getExecutor(model)
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
@@ -54,6 +54,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.withContext
@@ -319,40 +320,57 @@ public class BedrockLLMClient(
                 logger.error(exception) { exception.message }
                 close(exception)
             }
-        }.map { chunkJsonString ->
+        }.filterNot {
+            it.isBlank()
+        }.run {
+            when (modelFamily) {
+                is BedrockModelFamilies.AI21Jamba -> genericProcessStream(
+                    this,
+                    BedrockAI21JambaSerialization::parseJambaStreamChunk
+                )
+
+                is BedrockModelFamilies.AmazonNova -> genericProcessStream(
+                    this,
+                    BedrockAmazonNovaSerialization::parseNovaStreamChunk
+                )
+
+                is BedrockModelFamilies.Meta -> genericProcessStream(
+                    this,
+                    BedrockMetaLlamaSerialization::parseLlamaStreamChunk
+                )
+
+                is BedrockModelFamilies.AnthropicClaude -> BedrockAnthropicClaudeSerialization.transformAnthropicStreamChunks(
+                    chunkJsonStringFlow = this,
+                    clock = clock,
+                )
+
+                is BedrockModelFamilies.TitanEmbedding, is BedrockModelFamilies.Cohere ->
+                    throw LLMClientException(
+                        clientName,
+                        "Embedding models do not support streaming chat completions. Use embed() instead."
+                    )
+            }
+        }
+    }
+
+    /**
+     * Processes a flow of JSON strings into StreamFrames using the provided processor function.
+     * Handles exceptions by logging and re-throwing them.
+     */
+    private fun genericProcessStream(
+        chunkJsonStringFlow: Flow<String>,
+        processor: (String) -> List<StreamFrame>
+    ): Flow<StreamFrame> =
+        chunkJsonStringFlow.map { chunkJsonString ->
             try {
-                if (chunkJsonString.isBlank()) return@map emptyList()
-                when (modelFamily) {
-                    is BedrockModelFamilies.AI21Jamba -> BedrockAI21JambaSerialization.parseJambaStreamChunk(
-                        chunkJsonString
-                    )
-
-                    is BedrockModelFamilies.AmazonNova -> BedrockAmazonNovaSerialization.parseNovaStreamChunk(
-                        chunkJsonString
-                    )
-
-                    is BedrockModelFamilies.AnthropicClaude -> BedrockAnthropicClaudeSerialization.parseAnthropicStreamChunk(
-                        chunkJsonString
-                    )
-
-                    is BedrockModelFamilies.Meta -> BedrockMetaLlamaSerialization.parseLlamaStreamChunk(chunkJsonString)
-
-                    is BedrockModelFamilies.TitanEmbedding, is BedrockModelFamilies.Cohere ->
-                        throw LLMClientException(
-                            clientName,
-                            "Embedding models do not support streaming chat completions. Use embed() instead."
-                        )
-                }
+                processor(chunkJsonString)
             } catch (e: Exception) {
                 logger.warn(e) { "Failed to parse Bedrock stream chunk: $chunkJsonString" }
                 throw e
             }
         }.transform { frames ->
-            frames.forEach {
-                emit(it)
-            }
+            frames.forEach { emit(it) }
         }
-    }
 
     override suspend fun embed(text: String, model: LLModel): List<Double> {
         model.requireCapability(LLMCapability.Embed)

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/BedrockDataClasses.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/BedrockDataClasses.kt
@@ -5,7 +5,6 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNames
 import kotlinx.serialization.json.JsonObject
 
 /**
@@ -205,7 +204,7 @@ public data class BedrockAnthropicResponse(
     val role: String,
     val content: List<AnthropicContent>,
     val model: String,
-    @JsonNames("stop_reason") val stopReason: String? = null,
+    val stopReason: String? = null,
     val usage: BedrockAnthropicUsage? = null
 )
 
@@ -220,6 +219,6 @@ public data class BedrockAnthropicResponse(
  */
 @Serializable
 public data class BedrockAnthropicUsage(
-    @SerialName("input_tokens") @JsonNames("inputTokens", "input_tokens") val inputTokens: Int,
-    @SerialName("output_tokens") @JsonNames("outputTokens", "output_tokens") val outputTokens: Int
+    val inputTokens: Int,
+    val outputTokens: Int
 )


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

Please add a brief description of the proposed change here.
Also, please tick the appropriate points in the checklist below.
-->
Updates how Bedrock Anthropic responses are parsed to include tool usage. It reuses the logic from the Anthropic LLM client. As a result, this PR also has a couple of additional effects:
- Enforcing snake case for properties in Bedrock Anthropic responses
- Changes how other non-Anthropic Bedrock providers are handled

One thing I noticed is that the Bedrock Anthropic implementation uses a mix of data classes from its own implementation and from `prompt-executor-anthropic-client` for requests and responses. As a follow-up, another pass on what needs to be separate and what can be re-used from the Anthropic module should be done.

This should resolve [KG-627](https://youtrack.jetbrains.com/issue/KG-627/Error-from-Bedrock-executor-on-a-streaming-with-a-tool-call).
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Tool usage is missing when using Anthropic models with streaming in Bedrock.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [x] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [ ] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
