### PR TITLE
Fix source links in api docs

### DIFF
--- a/convention-plugin-ai/src/main/kotlin/ai.kotlin.dokka.gradle.kts
+++ b/convention-plugin-ai/src/main/kotlin/ai.kotlin.dokka.gradle.kts
@@ -10,11 +10,19 @@ dokka {
             footerMessage = "Copyright © 2000-2025 JetBrains s.r.o."
         }
 
-        sourceLink {
-            localDirectory = rootDir
-            remoteUrl("https://github.com/JetBrains/koog/tree/main")
-            remoteLineSuffix = "#L"
-        }
+            sourceLink {
+                localDirectory = rootDir
+                // Point to git tag for releases, develop branch for snapshots
+                val versionString = project.version.toString()
+                val sourceRef = if (versionString.contains("-")) {
+                    // most likely source ref is smth like 0.7.0-SNAPSHOT
+                    "develop"
+                } else {
+                    versionString
+                }
+                remoteUrl("https://github.com/JetBrains/koog/tree/$sourceRef")
+                remoteLineSuffix = "#L"
+            }
 
         externalDocumentationLinks.register("ktor-client") {
             url("https://api.ktor.io/ktor-client/")


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

These changes fix source links in the docs and should be included in 0.6.1.

