### PR TITLE
ci: Migrate to tj-actions/changed-files to fix dynamic jobs skipping

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -1,4 +1,6 @@
-# This is used by the action https://github.com/dorny/paths-filter
+# This is used by the action https://github.com/tj-actions/changed-files
+# NOTE: Filter order is irrelevant (unlike .gitignore).
+# Positive filters are applied first, then negative filters.
 
 # Always include CI changes to all filters so that all CI changes are always tested
 ci-configs: &ci-configs

--- a/.github/scripts/print_changed_files.sh
+++ b/.github/scripts/print_changed_files.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Used to print action results for observability
+# https://github.com/tj-actions/changed-files
+
+printf "Matching file filters:\n\n"
+
+for f in .github/outputs/*_all_changed_files.txt; do
+    [ -f "$f" ] || continue
+    key=$(basename "$f" _all_changed_files.txt)
+    count=$(wc -w < "$f" | tr -d ' ')
+    echo "== $key ($count files) =="
+    cat "$f" | tr ' ' '\n'
+    printf "\n\n"
+done

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,16 +29,20 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      koog-src: ${{ steps.filter.outputs.koog-src }}
-      docs: ${{ steps.filter.outputs.docs }}
+      koog-src: ${{ steps.filter.outputs.koog-src_any_changed }}
+      docs: ${{ steps.filter.outputs.docs_any_changed }}
     steps:
       - uses: actions/checkout@v5
 
-      - uses: dorny/paths-filter@v3
+      - uses: tj-actions/changed-files@e0021407031f5be11a464abee9a0776171c79891 # v47.0.1
         name: Check changed files
         id: filter
         with:
-          filters: .github/file-filters.yml
+          write_output_files: 'true'
+          files_yaml_from_source_file: .github/file-filters.yml
+
+      - run: .github/scripts/print_changed_files.sh
+        name: 'Print changed files'
 
   compilation:
     needs: changes

--- a/.github/workflows/code-agent-examples.yml
+++ b/.github/workflows/code-agent-examples.yml
@@ -21,16 +21,20 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      koog-src: ${{ steps.filter.outputs.koog-src }}
-      code-agent: ${{ steps.filter.outputs.code-agent }}
+      koog-src: ${{ steps.filter.outputs.koog-src_any_changed }}
+      code-agent: ${{steps.filter.outputs.code-agent_any_changed }}
     steps:
       - uses: actions/checkout@v5
 
-      - uses: dorny/paths-filter@v3
+      - uses: tj-actions/changed-files@e0021407031f5be11a464abee9a0776171c79891 # v47.0.1
         name: Check changed files
         id: filter
         with:
-          filters: .github/file-filters.yml
+          write_output_files: 'true'
+          files_yaml_from_source_file: .github/file-filters.yml
+
+      - run: .github/scripts/print_changed_files.sh
+        name: 'Print changed files'
 
   compilation:
     needs: changes

--- a/.github/workflows/simple-examples.yml
+++ b/.github/workflows/simple-examples.yml
@@ -20,16 +20,20 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      koog-src: ${{ steps.filter.outputs.koog-src }}
-      simple-examples: ${{ steps.filter.outputs.simple-examples }}
+      koog-src: ${{ steps.filter.outputs.koog-src_any_changed }}
+      simple-examples: ${{ steps.filter.outputs.simple-examples_any_changed  }}
     steps:
       - uses: actions/checkout@v5
 
-      - uses: dorny/paths-filter@v3
+      - uses: tj-actions/changed-files@e0021407031f5be11a464abee9a0776171c79891 # v47.0.1
         name: Check changed files
         id: filter
         with:
-          filters: .github/file-filters.yml
+          write_output_files: 'true'
+          files_yaml_from_source_file: .github/file-filters.yml
+
+      - run: .github/scripts/print_changed_files.sh
+        name: 'Print changed files'
 
   compilation:
     needs: changes


### PR DESCRIPTION
In #1449 I introduced https://github.com/dorny/paths-filter to skip unneeded jobs dynamically. However, this action turned out to be not flexible enough since it doesn't support proper negative filtering (with `!` prefix, similar to `.gitignore` syntax). This produced false positives, leading to unnecessary job runs. Now I migrated to https://github.com/tj-actions/changed-files that does support negative filtering, this should allow skipping the jobs properly.