### PR TITLE
fix(agents): KG-675: Opentelemetry feature failure for failed llm requests

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/ContextualPromptExecutor.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/ContextualPromptExecutor.kt
@@ -55,22 +55,27 @@ public class ContextualPromptExecutor(
             prompt
         }
 
-        val responses = executor.execute(effectivePrompt, model, tools)
+        try {
+            val responses = executor.execute(effectivePrompt, model, tools)
 
-        logger.trace { "Finished LLM call (event id: $eventId) with responses: [${responses.joinToString { "${it.role}: ${it.content}" }}]" }
-        context.pipeline.onLLMCallCompleted(
-            eventId,
-            context.executionInfo,
-            context.runId,
-            effectivePrompt,
-            model,
-            tools,
-            responses,
-            null,
-            context
-        )
+            logger.trace { "Finished LLM call (event id: $eventId) with responses: [${responses.joinToString { "${it.role}: ${it.content}" }}]" }
+            context.pipeline.onLLMCallCompleted(
+                eventId,
+                context.executionInfo,
+                context.runId,
+                effectivePrompt,
+                model,
+                tools,
+                responses,
+                null,
+                context
+            )
 
-        return responses
+            return responses
+        } catch (e: Throwable) {
+            context.pipeline.onLLMCallFailed(eventId, context.executionInfo, context.runId, prompt, model, tools, context, e)
+            throw e
+        }
     }
 
     /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/ContextualPromptExecutor.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/ContextualPromptExecutor.kt
@@ -57,23 +57,13 @@ public class ContextualPromptExecutor(
 
         try {
             val responses = executor.execute(effectivePrompt, model, tools)
-
             logger.trace { "Finished LLM call (event id: $eventId) with responses: [${responses.joinToString { "${it.role}: ${it.content}" }}]" }
-            context.pipeline.onLLMCallCompleted(
-                eventId,
-                context.executionInfo,
-                context.runId,
-                effectivePrompt,
-                model,
-                tools,
-                responses,
-                null,
-                context
-            )
 
+            context.pipeline.onLLMCallCompleted(eventId, context.executionInfo, context.runId, effectivePrompt, model, tools, responses, moderationResponse = null, context)
             return responses
         } catch (e: Throwable) {
-            context.pipeline.onLLMCallFailed(eventId, context.executionInfo, context.runId, prompt, model, tools, context, e)
+            logger.debug(e) { "Error in executing LLM call (event id: $eventId): $e" }
+            context.pipeline.onLLMCallFailed(eventId, context.executionInfo, context.runId, prompt, model, tools, context, error = e)
             throw e
         }
     }
@@ -107,15 +97,7 @@ public class ContextualPromptExecutor(
             val promptBeforeInterceptors = context.llm.prompt // because onLLMStreamingStarting might change it
 
             logger.debug { "Starting LLM streaming call (event id: $eventId)" }
-            context.pipeline.onLLMStreamingStarting(
-                eventId,
-                context.executionInfo,
-                context.runId,
-                prompt,
-                model,
-                tools,
-                context
-            )
+            context.pipeline.onLLMStreamingStarting(eventId, context.executionInfo, context.runId, prompt, model, tools, context)
 
             effectivePrompt = if (context.llm.prompt !== promptBeforeInterceptors) {
                 logger.debug { "Executing LLM streaming call with modified prompt (event id: $eventId, prompt: ${context.llm.prompt}, tools: [${tools.joinToString { it.name }}])" }
@@ -131,40 +113,19 @@ public class ContextualPromptExecutor(
         }
             .onEach { frame ->
                 logger.trace { "Received frame from LLM streaming call (event id: $eventId): $frame" }
-                context.pipeline.onLLMStreamingFrameReceived(
-                    eventId,
-                    context.executionInfo,
-                    context.runId,
-                    effectivePrompt,
-                    model,
-                    frame,
-                    context
-                )
+                context.pipeline.onLLMStreamingFrameReceived(eventId, context.executionInfo, context.runId, prompt = effectivePrompt, model, streamFrame = frame, context)
             }
             .catch { error ->
                 logger.debug(error) { "Error in LLM streaming call (event id: $eventId): $error" }
-                context.pipeline.onLLMStreamingFailed(
-                    eventId,
-                    context.executionInfo,
-                    context.runId,
-                    effectivePrompt,
-                    model,
-                    error,
-                    context
-                )
+                context.pipeline.onLLMStreamingFailed(eventId, context.executionInfo, context.runId, prompt = effectivePrompt, model, throwable = error, context)
+
                 throw error
             }
             .onCompletion { error ->
                 logger.debug(error) { "Finished LLM streaming call (event id: $eventId): $error" }
-                context.pipeline.onLLMStreamingCompleted( // Note: it will be executed in any case (even if error is null)
-                    eventId,
-                    context.executionInfo,
-                    context.runId,
-                    effectivePrompt,
-                    model,
-                    tools,
-                    context
-                )
+
+                // Note: it will be executed in any case (even if error is null)
+                context.pipeline.onLLMStreamingCompleted(eventId, context.executionInfo, context.runId, prompt = effectivePrompt, model, tools, context)
             }
     }
 
@@ -200,20 +161,11 @@ public class ContextualPromptExecutor(
     ): ModerationResult {
         @OptIn(ExperimentalUuidApi::class)
         val eventId = Uuid.random().toString()
-
         val promptBeforeInterceptors = context.llm.prompt
 
         logger.debug { "Starting moderation LLM request (event id: $eventId, prompt: $prompt)" }
 
-        context.pipeline.onLLMCallStarting(
-            eventId,
-            context.executionInfo,
-            context.runId,
-            prompt,
-            model,
-            tools = emptyList(),
-            context
-        )
+        context.pipeline.onLLMCallStarting(eventId, context.executionInfo, context.runId, prompt, model, tools = emptyList(), context)
 
         val effectivePrompt = if (context.llm.prompt !== promptBeforeInterceptors) {
             logger.debug { "Executing moderation LLM request with modified prompt (event id: $eventId, prompt: ${context.llm.prompt})" }
@@ -223,22 +175,18 @@ public class ContextualPromptExecutor(
             prompt
         }
 
-        val result = executor.moderate(effectivePrompt, model)
-        logger.trace { "Finished moderation LLM request (event id: $eventId) with response: $result" }
+        try {
+            val result = executor.moderate(effectivePrompt, model)
+            logger.trace { "Finished moderation LLM request (event id: $eventId) with response: $result" }
 
-        context.pipeline.onLLMCallCompleted(
-            eventId,
-            context.executionInfo,
-            context.runId,
-            effectivePrompt,
-            model,
-            tools = emptyList(),
-            responses = emptyList(),
-            moderationResponse = result,
-            context = context
-        )
+            context.pipeline.onLLMCallCompleted(eventId, context.executionInfo, context.runId, effectivePrompt, model, tools = emptyList(), responses = emptyList(), moderationResponse = result, context)
+            return result
+        } catch (e: Throwable) {
+            logger.debug(e) { "Error in moderation LLM request (event id: $eventId): $e" }
+            context.pipeline.onLLMCallFailed(eventId, context.executionInfo, context.runId, prompt, model, tools = emptyList(), context, error = e)
 
-        return result
+            throw e
+        }
     }
 
     override suspend fun models(): List<LLModel> {

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/AgentLifecycleEventType.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/AgentLifecycleEventType.kt
@@ -101,6 +101,11 @@ public sealed interface AgentLifecycleEventType {
      */
     public object LLMCallCompleted : AgentLifecycleEventType
 
+    /**
+     * Represents an event triggered when a language model call fails.
+     */
+    public object LLMCallFailed : AgentLifecycleEventType
+
     //endregion LLM
 
     //region Tool

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/llm/LLMCallEventContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/llm/LLMCallEventContext.kt
@@ -13,7 +13,13 @@ import ai.koog.prompt.message.Message
 /**
  * Represents the context for handling LLM-specific events within the framework.
  */
-public interface LLMCallEventContext : AgentLifecycleEventContext
+public interface LLMCallEventContext : AgentLifecycleEventContext {
+    public val runId: String
+    public val prompt: Prompt
+    public val model: LLModel
+    public val tools: List<ToolDescriptor>
+    public val context: AIAgentContext
+}
 
 /**
  * Represents the context for handling a before LLM call event.
@@ -27,11 +33,33 @@ public interface LLMCallEventContext : AgentLifecycleEventContext
 public data class LLMCallStartingContext(
     override val eventId: String,
     override val executionInfo: AgentExecutionInfo,
-    val runId: String,
-    val prompt: Prompt,
-    val model: LLModel,
-    val tools: List<ToolDescriptor>,
-    val context: AIAgentContext
+    override val runId: String,
+    override val prompt: Prompt,
+    override val model: LLModel,
+    override val tools: List<ToolDescriptor>,
+    override val context: AIAgentContext
+) : LLMCallEventContext {
+    override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.LLMCallStarting
+}
+
+/**
+ * Represents the context for handling a after LLM call failed.
+ *
+ * @property executionInfo The execution information containing parentId and current execution path;
+ * @property runId The unique identifier for this LLM call session.
+ * @property prompt The prompt that will be sent to the language model.
+ * @property model The language model instance being used.
+ * @property tools The list of tool descriptors available for the LLM call.
+ */
+public data class LLMCallFailedContext(
+    override val eventId: String,
+    override val executionInfo: AgentExecutionInfo,
+    override val runId: String,
+    override val prompt: Prompt,
+    override val model: LLModel,
+    override val tools: List<ToolDescriptor>,
+    override val context: AIAgentContext,
+    val error: Throwable
 ) : LLMCallEventContext {
     override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.LLMCallStarting
 }
@@ -50,13 +78,13 @@ public data class LLMCallStartingContext(
 public data class LLMCallCompletedContext(
     override val eventId: String,
     override val executionInfo: AgentExecutionInfo,
-    val runId: String,
-    val prompt: Prompt,
-    val model: LLModel,
-    val tools: List<ToolDescriptor>,
+    override val runId: String,
+    override val prompt: Prompt,
+    override val model: LLModel,
+    override val tools: List<ToolDescriptor>,
     val responses: List<Message.Response>,
     val moderationResponse: ModerationResult?,
-    val context: AIAgentContext
+    override val context: AIAgentContext
 ) : LLMCallEventContext {
     override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.LLMCallCompleted
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/llm/LLMCallEventContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/llm/LLMCallEventContext.kt
@@ -14,10 +14,29 @@ import ai.koog.prompt.message.Message
  * Represents the context for handling LLM-specific events within the framework.
  */
 public interface LLMCallEventContext : AgentLifecycleEventContext {
+    /**
+     * The unique identifier for this LLM call session.
+     */
     public val runId: String
+
+    /**
+     * The prompt that will be sent to the language model.
+     */
     public val prompt: Prompt
+
+    /**
+     * The language model instance being used.
+     */
     public val model: LLModel
+
+    /**
+     * The list of tool descriptors available for the LLM call.
+     */
     public val tools: List<ToolDescriptor>
+
+    /**
+     * The AI agent context.
+     */
     public val context: AIAgentContext
 }
 
@@ -43,7 +62,7 @@ public data class LLMCallStartingContext(
 }
 
 /**
- * Represents the context for handling a after LLM call failed.
+ * Represents the context for handling an after LLM call failed.
  *
  * @property executionInfo The execution information containing parentId and current execution path;
  * @property runId The unique identifier for this LLM call session.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
@@ -19,6 +19,7 @@ import ai.koog.agents.core.feature.handler.agent.AgentEnvironmentTransformingCon
 import ai.koog.agents.core.feature.handler.agent.AgentExecutionFailedContext
 import ai.koog.agents.core.feature.handler.agent.AgentStartingContext
 import ai.koog.agents.core.feature.handler.llm.LLMCallCompletedContext
+import ai.koog.agents.core.feature.handler.llm.LLMCallFailedContext
 import ai.koog.agents.core.feature.handler.llm.LLMCallStartingContext
 import ai.koog.agents.core.feature.handler.strategy.StrategyCompletedContext
 import ai.koog.agents.core.feature.handler.strategy.StrategyStartingContext
@@ -292,6 +293,28 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
         responses: List<Message.Response>,
         moderationResponse: ModerationResult?,
         context: AIAgentContext
+    )
+
+    /**
+     * Notifies all registered LLM handlers if a validation error occurs during a language model call.
+     *
+     * @param eventId The unique identifier for the event group.
+     * @param executionInfo The execution information for the LLM call event
+     * @param runId Identifier for the current run.
+     * @param prompt The prompt that was sent to the language model
+     * @param model The language model instance that processed the request
+     * @param tools The list of tool descriptors that were available for the LLM call
+     * @param error The error that occurred during the LLM call
+     */
+    public override suspend fun onLLMCallFailed(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        runId: String,
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>,
+        context: AIAgentContext,
+        error: Throwable
     )
 
     //endregion Trigger LLM Call Handlers
@@ -669,6 +692,24 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
     public override fun interceptLLMCallCompleted(
         feature: AIAgentFeature<*, *>,
         handle: suspend (eventContext: LLMCallCompletedContext) -> Unit
+    )
+
+    /**
+     * Intercepts errors during LLM calls.
+     *
+     * @param feature The feature associated with this handler.
+     * @param handle The handler that processes LLM call errors.
+     *
+     * Example:
+     * ```
+     * pipeline.interceptLLMCallFailed(feature) { eventContext ->
+     *   // Handle the error here
+     * }
+     * ```
+     */
+    override fun interceptLLMCallFailed(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (eventContext: LLMCallFailedContext) -> Unit
     )
 
     /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
@@ -1,5 +1,3 @@
-@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
-
 package ai.koog.agents.core.feature.pipeline
 
 import ai.koog.agents.core.agent.AIAgent
@@ -61,6 +59,7 @@ import kotlin.time.Clock
  *
  * @property clock Clock instance for time-related operations
  */
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: Clock) : AIAgentPipelineAPI {
     /**
      * Provides access to a `Clock` instance representing the current system time.
@@ -137,11 +136,12 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
     /**
      * Notifies all registered handlers that an agent has finished execution.
      *
-     * @param eventId The unique identifier for the event group.
-     * @param executionInfo The execution information for the agent environment transformation event
-     * @param agentId The unique identifier of the agent that finished execution
-     * @param runId The unique identifier of the agent run
-     * @param result The result produced by the agent, or null if no result was produced
+     * @param eventId The unique identifier for the event group;
+     * @param executionInfo The execution information for the agent environment transformation event;
+     * @param agentId The unique identifier of the agent that finished execution;
+     * @param runId The unique identifier of the agent run;
+     * @param result The result produced by the agent, or null if no result was produced;
+     * @param context The context of the strategy execution.
      */
     @InternalAgentsApi
     public override suspend fun onAgentCompleted(
@@ -156,11 +156,12 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
     /**
      * Notifies all registered handlers about an error that occurred during agent execution.
      *
-     * @param eventId The unique identifier for the event group.
-     * @param executionInfo The execution information for the agent environment transformation event
-     * @param agentId The unique identifier of the agent that encountered the error
-     * @param runId The unique identifier of the agent run
-     * @param throwable The [Throwable] exception instance that was thrown during agent execution
+     * @param eventId The unique identifier for the event group;
+     * @param executionInfo The execution information for the agent environment transformation event;
+     * @param agentId The unique identifier of the agent that encountered the error;
+     * @param runId The unique identifier of the agent run;
+     * @param throwable The [Throwable] exception instance that was thrown during agent execution;
+     * @param context The context of the strategy execution.
      */
     @InternalAgentsApi
     public override suspend fun onAgentExecutionFailed(
@@ -304,6 +305,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param prompt The prompt that was sent to the language model
      * @param model The language model instance that processed the request
      * @param tools The list of tool descriptors that were available for the LLM call
+     * @param context The context of the strategy execution
      * @param error The error that occurred during the LLM call
      */
     public override suspend fun onLLMCallFailed(
@@ -331,6 +333,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param toolName The tool name that is being called
      * @param toolDescription The description of the tool that is being called.
      * @param toolArgs The arguments provided to the tool
+     * @param context The context of the strategy execution
      */
     @InternalAgentsApi
     public override suspend fun onToolCallStarting(
@@ -355,7 +358,8 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param toolDescription The description of the tool that was called;
      * @param toolArgs The arguments that failed validation;
      * @param message The validation error message;
-     * @param error The [AIAgentError] validation error.
+     * @param error The [AIAgentError] validation error;
+     * @param context The context of the strategy execution.
      */
     @InternalAgentsApi
     public override suspend fun onToolValidationFailed(
@@ -382,7 +386,8 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param toolDescription The description of the tool that was called;
      * @param toolArgs The arguments provided to the tool;
      * @param message A message describing the failure.
-     * @param error The [AIAgentError] that caused the failure.
+     * @param error The [AIAgentError] that caused the failure;
+     * @param context The context of the strategy execution.
      */
     @InternalAgentsApi
     public override suspend fun onToolCallFailed(
@@ -408,7 +413,8 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param toolName The tool name that was called;
      * @param toolDescription The description of the tool that was called;
      * @param toolArgs The arguments that were provided to the tool;
-     * @param toolResult The result produced by the tool, or null if no result was produced.
+     * @param toolResult The result produced by the tool, or null if no result was produced;
+     * @param context The context of the strategy execution.
      */
     @InternalAgentsApi
     public override suspend fun onToolCallCompleted(
@@ -438,7 +444,8 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param runId The unique identifier for this streaming session;
      * @param prompt The prompt being sent to the language model;
      * @param model The language model being used for streaming;
-     * @param tools The list of available tool descriptors for this streaming session.
+     * @param tools The list of available tool descriptors for this streaming session;
+     * @param context The context of the strategy execution.
      */
     @InternalAgentsApi
     public override suspend fun onLLMStreamingStarting(
@@ -462,7 +469,8 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param runId The unique identifier for this streaming session;
      * @param prompt The prompt being sent to the language model;
      * @param model The language model being used for streaming;
-     * @param streamFrame The individual stream frame containing partial response data.
+     * @param streamFrame The individual stream frame containing partial response data;
+     * @param context The context of the strategy execution.
      */
     @InternalAgentsApi
     public override suspend fun onLLMStreamingFrameReceived(
@@ -486,7 +494,8 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param runId The unique identifier for this streaming session;
      * @param prompt The prompt being sent to the language model;
      * @param model The language model being used for streaming;
-     * @param throwable The exception that occurred during streaming if applicable.
+     * @param throwable The exception that occurred during streaming if applicable;
+     * @param context The context of the strategy execution.
      */
     @InternalAgentsApi
     public override suspend fun onLLMStreamingFailed(
@@ -510,7 +519,8 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param runId The unique identifier for this streaming session;
      * @param prompt The prompt that was sent to the language model;
      * @param model The language model that was used for streaming;
-     * @param tools The list of tool descriptors that were available for this streaming session.
+     * @param tools The list of tool descriptors that were available for this streaming session;
+     * @param context The context of the strategy execution.
      */
     @InternalAgentsApi
     public override suspend fun onLLMStreamingCompleted(
@@ -622,7 +632,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
     )
 
     /**
-     * Intercepts strategy started event to perform actions when an agent strategy begins execution.
+     * Intercepts the strategy starting event to perform actions when an agent strategy begins execution.
      *
      * @param feature The feature associated with this handler.
      * @param handle A suspend function that processes the start of a strategy, accepting the strategy context
@@ -929,7 +939,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
     )
 
     /**
-     * Intercepts strategy started event to perform actions when an agent strategy begins execution.
+     * Intercepts the strategy starting event to perform actions when an agent strategy begins execution.
      */
     @Deprecated(
         message = "Please use interceptStrategyStarting instead. This method is deprecated and will be removed in the next release.",

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineAPI.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineAPI.kt
@@ -19,6 +19,7 @@ import ai.koog.agents.core.feature.handler.agent.AgentEnvironmentTransformingCon
 import ai.koog.agents.core.feature.handler.agent.AgentExecutionFailedContext
 import ai.koog.agents.core.feature.handler.agent.AgentStartingContext
 import ai.koog.agents.core.feature.handler.llm.LLMCallCompletedContext
+import ai.koog.agents.core.feature.handler.llm.LLMCallFailedContext
 import ai.koog.agents.core.feature.handler.llm.LLMCallStartingContext
 import ai.koog.agents.core.feature.handler.strategy.StrategyCompletedContext
 import ai.koog.agents.core.feature.handler.strategy.StrategyStartingContext
@@ -159,6 +160,17 @@ public interface AIAgentPipelineAPI {
         responses: List<Message.Response>,
         moderationResponse: ModerationResult? = null,
         context: AIAgentContext
+    )
+
+    public suspend fun onLLMCallFailed(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        runId: String,
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>,
+        context: AIAgentContext,
+        error: Throwable,
     )
 
     //endregion Trigger LLM Handlers
@@ -310,6 +322,11 @@ public interface AIAgentPipelineAPI {
     public fun interceptLLMCallCompleted(
         feature: AIAgentFeature<*, *>,
         handle: suspend (eventContext: LLMCallCompletedContext) -> Unit
+    )
+
+    public fun interceptLLMCallFailed(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (eventContext: LLMCallFailedContext) -> Unit
     )
 
     public fun interceptLLMStreamingStarting(

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineImpl.kt
@@ -25,6 +25,7 @@ import ai.koog.agents.core.feature.handler.agent.AgentEnvironmentTransformingCon
 import ai.koog.agents.core.feature.handler.agent.AgentExecutionFailedContext
 import ai.koog.agents.core.feature.handler.agent.AgentStartingContext
 import ai.koog.agents.core.feature.handler.llm.LLMCallCompletedContext
+import ai.koog.agents.core.feature.handler.llm.LLMCallFailedContext
 import ai.koog.agents.core.feature.handler.llm.LLMCallStartingContext
 import ai.koog.agents.core.feature.handler.strategy.StrategyCompletedContext
 import ai.koog.agents.core.feature.handler.strategy.StrategyStartingContext
@@ -304,6 +305,22 @@ public class AIAgentPipelineImpl(
         invokeRegisteredHandlersForEvent(
             eventType = AgentLifecycleEventType.LLMCallCompleted,
             context = LLMCallCompletedContext(eventId, executionInfo, runId, prompt, model, tools, responses, moderationResponse, context)
+        )
+    }
+
+    override suspend fun onLLMCallFailed(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        runId: String,
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>,
+        context: AIAgentContext,
+        error: Throwable
+    ) {
+        invokeRegisteredHandlersForEvent(
+            eventType = AgentLifecycleEventType.LLMCallFailed,
+            context = LLMCallFailedContext(eventId, executionInfo, runId, prompt, model, tools, context, error)
         )
     }
 
@@ -601,6 +618,18 @@ public class AIAgentPipelineImpl(
         addHandlerForFeature(
             featureKey = feature.key,
             eventType = AgentLifecycleEventType.LLMCallCompleted,
+            handler = createConditionalHandler(feature, handle)
+        )
+    }
+
+    @OptIn(InternalAgentsApi::class)
+    public override fun interceptLLMCallFailed(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (eventContext: LLMCallFailedContext) -> Unit
+    ) {
+        addHandlerForFeature(
+            featureKey = feature.key,
+            eventType = AgentLifecycleEventType.LLMCallFailed,
             handler = createConditionalHandler(feature, handle)
         )
     }

--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/feature/pipeline/AIAgentPipeline.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/feature/pipeline/AIAgentPipeline.kt
@@ -14,6 +14,7 @@ import ai.koog.agents.core.feature.handler.agent.AgentEnvironmentTransformingCon
 import ai.koog.agents.core.feature.handler.agent.AgentExecutionFailedContext
 import ai.koog.agents.core.feature.handler.agent.AgentStartingContext
 import ai.koog.agents.core.feature.handler.llm.LLMCallCompletedContext
+import ai.koog.agents.core.feature.handler.llm.LLMCallFailedContext
 import ai.koog.agents.core.feature.handler.llm.LLMCallStartingContext
 import ai.koog.agents.core.feature.handler.strategy.StrategyCompletedContext
 import ai.koog.agents.core.feature.handler.strategy.StrategyStartingContext
@@ -255,6 +256,32 @@ public actual abstract class AIAgentPipeline actual constructor(
         handle: Interceptor<LLMCallCompletedContext>
     ) {
         interceptLLMCallCompleted(feature) { ctx ->
+            config.submitToMainDispatcher {
+                handle.intercept(ctx)
+            }
+        }
+    }
+
+    /**
+     * Intercepts a failed call to the Language Learning Model (LLM) within a specific AI agent feature
+     * and delegates the handling of the failure context to the provided interceptor.
+     *
+     * JVM-friendly overload that accepts an async interceptor.
+     *
+     * Example (Java):
+     * pipeline.interceptLLMCallFailed(feature, eventContext -> {
+     *     // Process failure
+     *     return java.util.concurrent.CompletableFuture.completedFuture(null);
+     * });
+     */
+    @JavaAPI
+    @InternalAgentsApi
+    @JvmName("interceptLLMCallFailed")
+    public fun javaApiInterceptLLMCallFailed(
+        feature: AIAgentFeature<*, *>,
+        handle: Interceptor<LLMCallFailedContext>
+    ) {
+        interceptLLMCallFailed(feature) { ctx ->
             config.submitToMainDispatcher {
                 handle.intercept(ctx)
             }

--- a/agents/agents-features/agents-features-opentelemetry/README.md
+++ b/agents/agents-features/agents-features-opentelemetry/README.md
@@ -185,7 +185,7 @@ The OpenTelemetry feature creates different types of spans for various operation
         - `gen_ai.agent.id`
         - `gen_ai.conversation.id`
         - `gen_ai.system` (LLM provider)
-        - `gen_ai.response.finish_reasons` (on error)
+        - `gen_ai.response.finish_reasons` (derived from the final response in the session prompt: `Stop` for Assistant/Reasoning, `ToolCalls` for Tool.Call)
 
 3. **Strategy Span**
     - Purpose: Execution of a strategy within an agent run.
@@ -226,7 +226,7 @@ The OpenTelemetry feature creates different types of spans for various operation
         - `gen_ai.usage.input_tokens` (when available)
         - `gen_ai.usage.output_tokens` (when available)
         - `gen_ai.usage.total_tokens` (when available)
-        - `gen_ai.response.finish_reasons` (Stop, ToolCalls, etc.; `error` on LLM call failure)
+        - `gen_ai.response.finish_reasons` (Stop, ToolCalls, etc.)
         - `error.type` (on LLM call failure)
         - `gen_ai.response.metadata` (when `ResponseMetaInfo.metadata` is present — serialized JSON containing free-form provider or application metadata)
 

--- a/agents/agents-features/agents-features-opentelemetry/README.md
+++ b/agents/agents-features/agents-features-opentelemetry/README.md
@@ -226,7 +226,8 @@ The OpenTelemetry feature creates different types of spans for various operation
         - `gen_ai.usage.input_tokens` (when available)
         - `gen_ai.usage.output_tokens` (when available)
         - `gen_ai.usage.total_tokens` (when available)
-        - `gen_ai.response.finish_reasons` (Stop, ToolCalls, etc.)
+        - `gen_ai.response.finish_reasons` (Stop, ToolCalls, etc.; `error` on LLM call failure)
+        - `error.type` (on LLM call failure)
         - `gen_ai.response.metadata` (when `ResponseMetaInfo.metadata` is present — serialized JSON containing free-form provider or application metadata)
 
 6. **Execute Tool Span**

--- a/agents/agents-features/agents-features-opentelemetry/build.gradle.kts
+++ b/agents/agents-features/agents-features-opentelemetry/build.gradle.kts
@@ -37,6 +37,8 @@ kotlin {
             dependencies {
                 implementation(kotlin("test"))
                 implementation(libs.kotlinx.coroutines.test)
+                implementation(libs.ktor.client.core)
+                implementation(libs.ktor.client.cio)
             }
         }
 

--- a/agents/agents-features/agents-features-opentelemetry/build.gradle.kts
+++ b/agents/agents-features/agents-features-opentelemetry/build.gradle.kts
@@ -37,8 +37,6 @@ kotlin {
             dependencies {
                 implementation(kotlin("test"))
                 implementation(libs.kotlinx.coroutines.test)
-                implementation(libs.ktor.client.core)
-                implementation(libs.ktor.client.cio)
             }
         }
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/GenAIAttributes.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/GenAIAttributes.kt
@@ -290,10 +290,6 @@ internal object GenAIAttributes {
                 override val id = "content_filter"
             }
 
-            object Error : FinishReasonType {
-                override val id = "error"
-            }
-
             object Length : FinishReasonType {
                 override val id = "length"
             }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/extension/SpanExt.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/extension/SpanExt.kt
@@ -68,20 +68,20 @@ internal fun AIAgentError?.toSpanEndStatus(): SpanEndStatus =
     }
 
 /**
- * We want to add an actual error type as an error attribute.
+ * Check if an error is defined and add common error attributes to the span if not null.
  */
 internal fun GenAIAgentSpan.addCommonErrorAttributes(error: Throwable?) {
     error?.let {
-        addAttribute(CommonAttributes.Error.Type(it.extractActualErrorType()))
+        addAttribute(CommonAttributes.Error.Type(error.extractActualErrorType()))
     }
 }
 
 private fun Throwable.extractActualErrorType(): String {
     val cause = this.cause
     return when {
-        this is KoogHttpClientException -> "KoogHttpClientException-$clientName-httpCode=$statusCode"
-        cause is KoogHttpClientException -> "KoogHttpClientException-${cause.clientName}-httpCode=${cause.statusCode}"
-        cause != null -> "${this.javaClass.simpleName}-${cause.javaClass.typeName}"
+        this is KoogHttpClientException -> "${this::class.simpleName}-$clientName-httpCode=$statusCode"
+        cause is KoogHttpClientException -> "${cause::class.simpleName}-${cause.clientName}-httpCode=${cause.statusCode}"
+        cause != null -> "${this::class.simpleName}-${cause::class.simpleName}"
         else -> this.javaClass.typeName
     }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/extension/SpanExt.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/extension/SpanExt.kt
@@ -3,14 +3,17 @@ package ai.koog.agents.features.opentelemetry.extension
 import ai.koog.agents.core.feature.model.AIAgentError
 import ai.koog.agents.features.opentelemetry.attribute.Attribute
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.attribute.toSdkAttributes
 import ai.koog.agents.features.opentelemetry.event.GenAIAgentEvent
 import ai.koog.agents.features.opentelemetry.span.GenAIAgentSpan
 import ai.koog.agents.features.opentelemetry.span.SpanEndStatus
 import ai.koog.http.client.KoogHttpClientException
+import ai.koog.prompt.message.Message
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanBuilder
 import io.opentelemetry.api.trace.StatusCode
+import kotlinx.serialization.json.JsonElement
 
 internal fun Span.setSpanStatus(endStatus: SpanEndStatus? = null) {
     val statusCode = endStatus?.code ?: StatusCode.OK
@@ -25,7 +28,7 @@ internal fun Span.setSpanStatus(error: Throwable? = null) {
     }
 
     val statusCode = StatusCode.ERROR
-    val statusDescription = error.message
+    val statusDescription = error.message.toString()
     this.setStatus(statusCode, statusDescription)
 }
 
@@ -85,3 +88,51 @@ private fun Throwable.extractActualErrorType(): String {
         else -> this.javaClass.typeName
     }
 }
+
+/**
+ * Returns the [Message.System] messages in this list, for the `gen_ai.system_instructions` attribute.
+ */
+internal fun List<Message>.systemMessages(): List<Message.System> =
+    filterIsInstance<Message.System>()
+
+/**
+ * Returns the last [Message.Response] in this list, or `null` if no response has been produced yet.
+ */
+internal fun List<Message>.lastResponse(): Message.Response? =
+    filterIsInstance<Message.Response>().lastOrNull()
+
+/**
+ * Sum of `metaInfo.inputTokensCount` across all [Message.Response] entries, for the `gen_ai.usage.input_tokens` attribute.
+ */
+internal fun List<Message>.sumInputTokens(): Int =
+    filterIsInstance<Message.Response>().sumOf { it.metaInfo.inputTokensCount ?: 0 }
+
+/**
+ * Sum of `metaInfo.outputTokensCount` across all [Message.Response] entries, for the `gen_ai.usage.output_tokens` attribute.
+ */
+internal fun List<Message>.sumOutputTokens(): Int =
+    filterIsInstance<Message.Response>().sumOf { it.metaInfo.outputTokensCount ?: 0 }
+
+/**
+ * Merges the per-response `metaInfo.metadata` maps into a single flat map, for the `gen_ai.response.metadata` attribute.
+ * Later responses overwrite earlier ones on key collision.
+ */
+internal fun List<Message>.mergedResponseMetadata(): Map<String, JsonElement> =
+    filterIsInstance<Message.Response>()
+        .mapNotNull { it.metaInfo.metadata }
+        .fold(mutableMapOf()) { acc, m -> acc.apply { putAll(m) } }
+
+/**
+ * Maps a [Message.Response] to its `FinishReasonType` for the `gen_ai.response.finish_reasons` attribute.
+ * Exhaustive by design (no `else`) so a new [Message.Response] subtype surfaces as a compile error.
+ */
+internal fun Message.Response.toFinishReason(): GenAIAttributes.Response.FinishReasonType =
+    when (this) {
+        is Message.Assistant,
+        is Message.Reasoning -> {
+            GenAIAttributes.Response.FinishReasonType.Stop
+        }
+        is Message.Tool.Call -> {
+            GenAIAttributes.Response.FinishReasonType.ToolCalls
+        }
+    }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
@@ -14,14 +14,17 @@ import ai.koog.agents.core.feature.pipeline.AIAgentGraphPipeline
 import ai.koog.agents.core.feature.pipeline.AIAgentPipeline
 import ai.koog.agents.core.feature.pipeline.AIAgentPlannerPipeline
 import ai.koog.agents.core.tools.ToolRegistry
-import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
+import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes.Response.FinishReasonType
+import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes.Response.FinishReasons
 import ai.koog.agents.features.opentelemetry.event.AssistantMessageEvent
 import ai.koog.agents.features.opentelemetry.event.ChoiceEvent
 import ai.koog.agents.features.opentelemetry.event.ModerationResponseEvent
 import ai.koog.agents.features.opentelemetry.event.SystemMessageEvent
 import ai.koog.agents.features.opentelemetry.event.ToolMessageEvent
 import ai.koog.agents.features.opentelemetry.event.UserMessageEvent
+import ai.koog.agents.features.opentelemetry.extension.addCommonErrorAttributes
+import ai.koog.agents.features.opentelemetry.extension.toSpanEndStatus
 import ai.koog.agents.features.opentelemetry.integration.SpanAdapter
 import ai.koog.agents.features.opentelemetry.integration.mcp.McpMethod
 import ai.koog.agents.features.opentelemetry.metric.MetricCollector
@@ -155,6 +158,11 @@ public class OpenTelemetry {
 
             pipeline.interceptNodeExecutionFailed(this) intercept@{ eventContext ->
                 logger.debug { "Execute OpenTelemetry node execution failed handler" }
+
+                // Stop all unfinished spans, except InvokeAgentSpan and AgentCreateSpan
+                endUnfinishedSpans(spanCollector, config.isVerbose, eventContext.throwable) { span ->
+                    span.type == SpanType.INFERENCE
+                }
 
                 // Find existing span (Node Execute Span)
                 val patchedExecutionInfo = eventContext.executionInfo.appendRunId(eventContext.context.runId)
@@ -376,7 +384,7 @@ public class OpenTelemetry {
                 metricCollector.flushPendingAsErrors(eventContext.throwable)
 
                 // Stop all unfinished spans, except InvokeAgentSpan and AgentCreateSpan
-                endUnfinishedSpans(spanCollector, config.isVerbose) { span ->
+                endUnfinishedSpans(spanCollector, config.isVerbose, eventContext.throwable) { span ->
                     span.type != SpanType.CREATE_AGENT &&
                         span.type != SpanType.INVOKE_AGENT &&
                         span.id != eventContext.eventId
@@ -671,6 +679,35 @@ public class OpenTelemetry {
                 }
             }
 
+            pipeline.interceptLLMCallFailed(this) intercept@{ eventContext ->
+                logger.debug { "Execute OpenTelemetry LLM call failure handler" }
+
+                // Find the current span (Inference Span)
+                val patchedExecutionInfo = eventContext.executionInfo
+                    .appendRunId(eventContext.runId)
+                    .appendId(eventContext.eventId)
+
+                val inferenceSpan = spanCollector.getStartedSpan(
+                    executionInfo = patchedExecutionInfo,
+                    eventId = eventContext.eventId,
+                    spanType = SpanType.INFERENCE
+                ) ?: return@intercept
+
+                inferenceSpan.addAttribute(FinishReasons(listOf(FinishReasonType.Error)))
+                spanAdapter?.onBeforeSpanFinished(inferenceSpan)
+                endInferenceSpan(
+                    span = inferenceSpan,
+                    messages = emptyList(),
+                    model = eventContext.model,
+                    verbose = config.isVerbose,
+                    error = eventContext.error
+                )
+                spanCollector.removeSpan(
+                    span = inferenceSpan,
+                    path = patchedExecutionInfo
+                )
+            }
+
             //endregion LLM Call
 
             //region Tool Call
@@ -914,13 +951,15 @@ public class OpenTelemetry {
         internal fun endUnfinishedSpans(
             spanCollector: SpanCollector,
             verbose: Boolean = false,
+            error: Throwable? = null,
             filter: ((GenAIAgentSpan) -> Boolean)? = null
         ) {
             val spansToEnd = spanCollector.getActiveSpans(filter)
 
             spansToEnd.forEach { spanNode ->
                 try {
-                    spanNode.span.end(verbose = verbose)
+                    spanNode.span.addCommonErrorAttributes(error)
+                    spanNode.span.end(verbose = verbose, spanEndStatus = error.toSpanEndStatus())
                     spanCollector.removeSpan(spanNode.span, spanNode.path)
                 } catch (e: Exception) {
                     logger.warn(e) {

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
@@ -22,6 +22,8 @@ import ai.koog.agents.features.opentelemetry.event.ModerationResponseEvent
 import ai.koog.agents.features.opentelemetry.event.SystemMessageEvent
 import ai.koog.agents.features.opentelemetry.event.ToolMessageEvent
 import ai.koog.agents.features.opentelemetry.event.UserMessageEvent
+import ai.koog.agents.features.opentelemetry.extension.lastResponse
+import ai.koog.agents.features.opentelemetry.extension.toFinishReason
 import ai.koog.agents.features.opentelemetry.integration.SpanAdapter
 import ai.koog.agents.features.opentelemetry.integration.mcp.McpMethod
 import ai.koog.agents.features.opentelemetry.metric.MetricCollector
@@ -355,6 +357,12 @@ public class OpenTelemetry {
                     spanType = SpanType.INVOKE_AGENT
                 ) ?: return@intercept
 
+                eventContext.context.llm.prompt.messages.lastResponse()?.let { response ->
+                    invokeAgentSpan.addAttribute(
+                        GenAIAttributes.Response.FinishReasons(reasons = listOf(response.toFinishReason()))
+                    )
+                }
+
                 spanAdapter?.onBeforeSpanFinished(invokeAgentSpan)
                 endInvokeAgentSpan(
                     span = invokeAgentSpan,
@@ -389,12 +397,6 @@ public class OpenTelemetry {
                     eventId = eventContext.runId,
                     spanType = SpanType.INVOKE_AGENT
                 ) ?: return@intercept
-
-                invokeAgentSpan.addAttribute(
-                    attribute = GenAIAttributes.Response.FinishReasons(
-                        listOf(GenAIAttributes.Response.FinishReasonType.Error)
-                    )
-                )
 
                 spanAdapter?.onBeforeSpanFinished(invokeAgentSpan)
                 endInvokeAgentSpan(
@@ -612,18 +614,10 @@ public class OpenTelemetry {
                 inferenceSpan.addEvents(eventsToAdd)
 
                 // Finish Reasons Attribute
-                eventContext.responses.lastOrNull()?.let { message ->
-                    val finishReasonsAttribute = when (message) {
-                        is Message.Assistant, is Message.Reasoning -> {
-                            GenAIAttributes.Response.FinishReasons(reasons = listOf(GenAIAttributes.Response.FinishReasonType.Stop))
-                        }
-
-                        is Message.Tool.Call -> {
-                            GenAIAttributes.Response.FinishReasons(reasons = listOf(GenAIAttributes.Response.FinishReasonType.ToolCalls))
-                        }
-                    }
-
-                    inferenceSpan.addAttribute(finishReasonsAttribute)
+                eventContext.responses.lastOrNull()?.let { response ->
+                    inferenceSpan.addAttribute(
+                        GenAIAttributes.Response.FinishReasons(reasons = listOf(response.toFinishReason()))
+                    )
                 }
 
                 // Stop InferenceSpan
@@ -684,12 +678,6 @@ public class OpenTelemetry {
                     eventId = eventContext.eventId,
                     spanType = SpanType.INFERENCE
                 ) ?: return@intercept
-
-                inferenceSpan.addAttribute(
-                    GenAIAttributes.Response.FinishReasons(
-                        reasons = listOf(GenAIAttributes.Response.FinishReasonType.Error)
-                    )
-                )
 
                 spanAdapter?.onBeforeSpanFinished(inferenceSpan)
                 endInferenceSpan(

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
@@ -14,17 +14,14 @@ import ai.koog.agents.core.feature.pipeline.AIAgentGraphPipeline
 import ai.koog.agents.core.feature.pipeline.AIAgentPipeline
 import ai.koog.agents.core.feature.pipeline.AIAgentPlannerPipeline
 import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes.Response.FinishReasonType
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes.Response.FinishReasons
 import ai.koog.agents.features.opentelemetry.event.AssistantMessageEvent
 import ai.koog.agents.features.opentelemetry.event.ChoiceEvent
 import ai.koog.agents.features.opentelemetry.event.ModerationResponseEvent
 import ai.koog.agents.features.opentelemetry.event.SystemMessageEvent
 import ai.koog.agents.features.opentelemetry.event.ToolMessageEvent
 import ai.koog.agents.features.opentelemetry.event.UserMessageEvent
-import ai.koog.agents.features.opentelemetry.extension.addCommonErrorAttributes
-import ai.koog.agents.features.opentelemetry.extension.toSpanEndStatus
 import ai.koog.agents.features.opentelemetry.integration.SpanAdapter
 import ai.koog.agents.features.opentelemetry.integration.mcp.McpMethod
 import ai.koog.agents.features.opentelemetry.metric.MetricCollector
@@ -158,11 +155,6 @@ public class OpenTelemetry {
 
             pipeline.interceptNodeExecutionFailed(this) intercept@{ eventContext ->
                 logger.debug { "Execute OpenTelemetry node execution failed handler" }
-
-                // Stop all unfinished spans, except InvokeAgentSpan and AgentCreateSpan
-                endUnfinishedSpans(spanCollector, config.isVerbose, eventContext.throwable) { span ->
-                    span.type == SpanType.INFERENCE
-                }
 
                 // Find existing span (Node Execute Span)
                 val patchedExecutionInfo = eventContext.executionInfo.appendRunId(eventContext.context.runId)
@@ -384,7 +376,7 @@ public class OpenTelemetry {
                 metricCollector.flushPendingAsErrors(eventContext.throwable)
 
                 // Stop all unfinished spans, except InvokeAgentSpan and AgentCreateSpan
-                endUnfinishedSpans(spanCollector, config.isVerbose, eventContext.throwable) { span ->
+                endUnfinishedSpans(spanCollector, config.isVerbose) { span ->
                     span.type != SpanType.CREATE_AGENT &&
                         span.type != SpanType.INVOKE_AGENT &&
                         span.id != eventContext.eventId
@@ -693,7 +685,12 @@ public class OpenTelemetry {
                     spanType = SpanType.INFERENCE
                 ) ?: return@intercept
 
-                inferenceSpan.addAttribute(FinishReasons(listOf(FinishReasonType.Error)))
+                inferenceSpan.addAttribute(
+                    GenAIAttributes.Response.FinishReasons(
+                        reasons = listOf(GenAIAttributes.Response.FinishReasonType.Error)
+                    )
+                )
+
                 spanAdapter?.onBeforeSpanFinished(inferenceSpan)
                 endInferenceSpan(
                     span = inferenceSpan,
@@ -951,15 +948,13 @@ public class OpenTelemetry {
         internal fun endUnfinishedSpans(
             spanCollector: SpanCollector,
             verbose: Boolean = false,
-            error: Throwable? = null,
             filter: ((GenAIAgentSpan) -> Boolean)? = null
         ) {
             val spansToEnd = spanCollector.getActiveSpans(filter)
 
             spansToEnd.forEach { spanNode ->
                 try {
-                    spanNode.span.addCommonErrorAttributes(error)
-                    spanNode.span.end(verbose = verbose, spanEndStatus = error.toSpanEndStatus())
+                    spanNode.span.end(verbose = verbose)
                     spanCollector.removeSpan(spanNode.span, spanNode.path)
                 } catch (e: Exception) {
                     logger.warn(e) {

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/createAgentSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/createAgentSpan.kt
@@ -3,6 +3,7 @@ package ai.koog.agents.features.opentelemetry.span
 import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
 import ai.koog.agents.features.opentelemetry.extension.addCommonErrorAttributes
+import ai.koog.agents.features.opentelemetry.extension.systemMessages
 import ai.koog.agents.features.opentelemetry.extension.toSpanEndStatus
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
@@ -58,7 +59,7 @@ internal fun startCreateAgentSpan(
     // server.port - Ignore. Not supported in Koog
     // server.address - Ignore. Not supported in Koog
     // gen_ai.system_instructions
-    val systemMessages = messages.filterIsInstance<Message.System>()
+    val systemMessages = messages.systemMessages()
     if (systemMessages.isNotEmpty()) {
         builder.addAttribute(GenAIAttributes.SystemInstructions(systemMessages))
     }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/createAgentSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/createAgentSpan.kt
@@ -1,8 +1,8 @@
 package ai.koog.agents.features.opentelemetry.span
 
-import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
 import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
+import ai.koog.agents.features.opentelemetry.extension.addCommonErrorAttributes
 import ai.koog.agents.features.opentelemetry.extension.toSpanEndStatus
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
@@ -87,9 +87,6 @@ internal fun endCreateAgentSpan(
     }
 
     // error.type
-    error?.javaClass?.typeName?.let { typeName ->
-        span.addAttribute(CommonAttributes.Error.Type(typeName))
-    }
-
+    span.addCommonErrorAttributes(error)
     span.end(error.toSpanEndStatus(), verbose)
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/inferenceSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/inferenceSpan.kt
@@ -1,9 +1,9 @@
 package ai.koog.agents.features.opentelemetry.span
 
 import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
 import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
+import ai.koog.agents.features.opentelemetry.extension.addCommonErrorAttributes
 import ai.koog.agents.features.opentelemetry.extension.toSpanEndStatus
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
@@ -152,9 +152,7 @@ internal fun endInferenceSpan(
     }
 
     // error.type
-    error?.javaClass?.typeName?.let { typeName ->
-        span.addAttribute(CommonAttributes.Error.Type(typeName))
-    }
+    span.addCommonErrorAttributes(error)
 
     // gen_ai.response.finish_reasons - Ignore. Not supported in Koog
     // gen_ai.response.id - Ignore. Not supported in Koog

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/inferenceSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/inferenceSpan.kt
@@ -4,6 +4,10 @@ import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
 import ai.koog.agents.features.opentelemetry.extension.addCommonErrorAttributes
+import ai.koog.agents.features.opentelemetry.extension.mergedResponseMetadata
+import ai.koog.agents.features.opentelemetry.extension.sumInputTokens
+import ai.koog.agents.features.opentelemetry.extension.sumOutputTokens
+import ai.koog.agents.features.opentelemetry.extension.systemMessages
 import ai.koog.agents.features.opentelemetry.extension.toSpanEndStatus
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
@@ -11,7 +15,6 @@ import ai.koog.prompt.message.Message
 import ai.koog.prompt.params.LLMParams
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.Tracer
-import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
 /**
@@ -109,7 +112,7 @@ internal fun startInferenceSpan(
     }
 
     // gen_ai.system_instructions
-    val systemMessages = messages.filterIsInstance<Message.System>()
+    val systemMessages = messages.systemMessages()
     if (systemMessages.isNotEmpty()) {
         builder.addAttribute(GenAIAttributes.SystemInstructions(systemMessages))
     }
@@ -160,29 +163,16 @@ internal fun endInferenceSpan(
     span.addAttribute(GenAIAttributes.Response.Model(model))
 
     // gen_ai.response.metadata
-    val responseMetadata = messages.filterIsInstance<Message.Response>()
-        .mapNotNull { message -> message.metaInfo.metadata }
-        .fold(mutableMapOf<String, JsonElement>()) { acc, jsonObject ->
-            acc.putAll(jsonObject)
-            acc
-        }
+    val responseMetadata = messages.mergedResponseMetadata()
     if (responseMetadata.isNotEmpty()) {
         span.addAttribute(GenAIAttributes.Response.Metadata(JsonObject(responseMetadata).toString()))
     }
 
     // gen_ai.usage.input_tokens
-    span.addAttribute(
-        GenAIAttributes.Usage.InputTokens(
-            messages.filterIsInstance<Message.Response>().sumOf { message -> message.metaInfo.inputTokensCount ?: 0 }
-        )
-    )
+    span.addAttribute(GenAIAttributes.Usage.InputTokens(messages.sumInputTokens()))
 
     // gen_ai.usage.output_tokens
-    span.addAttribute(
-        GenAIAttributes.Usage.OutputTokens(
-            messages.filterIsInstance<Message.Response>().sumOf { message -> message.metaInfo.outputTokensCount ?: 0 }
-        )
-    )
+    span.addAttribute(GenAIAttributes.Usage.OutputTokens(messages.sumOutputTokens()))
 
     // gen_ai.output.messages
     if (messages.isNotEmpty()) {

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/invokeAgentSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/invokeAgentSpan.kt
@@ -1,9 +1,9 @@
 package ai.koog.agents.features.opentelemetry.span
 
 import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
 import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
+import ai.koog.agents.features.opentelemetry.extension.addCommonErrorAttributes
 import ai.koog.agents.features.opentelemetry.extension.toSpanEndStatus
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
@@ -158,9 +158,7 @@ internal fun endInvokeAgentSpan(
     }
 
     // error.type
-    error?.javaClass?.typeName?.let { typeName ->
-        span.addAttribute(CommonAttributes.Error.Type(typeName))
-    }
+    span.addCommonErrorAttributes(error)
 
     // gen_ai.response.finish_reasons - Ignore. Not supported in Koog
     // gen_ai.response.id - Ignore. Not supported in Koog

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/invokeAgentSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/invokeAgentSpan.kt
@@ -4,6 +4,9 @@ import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
 import ai.koog.agents.features.opentelemetry.extension.addCommonErrorAttributes
+import ai.koog.agents.features.opentelemetry.extension.sumInputTokens
+import ai.koog.agents.features.opentelemetry.extension.sumOutputTokens
+import ai.koog.agents.features.opentelemetry.extension.systemMessages
 import ai.koog.agents.features.opentelemetry.extension.toSpanEndStatus
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
@@ -116,7 +119,7 @@ internal fun startInvokeAgentSpan(
     }
 
     // gen_ai.system_instructions
-    val systemMessages = messages.filterIsInstance<Message.System>()
+    val systemMessages = messages.systemMessages()
     if (systemMessages.isNotEmpty()) {
         builder.addAttribute(GenAIAttributes.SystemInstructions(systemMessages))
     }
@@ -166,18 +169,10 @@ internal fun endInvokeAgentSpan(
     span.addAttribute(GenAIAttributes.Response.Model(model))
 
     // gen_ai.usage.input_tokens
-    span.addAttribute(
-        GenAIAttributes.Usage.InputTokens(
-            messages.filterIsInstance<Message.Response>().sumOf { message -> message.metaInfo.inputTokensCount ?: 0 }
-        )
-    )
+    span.addAttribute(GenAIAttributes.Usage.InputTokens(messages.sumInputTokens()))
 
     // gen_ai.usage.output_tokens
-    span.addAttribute(
-        GenAIAttributes.Usage.OutputTokens(
-            messages.filterIsInstance<Message.Response>().sumOf { message -> message.metaInfo.outputTokensCount ?: 0 }
-        )
-    )
+    span.addAttribute(GenAIAttributes.Usage.OutputTokens(messages.sumOutputTokens()))
 
     // gen_ai.output.messages
     if (messages.isNotEmpty()) {

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/nodeExecuteSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/nodeExecuteSpan.kt
@@ -1,8 +1,8 @@
 package ai.koog.agents.features.opentelemetry.span
 
-import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
 import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
+import ai.koog.agents.features.opentelemetry.extension.addCommonErrorAttributes
 import ai.koog.agents.features.opentelemetry.extension.toSpanEndStatus
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.Tracer
@@ -71,9 +71,7 @@ internal fun endNodeExecuteSpan(
     }
 
     // error.type
-    error?.javaClass?.typeName?.let { typeName ->
-        span.addAttribute(CommonAttributes.Error.Type(typeName))
-    }
+    span.addCommonErrorAttributes(error)
 
     nodeOutput?.let { output ->
         span.addAttribute(KoogAttributes.Koog.Node.Output(output))

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/strategySpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/strategySpan.kt
@@ -1,8 +1,8 @@
 package ai.koog.agents.features.opentelemetry.span
 
-import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
 import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
+import ai.koog.agents.features.opentelemetry.extension.addCommonErrorAttributes
 import ai.koog.agents.features.opentelemetry.extension.toSpanEndStatus
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.Tracer
@@ -62,9 +62,7 @@ internal fun endStrategySpan(
     }
 
     // error.type
-    error?.javaClass?.typeName?.let { typeName ->
-        span.addAttribute(CommonAttributes.Error.Type(typeName))
-    }
+    span.addCommonErrorAttributes(error)
 
     span.end(error.toSpanEndStatus(), verbose)
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/subgraphExecuteSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/subgraphExecuteSpan.kt
@@ -1,8 +1,8 @@
 package ai.koog.agents.features.opentelemetry.span
 
-import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
 import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
+import ai.koog.agents.features.opentelemetry.extension.addCommonErrorAttributes
 import ai.koog.agents.features.opentelemetry.extension.toSpanEndStatus
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.Tracer
@@ -71,9 +71,7 @@ internal fun endSubgraphExecuteSpan(
     }
 
     // error.type
-    error?.javaClass?.typeName?.let { typeName ->
-        span.addAttribute(CommonAttributes.Error.Type(typeName))
-    }
+    span.addCommonErrorAttributes(error)
 
     subgraphOutput?.let { output ->
         span.addAttribute(KoogAttributes.Koog.Subgraph.Output(output))

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryConfigTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryConfigTest.kt
@@ -269,6 +269,7 @@ class OpenTelemetryConfigTest : OpenTelemetryTestBase() {
                                     Message.User(USER_PROMPT_PARIS, RequestMetaInfo(testClock.now()))
                                 )
                             ),
+                            "gen_ai.response.finish_reasons" to listOf(GenAIAttributes.Response.FinishReasonType.Stop.id),
                             customBeforeStartAttribute.key to customBeforeStartAttribute.value,
                             customBeforeFinishAttribute.key to customBeforeFinishAttribute.value,
                             "koog.event.id" to mockExporter.lastRunId,

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryInferenceSpanTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryInferenceSpanTest.kt
@@ -1,9 +1,8 @@
 package ai.koog.agents.features.opentelemetry.feature.span
 
 import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.agent.entity.AIAgentSubgraph
+import ai.koog.agents.core.agent.entity.AIAgentSubgraphBase.Companion.START_NODE_PREFIX
 import ai.koog.agents.core.agent.singleRunStrategy
-import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.builder.subgraph
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
@@ -36,12 +35,12 @@ import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.tokenizer.SimpleRegexBasedTokenizer
+import ai.koog.serialization.kotlinx.KotlinxSerializer
 import io.ktor.client.HttpClient
 import io.ktor.client.request.HttpRequestPipeline
 import io.opentelemetry.sdk.trace.data.SpanData
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
-import ai.koog.serialization.kotlinx.KotlinxSerializer
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.params.ParameterizedTest
@@ -49,6 +48,7 @@ import org.junit.jupiter.params.provider.EnumSource
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
@@ -674,8 +674,9 @@ class OpenTelemetryInferenceSpanTest : OpenTelemetryTestBase() {
             }.run(OpenTelemetryTestAPI.Parameter.USER_PROMPT_PARIS)
         }
         val exception = result.exceptionOrNull()
-        assertFalse(exception == null, "Unexpected successful result $result")
+        assertNotNull(exception, "Unexpected successful result $result")
         assertFalse(exception is CancellationException, "Unexpected cancellation exception")
+
         testData.collectedSpans = withTimeout(10.seconds) {
             spanExporter.isCollected.first()
             spanExporter.collectedSpans
@@ -696,19 +697,12 @@ class OpenTelemetryInferenceSpanTest : OpenTelemetryTestBase() {
         }
         testData.filterNodeExecutionSpans().filter { span ->
             // KoogAttributes.Koog.Node.Id
-            "koog.node.id" to AIAgentSubgraph.START_NODE_PREFIX !in span.asKeyValue()
+            "koog.node.id" to START_NODE_PREFIX !in span.asKeyValue()
         }.forEach { actual ->
             assertEquals(
                 expected = expectedSpans,
                 actual = actual.asKeyValue().intersect(expectedSpans),
                 message = "Unexpected node execution spans:\nExpected:${expectedSpans}\nActual:${actual.asKeyValue()}"
-            )
-        }
-        testData.filterStrategySpans().single().let { actual ->
-            assertEquals(
-                expected = expectedSpans,
-                actual = actual.asKeyValue().intersect(expectedSpans),
-                message = "Unexpected strategy spans:\nExpected:${expectedSpans}\nActual:${actual.asKeyValue()}"
             )
         }
         testData.filterAgentInvokeSpans().single().let { actual ->

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryInferenceSpanTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryInferenceSpanTest.kt
@@ -127,6 +127,17 @@ class OpenTelemetryInferenceSpanTest : OpenTelemetryTestBase() {
         )
 
         assertSpans(expectedSpans, actualSpans)
+
+        val expectedInvokeAgentAttrs = setOf(
+            "gen_ai.response.finish_reasons" to listOf(FinishReasonType.Stop.id)
+        )
+        collectedTestData.filterAgentInvokeSpans().single().let { actual ->
+            assertEquals(
+                expected = expectedInvokeAgentAttrs,
+                actual = actual.asKeyValue().intersect(expectedInvokeAgentAttrs),
+                message = "invoke_agent span missing finish_reasons=[stop]:\nActual:${actual.asKeyValue()}"
+            )
+        }
     }
 
     @ParameterizedTest
@@ -688,7 +699,6 @@ class OpenTelemetryInferenceSpanTest : OpenTelemetryTestBase() {
             "error.type" to "KoogHttpClientException-openai-httpCode=429",
         )
         testData.filterInferenceSpans().single().let { actual ->
-            val expectedSpans = expectedSpans + setOf("gen_ai.response.finish_reasons" to listOf(FinishReasonType.Error.id))
             assertEquals(
                 expected = expectedSpans,
                 actual = actual.asKeyValue().intersect(expectedSpans),

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryInferenceSpanTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryInferenceSpanTest.kt
@@ -1,5 +1,8 @@
 package ai.koog.agents.features.opentelemetry.feature.span
 
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.entity.AIAgentSubgraph
+import ai.koog.agents.core.agent.singleRunStrategy
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.builder.subgraph
@@ -17,22 +20,37 @@ import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.runAgentWithSi
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.runAgentWithStrategy
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.testClock
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.toolCallMessage
+import ai.koog.agents.features.opentelemetry.OpenTelemetryTestData
 import ai.koog.agents.features.opentelemetry.assertSpans
 import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes.Operation.OperationNameType
 import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes.Response.FinishReasonType
+import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryTestBase
+import ai.koog.agents.features.opentelemetry.mock.MockSpanExporter
 import ai.koog.agents.features.opentelemetry.mock.TestGetWeatherTool
 import ai.koog.agents.testing.tools.getMockExecutor
 import ai.koog.agents.utils.HiddenString
+import ai.koog.http.client.KoogHttpClientException
+import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.tokenizer.SimpleRegexBasedTokenizer
+import io.ktor.client.HttpClient
+import io.ktor.client.request.HttpRequestPipeline
+import io.opentelemetry.sdk.trace.data.SpanData
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.first
 import ai.koog.serialization.kotlinx.KotlinxSerializer
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
 class OpenTelemetryInferenceSpanTest : OpenTelemetryTestBase() {
     private val serializer = KotlinxSerializer()
@@ -628,5 +646,81 @@ class OpenTelemetryInferenceSpanTest : OpenTelemetryTestBase() {
         )
 
         assertSpans(expectedSpans, actualSpans)
+    }
+
+    @Test
+    fun `expected spans on llm call failed`() = runTest {
+        // Http client that fails each request
+        val failingHttpClient = HttpClient {
+            install("FailingInterceptor") {
+                requestPipeline.intercept(HttpRequestPipeline.Before) {
+                    throw KoogHttpClientException("openai", statusCode = 429)
+                }
+            }
+        }
+
+        val spanExporter = MockSpanExporter()
+        val testData = OpenTelemetryTestData()
+        val result = runCatching {
+            AIAgent(
+                promptExecutor = MultiLLMPromptExecutor(OpenAILLMClient("fake-key", baseClient = failingHttpClient)),
+                llmModel = OpenTelemetryTestAPI.Parameter.defaultModel,
+                strategy = singleRunStrategy(),
+                systemPrompt = OpenTelemetryTestAPI.Parameter.SYSTEM_PROMPT
+            ) {
+                install(OpenTelemetry) {
+                    addSpanExporter(spanExporter)
+                }
+            }.run(OpenTelemetryTestAPI.Parameter.USER_PROMPT_PARIS)
+        }
+        val exception = result.exceptionOrNull()
+        assertFalse(exception == null, "Unexpected successful result $result")
+        assertFalse(exception is CancellationException, "Unexpected cancellation exception")
+        testData.collectedSpans = withTimeout(10.seconds) {
+            spanExporter.isCollected.first()
+            spanExporter.collectedSpans
+        }
+
+        // CHECKS
+        // We are expecting to provide the root cause of LLMClientException
+        val expectedSpans = setOf(
+            "error.type" to "KoogHttpClientException-openai-httpCode=429",
+        )
+        testData.filterInferenceSpans().single().let { actual ->
+            val expectedSpans = expectedSpans + setOf("gen_ai.response.finish_reasons" to listOf(FinishReasonType.Error.id))
+            assertEquals(
+                expected = expectedSpans,
+                actual = actual.asKeyValue().intersect(expectedSpans),
+                message = "Unexpected inference spans:\nExpected:${expectedSpans}\nActual:${actual.asKeyValue()}"
+            )
+        }
+        testData.filterNodeExecutionSpans().filter { span ->
+            // KoogAttributes.Koog.Node.Id
+            "koog.node.id" to AIAgentSubgraph.START_NODE_PREFIX !in span.asKeyValue()
+        }.forEach { actual ->
+            assertEquals(
+                expected = expectedSpans,
+                actual = actual.asKeyValue().intersect(expectedSpans),
+                message = "Unexpected node execution spans:\nExpected:${expectedSpans}\nActual:${actual.asKeyValue()}"
+            )
+        }
+        testData.filterStrategySpans().single().let { actual ->
+            assertEquals(
+                expected = expectedSpans,
+                actual = actual.asKeyValue().intersect(expectedSpans),
+                message = "Unexpected strategy spans:\nExpected:${expectedSpans}\nActual:${actual.asKeyValue()}"
+            )
+        }
+        testData.filterAgentInvokeSpans().single().let { actual ->
+            assertEquals(
+                expected = expectedSpans,
+                actual = actual.asKeyValue().intersect(expectedSpans),
+                message = "Unexpected create agent spans:\nExpected:${expectedSpans}\nActual:${actual.asKeyValue()}"
+            )
+        }
+    }
+
+    private fun SpanData.asKeyValue(): List<Pair<String, Any>> {
+        return attributes.asMap().map { it.key.key!! to it.value }
     }
 }

--- a/docs/docs/features/custom-features.md
+++ b/docs/docs/features/custom-features.md
@@ -139,6 +139,7 @@ Strategy lifecycle:
 LLM call lifecycle:
 
 - `interceptLLMCallStarting`: Invoked before an LLM call.
+- `interceptLLMCallFailed`: Invoked when an LLM call fails (the underlying prompt executor or moderation call throws).
 - `interceptLLMCallCompleted`: Invoked after an LLM call.
 
 LLM streaming lifecycle:

--- a/docs/docs/features/open-telemetry/index.md
+++ b/docs/docs/features/open-telemetry/index.md
@@ -458,7 +458,7 @@ takes a key and a value as its arguments.
 The OpenTelemetry feature captures the following agent activity:
 
 - **Agent lifecycle events**: agent start, stop, errors
-- **LLM interactions**: prompts, responses, token usage, latency, and failures (spans are marked with `error.type` and `gen_ai.response.finish_reasons = error` when an LLM call throws)
+- **LLM interactions**: prompts, responses, token usage, latency, and failures (spans are marked with span status `ERROR` and `error.type` when an LLM call throws)
 - **Tool calls**: execution traces for tool invocations
 - **System context**: metadata such as model name, environment, Koog version
 

--- a/docs/docs/features/open-telemetry/index.md
+++ b/docs/docs/features/open-telemetry/index.md
@@ -458,7 +458,7 @@ takes a key and a value as its arguments.
 The OpenTelemetry feature captures the following agent activity:
 
 - **Agent lifecycle events**: agent start, stop, errors
-- **LLM interactions**: prompts, responses, token usage, latency
+- **LLM interactions**: prompts, responses, token usage, latency, and failures (spans are marked with `error.type` and `gen_ai.response.finish_reasons = error` when an LLM call throws)
 - **Tool calls**: execution traces for tool invocations
 - **System context**: metadata such as model name, environment, Koog version
 


### PR DESCRIPTION
## Motivation and Context
[KG-675](https://youtrack.jetbrains.com/issue/KG-675)

## Breaking Changes
none

---

#### Type of the changes
- [*] Bug fix (non-breaking change which fixes an issue)

```
java.lang.IllegalStateException: GenAIAgentSpan (name: node nodeCallLLM, id: e5559524-a6df-41eb-a043-97270f3c85d5) Error deleting span node from the tree (path: 294b2913-2411-49bd-9e1d-26a09b5c516b/d2351487-57b1-4b5c-9ea1-185154cb773c/single_run_sequential/nodeCallLLM). Node still have <1> child span(s). Spans:
 - GenAIAgentSpan (name: chat gpt-4o, id: 21ff7374-dc8c-4051-8e8f-7f1f8c273bc6), active: true
	at ai.koog.agents.features.opentelemetry.span.SpanCollector.removeSpanFromTree(SpanCollector.kt:202)
	at ai.koog.agents.features.opentelemetry.span.SpanCollector.removeSpan(SpanCollector.kt:59)
	at ai.koog.agents.features.opentelemetry.feature.OpenTelemetry$Feature$install$9.invokeSuspend(OpenTelemetry.kt:331)
```
