### PR TITLE
feat(agents): Add java-style chained builders for agent-planner components

### DIFF
--- a/agents/agents-planner/build.gradle.kts
+++ b/agents/agents-planner/build.gradle.kts
@@ -13,9 +13,7 @@ kotlin {
         commonMain {
             dependencies {
                 api(project(":agents:agents-core"))
-                api(project(":agents:agents-ext"))
                 api(project(":agents:agents-features:agents-features-memory"))
-                api(project(":agents:agents-utils"))
                 api(project(":prompt:prompt-executor:prompt-executor-model"))
                 api(project(":prompt:prompt-structure"))
 
@@ -26,6 +24,7 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(kotlin("test"))
+                implementation(libs.kotest.assertions.core)
                 implementation(libs.kotlinx.coroutines.test)
                 implementation(project(":agents:agents-test"))
             }

--- a/agents/agents-planner/src/androidMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
+++ b/agents/agents-planner/src/androidMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
@@ -1,0 +1,25 @@
+@file:Suppress(
+    "MissingKDocForPublicAPI",
+    "EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING",
+    "ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT"
+)
+
+package ai.koog.agents.planner.goap
+
+public actual class ActionBuilder<State> : ActionBuilderApi<State> {
+    private val delegate = ActionBuilderImpl<State>()
+
+    public actual override fun name(name: String): ActionBuilder<State> = apply { delegate.name(name) }
+    public actual override fun description(description: String?): ActionBuilder<State> =
+        apply { delegate.description(description) }
+
+    public actual override fun precondition(precondition: Condition<State>): ActionBuilder<State> =
+        apply { delegate.precondition(precondition) }
+
+    public actual override fun belief(belief: Belief<State>): ActionBuilder<State> = apply { delegate.belief(belief) }
+    public actual override fun cost(cost: Cost<State>): ActionBuilder<State> = apply { delegate.cost(cost) }
+    public actual override fun executeAsync(execute: Execute<State>): ActionBuilder<State> =
+        apply { delegate.executeAsync(execute) }
+
+    public actual override fun build(): Action<State> = delegate.build()
+}

--- a/agents/agents-planner/src/androidMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
+++ b/agents/agents-planner/src/androidMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
@@ -18,8 +18,8 @@ public actual class ActionBuilder<State> : ActionBuilderApi<State> {
 
     public actual override fun belief(belief: Belief<State>): ActionBuilder<State> = apply { delegate.belief(belief) }
     public actual override fun cost(cost: Cost<State>): ActionBuilder<State> = apply { delegate.cost(cost) }
-    public actual override fun executeAsync(execute: Execute<State>): ActionBuilder<State> =
-        apply { delegate.executeAsync(execute) }
+    public actual override fun execute(execute: Execute<State>): ActionBuilder<State> =
+        apply { delegate.execute(execute) }
 
     public actual override fun build(): Action<State> = delegate.build()
 }

--- a/agents/agents-planner/src/appleMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
+++ b/agents/agents-planner/src/appleMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
@@ -1,0 +1,25 @@
+@file:Suppress(
+    "MissingKDocForPublicAPI",
+    "EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING",
+    "ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT"
+)
+
+package ai.koog.agents.planner.goap
+
+public actual class ActionBuilder<State> : ActionBuilderApi<State> {
+    private val delegate = ActionBuilderImpl<State>()
+
+    public actual override fun name(name: String): ActionBuilder<State> = apply { delegate.name(name) }
+    public actual override fun description(description: String?): ActionBuilder<State> =
+        apply { delegate.description(description) }
+
+    public actual override fun precondition(precondition: Condition<State>): ActionBuilder<State> =
+        apply { delegate.precondition(precondition) }
+
+    public actual override fun belief(belief: Belief<State>): ActionBuilder<State> = apply { delegate.belief(belief) }
+    public actual override fun cost(cost: Cost<State>): ActionBuilder<State> = apply { delegate.cost(cost) }
+    public actual override fun executeAsync(execute: Execute<State>): ActionBuilder<State> =
+        apply { delegate.executeAsync(execute) }
+
+    public actual override fun build(): Action<State> = delegate.build()
+}

--- a/agents/agents-planner/src/appleMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
+++ b/agents/agents-planner/src/appleMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
@@ -18,8 +18,8 @@ public actual class ActionBuilder<State> : ActionBuilderApi<State> {
 
     public actual override fun belief(belief: Belief<State>): ActionBuilder<State> = apply { delegate.belief(belief) }
     public actual override fun cost(cost: Cost<State>): ActionBuilder<State> = apply { delegate.cost(cost) }
-    public actual override fun executeAsync(execute: Execute<State>): ActionBuilder<State> =
-        apply { delegate.executeAsync(execute) }
+    public actual override fun execute(execute: Execute<State>): ActionBuilder<State> =
+        apply { delegate.execute(execute) }
 
     public actual override fun build(): Action<State> = delegate.build()
 }

--- a/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/AIAgentPlanner.kt
+++ b/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/AIAgentPlanner.kt
@@ -5,6 +5,7 @@ import ai.koog.agents.core.agent.context.AIAgentFunctionalContext
 import ai.koog.agents.core.agent.exception.AIAgentMaxNumberOfIterationsReachedException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 /**
  * An abstract base planner component, which can be used to implement different types of AI agent planner execution flows.
@@ -16,11 +17,19 @@ import kotlin.reflect.KType
  * 2. Execute a step in the plan: [executeStep]
  * 3. Repeat steps 1 and 2 until the plan is considered completed. Then the final [State] is returned.
  *
- * @property stateType [KType] of the [State].
+ * @param stateType [KType] of the [State].
  */
 public abstract class AIAgentPlanner<State, Plan>(
-    public val stateType: KType,
+    // FIXME: require the type explicitly when we decide, what to do with it in Java API
+    stateType: KType? = null,
 ) {
+    /**
+     * [KType] of the [State]
+     */
+    public val stateType: KType = stateType ?: typeOf<Any?>().also {
+        logger.warn { "State type is not specified, some agent features might behave unexpectedly." }
+    }
+
     private companion object {
         private val logger = KotlinLogging.logger { }
     }

--- a/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/PlannerAIAgent.kt
+++ b/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/PlannerAIAgent.kt
@@ -19,6 +19,7 @@ import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.prompt.executor.model.PromptExecutor
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.datetime.Clock
+import kotlin.jvm.JvmStatic
 
 /**
  * Represents an instance of planner agent using [AIAgentPlannerStrategy].
@@ -47,8 +48,18 @@ public class PlannerAIAgent<State, Plan>(
     logger = logger,
     id = id,
 ) {
-    private companion object {
+    /**
+     * Companion object providing the static `builder()` method.
+     */
+    public companion object {
         private val logger = KotlinLogging.logger {}
+
+        /**
+         * Creates a new instance of [PlannerAIAgentBuilder] for configuring and building a planner AI agent.
+         */
+        @JvmStatic
+        public fun <State, Plan> builder(strategy: AIAgentPlannerStrategy<State, Plan>): PlannerAIAgentBuilder<State, Plan> =
+            PlannerAIAgentBuilder(strategy)
     }
 
     override val pipeline: AIAgentFunctionalPipeline = AIAgentFunctionalPipeline(agentConfig, clock)

--- a/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/PlannerAIAgentBuilder.kt
+++ b/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/PlannerAIAgentBuilder.kt
@@ -1,0 +1,208 @@
+package ai.koog.agents.planner
+
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.agent.config.MissingToolsConversionStrategy
+import ai.koog.agents.core.agent.config.ToolCallDescriber
+import ai.koog.agents.core.feature.AIAgentFunctionalFeature
+import ai.koog.agents.core.feature.config.FeatureConfig
+import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.core.utils.ConfigureAction
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.llm.LLModel
+import kotlinx.datetime.Clock
+
+/**
+ * A builder for creating [PlannerAIAgent] instances.
+ */
+public class PlannerAIAgentBuilder<State, Plan>(
+    private val strategy: AIAgentPlannerStrategy<State, Plan>
+) {
+    private var promptExecutor: PromptExecutor? = null
+    private var toolRegistry: ToolRegistry = ToolRegistry.EMPTY
+    private var id: String? = null
+    private var prompt: Prompt = Prompt.Empty
+    private var llmModel: LLModel? = null
+    private var temperature: Double = 1.0
+    private var numberOfChoices: Int = 1
+    private var missingToolsConversionStrategy: MissingToolsConversionStrategy =
+        MissingToolsConversionStrategy.Missing(ToolCallDescriber.JSON)
+    private var maxIterations: Int = 50
+    private var clock: Clock = Clock.System
+    private var featureInstallers: MutableList<(PlannerAIAgent.FeatureContext.() -> Unit)> = mutableListOf()
+
+    /**
+     * Sets the `PromptExecutor` to be used by the builder instance.
+     *
+     * This method configures the builder with the provided `PromptExecutor`, which is responsible
+     * for executing prompts against language models, managing tool interactions, and handling output.
+     *
+     * @param promptExecutor An instance of `PromptExecutor` that will be utilized for processing prompts
+     * and interacting with language models.
+     * @return The current instance of the [PlannerAIAgentBuilder] for chaining additional configurations.
+     */
+    public fun promptExecutor(promptExecutor: PromptExecutor): PlannerAIAgentBuilder<State, Plan> = apply {
+        this.promptExecutor = promptExecutor
+    }
+
+    /**
+     * Sets the `LLModel` instance to be used by the builder.
+     *
+     * This method configures the builder with a specified Large Language Model (LLM),
+     * representing the model's provider, identifier, capabilities, and constraints such as
+     * context length or maximum output tokens.
+     *
+     * @param model The [LLModel] instance representing the large language model to set.
+     * @return The current instance of the [PlannerAIAgentBuilder] for chaining additional configurations.
+     */
+    public fun llmModel(model: LLModel): PlannerAIAgentBuilder<State, Plan> = apply {
+        this.llmModel = model
+    }
+
+    /**
+     * Sets the given `ToolRegistry` instance to the builder configuration.
+     *
+     * @param toolRegistry The instance of `ToolRegistry` to be used in the builder.
+     * @return The current instance of the [PlannerAIAgentBuilder] for chaining further configurations.
+     */
+    public fun toolRegistry(toolRegistry: ToolRegistry): PlannerAIAgentBuilder<State, Plan> = apply {
+        this.toolRegistry = toolRegistry
+    }
+
+    /**
+     * Sets the identifier for the builder configuration.
+     *
+     * @param id The identifier string to be set. Can be null.
+     * @return The current instance of the [PlannerAIAgentBuilder] for chaining method calls.
+     */
+    public fun id(id: String?): PlannerAIAgentBuilder<State, Plan> = apply {
+        this.id = id
+    }
+
+    /**
+     * Sets the system prompt to be used by the builder.
+     *
+     * This method configures the prompt with a system-level message that provides
+     * instructions or context for a language model.
+     *
+     * @param systemPrompt The content of the system message to set as the prompt.
+     * @return The current instance of the [PlannerAIAgentBuilder] with the updated system prompt.
+     */
+    public fun systemPrompt(systemPrompt: String): PlannerAIAgentBuilder<State, Plan> = apply {
+        this.prompt = prompt(id = "agent") { system(systemPrompt) }
+    }
+
+    /**
+     * Sets the prompt to be used by the builder.
+     *
+     * @param prompt The [Prompt] instance to set.
+     * @return The current instance of the [PlannerAIAgentBuilder].
+     */
+    public fun prompt(prompt: Prompt): PlannerAIAgentBuilder<State, Plan> = apply {
+        this.prompt = prompt
+    }
+
+    /**
+     * Sets the temperature value for the builder.
+     *
+     * Temperature is typically used to control the randomness of outputs in language models. Higher values result in more
+     * random outputs, while lower values make outputs more deterministic.
+     *
+     * @param temperature The temperature value to set. It should be a non-negative double, where common values are within
+     *                     the range [0.0, 1.0].
+     * @return The current instance of the [PlannerAIAgentBuilder] for method chaining.
+     */
+    public fun temperature(temperature: Double): PlannerAIAgentBuilder<State, Plan> = apply {
+        this.temperature = temperature
+    }
+
+    /**
+     * Sets the number of choices to be utilized by the builder instance.
+     *
+     * This method configures the builder with a specified number of discrete choices,
+     * which could be utilized in the decision-making process or output generation.
+     *
+     * @param numberOfChoices The integer representing the number of choices to configure.
+     *                        Must be a positive value.
+     * @return The current instance of the [PlannerAIAgentBuilder] for chaining additional configurations.
+     */
+    public fun numberOfChoices(numberOfChoices: Int): PlannerAIAgentBuilder<State, Plan> = apply {
+        this.numberOfChoices = numberOfChoices
+    }
+
+    /**
+     * Sets the maximum number of iterations for the builder.
+     *
+     * @param maxIterations The maximum number of iterations to be used. Must be a positive integer.
+     * @return The current instance of the [PlannerAIAgentBuilder] for chaining additional configurations.
+     */
+    public fun maxIterations(maxIterations: Int): PlannerAIAgentBuilder<State, Plan> = apply {
+        this.maxIterations = maxIterations
+    }
+
+    /**
+     * Configures the current `PlannerAIAgentBuilder` instance using the provided `AIAgentConfig`.
+     *
+     * This method applies the settings from the given `AIAgentConfig`, such as the prompt, language model,
+     * maximum agent iterations, and strategy to handle missing tools, to the builder instance.
+     *
+     * @param config An `AIAgentConfig` instance containing the configuration settings to be applied.
+     * @return The current instance of `PlannerAIAgentBuilder` for chaining further methods.
+     */
+    public fun agentConfig(config: AIAgentConfig): PlannerAIAgentBuilder<State, Plan> = apply {
+        this.llmModel = config.model
+        this.prompt = config.prompt
+        this.maxIterations = config.maxAgentIterations
+        this.missingToolsConversionStrategy = config.missingToolsConversionStrategy
+    }
+
+    /**
+     * Installs a planner-specific AI agent feature into the builder with its provided configuration.
+     *
+     * This method allows the integration of an [AIAgentFunctionalFeature] into the builder and its
+     * configuration using a lambda function. The feature is then added to the list of feature
+     * installers, enabling its functionality within the AI agent being constructed.
+     *
+     * @param TConfig The type of the configuration for the feature, extending [FeatureConfig].
+     * @param feature The [AIAgentFunctionalFeature] to be installed into the builder.
+     * @param configure A lambda function to configure the feature's properties and behavior.
+     * @return The current instance of the [PlannerAIAgentBuilder] for chaining additional configurations.
+     */
+    public fun <TConfig : FeatureConfig> install(
+        feature: AIAgentFunctionalFeature<TConfig, *>,
+        configure: ConfigureAction<TConfig>
+    ): PlannerAIAgentBuilder<State, Plan> = apply {
+        featureInstallers.add {
+            install(feature) {
+                configure.configure(this)
+            }
+        }
+    }
+
+    /**
+     * Builds and returns an instance of [AIAgent] configured according to the builder's settings.
+     *
+     * This method finalizes the current configuration and constructs an AI agent. The agent is
+     * equipped with the specified execution strategy, tool registry, identifier, prompt, language
+     * model, and other optional configurations. If required fields, such as `promptExecutor` or
+     * `llmModel`, are not set, this method throws an exception.
+     *
+     * @return An instance of [AIAgent] with the configured state type.
+     */
+    public fun build(): AIAgent<State, State> = PlannerAIAgent(
+        promptExecutor = requireNotNull(promptExecutor) { "Prompt executor must be set" },
+        agentConfig = AIAgentConfig(
+            prompt,
+            requireNotNull(llmModel) { "llmModel must me set" },
+            maxIterations,
+            missingToolsConversionStrategy
+        ),
+        strategy = strategy,
+        toolRegistry = toolRegistry,
+        id = id,
+        clock = clock,
+        installFeatures = { featureInstallers.forEach { it() } }
+    )
+}

--- a/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
+++ b/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
@@ -1,0 +1,16 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package ai.koog.agents.planner.goap
+
+/**
+ * Builder for [Action] instances.
+ */
+public expect class ActionBuilder<State>() : ActionBuilderApi<State> {
+    public override fun name(name: String): ActionBuilder<State>
+    public override fun description(description: String?): ActionBuilder<State>
+    public override fun precondition(precondition: Condition<State>): ActionBuilder<State>
+    public override fun belief(belief: Belief<State>): ActionBuilder<State>
+    public override fun cost(cost: Cost<State>): ActionBuilder<State>
+    public override fun executeAsync(execute: Execute<State>): ActionBuilder<State>
+    public override fun build(): Action<State>
+}

--- a/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
+++ b/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
@@ -11,6 +11,6 @@ public expect class ActionBuilder<State>() : ActionBuilderApi<State> {
     public override fun precondition(precondition: Condition<State>): ActionBuilder<State>
     public override fun belief(belief: Belief<State>): ActionBuilder<State>
     public override fun cost(cost: Cost<State>): ActionBuilder<State>
-    public override fun executeAsync(execute: Execute<State>): ActionBuilder<State>
+    public override fun execute(execute: Execute<State>): ActionBuilder<State>
     public override fun build(): Action<State>
 }

--- a/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/ActionBuilderApi.kt
+++ b/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/ActionBuilderApi.kt
@@ -1,0 +1,41 @@
+package ai.koog.agents.planner.goap
+
+/**
+ * API for building [Action] instances.
+ */
+public interface ActionBuilderApi<State> {
+    /**
+     * Sets the name of the action.
+     */
+    public fun name(name: String): ActionBuilderApi<State>
+
+    /**
+     * Sets the description of the action.
+     */
+    public fun description(description: String?): ActionBuilderApi<State>
+
+    /**
+     * Sets the precondition for the action.
+     */
+    public fun precondition(precondition: Condition<State>): ActionBuilderApi<State>
+
+    /**
+     * Sets the belief for the action.
+     */
+    public fun belief(belief: Belief<State>): ActionBuilderApi<State>
+
+    /**
+     * Sets the cost function for the action.
+     */
+    public fun cost(cost: Cost<State>): ActionBuilderApi<State>
+
+    /**
+     * Sets the execute function for the action.
+     */
+    public fun executeAsync(execute: Execute<State>): ActionBuilderApi<State>
+
+    /**
+     * Builds the [Action].
+     */
+    public fun build(): Action<State>
+}

--- a/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/ActionBuilderApi.kt
+++ b/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/ActionBuilderApi.kt
@@ -32,7 +32,7 @@ public interface ActionBuilderApi<State> {
     /**
      * Sets the execute function for the action.
      */
-    public fun executeAsync(execute: Execute<State>): ActionBuilderApi<State>
+    public fun execute(execute: Execute<State>): ActionBuilderApi<State>
 
     /**
      * Builds the [Action].

--- a/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/ActionBuilderImpl.kt
+++ b/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/ActionBuilderImpl.kt
@@ -1,0 +1,28 @@
+package ai.koog.agents.planner.goap
+
+internal class ActionBuilderImpl<State> : ActionBuilderApi<State> {
+    private var name: String? = null
+    private var description: String? = null
+    private var precondition: Condition<State>? = null
+    private var belief: Belief<State>? = null
+    private var cost: Cost<State> = { 1.0 }
+    private var execute: Execute<State>? = null
+
+    override fun name(name: String): ActionBuilderImpl<State> = apply { this.name = name }
+    override fun description(description: String?): ActionBuilderImpl<State> = apply { this.description = description }
+    override fun precondition(precondition: Condition<State>): ActionBuilderImpl<State> =
+        apply { this.precondition = precondition }
+
+    override fun belief(belief: Belief<State>): ActionBuilderImpl<State> = apply { this.belief = belief }
+    override fun cost(cost: Cost<State>): ActionBuilderImpl<State> = apply { this.cost = cost }
+    override fun executeAsync(execute: Execute<State>): ActionBuilderImpl<State> = apply { this.execute = execute }
+
+    override fun build(): Action<State> = Action(
+        name = requireNotNull(name) { "Action name is required" },
+        description = description,
+        precondition = requireNotNull(precondition) { "Action precondition is required" },
+        belief = requireNotNull(belief) { "Action belief is required" },
+        cost = cost,
+        execute = requireNotNull(execute) { "Action execute is required" }
+    )
+}

--- a/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/ActionBuilderImpl.kt
+++ b/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/ActionBuilderImpl.kt
@@ -15,7 +15,7 @@ internal class ActionBuilderImpl<State> : ActionBuilderApi<State> {
 
     override fun belief(belief: Belief<State>): ActionBuilderImpl<State> = apply { this.belief = belief }
     override fun cost(cost: Cost<State>): ActionBuilderImpl<State> = apply { this.cost = cost }
-    override fun executeAsync(execute: Execute<State>): ActionBuilderImpl<State> = apply { this.execute = execute }
+    override fun execute(execute: Execute<State>): ActionBuilderImpl<State> = apply { this.execute = execute }
 
     override fun build(): Action<State> = Action(
         name = requireNotNull(name) { "Action name is required" },

--- a/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/Entities.kt
+++ b/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/Entities.kt
@@ -1,18 +1,37 @@
 package ai.koog.agents.planner.goap
 
 import ai.koog.agents.core.agent.context.AIAgentFunctionalContext
+import kotlin.jvm.JvmStatic
+
+public typealias Condition<State> = (State) -> Boolean
+public typealias Belief<State> = (State) -> State
+public typealias Cost<State> = (State) -> Double
+public typealias Execute<State> = suspend (AIAgentFunctionalContext, State) -> State
+public typealias GoalValue = (Double) -> Double
 
 /**
  * Represents an action that can be performed by the agent.
  */
 public class Action<State>(
     public val name: String,
-    public val description: String? = null,
-    public val precondition: (State) -> Boolean,
-    public val belief: (State) -> State,
-    public val cost: (State) -> Double,
-    public val execute: suspend (AIAgentFunctionalContext, State) -> State
-)
+    public val description: String?,
+    public val precondition: Condition<State>,
+    public val belief: Belief<State>,
+    public val cost: Cost<State>,
+    public val execute: Execute<State>
+) {
+
+    /**
+     * Companion object for builder api.
+     */
+    public companion object {
+        /**
+         * Returns a new [ActionBuilder].
+         */
+        @JvmStatic
+        public fun <State> builder(): ActionBuilder<State> = ActionBuilder()
+    }
+}
 
 /**
  * Represents a goal that the agent wants to achieve.
@@ -20,10 +39,21 @@ public class Action<State>(
 public class Goal<State>(
     public val name: String,
     public val description: String?,
-    public val value: (Double) -> Double,
-    public val cost: (State) -> Double,
-    public val condition: (State) -> Boolean
-)
+    public val value: GoalValue,
+    public val cost: Cost<State>,
+    public val condition: Condition<State>
+) {
+    /**
+     * Companion object for builder api.
+     */
+    public companion object {
+        /**
+         * Returns a new [GoalBuilder].
+         */
+        @JvmStatic
+        public fun <State> builder(): GoalBuilder<State> = GoalBuilder()
+    }
+}
 
 /**
  * A GOAP plan.

--- a/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/GOAPPlanner.kt
+++ b/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/GOAPPlanner.kt
@@ -17,7 +17,7 @@ import kotlin.reflect.KType
 public open class GOAPPlanner<State> internal constructor(
     private val actions: List<Action<State>>,
     private val goals: List<Goal<State>>,
-    stateType: KType,
+    stateType: KType? = null,
 ) : AIAgentPlanner<State, GOAPPlan<State>>(
     stateType = stateType,
 ) {
@@ -26,7 +26,7 @@ public open class GOAPPlanner<State> internal constructor(
         state: State,
         plan: GOAPPlan<State>?
     ): GOAPPlan<State> = goals
-        .mapNotNull { goal -> buildPlanForGoal(state, goal, actions) }
+        .mapNotNull { goal -> buildPlanForGoal(state, goal) }
         .minByOrNull { plan -> plan.value }
         ?: throw IllegalStateException("No valid plan found for state: $state")
 
@@ -57,10 +57,9 @@ public open class GOAPPlanner<State> internal constructor(
     /**
      * Implements A-star search algorithm to find a plan for a given goal.
      */
-    private fun <State> buildPlanForGoal(
+    private fun buildPlanForGoal(
         state: State,
         goal: Goal<State>,
-        actions: List<Action<State>>,
     ): GOAPPlan<State>? {
         val gScore = mutableMapOf<State, Double>().withDefault { Double.MAX_VALUE }
         val fScore = mutableMapOf<State, Double>().withDefault { Double.MAX_VALUE }

--- a/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/GOAPPlannerBuilder.kt
+++ b/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/GOAPPlannerBuilder.kt
@@ -1,17 +1,24 @@
 package ai.koog.agents.planner.goap
 
-import ai.koog.agents.core.agent.context.AIAgentFunctionalContext
+import kotlin.jvm.JvmOverloads
 import kotlin.math.exp
 import kotlin.reflect.KType
 
 /**
  * [GOAPPlanner] DSL builder.
  */
-public class GOAPPlannerBuilder<State>(
-    private val stateType: KType,
+public class GOAPPlannerBuilder<State> @JvmOverloads constructor(
+    private val stateType: KType? = null,
 ) {
     private val actions: MutableList<Action<State>> = mutableListOf()
     private val goals: MutableList<Goal<State>> = mutableListOf()
+
+    /**
+     * Defines an action available to the GOAP agent.
+     *
+     * Returns the builder instance for chained calls.
+     */
+    public fun action(action: Action<State>): GOAPPlannerBuilder<State> = apply { actions.add(action) }
 
     /**
      * Defines an action available to the GOAP agent.
@@ -26,13 +33,20 @@ public class GOAPPlannerBuilder<State>(
     public fun action(
         name: String,
         description: String? = null,
-        precondition: (State) -> Boolean,
-        belief: (State) -> State,
-        cost: (State) -> Double = { 1.0 },
-        execute: suspend (AIAgentFunctionalContext, State) -> State
+        precondition: Condition<State>,
+        belief: Belief<State>,
+        cost: Cost<State> = { 1.0 },
+        execute: Execute<State>,
     ) {
-        actions.add(Action(name, description, precondition, belief, cost, execute))
+        action(Action(name, description, precondition, belief, cost, execute))
     }
+
+    /**
+     * Defines a goal for the GOAP agent.
+     *
+     * Returns the builder instance for chained calls.
+     */
+    public fun goal(goal: Goal<State>): GOAPPlannerBuilder<State> = apply { goals.add(goal) }
 
     /**
      * Defines a goal for the GOAP agent.
@@ -47,10 +61,10 @@ public class GOAPPlannerBuilder<State>(
         name: String,
         description: String? = null,
         value: (Double) -> Double = { cost -> exp(-cost) },
-        cost: (State) -> Double = { 1.0 },
-        condition: (State) -> Boolean,
+        cost: Cost<State> = { 1.0 },
+        condition: Condition<State>,
     ) {
-        goals.add(Goal(name, description, value, cost, condition))
+        goal(Goal(name, description, value, cost, condition))
     }
 
     /**

--- a/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/GoalBuilder.kt
+++ b/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/GoalBuilder.kt
@@ -1,0 +1,48 @@
+package ai.koog.agents.planner.goap
+
+/**
+ * Builder for [Goal] instances.
+ */
+public class GoalBuilder<State> {
+    private var name: String? = null
+    private var description: String? = null
+    private var value: (Double) -> Double = { 1 / it }
+    private var cost: Cost<State> = { 1.0 }
+    private var condition: Condition<State>? = null
+
+    /**
+     * Sets the name of the goal.
+     */
+    public fun name(name: String): GoalBuilder<State> = apply { this.name = name }
+
+    /**
+     * Sets the description of the goal.
+     */
+    public fun description(description: String?): GoalBuilder<State> = apply { this.description = description }
+
+    /**
+     * Sets the value function for the goal.
+     */
+    public fun value(value: (Double) -> Double): GoalBuilder<State> = apply { this.value = value }
+
+    /**
+     * Sets the cost function for the goal.
+     */
+    public fun cost(cost: Cost<State>): GoalBuilder<State> = apply { this.cost = cost }
+
+    /**
+     * Sets the condition function for the goal.
+     */
+    public fun condition(condition: Condition<State>): GoalBuilder<State> = apply { this.condition = condition }
+
+    /**
+     * Creates an instance of [Goal] based on the builder's configuration.
+     */
+    public fun build(): Goal<State> = Goal(
+        name = requireNotNull(name) { "Goal name is required" },
+        description = description,
+        value = value,
+        cost = cost,
+        condition = requireNotNull(condition) { "Goal condition is required" }
+    )
+}

--- a/agents/agents-planner/src/commonTest/kotlin/ai/koog/agents/planner/goap/ActionBuilderTest.kt
+++ b/agents/agents-planner/src/commonTest/kotlin/ai/koog/agents/planner/goap/ActionBuilderTest.kt
@@ -1,0 +1,78 @@
+package ai.koog.agents.planner.goap
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.nulls.shouldNotBeNull
+import kotlin.test.Test
+
+class ActionBuilderTest {
+
+    private companion object {
+        private const val NAME = "test-action"
+        private const val DESCRIPTION = "test-description"
+    }
+
+    @Test
+    fun testBuildAction() {
+        val action = Action.builder<String>()
+            .name(NAME)
+            .description(DESCRIPTION)
+            .precondition { true }
+            .belief { it }
+            .executeAsync { _, state -> state }
+            .build()
+
+        action.name.shouldBeEqual(NAME)
+        action.description
+            .shouldNotBeNull()
+            .shouldBeEqual(DESCRIPTION)
+    }
+
+    @Test
+    fun testMissingNameFails() {
+        shouldThrow<IllegalArgumentException> {
+            Action.builder<String>()
+                .description(DESCRIPTION)
+                .precondition { true }
+                .belief { it }
+                .executeAsync { _, state -> state }
+                .build()
+        }
+    }
+
+    @Test
+    fun testMissingPreconditionFails() {
+        shouldThrow<IllegalArgumentException> {
+            Action.builder<String>()
+                .name(NAME)
+                .description(DESCRIPTION)
+                .belief { it }
+                .executeAsync { _, state -> state }
+                .build()
+        }
+    }
+
+    @Test
+    fun testMissingBeliefFails() {
+        shouldThrow<IllegalArgumentException> {
+            Action.builder<String>()
+                .name(NAME)
+                .description(DESCRIPTION)
+                .precondition { true }
+                .executeAsync { _, state -> state }
+                .build()
+        }
+    }
+
+    @Test
+    fun testMissingExecuteFails() {
+        shouldThrow<IllegalArgumentException> {
+            Action.builder<String>()
+                .name(NAME)
+                .description(DESCRIPTION)
+                .precondition { true }
+                .belief { it }
+                .build()
+        }
+    }
+}

--- a/agents/agents-planner/src/commonTest/kotlin/ai/koog/agents/planner/goap/ActionBuilderTest.kt
+++ b/agents/agents-planner/src/commonTest/kotlin/ai/koog/agents/planner/goap/ActionBuilderTest.kt
@@ -19,7 +19,7 @@ class ActionBuilderTest {
             .description(DESCRIPTION)
             .precondition { true }
             .belief { it }
-            .executeAsync { _, state -> state }
+            .execute { _, state -> state }
             .build()
 
         action.name.shouldBeEqual(NAME)
@@ -35,7 +35,7 @@ class ActionBuilderTest {
                 .description(DESCRIPTION)
                 .precondition { true }
                 .belief { it }
-                .executeAsync { _, state -> state }
+                .execute { _, state -> state }
                 .build()
         }
     }
@@ -47,7 +47,7 @@ class ActionBuilderTest {
                 .name(NAME)
                 .description(DESCRIPTION)
                 .belief { it }
-                .executeAsync { _, state -> state }
+                .execute { _, state -> state }
                 .build()
         }
     }
@@ -59,7 +59,7 @@ class ActionBuilderTest {
                 .name(NAME)
                 .description(DESCRIPTION)
                 .precondition { true }
-                .executeAsync { _, state -> state }
+                .execute { _, state -> state }
                 .build()
         }
     }

--- a/agents/agents-planner/src/commonTest/kotlin/ai/koog/agents/planner/goap/GoalBuilderTest.kt
+++ b/agents/agents-planner/src/commonTest/kotlin/ai/koog/agents/planner/goap/GoalBuilderTest.kt
@@ -1,0 +1,43 @@
+package ai.koog.agents.planner.goap
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class GoalBuilderTest {
+
+    @Test
+    fun testBuildGoal() {
+        val goal = Goal.builder<String>()
+            .name("test-goal")
+            .description("test-description")
+            .condition { it == "end" }
+            .cost { 10.0 }
+            .value { cost -> cost * 2.0 }
+            .build()
+
+        goal.name shouldBe "test-goal"
+        goal.description shouldBe "test-description"
+        goal.value(10.0) shouldBe 20.0
+    }
+
+    @Test
+    fun testMissingNameFails() {
+        shouldThrow<IllegalArgumentException> {
+            Goal.builder<String>()
+                .condition { true }
+                .cost { 1.0 }
+                .build()
+        }
+    }
+
+    @Test
+    fun testMissingConditionFails() {
+        shouldThrow<IllegalArgumentException> {
+            Goal.builder<String>()
+                .name("test")
+                .cost { 1.0 }
+                .build()
+        }
+    }
+}

--- a/agents/agents-planner/src/jsMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
+++ b/agents/agents-planner/src/jsMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
@@ -1,0 +1,25 @@
+@file:Suppress(
+    "MissingKDocForPublicAPI",
+    "EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING",
+    "ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT"
+)
+
+package ai.koog.agents.planner.goap
+
+public actual class ActionBuilder<State> : ActionBuilderApi<State> {
+    private val delegate = ActionBuilderImpl<State>()
+
+    public actual override fun name(name: String): ActionBuilder<State> = apply { delegate.name(name) }
+    public actual override fun description(description: String?): ActionBuilder<State> =
+        apply { delegate.description(description) }
+
+    public actual override fun precondition(precondition: Condition<State>): ActionBuilder<State> =
+        apply { delegate.precondition(precondition) }
+
+    public actual override fun belief(belief: Belief<State>): ActionBuilder<State> = apply { delegate.belief(belief) }
+    public actual override fun cost(cost: Cost<State>): ActionBuilder<State> = apply { delegate.cost(cost) }
+    public actual override fun executeAsync(execute: Execute<State>): ActionBuilder<State> =
+        apply { delegate.executeAsync(execute) }
+
+    public actual override fun build(): Action<State> = delegate.build()
+}

--- a/agents/agents-planner/src/jsMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
+++ b/agents/agents-planner/src/jsMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
@@ -18,8 +18,8 @@ public actual class ActionBuilder<State> : ActionBuilderApi<State> {
 
     public actual override fun belief(belief: Belief<State>): ActionBuilder<State> = apply { delegate.belief(belief) }
     public actual override fun cost(cost: Cost<State>): ActionBuilder<State> = apply { delegate.cost(cost) }
-    public actual override fun executeAsync(execute: Execute<State>): ActionBuilder<State> =
-        apply { delegate.executeAsync(execute) }
+    public actual override fun execute(execute: Execute<State>): ActionBuilder<State> =
+        apply { delegate.execute(execute) }
 
     public actual override fun build(): Action<State> = delegate.build()
 }

--- a/agents/agents-planner/src/jvmMain/java/ai/koog/agents/planner/JavaAIAgentPlanner.java
+++ b/agents/agents-planner/src/jvmMain/java/ai/koog/agents/planner/JavaAIAgentPlanner.java
@@ -1,0 +1,61 @@
+package ai.koog.agents.planner;
+
+import ai.koog.agents.core.agent.context.AIAgentFunctionalContext;
+import kotlin.coroutines.Continuation;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public abstract class JavaAIAgentPlanner<State, Plan> extends AIAgentPlanner<State, Plan> {
+
+    public JavaAIAgentPlanner() {
+        super(null);
+    }
+
+    abstract protected Plan buildPlan(
+        AIAgentFunctionalContext context,
+        State state,
+        @Nullable Plan plan
+    );
+
+    abstract protected State executeStep(
+        AIAgentFunctionalContext context,
+        State state,
+        Plan plan
+    );
+
+    abstract protected Boolean isPlanCompleted(
+        AIAgentFunctionalContext context,
+        State state,
+        Plan plan
+    );
+
+    @Override
+    protected Plan buildPlan(
+        AIAgentFunctionalContext context,
+        State state,
+        @Nullable Plan plan,
+        @NotNull Continuation<? super Plan> continuation
+    ) {
+        return buildPlan(context, state, plan);
+    }
+
+    @Override
+    protected State executeStep(
+        AIAgentFunctionalContext context,
+        State state,
+        Plan plan,
+        @NotNull Continuation<? super State> continuation
+    ) {
+        return executeStep(context, state, plan);
+    }
+
+    @Override
+    protected Boolean isPlanCompleted(
+        AIAgentFunctionalContext context,
+        State state,
+        Plan plan,
+        @NotNull Continuation<? super Boolean> continuation
+    ) {
+        return isPlanCompleted(context, state, plan);
+    }
+}

--- a/agents/agents-planner/src/jvmMain/java/ai/koog/agents/planner/JavaAIAgentPlanner.java
+++ b/agents/agents-planner/src/jvmMain/java/ai/koog/agents/planner/JavaAIAgentPlanner.java
@@ -1,10 +1,12 @@
 package ai.koog.agents.planner;
 
+import ai.koog.agents.annotations.JavaAPI;
 import ai.koog.agents.core.agent.context.AIAgentFunctionalContext;
 import kotlin.coroutines.Continuation;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+@JavaAPI
 public abstract class JavaAIAgentPlanner<State, Plan> extends AIAgentPlanner<State, Plan> {
 
     public JavaAIAgentPlanner() {
@@ -30,7 +32,7 @@ public abstract class JavaAIAgentPlanner<State, Plan> extends AIAgentPlanner<Sta
     );
 
     @Override
-    protected Plan buildPlan(
+    protected final Plan buildPlan(
         AIAgentFunctionalContext context,
         State state,
         @Nullable Plan plan,
@@ -40,7 +42,7 @@ public abstract class JavaAIAgentPlanner<State, Plan> extends AIAgentPlanner<Sta
     }
 
     @Override
-    protected State executeStep(
+    protected final State executeStep(
         AIAgentFunctionalContext context,
         State state,
         Plan plan,
@@ -50,7 +52,7 @@ public abstract class JavaAIAgentPlanner<State, Plan> extends AIAgentPlanner<Sta
     }
 
     @Override
-    protected Boolean isPlanCompleted(
+    protected final Boolean isPlanCompleted(
         AIAgentFunctionalContext context,
         State state,
         Plan plan,

--- a/agents/agents-planner/src/jvmMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
+++ b/agents/agents-planner/src/jvmMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
@@ -1,0 +1,48 @@
+@file:Suppress(
+    "MissingKDocForPublicAPI",
+    "EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING",
+    "ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT"
+)
+
+package ai.koog.agents.planner.goap
+
+import ai.koog.agents.annotations.JavaAPI
+import ai.koog.agents.core.agent.context.AIAgentFunctionalContext
+import ai.koog.agents.core.annotation.InternalAgentsApi
+import ai.koog.agents.core.utils.runOnStrategyDispatcher
+
+@OptIn(InternalAgentsApi::class)
+public actual class ActionBuilder<State> : ActionBuilderApi<State> {
+    private val delegate = ActionBuilderImpl<State>()
+    public actual override fun name(name: String): ActionBuilder<State> = apply { delegate.name(name) }
+    public actual override fun description(description: String?): ActionBuilder<State> =
+        apply { delegate.description(description) }
+
+    public actual override fun precondition(precondition: Condition<State>): ActionBuilder<State> =
+        apply { delegate.precondition(precondition) }
+
+    public actual override fun belief(belief: Belief<State>): ActionBuilder<State> = apply { delegate.belief(belief) }
+    public actual override fun cost(cost: Cost<State>): ActionBuilder<State> = apply { delegate.cost(cost) }
+    public actual override fun executeAsync(execute: Execute<State>): ActionBuilder<State> =
+        apply { delegate.executeAsync(execute) }
+
+    /**
+     * Sets the synchronous execute function for the action.
+     */
+    @JavaAPI
+    public fun execute(execute: ExecuteSync<State>): ActionBuilder<State> =
+        executeAsync { context, state ->
+            context.config.runOnStrategyDispatcher {
+                execute.execute(context, state)
+            }
+        }
+
+    public actual override fun build(): Action<State> = delegate.build()
+
+    /**
+     * Synchronous GOAP action execution.
+     */
+    public fun interface ExecuteSync<State> {
+        public fun execute(context: AIAgentFunctionalContext, state: State): State
+    }
+}

--- a/agents/agents-planner/src/jvmMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
+++ b/agents/agents-planner/src/jvmMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
@@ -23,15 +23,15 @@ public actual class ActionBuilder<State> : ActionBuilderApi<State> {
 
     public actual override fun belief(belief: Belief<State>): ActionBuilder<State> = apply { delegate.belief(belief) }
     public actual override fun cost(cost: Cost<State>): ActionBuilder<State> = apply { delegate.cost(cost) }
-    public actual override fun executeAsync(execute: Execute<State>): ActionBuilder<State> =
-        apply { delegate.executeAsync(execute) }
+    public actual override fun execute(execute: Execute<State>): ActionBuilder<State> =
+        apply { delegate.execute(execute) }
 
     /**
      * Sets the synchronous execute function for the action.
      */
     @JavaAPI
-    public fun execute(execute: ExecuteSync<State>): ActionBuilder<State> =
-        executeAsync { context, state ->
+    public fun executeSync(execute: ExecuteSync<State>): ActionBuilder<State> =
+        execute { context, state ->
             context.config.runOnStrategyDispatcher {
                 execute.execute(context, state)
             }

--- a/agents/agents-planner/src/jvmTest/java/ai/koog/agents/planner/AIAgentPlannerJavaTest.java
+++ b/agents/agents-planner/src/jvmTest/java/ai/koog/agents/planner/AIAgentPlannerJavaTest.java
@@ -1,0 +1,43 @@
+package ai.koog.agents.planner;
+
+import ai.koog.agents.core.agent.context.AIAgentFunctionalContext;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+public class AIAgentPlannerJavaTest {
+
+    public class MockAIAgentPlanner extends JavaAIAgentPlanner<String, String> {
+
+        @Override
+        protected String buildPlan(
+            AIAgentFunctionalContext context,
+            String state,
+            @Nullable String plan
+        ) {
+            return "plan";
+        }
+
+        @Override
+        protected String executeStep(
+            AIAgentFunctionalContext context,
+            String state,
+            String plan
+        ) {
+            return "state";
+        }
+
+        @Override
+        protected Boolean isPlanCompleted(
+            AIAgentFunctionalContext context,
+            String state,
+            String plan
+        ) {
+            return state.equals("state");
+        }
+    }
+
+    @Test
+    public void testJavaAIAgentPlanner() {
+        MockAIAgentPlanner planner = new MockAIAgentPlanner();
+    }
+}

--- a/agents/agents-planner/src/jvmTest/java/ai/koog/agents/planner/goap/ActionBuilderJavaTest.java
+++ b/agents/agents-planner/src/jvmTest/java/ai/koog/agents/planner/goap/ActionBuilderJavaTest.java
@@ -1,0 +1,67 @@
+package ai.koog.agents.planner.goap;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ActionBuilderJavaTest {
+
+    @Test
+    public void testBuildAction() {
+        Action<String> action = Action.<String>builder()
+            .name("test-action")
+            .description("test-description")
+            .precondition(state -> true)
+            .belief((state) -> "end")
+            .execute((context, state) -> "executed")
+            .build();
+
+        assertEquals("test-action", action.getName());
+        assertEquals("test-description", action.getDescription());
+    }
+
+    @Test
+    public void testMissingNameFails() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            Action.<String>builder()
+                .precondition(state -> true)
+                .belief(state -> state)
+                .execute((context, state) -> state)
+                .build();
+        });
+    }
+
+    @Test
+    public void testMissingPreconditionFails() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            Action.<String>builder()
+                .name("test")
+                .belief(state -> state)
+                .execute((context, state) -> state)
+                .build();
+        });
+    }
+
+    @Test
+    public void testMissingBeliefFails() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            Action.<String>builder()
+                .name("test")
+                .precondition(state -> true)
+                .execute((context, state) -> state)
+                .build();
+        });
+    }
+
+    @Test
+    public void testMissingExecuteFails() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            Action.<String>builder()
+                .name("test")
+                .precondition(state -> true)
+                .belief(state -> state)
+                .build();
+        });
+    }
+}

--- a/agents/agents-planner/src/jvmTest/java/ai/koog/agents/planner/goap/ActionBuilderJavaTest.java
+++ b/agents/agents-planner/src/jvmTest/java/ai/koog/agents/planner/goap/ActionBuilderJavaTest.java
@@ -14,7 +14,7 @@ public class ActionBuilderJavaTest {
             .description("test-description")
             .precondition(state -> true)
             .belief((state) -> "end")
-            .execute((context, state) -> "executed")
+            .executeSync((context, state) -> "executed")
             .build();
 
         assertEquals("test-action", action.getName());
@@ -27,7 +27,7 @@ public class ActionBuilderJavaTest {
             Action.<String>builder()
                 .precondition(state -> true)
                 .belief(state -> state)
-                .execute((context, state) -> state)
+                .executeSync((context, state) -> state)
                 .build();
         });
     }
@@ -38,7 +38,7 @@ public class ActionBuilderJavaTest {
             Action.<String>builder()
                 .name("test")
                 .belief(state -> state)
-                .execute((context, state) -> state)
+                .executeSync((context, state) -> state)
                 .build();
         });
     }
@@ -49,7 +49,7 @@ public class ActionBuilderJavaTest {
             Action.<String>builder()
                 .name("test")
                 .precondition(state -> true)
-                .execute((context, state) -> state)
+                .executeSync((context, state) -> state)
                 .build();
         });
     }

--- a/agents/agents-planner/src/jvmTest/java/ai/koog/agents/planner/goap/GoalBuilderJavaTest.java
+++ b/agents/agents-planner/src/jvmTest/java/ai/koog/agents/planner/goap/GoalBuilderJavaTest.java
@@ -1,0 +1,43 @@
+package ai.koog.agents.planner.goap;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class GoalBuilderJavaTest {
+
+    @Test
+    public void testBuildGoal() {
+        Goal<String> goal = Goal.<String>builder()
+            .name("test-goal")
+            .description("test-description")
+            .condition(state -> true)
+            .cost(state -> 10.0)
+            .value(cost -> cost * 2.0)
+            .build();
+
+        assertEquals("test-goal", goal.getName());
+        assertEquals("test-description", goal.getDescription());
+    }
+
+    @Test
+    public void testMissingNameFails() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            Goal.<String>builder()
+                .condition(state -> true)
+                .cost(state -> 1.0)
+                .build();
+        });
+    }
+
+    @Test
+    public void testMissingConditionFails() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            Goal.<String>builder()
+                .name("test")
+                .cost(state -> 1.0)
+                .build();
+        });
+    }
+}

--- a/agents/agents-planner/src/wasmJsMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
+++ b/agents/agents-planner/src/wasmJsMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
@@ -1,0 +1,25 @@
+@file:Suppress(
+    "MissingKDocForPublicAPI",
+    "EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING",
+    "ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT"
+)
+
+package ai.koog.agents.planner.goap
+
+public actual class ActionBuilder<State> : ActionBuilderApi<State> {
+    private val delegate = ActionBuilderImpl<State>()
+
+    public actual override fun name(name: String): ActionBuilder<State> = apply { delegate.name(name) }
+    public actual override fun description(description: String?): ActionBuilder<State> =
+        apply { delegate.description(description) }
+
+    public actual override fun precondition(precondition: Condition<State>): ActionBuilder<State> =
+        apply { delegate.precondition(precondition) }
+
+    public actual override fun belief(belief: Belief<State>): ActionBuilder<State> = apply { delegate.belief(belief) }
+    public actual override fun cost(cost: Cost<State>): ActionBuilder<State> = apply { delegate.cost(cost) }
+    public actual override fun executeAsync(execute: Execute<State>): ActionBuilder<State> =
+        apply { delegate.executeAsync(execute) }
+
+    public actual override fun build(): Action<State> = delegate.build()
+}

--- a/agents/agents-planner/src/wasmJsMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
+++ b/agents/agents-planner/src/wasmJsMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
@@ -18,8 +18,8 @@ public actual class ActionBuilder<State> : ActionBuilderApi<State> {
 
     public actual override fun belief(belief: Belief<State>): ActionBuilder<State> = apply { delegate.belief(belief) }
     public actual override fun cost(cost: Cost<State>): ActionBuilder<State> = apply { delegate.cost(cost) }
-    public actual override fun executeAsync(execute: Execute<State>): ActionBuilder<State> =
-        apply { delegate.executeAsync(execute) }
+    public actual override fun execute(execute: Execute<State>): ActionBuilder<State> =
+        apply { delegate.execute(execute) }
 
     public actual override fun build(): Action<State> = delegate.build()
 }

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
                 implementation(project(":agents:agents-features:agents-features-acp"))
                 implementation(project(":agents:agents-mcp"))
                 implementation(project(":agents:agents-mcp-server"))
+                implementation(project(":agents:agents-planner"))
                 implementation(project(":agents:agents-test"))
                 implementation(
                     project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-anthropic-client")

--- a/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaPlannerAIAgentIntegrationTest.java
+++ b/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaPlannerAIAgentIntegrationTest.java
@@ -1,0 +1,136 @@
+package ai.koog.integration.tests.agent;
+
+import ai.koog.agents.core.agent.AIAgent;
+import ai.koog.agents.core.agent.context.AIAgentFunctionalContext;
+import ai.koog.agents.planner.AIAgentPlanner;
+import ai.koog.agents.planner.AIAgentPlannerStrategy;
+import ai.koog.agents.planner.JavaAIAgentPlanner;
+import ai.koog.agents.planner.PlannerAIAgent;
+import ai.koog.agents.planner.goap.Action;
+import ai.koog.agents.planner.goap.GOAPPlanner;
+import ai.koog.agents.planner.goap.GOAPPlannerBuilder;
+import ai.koog.agents.planner.goap.Goal;
+import ai.koog.agents.planner.llm.SimpleLLMPlanner;
+import ai.koog.agents.planner.llm.SimplePlan;
+import ai.koog.integration.tests.utils.annotations.Retry;
+import ai.koog.prompt.dsl.Prompt;
+import ai.koog.prompt.executor.clients.LLMClient;
+import ai.koog.prompt.executor.clients.openai.OpenAILLMClient;
+import ai.koog.prompt.executor.clients.openai.OpenAIModels;
+import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor;
+import ai.koog.prompt.executor.model.PromptExecutor;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JavaPlannerAIAgentIntegrationTest {
+
+    static class TestPlanner extends JavaAIAgentPlanner<String, String> {
+
+        @Override
+        protected String buildPlan(AIAgentFunctionalContext context, String state, @Nullable String plan) {
+            return "Request llm with state.";
+        }
+
+        @Override
+        protected String executeStep(AIAgentFunctionalContext context, String state, String plan) {
+            return context.llm().writeSession(session -> {
+                session.setPrompt(Prompt.builder("tmp").system(SYSTEM_PROMPT).user(state).build());
+                return session.requestLLM().getContent();
+            });
+        }
+
+        @Override
+        protected Boolean isPlanCompleted(AIAgentFunctionalContext context, String state, String plan) {
+            return !state.equals(REQUEST);
+        }
+    }
+
+    private static final String STRATEGY_NAME = "my-strategy";
+
+    private static String getOpenAiApiKey() {
+        String key = System.getenv("OPEN_AI_API_TEST_KEY");
+        if (key == null) {
+            throw new IllegalArgumentException("OPEN_AI_API_TEST_KEY environment variable is required");
+        }
+        return key;
+    }
+
+    private static final LLMClient client = new OpenAILLMClient(getOpenAiApiKey());
+    private static final PromptExecutor promptExecutor = new MultiLLMPromptExecutor(client);
+    private static final String SYSTEM_PROMPT = "You are a helpful assistant.";
+    private static final String REQUEST = "What's 1 + 1?";
+
+    @SuppressWarnings("unchecked")
+    private static <Plan> void testPlanner(AIAgentPlanner<String, Plan> planner) {
+        AIAgentPlannerStrategy<String, Plan> strategy = new AIAgentPlannerStrategy<String, Plan>(STRATEGY_NAME, planner);
+        AIAgent<String, String> agent = (AIAgent<String, String>) (Object) PlannerAIAgent.<String, Plan>builder(strategy)
+            .promptExecutor(promptExecutor)
+            .llmModel(OpenAIModels.Chat.GPT4o)
+            .systemPrompt(SYSTEM_PROMPT)
+            .build();
+
+        assertNotNull(agent);
+        String result = agent.run(REQUEST);
+        assertNotNull(result);
+        assertTrue(result.contains("2"));
+    }
+
+    @Test
+    @Retry
+    public void integration_testSimplePlanner() {
+        AIAgentPlanner<String, SimplePlan> planner = new SimpleLLMPlanner();
+
+        testPlanner(planner);
+    }
+
+    @Test
+    @Retry
+    public void integration_testCustomPlanner() {
+        AIAgentPlanner<String, String> planner = new TestPlanner();
+
+        testPlanner(planner);
+    }
+
+    @Test
+    @Retry
+    public void integration_testGoapPlanner() {
+        Action<String> formulateAction = Action.<String>builder()
+            .name("formulate-problem")
+            .precondition(state -> true)
+            .belief(state -> "Problem: example problem")
+            .execute((context, state) -> context.llm().writeSession(session -> {
+                session.setPrompt(Prompt.builder("tmp").system(SYSTEM_PROMPT).user("Formulate problem: " + state + ". Answer with the problem formulation in the form \"Problem: ...\"").build());
+                return session.requestLLM().getContent();
+            }))
+            .build();
+
+        Action<String> solveAction = Action.<String>builder()
+            .name("solve-problem")
+            .precondition(state -> state.contains("Problem"))
+            .belief(state -> "Solution: example solution")
+            .execute((context, state) -> context.llm().writeSession(session -> {
+                session.setPrompt(Prompt.builder("tmp").system(SYSTEM_PROMPT).user("Find solution. " + state + ". Answer with the solution in the form \"Solution: ...\"").build());
+                return session.requestLLM().getContent();
+            }))
+            .build();
+
+        Goal<String> goal = Goal.<String>builder()
+            .name("find-solution")
+            .cost(state -> 1.0)
+            .condition(state -> state.contains("Solution"))
+            .build();
+
+        GOAPPlannerBuilder<String> builder = new GOAPPlannerBuilder<String>();
+
+        GOAPPlanner<String> planner = builder
+            .action(formulateAction)
+            .action(solveAction)
+            .goal(goal)
+            .build();
+
+        testPlanner(planner);
+    }
+}

--- a/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaPlannerAIAgentIntegrationTest.java
+++ b/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaPlannerAIAgentIntegrationTest.java
@@ -101,7 +101,7 @@ public class JavaPlannerAIAgentIntegrationTest {
             .name("formulate-problem")
             .precondition(state -> true)
             .belief(state -> "Problem: example problem")
-            .execute((context, state) -> context.llm().writeSession(session -> {
+            .executeSync((context, state) -> context.llm().writeSession(session -> {
                 session.setPrompt(Prompt.builder("tmp").system(SYSTEM_PROMPT).user("Formulate problem: " + state + ". Answer with the problem formulation in the form \"Problem: ...\"").build());
                 return session.requestLLM().getContent();
             }))
@@ -111,7 +111,7 @@ public class JavaPlannerAIAgentIntegrationTest {
             .name("solve-problem")
             .precondition(state -> state.contains("Problem"))
             .belief(state -> "Solution: example solution")
-            .execute((context, state) -> context.llm().writeSession(session -> {
+            .executeSync((context, state) -> context.llm().writeSession(session -> {
                 session.setPrompt(Prompt.builder("tmp").system(SYSTEM_PROMPT).user("Find solution. " + state + ". Answer with the solution in the form \"Solution: ...\"").build());
                 return session.requestLLM().getContent();
             }))


### PR DESCRIPTION
Added java-style chained builders for planners:
    - `PlannerAIAgentBuilder` for creating planner agents
    - Builders for creating `GOAP` components

Added `JavaAIAgentPlanner` for synchronous implementations of the `AIAgentPlanner` in Java

closes [KG-642](https://youtrack.jetbrains.com/issue/KG-642)

