### PR TITLE
Set OTel exporter dependencies to `api` scope in build scripts

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/build.gradle.kts
+++ b/agents/agents-features/agents-features-opentelemetry/build.gradle.kts
@@ -25,8 +25,8 @@ kotlin {
             dependencies {
                 api(project.dependencies.platform(libs.opentelemetry.bom))
                 api(libs.opentelemetry.sdk)
-                implementation(libs.opentelemetry.exporter.otlp)
-                implementation(libs.opentelemetry.exporter.logging)
+                api(libs.opentelemetry.exporter.otlp)
+                api(libs.opentelemetry.exporter.logging)
             }
 
             resources.srcDir(layout.buildDirectory.dir("generated/resources"))

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -23,8 +23,8 @@ dependencies {
     implementation(project(":agents:agents-features:agents-features-acp"))
     implementation(project(":agents:agents-test"))
     implementation(project(":koog-agents"))
-    implementation(libs.opentelemetry.exporter.logging)
-    implementation(libs.opentelemetry.exporter.otlp)
+    api(libs.opentelemetry.exporter.logging)
+    api(libs.opentelemetry.exporter.otlp)
 }
 
 dokka {


### PR DESCRIPTION
Update the dependency for open telemetry library

## Motivation and Context
Change OpenTelemetry exporter dependencies from implementation to api. The Weave and Langfuse integrations expose OtlpHttpSpanExporter in their public API, so the exporter dependencies must be available to consumers.

## Breaking Changes
No

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring
- [ ] CI/CD changes
- [ ] Dependencies update

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
