### PR TITLE
build: add shared JVM and non-JVM source sets to `ai.kotlin.multiplatform` configuration

### DIFF
--- a/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
+++ b/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
@@ -47,8 +47,70 @@ kotlin {
         binaries.library()
     }
 
+    applyDefaultHierarchyTemplate()
+
     sourceSets {
+        /*
+         Source set to share the code that is common to all non-JVM targets.
+         */
+        val nonJvmCommonMain by creating {
+            dependsOn(commonMain.get())
+        }
+
+        val nonJvmCommonTest by creating {
+            dependsOn(commonTest.get())
+        }
+
+        /*
+          Source set to share the code between JVM and Android targets, since they both support certain JVM features.
+         */
+        val jvmCommonMain by creating {
+            dependsOn(commonMain.get())
+        }
+
+        val jvmCommonTest by creating {
+            dependsOn(commonTest.get())
+        }
+
+        appleMain {
+            dependsOn(nonJvmCommonMain)
+        }
+
+        appleTest {
+            dependsOn(nonJvmCommonTest)
+        }
+
+        jsMain {
+            dependsOn(nonJvmCommonMain)
+        }
+
+        jsTest {
+            dependsOn(nonJvmCommonTest)
+        }
+
+        wasmJsMain {
+            dependsOn(nonJvmCommonMain)
+        }
+
+        wasmJsTest {
+            dependsOn(nonJvmCommonTest)
+        }
+
+        jvmMain {
+            dependsOn(jvmCommonMain)
+        }
+
+        jvmTest {
+            dependsOn(jvmCommonTest)
+        }
+
+        androidMain {
+            dependsOn(jvmCommonMain)
+        }
+
         androidUnitTest {
+            dependsOn(jvmCommonTest)
+
             dependencies {
                 implementation(kotlin("test-junit"))
             }


### PR DESCRIPTION
The use-case of splitting a feature implementation into JVM and non-JVM versions is getting more popular as we implement Java API. To avoid copy-pasting the same code to different targets, this PR adds shared source sets.

Source sets introduced:
* `nonJvmCommonMain` - code shared accross all non-JVM targets. All such targets depend on this source set automatically
* `nonJvmCommonTest` - following the standard convention, tests for code in `nonJvmCommonMain`
* `jvmCommonMain` - shared between JVM and Android
* `jvmCommonTest`- tests for the source set above