### PR TITLE
ci: Add test summary job to properly report status when tests are skipped

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -104,6 +104,8 @@ jobs:
           uv sync --frozen --all-extras
           uv run mkdocs build
 
+  # Do not set individual matrix jobs (e.g., "tests (ubuntu-latest)") as required in GitHub branch protection.
+  # Instead, use the summary job `tests-result` below, which properly reports status when tests are skipped.
   tests:
     needs: compilation
     if: ${{ needs.changes.outputs.koog-src == 'true' }}
@@ -174,6 +176,24 @@ jobs:
           include_empty_in_summary: false
           include_time_in_summary: true
           annotate_only: true
+
+  # Matrix jobs don't report status when skipped, causing required checks to hang.
+  # This summary job always checks `tests` jobs result and reports status for branch protection.
+  tests-result:
+    needs: [ changes, tests ]
+    if: always()
+    runs-on: ubuntu-slim
+    steps:
+      - name: Check tests status
+        #language=bash
+        run: |
+          if [[ "${{ needs.tests.result }}" == "skipped" ]]; then
+            echo "Tests skipped"
+            exit 0
+          elif [[ "${{ needs.tests.result }}" != "success" ]]; then
+            echo "Tests didn't finish successfully"
+            exit 1
+          fi 
 
   knit:
     needs: changes


### PR DESCRIPTION
When matrix jobs that are set as required are skipped, GitHub doesn't properly report their status, so they hang and block PR. A common workaround is to introduce a summary job that will always run and check the status of the matrix jobs. Then, this summary job is set is required in branch protection rules.