### PR TITLE
feat(prompt): Add support for Moonshot Kimi K2 Thinking Model

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/Module.md
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/Module.md
@@ -63,6 +63,12 @@ across multiple model providers.
 | Mistral 7B    | Fast   | Text          | Text           | $0.15/$0.2 per 1M | Efficient, 7B params        |
 | Mistral Small | Fast   | Text          | Text           | $1/$3 per 1M      | Lightweight, cost-effective |
 
+### Moonshot Kimi Models
+
+| Model           | Speed  | Input Support | Output Support | Context | Pricing          | Notes                                |
+|-----------------|--------|---------------|----------------|---------|------------------|--------------------------------------|
+| Kimi K2 Thinking| Medium | Text, Tools   | Text, Tools    | 256K    | $0.6/$2.5 per 1M | Deep reasoning, thinking traces      |
+
 *Pricing shown as Input/Output per 1M tokens
 
 ## Media Content Support
@@ -78,8 +84,9 @@ across multiple model providers.
 
 - **Images**: Only Claude 3 models support image input
 - **Size limits**: AWS Bedrock enforces a 5MB limit for image data
-- **Tools**: Only Claude 3 models and Mistral Large support function calling
+- **Tools**: Claude 3, Mistral Large, and Kimi K2 Thinking models support function calling
 - **Streaming**: All models support token streaming
+- **Kimi K2 Thinking**: Requires Bedrock Converse API (`BedrockAPIMethod.Converse`), supports reasoning traces with up to 256K context
 
 ## Features
 
@@ -259,6 +266,36 @@ val mistralToolResponse = client.execute(
     model = BedrockModels.MistralLarge,
     tools = listOf(searchTool)
 )
+
+// Use Kimi K2 Thinking with deep reasoning (requires Converse API)
+val kimiClient = createBedrockLLMClient(
+    awsAccessKeyId = ApiKeyService.awsAccessKey,
+    awsSecretAccessKey = ApiKeyService.awsSecretAccessKey,
+    settings = BedrockClientSettings(
+        region = "us-east-1",
+        apiMethod = BedrockAPIMethod.Converse // Required for Kimi models
+    )
+)
+
+val kimiResponse = kimiClient.execute(
+    prompt = prompt {
+        user("Solve this complex problem step by step: What are the environmental impacts of quantum computing?")
+    },
+    model = BedrockModels.MoonshotKimiK2Thinking
+)
+
+// Kimi K2 Thinking supports reasoning traces
+kimiResponse.forEach { message ->
+    when (message) {
+        is Message.Reasoning -> {
+            // Access the model's chain-of-thought reasoning
+            println("Reasoning trace: ${message.content}")
+        }
+        is Message.Assistant -> {
+            println("Final answer: ${message.content}")
+        }
+    }
+}
 ```
 
 ## Testing

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
@@ -216,6 +216,8 @@ public class BedrockLLMClient @JvmOverloads constructor(
 
             model.id.contains("cohere.embed") -> BedrockModelFamilies.Cohere
 
+            model.id.contains("moonshot.kimi") -> BedrockModelFamilies.MoonshotKimi
+
             else -> {
                 if (fallbackModelFamily != null) {
                     logger.warn { "Model ${model.id} is not a supported Bedrock model, using fallback: ${fallbackModelFamily.display}" }
@@ -290,6 +292,12 @@ public class BedrockLLMClient @JvmOverloads constructor(
                     is BedrockModelFamilies.Meta -> BedrockMetaLlamaSerialization.parseLlamaResponse(
                         responseBodyString,
                         clock
+                    )
+
+                    is BedrockModelFamilies.MoonshotKimi -> throw LLMClientException(
+                        clientName,
+                        "Model family ${modelFamily.display} requires the Bedrock Converse API. " +
+                            "Please configure BedrockClientSettings with apiMethod = BedrockAPIMethod.Converse"
                     )
 
                     is BedrockModelFamilies.TitanEmbedding, is BedrockModelFamilies.Cohere -> throw LLMClientException(
@@ -425,6 +433,12 @@ public class BedrockLLMClient @JvmOverloads constructor(
                     clock = clock,
                 )
 
+                is BedrockModelFamilies.MoonshotKimi -> throw LLMClientException(
+                    clientName,
+                    "Model family ${modelFamily.display} requires the Bedrock Converse API. " +
+                        "Please configure BedrockClientSettings with apiMethod = BedrockAPIMethod.Converse"
+                )
+
                 is BedrockModelFamilies.TitanEmbedding, is BedrockModelFamilies.Cohere ->
                     throw LLMClientException(
                         clientName,
@@ -556,6 +570,12 @@ public class BedrockLLMClient @JvmOverloads constructor(
             is BedrockModelFamilies.Meta -> json.encodeToString(
                 LlamaRequest.serializer(),
                 BedrockMetaLlamaSerialization.createLlamaRequest(prompt, model)
+            )
+
+            is BedrockModelFamilies.MoonshotKimi -> throw LLMClientException(
+                clientName,
+                "Model family ${getBedrockModelFamily(model).display} requires the Bedrock Converse API. " +
+                    "Please configure BedrockClientSettings with apiMethod = BedrockAPIMethod.Converse"
             )
 
             is BedrockModelFamilies.TitanEmbedding,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModelFamilies.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModelFamilies.kt
@@ -47,4 +47,10 @@ public sealed class BedrockModelFamilies(
      */
     @Serializable
     public data object Cohere : BedrockModelFamilies("bedrock.cohere", "AWS Bedrock (Cohere Embeddings)")
+
+    /**
+     * Represents the Moonshot AI (Kimi) sub-provider under AWS Bedrock.
+     */
+    @Serializable
+    public data object MoonshotKimi : BedrockModelFamilies("bedrock.moonshot", "AWS Bedrock (Moonshot Kimi)")
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModels.kt
@@ -534,6 +534,36 @@ public object BedrockModels : LLModelDefinitions {
     ).effectiveModel
 
     /**
+     * Moonshot Kimi K2 Thinking - Advanced reasoning model with extended thinking capabilities
+     *
+     * Kimi K2 Thinking is a sparse Mixture-of-Experts model with one trillion total parameters,
+     * with only 32 billion parameters activating per inference.
+     *
+     * Features:
+     * - 256K context window
+     * - Deep reasoning with interleaved chain-of-thought
+     * - Robust tool calling (supports 200-300 sequential tool calls)
+     * - Native INT4 quantization for 2x speed-up
+     * - Strong performance on research-heavy, multistep workflows
+     * - Enhanced Chinese language reasoning capabilities
+     *
+     * Important: This model requires the Bedrock Converse API (apiMethod = BedrockAPIMethod.Converse).
+     * When using this model, ensure you configure BedrockClientSettings with BedrockAPIMethod.Converse.
+     *
+     * @see <a href="https://moonshotai.github.io/Kimi-K2/">
+     * @see <a href="https://huggingface.co/moonshotai/Kimi-K2-Thinking">
+     */
+    public val MoonshotKimiK2Thinking: LLModel = BedrockModel(
+        LLModel(
+            provider = LLMProvider.Bedrock,
+            id = "moonshot.kimi-k2-thinking",
+            capabilities = standardCapabilities + toolCapabilities,
+            contextLength = 256_000,
+        ),
+        inferenceProfilePrefix = null
+    ).effectiveModel
+
+    /**
      * Embedding models available through the AWS Bedrock API.
      *
      * **Note:** Multimodality (image, audio, video) embeddings are currently not supported by the Bedrock client.

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModels.kt
@@ -682,6 +682,9 @@ public object BedrockModels : LLModelDefinitions {
         Embeddings.AmazonTitanEmbedTextV2,
         Embeddings.CohereEmbedEnglishV3,
         Embeddings.CohereEmbedMultilingualV3,
+
+        // Moonshot Kimi K2 Thinking
+        MoonshotKimiK2Thinking,
     )
 
     /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClientTest.kt
@@ -902,9 +902,10 @@ class BedrockLLMClientTest {
         assertEquals("moonshot.kimi-k2-thinking", model.id)
         assertEquals(LLMProvider.Bedrock, model.provider)
         assertEquals(256_000, model.contextLength)
-        assertTrue(model.capabilities.contains(LLMCapability.Completion))
-        assertTrue(model.capabilities.contains(LLMCapability.Tools))
-        assertTrue(model.capabilities.contains(LLMCapability.Temperature))
+        val capabilities = assertNotNull(model.capabilities)
+        assertTrue(capabilities.contains(LLMCapability.Completion))
+        assertTrue(capabilities.contains(LLMCapability.Tools))
+        assertTrue(capabilities.contains(LLMCapability.Temperature))
     }
 
     @Test

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClientTest.kt
@@ -717,6 +717,14 @@ class BedrockLLMClientTest {
             contextLength = 512
         )
         assertEquals(BedrockModelFamilies.Cohere, client.getBedrockModelFamily(cohereModel))
+
+        val kimiModel = LLModel(
+            provider = LLMProvider.Bedrock,
+            id = "moonshot.kimi-k2-thinking",
+            capabilities = listOf(LLMCapability.Completion, LLMCapability.Tools),
+            contextLength = 256_000
+        )
+        assertEquals(BedrockModelFamilies.MoonshotKimi, client.getBedrockModelFamily(kimiModel))
     }
 
     @Test
@@ -885,5 +893,80 @@ class BedrockLLMClientTest {
         assertEquals("https://custom.endpoint.com", settings.endpointUrl)
         assertEquals(5, settings.maxRetries)
         assertEquals(true, settings.enableLogging)
+    }
+
+    @Test
+    fun `MoonshotKimiK2Thinking model has correct properties`() {
+        val model = BedrockModels.MoonshotKimiK2Thinking
+
+        assertEquals("moonshot.kimi-k2-thinking", model.id)
+        assertEquals(LLMProvider.Bedrock, model.provider)
+        assertEquals(256_000, model.contextLength)
+        assertTrue(model.capabilities.contains(LLMCapability.Completion))
+        assertTrue(model.capabilities.contains(LLMCapability.Tools))
+        assertTrue(model.capabilities.contains(LLMCapability.Temperature))
+    }
+
+    @Test
+    fun `Kimi K2 Thinking model requires Converse API for execute`() = runTest {
+        val client = BedrockLLMClient(
+            identityProvider = StaticCredentialsProvider {
+                accessKeyId = "test-key"
+                secretAccessKey = "test-secret"
+            },
+            settings = BedrockClientSettings(
+                region = BedrockRegions.US_EAST_1.regionCode,
+                apiMethod = BedrockAPIMethod.InvokeModel
+            ),
+            clock = Clock.System
+        )
+
+        val prompt = Prompt.build("test") {
+            user("Hello, Kimi!")
+        }
+
+        val exception = assertFailsWith<LLMClientException> {
+            client.execute(prompt, BedrockModels.MoonshotKimiK2Thinking, emptyList())
+        }
+
+        assertTrue(exception.message!!.contains("requires the Bedrock Converse API"))
+        assertTrue(exception.message!!.contains("BedrockAPIMethod.Converse"))
+    }
+
+    @Test
+    fun `Kimi K2 Thinking model requires Converse API for executeStreaming`() = runTest {
+        val client = BedrockLLMClient(
+            identityProvider = StaticCredentialsProvider {
+                accessKeyId = "test-key"
+                secretAccessKey = "test-secret"
+            },
+            settings = BedrockClientSettings(
+                region = BedrockRegions.US_EAST_1.regionCode,
+                apiMethod = BedrockAPIMethod.InvokeModel
+            ),
+            clock = Clock.System
+        )
+
+        val prompt = Prompt.build("test") {
+            user("Hello, Kimi!")
+        }
+
+        val exception = assertFailsWith<LLMClientException> {
+            client.executeStreaming(prompt, BedrockModels.MoonshotKimiK2Thinking, emptyList()).toList()
+        }
+
+        assertTrue(exception.message!!.contains("requires the Bedrock Converse API"))
+        assertTrue(exception.message!!.contains("BedrockAPIMethod.Converse"))
+    }
+
+    @Test
+    fun `MoonshotKimiK2Thinking model has no inference profile prefix`() {
+        val model = BedrockModels.MoonshotKimiK2Thinking
+
+        // The model should NOT have any inference profile prefix
+        assertFalse(model.id.startsWith("us."))
+        assertFalse(model.id.startsWith("eu."))
+        assertFalse(model.id.startsWith("global."))
+        assertEquals("moonshot.kimi-k2-thinking", model.id)
     }
 }


### PR DESCRIPTION

<!--
Thank you for opening a pull request!

Please add a brief description of the proposed change here.
Also, please tick the appropriate points in the checklist below.
-->

## Description
<!-- Why is this change needed? What problem does it solve? -->

Add Moonshot Kimi K2 Thinking model support to the Bedrock client, including a new model family, model definition, and Converse API enforcement with clear error messaging for misconfigured clients.                                                              
   
closes #1246                                
