### PR TITLE
example: add StreamingKtorServer to demonstrate simple LLM response streaming via HTTP endpoint

### DIFF
--- a/examples/simple-examples/README.md
+++ b/examples/simple-examples/README.md
@@ -51,6 +51,7 @@ Welcome to the **Koog Framework Simple Examples** collection! This project showc
 | **Calculator V2**           | Enhanced calculator with improved functionality                   | `runExampleCalculatorV2`            | -                                                    |
 | **Calculator Local**        | Calculator using local LLM models                                 | `runExampleCalculatorLocal`         | -                                                    |
 | **Streaming with Tools**    | Agent demonstrating streaming responses while using tools         | `runExampleStreamingWithTools`      | -                                                    |
+| **Streaming Ktor Server**   | HTTP server streaming LLM responses in real-time via Ktor         | `runExampleStreamingKtorServer`     | -                                                    |
 | **Banking Routing**         | Comprehensive AI banking assistant with routing capabilities      | `runExampleRoutingViaGraph`         | [📓 Banking.ipynb](../notebooks/Banking.ipynb)       |
 | **Banking Agents as Tools** | Banking routing using agents as tools pattern                     | `runExampleRoutingViaAgentsAsTools` | -                                                    |
 | **Chess**                   | Intelligent chess-playing agent with interactive choice selection | -                                   | [📓 Chess.ipynb](../notebooks/Chess.ipynb)           |
@@ -131,6 +132,7 @@ Run any example using:
 - `runExampleCalculatorV2` - Enhanced calculator
 - `runExampleCalculatorLocal` - Calculator with local LLM
 - `runExampleStreamingWithTools` - Streaming responses with tool usage
+- `runExampleStreamingKtorServer` - HTTP server with real-time streaming
 - `runExampleGuesser` - Number guessing game agent
 - `runExampleEssay` - Essay writing agent
 

--- a/examples/simple-examples/build.gradle.kts
+++ b/examples/simple-examples/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
 
     implementation(libs.ktor.client.cio)
     implementation(libs.ktor.server.cio)
+    implementation(libs.ktor.server.sse)
 
     testImplementation(kotlin("test"))
     testImplementation(libs.kotlinx.coroutines.test)
@@ -118,6 +119,7 @@ registerRunExampleTask("runExampleFilePersistentAgent", "ai.koog.agents.example.
 registerRunExampleTask("runExampleSQLPersistentAgent", "ai.koog.agents.example.snapshot.sql.SQLPersistentAgentExample")
 registerRunExampleTask("runExampleWebSearchAgent", "ai.koog.agents.example.websearch.WebSearchAgentKt")
 registerRunExampleTask("runExampleStreamingWithTools", "ai.koog.agents.example.streaming.StreamingAgentWithToolsKt")
+registerRunExampleTask("runExampleStreamingKtorServer", "ai.koog.agents.example.streaming.StreamingKtorServerKt")
 
 registerRunExampleTask("runExampleGOAPGrouper", "ai.koog.agents.example.goap.GrouperAgentKt")
 /*

--- a/examples/simple-examples/gradle/libs.versions.toml
+++ b/examples/simple-examples/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 ktor-bom = { module = "io.ktor:ktor-bom", version.ref = "ktor3" }
 ktor-server-cio = { module = "io.ktor:ktor-server-cio" }
+ktor-server-sse = { module = "io.ktor:ktor-server-sse" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/streaming/StreamingKtorServer.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/streaming/StreamingKtorServer.kt
@@ -1,0 +1,149 @@
+package ai.koog.agents.example.streaming
+
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.GraphAIAgent
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreaming
+import ai.koog.agents.example.ApiKeyService
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
+import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.streaming.StreamFrame
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationStopped
+import io.ktor.server.application.install
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.header
+import io.ktor.server.response.respondOutputStream
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import io.ktor.server.sse.SSE
+import io.ktor.server.sse.sse
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlin.reflect.typeOf
+
+/**
+ * Example: Streaming AI Agent with Ktor Server
+ * Demonstrates real-time text streaming from an LLM through a web endpoint
+ */
+fun main() {
+    println("Starting Koog Streaming Server on http://localhost:8080")
+    println("Available endpoints:")
+    println(" - SSE /stream: Streaming agent")
+    println()
+
+    createServer().start(wait = true)
+}
+
+
+private fun createServer(): EmbeddedServer<*, *> {
+    val promptExecutor = MultiLLMPromptExecutor(
+        LLMProvider.OpenAI to OpenAILLMClient(ApiKeyService.openAIApiKey),
+    )
+
+    return embeddedServer(
+        factory = CIO,
+        port = 8080,
+        host = "127.0.0.1",
+    ) {
+        install(SSE)
+
+        monitor.subscribe(ApplicationStopped) {
+            promptExecutor.close()
+        }
+
+        configureRouting(
+            promptExecutor = promptExecutor,
+        )
+    }
+}
+
+/**
+ * Defines the /stream endpoint that receives text and streams AI responses
+ */
+private fun Application.configureRouting(
+    promptExecutor: PromptExecutor,
+) {
+    routing {
+        post("/stream") {
+            val request = call.receiveText()
+            println("Received request:\n$request")
+
+            call.response.header("Content-Type", "text/plain; charset=UTF-8")
+
+            // Stream response chunks as they arrive from the LLM
+            call.respondOutputStream {
+                val agent = createAgent(
+                    promptExecutor = promptExecutor,
+                    sendChunk = { text ->
+                        write(text.toByteArray())
+                        flush()
+                    }
+                )
+
+                val result = agent.run(request)
+                println("Agent result:\n$result")
+            }
+        }
+    }
+}
+
+private fun createAgent(
+    promptExecutor: PromptExecutor,
+    sendChunk: suspend (String) -> Unit,
+): AIAgent<String, String> {
+    val agentConfig = AIAgentConfig(
+        prompt = prompt("assistant-prompt") {
+            system {
+                +"You are a helpful assistant."
+            }
+        },
+        model = OpenAIModels.Chat.GPT5_2,
+        maxAgentIterations = 10,
+    )
+
+    return GraphAIAgent(
+        typeOf<String>(),
+        typeOf<String>(),
+        promptExecutor = promptExecutor,
+        agentConfig = agentConfig,
+        strategy = createStrategy(
+            sendChunk = sendChunk,
+        ),
+    )
+}
+
+/**
+ * Simple strategy that forwards the input to the LLM and streams the output chunks.
+ */
+private fun createStrategy(
+    sendChunk: suspend (String) -> Unit,
+): AIAgentGraphStrategy<String, String> = strategy<String, String>(
+    name = "assistant-strategy"
+) {
+    val processStream by node<Flow<StreamFrame>, String> { input ->
+        val totalText = StringBuilder()
+
+        // Filter for text append frames and stream each chunk immediately
+        input.filterIsInstance<StreamFrame.Append>()
+            .collect {
+                sendChunk(it.text)
+                totalText.append(it.text)
+            }
+
+        totalText.toString()
+    }
+
+    val requestLLMStream by nodeLLMRequestStreaming()
+
+    nodeStart then requestLLMStream then processStream then nodeFinish
+}


### PR DESCRIPTION
Add example demonstrating how to stream LLM responses AI Agent receives through an HTTP endpoint. It uses a simple approach with custom node and a callback lambda.