### PR TITLE
fix: Fix IDs for Llama3 models

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterModels.kt
@@ -431,7 +431,7 @@ public object OpenRouterModels : LLModelDefinitions {
 
     /**
      * Represents the Llama3 model configuration provided by OpenRouter.
-     * This model is identified by the unique ID "meta/llama-3-70b" and
+     * This model is identified by the unique ID "meta-llama/llama-3-70b" and
      * supports the standard set of language model capabilities.
      *
      * @see <a href="https://huggingface.co/meta-llama/Meta-Llama-3-70B">
@@ -439,7 +439,7 @@ public object OpenRouterModels : LLModelDefinitions {
     @JvmField
     public val Llama3: LLModel = LLModel(
         provider = LLMProvider.OpenRouter,
-        id = "meta/llama-3-70b",
+        id = "meta-llama/llama-3-70b",
         capabilities = standardCapabilities + listOf(
             LLMCapability.Schema.JSON.Standard,
             LLMCapability.ToolChoice
@@ -456,7 +456,7 @@ public object OpenRouterModels : LLModelDefinitions {
     @JvmField
     public val Llama3Instruct: LLModel = LLModel(
         provider = LLMProvider.OpenRouter,
-        id = "meta/llama-3-70b-instruct",
+        id = "meta-llama/llama-3-70b-instruct",
         capabilities = standardCapabilities + listOf(
             LLMCapability.Schema.JSON.Standard,
             LLMCapability.ToolChoice


### PR DESCRIPTION
The Llama IDs for OpenRouter are prefixed by "meta-llama" instead of just "meta". Fix the ID so that they can be used successfully.

## Motivation and Context
Attempting to use the models as implemented fails. OpenRouter returns with an error of the form: `{"error":{"message":"meta/llama-3-70b is not a valid model ID","code":400}, ...}`

## Breaking Changes
No

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
