### PR TITLE
ci: run conventional PR check for sync events too

### DIFF
--- a/.github/workflows/conventional-prs.yml
+++ b/.github/workflows/conventional-prs.yml
@@ -7,7 +7,7 @@ on:
       - opened
       - reopened
       - edited
-      # - synchronize (if you use required Actions)
+      - synchronize
 
 jobs:
   main:


### PR DESCRIPTION
Since conventional PR check is required for all PRs targeting develop, it has to be rerun on every push. Otherwise it won't run and prevent PRs from passing all required checks.