### PR TITLE
tests: Refactor A2A test, bump Testcontainers, improve Awaitility extension & tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,6 +20,8 @@ Also, please tick the appropriate points in the checklist below.
 - [ ] Documentation update
 - [ ] Tests improvement
 - [ ] Refactoring
+- [ ] CI/CD changes
+- [ ] Dependencies update
 
 #### Checklist
 - [ ] The pull request has a description of the proposed change

--- a/a2a/a2a-client/build.gradle.kts
+++ b/a2a/a2a-client/build.gradle.kts
@@ -1,7 +1,4 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
-import org.gradle.internal.os.OperatingSystem
-import org.gradle.kotlin.dsl.support.serviceOf
-import java.io.ByteArrayOutputStream
 
 group = rootProject.group
 version = rootProject.version
@@ -41,7 +38,7 @@ kotlin {
 
                 implementation(libs.ktor.client.cio)
                 implementation(libs.ktor.client.logging)
-                implementation(libs.testcontainers.junit)
+                implementation(libs.testcontainers)
                 runtimeOnly(libs.logback.classic)
             }
         }
@@ -57,36 +54,3 @@ kotlin {
 }
 
 publishToMaven()
-
-tasks.register<Exec>("dockerBuildTestPythonA2AServer") {
-    group = "docker"
-    description = "Build Python A2A test server image"
-    workingDir = file("../test-python-a2a-server")
-    commandLine = listOf("docker", "build", "-t", "test-python-a2a-server", ".")
-
-    onlyIf {
-        // do not attempt to check for docker on windows
-        if (OperatingSystem.current().isWindows) {
-            return@onlyIf false
-        }
-
-        try {
-            val buffer = ByteArrayOutputStream()
-
-            serviceOf<ExecOperations>().exec {
-                commandLine = listOf("docker", "--version")
-                standardOutput = buffer
-                errorOutput = buffer
-            }
-
-            true
-        } catch (_: Exception) {
-            logger.warn("Docker not available. Skipping task 'dockerBuildTestPythonA2AServer'")
-
-            false
-        }
-    }
-}
-tasks.named("jvmTest") {
-    dependsOn("dockerBuildTestPythonA2AServer")
-}

--- a/a2a/a2a-client/src/jvmTest/kotlin/ai/koog/a2a/client/TestA2AServerContainer.kt
+++ b/a2a/a2a-client/src/jvmTest/kotlin/ai/koog/a2a/client/TestA2AServerContainer.kt
@@ -1,0 +1,57 @@
+package ai.koog.a2a.client
+
+import org.slf4j.LoggerFactory
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.output.Slf4jLogConsumer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.images.builder.ImageFromDockerfile
+import kotlin.io.path.Path
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+/**
+ * Object representing a Dockerized test server for Python-based A2A (Agent-to-Agent) communication.
+ * This server is instantiated using Testcontainers and is primarily utilized for integration testing
+ * purposes, such as validating JSON-RPC HTTP communication in an A2A client context.
+ *
+ * The server is built from a Dockerfile located in the `../test-python-a2a-server` directory and runs
+ * on a predefined exposed port. It provides runtime flexibility to inspect the server's dynamically
+ * assigned host and port.
+ *
+ * This `object` ensures the server is only started once for use in test environments, with the
+ * capability of shutting it down after the tests are completed.
+ *
+ * The server should be initialized before tests, retrieving its host and port, and
+ * using them to configure a test client.
+ */
+object TestA2AServerContainer {
+
+    private const val EXPOSED_PORT = 9999
+    private val STARTUP_TIMEOUT = 20.seconds.toJavaDuration()
+
+    private val image =
+        ImageFromDockerfile("test-python-a2a-server:latest", false) // "false" prevents deleting intermediate images
+            .withFileFromPath(".", Path("../test-python-a2a-server")) // Specify Dockerfile context path
+    private val container: GenericContainer<*> =
+        GenericContainer(image)
+            .withTmpFs(mapOf("/tmp" to "rw,noexec,size=16m"))
+            .withExposedPorts(EXPOSED_PORT)
+            .withReuse(true)
+            .waitingFor(Wait.forListeningPort())
+            .withLogConsumer(Slf4jLogConsumer(LoggerFactory.getLogger(TestA2AServerContainer::class.java)))
+            .withStartupTimeout(STARTUP_TIMEOUT)
+
+    init {
+        container.start()
+    }
+
+    fun shutdown() = runCatching { container.stop() }
+
+    val host: String by lazy {
+        container.host
+    }
+
+    val port: Int by lazy {
+        container.getMappedPort(EXPOSED_PORT)
+    }
+}

--- a/a2a/test-python-a2a-server/pyproject.toml
+++ b/a2a/test-python-a2a-server/pyproject.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 description = "Python A2A server for integration tests."
 requires-python = ">=3.12"
 dependencies = [
-    "a2a-sdk[http-server]==0.3.5",
+    "a2a-sdk[http-server]==0.3.22",
     "uvicorn==0.35.0",
 ]

--- a/a2a/test-python-a2a-server/uv.lock
+++ b/a2a/test-python-a2a-server/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "a2a-sdk"
-version = "0.3.5"
+version = "0.3.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
@@ -17,9 +17,9 @@ dependencies = [
     { name = "protobuf" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/0d/12ebef081b096ca5fafd1ec8cc589739abba07b46ae7899c7420e599f2a6/a2a_sdk-0.3.5.tar.gz", hash = "sha256:48cf37dedeb63cf0a072512221a12ed4b3950df695c9d65eadb839a99392c3e5", size = 222064, upload-time = "2025-09-08T17:30:35.826Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/a3/76f2d94a32a1b0dc760432d893a09ec5ed31de5ad51b1ef0f9d199ceb260/a2a_sdk-0.3.22.tar.gz", hash = "sha256:77a5694bfc4f26679c11b70c7f1062522206d430b34bc1215cfbb1eba67b7e7d", size = 231535, upload-time = "2025-12-16T18:39:21.19Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/96/c33802d929b0f884cb6e509195d69914632536256d273bd7127e900d79ea/a2a_sdk-0.3.5-py3-none-any.whl", hash = "sha256:fd85b1e4e7be18a89b5d723e4013171510150a235275876f98de9e1ba869457e", size = 136911, upload-time = "2025-09-08T17:30:34.091Z" },
+    { url = "https://files.pythonhosted.org/packages/64/e8/f4e39fd1cf0b3c4537b974637143f3ebfe1158dad7232d9eef15666a81ba/a2a_sdk-0.3.22-py3-none-any.whl", hash = "sha256:b98701135bb90b0ff85d35f31533b6b7a299bf810658c1c65f3814a6c15ea385", size = 144347, upload-time = "2025-12-16T18:39:19.218Z" },
 ]
 
 [package.optional-dependencies]
@@ -420,7 +420,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", extras = ["http-server"], specifier = "==0.3.5" },
+    { name = "a2a-sdk", extras = ["http-server"], specifier = "==0.3.22" },
     { name = "uvicorn", specifier = "==0.35.0" },
 ]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ mockito = "5.21.0"
 mockk = "1.14.7"
 mokksy = "0.5.1"
 mysql = "8.0.33"
-netty = "4.2.6.Final"
+netty = "4.2.9.Final"
 okhttp = "5.3.2"
 opentelemetry = "1.51.0"
 oshai-logging = "7.0.7"
@@ -38,7 +38,7 @@ slf4j = "2.0.17"
 spring-boot = "3.5.9"
 spring-management = "1.1.7"
 sqlite = "3.51.1.0"
-testcontainers = "1.19.7"
+testcontainers = "1.21.4"
 
 [libraries]
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "annotations" }
@@ -90,7 +90,6 @@ mcp-server = { module = "io.modelcontextprotocol:kotlin-sdk-server", version.ref
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 jetsign-gradle-plugin = { module = "com.jetbrains:jet-sign", version.ref = "jetsign" }
 testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
-testcontainers-junit = { module = "org.testcontainers:junit-jupiter", version.ref = "testcontainers" }
 testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "testcontainers" }
 testcontainers-mysql = { module = "org.testcontainers:mysql", version.ref = "testcontainers" }
 exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }

--- a/test-utils/src/jvmMain/kotlin/ai/koog/test/utils/AwaitilityExtensions.kt
+++ b/test-utils/src/jvmMain/kotlin/ai/koog/test/utils/AwaitilityExtensions.kt
@@ -3,50 +3,65 @@ package ai.koog.test.utils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
 import org.awaitility.core.ConditionFactory
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.coroutines.ContinuationInterceptor
 import kotlin.time.Duration
 import kotlin.time.toJavaDuration
 
 /**
- * Repeatedly evaluates the given block until it does not throw any exceptions,
- * providing support for asynchronous or coroutine-based operations. This method
- * is particularly helpful in cases where conditions are expected to eventually
+ * Repeatedly evaluates the given [block] until it does not throw any exceptions.
+ *
+ * This method is particularly helpful in cases where conditions are expected to eventually
  * become true due to the nature of concurrent or delayed behavior.
+ *
+ * This version allows providing a [scope] to inherit the coroutine context. It automatically
+ * removes the [ContinuationInterceptor] to prevent deadlocks when used within `runTest`.
  *
  * @param scope The [CoroutineScope] used to provide the context for the suspendable block.
  * @param block A suspendable lambda function containing the assertions or conditions to be verified.
+ * @return The result of the [block] when it successfully completes without throwing an exception.
  */
-public fun ConditionFactory.untilAsserted(scope: CoroutineScope, block: suspend () -> Unit) {
-    val self: ConditionFactory = this
-    self.untilAsserted {
-        runBlocking(scope.coroutineContext.minusKey(ContinuationInterceptor)) {
-            block()
-        }
+@OptIn(ExperimentalAtomicApi::class)
+public fun <T> ConditionFactory.untilAsserted(scope: CoroutineScope, block: suspend () -> T?): T? {
+    val result = AtomicReference<T?>(null)
+    untilAsserted {
+        result.store(
+            runBlocking(scope.coroutineContext.minusKey(ContinuationInterceptor)) {
+                block()
+            }
+        )
     }
+    return result.load()
 }
 
 /**
- * Repeatedly evaluates the given block until it does not throw any exceptions.
+ * Repeatedly evaluates the given [block] until it does not throw any exceptions.
+ *
  * This method is useful for asserting conditions that may eventually become true,
  * particularly in scenarios involving asynchronous or concurrent operations.
  *
  * @param block A suspendable lambda function containing the assertions or conditions to be verified.
+ * @return The result of the [block] when it successfully completes without throwing an exception.
  */
-public fun ConditionFactory.untilAsserted(block: suspend () -> Unit) {
-    val self: ConditionFactory = this
-    self.untilAsserted {
-        runBlocking {
-            block()
-        }
+@OptIn(ExperimentalAtomicApi::class)
+public fun <T> ConditionFactory.untilAsserted(block: suspend () -> T?): T? {
+    val result = AtomicReference<T?>(null)
+    untilAsserted {
+        result.store(
+            runBlocking {
+                block()
+            }
+        )
     }
+    return result.load()
 }
 
 /**
- * Repeatedly evaluates the given block until it does not throw any exceptions.
- * This method is useful for asserting conditions that may eventually become true,
- * particularly in scenarios involving asynchronous or concurrent operations.
+ * Sets the maximum duration to wait for the condition to be satisfied.
  *
- * @param block A suspendable lambda function containing the assertions or conditions to be verified.
+ * @param duration The maximum duration as a Kotlin [Duration].
+ * @return The updated [ConditionFactory] instance.
  */
 public fun ConditionFactory.atMost(duration: Duration): ConditionFactory =
     this.atMost(duration.toJavaDuration())
@@ -54,8 +69,8 @@ public fun ConditionFactory.atMost(duration: Duration): ConditionFactory =
 /**
  * Specifies the minimum amount of time that the condition should be evaluated for.
  *
- * @param duration The minimum duration to evaluate the condition, represented as a [Duration].
- * @return The updated [ConditionFactory] instance with the specified minimum duration applied.
+ * @param duration The minimum duration to evaluate the condition as a Kotlin [Duration].
+ * @return The updated [ConditionFactory] instance.
  */
 public fun ConditionFactory.atLeast(duration: Duration): ConditionFactory =
     this.atLeast(duration.toJavaDuration())
@@ -63,8 +78,8 @@ public fun ConditionFactory.atLeast(duration: Duration): ConditionFactory =
 /**
  * Specifies the delay before polling begins when evaluating a condition.
  *
- * @param duration The duration to wait before the first polling attempt, represented as a [Duration].
- * @return The updated [ConditionFactory] instance with the specified polling delay applied.
+ * @param duration The duration to wait before the first polling attempt as a Kotlin [Duration].
+ * @return The updated [ConditionFactory] instance.
  */
 public fun ConditionFactory.pollDelay(duration: Duration): ConditionFactory =
     this.pollDelay(duration.toJavaDuration())
@@ -72,8 +87,8 @@ public fun ConditionFactory.pollDelay(duration: Duration): ConditionFactory =
 /**
  * Specifies the interval between consecutive polling attempts when evaluating a condition.
  *
- * @param duration The interval duration between polling attempts, represented as a [Duration].
- * @return The updated [ConditionFactory] instance with the specified polling interval applied.
+ * @param duration The interval duration between polling attempts as a Kotlin [Duration].
+ * @return The updated [ConditionFactory] instance.
  */
 public fun ConditionFactory.pollInterval(duration: Duration): ConditionFactory =
     this.pollInterval(duration.toJavaDuration())

--- a/test-utils/src/jvmMain/kotlin/ai/koog/test/utils/DockerAvailableCondition.kt
+++ b/test-utils/src/jvmMain/kotlin/ai/koog/test/utils/DockerAvailableCondition.kt
@@ -9,12 +9,17 @@ import org.testcontainers.DockerClientFactory
  * Helper test condition method to skip test suite if Docker is not available.
  */
 public class DockerAvailableCondition : ExecutionCondition {
-    override fun evaluateExecutionCondition(context: ExtensionContext): ConditionEvaluationResult {
-        return try {
-            DockerClientFactory.instance().client()
-            ConditionEvaluationResult.enabled("Docker is available")
-        } catch (e: Exception) {
-            ConditionEvaluationResult.disabled("Docker is not available, skipping this test")
+
+    private companion object {
+        private val isAvailable: ConditionEvaluationResult by lazy {
+            try {
+                DockerClientFactory.instance().client()
+                ConditionEvaluationResult.enabled("Docker is available")
+            } catch (_: Exception) {
+                ConditionEvaluationResult.disabled("Docker is not available, skipping this test")
+            }
         }
     }
+
+    override fun evaluateExecutionCondition(context: ExtensionContext): ConditionEvaluationResult = isAvailable
 }

--- a/test-utils/src/jvmTest/kotlin/ai/koog/test/utils/AwaitilityExtensionsTest.kt
+++ b/test-utils/src/jvmTest/kotlin/ai/koog/test/utils/AwaitilityExtensionsTest.kt
@@ -7,7 +7,6 @@ import org.awaitility.core.ConditionTimeoutException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.time.Duration
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.fail
 import kotlin.time.Duration.Companion.milliseconds
@@ -19,7 +18,7 @@ class AwaitilityExtensionsTest {
     fun `untilAsserted with suspend block eventually succeeds`() = runTest {
         val counter = AtomicInteger(0)
 
-        await()
+        val result = await()
             .atMost(2.seconds)
             .untilAsserted(block = {
                 delay(30)
@@ -27,8 +26,10 @@ class AwaitilityExtensionsTest {
                 if (current < 5) {
                     throw AssertionError("Not enough yet: $current")
                 }
+                "success-$current"
             })
 
+        assertEquals("success-5", result)
         assertEquals(5, counter.get())
     }
 
@@ -49,7 +50,7 @@ class AwaitilityExtensionsTest {
     fun `untilAsserted with scope and suspend block should eventually succeed`() = runTest {
         val counter = AtomicInteger(0)
 
-        await()
+        val result = await()
             .atMost(2.seconds)
             .atLeast(40.milliseconds)
             .pollInterval(10.milliseconds)
@@ -58,8 +59,10 @@ class AwaitilityExtensionsTest {
                 if (current < 5) {
                     throw AssertionError("Not enough yet: $current")
                 }
+                "result-$current"
             }
 
+        assertEquals("result-5", result)
         assertEquals(5, counter.get())
     }
 
@@ -70,7 +73,7 @@ class AwaitilityExtensionsTest {
                 .pollDelay(0.milliseconds)
                 .atLeast(10.milliseconds)
                 .atMost(200.milliseconds)
-                .pollInterval(Duration.ofMillis(10))
+                .pollInterval(10.milliseconds)
                 .untilAsserted(this) {
                     delay(50)
                     throw AssertionError("Always failing")


### PR DESCRIPTION
Replace Testcontainers JUnit dependency and refactor Docker test setup

1. Replace Testcontainers JUnit dependency and refactor Docker test setup

    - Removed `testcontainers-junit` dependency and replaced usage with direct `testcontainers` library.
    - Don't build container in Gradle
    - Upgraded `testcontainers` to the latest version.
    - Refactored Python A2A server Docker handling into `TestA2AServerContainer` object for cleaner test configuration.

2. Enhance Awaitility extensions to support return values

    - Added support for returning values from `untilAsserted` extensions.
    - Updated test cases to verify return value functionality.

3. Replace direct assertions with Awaitility in A2A tests

    - Refactored tests to use Awaitility's coroutine extensions for asserting eventually consistent conditions.
    - Simplified `sendMessageStreaming`, `resubscribeTask`, and notification configuration logic.
    
4. Use lazy/cached initialization for Docker availability check

## Motivation and Context
A2AClientJsonRpcIntegrationTest is flaky

## Breaking Changes
No

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tests improvement
- [x] Refactoring
- [x] Dependency changes

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [ ] All new and existing tests passed
