### PR TITLE
fix: KG-533 readfiletool empty files as binary

### DIFF
--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/ReadFileTool.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/ReadFileTool.kt
@@ -92,7 +92,9 @@ public class ReadFileTool<Path>(private val fs: FileSystemProvider.ReadOnly<Path
         validate(metadata.type == FileMetadata.FileType.File) { "Not a file: ${args.path}" }
 
         val type = fs.getFileContentType(path)
-        validate(type == FileMetadata.FileContentType.Text) { "File is not a text file: ${args.path}" }
+        val isEmpty = fs.size(path) == 0L
+        val isText = isEmpty || (type == FileMetadata.FileContentType.Text)
+        validate(isText) { "File is not a text file: ${args.path}" }
 
         return runCatching {
             var warningMessage: String? = null

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/ReadFileUtil.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/ReadFileUtil.kt
@@ -52,10 +52,12 @@ private fun buildContent(
     endLine: Int,
     onEndLineExceedsFileLength: ((requestedEndLine: Int, fileLineCount: Int) -> Unit)?
 ): FileSystemEntry.File.Content {
-    val lineCount = content.lineSequence().count()
+    val lineCount = if (content.isEmpty()) 0 else content.lineSequence().count()
 
     require(startLine >= 0) { "startLine=$startLine must be >= 0" }
-    require(startLine < lineCount) { "startLine=$startLine must be < lineCount=$lineCount" }
+    if (lineCount > 0) {
+        require(startLine < lineCount) { "startLine=$startLine must be < lineCount=$lineCount" }
+    }
 
     require(endLine >= -1) { "endLine=$endLine must be >= -1" }
     require(endLine == -1 || endLine > startLine) { "endLine=$endLine must be > startLine=$startLine or -1" }

--- a/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/ReadFileToolJvmTest.kt
+++ b/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/ReadFileToolJvmTest.kt
@@ -209,7 +209,7 @@ class ReadFileToolJvmTest {
         val f = createTestFile("empty.md", "")
         val result = readFile(f)
         val expected = """
-            ${"${f.toAbsolutePath().toString().norm()} (0 bytes, 1 line)"}
+            ${"${f.toAbsolutePath().toString().norm()} (0 bytes, 0 lines)"}
             Content:
             ```markdown
             ```
@@ -259,7 +259,7 @@ class ReadFileToolJvmTest {
         val f = createTestFile("Empty.kt", "")
         val result = readFile(f)
         val expected = """
-            ${"${f.toAbsolutePath().toString().norm()} (0 bytes, 1 line)"}
+            ${"${f.toAbsolutePath().toString().norm()} (0 bytes, 0 lines)"}
             Content:
             ```kotlin
             ```

--- a/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/ReadFileToolJvmTest.kt
+++ b/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/ReadFileToolJvmTest.kt
@@ -205,11 +205,17 @@ class ReadFileToolJvmTest {
     }
 
     @Test
-    fun `throws ValidationFailure when reading empty markdown file`() {
+    fun `reading empty markdown file renders empty fenced block`() = runBlocking {
         val f = createTestFile("empty.md", "")
-        assertThrows<ToolException.ValidationFailure> {
-            runBlocking { readFile(f) }
-        }
+        val result = readFile(f)
+        val expected = """
+            ${"${f.toAbsolutePath().toString().norm()} (0 bytes, 1 line)"}
+            Content:
+            ```markdown
+            ```
+        """.trimIndent()
+
+        assertEquals(expected, tool.encodeResultToString(result))
     }
 
     @Test
@@ -249,11 +255,17 @@ class ReadFileToolJvmTest {
     }
 
     @Test
-    fun `throws ValidationFailure when reading empty kotlin file`() {
+    fun `reading empty kotlin file renders empty fenced block`() = runBlocking {
         val f = createTestFile("Empty.kt", "")
-        assertThrows<ToolException.ValidationFailure> {
-            runBlocking { readFile(f) }
-        }
+        val result = readFile(f)
+        val expected = """
+            ${"${f.toAbsolutePath().toString().norm()} (0 bytes, 1 line)"}
+            Content:
+            ```kotlin
+            ```
+        """.trimIndent()
+
+        assertEquals(expected, tool.encodeResultToString(result))
     }
 
     @Test

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/model/FileSystemEntryBuilders.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/model/FileSystemEntryBuilders.kt
@@ -118,5 +118,7 @@ public suspend fun <Path> buildFileSize(
         return listOf(bytes)
     }
 
-    return listOf(bytes, FileSize.Lines(fs.readText(path).lineSequence().count()))
+    val text = fs.readText(path)
+    val lineCount = if (text.isEmpty()) 0 else text.lineSequence().count()
+    return listOf(bytes, FileSize.Lines(lineCount))
 }


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

Please add a brief description of the proposed change here.
Also, please tick the appropriate points in the checklist below.
-->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
[KG-533](https://youtrack.jetbrains.com/issue/KG-533) ReadFileTool incorrectly reports empty files as binary

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
