### PR TITLE
feat(agents): add simpleAzureOpenAIExecutor for v1 endpoint

### DIFF
--- a/prompt/prompt-executor/prompt-executor-llms-all/src/commonMain/kotlin/ai/koog/prompt/executor/llms/all/SimplePromptExecutors.kt
+++ b/prompt/prompt-executor/prompt-executor-llms-all/src/commonMain/kotlin/ai/koog/prompt/executor/llms/all/SimplePromptExecutors.kt
@@ -84,7 +84,7 @@ public fun simpleAzureOpenAIExecutor(
 
     return SingleLLMPromptExecutor(
         OpenAILLMClient(
-            "",
+            "", // Authorization: Bearer not needed when using api-key header for Azure OpenAI
             OpenAIClientSettings(baseUrl),
             HttpClient {
                 defaultRequest {

--- a/prompt/prompt-executor/prompt-executor-llms-all/src/commonMain/kotlin/ai/koog/prompt/executor/llms/all/SimplePromptExecutors.kt
+++ b/prompt/prompt-executor/prompt-executor-llms-all/src/commonMain/kotlin/ai/koog/prompt/executor/llms/all/SimplePromptExecutors.kt
@@ -3,12 +3,16 @@ package ai.koog.prompt.executor.llms.all
 import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
 import ai.koog.prompt.executor.clients.google.GoogleLLMClient
 import ai.koog.prompt.executor.clients.mistralai.MistralAILLMClient
+import ai.koog.prompt.executor.clients.openai.OpenAIClientSettings
 import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
 import ai.koog.prompt.executor.clients.openai.azure.AzureOpenAIClientSettings
 import ai.koog.prompt.executor.clients.openai.azure.AzureOpenAIServiceVersion
 import ai.koog.prompt.executor.clients.openrouter.OpenRouterLLMClient
 import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
 import ai.koog.prompt.executor.ollama.client.OllamaClient
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.header
 
 /**
  * Creates a `SingleLLMPromptExecutor` instance configured to use the OpenAI client.
@@ -54,6 +58,41 @@ public fun simpleAzureOpenAIExecutor(
     apiToken: String,
 ): SingleLLMPromptExecutor =
     SingleLLMPromptExecutor(OpenAILLMClient(apiToken, AzureOpenAIClientSettings(baseUrl, version)))
+
+/**
+ * Creates an instance of `SingleLLMPromptExecutor` with an `OpenAILLMClient` configured for Azure OpenAI.
+ *
+ * @param baseUrl The base URL for the Azure OpenAI service.
+ * @param apiKey The API key (or Entra ID token) used for authentication with the Azure OpenAI service.
+ * @param usesAzureEntraId Indicates whether the authentication uses Azure Entra ID token (true)
+ * or `api-key` header (false). Defaults to true.
+ * @return A new instance of `SingleLLMPromptExecutor` configured with the `OpenAILLMClient` for Azure OpenAI.
+ */
+public fun simpleAzureOpenAIExecutor(
+    baseUrl: String,
+    apiKey: String,
+    usesAzureEntraId: Boolean = true
+): SingleLLMPromptExecutor {
+    if (usesAzureEntraId) {
+        return SingleLLMPromptExecutor(
+            OpenAILLMClient(
+                apiKey,
+                OpenAIClientSettings(baseUrl),
+            )
+        )
+    }
+
+    return SingleLLMPromptExecutor(
+        OpenAILLMClient(
+            "",
+            OpenAIClientSettings(baseUrl),
+            HttpClient {
+                defaultRequest {
+                    header("api-key", apiKey)
+                }
+            }
+        ))
+}
 
 /**
  * Creates an instance of `SingleLLMPromptExecutor` with an `AnthropicLLMClient`.

--- a/prompt/prompt-executor/prompt-executor-llms-all/src/commonMain/kotlin/ai/koog/prompt/executor/llms/all/SimplePromptExecutors.kt
+++ b/prompt/prompt-executor/prompt-executor-llms-all/src/commonMain/kotlin/ai/koog/prompt/executor/llms/all/SimplePromptExecutors.kt
@@ -62,7 +62,7 @@ public fun simpleAzureOpenAIExecutor(
 /**
  * Creates an instance of `SingleLLMPromptExecutor` with an `OpenAILLMClient` configured for Azure OpenAI.
  *
- * @param baseUrl The base URL for the Azure OpenAI service.
+ * @param baseUrl The v1 base URL for the Azure OpenAI service.
  * @param apiKey The API key (or Entra ID token) used for authentication with the Azure OpenAI service.
  * @param usesAzureEntraId Indicates whether the authentication uses Azure Entra ID token (true)
  * or `api-key` header (false). Defaults to true.


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

Added a `simpleAzureOpenAIExecutor`. This executor works with the new v1 endpoint and removes the need to specify a version[^1]. Azure currently supports two authentication methods: API keys and Azure Entra ID tokens. This PR supports both [^2].

[^1]: https://learn.microsoft.com/en-us/azure/ai-foundry/openai/api-version-lifecycle?view=foundry-classic&tabs=python
[^2]: https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/authentication-authorization-foundry?view=foundry-classic#authentication-methods