### PR TITLE
fix(integration-tests): fix failing heavy tests

### DIFF
--- a/integration-tests/src/jvmMain/kotlin/ai/koog/integration/tests/utils/annotations/RetryExtension.kt
+++ b/integration-tests/src/jvmMain/kotlin/ai/koog/integration/tests/utils/annotations/RetryExtension.kt
@@ -13,6 +13,11 @@ class RetryExtension : InvocationInterceptor {
     companion object {
         private const val GOOGLE_API_ERROR = "Field 'parts' is required for type with serial name"
         private const val GOOGLE_429_ERROR = "Error from GoogleAI API: 429 Too Many Requests"
+        private const val GOOGLE_RESOURCE_EXHAUSTED =
+            "You exceeded your current quota, please check your plan and billing details"
+        private const val GOOGLE_QUOTA_EXCEEDED = "Quota exceeded"
+        private const val GOOGLE_RESOURCE_EXHAUSTED_STATUS = "RESOURCE_EXHAUSTED"
+        private const val GOOGLE_429_STATUS = "Status code: 429"
         private const val GOOGLE_500_ERROR = "Error from GoogleAI API: 500 Internal Server Error"
         private const val GOOGLE_503_ERROR = "Error from GoogleAI API: 503 Service Unavailable"
         private const val ANTHROPIC_502_ERROR = "Error from Anthropic API: 502 Bad Gateway"
@@ -27,6 +32,10 @@ class RetryExtension : InvocationInterceptor {
             listOf(
                 GOOGLE_API_ERROR,
                 GOOGLE_429_ERROR,
+                GOOGLE_429_STATUS,
+                GOOGLE_RESOURCE_EXHAUSTED,
+                GOOGLE_QUOTA_EXCEEDED,
+                GOOGLE_RESOURCE_EXHAUSTED_STATUS,
                 GOOGLE_500_ERROR,
                 GOOGLE_503_ERROR,
                 ANTHROPIC_502_ERROR,
@@ -35,7 +44,8 @@ class RetryExtension : InvocationInterceptor {
                 MISTRAL_503_ERROR,
                 OPENROUTER_API_ERROR,
             )
-        return e.message?.let { message -> message in errorMessages } == true
+        val message = e.message
+        return message != null && errorMessages.any { message.contains(it, ignoreCase = true) }
     }
 
     override fun interceptTestMethod(

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/acp/AcpProtocolTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/acp/AcpProtocolTest.kt
@@ -3,7 +3,7 @@ package ai.koog.integration.tests.acp
 import ai.koog.agents.testing.tools.RandomNumberTool
 import ai.koog.integration.tests.utils.getLLMClientForProvider
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
+import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import com.agentclientprotocol.common.SessionCreationParameters
 import com.agentclientprotocol.model.AcpMethod
 import com.agentclientprotocol.model.AuthMethod
@@ -48,7 +48,7 @@ class AcpProtocolTest {
 
     @Test
     fun integration_testNotificationDelivery() = runTest(timeout = 1.minutes) {
-        SingleLLMPromptExecutor(getLLMClientForProvider(DEFAULT_MODEL.provider)).use { promptExecutor ->
+        MultiLLMPromptExecutor(getLLMClientForProvider(DEFAULT_MODEL.provider)).use { promptExecutor ->
             withContext(Dispatchers.Default.limitedParallelism(1)) {
                 withTimeout(30.seconds) {
                     val randomNumberTool = RandomNumberTool()
@@ -89,7 +89,7 @@ class AcpProtocolTest {
         audio: Boolean,
         image: Boolean
     ) = runTest(timeout = 1.minutes) {
-        SingleLLMPromptExecutor(getLLMClientForProvider(DEFAULT_MODEL.provider)).use { promptExecutor ->
+        MultiLLMPromptExecutor(getLLMClientForProvider(DEFAULT_MODEL.provider)).use { promptExecutor ->
             withContext(Dispatchers.Default.limitedParallelism(1)) {
                 withTimeout(30.seconds) {
                     val randomNumberTool = RandomNumberTool()
@@ -146,7 +146,7 @@ class AcpProtocolTest {
 
     @Test
     fun integration_testAuthenticationWithAuthMethod() = runTest(timeout = 1.minutes) {
-        SingleLLMPromptExecutor(getLLMClientForProvider(DEFAULT_MODEL.provider)).use { promptExecutor ->
+        MultiLLMPromptExecutor(getLLMClientForProvider(DEFAULT_MODEL.provider)).use { promptExecutor ->
             withContext(Dispatchers.Default.limitedParallelism(2)) {
                 withTimeout(30.seconds) {
                     val setup = setupAcpClient(
@@ -176,7 +176,7 @@ class AcpProtocolTest {
 
     @Test
     fun integration_testAuthenticationError() = runTest(timeout = 1.minutes) {
-        SingleLLMPromptExecutor(getLLMClientForProvider(DEFAULT_MODEL.provider)).use { promptExecutor ->
+        MultiLLMPromptExecutor(getLLMClientForProvider(DEFAULT_MODEL.provider)).use { promptExecutor ->
             withContext(Dispatchers.Default.limitedParallelism(2)) {
                 withTimeout(10.seconds) {
                     val setup = setupAcpClient(

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/acp/AcpServerTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/acp/AcpServerTest.kt
@@ -5,7 +5,7 @@ import ai.koog.integration.tests.utils.getLLMClientForProvider
 import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
 import ai.koog.prompt.executor.clients.google.GoogleModels
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
+import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import com.agentclientprotocol.common.Event
@@ -38,7 +38,7 @@ class AcpServerTest {
     @ParameterizedTest
     @MethodSource("getModels")
     fun integration_testACPWithTools(model: LLModel) = runTest(timeout = 1.minutes) {
-        SingleLLMPromptExecutor(getLLMClientForProvider(model.provider)).use { promptExecutor ->
+        MultiLLMPromptExecutor(getLLMClientForProvider(model.provider)).use { promptExecutor ->
             withContext(Dispatchers.Default.limitedParallelism(1)) {
                 withTimeout(30.seconds) {
                     val result = runAcpAgent(promptExecutor, model)
@@ -64,12 +64,11 @@ class AcpServerTest {
             val events = mutableListOf<Event>()
             setup.session!!.prompt(promptContent).collect { events.add(it) }
 
-            val toolCalls = events.filterIsInstance<Event.SessionUpdateEvent>()
+            val updates = events.filterIsInstance<Event.SessionUpdateEvent>()
                 .map { it.update }
-                .filterIsInstance<SessionUpdate.ToolCall>()
 
-            toolCalls.any { it.status == ToolCallStatus.IN_PROGRESS } shouldBe true
-            toolCalls.any { it.status == ToolCallStatus.COMPLETED } shouldBe true
+            updates.any { it is SessionUpdate.ToolCall && it.status == ToolCallStatus.IN_PROGRESS } shouldBe true
+            updates.any { it is SessionUpdate.ToolCallUpdate && it.status == ToolCallStatus.COMPLETED } shouldBe true
 
             "Tool ${randomNumberTool.name} generated: ${randomNumberTool.last}"
         } finally {

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/acp/AcpTestFixture.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/acp/AcpTestFixture.kt
@@ -148,7 +148,7 @@ suspend fun setupAcpClient(
     agentInfo.authMethods shouldBe authMethods
 
     if (authenticate && authMethods.isNotEmpty()) {
-        clientProtocol.sendRequest<AuthenticateRequest, AuthenticateResponse>(
+        clientProtocol.sendRequest(
             AcpMethod.AgentMethods.Authenticate,
             AuthenticateRequest(authMethods.first().id)
         )

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
@@ -614,7 +614,7 @@ class AIAgentIntegrationTest : AIAgentTestBase() {
             }
         )
 
-        agent.run("Start the test")
+        agent.run("Start the test", agent.id)
 
         with(checkpointStorageProvider.getCheckpoints(agent.id)) {
             shouldNotBeEmpty()
@@ -641,7 +641,7 @@ class AIAgentIntegrationTest : AIAgentTestBase() {
         )
 
         // Verify that the agent continued from the checkpoint
-        restoredAgent.run("Continue the test") shouldContain sayBye
+        restoredAgent.run("Continue the test", agent.id) shouldContain sayBye
     }
 
     @ParameterizedTest
@@ -740,7 +740,7 @@ class AIAgentIntegrationTest : AIAgentTestBase() {
         )
 
         withClue("Final result should contain output from the second execution of $rollback") {
-            agent.run("Start the test") shouldContain alreadyRolledBackMessage
+            agent.run("Start the test", agent.id) shouldContain alreadyRolledBackMessage
         }
 
         with(executionLog.toString()) {
@@ -817,8 +817,7 @@ class AIAgentIntegrationTest : AIAgentTestBase() {
                 }
             }
         )
-
-        agent.run(testInput)
+        agent.run(testInput, agent.id)
 
         with(checkpointStorageProvider.getCheckpoints(agent.id)) {
             size shouldBeGreaterThanOrEqual 3
@@ -895,8 +894,7 @@ class AIAgentIntegrationTest : AIAgentTestBase() {
                 }
             }
         )
-
-        agent.run(testInput)
+        agent.run(testInput, agent.id)
 
         val expectedNodePath = path(agentId, strategyName, bye)
         with(fileStorageProvider.getCheckpoints(agent.id).filter { it.nodePath != "tombstone" }) {
@@ -952,7 +950,7 @@ class AIAgentIntegrationTest : AIAgentTestBase() {
                     },
                 )
 
-                agent.run("What is 12 + 34?")
+                agent.run("What is 12 + 34?", agent.id)
 
                 with(state) {
                     actualToolCalls shouldBe listOf(SimpleCalculatorTool.descriptor.name)

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentTestBase.kt
@@ -34,7 +34,6 @@ import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
 import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
-import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
@@ -93,8 +92,8 @@ open class AIAgentTestBase {
 
     val systemPrompt = "You are a helpful assistant."
 
-    fun getExecutor(model: LLModel): SingleLLMPromptExecutor =
-        SingleLLMPromptExecutor(getLLMClientForProvider(model.provider))
+    fun getExecutor(model: LLModel): MultiLLMPromptExecutor =
+        MultiLLMPromptExecutor(getLLMClientForProvider(model.provider))
 
     protected class State(
         var reasoningCallsCount: Int = 0,

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/mcp/McpServerTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/mcp/McpServerTest.kt
@@ -11,7 +11,7 @@ import ai.koog.agents.testing.tools.RandomNumberTool
 import ai.koog.integration.tests.utils.RetryUtils
 import ai.koog.integration.tests.utils.getLLMClientForProvider
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
+import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.llm.LLModel
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldContainExactly
@@ -35,8 +35,6 @@ class McpServerTest {
         @JvmStatic
         fun getModels() = listOf(
             OpenAIModels.Chat.GPT4o,
-            // Enable when fixed: KG-588 singleRunStrategy outputs empty response when using an MCP server
-            // GoogleModels.Gemini2_5FlashLite
         )
     }
 
@@ -71,7 +69,7 @@ class McpServerTest {
             withContext(Dispatchers.Default.limitedParallelism(1)) {
                 withTimeout(40.seconds) {
                     AIAgent(
-                        promptExecutor = SingleLLMPromptExecutor(getLLMClientForProvider(model.provider)),
+                        promptExecutor = MultiLLMPromptExecutor(getLLMClientForProvider(model.provider)),
                         strategy = singleRunStrategy(),
                         llmModel = model,
                         toolRegistry = toolRegistry,

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/RetryUtils.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/RetryUtils.kt
@@ -12,6 +12,9 @@ object RetryUtils {
     private const val GOOGLE_429_ERROR = "Expected status code 200 but was 429"
     private const val GOOGLE_RESOURCE_EXHAUSTED =
         "You exceeded your current quota, please check your plan and billing details"
+    private const val GOOGLE_QUOTA_EXCEEDED = "Quota exceeded"
+    private const val GOOGLE_RESOURCE_EXHAUSTED_STATUS = "RESOURCE_EXHAUSTED"
+    private const val GOOGLE_429_STATUS = "Status code: 429"
     private const val GOOGLE_500_ERROR = "Error from GoogleAI API: 500 Internal Server Error"
     private const val GOOGLE_503_ERROR = "Error from GoogleAI API: 503 Service Unavailable"
     private const val ANTHROPIC_429_ERROR = "Error from Anthropic API: 429 Too Many Requests"
@@ -34,7 +37,10 @@ object RetryUtils {
     private fun isThirdPartyError(e: Throwable): Boolean {
         val errorMessages = listOf(
             GOOGLE_429_ERROR,
+            GOOGLE_429_STATUS,
             GOOGLE_RESOURCE_EXHAUSTED,
+            GOOGLE_QUOTA_EXCEEDED,
+            GOOGLE_RESOURCE_EXHAUSTED_STATUS,
             GOOGLE_500_ERROR,
             GOOGLE_503_ERROR,
             ANTHROPIC_429_ERROR,
@@ -76,7 +82,6 @@ object RetryUtils {
                         false,
                         "Skipping test due to third-party service error: ${throwable.message}"
                     )
-                    return@runBlocking action()
                 }
 
                 if (attempt < times) {


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

1. Fix failure caused by a random agent ID in persistency tests
2. Fix failure caused by too narrow event filtration in the ACP tests
3. Replace deprecated SingleLLMPromptExecutor with MultiLLMPromptExecutor where possible


<!-- Include BREAKING section below only if this PR introduces breaking changes. Otherwise, delete it. -->
BREAKING:
* none

<!-- Include DEPRECATED section below only if this PR deprecates any public APIs. Otherwise, delete it. -->
DEPRECATED:
* none

<!-- Include references to related issues below, e.g., closes #1, closes KG-1. Otherwise, delete it. -->