### PR TITLE
docs: Source link now leads to actual release branch

### DIFF
--- a/convention-plugin-ai/src/main/kotlin/ai.kotlin.dokka.gradle.kts
+++ b/convention-plugin-ai/src/main/kotlin/ai.kotlin.dokka.gradle.kts
@@ -13,7 +13,15 @@ dokka {
 
             sourceLink {
                 localDirectory = rootDir
-                remoteUrl("https://github.com/JetBrains/koog/tree/main")
+                // Point to git tag for releases, develop branch for snapshots
+                val versionString = project.version.toString()
+                val sourceRef = if (versionString.contains("-")) {
+                    // most likely source ref is smth like 0.7.0-SNAPSHOT
+                    "develop"
+                } else {
+                    versionString
+                }
+                remoteUrl("https://github.com/JetBrains/koog/tree/$sourceRef")
                 remoteLineSuffix = "#L"
             }
 


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

Source link in api.koog.ai now leads to actual release branch instead of develop