### PR TITLE
ci: add explicit skip condition for tests job to report status for required checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -106,6 +106,7 @@ jobs:
 
   tests:
     needs: compilation
+    if: ${{ needs.changes.outputs.koog-src == 'true' }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/simple-examples.yml
+++ b/.github/workflows/simple-examples.yml
@@ -74,6 +74,7 @@ jobs:
 
   tests:
     needs: compilation
+    if: ${{ needs.changes.outputs.koog-src == 'true' || needs.changes.outputs.simple-examples == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Since `tests` job in `checks.yaml` is set as required for all PRs targeting `develop`, an explicit `if` skip condition is needed here. Otherwise the job won't run when `compilation` is skipped, thus never reporting the status and leading to stuck PR status checks.