### PR TITLE
KG-156 update description of singleRunStrategy

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentSimpleStrategies.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentSimpleStrategies.kt
@@ -25,11 +25,11 @@ import kotlin.jvm.JvmOverloads
  * 3. Execute a tool based on the LLM's response.
  * 4. Send the tool result back to the LLM.
  * 5. Repeat until LLM indicates no further tool calls are needed or the agent finishes.
- * @param runMode The mode in which the single-run strategy should operate. Defaults to SingleRunMode.SINGLE.
- *                - SingleRunMode.SINGLE: Executes without allowing multiple simultaneous tool calls.
- *                - SingleRunMode.SEQUENTIAL: Executes simultaneous tool calls sequentially.
- *                - SingleRunMode.PARALLEL: Executes multiple tool calls in parallel.
- * @return An instance of AIAgentStrategy configured according to the specified single-run mode.
+ * @param runMode The mode in which the single-run strategy should operate. Defaults to [ToolCalls.SEQUENTIAL].
+ *                - [ToolCalls.SEQUENTIAL]: Executes multiple tool calls sequentially.
+ *                - [ToolCalls.PARALLEL]: Executes multiple tool calls in parallel.
+ *                - [ToolCalls.SINGLE_RUN_SEQUENTIAL]: Executes a single tool call per step.
+ * @return An instance of AIAgentStrategy configured according to the specified run mode.
  */
 @JvmOverloads
 public fun singleRunStrategy(runMode: ToolCalls = ToolCalls.SEQUENTIAL): AIAgentGraphStrategy<String, String> =


### PR DESCRIPTION
Related to: [KG-156](https://youtrack.jetbrains.com/issue/KG-156)

## Motivation and Context
Updated KDoc for `singleRunStrategy` to correctly reflect that the default mode is `ToolCalls.SEQUENTIAL` and swapped outdated `SingleRunMode` references for the `ToolCalls` enum.

## Breaking Changes
None.

---

#### Type of the changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Tests improvement
- [ ] Refactoring
- [ ] CI/CD changes
- [ ] Dependencies update

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [ ] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
