### PR TITLE
feat(agents): Support OpenTelemetry feature for functional pipeline (#1447)

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentFunctionalStrategy.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentFunctionalStrategy.kt
@@ -1,7 +1,10 @@
 package ai.koog.agents.core.agent
 
 import ai.koog.agents.core.agent.context.AIAgentFunctionalContext
+import ai.koog.agents.core.agent.context.with
 import ai.koog.agents.core.agent.entity.AIAgentStrategy
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.reflect.typeOf
 
 /**
  * A strategy for implementing AI agent behavior that operates in a loop-based manner.
@@ -23,7 +26,22 @@ public class AIAgentFunctionalStrategy<TInput, TOutput>(
     override suspend fun execute(
         context: AIAgentFunctionalContext,
         input: TInput
-    ): TOutput = context.func(input)
+    ): TOutput {
+        return try {
+            context.with(partName = name) { executionInfo, eventId ->
+                context.pipeline.onStrategyStarting(eventId, executionInfo, this, context)
+                val result = context.func(input)
+                context.pipeline.onStrategyCompleted(eventId, executionInfo, this, context, result, typeOf<Any>())
+
+                result
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            context.environment.reportProblem(e)
+            throw e
+        }
+    }
 }
 
 /**

--- a/agents/agents-features/agents-features-opentelemetry/build.gradle.kts
+++ b/agents/agents-features/agents-features-opentelemetry/build.gradle.kts
@@ -43,6 +43,8 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-junit5"))
                 implementation(project(":agents:agents-test"))
+
+                implementation(libs.junit.jupiter.params)
             }
         }
     }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
@@ -4,8 +4,11 @@ import ai.koog.agents.core.agent.GraphAIAgent
 import ai.koog.agents.core.agent.entity.AIAgentStorageKey
 import ai.koog.agents.core.agent.execution.AgentExecutionInfo
 import ai.koog.agents.core.annotation.InternalAgentsApi
+import ai.koog.agents.core.feature.AIAgentFunctionalFeature
 import ai.koog.agents.core.feature.AIAgentGraphFeature
+import ai.koog.agents.core.feature.pipeline.AIAgentFunctionalPipeline
 import ai.koog.agents.core.feature.pipeline.AIAgentGraphPipeline
+import ai.koog.agents.core.feature.pipeline.AIAgentPipeline
 import ai.koog.agents.core.utils.SerializationUtils
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
 import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
@@ -46,7 +49,9 @@ public class OpenTelemetry {
     /**
      * Companion object implementing agent feature, handling [OpenTelemetry] creation and installation.
      */
-    public companion object Feature : AIAgentGraphFeature<OpenTelemetryConfig, OpenTelemetry> {
+    public companion object Feature :
+        AIAgentGraphFeature<OpenTelemetryConfig, OpenTelemetry>,
+        AIAgentFunctionalFeature<OpenTelemetryConfig, OpenTelemetry> {
 
         private val logger = KotlinLogging.logger { }
 
@@ -58,12 +63,199 @@ public class OpenTelemetry {
 
         override fun install(
             config: OpenTelemetryConfig,
-            pipeline: AIAgentGraphPipeline,
+            pipeline: AIAgentGraphPipeline
         ): OpenTelemetry {
             val openTelemetry = OpenTelemetry()
             val spanCollector = SpanCollector()
             val spanAdapter = config.spanAdapter
+            val tracer = config.tracer
 
+            installCommon(config, pipeline, spanCollector)
+
+            //region Node
+
+            pipeline.interceptNodeExecutionStarting(this) intercept@{ eventContext ->
+                logger.debug { "Execute OpenTelemetry node starting handler" }
+
+                val patchedExecutionInfo = eventContext.executionInfo.appendRunId(eventContext.context.runId)
+                val parentSpan = spanCollector.getParentSpanForEvent(
+                    executionInfo = patchedExecutionInfo,
+                ) ?: run {
+                    logger.warn { "Failed to find parent span for node: ${eventContext.node.id}. Path: ${patchedExecutionInfo.path()}" }
+                    return@intercept
+                }
+
+                val nodeInput = nodeDataToString(eventContext.input, eventContext.inputType)
+
+                val nodeExecuteSpan = startNodeExecuteSpan(
+                    tracer = tracer,
+                    parentSpan = parentSpan,
+                    id = eventContext.eventId,
+                    runId = eventContext.context.runId,
+                    nodeId = eventContext.node.id,
+                    nodeInput = nodeInput
+                )
+
+                spanAdapter?.onBeforeSpanStarted(nodeExecuteSpan)
+                spanCollector.collectSpan(
+                    span = nodeExecuteSpan,
+                    path = patchedExecutionInfo
+                )
+            }
+
+            pipeline.interceptNodeExecutionCompleted(this) intercept@{ eventContext ->
+                logger.debug { "Execute OpenTelemetry node completed handler" }
+
+                // Find existing span (Node Execute Span)
+                val patchedExecutionInfo = eventContext.executionInfo.appendRunId(eventContext.context.runId)
+                val nodeExecuteSpan = spanCollector.getStartedSpan(
+                    executionInfo = patchedExecutionInfo,
+                    eventId = eventContext.eventId,
+                    spanType = SpanType.NODE
+                ) ?: return@intercept
+
+                val nodeOutput = nodeDataToString(eventContext.output, eventContext.outputType)
+
+                spanAdapter?.onBeforeSpanFinished(nodeExecuteSpan)
+                endNodeExecuteSpan(
+                    span = nodeExecuteSpan,
+                    nodeOutput = nodeOutput,
+                    verbose = config.isVerbose
+                )
+                spanCollector.removeSpan(
+                    span = nodeExecuteSpan,
+                    path = patchedExecutionInfo
+                )
+            }
+
+            pipeline.interceptNodeExecutionFailed(this) intercept@{ eventContext ->
+                logger.debug { "Execute OpenTelemetry node execution failed handler" }
+
+                // Find existing span (Node Execute Span)
+                val patchedExecutionInfo = eventContext.executionInfo.appendRunId(eventContext.context.runId)
+                val nodeExecuteSpan = spanCollector.getStartedSpan(
+                    executionInfo = patchedExecutionInfo,
+                    eventId = eventContext.eventId,
+                    spanType = SpanType.NODE
+                ) ?: return@intercept
+
+                spanAdapter?.onBeforeSpanFinished(nodeExecuteSpan)
+                endNodeExecuteSpan(
+                    span = nodeExecuteSpan,
+                    nodeOutput = null,
+                    error = eventContext.throwable,
+                    verbose = config.isVerbose
+                )
+                spanCollector.removeSpan(
+                    span = nodeExecuteSpan,
+                    path = patchedExecutionInfo
+                )
+            }
+
+            //endregion Node
+
+            //region Subgraph
+
+            pipeline.interceptSubgraphExecutionStarting(this) intercept@{ eventContext ->
+                logger.debug { "Execute OpenTelemetry before subgraph handler" }
+
+                val patchedExecutionInfo = eventContext.executionInfo.appendRunId(eventContext.context.runId)
+                val parentSpan = spanCollector.getParentSpanForEvent(
+                    executionInfo = patchedExecutionInfo,
+                ) ?: return@intercept
+
+                val subgraphInput = nodeDataToString(eventContext.input, eventContext.inputType)
+
+                val subgraphExecuteSpan = startSubgraphExecuteSpan(
+                    tracer = tracer,
+                    parentSpan = parentSpan,
+                    id = eventContext.eventId,
+                    runId = eventContext.context.runId,
+                    subgraphId = eventContext.subgraph.id,
+                    subgraphInput = subgraphInput
+                )
+
+                spanAdapter?.onBeforeSpanStarted(subgraphExecuteSpan)
+                spanCollector.collectSpan(
+                    span = subgraphExecuteSpan,
+                    path = patchedExecutionInfo
+                )
+            }
+
+            pipeline.interceptSubgraphExecutionCompleted(this) intercept@{ eventContext ->
+                logger.debug { "Execute OpenTelemetry after subgraph handler" }
+
+                // Find the existing span (Subgraph Execute Span)
+                val patchedExecutionInfo = eventContext.executionInfo.appendRunId(eventContext.context.runId)
+                val subgraphExecuteSpan = spanCollector.getStartedSpan(
+                    executionInfo = patchedExecutionInfo,
+                    eventId = eventContext.eventId,
+                    spanType = SpanType.SUBGRAPH
+                ) ?: return@intercept
+
+                val subgraphOutput = nodeDataToString(eventContext.output, eventContext.outputType)
+
+                spanAdapter?.onBeforeSpanFinished(subgraphExecuteSpan)
+                endSubgraphExecuteSpan(
+                    span = subgraphExecuteSpan,
+                    subgraphOutput = subgraphOutput,
+                    verbose = config.isVerbose
+                )
+                spanCollector.removeSpan(
+                    span = subgraphExecuteSpan,
+                    path = patchedExecutionInfo
+                )
+            }
+
+            pipeline.interceptSubgraphExecutionFailed(this) intercept@{ eventContext ->
+                logger.debug { "Execute OpenTelemetry subgraph execution error handler" }
+
+                // Find the existing span (Subgraph Execute Span)
+                val patchedExecutionInfo = eventContext.executionInfo.appendRunId(eventContext.context.runId)
+                val subgraphExecuteSpan = spanCollector.getStartedSpan(
+                    executionInfo = patchedExecutionInfo,
+                    eventId = eventContext.eventId,
+                    spanType = SpanType.SUBGRAPH
+                ) ?: return@intercept
+
+                spanAdapter?.onBeforeSpanFinished(subgraphExecuteSpan)
+                endSubgraphExecuteSpan(
+                    span = subgraphExecuteSpan,
+                    subgraphOutput = null,
+                    error = eventContext.throwable,
+                    verbose = config.isVerbose
+                )
+                spanCollector.removeSpan(
+                    span = subgraphExecuteSpan,
+                    path = patchedExecutionInfo
+                )
+            }
+
+            //endregion Subgraph
+
+            return openTelemetry
+        }
+
+        override fun install(
+            config: OpenTelemetryConfig,
+            pipeline: AIAgentFunctionalPipeline
+        ): OpenTelemetry {
+            val openTelemetry = OpenTelemetry()
+            val spanCollector = SpanCollector()
+
+            installCommon(config, pipeline, spanCollector)
+
+            return openTelemetry
+        }
+
+        //region Private Methods
+
+        private fun installCommon(
+            config: OpenTelemetryConfig,
+            pipeline: AIAgentPipeline,
+            spanCollector: SpanCollector,
+        ) {
+            val spanAdapter = config.spanAdapter
             val tracer = config.tracer
 
             //region Agent
@@ -253,167 +445,6 @@ public class OpenTelemetry {
             }
 
             //endregion Strategy
-
-            //region Node
-
-            pipeline.interceptNodeExecutionStarting(this) intercept@{ eventContext ->
-                logger.debug { "Execute OpenTelemetry node starting handler" }
-
-                val patchedExecutionInfo = eventContext.executionInfo.appendRunId(eventContext.context.runId)
-                val parentSpan = spanCollector.getParentSpanForEvent(
-                    executionInfo = patchedExecutionInfo,
-                ) ?: run {
-                    logger.warn { "Failed to find parent span for node: ${eventContext.node.id}. Path: ${patchedExecutionInfo.path()}" }
-                    return@intercept
-                }
-
-                val nodeInput = nodeDataToString(eventContext.input, eventContext.inputType)
-
-                val nodeExecuteSpan = startNodeExecuteSpan(
-                    tracer = tracer,
-                    parentSpan = parentSpan,
-                    id = eventContext.eventId,
-                    runId = eventContext.context.runId,
-                    nodeId = eventContext.node.id,
-                    nodeInput = nodeInput
-                )
-
-                spanAdapter?.onBeforeSpanStarted(nodeExecuteSpan)
-                spanCollector.collectSpan(
-                    span = nodeExecuteSpan,
-                    path = patchedExecutionInfo
-                )
-            }
-
-            pipeline.interceptNodeExecutionCompleted(this) intercept@{ eventContext ->
-                logger.debug { "Execute OpenTelemetry node completed handler" }
-
-                // Find existing span (Node Execute Span)
-                val patchedExecutionInfo = eventContext.executionInfo.appendRunId(eventContext.context.runId)
-                val nodeExecuteSpan = spanCollector.getStartedSpan(
-                    executionInfo = patchedExecutionInfo,
-                    eventId = eventContext.eventId,
-                    spanType = SpanType.NODE
-                ) ?: return@intercept
-
-                val nodeOutput = nodeDataToString(eventContext.output, eventContext.outputType)
-
-                spanAdapter?.onBeforeSpanFinished(nodeExecuteSpan)
-                endNodeExecuteSpan(
-                    span = nodeExecuteSpan,
-                    nodeOutput = nodeOutput,
-                    verbose = config.isVerbose
-                )
-                spanCollector.removeSpan(
-                    span = nodeExecuteSpan,
-                    path = patchedExecutionInfo
-                )
-            }
-
-            pipeline.interceptNodeExecutionFailed(this) intercept@{ eventContext ->
-                logger.debug { "Execute OpenTelemetry node execution failed handler" }
-
-                // Find existing span (Node Execute Span)
-                val patchedExecutionInfo = eventContext.executionInfo.appendRunId(eventContext.context.runId)
-                val nodeExecuteSpan = spanCollector.getStartedSpan(
-                    executionInfo = patchedExecutionInfo,
-                    eventId = eventContext.eventId,
-                    spanType = SpanType.NODE
-                ) ?: return@intercept
-
-                spanAdapter?.onBeforeSpanFinished(nodeExecuteSpan)
-                endNodeExecuteSpan(
-                    span = nodeExecuteSpan,
-                    nodeOutput = null,
-                    error = eventContext.throwable,
-                    verbose = config.isVerbose
-                )
-                spanCollector.removeSpan(
-                    span = nodeExecuteSpan,
-                    path = patchedExecutionInfo
-                )
-            }
-
-            //endregion Node
-
-            //region Subgraph
-
-            pipeline.interceptSubgraphExecutionStarting(this) intercept@{ eventContext ->
-                logger.debug { "Execute OpenTelemetry before subgraph handler" }
-
-                val patchedExecutionInfo = eventContext.executionInfo.appendRunId(eventContext.context.runId)
-                val parentSpan = spanCollector.getParentSpanForEvent(
-                    executionInfo = patchedExecutionInfo,
-                ) ?: return@intercept
-
-                val subgraphInput = nodeDataToString(eventContext.input, eventContext.inputType)
-
-                val subgraphExecuteSpan = startSubgraphExecuteSpan(
-                    tracer = tracer,
-                    parentSpan = parentSpan,
-                    id = eventContext.eventId,
-                    runId = eventContext.context.runId,
-                    subgraphId = eventContext.subgraph.id,
-                    subgraphInput = subgraphInput
-                )
-
-                spanAdapter?.onBeforeSpanStarted(subgraphExecuteSpan)
-                spanCollector.collectSpan(
-                    span = subgraphExecuteSpan,
-                    path = patchedExecutionInfo
-                )
-            }
-
-            pipeline.interceptSubgraphExecutionCompleted(this) intercept@{ eventContext ->
-                logger.debug { "Execute OpenTelemetry after subgraph handler" }
-
-                // Find the existing span (Subgraph Execute Span)
-                val patchedExecutionInfo = eventContext.executionInfo.appendRunId(eventContext.context.runId)
-                val subgraphExecuteSpan = spanCollector.getStartedSpan(
-                    executionInfo = patchedExecutionInfo,
-                    eventId = eventContext.eventId,
-                    spanType = SpanType.SUBGRAPH
-                ) ?: return@intercept
-
-                val subgraphOutput = nodeDataToString(eventContext.output, eventContext.outputType)
-
-                spanAdapter?.onBeforeSpanFinished(subgraphExecuteSpan)
-                endSubgraphExecuteSpan(
-                    span = subgraphExecuteSpan,
-                    subgraphOutput = subgraphOutput,
-                    verbose = config.isVerbose
-                )
-                spanCollector.removeSpan(
-                    span = subgraphExecuteSpan,
-                    path = patchedExecutionInfo
-                )
-            }
-
-            pipeline.interceptSubgraphExecutionFailed(this) intercept@{ eventContext ->
-                logger.debug { "Execute OpenTelemetry subgraph execution error handler" }
-
-                // Find the existing span (Subgraph Execute Span)
-                val patchedExecutionInfo = eventContext.executionInfo.appendRunId(eventContext.context.runId)
-                val subgraphExecuteSpan = spanCollector.getStartedSpan(
-                    executionInfo = patchedExecutionInfo,
-                    eventId = eventContext.eventId,
-                    spanType = SpanType.SUBGRAPH
-                ) ?: return@intercept
-
-                spanAdapter?.onBeforeSpanFinished(subgraphExecuteSpan)
-                endSubgraphExecuteSpan(
-                    span = subgraphExecuteSpan,
-                    subgraphOutput = null,
-                    error = eventContext.throwable,
-                    verbose = config.isVerbose
-                )
-                spanCollector.removeSpan(
-                    span = subgraphExecuteSpan,
-                    path = patchedExecutionInfo
-                )
-            }
-
-            //endregion Subgraph
 
             //region LLM Call
 
@@ -692,11 +723,7 @@ public class OpenTelemetry {
             }
 
             //endregion Tool Call
-
-            return openTelemetry
         }
-
-        //region Private Methods
 
         /**
          * Retrieves the [String] representation of the given data based on its type.

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/AgentTypes.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/AgentTypes.kt
@@ -1,0 +1,6 @@
+package ai.koog.agents.features.opentelemetry
+
+enum class AgentType {
+    Graph,
+    Functional
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestAPI.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestAPI.kt
@@ -1,28 +1,36 @@
 package ai.koog.agents.features.opentelemetry
 
 import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.AIAgentFunctionalStrategy
 import ai.koog.agents.core.agent.AIAgentService
-import ai.koog.agents.core.agent.GraphAIAgent
-import ai.koog.agents.core.agent.GraphAIAgentService
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
+import ai.koog.agents.core.agent.entity.AIAgentStrategy
+import ai.koog.agents.core.agent.functionalStrategy
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.core.dsl.extension.executeTool
 import ai.koog.agents.core.dsl.extension.nodeExecuteTool
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResult
 import ai.koog.agents.core.dsl.extension.onAssistantMessage
 import ai.koog.agents.core.dsl.extension.onToolCall
+import ai.koog.agents.core.dsl.extension.requestLLM
+import ai.koog.agents.core.dsl.extension.sendToolResult
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.DEFAULT_AGENT_ID
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.DEFAULT_PROMPT_ID
+import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.MOCK_LLM_RESPONSE_PARIS
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.SYSTEM_PROMPT
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.TEMPERATURE
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.USER_PROMPT_PARIS
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.defaultModel
+import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Strategy.getSingleLLMCallStrategy
+import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Strategy.getSingleToolCallStrategy
 import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
+import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryConfig
 import ai.koog.agents.features.opentelemetry.mock.MockSpanExporter
 import ai.koog.agents.testing.tools.getMockExecutor
 import ai.koog.prompt.dsl.prompt
@@ -56,6 +64,7 @@ internal object OpenTelemetryTestAPI {
     internal object Parameter {
         internal const val DEFAULT_AGENT_ID = "test-agent-id"
         internal const val DEFAULT_PROMPT_ID = "test-prompt-id"
+        internal const val DEFAULT_STRATEGY_NAME = "test-strategy"
         internal val defaultModel = OpenAIModels.Chat.GPT4o
 
         internal const val SYSTEM_PROMPT = "You are the application that predicts weather"
@@ -76,19 +85,76 @@ internal object OpenTelemetryTestAPI {
         val toolCallId: String? = "tool-call-id",
     )
 
+    internal object Strategy {
+        internal val simpleGraphStrategy = strategy<String, String>(Parameter.DEFAULT_STRATEGY_NAME) {
+            nodeStart then nodeFinish
+        }
+        internal val simpleFunctionalStrategy =
+            functionalStrategy<String, String>(Parameter.DEFAULT_STRATEGY_NAME) { it }
+
+        internal fun getSimpleStrategy(agentType: AgentType) = when (agentType) {
+            AgentType.Graph -> simpleGraphStrategy
+            AgentType.Functional -> simpleFunctionalStrategy
+        }
+
+        internal val singleLLMCallGraphStrategy = strategy(Parameter.DEFAULT_STRATEGY_NAME) {
+            val nodeSendInput by nodeLLMRequest("test-llm-call")
+
+            edge(nodeStart forwardTo nodeSendInput)
+            edge(nodeSendInput forwardTo nodeFinish onAssistantMessage { true })
+        }
+        internal val singleLLMCallFunctionalStrategy =
+            functionalStrategy<String, String>(Parameter.DEFAULT_STRATEGY_NAME) { input ->
+                requestLLM(input).content
+            }
+
+        fun getSingleLLMCallStrategy(agentType: AgentType) = when (agentType) {
+            AgentType.Graph -> singleLLMCallGraphStrategy
+            AgentType.Functional -> singleLLMCallFunctionalStrategy
+        }
+
+        internal val singleToolCallGraphStrategy = strategy(Parameter.DEFAULT_STRATEGY_NAME) {
+            val nodeCallLLM by nodeLLMRequest("test-llm-call")
+            val nodeExecuteTool by nodeExecuteTool("test-tool-call")
+            val nodeSendToolResult by nodeLLMSendToolResult("test-node-llm-send-tool-result")
+
+            edge(nodeStart forwardTo nodeCallLLM)
+            edge(nodeCallLLM forwardTo nodeExecuteTool onToolCall { true })
+            edge(nodeCallLLM forwardTo nodeFinish onAssistantMessage { true })
+            edge(nodeExecuteTool forwardTo nodeSendToolResult)
+            edge(nodeSendToolResult forwardTo nodeFinish onAssistantMessage { true })
+            edge(nodeSendToolResult forwardTo nodeExecuteTool onToolCall { true })
+        }
+        internal val singleToolCallFunctionalStrategy =
+            functionalStrategy<String, String>(Parameter.DEFAULT_STRATEGY_NAME) { input ->
+                var result = requestLLM(input)
+
+                while (result is Message.Tool.Call) {
+                    result = sendToolResult(executeTool(result))
+                }
+
+                result.content
+            }
+
+        fun getSingleToolCallStrategy(agentType: AgentType) = when (agentType) {
+            AgentType.Graph -> singleToolCallGraphStrategy
+            AgentType.Functional -> singleToolCallFunctionalStrategy
+        }
+    }
+
+    internal val defaultMockExecutor = getMockExecutor(clock = testClock) {
+        mockLLMAnswer(MOCK_LLM_RESPONSE_PARIS) onRequestEquals USER_PROMPT_PARIS
+    }
+
     //region Agents With Strategies
 
     internal suspend fun runAgentWithSingleLLMCallStrategy(
         userPrompt: String,
         mockLLMResponse: String,
         verbose: Boolean = true,
+        agentType: AgentType,
     ): OpenTelemetryTestData {
-        val strategy = strategy("test-single-llm-strategy") {
-            val nodeCallLLM by nodeLLMRequest("test-llm-call")
-
-            edge(nodeStart forwardTo nodeCallLLM)
-            edge(nodeCallLLM forwardTo nodeFinish onAssistantMessage { true })
-        }
+        val strategy = getSingleLLMCallStrategy(agentType)
 
         val executor = getMockExecutor(clock = testClock) {
             mockLLMAnswer(mockLLMResponse) onRequestEquals userPrompt
@@ -107,19 +173,9 @@ internal object OpenTelemetryTestAPI {
         mockToolCallResponse: MockToolCallResponse<TArgs, TResult>,
         mockLLMResponse: String,
         verbose: Boolean = true,
+        agentType: AgentType = AgentType.Graph,
     ): OpenTelemetryTestData {
-        val strategy = strategy("test-tool-calls-strategy") {
-            val nodeCallLLM by nodeLLMRequest("test-llm-call")
-            val nodeExecuteTool by nodeExecuteTool("test-tool-call")
-            val nodeSendToolResult by nodeLLMSendToolResult("test-node-llm-send-tool-result")
-
-            edge(nodeStart forwardTo nodeCallLLM)
-            edge(nodeCallLLM forwardTo nodeExecuteTool onToolCall { true })
-            edge(nodeCallLLM forwardTo nodeFinish onAssistantMessage { true })
-            edge(nodeExecuteTool forwardTo nodeSendToolResult)
-            edge(nodeSendToolResult forwardTo nodeFinish onAssistantMessage { true })
-            edge(nodeSendToolResult forwardTo nodeExecuteTool onToolCall { true })
-        }
+        val strategy = getSingleToolCallStrategy(agentType)
 
         val toolRegistry = ToolRegistry {
             tool(mockToolCallResponse.tool)
@@ -147,7 +203,7 @@ internal object OpenTelemetryTestAPI {
     }
 
     internal suspend fun runAgentWithStrategy(
-        strategy: AIAgentGraphStrategy<String, String>,
+        strategy: AIAgentStrategy<String, String, *>,
         agentId: String? = null,
         promptId: String? = null,
         model: LLModel? = null,
@@ -177,10 +233,8 @@ internal object OpenTelemetryTestAPI {
                 temperature = TEMPERATURE,
                 maxTokens = maxTokens,
             ) {
-                install(OpenTelemetry) {
-                    addSpanExporter(mockExporter)
-                    setVerbose(verbose)
-                }
+                addSpanExporter(mockExporter)
+                setVerbose(verbose)
             }.use { agent ->
                 agent.run(userPrompt ?: USER_PROMPT_PARIS)
             }
@@ -212,8 +266,8 @@ internal object OpenTelemetryTestAPI {
     //region Agents
 
     internal suspend fun createAgent(
-        agentId: String = "test-agent-id",
-        strategy: AIAgentGraphStrategy<String, String>,
+        agentId: String = DEFAULT_AGENT_ID,
+        strategy: AIAgentStrategy<String, String, *>,
         executor: PromptExecutor? = null,
         promptId: String? = null,
         toolRegistry: ToolRegistry? = null,
@@ -223,7 +277,7 @@ internal object OpenTelemetryTestAPI {
         systemPrompt: String? = null,
         userPrompt: String? = null,
         assistantPrompt: String? = null,
-        installFeatures: GraphAIAgent.FeatureContext.() -> Unit = { }
+        configureOtel: OpenTelemetryConfig.() -> Unit = { }
     ): AIAgent<String, String> {
         val agentService = createAgentService(
             strategy,
@@ -236,14 +290,14 @@ internal object OpenTelemetryTestAPI {
             systemPrompt,
             userPrompt,
             assistantPrompt,
-            installFeatures
+            configureOtel
         )
 
         return agentService.createAgent(id = agentId)
     }
 
     internal fun createAgentService(
-        strategy: AIAgentGraphStrategy<String, String>,
+        strategy: AIAgentStrategy<String, String, *>,
         executor: PromptExecutor? = null,
         promptId: String? = null,
         toolRegistry: ToolRegistry? = null,
@@ -253,8 +307,8 @@ internal object OpenTelemetryTestAPI {
         systemPrompt: String? = null,
         userPrompt: String? = null,
         assistantPrompt: String? = null,
-        installFeatures: GraphAIAgent.FeatureContext.() -> Unit = { }
-    ): GraphAIAgentService<String, String> {
+        configureOtel: OpenTelemetryConfig.() -> Unit = { }
+    ): AIAgentService<String, String, *> {
         val agentConfig = AIAgentConfig(
             prompt = prompt(
                 id = promptId ?: "Test prompt",
@@ -271,14 +325,30 @@ internal object OpenTelemetryTestAPI {
             model = model ?: OpenAIModels.Chat.GPT4o,
             maxAgentIterations = 10,
         )
+        val promptExecutor = executor ?: getMockExecutor(clock = testClock) { }
+        val toolRegistry = toolRegistry ?: ToolRegistry.EMPTY
 
-        return AIAgentService(
-            promptExecutor = executor ?: getMockExecutor(clock = testClock) { },
-            strategy = strategy,
-            agentConfig = agentConfig,
-            toolRegistry = toolRegistry ?: ToolRegistry { },
-            installFeatures = installFeatures,
-        )
+        return when (strategy) {
+            is AIAgentGraphStrategy -> AIAgentService(
+                promptExecutor = promptExecutor,
+                strategy = strategy,
+                agentConfig = agentConfig,
+                toolRegistry = toolRegistry
+            ) {
+                install(OpenTelemetry) { configureOtel() }
+            }
+
+            is AIAgentFunctionalStrategy -> AIAgentService(
+                promptExecutor = executor ?: getMockExecutor(clock = testClock) { },
+                strategy = strategy,
+                agentConfig = agentConfig,
+                toolRegistry = toolRegistry
+            ) {
+                install(OpenTelemetry) { configureOtel() }
+            }
+
+            else -> throw IllegalArgumentException("Unsupported strategy type: ${strategy::class.simpleName}")
+        }
     }
 
     //endregion Agents

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryConfigTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryConfigTest.kt
@@ -1,31 +1,38 @@
 package ai.koog.agents.features.opentelemetry.feature
 
-import ai.koog.agents.core.dsl.builder.forwardTo
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.nodeLLMRequest
-import ai.koog.agents.core.dsl.extension.onAssistantMessage
+import ai.koog.agents.core.agent.entity.AIAgentSubgraph.Companion.FINISH_NODE_PREFIX
+import ai.koog.agents.core.agent.entity.AIAgentSubgraph.Companion.START_NODE_PREFIX
+import ai.koog.agents.features.opentelemetry.AgentType
+import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.DEFAULT_AGENT_ID
+import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.DEFAULT_PROMPT_ID
+import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.DEFAULT_STRATEGY_NAME
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.SYSTEM_PROMPT
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.TEMPERATURE
+import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.USER_PROMPT_PARIS
+import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.defaultModel
+import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Strategy.getSimpleStrategy
+import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Strategy.getSingleLLMCallStrategy
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.createAgent
+import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.defaultMockExecutor
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.getMessagesString
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.getSystemInstructionsString
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.testClock
 import ai.koog.agents.features.opentelemetry.assertSpans
 import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
 import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
+import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes.Operation.OperationNameType
 import ai.koog.agents.features.opentelemetry.integration.SpanAdapter
 import ai.koog.agents.features.opentelemetry.mock.MockSpanExporter
 import ai.koog.agents.features.opentelemetry.span.GenAIAgentSpan
-import ai.koog.agents.testing.tools.getMockExecutor
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.utils.io.use
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import java.util.Properties
-import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertTrue
@@ -38,22 +45,19 @@ import kotlin.test.assertTrue
  */
 class OpenTelemetryConfigTest : OpenTelemetryTestBase() {
 
-    @Test
-    fun `test Open Telemetry feature default configuration`() = runTest {
-        val strategy = strategy<String, String>("test-strategy") {
-            nodeStart then nodeFinish
-        }
-
+    @ParameterizedTest
+    @EnumSource(AgentType::class)
+    fun `test Open Telemetry feature default configuration`(agentType: AgentType) = runTest {
         var actualServiceName: String? = null
         var actualServiceVersion: String? = null
         var actualIsVerbose: Boolean? = null
 
-        createAgent(strategy = strategy) {
-            install(OpenTelemetry) {
-                actualServiceName = serviceName
-                actualServiceVersion = serviceVersion
-                actualIsVerbose = isVerbose
-            }
+        createAgent(
+            strategy = getSimpleStrategy(agentType)
+        ) {
+            actualServiceName = serviceName
+            actualServiceVersion = serviceVersion
+            actualIsVerbose = isVerbose
         }
 
         val props = Properties()
@@ -64,12 +68,9 @@ class OpenTelemetryConfigTest : OpenTelemetryTestBase() {
         assertEquals(false, actualIsVerbose)
     }
 
-    @Test
-    fun `test custom configuration is applied`() = runTest {
-        val strategy = strategy<String, String>("test-strategy") {
-            nodeStart then nodeFinish
-        }
-
+    @ParameterizedTest
+    @EnumSource(AgentType::class)
+    fun `test custom configuration is applied`(agentType: AgentType) = runTest {
         val expectedServiceName = "test-service-name"
         val expectedServiceVersion = "test-service-version"
         val expectedIsVerbose = true
@@ -78,15 +79,15 @@ class OpenTelemetryConfigTest : OpenTelemetryTestBase() {
         var actualServiceVersion: String? = null
         var actualIsVerbose: Boolean? = null
 
-        createAgent(strategy = strategy) {
-            install(OpenTelemetry) {
-                setServiceInfo(expectedServiceName, expectedServiceVersion)
-                setVerbose(expectedIsVerbose)
+        createAgent(
+            strategy = getSimpleStrategy(agentType),
+        ) {
+            setServiceInfo(expectedServiceName, expectedServiceVersion)
+            setVerbose(expectedIsVerbose)
 
-                actualServiceName = serviceName
-                actualServiceVersion = serviceVersion
-                actualIsVerbose = isVerbose
-            }
+            actualServiceName = serviceName
+            actualServiceVersion = serviceVersion
+            actualIsVerbose = isVerbose
         }
 
         assertEquals(expectedServiceName, actualServiceName)
@@ -94,18 +95,15 @@ class OpenTelemetryConfigTest : OpenTelemetryTestBase() {
         assertEquals(expectedIsVerbose, actualIsVerbose)
     }
 
-    @Test
-    fun `test filter is not allowed for open telemetry feature`() = runTest {
-        val strategy = strategy<String, String>("test-strategy") {
-            nodeStart then nodeFinish
-        }
-
+    @ParameterizedTest
+    @EnumSource(AgentType::class)
+    fun `test filter is not allowed for open telemetry feature`(agentType: AgentType) = runTest {
         val throwable = assertFails {
-            createAgent(strategy = strategy) {
-                install(OpenTelemetry) {
-                    // Try to filter out all events. OpenTelemetryConfig should ignore this filter
-                    setEventFilter { false }
-                }
+            createAgent(
+                strategy = getSimpleStrategy(agentType),
+            ) {
+                // Try to filter out all events. OpenTelemetryConfig should ignore this filter
+                setEventFilter { false }
             }
         }
 
@@ -120,85 +118,70 @@ class OpenTelemetryConfigTest : OpenTelemetryTestBase() {
         )
     }
 
-    @Test
-    fun `test install Open Telemetry feature with custom sdk, should use provided sdk`() = runTest {
-        val strategy = strategy<String, String>("test-strategy") {
-            edge(nodeStart forwardTo nodeFinish transformed { "Done" })
-        }
-
+    @ParameterizedTest
+    @EnumSource(AgentType::class)
+    fun `test install Open Telemetry feature with custom sdk, should use provided sdk`(agentType: AgentType) = runTest {
         val expectedSdk = OpenTelemetrySdk.builder().build()
         var actualSdk: OpenTelemetrySdk? = null
 
         createAgent(
-            strategy = strategy,
+            strategy = getSimpleStrategy(agentType),
         ) {
-            install(OpenTelemetry) {
-                setSdk(expectedSdk)
-                actualSdk = sdk
-            }
+            setSdk(expectedSdk)
+            actualSdk = sdk
         }
 
         assertEquals(expectedSdk, actualSdk)
     }
 
-    @Test
-    fun `test custom sdk configuration emits correct spans`() = runTest {
+    @ParameterizedTest
+    @EnumSource(AgentType::class)
+    fun `test custom sdk configuration emits correct spans`(agentType: AgentType) = runTest {
         MockSpanExporter().use { mockExporter ->
-            val userPrompt = "What's the weather in Paris?"
-
-            val strategy = strategy("test-strategy") {
-                val nodeSendInput by nodeLLMRequest("test-llm-call")
-                edge(nodeStart forwardTo nodeSendInput)
-                edge(nodeSendInput forwardTo nodeFinish onAssistantMessage { true })
-            }
-
-            val mockResponse = "The weather in Paris is rainy and overcast, with temperatures around 57°F"
-
-            val mockExecutor = getMockExecutor {
-                mockLLMAnswer(mockResponse) onRequestEquals userPrompt
-            }
 
             val expectedSdk = createCustomSdk(mockExporter)
 
             val agent = createAgent(
-                executor = mockExecutor,
-                strategy = strategy,
+                strategy = getSingleLLMCallStrategy(agentType),
+                executor = defaultMockExecutor,
             ) {
-                install(OpenTelemetry) {
-                    setSdk(expectedSdk)
-                }
+                setSdk(expectedSdk)
             }
 
-            agent.run(userPrompt)
-            val collectedSpans = mockExporter.collectedSpans
+            agent.run(USER_PROMPT_PARIS)
+            val actualSpanNames = mockExporter.collectedSpans.map { it.name }
             agent.close()
 
-            assertEquals(7, collectedSpans.size)
+            val expectedSpanNames = when (agentType) {
+                AgentType.Graph -> listOf(
+                    "node $START_NODE_PREFIX",
+                    "${OperationNameType.CHAT.id} ${defaultModel.id}",
+                    "node test-llm-call",
+                    "node $FINISH_NODE_PREFIX",
+                    "strategy $DEFAULT_STRATEGY_NAME",
+                    "${OperationNameType.INVOKE_AGENT.id} $DEFAULT_AGENT_ID",
+                    "${OperationNameType.CREATE_AGENT.id} $DEFAULT_AGENT_ID"
+                )
+
+                AgentType.Functional -> listOf(
+                    "${OperationNameType.CHAT.id} ${defaultModel.id}",
+                    "strategy $DEFAULT_STRATEGY_NAME",
+                    "${OperationNameType.INVOKE_AGENT.id} $DEFAULT_AGENT_ID",
+                    "${OperationNameType.CREATE_AGENT.id} $DEFAULT_AGENT_ID"
+                )
+            }
+
+            assertEquals(expectedSpanNames.size, actualSpanNames.size)
+            expectedSpanNames.zip(actualSpanNames).forEach { (expectedSpanName, actualSpanName) ->
+                assertEquals(expectedSpanName, actualSpanName)
+            }
         }
     }
 
-    @Test
-    fun `test span adapter applies custom attribute to invoke agent span`() = runTest {
+    @ParameterizedTest
+    @EnumSource(AgentType::class)
+    fun `test span adapter applies custom attribute to invoke agent span`(agentType: AgentType) = runTest {
         MockSpanExporter().use { mockExporter ->
-
-            val userPrompt = "What's the weather in Paris?"
-            val agentId = "test-agent-id"
-            val promptId = "test-prompt-id"
-            val model = OpenAIModels.Chat.GPT4o
-
-            val strategyName = "test-strategy"
-
-            val strategy = strategy(strategyName) {
-                val nodeSendInput by nodeLLMRequest("test-llm-call")
-
-                edge(nodeStart forwardTo nodeSendInput)
-                edge(nodeSendInput forwardTo nodeFinish onAssistantMessage { true })
-            }
-
-            val mockResponse = "Sunny"
-            val mockExecutor = getMockExecutor(clock = testClock) {
-                mockLLMAnswer(mockResponse) onRequestEquals userPrompt
-            }
 
             // Custom SpanAdapter that adds a test attribute to each processed span
             val customBeforeStartAttribute = CustomAttribute(key = "test.adapter.before.start.key", value = "test-value-before-start")
@@ -214,22 +197,20 @@ class OpenTelemetryConfigTest : OpenTelemetryTestBase() {
             }
 
             createAgent(
-                agentId = agentId,
-                strategy = strategy,
-                promptId = promptId,
-                executor = mockExecutor,
-                model = model,
+                strategy = getSingleLLMCallStrategy(agentType),
+                agentId = DEFAULT_AGENT_ID,
+                promptId = DEFAULT_PROMPT_ID,
+                executor = defaultMockExecutor,
+                model = defaultModel,
                 systemPrompt = SYSTEM_PROMPT,
                 temperature = TEMPERATURE,
-                userPrompt = userPrompt,
+                userPrompt = USER_PROMPT_PARIS,
             ) {
-                install(OpenTelemetry) {
-                    addSpanExporter(mockExporter)
+                addSpanExporter(mockExporter)
 
-                    // Add custom span adapter
-                    addSpanAdapter(adapter)
-                    setVerbose(true)
-                }
+                // Add custom span adapter
+                addSpanAdapter(adapter)
+                setVerbose(true)
             }.use { agent ->
                 agent.run("")
             }
@@ -238,12 +219,12 @@ class OpenTelemetryConfigTest : OpenTelemetryTestBase() {
             assertTrue(collectedSpans.isNotEmpty(), "Spans should be created during agent execution")
 
             val conversationIdAttribute = SpanAttributes.Conversation.Id(mockExporter.lastRunId)
-            val operationNameAttribute = SpanAttributes.Operation.Name(SpanAttributes.Operation.OperationNameType.INVOKE_AGENT)
+            val operationNameAttribute = SpanAttributes.Operation.Name(OperationNameType.INVOKE_AGENT)
 
             fun attributesMatches(attributes: Map<AttributeKey<*>, Any>): Boolean {
                 var conversationIdAttributeExists = false
                 var operationNameAttributeExists = false
-                attributes.forEach { key, value ->
+                attributes.forEach { (key, value) ->
                     if (key.key == conversationIdAttribute.key && value == conversationIdAttribute.value) {
                         conversationIdAttributeExists = true
                     }
@@ -263,29 +244,29 @@ class OpenTelemetryConfigTest : OpenTelemetryTestBase() {
 
             val expectedInvokeAgentSpans = listOf(
                 mapOf(
-                    "${SpanAttributes.Operation.OperationNameType.INVOKE_AGENT.id} $agentId" to mapOf(
+                    "${OperationNameType.INVOKE_AGENT.id} $DEFAULT_AGENT_ID" to mapOf(
                         "attributes" to mapOf(
-                            "gen_ai.operation.name" to SpanAttributes.Operation.OperationNameType.INVOKE_AGENT.id,
-                            "gen_ai.provider.name" to model.provider.id,
-                            "gen_ai.agent.id" to agentId,
+                            "gen_ai.operation.name" to OperationNameType.INVOKE_AGENT.id,
+                            "gen_ai.provider.name" to defaultModel.provider.id,
+                            "gen_ai.agent.id" to DEFAULT_AGENT_ID,
                             "gen_ai.conversation.id" to mockExporter.lastRunId,
                             "gen_ai.output.type" to "text",
-                            "gen_ai.request.model" to model.id,
+                            "gen_ai.request.model" to defaultModel.id,
                             "gen_ai.request.temperature" to TEMPERATURE,
                             "gen_ai.input.messages" to getMessagesString(
                                 listOf(
                                     Message.System(SYSTEM_PROMPT, RequestMetaInfo(testClock.now())),
-                                    Message.User(userPrompt, RequestMetaInfo(testClock.now()))
+                                    Message.User(USER_PROMPT_PARIS, RequestMetaInfo(testClock.now()))
                                 )
                             ),
                             "system_instructions" to getSystemInstructionsString(listOf(SYSTEM_PROMPT)),
-                            "gen_ai.response.model" to model.id,
+                            "gen_ai.response.model" to defaultModel.id,
                             "gen_ai.usage.input_tokens" to 0L,
                             "gen_ai.usage.output_tokens" to 0L,
                             "gen_ai.output.messages" to getMessagesString(
                                 listOf(
                                     Message.System(SYSTEM_PROMPT, RequestMetaInfo(testClock.now())),
-                                    Message.User(userPrompt, RequestMetaInfo(testClock.now()))
+                                    Message.User(USER_PROMPT_PARIS, RequestMetaInfo(testClock.now()))
                                 )
                             ),
                             customBeforeStartAttribute.key to customBeforeStartAttribute.value,

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryAgentSpanTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryAgentSpanTest.kt
@@ -1,9 +1,10 @@
 package ai.koog.agents.features.opentelemetry.feature.span
 
-import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.features.opentelemetry.AgentType
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.DEFAULT_AGENT_ID
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.defaultModel
+import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Strategy.getSimpleStrategy
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.getMessagesString
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.getSystemInstructionsString
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.runAgentWithStrategy
@@ -15,18 +16,18 @@ import ai.koog.agents.utils.HiddenString
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import kotlin.test.assertTrue
 
 class OpenTelemetryAgentSpanTest : OpenTelemetryTestBase() {
 
-    @Test
-    fun `test create and invoke agent spans are collected`() = runTest {
+    @ParameterizedTest
+    @EnumSource(AgentType::class)
+    fun `test create and invoke agent spans are collected`(agentType: AgentType) = runTest {
         val userInput = "User input"
 
-        val strategy = strategy<String, String>("test-strategy") {
-            nodeStart then nodeFinish
-        }
+        val strategy = getSimpleStrategy(agentType)
 
         val collectedTestData = runAgentWithStrategy(
             strategy = strategy,
@@ -104,13 +105,12 @@ class OpenTelemetryAgentSpanTest : OpenTelemetryTestBase() {
      *
      * Verbose level does not affect logs visibility for agent create and invoke spans
      */
-    @Test
-    fun `test create and invoke agent spans with verbose logging disabled`() = runTest {
+    @ParameterizedTest
+    @EnumSource(AgentType::class)
+    fun `test create and invoke agent spans with verbose logging disabled`(agentType: AgentType) = runTest {
         val userInput = "User input"
 
-        val strategy = strategy<String, String>("test-strategy") {
-            nodeStart then nodeFinish
-        }
+        val strategy = getSimpleStrategy(agentType)
 
         val collectedTestData = runAgentWithStrategy(
             strategy = strategy,

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryInferenceSpanTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryInferenceSpanTest.kt
@@ -4,6 +4,7 @@ import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.onAssistantMessage
+import ai.koog.agents.features.opentelemetry.AgentType
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.MockToolCallResponse
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.assistantMessage
@@ -26,20 +27,24 @@ import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.tokenizer.SimpleRegexBasedTokenizer
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
 class OpenTelemetryInferenceSpanTest : OpenTelemetryTestBase() {
 
-    @Test
-    fun `test inference spans are collected`() = runTest {
+    @ParameterizedTest
+    @EnumSource(AgentType::class)
+    fun `test inference spans are collected`(agentType: AgentType) = runTest {
         val userInput = OpenTelemetryTestAPI.Parameter.USER_PROMPT_PARIS
         val mockLLMResponse = OpenTelemetryTestAPI.Parameter.MOCK_LLM_RESPONSE_PARIS
 
         val collectedTestData = runAgentWithSingleLLMCallStrategy(
             userPrompt = userInput,
             mockLLMResponse = mockLLMResponse,
-            verbose = true
+            verbose = true,
+            agentType = agentType
         )
 
         val runId = collectedTestData.lastRunId
@@ -103,8 +108,9 @@ class OpenTelemetryInferenceSpanTest : OpenTelemetryTestBase() {
         assertSpans(expectedSpans, actualSpans)
     }
 
-    @Test
-    fun `test inference spans with tool calls collect events`() = runTest {
+    @ParameterizedTest
+    @EnumSource(AgentType::class)
+    fun `test inference spans with tool calls collect events`(agentType: AgentType) = runTest {
         val userInput = OpenTelemetryTestAPI.Parameter.USER_PROMPT_PARIS
         val toolCallId = "tool-call-id"
         val location = "Paris"
@@ -122,7 +128,8 @@ class OpenTelemetryInferenceSpanTest : OpenTelemetryTestBase() {
             userPrompt = userInput,
             mockToolCallResponse = mockToolCallResponse,
             mockLLMResponse = mockLLMResponse,
-            verbose = true
+            verbose = true,
+            agentType = agentType
         )
 
         val runId = collectedTestData.lastRunId
@@ -250,8 +257,9 @@ class OpenTelemetryInferenceSpanTest : OpenTelemetryTestBase() {
         assertSpans(expectedSpans, actualSpans)
     }
 
-    @Test
-    fun `test inference spans with verbose logging disabled`() = runTest {
+    @ParameterizedTest
+    @EnumSource(AgentType::class)
+    fun `test inference spans with verbose logging disabled`(agentType: AgentType) = runTest {
         val userInput = OpenTelemetryTestAPI.Parameter.USER_PROMPT_PARIS
         val toolCallId = "tool-call-id"
         val location = "Paris"
@@ -269,7 +277,8 @@ class OpenTelemetryInferenceSpanTest : OpenTelemetryTestBase() {
             userPrompt = userInput,
             mockToolCallResponse = mockToolCallResponse,
             mockLLMResponse = mockLLMResponse,
-            verbose = false
+            verbose = false,
+            agentType = agentType
         )
 
         val runId = collectedTestData.lastRunId

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetrySpanTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetrySpanTest.kt
@@ -2,7 +2,9 @@ package ai.koog.agents.features.opentelemetry.feature.span
 
 import ai.koog.agents.core.agent.entity.AIAgentSubgraph.Companion.FINISH_NODE_PREFIX
 import ai.koog.agents.core.agent.entity.AIAgentSubgraph.Companion.START_NODE_PREFIX
+import ai.koog.agents.core.agent.functionalStrategy
 import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.features.opentelemetry.AgentType
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.MOCK_LLM_RESPONSE_LONDON
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.MOCK_LLM_RESPONSE_PARIS
@@ -15,13 +17,14 @@ import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.getSystemInstr
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestData
 import ai.koog.agents.features.opentelemetry.assertSpans
 import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes.Operation.OperationNameType
-import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryTestBase
 import ai.koog.agents.features.opentelemetry.mock.MockSpanExporter
+import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import kotlin.test.assertTrue
 
 /**
@@ -32,34 +35,150 @@ import kotlin.test.assertTrue
  */
 class OpenTelemetrySpanTest : OpenTelemetryTestBase() {
 
-    @Test
-    fun `test spans for same agent run multiple times`() = runTest {
+    val systemPrompt = SYSTEM_PROMPT
+
+    val userPrompt0 = USER_PROMPT_PARIS
+    val nodeOutput0 = MOCK_LLM_RESPONSE_PARIS
+
+    val userPrompt1 = USER_PROMPT_LONDON
+    val nodeOutput1 = MOCK_LLM_RESPONSE_LONDON
+
+    val agentId = "test-agent-id"
+    val promptId = "test-prompt-id"
+
+    val strategyName = "test-strategy"
+    val nodeName = "test-node"
+
+    private fun getExpectedCommonSpans(
+        runId: String,
+        model: LLModel,
+        strategyEvent: String,
+        actualCreateAgentEvent: String
+    ) = listOf(
+        mapOf(
+            "strategy $strategyName" to mapOf(
+                "attributes" to mapOf(
+                    "koog.strategy.name" to strategyName,
+                    "gen_ai.conversation.id" to runId,
+                    "koog.event.id" to strategyEvent
+                ),
+                "events" to emptyMap()
+            )
+        ),
+        mapOf(
+            "${OperationNameType.INVOKE_AGENT.id} $agentId" to mapOf(
+                "attributes" to mapOf(
+                    "gen_ai.operation.name" to OperationNameType.INVOKE_AGENT.id,
+                    "gen_ai.provider.name" to model.provider.id,
+                    "gen_ai.agent.id" to agentId,
+                    "gen_ai.conversation.id" to runId,
+                    "gen_ai.output.type" to "text",
+                    "gen_ai.request.model" to model.id,
+                    "gen_ai.request.temperature" to OpenTelemetryTestAPI.Parameter.TEMPERATURE,
+                    "gen_ai.input.messages" to getMessagesString(
+                        listOf(
+                            Message.System(systemPrompt, RequestMetaInfo(OpenTelemetryTestAPI.testClock.now())),
+                            // User message is not added in invoked agent span
+                            // as it is propagated through user input in run() agent method
+                        )
+                    ),
+                    "system_instructions" to getSystemInstructionsString(listOf(systemPrompt)),
+                    "gen_ai.response.model" to model.id,
+                    "gen_ai.usage.input_tokens" to 0L,
+                    "gen_ai.usage.output_tokens" to 0L,
+                    "gen_ai.output.messages" to getMessagesString(
+                        listOf(
+                            Message.System(systemPrompt, RequestMetaInfo(OpenTelemetryTestAPI.testClock.now())),
+                            // User message is not added in invoked agent span
+                            // as it is propagated through user input in run() agent method
+                        )
+                    ),
+                    "koog.event.id" to runId,
+                ),
+                "events" to emptyMap()
+            )
+        ),
+        mapOf(
+            "${OperationNameType.CREATE_AGENT.id} $agentId" to mapOf(
+                "attributes" to mapOf(
+                    "gen_ai.operation.name" to OperationNameType.CREATE_AGENT.id,
+                    "gen_ai.provider.name" to model.provider.id,
+                    "gen_ai.agent.id" to agentId,
+                    "gen_ai.request.model" to model.id,
+                    "system_instructions" to getSystemInstructionsString(listOf(systemPrompt)),
+                    "koog.event.id" to actualCreateAgentEvent
+                ),
+                "events" to emptyMap()
+            )
+        )
+    )
+
+    private fun getExpectedNodeSpans(
+        runId: String,
+        userPrompt: String,
+        nodeOutput: String,
+        startNodeEvent: String,
+        testNodeEvent: String,
+        finishNodeEvent: String
+    ) = listOf(
+        // First run
+        mapOf(
+            "node $START_NODE_PREFIX" to mapOf(
+                "attributes" to mapOf(
+                    "gen_ai.conversation.id" to runId,
+                    "koog.node.id" to START_NODE_PREFIX,
+                    "koog.node.input" to "\"$userPrompt\"",
+                    "koog.node.output" to "\"$userPrompt\"",
+                    "koog.event.id" to startNodeEvent,
+                ),
+                "events" to emptyMap()
+            )
+        ),
+        mapOf(
+            "node $nodeName" to mapOf(
+                "attributes" to mapOf(
+                    "gen_ai.conversation.id" to runId,
+                    "koog.node.id" to nodeName,
+                    "koog.node.input" to "\"$userPrompt\"",
+                    "koog.node.output" to "\"$nodeOutput\"",
+                    "koog.event.id" to testNodeEvent,
+                ),
+                "events" to emptyMap()
+            )
+        ),
+        mapOf(
+            "node $FINISH_NODE_PREFIX" to mapOf(
+                "attributes" to mapOf(
+                    "gen_ai.conversation.id" to runId,
+                    "koog.node.id" to FINISH_NODE_PREFIX,
+                    "koog.node.input" to "\"$nodeOutput\"",
+                    "koog.node.output" to "\"$nodeOutput\"",
+                    "koog.event.id" to finishNodeEvent,
+                ),
+                "events" to emptyMap()
+            )
+        )
+    )
+
+    @ParameterizedTest
+    @EnumSource(AgentType::class)
+    fun `test spans for same agent run multiple times`(agentType: AgentType) = runTest {
         MockSpanExporter().use { mockExporter ->
-            val systemPrompt = SYSTEM_PROMPT
-
-            val userPrompt0 = USER_PROMPT_PARIS
-            val nodeOutput0 = MOCK_LLM_RESPONSE_PARIS
-
-            val userPrompt1 = USER_PROMPT_LONDON
-            val nodeOutput1 = MOCK_LLM_RESPONSE_LONDON
-
-            val agentId = "test-agent-id"
-            val promptId = "test-prompt-id"
-
-            val strategyName = "test-strategy"
-            val nodeName = "test-node"
-
             var index = 0
 
-            val strategy = strategy<String, String>(strategyName) {
-                val nodeBlank by node<String, String>(nodeName) {
-                    if (index == 0) {
-                        nodeOutput0
-                    } else {
-                        nodeOutput1
+            val strategy = when (agentType) {
+                AgentType.Graph -> strategy<String, String>(strategyName) {
+                    val nodeBlank by node<String, String>(nodeName) {
+                        if (index == 0) {
+                            nodeOutput0
+                        } else {
+                            nodeOutput1
+                        }
                     }
+                    nodeStart then nodeBlank then nodeFinish
                 }
-                nodeStart then nodeBlank then nodeFinish
+
+                AgentType.Functional -> functionalStrategy(strategyName) { it }
             }
 
             val collectedTestData = OpenTelemetryTestData().apply {
@@ -72,10 +191,8 @@ class OpenTelemetrySpanTest : OpenTelemetryTestBase() {
                 systemPrompt = systemPrompt,
                 temperature = OpenTelemetryTestAPI.Parameter.TEMPERATURE,
             ) {
-                install(OpenTelemetry.Feature) {
-                    addSpanExporter(mockExporter)
-                    setVerbose(true)
-                }
+                addSpanExporter(mockExporter)
+                setVerbose(true)
             }
 
             agentService.createAgentAndRun(userPrompt0, id = agentId)
@@ -92,199 +209,49 @@ class OpenTelemetrySpanTest : OpenTelemetryTestBase() {
 
             val actualCreateAgentEvents = collectedTestData.filterCreateAgentEventIds(agentId)
             val strategyEvents = collectedTestData.filterStrategyEventIds(strategyName)
-            val startNodeEvents = collectedTestData.filterNodeEventIdsByNodeId(START_NODE_PREFIX)
-            val testNodeEvents = collectedTestData.filterNodeEventIdsByNodeId(nodeName)
-            val finishNodeEvents = collectedTestData.filterNodeEventIdsByNodeId(FINISH_NODE_PREFIX)
 
-            val expectedSpans = listOf(
-                // First run
-                mapOf(
-                    "node $START_NODE_PREFIX" to mapOf(
-                        "attributes" to mapOf(
-                            "gen_ai.conversation.id" to mockExporter.runIds[0],
-                            "koog.node.id" to START_NODE_PREFIX,
-                            "koog.node.input" to "\"$userPrompt0\"",
-                            "koog.node.output" to "\"$userPrompt0\"",
-                            "koog.event.id" to startNodeEvents[0],
-                        ),
-                        "events" to emptyMap()
-                    )
-                ),
-                mapOf(
-                    "node $nodeName" to mapOf(
-                        "attributes" to mapOf(
-                            "gen_ai.conversation.id" to mockExporter.runIds[0],
-                            "koog.node.id" to nodeName,
-                            "koog.node.input" to "\"$userPrompt0\"",
-                            "koog.node.output" to "\"$nodeOutput0\"",
-                            "koog.event.id" to testNodeEvents[0],
-                        ),
-                        "events" to emptyMap()
-                    )
-                ),
-                mapOf(
-                    "node $FINISH_NODE_PREFIX" to mapOf(
-                        "attributes" to mapOf(
-                            "gen_ai.conversation.id" to mockExporter.runIds[0],
-                            "koog.node.id" to FINISH_NODE_PREFIX,
-                            "koog.node.input" to "\"$nodeOutput0\"",
-                            "koog.node.output" to "\"$nodeOutput0\"",
-                            "koog.event.id" to finishNodeEvents[0],
-                        ),
-                        "events" to emptyMap()
-                    )
-                ),
-                mapOf(
-                    "strategy $strategyName" to mapOf(
-                        "attributes" to mapOf(
-                            "koog.strategy.name" to strategyName,
-                            "gen_ai.conversation.id" to mockExporter.runIds[0],
-                            "koog.event.id" to strategyEvents[0]
-                        ),
-                        "events" to emptyMap()
-                    )
-                ),
-                mapOf(
-                    "${OperationNameType.INVOKE_AGENT.id} $agentId" to mapOf(
-                        "attributes" to mapOf(
-                            "gen_ai.operation.name" to OperationNameType.INVOKE_AGENT.id,
-                            "gen_ai.provider.name" to model.provider.id,
-                            "gen_ai.agent.id" to agentId,
-                            "gen_ai.conversation.id" to mockExporter.runIds[0],
-                            "gen_ai.output.type" to "text",
-                            "gen_ai.request.model" to model.id,
-                            "gen_ai.request.temperature" to OpenTelemetryTestAPI.Parameter.TEMPERATURE,
-                            "gen_ai.input.messages" to getMessagesString(
-                                listOf(
-                                    Message.System(systemPrompt, RequestMetaInfo(OpenTelemetryTestAPI.testClock.now())),
-                                    // User message is not added in invoked agent span
-                                    // as it is propagated through user input in run() agent method
-                                )
-                            ),
-                            "system_instructions" to getSystemInstructionsString(listOf(systemPrompt)),
-                            "gen_ai.response.model" to model.id,
-                            "gen_ai.usage.input_tokens" to 0L,
-                            "gen_ai.usage.output_tokens" to 0L,
-                            "gen_ai.output.messages" to getMessagesString(
-                                listOf(
-                                    Message.System(systemPrompt, RequestMetaInfo(OpenTelemetryTestAPI.testClock.now())),
-                                    // User message is not added in invoked agent span
-                                    // as it is propagated through user input in run() agent method
-                                )
-                            ),
-                            "koog.event.id" to mockExporter.runIds[0],
-                        ),
-                        "events" to emptyMap()
-                    )
-                ),
-                mapOf(
-                    "${OperationNameType.CREATE_AGENT.id} $agentId" to mapOf(
-                        "attributes" to mapOf(
-                            "gen_ai.operation.name" to OperationNameType.CREATE_AGENT.id,
-                            "gen_ai.provider.name" to model.provider.id,
-                            "gen_ai.agent.id" to agentId,
-                            "gen_ai.request.model" to model.id,
-                            "system_instructions" to getSystemInstructionsString(listOf(systemPrompt)),
-                            "koog.event.id" to actualCreateAgentEvents[0]
-                        ),
-                        "events" to emptyMap()
-                    )
-                ),
-
-                // Second run
-                mapOf(
-                    "node $START_NODE_PREFIX" to mapOf(
-                        "attributes" to mapOf(
-                            "gen_ai.conversation.id" to mockExporter.runIds[1],
-                            "koog.node.id" to START_NODE_PREFIX,
-                            "koog.node.input" to "\"$userPrompt1\"",
-                            "koog.node.output" to "\"$userPrompt1\"",
-                            "koog.event.id" to startNodeEvents[1],
-                        ),
-                        "events" to emptyMap()
-                    )
-                ),
-                mapOf(
-                    "node $nodeName" to mapOf(
-                        "attributes" to mapOf(
-                            "gen_ai.conversation.id" to mockExporter.runIds[1],
-                            "koog.node.id" to nodeName,
-                            "koog.node.input" to "\"$userPrompt1\"",
-                            "koog.node.output" to "\"$nodeOutput1\"",
-                            "koog.event.id" to testNodeEvents[1],
-                        ),
-                        "events" to emptyMap()
-                    )
-                ),
-                mapOf(
-                    "node $FINISH_NODE_PREFIX" to mapOf(
-                        "attributes" to mapOf(
-                            "gen_ai.conversation.id" to mockExporter.runIds[1],
-                            "koog.node.id" to FINISH_NODE_PREFIX,
-                            "koog.node.input" to "\"$nodeOutput1\"",
-                            "koog.node.output" to "\"$nodeOutput1\"",
-                            "koog.event.id" to finishNodeEvents[1],
-                        ),
-                        "events" to emptyMap()
-                    )
-                ),
-                mapOf(
-                    "strategy $strategyName" to mapOf(
-                        "attributes" to mapOf(
-                            "koog.strategy.name" to strategyName,
-                            "gen_ai.conversation.id" to mockExporter.runIds[1],
-                            "koog.event.id" to strategyEvents[1]
-                        ),
-                        "events" to emptyMap()
-                    )
-                ),
-                mapOf(
-                    "${OperationNameType.INVOKE_AGENT.id} $agentId" to mapOf(
-                        "attributes" to mapOf(
-                            "gen_ai.operation.name" to OperationNameType.INVOKE_AGENT.id,
-                            "gen_ai.provider.name" to model.provider.id,
-                            "gen_ai.agent.id" to agentId,
-                            "gen_ai.conversation.id" to mockExporter.runIds[1],
-                            "gen_ai.output.type" to "text",
-                            "gen_ai.request.model" to model.id,
-                            "gen_ai.request.temperature" to OpenTelemetryTestAPI.Parameter.TEMPERATURE,
-                            "gen_ai.input.messages" to getMessagesString(
-                                listOf(
-                                    Message.System(systemPrompt, RequestMetaInfo(OpenTelemetryTestAPI.testClock.now())),
-                                    // User message is not added in invoked agent span
-                                    // as it is propagated through user input in run() agent method
-                                )
-                            ),
-                            "system_instructions" to getSystemInstructionsString(listOf(systemPrompt)),
-                            "gen_ai.response.model" to model.id,
-                            "gen_ai.usage.input_tokens" to 0L,
-                            "gen_ai.usage.output_tokens" to 0L,
-                            "gen_ai.output.messages" to getMessagesString(
-                                listOf(
-                                    Message.System(systemPrompt, RequestMetaInfo(OpenTelemetryTestAPI.testClock.now())),
-                                    // User message is not added in invoked agent span
-                                    // as it is propagated through user input in run() agent method
-                                )
-                            ),
-                            "koog.event.id" to mockExporter.runIds[1],
-                        ),
-                        "events" to emptyMap()
-                    )
-                ),
-                mapOf(
-                    "${OperationNameType.CREATE_AGENT.id} $agentId" to mapOf(
-                        "attributes" to mapOf(
-                            "gen_ai.operation.name" to OperationNameType.CREATE_AGENT.id,
-                            "gen_ai.provider.name" to model.provider.id,
-                            "gen_ai.agent.id" to agentId,
-                            "gen_ai.request.model" to model.id,
-                            "system_instructions" to getSystemInstructionsString(listOf(systemPrompt)),
-                            "koog.event.id" to actualCreateAgentEvents[1]
-                        ),
-                        "events" to emptyMap()
-                    )
-                ),
+            val expectedCommonSpansFirstRun = getExpectedCommonSpans(
+                mockExporter.runIds[0],
+                model,
+                strategyEvents[0],
+                actualCreateAgentEvents[0]
             )
+            val expectedCommonSpansSecondRun = getExpectedCommonSpans(
+                mockExporter.runIds[1],
+                model,
+                strategyEvents[1],
+                actualCreateAgentEvents[1]
+            )
+
+            val expectedSpans = when (agentType) {
+                AgentType.Graph -> {
+                    val startNodeEvents = collectedTestData.filterNodeEventIdsByNodeId(START_NODE_PREFIX)
+                    val testNodeEvents = collectedTestData.filterNodeEventIdsByNodeId(nodeName)
+                    val finishNodeEvents = collectedTestData.filterNodeEventIdsByNodeId(FINISH_NODE_PREFIX)
+
+                    val expectedNodeSpansFirstRun = getExpectedNodeSpans(
+                        mockExporter.runIds[0],
+                        userPrompt0,
+                        nodeOutput0,
+                        startNodeEvents[0],
+                        testNodeEvents[0],
+                        finishNodeEvents[0]
+                    )
+
+                    val expectedNodeSpansSecondRun = getExpectedNodeSpans(
+                        mockExporter.runIds[1],
+                        userPrompt1,
+                        nodeOutput1,
+                        startNodeEvents[1],
+                        testNodeEvents[1],
+                        finishNodeEvents[1]
+                    )
+
+                    expectedNodeSpansFirstRun + expectedCommonSpansFirstRun + expectedNodeSpansSecondRun + expectedCommonSpansSecondRun
+                }
+
+                AgentType.Functional -> expectedCommonSpansFirstRun + expectedCommonSpansSecondRun
+            }
 
             assertSpans(expectedSpans, collectedSpans)
         }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryStrategyTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryStrategyTest.kt
@@ -1,27 +1,26 @@
 package ai.koog.agents.features.opentelemetry.feature.span
 
-import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.features.opentelemetry.AgentType
+import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.DEFAULT_STRATEGY_NAME
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.USER_PROMPT_PARIS
+import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Strategy.getSimpleStrategy
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.runAgentWithStrategy
 import ai.koog.agents.features.opentelemetry.assertSpans
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryTestBase
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import kotlin.test.assertTrue
 
 class OpenTelemetryStrategyTest : OpenTelemetryTestBase() {
 
-    @Test
-    fun `test strategy spans are collected`() = runTest {
+    @ParameterizedTest
+    @EnumSource(AgentType::class)
+    fun `test strategy spans are collected`(agentType: AgentType) = runTest {
         val userInput = USER_PROMPT_PARIS
-        val strategyName = "test-strategy"
-        val nodeName = "test-node"
-        val nodeOutput = "$userInput (node)"
+        val strategyName = DEFAULT_STRATEGY_NAME
 
-        val strategy = strategy<String, String>(strategyName) {
-            val nodeBlank by node<String, String>(nodeName) { nodeOutput }
-            nodeStart then nodeBlank then nodeFinish
-        }
+        val strategy = getSimpleStrategy(agentType)
 
         val collectedTestData = runAgentWithStrategy(
             strategy = strategy,
@@ -50,17 +49,13 @@ class OpenTelemetryStrategyTest : OpenTelemetryTestBase() {
         assertSpans(expectedSpans, strategySpans)
     }
 
-    @Test
-    fun `test strategy spans with verbose logging disabled`() = runTest {
+    @ParameterizedTest
+    @EnumSource(AgentType::class)
+    fun `test strategy spans with verbose logging disabled`(agentType: AgentType) = runTest {
         val userInput = USER_PROMPT_PARIS
-        val strategyName = "test-strategy"
-        val nodeName = "test-node"
-        val nodeOutput = "$userInput (node)"
+        val strategyName = DEFAULT_STRATEGY_NAME
 
-        val strategy = strategy<String, String>(strategyName) {
-            val nodeBlank by node<String, String>(nodeName) { nodeOutput }
-            nodeStart then nodeBlank then nodeFinish
-        }
+        val strategy = getSimpleStrategy(agentType)
 
         val collectedTestData = runAgentWithStrategy(
             strategy = strategy,

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/TraceStructureTestBase.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/TraceStructureTestBase.kt
@@ -26,7 +26,6 @@ import ai.koog.agents.features.opentelemetry.assertSpans
 import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
 import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
 import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes.Response.FinishReasonType
-import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryConfig
 import ai.koog.agents.features.opentelemetry.mock.MockSpanExporter
 import ai.koog.agents.features.opentelemetry.mock.TestGetWeatherTool
@@ -478,20 +477,18 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
                 model = model,
                 temperature = temperature,
             ) {
-                install(OpenTelemetry) {
-                    addSpanExporter(mockExporter)
-                    setVerbose(true)
-                    openTelemetryConfigurator()
-                    addSpanAdapter(object : SpanAdapter() {
-                        override fun onBeforeSpanStarted(span: GenAIAgentSpan) {
-                            span.addAttribute(CustomAttribute("custom.after.start", "value-start"))
-                        }
+                addSpanExporter(mockExporter)
+                setVerbose(true)
+                openTelemetryConfigurator()
+                addSpanAdapter(object : SpanAdapter() {
+                    override fun onBeforeSpanStarted(span: GenAIAgentSpan) {
+                        span.addAttribute(CustomAttribute("custom.after.start", "value-start"))
+                    }
 
-                        override fun onBeforeSpanFinished(span: GenAIAgentSpan) {
-                            span.addAttribute(CustomAttribute("custom.before.finish", 123))
-                        }
-                    })
-                }
+                    override fun onBeforeSpanFinished(span: GenAIAgentSpan) {
+                        span.addAttribute(CustomAttribute("custom.before.finish", 123))
+                    }
+                })
             }
 
             agent.run(userPrompt)
@@ -944,11 +941,9 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
             systemPrompt = systemPrompt,
             toolRegistry = toolRegistry,
         ) {
-            install(OpenTelemetry.Feature) {
-                spanExporter?.let { exporter -> addSpanExporter(exporter) }
-                setVerbose(verbose)
-                openTelemetryConfigurator()
-            }
+            spanExporter?.let { exporter -> addSpanExporter(exporter) }
+            setVerbose(verbose)
+            openTelemetryConfigurator()
         }.use { agent ->
             agent.run(userPrompt ?: "User prompt message")
         }


### PR DESCRIPTION
Added a method to install the `OpenTelemetry` feature in a functional strategy.

closes [KG-677](https://youtrack.jetbrains.com/issue/KG-677)