### PR TITLE
Introduce a transforming interceptor to EventHandler

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/ContextualPromptExecutor.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/ContextualPromptExecutor.kt
@@ -45,7 +45,6 @@ public class ContextualPromptExecutor(
             context.runId,
             prompt,
             model,
-            tools,
             context
         )
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/AgentLifecycleEventType.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/AgentLifecycleEventType.kt
@@ -92,7 +92,14 @@ public sealed interface AgentLifecycleEventType {
     //region LLM
 
     /**
-     * Represents an event triggered when an error occurs during a language model call.
+     * Represents an event triggered when a prompt is being transformed.
+     * This allows features to modify the prompt before [LLMCallStarting] is triggered
+     * and before the prompt is sent to the language model.
+     */
+    public object LLMPromptTransforming : AgentLifecycleEventType
+
+    /**
+     * Represents an event triggered before a call is made to the language model.
      */
     public object LLMCallStarting : AgentLifecycleEventType
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/llm/LLMCallEventContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/llm/LLMCallEventContext.kt
@@ -28,7 +28,6 @@ public interface LLMCallEventContext : AgentLifecycleEventContext
  * @property prompt The prompt that will be transformed. This is the current state of the prompt
  *                  after any previous transformations.
  * @property model The language model instance that will be used for the call.
- * @property tools The list of tool descriptors available for the LLM call.
  * @property context The AI agent context providing access to agent state and configuration.
  */
 public data class LLMPromptTransformingContext(
@@ -37,7 +36,6 @@ public data class LLMPromptTransformingContext(
     val runId: String,
     val prompt: Prompt,
     val model: LLModel,
-    val tools: List<ToolDescriptor>,
     val context: AIAgentContext
 ) : LLMCallEventContext {
     override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.LLMPromptTransforming

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/llm/LLMCallEventContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/llm/LLMCallEventContext.kt
@@ -16,6 +16,34 @@ import ai.koog.prompt.message.Message
 public interface LLMCallEventContext : AgentLifecycleEventContext
 
 /**
+ * Represents the context for transforming a prompt before it is sent to the language model.
+ * This context is used by features that need to modify the prompt, such as adding context from
+ * a database, implementing RAG (Retrieval-Augmented Generation), or applying prompt templates.
+ *
+ * Prompt transformation occurs before [LLMCallStartingContext] is triggered, allowing
+ * modifications to be applied prior to the LLM call event handlers.
+ *
+ * @property executionInfo The execution information containing parentId and current execution path.
+ * @property runId The unique identifier for this LLM call session.
+ * @property prompt The prompt that will be transformed. This is the current state of the prompt
+ *                  after any previous transformations.
+ * @property model The language model instance that will be used for the call.
+ * @property tools The list of tool descriptors available for the LLM call.
+ * @property context The AI agent context providing access to agent state and configuration.
+ */
+public data class LLMPromptTransformingContext(
+    override val eventId: String,
+    override val executionInfo: AgentExecutionInfo,
+    val runId: String,
+    val prompt: Prompt,
+    val model: LLModel,
+    val tools: List<ToolDescriptor>,
+    val context: AIAgentContext
+) : LLMCallEventContext {
+    override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.LLMPromptTransforming
+}
+
+/**
  * Represents the context for handling a before LLM call event.
  *
  * @property executionInfo The execution information containing parentId and current execution path;

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
@@ -258,7 +258,6 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param runId The unique identifier for this LLM call session
      * @param prompt The original prompt to be transformed
      * @param model The language model that will be used
-     * @param tools The list of tool descriptors available for the LLM call
      * @param context The AI agent context
      * @return The transformed prompt that will be sent to the language model
      */
@@ -268,7 +267,6 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
         runId: String,
         prompt: Prompt,
         model: LLModel,
-        tools: List<ToolDescriptor>,
         context: AIAgentContext
     ): Prompt
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineAPI.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineAPI.kt
@@ -133,7 +133,6 @@ public interface AIAgentPipelineAPI {
         runId: String,
         prompt: Prompt,
         model: LLModel,
-        tools: List<ToolDescriptor>,
         context: AIAgentContext
     ): Prompt
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineAPI.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineAPI.kt
@@ -21,6 +21,7 @@ import ai.koog.agents.core.feature.handler.agent.AgentExecutionFailedContext
 import ai.koog.agents.core.feature.handler.agent.AgentStartingContext
 import ai.koog.agents.core.feature.handler.llm.LLMCallCompletedContext
 import ai.koog.agents.core.feature.handler.llm.LLMCallStartingContext
+import ai.koog.agents.core.feature.handler.llm.LLMPromptTransformingContext
 import ai.koog.agents.core.feature.handler.strategy.StrategyCompletedContext
 import ai.koog.agents.core.feature.handler.strategy.StrategyStartingContext
 import ai.koog.agents.core.feature.handler.streaming.LLMStreamingCompletedContext
@@ -126,6 +127,16 @@ public interface AIAgentPipelineAPI {
     //endregion
 
     //region Trigger LLM Handlers
+    public suspend fun onLLMPromptTransforming(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        runId: String,
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>,
+        context: AIAgentContext
+    ): Prompt
+
     public suspend fun onLLMCallStarting(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -272,6 +283,11 @@ public interface AIAgentPipelineAPI {
     public fun interceptStrategyCompleted(
         feature: AIAgentFeature<*, *>,
         handle: suspend (StrategyCompletedContext) -> Unit
+    )
+
+    public fun interceptLLMPromptTransforming(
+        feature: AIAgentFeature<*, *>,
+        transform: suspend LLMPromptTransformingContext.(Prompt) -> Prompt
     )
 
     public fun interceptLLMCallStarting(

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineImpl.kt
@@ -285,10 +285,9 @@ public class AIAgentPipelineImpl(
         runId: String,
         prompt: Prompt,
         model: LLModel,
-        tools: List<ToolDescriptor>,
         context: AIAgentContext
     ): Prompt {
-        val eventContext = LLMPromptTransformingContext(eventId, executionInfo, runId, prompt, model, tools, context)
+        val eventContext = LLMPromptTransformingContext(eventId, executionInfo, runId, prompt, model, context)
         return llmCallEventHandlers.values.fold(prompt) { currentPrompt, handler ->
             handler.transformRequest(eventContext.copy(prompt = currentPrompt), currentPrompt)
         }

--- a/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandler.kt
+++ b/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandler.kt
@@ -144,6 +144,10 @@ public class EventHandler {
                 config.invokeOnStrategyCompleted(eventContext)
             }
 
+            pipeline.interceptLLMPromptTransforming(this) intercept@{ prompt ->
+                config.invokeOnLLMPromptTransforming(this, prompt)
+            }
+
             pipeline.interceptLLMCallStarting(this) intercept@{ eventContext: LLMCallStartingContext ->
                 config.invokeOnLLMCallStarting(eventContext)
             }

--- a/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerConfig.kt
+++ b/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerConfig.kt
@@ -23,6 +23,7 @@ import ai.koog.agents.core.feature.handler.agent.AgentExecutionFailedContext
 import ai.koog.agents.core.feature.handler.agent.AgentStartingContext
 import ai.koog.agents.core.feature.handler.llm.LLMCallCompletedContext
 import ai.koog.agents.core.feature.handler.llm.LLMCallStartingContext
+import ai.koog.agents.core.feature.handler.llm.LLMPromptTransformingContext
 import ai.koog.agents.core.feature.handler.node.NodeExecutionCompletedContext
 import ai.koog.agents.core.feature.handler.node.NodeExecutionFailedContext
 import ai.koog.agents.core.feature.handler.node.NodeExecutionStartingContext
@@ -39,6 +40,7 @@ import ai.koog.agents.core.feature.handler.tool.ToolCallCompletedContext
 import ai.koog.agents.core.feature.handler.tool.ToolCallFailedContext
 import ai.koog.agents.core.feature.handler.tool.ToolCallStartingContext
 import ai.koog.agents.core.feature.handler.tool.ToolValidationFailedContext
+import ai.koog.prompt.dsl.Prompt
 
 /**
  * Configuration class for the EventHandler feature.
@@ -115,6 +117,8 @@ public expect class EventHandlerConfig constructor() : FeatureConfig, EventHandl
     //endregion Subgraph Handlers
 
     //region LLM Call Handlers
+
+    public override fun onLLMPromptTransforming(transformer: suspend LLMPromptTransformingContext.(Prompt) -> Prompt)
 
     public override fun onLLMCallStarting(handler: suspend (eventContext: LLMCallStartingContext) -> Unit)
 
@@ -292,6 +296,9 @@ public expect class EventHandlerConfig constructor() : FeatureConfig, EventHandl
     //endregion Invoke Node Handlers
 
     //region Invoke LLM Call Handlers
+
+    @InternalAgentsApi
+    public override suspend fun invokeOnLLMPromptTransforming(eventContext: LLMPromptTransformingContext, prompt: Prompt): Prompt
 
     @InternalAgentsApi
     public override suspend fun invokeOnLLMCallStarting(eventContext: LLMCallStartingContext)

--- a/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerConfigAPI.kt
+++ b/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerConfigAPI.kt
@@ -22,6 +22,7 @@ import ai.koog.agents.core.feature.handler.agent.AgentExecutionFailedContext
 import ai.koog.agents.core.feature.handler.agent.AgentStartingContext
 import ai.koog.agents.core.feature.handler.llm.LLMCallCompletedContext
 import ai.koog.agents.core.feature.handler.llm.LLMCallStartingContext
+import ai.koog.agents.core.feature.handler.llm.LLMPromptTransformingContext
 import ai.koog.agents.core.feature.handler.node.NodeExecutionCompletedContext
 import ai.koog.agents.core.feature.handler.node.NodeExecutionFailedContext
 import ai.koog.agents.core.feature.handler.node.NodeExecutionStartingContext
@@ -38,6 +39,7 @@ import ai.koog.agents.core.feature.handler.tool.ToolCallCompletedContext
 import ai.koog.agents.core.feature.handler.tool.ToolCallFailedContext
 import ai.koog.agents.core.feature.handler.tool.ToolCallStartingContext
 import ai.koog.agents.core.feature.handler.tool.ToolValidationFailedContext
+import ai.koog.prompt.dsl.Prompt
 
 /**
  * API for the [EventHandlerConfig]
@@ -147,6 +149,44 @@ public interface EventHandlerConfigAPI {
     //endregion Subgraph Handlers
 
     //region LLM Call Handlers
+
+    /**
+     * Registers a transformer that can modify the prompt before it is sent to the language model.
+     *
+     * This transformer is invoked before [onLLMCallStarting], allowing prompt modification
+     * prior to the LLM call event handlers being triggered.
+     *
+     * This method enables features to implement patterns such as:
+     * - RAG (Retrieval-Augmented Generation): Query a vector database and add relevant context
+     * - Prompt augmentation: Add system instructions, user context, or conversation history
+     * - Content filtering: Sanitize or modify prompts before sending
+     * - Logging and auditing: Record prompts for compliance or debugging
+     *
+     * Multiple transformers can be registered and will be applied in sequence (chain pattern).
+     * Each transformer receives the prompt from the previous one and returns a modified version.
+     *
+     * Example:
+     * ```kotlin
+     * install(EventHandler) {
+     *     onLLMPromptTransforming { prompt ->
+     *         // Query database for relevant context
+     *         val relevantDocs = database.search(prompt.messages.last().content)
+     *
+     *         // Return augmented prompt with additional context
+     *         prompt.copy(
+     *             messages = listOf(
+     *                 Message.System("Context: ${relevantDocs.joinToString()}"),
+     *                 *prompt.messages.toTypedArray()
+     *             )
+     *         )
+     *     }
+     * }
+     * ```
+     *
+     * @param transformer A function that takes the transforming context and current prompt,
+     *                    and returns the transformed prompt
+     */
+    public fun onLLMPromptTransforming(transformer: suspend LLMPromptTransformingContext.(Prompt) -> Prompt)
 
     /**
      * Append handler called before a call is made to the language model.
@@ -484,6 +524,16 @@ public interface EventHandlerConfigAPI {
     //endregion Invoke Node Handlers
 
     //region Invoke LLM Call Handlers
+
+    /**
+     * Invoke transformers to modify the prompt before it is sent to the language model.
+     *
+     * @param eventContext The context containing information about the LLM request
+     * @param prompt The prompt to be transformed
+     * @return The transformed prompt
+     */
+    @InternalAgentsApi
+    public suspend fun invokeOnLLMPromptTransforming(eventContext: LLMPromptTransformingContext, prompt: Prompt): Prompt
 
     /**
      * Invoke handlers for before a call is made to the language model event.


### PR DESCRIPTION
Add onLLMPromptTransforming handler that can transform Prompt before passing it to onLLMCallStarting.

## Motivation and Context
For some use cases like RAG or chat memory it might be useful to intercept every request to an LLM in order to augment it somehow (with relevant documents from a knowledge base for RAG or with previous messages for chat memory).

## Breaking Changes
None.

---

#### Type of the changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring
- [ ] CI/CD changes
- [ ] Dependencies update

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [X] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [ ] An issue describing the proposed change exists
- [ ] The pull request includes a link to the issue
- [ ] The change was discussed and approved in the issue
- [ ] Docs have been added / updated
