### PR TITLE
ci: add PR title verification according to conventional commits, update contributing guidelines and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,37 +1,27 @@
 <!--
-Thank you for opening a pull request!
+PR title should follow Conventional Commits format:
+  type(scope): description
 
-Please add a brief description of the proposed change here.
-Also, please tick the appropriate points in the checklist below.
+For breaking changes, append ! after type/scope:
+  type(scope)!: description
+
+Examples:
+  feat(agents): add streaming response node
+  fix(prompt): handle null responses in PromptExecutor
+  refactor(agents)!: remove deprecated methods from Tool
+
+See CONTRIBUTING.md for more details
 -->
 
-## Motivation and Context
-<!-- Why is this change needed? What problem does it solve? -->
+Describe what this PR changes and why.
 
-## Breaking Changes
-<!-- Will users need to update their code or configurations? -->
 
----
+<!-- Include BREAKING section below only if this PR introduces breaking changes. Otherwise, delete it. -->
+BREAKING:
+*
 
-#### Type of the changes
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] Breaking change (fix or feature that would cause existing functionality to change)
-- [ ] Documentation update
-- [ ] Tests improvement
-- [ ] Refactoring
-- [ ] CI/CD changes
-- [ ] Dependencies update
+<!-- Include DEPRECATED section below only if this PR deprecates any public APIs. Otherwise, delete it. -->
+DEPRECATED:
+*
 
-#### Checklist
-- [ ] The pull request has a description of the proposed change
-- [ ] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
-- [ ] The pull request uses **`develop`** as the base branch
-- [ ] Tests for the changes have been added
-- [ ] All new and existing tests passed
-
-##### Additional steps for pull requests adding a new feature
-- [ ] An issue describing the proposed change exists
-- [ ] The pull request includes a link to the issue
-- [ ] The change was discussed and approved in the issue
-- [ ] Docs have been added / updated
+closes #

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,4 +24,5 @@ BREAKING:
 DEPRECATED:
 *
 
-closes #
+<!-- Include references to related issues below, e.g., closes #1, closes KG-1. Otherwise, delete it. -->
+closes

--- a/.github/workflows/conventional-prs.yml
+++ b/.github/workflows/conventional-prs.yml
@@ -1,0 +1,51 @@
+name: 'Conventional PRs'
+
+on:
+  pull_request:
+    branches: [ "develop" ]
+    types:
+      - opened
+      - reopened
+      - edited
+      # - synchronize (if you use required Actions)
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Docs: https://github.com/amannn/action-semantic-pull-request?tab=readme-ov-file#configuration
+        with:
+          # TODO verify types
+          types: |
+            fix
+            feat
+            build
+            chore
+            ci
+            docs
+            refactor
+            test
+          # TODO verify scopes (for now took from top-level modules)
+          scopes: |
+            a2a
+            agents
+            docs
+            embeddings
+            http-client
+            integration-tests
+            koog-agents
+            koog-ktor
+            koog-spring-boot-starter
+            prompt
+            rag
+            test-utils
+            utils
+          # ignore dependabot
+          ignoreLabels: |
+            dependencies

--- a/.github/workflows/conventional-prs.yml
+++ b/.github/workflows/conventional-prs.yml
@@ -20,22 +20,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Docs: https://github.com/amannn/action-semantic-pull-request?tab=readme-ov-file#configuration
+        # Remember to update CONTRIBUTING.md if you change these configs!
         with:
-          # TODO verify types
           types: |
             fix
             feat
             build
-            chore
             ci
             docs
             refactor
             test
-          # TODO verify scopes (for now took from top-level modules)
+            example
+          # top-level modules for now, might be refined later
           scopes: |
             a2a
             agents
-            docs
             embeddings
             http-client
             integration-tests

--- a/.github/workflows/conventional-prs.yml
+++ b/.github/workflows/conventional-prs.yml
@@ -36,11 +36,10 @@ jobs:
             a2a
             agents
             embeddings
-            http-client
             integration-tests
             koog-agents
             koog-ktor
-            koog-spring-boot-starter
+            spring-boot
             prompt
             rag
             test-utils

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,11 +56,10 @@ The following scopes are supported:
 - `a2a`
 - `agents`
 - `embeddings`
-- `http-client`
 - `integration-tests`
 - `koog-agents`
 - `koog-ktor`
-- `koog-spring-boot-starter`
+- `spring-boot`
 - `prompt`
 - `rag`
 - `test-utils`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,3 @@
-<!-- Basic guidelines, should be refined -->
-
 # Contributing Guidelines
 
 One can contribute to the project by reporting issues or submitting changes via pull request.
@@ -9,27 +7,19 @@ One can contribute to the project by reporting issues or submitting changes via 
 Please use [Koog official YouTrack project](https://youtrack.jetbrains.com/issues/KG) for filing feature
 requests and bug reports.
 
-Questions about usage and general inquiries are better suited for StackOverflow or the [#koog-agentic-framework](https://kotlinlang.slack.com/messages/koog-agentic-framework/) channel in KotlinLang Slack.
+Questions about usage and general inquiries are better suited for the [#koog-agentic-framework](https://kotlinlang.slack.com/messages/koog-agentic-framework/) channel in KotlinLang Slack.
 
 ## Submitting changes
 
+### General guidelines
+
 Submit pull requests [here](https://github.com/JetBrains/koog/pulls).
 However, please keep in mind that maintainers will have to support the resulting code of the project,
-so do familiarize yourself with the following guidelines.
+so do familiarize yourself with the following guidelines:
 
-<!-- TODO: discuss git flow -->
-<!-- TODO: align coding conventions with what the team is actually using -->
-
-* All development (both new features and bug fixes) is performed in the `develop` branch.
-    * The `main` branch contains the sources of the most recently released version.
-    * Base your PRs against the `develop` branch.
-    * The `develop` branch is pushed to the `main` branch during release.
-    * Documentation in markdown files can be updated directly in the `main` branch,
-      unless the documentation is in the source code, and the patch changes line numbers.
+* All development (both new features and bug fixes) is performed in the `develop` branch. Base your PRs against it.
 * If you make any code changes:
     * Follow the [Kotlin Coding Conventions](https://kotlinlang.org/docs/reference/coding-conventions.html).
-        * Use 4 spaces for indentation.
-        * Use imports with '*'.
     * [Build the project](#building) to make sure it all works and passes the tests.
 * If you fix a bug:
     * Write the test that reproduces the bug.
@@ -39,9 +29,111 @@ so do familiarize yourself with the following guidelines.
       name test functions as `testXxx`. Don't use backticks in test names.
 * Comment on the existing issue if you want to work on it. Ensure that the issue not only describes a problem but also describes a solution that has received positive feedback. Propose a solution if none has been suggested.
 
+### Conventional PRs
+
+This project uses the "Squash & Merge" strategy, which turns each PR into a single commit when merged into `develop`.
+Because of this, we follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for PR titles and descriptions.
+
+**For breaking changes**, append `!` after the type/scope: `refactor(agents)!: remove deprecated methods from Tool`
+
+#### Supported types
+
+- `feat` — New feature
+- `fix` — Bug fix
+- `docs` — Documentation changes
+- `refactor` — Code refactoring (no functional changes)
+- `test` — Adding or updating tests
+- `build` — Build system or dependency changes
+- `ci` — CI/CD configuration changes
+- `example` — Changes to examples
+
+#### Supported scopes (optional)
+
+You don't have to specify a scope for PRs that affect multiple scopes, but it's recommended to set scope(s) when possible
+for greater clarity. Currently, scopes are based on the top-level modules of the project. This might change in the future.
+The following scopes are supported:
+
+- `a2a`
+- `agents`
+- `embeddings`
+- `http-client`
+- `integration-tests`
+- `koog-agents`
+- `koog-ktor`
+- `koog-spring-boot-starter`
+- `prompt`
+- `rag`
+- `test-utils`
+- `utils`
+
+#### Description
+
+* Always provide a clear description of the changes you're making and why you're making them.
+* Include "BREAKING:" section if the PR introduces breaking changes (incompatible API changes), e.g.:
+```
+BREAKING:
+* Tool.execute() now requires an additional parameter
+* Removed deprecated Message.metadata property
+```
+* Include "DEPRECATED:" section if the PR deprecates any public APIs, e.g.:
+```
+DEPRECATED:
+* Tool.foo method in favor of Tool.bar
+* Message.baz property
+```
+* Use "closes" keyword to link the PR to the issue(s) it addresses, e.g., "closes #1, closes KG-1".
+
+#### Examples
+
+The following are examples of properly formatted PR titles and descriptions:
+
+**New feature:**
+```
+feat(agents): add support for streaming responses
+
+
+Add streaming response support to the agents module, allowing real-time
+token-by-token processing of LLM outputs.
+
+closes #123, closes KG-456
+```
+
+**PR with deprecations:**
+```
+refactor(prompt): simplify PromptExecutor interface by deprecating redundant methods
+
+
+Refactors the PromptExecutor interface to deprecate redundant methods and improve
+type safety for structured outputs.
+
+DEPRECATED:
+* PromptExecutor.executeWithSchema() in favor of PromptExecutor.execute() with structured parameter
+* Message.metadata property
+
+closes KG-789
+```
+
+**PR with breaking changes:**
+```
+feat(agents)!: redesign Tool interface for better type safety
+
+
+Redesigns the Tool interface to enforce stricter type safety and improve
+error handling. This is a breaking change that requires migration.
+
+BREAKING:
+* Tool.execute() now returns Result<T> instead of T
+* ToolRegistry.register() requires explicit error handler
+* Removed Tool.executeUnsafe() method
+
+Migration guide: https://docs.koog.ai/migration/tool-interface-v2
+
+closes KG-890
+```
+
 ## Working with AI Code Agents
 
-This project includes some helpful guidelines to make AI coding assistants work better with codebase. 
+This project includes some helpful guidelines to make AI coding assistants work better with the codebase. 
 
 ### Agent Guidelines
 
@@ -63,8 +155,8 @@ When you're pairing with an AI assistant on this project:
 
 ## Documentation
 
-The documentation is published on https://docs.koog.ai/, and its sources are in the
-[docs](https://github.com/JetBrains/koog/tree/develop/docs) folder in this repository.
+The documentation is published on https://docs.koog.ai/, and its sources are located in the
+[docs](https://github.com/JetBrains/koog/tree/develop/docs) directory.
 
 ## Building
 
@@ -79,10 +171,10 @@ Koog is a Kotlin Multiplatform framework, and you need a bunch of tools to build
 
 ### How to build
 
-This library is built with Gradle.
+This project is built with Gradle.
 
 * Run `./gradlew build` to build. It also runs all the tests.
-* Run `./gradlew <module>:check` to test the module you are looking at to speed
+* Run `./gradlew <module>:check` to test the module you are looking and to speed
   things up during development.
 
 You can import this project into IDEA, but you have to delegate build actions


### PR DESCRIPTION
To enforce [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) in `develop`, added a new action to verify that PRs targeting `develop` have conventional title according to configured rules. This should be enough for now, since we have only "Squash" option enabled for PRs, so PR title essentially becomes commit title. 

Also updated contributing guidelines and PR template to describe this new convention.