### PR TITLE
Remove redundant command info from ExecuteShellCommandTool

### DIFF
--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/shell/ExecuteShellCommandTool.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/shell/ExecuteShellCommandTool.kt
@@ -62,13 +62,11 @@ public class ExecuteShellCommandTool(
     /**
      * Result of attempting to run a command.
      *
-     * @property command The command string that was run (or denied)
      * @property exitCode The exit code returned by the process, or null if the command never started
      * @property output Everything the command printed to the screen, or an explanation if it didn't run (e.g., "Command timed out", "denied by user")
      */
     @Serializable
     public data class Result(
-        val command: String,
         val exitCode: Int?,
         val output: String
     )
@@ -89,20 +87,19 @@ public class ExecuteShellCommandTool(
     ) {
         is ShellCommandConfirmation.Approved -> try {
             val result = executor.execute(args.command, args.workingDirectory, args.timeoutSeconds)
-            Result(args.command, result.exitCode, result.output)
+            Result(result.exitCode, result.output)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Result(args.command, null, "Failed to execute command: ${e.message}")
+            Result(null, "Failed to execute command: ${e.message}")
         }
 
         is ShellCommandConfirmation.Denied ->
-            Result(args.command, null, "Command execution denied with user response: ${confirmation.userResponse}")
+            Result(null, "Command execution denied with user response: ${confirmation.userResponse}")
     }
 
     override fun encodeResultToString(result: Result): String = with(result) {
         buildString {
-            appendLine("Command: $command")
             if (output.isNotEmpty()) {
                 appendLine(output)
             } else if (exitCode != null) {

--- a/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/shell/ExecuteShellCommandToolJvmTest.kt
+++ b/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/shell/ExecuteShellCommandToolJvmTest.kt
@@ -71,7 +71,6 @@ class ExecuteShellCommandToolJvmTest {
         val result = tool.executeShellCommand("grep ^a fruits.txt", workingDirectory = tempDir.toString())
 
         val expected = """
-            Command: grep ^a fruits.txt
             apple
             apricot
             avocado
@@ -91,7 +90,6 @@ class ExecuteShellCommandToolJvmTest {
         val result = tool.executeShellCommand("findstr /B a fruits.txt", workingDirectory = tempDir.toString())
 
         val expected = """
-            Command: findstr /B a fruits.txt
             apple
             apricot
             avocado
@@ -113,7 +111,6 @@ class ExecuteShellCommandToolJvmTest {
         val result = tool.executeShellCommand("find . -name '*.txt' -type f | sort", workingDirectory = tempDir.toString())
 
         val expected = """
-            Command: find . -name '*.txt' -type f | sort
             ./config.txt
             ./report.txt
             Exit code: 0
@@ -134,7 +131,6 @@ class ExecuteShellCommandToolJvmTest {
         val result = tool.executeShellCommand("dir /b *.txt | sort", workingDirectory = tempDir.toString())
 
         val expected = """
-            Command: dir /b *.txt | sort
             config.txt
             report.txt
             Exit code: 0
@@ -152,8 +148,7 @@ class ExecuteShellCommandToolJvmTest {
         val result = tool.executeShellCommand("find /c /v \"\" file.txt", workingDirectory = tempDir.toString())
 
         val expected = """
-            Command: find /c /v "" file.txt
-            
+
             ---------- FILE.TXT: 4
             Exit code: 0
         """.trimIndent()
@@ -173,7 +168,6 @@ class ExecuteShellCommandToolJvmTest {
         val result = tool.executeShellCommand("find . -type f | sort", workingDirectory = tempDir.toString())
 
         val expected = """
-            Command: find . -type f | sort
             ./README.md
             ./src/main/App.kt
             ./src/main/Utils.kt
@@ -197,7 +191,6 @@ class ExecuteShellCommandToolJvmTest {
         val tempDirStr = tempDir.toAbsolutePath().toString()
 
         val expected = """
-            Command: dir /s /b /o:n
             $tempDirStr\README.md
             $tempDirStr\src
             $tempDirStr\src\main
@@ -218,7 +211,6 @@ class ExecuteShellCommandToolJvmTest {
         val result = tool.executeShellCommand("mkdir newdir", workingDirectory = testDir.toString())
 
         val expected = """
-            Command: mkdir newdir
             (no output)
             Exit code: 0
         """.trimIndent()
@@ -236,7 +228,6 @@ class ExecuteShellCommandToolJvmTest {
         val result = tool.executeShellCommand("grep nonexistent /nonexistent/file.txt")
 
         val expected = """
-            Command: grep nonexistent /nonexistent/file.txt
             grep: /nonexistent/file.txt: No such file or directory
             Exit code: 2
         """.trimIndent()
@@ -251,7 +242,6 @@ class ExecuteShellCommandToolJvmTest {
         val result = tool.executeShellCommand("type C:\\nonexistent\\file.txt")
 
         val expected = """
-            Command: type C:\nonexistent\file.txt
             The system cannot find the path specified.
             Exit code: 1
         """.trimIndent()
@@ -268,7 +258,6 @@ class ExecuteShellCommandToolJvmTest {
         val result = tool.executeShellCommand("cat file1.txt file2.txt", workingDirectory = tempDir.toString())
 
         val expected = """
-            Command: cat file1.txt file2.txt
             Hello from file1
             cat: file2.txt: No such file or directory
             Exit code: 1
@@ -286,12 +275,11 @@ class ExecuteShellCommandToolJvmTest {
         val result = tool.executeShellCommand("type file1.txt file2.txt", workingDirectory = tempDir.toString())
 
         val expected = """
-            Command: type file1.txt file2.txt
             Hello from file1
-            
+
             file1.txt
-            
-            
+
+
             The system cannot find the file specified.
             Error occurred while processing: file2.txt.
             Exit code: 1
@@ -310,7 +298,6 @@ class ExecuteShellCommandToolJvmTest {
         val result = tool.executeShellCommand("rm important-file.txt",)
 
         val expected = """
-            Command: rm important-file.txt
             Command execution denied with user response: No
         """.trimIndent()
 
@@ -326,7 +313,6 @@ class ExecuteShellCommandToolJvmTest {
         val result = tool.executeShellCommand("rm important-file.txt")
 
         val expected = """
-            Command: rm important-file.txt
             Command execution denied with user response: Cannot delete important files
         """.trimIndent()
 
@@ -352,7 +338,6 @@ class ExecuteShellCommandToolJvmTest {
         }
 
         val partialExpected = """
-        Command: echo beforeSleep && sleep 10 && echo afterSleep
         beforeSleep
         """.trimIndent()
 
@@ -388,7 +373,6 @@ class ExecuteShellCommandToolJvmTest {
         }
 
         val partialExpected = """
-        Command: powershell -Command "'beforeSleep'; Start-Sleep -Seconds 10; 'afterSleep'"
         """.trimIndent()
 
         val output = tool.encodeResultToString(result)

--- a/examples/code-agent/step-05-history/src/main/kotlin/CodeAgentHistoryCompressionConfig.kt
+++ b/examples/code-agent/step-05-history/src/main/kotlin/CodeAgentHistoryCompressionConfig.kt
@@ -16,7 +16,7 @@ val COMPRESSION_MODEL: LLModel = OpenAIModels.Chat.GPT4_1Mini
  * Triggers compression when history exceeds 200 messages OR 200k characters (~50k tokens).
  */
 val CODE_AGENT_HISTORY_TOO_BIG: (Prompt) -> Boolean = { prompt ->
-    prompt.messages.size > 50 || prompt.messages.sumOf { it.content.length } > 50_000
+    prompt.messages.size > 200 || prompt.messages.sumOf { it.content.length } > 200_000
 }
 
 /**
@@ -63,5 +63,8 @@ val CODE_AGENT_COMPRESSION = RetrieveFactsFromHistory(
         "pending-tasks-and-issues",
         "What are the immediate next steps planned or required? Are there any unresolved questions, issues, decisions to be made, or blockers encountered?",
         FactType.MULTIPLE
-    )
+    ),
+    Concept("modified-files-exact-trail",
+        "List EVERY file that was read, created, modified, or deleted with EXACT file paths. For files that were modified, what specific changes were made?",
+        FactType.MULTIPLE)
 )

--- a/examples/code-agent/step-05-history/src/main/kotlin/CodeAgentHistoryCompressionConfig.kt
+++ b/examples/code-agent/step-05-history/src/main/kotlin/CodeAgentHistoryCompressionConfig.kt
@@ -4,6 +4,13 @@ import ai.koog.agents.memory.feature.history.RetrieveFactsFromHistory
 import ai.koog.agents.memory.model.Concept
 import ai.koog.agents.memory.model.FactType
 import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import ai.koog.prompt.llm.LLModel
+
+/**
+ * The model used for history compression
+ */
+val COMPRESSION_MODEL: LLModel = OpenAIModels.Chat.GPT4oMini
 
 /**
  * Triggers compression when history exceeds 200 messages OR 200k characters (~50k tokens).

--- a/examples/code-agent/step-05-history/src/main/kotlin/CodeAgentHistoryCompressionConfig.kt
+++ b/examples/code-agent/step-05-history/src/main/kotlin/CodeAgentHistoryCompressionConfig.kt
@@ -63,8 +63,5 @@ val CODE_AGENT_COMPRESSION = RetrieveFactsFromHistory(
         "pending-tasks-and-issues",
         "What are the immediate next steps planned or required? Are there any unresolved questions, issues, decisions to be made, or blockers encountered?",
         FactType.MULTIPLE
-    ),
-    Concept("modified-files-exact-trail",
-        "List EVERY file that was read, created, modified, or deleted with EXACT file paths. For files that were modified, what specific changes were made?",
-        FactType.MULTIPLE)
+    )
 )

--- a/examples/code-agent/step-05-history/src/main/kotlin/CodeAgentHistoryCompressionConfig.kt
+++ b/examples/code-agent/step-05-history/src/main/kotlin/CodeAgentHistoryCompressionConfig.kt
@@ -16,7 +16,7 @@ val COMPRESSION_MODEL: LLModel = OpenAIModels.Chat.GPT4_1Mini
  * Triggers compression when history exceeds 200 messages OR 200k characters (~50k tokens).
  */
 val CODE_AGENT_HISTORY_TOO_BIG: (Prompt) -> Boolean = { prompt ->
-    prompt.messages.size > 3 || prompt.messages.sumOf { it.content.length } > 200_000
+    prompt.messages.size > 200 || prompt.messages.sumOf { it.content.length } > 200_000
 }
 
 /**

--- a/examples/code-agent/step-05-history/src/main/kotlin/CodeAgentHistoryCompressionConfig.kt
+++ b/examples/code-agent/step-05-history/src/main/kotlin/CodeAgentHistoryCompressionConfig.kt
@@ -10,13 +10,13 @@ import ai.koog.prompt.llm.LLModel
 /**
  * The model used for history compression
  */
-val COMPRESSION_MODEL: LLModel = OpenAIModels.Chat.GPT4oMini
+val COMPRESSION_MODEL: LLModel = OpenAIModels.Chat.GPT4_1Mini
 
 /**
  * Triggers compression when history exceeds 200 messages OR 200k characters (~50k tokens).
  */
 val CODE_AGENT_HISTORY_TOO_BIG: (Prompt) -> Boolean = { prompt ->
-    prompt.messages.size > 200 || prompt.messages.sumOf { it.content.length } > 200_000
+    prompt.messages.size > 3 || prompt.messages.sumOf { it.content.length } > 200_000
 }
 
 /**

--- a/examples/code-agent/step-05-history/src/main/kotlin/CodeAgentHistoryCompressionConfig.kt
+++ b/examples/code-agent/step-05-history/src/main/kotlin/CodeAgentHistoryCompressionConfig.kt
@@ -16,7 +16,7 @@ val COMPRESSION_MODEL: LLModel = OpenAIModels.Chat.GPT4_1Mini
  * Triggers compression when history exceeds 200 messages OR 200k characters (~50k tokens).
  */
 val CODE_AGENT_HISTORY_TOO_BIG: (Prompt) -> Boolean = { prompt ->
-    prompt.messages.size > 200 || prompt.messages.sumOf { it.content.length } > 200_000
+    prompt.messages.size > 100 || prompt.messages.sumOf { it.content.length } > 100_000
 }
 
 /**

--- a/examples/code-agent/step-05-history/src/main/kotlin/CodeAgentHistoryCompressionConfig.kt
+++ b/examples/code-agent/step-05-history/src/main/kotlin/CodeAgentHistoryCompressionConfig.kt
@@ -16,7 +16,7 @@ val COMPRESSION_MODEL: LLModel = OpenAIModels.Chat.GPT4_1Mini
  * Triggers compression when history exceeds 200 messages OR 200k characters (~50k tokens).
  */
 val CODE_AGENT_HISTORY_TOO_BIG: (Prompt) -> Boolean = { prompt ->
-    prompt.messages.size > 100 || prompt.messages.sumOf { it.content.length } > 100_000
+    prompt.messages.size > 50 || prompt.messages.sumOf { it.content.length } > 50_000
 }
 
 /**

--- a/examples/code-agent/step-05-history/src/main/kotlin/Main.kt
+++ b/examples/code-agent/step-05-history/src/main/kotlin/Main.kt
@@ -1,10 +1,8 @@
 package ai.koog.agents.example.codeagent.step05
 
 import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.singleRunStrategy
 import ai.koog.agents.core.tools.ToolRegistry
-import ai.koog.agents.ext.agent.HistoryCompressionConfig
-import ai.koog.agents.ext.agent.singleRunStrategyWithHistoryCompression
-
 import ai.koog.agents.ext.tool.file.EditFileTool
 import ai.koog.agents.ext.tool.file.ListDirectoryTool
 import ai.koog.agents.ext.tool.file.ReadFileTool
@@ -40,13 +38,7 @@ val agent = AIAgent(
         You also have an intelligent find micro agent at your disposition, which can help you find code components and other constructs 
         more cheaply than you can do it yourself. Lean on it for any and all search operations. Do not use shell execution for find tasks.
     """.trimIndent(),
-    strategy = singleRunStrategyWithHistoryCompression(
-        config = HistoryCompressionConfig(
-            isHistoryTooBig = CODE_AGENT_HISTORY_TOO_BIG,
-            compressionStrategy = CODE_AGENT_COMPRESSION,
-            retrievalModel = COMPRESSION_MODEL
-        )
-    ),
+    strategy = singleRunStrategy(),
     maxIterations = 400
 ) {
     setupObservability(agentName = "main")

--- a/examples/code-agent/step-05-history/src/main/kotlin/Main.kt
+++ b/examples/code-agent/step-05-history/src/main/kotlin/Main.kt
@@ -1,9 +1,8 @@
 package ai.koog.agents.example.codeagent.step05
 
 import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.singleRunStrategy
 import ai.koog.agents.core.tools.ToolRegistry
-import ai.koog.agents.ext.agent.HistoryCompressionConfig
-import ai.koog.agents.ext.agent.singleRunStrategyWithHistoryCompression
 
 import ai.koog.agents.ext.tool.file.EditFileTool
 import ai.koog.agents.ext.tool.file.ListDirectoryTool
@@ -12,20 +11,13 @@ import ai.koog.agents.ext.tool.shell.ExecuteShellCommandTool
 import ai.koog.agents.ext.tool.shell.JvmShellCommandExecutor
 import ai.koog.agents.ext.tool.shell.PrintShellCommandConfirmationHandler
 import ai.koog.agents.ext.tool.shell.ShellCommandConfirmation
-import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
 import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
-import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
-import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
-import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.executor.llms.all.simpleAnthropicExecutor
 import ai.koog.rag.base.files.JVMFileSystemProvider
 
-val multiExecutor = MultiLLMPromptExecutor(
-    LLMProvider.Anthropic to AnthropicLLMClient(System.getenv("ANTHROPIC_API_KEY")),
-    LLMProvider.OpenAI to OpenAILLMClient(System.getenv("OPENAI_API_KEY"))
-)
-
+val executor = simpleAnthropicExecutor(System.getenv("ANTHROPIC_API_KEY"))
 val agent = AIAgent(
-    promptExecutor = multiExecutor,
+    promptExecutor = executor,
     llmModel = AnthropicModels.Sonnet_4_5,
     toolRegistry = ToolRegistry {
         tool(ListDirectoryTool(JVMFileSystemProvider.ReadOnly))
@@ -47,13 +39,7 @@ val agent = AIAgent(
         You also have an intelligent find micro agent at your disposition, which can help you find code components and other constructs 
         more cheaply than you can do it yourself. Lean on it for any and all search operations. Do not use shell execution for find tasks.
     """.trimIndent(),
-    strategy = singleRunStrategyWithHistoryCompression(
-        config = HistoryCompressionConfig(
-            isHistoryTooBig = CODE_AGENT_HISTORY_TOO_BIG,
-            compressionStrategy = CODE_AGENT_COMPRESSION,
-            retrievalModel = COMPRESSION_MODEL
-        )
-    ),
+    strategy = singleRunStrategy(),
     maxIterations = 400
 ) {
     setupObservability(agentName = "main")
@@ -80,6 +66,6 @@ suspend fun main(args: Array<String>) {
         val result = agent.run(input)
         println(result)
     } finally {
-        multiExecutor.close()
+        executor.close()
     }
 }

--- a/examples/code-agent/step-05-history/src/main/kotlin/Main.kt
+++ b/examples/code-agent/step-05-history/src/main/kotlin/Main.kt
@@ -43,7 +43,8 @@ val agent = AIAgent(
     strategy = singleRunStrategyWithHistoryCompression(
         config = HistoryCompressionConfig(
             isHistoryTooBig = CODE_AGENT_HISTORY_TOO_BIG,
-            compressionStrategy = CODE_AGENT_COMPRESSION
+            compressionStrategy = CODE_AGENT_COMPRESSION,
+            retrievalModel = COMPRESSION_MODEL
         )
     ),
     maxIterations = 400

--- a/examples/code-agent/step-05-history/src/main/kotlin/Main.kt
+++ b/examples/code-agent/step-05-history/src/main/kotlin/Main.kt
@@ -1,8 +1,10 @@
 package ai.koog.agents.example.codeagent.step05
 
 import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.agent.singleRunStrategy
 import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.ext.agent.HistoryCompressionConfig
+import ai.koog.agents.ext.agent.singleRunStrategyWithHistoryCompression
+
 import ai.koog.agents.ext.tool.file.EditFileTool
 import ai.koog.agents.ext.tool.file.ListDirectoryTool
 import ai.koog.agents.ext.tool.file.ReadFileTool
@@ -38,7 +40,13 @@ val agent = AIAgent(
         You also have an intelligent find micro agent at your disposition, which can help you find code components and other constructs 
         more cheaply than you can do it yourself. Lean on it for any and all search operations. Do not use shell execution for find tasks.
     """.trimIndent(),
-    strategy = singleRunStrategy(),
+    strategy = singleRunStrategyWithHistoryCompression(
+        config = HistoryCompressionConfig(
+            isHistoryTooBig = CODE_AGENT_HISTORY_TOO_BIG,
+            compressionStrategy = CODE_AGENT_COMPRESSION,
+            retrievalModel = COMPRESSION_MODEL
+        )
+    ),
     maxIterations = 400
 ) {
     setupObservability(agentName = "main")

--- a/examples/code-agent/step-05-history/src/main/kotlin/Observability.kt
+++ b/examples/code-agent/step-05-history/src/main/kotlin/Observability.kt
@@ -27,14 +27,12 @@ fun GraphAIAgent.FeatureContext.setupObservability(agentName: String) {
             logger.info { "[$agentName] Tool '${ctx.toolName}' called with args: ${ctx.toolArgs.toString().take(100)}" }
         }
         onNodeExecutionStarting { ctx ->
-            logger.info { "[$agentName] Node '${ctx.node.name}' STARTING" }
             if (ctx.node.name == "compressHistory") {
                 val messages = ctx.context.llm.prompt.messages
                 logger.info { "[$agentName] Pre-compression: ${messages.size} msgs, ${messages.sumOf { it.content.length }} chars" }
             }
         }
         onNodeExecutionCompleted { ctx ->
-            logger.info { "[$agentName] Node '${ctx.node.name}' COMPLETED" }
             if (ctx.node.name == "compressHistory") {
                 val messages = ctx.context.llm.prompt.messages
                 logger.info { "[$agentName] Post-compression: ${messages.size} msgs, ${messages.sumOf { it.content.length }} chars" }

--- a/examples/code-agent/step-05-history/src/main/kotlin/Observability.kt
+++ b/examples/code-agent/step-05-history/src/main/kotlin/Observability.kt
@@ -29,15 +29,15 @@ fun GraphAIAgent.FeatureContext.setupObservability(agentName: String) {
         onNodeExecutionStarting { ctx ->
             logger.info { "[$agentName] Node '${ctx.node.name}' STARTING" }
             if (ctx.node.name == "compressHistory") {
-                logger.info { "[$agentName] Pre-compression history size: ${ctx.context.config.prompt.messages.size} messages" }
-                logger.info { "[$agentName] Pre-compression total chars: ${ctx.context.config.prompt.messages.sumOf { it.content.length }}" }
+                val messages = ctx.context.llm.prompt.messages
+                logger.info { "[$agentName] Pre-compression: ${messages.size} msgs, ${messages.sumOf { it.content.length }} chars" }
             }
         }
         onNodeExecutionCompleted { ctx ->
             logger.info { "[$agentName] Node '${ctx.node.name}' COMPLETED" }
             if (ctx.node.name == "compressHistory") {
-                logger.info { "[$agentName] Post-compression history size: ${ctx.context.config.prompt.messages.size} messages" }
-                logger.info { "[$agentName] Post-compression total chars: ${ctx.context.config.prompt.messages.sumOf { it.content.length }}" }
+                val messages = ctx.context.llm.prompt.messages
+                logger.info { "[$agentName] Post-compression: ${messages.size} msgs, ${messages.sumOf { it.content.length }} chars" }
             }
         }
     }

--- a/examples/code-agent/step-05-history/src/main/kotlin/Observability.kt
+++ b/examples/code-agent/step-05-history/src/main/kotlin/Observability.kt
@@ -5,6 +5,9 @@ import ai.koog.agents.features.eventHandler.feature.handleEvents
 import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
 import ai.koog.agents.features.opentelemetry.integration.langfuse.addLangfuseExporter
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger = KotlinLogging.logger("code-agent-events")
 
 /**
  * Extracted observability setup used by agents in this module.
@@ -21,7 +24,21 @@ fun GraphAIAgent.FeatureContext.setupObservability(agentName: String) {
     }
     handleEvents {
         onToolCallStarting { ctx ->
-            println("[$agentName] Tool '${ctx.toolName}' called with args: ${ctx.toolArgs.toString().take(100)}")
+            logger.info { "[$agentName] Tool '${ctx.toolName}' called with args: ${ctx.toolArgs.toString().take(100)}" }
+        }
+        onNodeExecutionStarting { ctx ->
+            logger.info { "[$agentName] Node '${ctx.node.name}' STARTING" }
+            if (ctx.node.name == "compressHistory") {
+                logger.info { "[$agentName] Pre-compression history size: ${ctx.context.config.prompt.messages.size} messages" }
+                logger.info { "[$agentName] Pre-compression total chars: ${ctx.context.config.prompt.messages.sumOf { it.content.length }}" }
+            }
+        }
+        onNodeExecutionCompleted { ctx ->
+            logger.info { "[$agentName] Node '${ctx.node.name}' COMPLETED" }
+            if (ctx.node.name == "compressHistory") {
+                logger.info { "[$agentName] Post-compression history size: ${ctx.context.config.prompt.messages.size} messages" }
+                logger.info { "[$agentName] Post-compression total chars: ${ctx.context.config.prompt.messages.sumOf { it.content.length }}" }
+            }
         }
     }
 }

--- a/examples/code-agent/step-05-history/src/main/resources/logback.xml
+++ b/examples/code-agent/step-05-history/src/main/resources/logback.xml
@@ -18,7 +18,7 @@
         </encoder>
     </appender>
 
-    <root level="ALL">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE" />
     </root>

--- a/examples/code-agent/step-05-history/src/main/resources/logback.xml
+++ b/examples/code-agent/step-05-history/src/main/resources/logback.xml
@@ -5,7 +5,24 @@
         </encoder>
     </appender>
 
-    <root level="ERROR">
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${user.home}/.dev/logs/code-agent.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${user.home}/.dev/logs/code-agent.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${FILE_LOG_LEVEL:-INFO}</level>
+        </filter>
+    </appender>
+
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/examples/code-agent/step-05-history/src/main/resources/logback.xml
+++ b/examples/code-agent/step-05-history/src/main/resources/logback.xml
@@ -16,12 +16,11 @@
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${FILE_LOG_LEVEL:-INFO}</level>
-        </filter>
     </appender>
 
-    <root level="INFO">
+    <logger name="code-agent-events" level="INFO" />
+
+    <root level="ERROR">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE" />
     </root>

--- a/examples/code-agent/step-05-history/src/main/resources/logback.xml
+++ b/examples/code-agent/step-05-history/src/main/resources/logback.xml
@@ -18,9 +18,7 @@
         </encoder>
     </appender>
 
-    <logger name="code-agent-events" level="INFO" />
-
-    <root level="ERROR">
+    <root level="ALL">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE" />
     </root>


### PR DESCRIPTION
## Summary

Remove redundant `command` field from `ExecuteShellCommandTool.Result` and its output formatting. The command information was being duplicated in the output since it's already known from the context of the tool call.

## Changes

- Remove `command` field from `ExecuteShellCommandTool.Result` data class
- Update `encodeResultToString()` to remove "Command: ..." line from output
- Update all test assertions to match new output format

## Test plan

All existing tests updated and passing with new output format.