### PR TITLE
Added new multi model prompt executor for azure multi-models workflows

### DIFF
--- a/prompt/prompt-executor/prompt-executor-llms/Module.md
+++ b/prompt/prompt-executor/prompt-executor-llms/Module.md
@@ -8,8 +8,11 @@ This module provides implementations of the `PromptExecutor` interface for execu
 
 - `SingleLLMPromptExecutor`: Executes prompts using a single LLM client
 - `MultiLLMPromptExecutor`: Executes prompts across multiple LLM providers with fallback capabilities
+- `MultiModelLLMPromptExecutor`*: Executes prompts across multiple LLM models with model-specific client routing and fallback strategy
 
 These executors handle both standard and streaming execution of prompts, delegating the actual LLM interaction to the provided LLM clients.
+
+*Info: `MultiModelLLMPromptExecutor` solves a specific problem with Azure AI Services where the model parameter is ignored and the actual model is determined by the deployment in the base-uri. New model with Azure AI provider requires a new deployment and client, so to switch models you need to switch deployments. This executor allows you to map models to specific clients (deployments) and route requests accordingly.
 
 ### Using in your project
 
@@ -33,6 +36,17 @@ val anthropicClient = AnthropicClient(apiKey = "your-anthropic-key")
 val multiExecutor = MultiLLMPromptExecutor(
     LLMProvider.OPENAI to openAIClient,
     LLMProvider.ANTHROPIC to anthropicClient
+)
+
+val multiModelExecutor = MultiModelLLMPromptExecutor(
+    llmClients = mapOf(
+        OpenAIModels.Chat.GPT4o to gpt4Client,
+        OpenAIModels.CostOptimized.GPT4oMini to gpt4oMiniClient,
+    ),
+    fallback = MultiModelLLMPromptExecutor.FallbackPromptExecutorSettings(
+        fallbackModel = OpenAIModels.Chat.GPT4o,
+        fallbackClient = gpt4Client
+    )
 )
 
 // Execute a prompt

--- a/prompt/prompt-executor/prompt-executor-llms/src/commonMain/kotlin/ai/koog/prompt/executor/llms/MultiModelLLMPromptExecutor.kt
+++ b/prompt/prompt-executor/prompt-executor-llms/src/commonMain/kotlin/ai/koog/prompt/executor/llms/MultiModelLLMPromptExecutor.kt
@@ -1,0 +1,208 @@
+package ai.koog.prompt.executor.llms
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.prompt.dsl.ModerationResult
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.executor.clients.LLMClient
+import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.LLMChoice
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.streaming.StreamFrame
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.flow.Flow
+
+
+/**
+ * Tips: Especially for Azure OpenAI services provider . Designed to handle multi-model scenarios run on Azure OpenAI
+ * services where base-uri contains deployment name and model in request is ignored.
+ *
+ * MultiModelLLMPromptExecutor is a class responsible for executing prompts
+ * across multiple Large Language Models (LLMs). This implementation maps specific LLM models
+ * to their respective clients and supports a fallback strategy when a requested model is not available.
+ *
+ * @constructor Constructs an executor instance with a map of LLM models associated with their respective clients.
+ * @param llmClients A map containing LLM models associated with their respective [LLMClient]s.
+ * @param fallback Optional settings to configure the fallback mechanism in case a specific model is not directly available.
+ */
+public open class MultiModelLLMPromptExecutor(
+    private val llmClients: Map<LLModel, LLMClient>,
+    private val fallback: FallbackPromptMultiModelExecutorSettings? = null,
+) : PromptExecutor {
+    /**
+     * Represents configuration for a fallback large language model (LLM) execution strategy.
+     *
+     * This class is used to specify a fallback LLM model and client that can be utilized
+     * when the requested model is not available in the primary clients map. It ensures that
+     * a default execution path exists for prompt processing.
+     *
+     * @property fallbackModel The LLModel to be used for fallback execution when the requested model is not found.
+     * @property fallbackClient The LLMClient instance responsible for handling fallback requests.
+     */
+    public data class FallbackPromptMultiModelExecutorSettings(
+        val fallbackModel: LLModel,
+        val fallbackClient: LLMClient,
+    )
+
+    private companion object {
+        private val logger = KotlinLogging.logger("ai.koog.prompt.executor.llms.LLMPromptExecutor")
+    }
+
+    /**
+     * Lazily initialized fallback client for interacting with a fallback LLM model.
+     *
+     * Returns the fallback client from the `fallback` settings if available.
+     * This client is intended to handle cases where the requested model is not found.
+     *
+     * Returns `null` if `fallback` is not specified.
+     */
+    private val fallbackClient: LLMClient? by lazy { fallback?.fallbackClient }
+
+    init {
+        if (fallback != null) {
+            check(fallback.fallbackModel in llmClients.keys) {
+                "Fallback model not found in clients: ${fallback.fallbackModel}"
+            }
+        }
+    }
+
+    /**
+     * Executes a given prompt using the specified tools and model, and returns a list of response messages.
+     *
+     * @param prompt The `Prompt` to be executed, containing the input messages and parameters.
+     * @param tools A list of `ToolDescriptor` objects representing external tools available for use during execution.
+     * @param model The LLM model to use for execution.
+     * @return A list of `Message.Response` objects containing the responses generated based on the prompt.
+     * @throws IllegalArgumentException If no client is found for the model and no fallback settings are configured.
+     */
+    override suspend fun execute(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>,
+    ): List<Message.Response> {
+        logger.debug { "Executing prompt: $prompt with tools: $tools and model: $model" }
+
+        val response =
+            when {
+                model in llmClients -> llmClients[model]!!.execute(prompt, model, tools)
+                fallback != null ->
+                    fallbackClient!!.execute(
+                        prompt,
+                        fallback.fallbackModel,
+                        tools,
+                    )
+
+                else -> throw IllegalArgumentException("No client found for model: $model")
+            }
+
+        logger.debug { "Response: $response" }
+
+        return response
+    }
+
+    /**
+     * Executes the given prompt with the specified model and streams the response in chunks as a flow.
+     *
+     * @param prompt The prompt to execute, containing the messages and parameters.
+     * @param model The LLM model to use for execution.
+     * @param tools A list of `ToolDescriptor` objects representing external tools available for use during execution.
+     * @return A Flow of StreamFrame objects representing the streaming response.
+     * @throws IllegalArgumentException If no client is found for the model.
+     */
+    override fun executeStreaming(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>,
+    ): Flow<StreamFrame> {
+        logger.debug { "Executing streaming prompt: $prompt with model: $model" }
+
+        val client =
+            when {
+                model in llmClients -> llmClients[model]
+                fallback != null -> fallbackClient
+                else -> null
+            }
+
+        requireNotNull(client) { "No client found for model: $model" }
+
+        return client.executeStreaming(prompt, model, tools)
+    }
+
+    /**
+     * Executes a given prompt using the specified tools and model and returns a list of model choices.
+     *
+     * @param prompt The `Prompt` to be executed, containing the input messages and parameters.
+     * @param tools A list of `ToolDescriptor` objects representing external tools available for use during execution.
+     * @param model The LLM model to use for execution.
+     * @return A list of `LLMChoice` objects containing the choices generated based on the prompt.
+     * @throws IllegalArgumentException If no client is found for the model and no fallback settings are configured.
+     */
+    override suspend fun executeMultipleChoices(
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>,
+    ): List<LLMChoice> {
+        logger.debug { "Executing prompt: $prompt with tools: $tools and model: $model" }
+
+        val choices =
+            when {
+                model in llmClients -> llmClients[model]!!.executeMultipleChoices(prompt, model, tools)
+                fallback != null ->
+                    fallbackClient!!.executeMultipleChoices(
+                        prompt,
+                        fallback.fallbackModel,
+                        tools,
+                    )
+
+                else -> throw IllegalArgumentException("No client found for model: $model")
+            }
+
+        logger.debug { "Choices: $choices" }
+
+        return choices
+    }
+
+    /**
+     * Moderates the provided multi-modal content using the specified model.
+     *
+     * @param prompt The `Prompt` containing the content to be moderated.
+     * @param model The `LLModel` to use for moderation, including its ID and provider information.
+     * @return A `ModerationResult` representing the result of the moderation process.
+     * @throws IllegalArgumentException If no client is found for the model.
+     */
+    override suspend fun moderate(
+        prompt: Prompt,
+        model: LLModel,
+    ): ModerationResult {
+        logger.debug { "Moderating multi-modal content with model: ${model.id}" }
+
+        val client =
+            when {
+                model in llmClients -> llmClients[model]
+                fallback != null -> fallbackClient
+                else -> null
+            }
+
+        requireNotNull(client) { "No client found for model: $model" }
+
+        return client.moderate(prompt, model)
+    }
+
+    /**
+     * Retrieves a list of all available model IDs from the registered clients.
+     *
+     * @return A list of model IDs (Strings) representing all available models.
+     */
+    override suspend fun models(): List<String> {
+        logger.debug { "Fetching available models from all clients" }
+
+        return llmClients.keys.map { it.id }
+    }
+
+    /**
+     * Closes all registered LLM clients, releasing any resources they may hold.
+     */
+    override fun close() {
+        llmClients.forEach { (_, client) -> client.close() }
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/MultiModelLLMPromptExecutorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/MultiModelLLMPromptExecutorTest.kt
@@ -1,0 +1,235 @@
+package ai.koog.prompt.executor.llms
+
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import ai.koog.prompt.streaming.filterTextOnly
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class MultiModelLLMPromptExecutorTest {
+
+    val mockClock = object : Clock {
+        override fun now(): Instant = Instant.parse("2023-01-01T00:00:00Z")
+    }
+
+    @Test
+    fun testExecuteWithGPT4() = runTest {
+        val gpt4Client = MockOpenAILLMClient(executeResponseContent = "GPT-4 response", clock = mockClock)
+        val gpt5Client = MockOpenAILLMClient(executeResponseContent = "GPT-5 response", clock = mockClock)
+
+        val executor = MultiModelLLMPromptExecutor(
+            llmClients = mapOf(
+                OpenAIModels.Chat.GPT4o to gpt4Client,
+                OpenAIModels.Chat.GPT5 to gpt5Client
+            )
+        )
+
+        val model = OpenAIModels.Chat.GPT4o
+        val prompt = Prompt.build("test-prompt") {
+            system("You are a helpful assistant.")
+            user("What is the capital of France?")
+        }
+
+        val response = executor.execute(prompt = prompt, model = model, tools = emptyList()).single()
+
+        assertEquals("GPT-4 response", response.content)
+    }
+
+    @Test
+    fun testExecuteWithGPT5() = runTest {
+        val gpt4Client = MockOpenAILLMClient(executeResponseContent = "GPT-4 response", clock = mockClock)
+        val gpt5Client = MockOpenAILLMClient(executeResponseContent = "GPT-5 response", clock = mockClock)
+
+        val executor = MultiModelLLMPromptExecutor(
+            llmClients = mapOf(
+                OpenAIModels.Chat.GPT4o to gpt4Client,
+                OpenAIModels.Chat.GPT5 to gpt5Client
+            )
+        )
+
+        val model = OpenAIModels.Chat.GPT5
+        val prompt = Prompt.build("test-prompt") {
+            system("You are a helpful assistant.")
+            user("What is the capital of France?")
+        }
+
+        val response = executor.execute(prompt = prompt, model = model, tools = emptyList()).single()
+
+        assertEquals("GPT-5 response", response.content)
+    }
+
+    @Test
+    fun testExecuteWithFallback() = runTest {
+        val gpt4Client = MockOpenAILLMClient(executeResponseContent = "GPT-4 response", clock = mockClock)
+        val gpt5Client = MockOpenAILLMClient(executeResponseContent = "GPT-5 fallback response", clock = mockClock)
+
+        val executor = MultiModelLLMPromptExecutor(
+            llmClients = mapOf(
+                OpenAIModels.Chat.GPT4o to gpt4Client,
+                OpenAIModels.Chat.GPT5 to gpt5Client
+            ),
+            fallback = MultiModelLLMPromptExecutor.FallbackPromptMultiModelExecutorSettings(
+                fallbackModel = OpenAIModels.Chat.GPT5,
+                fallbackClient = gpt5Client
+            )
+        )
+
+        val notSupportedModel = OpenAIModels.Chat.GPT4oMini
+        val prompt = Prompt.build("test-prompt") {
+            system("You are a helpful assistant.")
+            user("What is the capital of France?")
+        }
+
+        val response = executor.execute(prompt = prompt, model = notSupportedModel, tools = emptyList()).single()
+
+        assertEquals("GPT-5 fallback response", response.content)
+    }
+
+    @Test
+    fun testExecuteStreamingWithGPT4() = runTest {
+        val gpt4Client = MockOpenAILLMClient(clock = mockClock)
+        val gpt5Client = MockOpenAILLMClient(clock = mockClock)
+
+        val executor = MultiModelLLMPromptExecutor(
+            llmClients = mapOf(
+                OpenAIModels.Chat.GPT4o to gpt4Client,
+                OpenAIModels.Chat.GPT5 to gpt5Client
+            )
+        )
+
+        val model = OpenAIModels.Chat.GPT4o
+        val prompt = Prompt.build("test-prompt") {
+            system("You are a helpful assistant.")
+            user("What is the capital of France?")
+        }
+
+        val responseChunks = executor.executeStreaming(prompt, model, emptyList())
+            .filterTextOnly()
+            .toList()
+        assertEquals(3, responseChunks.size, "Response should have three chunks")
+        assertEquals(
+            "OpenAI streaming response",
+            responseChunks.joinToString(""),
+            "Response should be from GPT-4 client"
+        )
+    }
+
+    @Test
+    fun testExecuteStreamingWithFallback() = runTest {
+        val gpt4Client = MockOpenAILLMClient(clock = mockClock)
+        val gpt5Client = MockOpenAILLMClient(clock = mockClock)
+
+        val executor = MultiModelLLMPromptExecutor(
+            llmClients = mapOf(
+                OpenAIModels.Chat.GPT4o to gpt4Client,
+                OpenAIModels.Chat.GPT5 to gpt5Client
+            ),
+            fallback = MultiModelLLMPromptExecutor.FallbackPromptMultiModelExecutorSettings(
+                fallbackModel = OpenAIModels.Chat.GPT5,
+                fallbackClient = gpt5Client
+            )
+        )
+
+        val notSupportedModel = OpenAIModels.Chat.GPT4oMini
+        val prompt = Prompt.build("test-prompt") {
+            system("You are a helpful assistant.")
+            user("What is the capital of France?")
+        }
+
+        val responseChunks = executor.executeStreaming(prompt, notSupportedModel, emptyList())
+            .filterTextOnly()
+            .toList()
+        assertEquals(3, responseChunks.size, "Response should have three chunks")
+        assertEquals(
+            "OpenAI streaming response",
+            responseChunks.joinToString(""),
+            "Response should be from fallback client"
+        )
+    }
+
+    @Test
+    fun testExecuteWithUnsupportedModelNoFallback() = runTest {
+        val gpt4Client = MockOpenAILLMClient(clock = mockClock)
+
+        val executor = MultiModelLLMPromptExecutor(
+            llmClients = mapOf(
+                OpenAIModels.Chat.GPT4o to gpt4Client
+            )
+        )
+
+        val notSupportedModel = OpenAIModels.Chat.GPT4oMini
+        val prompt = Prompt.build("test-prompt") {
+            system("You are a helpful assistant.")
+            user("What is the capital of France?")
+        }
+
+        assertFailsWith<IllegalArgumentException>("Should throw IllegalArgumentException for unsupported model without fallback") {
+            executor.execute(prompt = prompt, model = notSupportedModel, tools = emptyList())
+        }
+    }
+
+    @Test
+    fun testExecuteStreamingWithUnsupportedModelNoFallback() = runTest {
+        val gpt4Client = MockOpenAILLMClient(clock = mockClock)
+
+        val executor = MultiModelLLMPromptExecutor(
+            llmClients = mapOf(
+                OpenAIModels.Chat.GPT4o to gpt4Client
+            )
+        )
+
+        val notSupportedModel = OpenAIModels.Chat.GPT4oMini
+        val prompt = Prompt.build("test-prompt") {
+            system("You are a helpful assistant.")
+            user("What is the capital of France?")
+        }
+
+        assertFailsWith<IllegalArgumentException>("Should throw IllegalArgumentException for unsupported model without fallback") {
+            executor.executeStreaming(prompt, notSupportedModel, emptyList()).collect()
+        }
+    }
+
+    @Test
+    fun testModelsReturnsMappedModels() = runTest {
+        val gpt4Client = MockOpenAILLMClient(clock = mockClock)
+        val gpt5Client = MockOpenAILLMClient(clock = mockClock)
+
+        val executor = MultiModelLLMPromptExecutor(
+            llmClients = mapOf(
+                OpenAIModels.Chat.GPT4o to gpt4Client,
+                OpenAIModels.Chat.GPT5 to gpt5Client
+            )
+        )
+
+        val models = executor.models()
+
+        assertEquals(2, models.size)
+        assertEquals(true, models.contains(OpenAIModels.Chat.GPT4o.id))
+        assertEquals(true, models.contains(OpenAIModels.Chat.GPT5.id))
+    }
+
+    @Test
+    fun testFallbackModelMustBeInClients() {
+        val gpt4Client = MockOpenAILLMClient(clock = mockClock)
+        val gpt5Client = MockOpenAILLMClient(clock = mockClock)
+        val fallbackModel = OpenAIModels.Chat.GPT5
+
+        assertFailsWith<IllegalStateException>("Should throw IllegalStateException when fallback model is not in clients") {
+            MultiModelLLMPromptExecutor(
+                llmClients = mapOf(
+                    OpenAIModels.Chat.GPT4o to gpt4Client
+                ),
+                fallback = MultiModelLLMPromptExecutor.FallbackPromptMultiModelExecutorSettings(
+                    fallbackModel = fallbackModel,
+                    fallbackClient = gpt5Client
+                )
+            )
+        }
+    }
+}


### PR DESCRIPTION

I created multi-model executor for Azure purposes. 
Azure Service has different strategy than other ai providers. You deploy some model and use it. Below is example base-uri for deployment:
`https://<your-project>.openai.azure.com/openai/deployments/gpt-4o/`
The llm model parameter is ignored and response is always from deployed model. 

## Motivation and Context
I want to use 2 different models in my strategy/action e.g 4.1-mini for small and simple actions and gpt-4o for summarize and return to user.

I can create subgraph with small model 41-mini parameter but on azure provider this model from request is ignored. I can use only model which I put to base-uri in client. So I have to deploy multiple OpenAI clients on azure and create multiple AIClients in koog. 

## Breaking Changes
There is no breaking changes. I added new executor for specific cases. 
Created new multi-model prompt executor - similar to MulitLLMPrompExecutor. With key in map LLMModel not LLMProvider. 

---

#### Type of the changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tests improvement
- [ ] Refactoring
- [ ] CI/CD changes
- [ ] Dependencies update

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
