### PR TITLE
ci: Better dynamic jobs filtering for PR checks based on files changed

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -1,0 +1,27 @@
+# This is used by the action https://github.com/dorny/paths-filter
+
+# Always include CI changes to all filters so that all CI changes are always tested
+ci-configs: &ci-configs
+  - .github/**
+
+# Mostly Koog's source code
+koog-src:
+  - *ci-configs
+  - '**'
+  - '!examples/**'
+  - '!docs/**'
+  - '!*.md'
+  - '!.editorconfig'
+  - '!.gitignore'
+
+docs:
+  - *ci-configs
+  - 'docs/**'
+
+simple-examples:
+  - *ci-configs
+  - 'examples/simple-examples/**'
+
+code-agent:
+  - *ci-configs
+  - 'examples/code-agent/**'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,17 +10,7 @@ name: Checks
 on:
   push:
     branches: [ "main", "develop" ]
-    paths-ignore:
-      - 'examples/**'
-      - '!examples/code-agent/**'
-      - '!examples/simple-examples/**'
-      - '*.md'
   pull_request:
-    paths-ignore:
-      - 'examples/**'
-      - '!examples/code-agent/**'
-      - '!examples/simple-examples/**'
-      - '*.md'
   workflow_dispatch:
 
 concurrency:
@@ -34,8 +24,25 @@ env:
   JAVA_OPTS: "-Xms8g -Xmx8g -Dfile.encoding=UTF-8 -Djava.awt.headless=true -Dkotlin.daemon.jvm.options=-Xmx6g"
 
 jobs:
-  compilation:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      koog-src: ${{ steps.filter.outputs.koog-src }}
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v5
 
+      - uses: dorny/paths-filter@v3
+        name: Check changed files
+        id: filter
+        with:
+          filters: .github/file-filters.yml
+
+  compilation:
+    needs: changes
+    if: ${{ needs.changes.outputs.koog-src == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -63,8 +70,9 @@ jobs:
         run: ./gradlew jvmTestClasses jsTestClasses
 
   docs:
+    needs: changes
+    if: ${{ needs.changes.outputs.docs == 'true' }}
     runs-on: ubuntu-latest
-
     permissions:
       contents: read
 
@@ -93,7 +101,7 @@ jobs:
           uv run mkdocs build
 
   tests:
-
+    needs: compilation
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -162,7 +170,9 @@ jobs:
           include_time_in_summary: true
           annotate_only: true
 
-  knit-and-dokka:
+  knit:
+    needs: changes
+    if: ${{ needs.changes.outputs.koog-src == 'true' || needs.changes.outputs.docs == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -171,7 +181,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - uses: gradle/actions/setup-gradle@v5
-      - name: Generate and verify code examples
+      - name: Verify code snippets in docs
         run: |
           echo "Starting knit generation..."
           FILES_BEFORE_KNIT=$(find docs/src/ -name "*.kt" 2>/dev/null | wc -l || echo "0")
@@ -186,4 +196,19 @@ jobs:
           echo "Knit generated $KNIT_GENERATED_FILES files"
 
           echo "Starting assemble..."
-          ./gradlew :docs:assemble dokkaGenerate
+          ./gradlew :docs:assemble
+
+  dokka:
+    needs: changes
+    if: ${{ needs.changes.outputs.koog-src == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
+        with:
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+      - uses: gradle/actions/setup-gradle@v5
+      - name: Generate API docs
+        run: |
+          ./gradlew dokkaGenerate

--- a/.github/workflows/code-agent-examples.yml
+++ b/.github/workflows/code-agent-examples.yml
@@ -16,7 +16,25 @@ env:
   JAVA_DISTRIBUTION: 'corretto'
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      koog-src: ${{ steps.filter.outputs.koog-src }}
+      code-agent: ${{ steps.filter.outputs.code-agent }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dorny/paths-filter@v3
+        name: Check changed files
+        id: filter
+        with:
+          filters: .github/file-filters.yml
+
   compilation:
+    needs: changes
+    if: ${{ needs.changes.outputs.koog-src == 'true' || needs.changes.outputs.code-agent == 'true' }}
     name: Compile ${{ matrix.step }}
 
     runs-on: ubuntu-latest

--- a/.github/workflows/simple-examples.yml
+++ b/.github/workflows/simple-examples.yml
@@ -3,11 +3,7 @@ name: Simple Examples
 on:
   push:
     branches: [ "main", "develop" ]
-    paths:
-      - 'examples/simple-examples/**'
   pull_request:
-    paths:
-      - 'examples/simple-examples/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -19,8 +15,25 @@ env:
   JAVA_DISTRIBUTION: 'corretto'
 
 jobs:
-  compilation:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      koog-src: ${{ steps.filter.outputs.koog-src }}
+      simple-examples: ${{ steps.filter.outputs.simple-examples }}
+    steps:
+      - uses: actions/checkout@v5
 
+      - uses: dorny/paths-filter@v3
+        name: Check changed files
+        id: filter
+        with:
+          filters: .github/file-filters.yml
+
+  compilation:
+    needs: changes
+    if: ${{ needs.changes.outputs.koog-src == 'true' || needs.changes.outputs.simple-examples == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Earlier, CI configs were updated to skip jobs based on the files changed in a PR. However, using built-in GitHub Action file filters turned out to be not flexible enough, leading to stuck PR checks. This PR migrates to a more dynamic jobs filtering using https://github.com/dorny/paths-filter action instead.