### PR TITLE
Heuristic required tool choice

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentSubgraph.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentSubgraph.kt
@@ -170,7 +170,7 @@ public open class AIAgentSubgraph<TInput, TOutput>(
                         tools = newTools,
                         model = llmModel ?: context.llm.model,
                         prompt = context.llm.prompt.copy(params = llmParams ?: context.llm.prompt.params),
-                        responseProcessor = responseProcessor
+                        responseProcessor = responseProcessor ?: context.llm.responseProcessor,
                     ),
                 ),
             )

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMSession.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMSession.kt
@@ -107,7 +107,7 @@ public open class AIAgentLLMSession(
         val promptWithOnlyCallingTools = preparePromptWithToolChoice(LLMParams.ToolChoice.Required)
         val responses = executeMultiple(promptWithOnlyCallingTools, tools)
         return responses.firstOrNull { it is Message.Tool.Call }
-            ?: error("requestLLMOnlyCallingTools expected at least one Tool.Call but received: ${responses.map { it::class.simpleName }}")
+            ?: responses.first { it !is Message.Reasoning }
     }
 
     public open override suspend fun requestLLMMultipleOnlyCallingTools(): List<Message.Response> {

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMSession.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMSession.kt
@@ -95,31 +95,33 @@ public open class AIAgentLLMSession(
         return executeMultiple(promptWithDisabledTools, emptyList()).first { it !is Message.Reasoning }
     }
 
-    private fun preparePromptWithToolChoice(toolChoice: LLMParams.ToolChoice) =
-        prompt.withUpdatedParams {
-            this.toolChoice = toolChoice
-        }
-
     public open override suspend fun requestLLMOnlyCallingTools(): Message.Response {
         validateSession()
-        // We use the multiple-response method to ensure we capture all context (e.g. thinking)
-        // even though we only return the specific tool call.
-        val promptWithOnlyCallingTools = preparePromptWithToolChoice(LLMParams.ToolChoice.Required)
+        val promptWithOnlyCallingTools = prompt.withUpdatedParams {
+            toolChoice = LLMParams.ToolChoice.Required
+        }
         val responses = executeMultiple(promptWithOnlyCallingTools, tools)
+
+        // some models might fail to produce a tool call
+        // it's better to not fail here and allow the user to handle that
         return responses.firstOrNull { it is Message.Tool.Call }
-            ?: responses.first { it !is Message.Reasoning }
+            ?: responses.first { it is Message.Assistant }
     }
 
     public open override suspend fun requestLLMMultipleOnlyCallingTools(): List<Message.Response> {
         validateSession()
-        val promptWithOnlyCallingTools = preparePromptWithToolChoice(LLMParams.ToolChoice.Required)
+        val promptWithOnlyCallingTools = prompt.withUpdatedParams {
+            toolChoice = LLMParams.ToolChoice.Required
+        }
         return executeMultiple(promptWithOnlyCallingTools, tools)
     }
 
     public open override suspend fun requestLLMForceOneTool(tool: ToolDescriptor): Message.Response {
         validateSession()
         check(tools.contains(tool)) { "Unable to force call to tool `${tool.name}` because it is not defined" }
-        val promptWithForcingOneTool = preparePromptWithToolChoice(LLMParams.ToolChoice.Named(tool.name))
+        val promptWithForcingOneTool = prompt.withUpdatedParams {
+            toolChoice = LLMParams.ToolChoice.Named(tool.name)
+        }
         return executeSingle(promptWithForcingOneTool, tools)
     }
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMSession.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMSession.kt
@@ -16,6 +16,7 @@ import ai.koog.prompt.message.LLMChoice
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.processor.ResponseProcessor
+import ai.koog.prompt.processor.executeProcessed
 import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.structure.StructureFixingParser
 import ai.koog.prompt.structure.StructuredRequestConfig
@@ -64,7 +65,7 @@ public open class AIAgentLLMSession(
     @InternalAgentsApi
     public open override suspend fun executeMultiple(prompt: Prompt, tools: List<ToolDescriptor>): List<Message.Response> {
         val preparedPrompt = preparePrompt(prompt, tools)
-        return executor.execute(preparedPrompt, model, tools)
+        return executor.executeProcessed(preparedPrompt, model, tools, responseProcessor)
     }
 
     @InternalAgentsApi
@@ -94,29 +95,31 @@ public open class AIAgentLLMSession(
         return executeMultiple(promptWithDisabledTools, emptyList()).first { it !is Message.Reasoning }
     }
 
+    private fun preparePromptWithToolChoice(toolChoice: LLMParams.ToolChoice) =
+        prompt.withUpdatedParams {
+            this.toolChoice = toolChoice
+        }
+
     public open override suspend fun requestLLMOnlyCallingTools(): Message.Response {
         validateSession()
         // We use the multiple-response method to ensure we capture all context (e.g. thinking)
         // even though we only return the specific tool call.
-        val responses = requestLLMMultipleOnlyCallingTools()
+        val promptWithOnlyCallingTools = preparePromptWithToolChoice(LLMParams.ToolChoice.Required)
+        val responses = executeMultiple(promptWithOnlyCallingTools, tools)
         return responses.firstOrNull { it is Message.Tool.Call }
             ?: error("requestLLMOnlyCallingTools expected at least one Tool.Call but received: ${responses.map { it::class.simpleName }}")
     }
 
     public open override suspend fun requestLLMMultipleOnlyCallingTools(): List<Message.Response> {
         validateSession()
-        val promptWithOnlyCallingTools = prompt.withUpdatedParams {
-            toolChoice = LLMParams.ToolChoice.Required
-        }
+        val promptWithOnlyCallingTools = preparePromptWithToolChoice(LLMParams.ToolChoice.Required)
         return executeMultiple(promptWithOnlyCallingTools, tools)
     }
 
     public open override suspend fun requestLLMForceOneTool(tool: ToolDescriptor): Message.Response {
         validateSession()
         check(tools.contains(tool)) { "Unable to force call to tool `${tool.name}` because it is not defined" }
-        val promptWithForcingOneTool = prompt.withUpdatedParams {
-            toolChoice = LLMParams.ToolChoice.Named(tool.name)
-        }
+        val promptWithForcingOneTool = preparePromptWithToolChoice(LLMParams.ToolChoice.Named(tool.name))
         return executeSingle(promptWithForcingOneTool, tools)
     }
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionImpl.kt
@@ -96,6 +96,11 @@ internal class AIAgentLLMWriteSessionImpl internal constructor(
         return super<AIAgentLLMSession>.requestLLMWithoutTools().also { response -> appendPrompt { message(response) } }
     }
 
+    override suspend fun requestLLMOnlyCallingTools(): Message.Response {
+        return super<AIAgentLLMSession>.requestLLMOnlyCallingTools()
+            .also { response -> appendPrompt { message(response) } }
+    }
+
     override suspend fun requestLLMMultipleOnlyCallingTools(): List<Message.Response> {
         return super<AIAgentLLMSession>.requestLLMMultipleOnlyCallingTools()
             .also { responses ->

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
@@ -82,7 +82,7 @@ public inline fun <reified T> AIAgentSubgraphBuilderBase<*, *>.nodeUpdatePrompt(
  * @param name Optional name for the node.
  */
 @AIAgentBuilderDslMarker
-public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMSendMessageOnlyCallingTools(
+public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMRequestOnlyCallingTools(
     name: String? = null
 ): AIAgentNodeDelegate<String, Message.Response> =
     node(name) { message ->
@@ -96,13 +96,47 @@ public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMSendMessageOnlyCallingTools(
     }
 
 /**
+ * A node that appends a user message to the LLM prompt and gets a response where the LLM can only call tools.
+ *
+ * @param name Optional name for the node.
+ */
+@Deprecated(
+    "Please use nodeLLMRequestOnlyCallingTools instead.",
+    ReplaceWith("nodeLLMRequestOnlyCallingTools(name)")
+)
+@AIAgentBuilderDslMarker
+public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMSendMessageOnlyCallingTools(
+    name: String? = null
+): AIAgentNodeDelegate<String, Message.Response> =
+    nodeLLMRequestOnlyCallingTools(name)
+
+/**
+ * A node that appends a user message to the LLM prompt and gets multiple LLM responses where the LLM can only call tools.
+ *
+ * @param name Optional name for the node.
+ */
+@AIAgentBuilderDslMarker
+public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMRequestMultipleOnlyCallingTools(
+    name: String? = null
+): AIAgentNodeDelegate<String, List<Message.Response>> =
+    node(name) { message ->
+        llm.writeSession {
+            appendPrompt {
+                user(message)
+            }
+
+            requestLLMMultipleOnlyCallingTools()
+        }
+    }
+
+/**
  * A node that that appends a user message to the LLM prompt and forces the LLM to use a specific tool.
  *
  * @param name Optional node name.
  * @param tool Tool descriptor the LLM is required to use.
  */
 @AIAgentBuilderDslMarker
-public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMSendMessageForceOneTool(
+public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMRequestForceOneTool(
     name: String? = null,
     tool: ToolDescriptor
 ): AIAgentNodeDelegate<String, Message.Response> =
@@ -117,17 +151,51 @@ public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMSendMessageForceOneTool(
     }
 
 /**
+ * A node that that appends a user message to the LLM prompt and forces the LLM to use a specific tool.
+ *
+ * @param name Optional node name.
+ * @param tool Tool descriptor the LLM is required to use.
+ */
+@Deprecated(
+    "Please use nodeLLMRequestForceOneTool instead.",
+    ReplaceWith("nodeLLMRequestForceOneTool(name, tool)")
+)
+@AIAgentBuilderDslMarker
+public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMSendMessageForceOneTool(
+    name: String? = null,
+    tool: ToolDescriptor
+): AIAgentNodeDelegate<String, Message.Response> =
+    nodeLLMRequestForceOneTool(name, tool)
+
+/**
  * A node that appends a user message to the LLM prompt and forces the LLM to use a specific tool.
  *
  * @param name Optional node name.
  * @param tool Tool the LLM is required to use.
  */
 @AIAgentBuilderDslMarker
+public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMRequestForceOneTool(
+    name: String? = null,
+    tool: Tool<*, *>
+): AIAgentNodeDelegate<String, Message.Response> =
+    nodeLLMRequestForceOneTool(name, tool.descriptor)
+
+/**
+ * A node that appends a user message to the LLM prompt and forces the LLM to use a specific tool.
+ *
+ * @param name Optional node name.
+ * @param tool Tool the LLM is required to use.
+ */
+@Deprecated(
+    "Please use nodeLLMRequestForceOneTool instead.",
+    ReplaceWith("nodeLLMRequestForceOneTool(name, tool)")
+)
+@AIAgentBuilderDslMarker
 public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMSendMessageForceOneTool(
     name: String? = null,
     tool: Tool<*, *>
 ): AIAgentNodeDelegate<String, Message.Response> =
-    nodeLLMSendMessageForceOneTool(name, tool.descriptor)
+    nodeLLMRequestForceOneTool(name, tool)
 
 /**
  * A node that appends a user message to the LLM prompt and gets a response with optional tool usage.
@@ -408,6 +476,27 @@ public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMSendToolResult(
     }
 
 /**
+ * A node that adds a tool result to the prompt and gets an LLM response where the LLM can only call tools.
+ *
+ * @param name Optional node name.
+ */
+@AIAgentBuilderDslMarker
+public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMSendToolResultOnlyCallingTools(
+    name: String? = null
+): AIAgentNodeDelegate<List<ReceivedToolResult>, Message.Response> =
+    node(name) { results ->
+        llm.writeSession {
+            appendPrompt {
+                tool {
+                    results.forEach { result(it) }
+                }
+            }
+
+            requestLLMOnlyCallingTools()
+        }
+    }
+
+/**
  * A node that executes multiple tool calls. These calls can optionally be executed in parallel.
  *
  * @param name Optional node name.
@@ -478,6 +567,27 @@ public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMSendMultipleToolResults(
             }
 
             requestLLMMultiple()
+        }
+    }
+
+/**
+ * A node that adds multiple tool results to the prompt and gets multiple LLM responses where the LLM can only call tools.
+ *
+ * @param name Optional node name.
+ */
+@AIAgentBuilderDslMarker
+public fun AIAgentSubgraphBuilderBase<*, *>.nodeLLMSendMultipleToolResultsOnlyCallingTools(
+    name: String? = null
+): AIAgentNodeDelegate<List<ReceivedToolResult>, List<Message.Response>> =
+    node(name) { results ->
+        llm.writeSession {
+            appendPrompt {
+                tool {
+                    results.forEach { result(it) }
+                }
+            }
+
+            requestLLMMultipleOnlyCallingTools()
         }
     }
 

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionTest.kt
@@ -395,7 +395,10 @@ class AIAgentLLMWriteSessionTest {
     }
 
     @Test
-    // This behavior is not supported yet.
+    // This behavior is not supported for non-list responses from "requestLLM..." methods
+    // The test was passing due to a bug in the requestLLMOnlyCallingTools implementation
+    // See KG-663
+    // TODO(): remove the test after deprecating non-list responses from LLM
     @Ignore
     fun testRequestLLMOnlyCallingToolsWithThinking() = runTest {
         val thinkingContent = "<thinking>Checking file...</thinking>"

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionTest.kt
@@ -423,31 +423,6 @@ class AIAgentLLMWriteSessionTest {
     }
 
     @Test
-    fun testRequestLLMOnlyCallingToolsNoToolCallThrowsException() = runTest {
-        val mockExecutor = getMockExecutor(clock = testClock) {
-            // Simulate model refusing to use tools and just responding with text
-            mockLLMAnswer("I cannot use tools for this request.").asDefaultResponse
-        }
-
-        val session = createSession(mockExecutor, listOf(TestTool()))
-
-        val exception = kotlin.runCatching {
-            session.requestLLMOnlyCallingTools()
-        }.exceptionOrNull()
-
-        assertNotNull(exception, "Expected an exception when no tool call is found")
-        assertTrue(
-            exception is IllegalStateException,
-            "Expected IllegalStateException but got ${exception::class.simpleName}"
-        )
-        assertEquals(
-            exception.message?.contains("expected at least one Tool.Call"),
-            true,
-            "Exception message should indicate missing tool call"
-        )
-    }
-
-    @Test
     fun testRequestLLMOnlyCallingToolsWithMultipleToolCalls() = runTest {
         val testTool = TestTool()
 

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionTest.kt
@@ -26,8 +26,11 @@ import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.processor.ResponseProcessor
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
+import kotlin.test.Ignore
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -392,6 +395,8 @@ class AIAgentLLMWriteSessionTest {
     }
 
     @Test
+    // This behavior is not supported yet.
+    @Ignore
     fun testRequestLLMOnlyCallingToolsWithThinking() = runTest {
         val thinkingContent = "<thinking>Checking file...</thinking>"
         val testTool = TestTool()
@@ -435,8 +440,9 @@ class AIAgentLLMWriteSessionTest {
             exception is IllegalStateException,
             "Expected IllegalStateException but got ${exception::class.simpleName}"
         )
-        assertTrue(
-            exception.message?.contains("expected at least one Tool.Call") == true,
+        assertEquals(
+            exception.message?.contains("expected at least one Tool.Call"),
+            true,
             "Exception message should indicate missing tool call"
         )
     }
@@ -464,8 +470,9 @@ class AIAgentLLMWriteSessionTest {
         assertTrue(response is Message.Tool.Call, "Expected response to be a Tool Call")
         assertEquals("test-tool", response.tool)
 
-        // Both tool calls should be in history
-        val lastTwoMessages = session.prompt.messages.takeLast(2)
-        assertTrue(lastTwoMessages.all { it is Message.Tool.Call })
+        // Only the first tool call should be added to the history
+        val lastMessage = session.prompt.messages.last()
+        assertIs<Message.Tool.Call>(lastMessage)
+        assertContains(lastMessage.content, "first")
     }
 }

--- a/prompt/prompt-processor/src/commonMain/kotlin/ai/koog/prompt/processor/Prompts.kt
+++ b/prompt/prompt-processor/src/commonMain/kotlin/ai/koog/prompt/processor/Prompts.kt
@@ -98,6 +98,13 @@ internal object Prompts {
                 item("Incorrect json formatting in tool call json: unescaped characters, missing quotes, etc.")
             }
 
+            h2("SPECIAL TOOLS")
+            +"Pay attention to the special tools. For example:"
+            bulleted {
+                item("A finish tool: if a user provided a tool to finish the subgraph, you need to call this tool when the task is completed")
+                item("A chat tool: if a user provided a tool for chatting, you need to call this tool to send a message to the chat")
+            }
+
             h2("Available tools")
             showTools(tools)
         }


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

Please add a brief description of the proposed change here.
Also, please tick the appropriate points in the checklist below.
-->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Models without the tool choice capability (e.g. most of the ollama models) cannot rely on the `toolChoice` in the model api. This makes some workflows inconsistent, in particular, `subgraphWithTask` does not work with such models since it relies on the `toolChoice` parameter. This pr introduces a workaround for this issue using `LLMBasedToolCallFixProcessor`, which now will use prompts to force LLM to generate a tool when the `toolChoice` is set to `Required`.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [x] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
