### PR TITLE
build: publish XCFramework binary for SPM

### DIFF
--- a/.github/workflows/build-xcframework.yml
+++ b/.github/workflows/build-xcframework.yml
@@ -5,6 +5,11 @@ on:
     types: [published]
   workflow_dispatch: # Manual trigger
 
+env:
+  JAVA_VERSION: 17
+  JAVA_DISTRIBUTION: 'corretto'
+  JAVA_OPTS: "-Xms8g -Xmx8g -Dfile.encoding=UTF-8 -Djava.awt.headless=true -Dkotlin.daemon.jvm.options=-Xmx6g"
+
 jobs:
   build-xcframework:
     name: Build iOS XCFramework
@@ -31,14 +36,8 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Using version: $VERSION"
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          java-version: 17
-          distribution: corretto
-
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
         with:
           cache-read-only: false
 
@@ -46,8 +45,6 @@ jobs:
         run: xcodebuild -version
 
       - name: Build XCFramework
-        env:
-          JAVA_OPTS: "-Xms8g -Xmx8g -Dfile.encoding=UTF-8 -Djava.awt.headless=true -Dkotlin.daemon.jvm.options=-Xmx6g"
         run: |
           echo "Assembling XCFramework binary..."
           ./gradlew :koog-agents:assembleKoogXCFramework -Pkoog.build.xcframework=true --no-daemon --stacktrace

--- a/.github/workflows/build-xcframework.yml
+++ b/.github/workflows/build-xcframework.yml
@@ -1,0 +1,89 @@
+name: Build XCFramework
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: # Manual trigger
+  push:
+    branches:
+      - amanowicz/KG-682_spm_support
+
+jobs:
+  build-xcframework:
+    name: Build iOS XCFramework
+    runs-on: macos-latest  # Required for Xcode
+    timeout-minutes: 60
+    permissions:
+      contents: write  # Required for uploading release assets
+
+    steps:
+      - name: Configure Git
+        run: |
+          git config --global core.autocrlf input
+
+      - uses: actions/checkout@v5
+
+      - name: Extract version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" == "release" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+          else
+            VERSION="${{ github.sha }}"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Using version: $VERSION"
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: 17
+          distribution: corretto
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: false
+
+      - name: Verify Xcode installation
+        run: xcodebuild -version
+
+      - name: Build XCFramework
+        env:
+          JAVA_OPTS: "-Xms8g -Xmx8g -Dfile.encoding=UTF-8 -Djava.awt.headless=true -Dkotlin.daemon.jvm.options=-Xmx6g"
+        run: |
+          echo "Assembling XCFramework binary..."
+          ./gradlew :koog-agents:assembleKoogXCFramework --no-daemon --stacktrace
+          echo "XCFramework binary assembled"
+
+      # Uploading XCF binary on manual runs without polluting the release - for debugging & testing
+      # Note that 'actions/upload-artifact@v4' always zips the artifact, so we don't have to do it for manual runs
+      - name: Upload XCFramework artifact for manual runs
+        # disable for branch test
+        #if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Koog-xcframework-${{ steps.version.outputs.version }}
+          path: koog-agents/build/XCFrameworks/release/
+          retention-days: 30
+
+      - name: Create XCFramework zip for release
+        if: github.event_name == 'release'
+        id: archive
+        run: |
+          ARCHIVE_NAME="Koog-${{ steps.version.outputs.version }}.xcframework.zip"
+          cd koog-agents/build/XCFrameworks/release
+          zip -r "$ARCHIVE_NAME" Koog.xcframework
+          echo "archive_path=$(pwd)/$ARCHIVE_NAME" >> $GITHUB_OUTPUT
+          echo "XCFramework zip created:"
+          ls -lh "$ARCHIVE_NAME"
+          # Calculate checksum for SPM
+          shasum -a 256 "$ARCHIVE_NAME"
+
+      - name: Upload XCFramework artifact to release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ steps.archive.outputs.archive_path }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-xcframework.yml
+++ b/.github/workflows/build-xcframework.yml
@@ -50,7 +50,7 @@ jobs:
           JAVA_OPTS: "-Xms8g -Xmx8g -Dfile.encoding=UTF-8 -Djava.awt.headless=true -Dkotlin.daemon.jvm.options=-Xmx6g"
         run: |
           echo "Assembling XCFramework binary..."
-          ./gradlew :koog-agents:assembleKoogXCFramework --no-daemon --stacktrace
+          ./gradlew :koog-agents:assembleKoogXCFramework -Pkoog.build.xcframework=true --no-daemon --stacktrace
           echo "XCFramework binary assembled"
 
       # Uploading XCF binary on manual runs without polluting the release - for debugging & testing

--- a/.github/workflows/build-xcframework.yml
+++ b/.github/workflows/build-xcframework.yml
@@ -4,9 +4,6 @@ on:
   release:
     types: [published]
   workflow_dispatch: # Manual trigger
-  push:
-    branches:
-      - amanowicz/KG-682_spm_support
 
 jobs:
   build-xcframework:

--- a/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
+++ b/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
@@ -4,6 +4,7 @@ import ai.koog.gradle.publish.maven.configureJvmJarManifest
 import ai.koog.gradle.tests.configureTests
 import jetbrains.sign.GpgSignSignatoryProvider
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 plugins {
     kotlin("multiplatform")
@@ -17,13 +18,22 @@ plugins {
 kotlin {
     // Tiers are in accordance with <https://kotlinlang.org/docs/native-target-support.html>
     // Tier 1
-    iosSimulatorArm64()
-    iosX64()
+    val iosSimulatorArm64 = iosSimulatorArm64()
+    val iosArm64 = iosArm64()
 
     // Tier 2
-    iosArm64()
 
     // Tier 3
+    val iosX64 = iosX64()
+
+    val xcf = XCFramework(project.name)
+    listOf(iosSimulatorArm64, iosArm64, iosX64).forEach {
+        it.binaries.framework {
+            baseName = project.name
+            binaryOption("bundleId", "ai.koog.${project.name}")
+            xcf.add(this)
+        }
+    }
 
     // Android
     androidTarget()

--- a/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
+++ b/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
@@ -2,9 +2,9 @@
 
 import ai.koog.gradle.publish.maven.configureJvmJarManifest
 import ai.koog.gradle.tests.configureTests
+import ai.koog.gradle.xcframework.XCFrameworkConfig.configureXCFrameworkIfRequested
 import jetbrains.sign.GpgSignSignatoryProvider
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
-import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 plugins {
     kotlin("multiplatform")
@@ -18,22 +18,16 @@ plugins {
 kotlin {
     // Tiers are in accordance with <https://kotlinlang.org/docs/native-target-support.html>
     // Tier 1
-    val iosSimulatorArm64 = iosSimulatorArm64()
-    val iosArm64 = iosArm64()
+    iosSimulatorArm64()
+    iosArm64()
 
     // Tier 2
 
     // Tier 3
-    val iosX64 = iosX64()
+    iosX64()
 
-    val xcf = XCFramework("Koog")
-    listOf(iosSimulatorArm64, iosArm64, iosX64).forEach {
-        it.binaries.framework {
-            baseName = "Koog"
-            binaryOption("bundleId", "ai.koog")
-            xcf.add(this)
-        }
-    }
+    // Configure XCFramework for iOS targets (opt-in via -Pkoog.build.xcframework=true)
+    configureXCFrameworkIfRequested(project)
 
     // Android
     androidTarget()

--- a/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
+++ b/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
@@ -26,11 +26,11 @@ kotlin {
     // Tier 3
     val iosX64 = iosX64()
 
-    val xcf = XCFramework(project.name)
+    val xcf = XCFramework("Koog")
     listOf(iosSimulatorArm64, iosArm64, iosX64).forEach {
         it.binaries.framework {
-            baseName = project.name
-            binaryOption("bundleId", "ai.koog.${project.name}")
+            baseName = "Koog"
+            binaryOption("bundleId", "ai.koog")
             xcf.add(this)
         }
     }

--- a/convention-plugin-ai/src/main/kotlin/ai/koog/gradle/xcframework/XCFrameworkConfig.kt
+++ b/convention-plugin-ai/src/main/kotlin/ai/koog/gradle/xcframework/XCFrameworkConfig.kt
@@ -1,6 +1,7 @@
 package ai.koog.gradle.xcframework
 
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
@@ -34,9 +35,9 @@ object XCFrameworkConfig {
      * @param project The Gradle project
      */
     fun KotlinMultiplatformExtension.configureXCFrameworkIfRequested(project: Project) {
-        if (isEnabled(project)){
+        if (isEnabled(project)) {
             val xcf = project.XCFramework("Koog")
-            targets.withType(KotlinNativeTarget::class.java)
+            targets.withType<KotlinNativeTarget>()
                 .matching { it.konanTarget.family.isAppleFamily }
                 .configureEach {
                     binaries.framework {
@@ -59,8 +60,8 @@ object XCFrameworkConfig {
         project: Project,
         projectPaths: Set<String>
     ) {
-        if (isEnabled(project)){
-            targets.withType(KotlinNativeTarget::class.java).configureEach {
+        if (isEnabled(project)) {
+            targets.withType<KotlinNativeTarget>().configureEach {
                 binaries.withType(Framework::class.java).configureEach {
                     projectPaths.forEach {
                         export(project.project(it))

--- a/convention-plugin-ai/src/main/kotlin/ai/koog/gradle/xcframework/XCFrameworkConfig.kt
+++ b/convention-plugin-ai/src/main/kotlin/ai/koog/gradle/xcframework/XCFrameworkConfig.kt
@@ -1,0 +1,72 @@
+package ai.koog.gradle.xcframework
+
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
+
+/**
+ * Helper object for configuring XCFramework builds in Kotlin Multiplatform projects.
+ *
+ * XCFramework building is opt-in via the Gradle property `koog.build.xcframework=true`.
+ * This prevents slow framework compilation during regular CI runs (assemble, test, etc.).
+ *
+ * Usage:
+ * ```
+ * ./gradlew {module} assembleKoogXCFramework -Pkoog.build.xcframework=true
+ * ```
+ */
+object XCFrameworkConfig {
+
+    private const val PROPERTY_NAME = "koog.build.xcframework"
+
+    /**
+     * Checks if XCFramework building is enabled via the Gradle property.
+     */
+    fun isEnabled(project: Project): Boolean =
+        project.findProperty(PROPERTY_NAME)?.toString()?.toBoolean() ?: false
+
+    /**
+     * Configures XCFramework for iOS targets if enabled.
+     * Creates framework binaries for all targets defined for the project.
+     *
+     * @param project The Gradle project
+     */
+    fun KotlinMultiplatformExtension.configureXCFrameworkIfRequested(project: Project) {
+        if (isEnabled(project)){
+            val xcf = project.XCFramework("Koog")
+            targets.withType(KotlinNativeTarget::class.java)
+                .matching { it.konanTarget.family.isAppleFamily }
+                .configureEach {
+                    binaries.framework {
+                        baseName = "Koog"
+                        binaryOption("bundleId", "ai.koog")
+                        xcf.add(this)
+                    }
+                }
+        }
+    }
+
+    /**
+     * Configures framework exports for all native targets if XCFramework building is enabled.
+     * This exports all specified projects to the iOS framework, making them available to Swift.
+     *
+     * @param project The Gradle project
+     * @param projectPaths Set of project paths to export (e.g., ":agents:agents-core")
+     */
+    fun KotlinMultiplatformExtension.configureFrameworkExportsIfRequested(
+        project: Project,
+        projectPaths: Set<String>
+    ) {
+        if (isEnabled(project)){
+            targets.withType(KotlinNativeTarget::class.java).configureEach {
+                binaries.withType(Framework::class.java).configureEach {
+                    projectPaths.forEach {
+                        export(project.project(it))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/koog-agents/build.gradle.kts
+++ b/koog-agents/build.gradle.kts
@@ -1,6 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
-import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import ai.koog.gradle.xcframework.XCFrameworkConfig.configureFrameworkExportsIfRequested
 
 group = rootProject.group
 version = rootProject.version
@@ -94,13 +93,7 @@ kotlin {
         .filter { it.buildFile.exists() }
     val projectsPaths = projects.mapTo(sortedSetOf()) { it.path }
 
-    targets.withType<KotlinNativeTarget>().configureEach {
-        binaries.withType<Framework>().configureEach {
-            projectsPaths.forEach {
-                export(project(it))
-            }
-        }
-    }
+    configureFrameworkExportsIfRequested(project, projectsPaths)
 
     sourceSets {
         commonMain {

--- a/koog-agents/build.gradle.kts
+++ b/koog-agents/build.gradle.kts
@@ -1,4 +1,6 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
+import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 group = rootProject.group
 version = rootProject.version
@@ -87,14 +89,22 @@ val included = setOf(
 )
 
 kotlin {
+    val projects = rootProject.subprojects
+        .filterNot { it.path in excluded }
+        .filter { it.buildFile.exists() }
+    val projectsPaths = projects.mapTo(sortedSetOf()) { it.path }
+
+    targets.withType<KotlinNativeTarget>().configureEach {
+        binaries.withType<Framework>().configureEach {
+            projectsPaths.forEach {
+                export(project(it))
+            }
+        }
+    }
+
     sourceSets {
         commonMain {
             dependencies {
-                val projects = rootProject.subprojects
-                    .filterNot { it.path in excluded }
-                    .filter { it.buildFile.exists() }
-
-                val projectsPaths = projects.mapTo(sortedSetOf()) { it.path }
 
                 val obsoleteIncluded = included - projectsPaths
                 require(obsoleteIncluded.isEmpty()) {

--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/generator/JsonSchemaConsts.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/generator/JsonSchemaConsts.kt
@@ -1,5 +1,8 @@
 package ai.koog.prompt.structure.json.generator
 
+import kotlin.experimental.ExperimentalObjCName
+import kotlin.native.ObjCName
+
 /**
  * Collection of special constants, such as keys and data types, from JSON schema definition.
  */
@@ -46,6 +49,9 @@ public object JsonSchemaConsts {
         public const val BOOLEAN: String = "boolean"
         public const val ARRAY: String = "array"
         public const val OBJECT: String = "object"
+
+        @OptIn(ExperimentalObjCName::class)
+        @ObjCName("JSON_NULL")
         public const val NULL: String = "null"
     }
 }


### PR DESCRIPTION
# Add Swift Package Manager (SPM) Support via XCFramework

## Summary
Adds infrastructure to build and distribute Koog as an XCFramework for iOS/macOS development via Swift Package Manager.

## Changes
1. **XCFramework Build Configuration** (`.github/workflows/build-xcframework.yml`)
   - New CI workflow that builds XCFramework on releases and manual trigger
   - Runs on macOS with Xcode support
   - Creates versioned zip archives with SHA-256 checksums
   - Uploads artifacts to GitHub releases

2. **iOS Target Support** (`ai.kotlin.multiplatform.gradle.kts`)
   - Configure iOS targets (arm64, simulator arm64, x64) to produce Framework binaries
   - Set up XCFramework assembly from individual frameworks
   - Use 'Koog' as framework name (follows Swift PascalCase convention)

3. **Module Export** (`koog-agents/build.gradle.kts`)
   - Export all included modules through Framework binaries
   - Makes Koog APIs accessible to Swift consumers

## Architecture
- **Single XCFramework**: `Koog.xcframework` contains all Koog modules
- **Distribution**: GitHub Releases (binary artifacts)
- **Consumption**: Separate SPM repository will reference these artifacts via Package.swift

## Testing
- [x] Manual: Verified XCFramework builds locally
- [x] Manual: Framework structure validated
- [x] Manual: Tested import in sample Xcode project 
- [ ] CI: Automated testing (future work)

## Next Steps (Follow-up Work)
1. Create separate SPM repository with Package.swift
2. Add modular framework distribution (separate frameworks per module)
3. Add automated Swift compilation tests

## Related Issues
Closes KG-682

<img width="791" height="589" alt="image" src="https://github.com/user-attachments/assets/aa098558-27e2-4189-a5d8-dd98fc06f554" />
