### PR TITLE
feat(agents): add LongTermMemory feature for memory retrieval and ingestion

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/ContextualPromptExecutor.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/ContextualPromptExecutor.kt
@@ -15,9 +15,9 @@ import ai.koog.prompt.structure.json.generator.StandardJsonSchemaGenerator
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.onStart
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -42,17 +42,27 @@ public class ContextualPromptExecutor(
         @OptIn(ExperimentalUuidApi::class)
         val eventId = Uuid.random().toString()
 
-        logger.debug { "Executing LLM call (event id: $eventId, prompt: $prompt, tools: [${tools.joinToString { it.name }}])" }
+        val promptBeforeInterceptors = context.llm.prompt // because onLLMCallStarting might change context.llm.prompt
+
+        logger.debug { "Starting LLM call (event id: $eventId, prompt: $prompt, tools: [${tools.joinToString { it.name }}])" }
         context.pipeline.onLLMCallStarting(eventId, context.executionInfo, context.runId, prompt, model, tools, context)
 
-        val responses = executor.execute(prompt, model, tools)
+        val effectivePrompt = if (context.llm.prompt !== promptBeforeInterceptors) {
+            logger.debug { "Executing LLM call with modified prompt (event id: $eventId, prompt: $prompt, tools: [${tools.joinToString { it.name }}])" }
+            context.llm.prompt
+        } else {
+            logger.debug { "Executing LLM call (event id: $eventId, prompt: $prompt, tools: [${tools.joinToString { it.name }}])" }
+            prompt
+        }
+
+        val responses = executor.execute(effectivePrompt, model, tools)
 
         logger.trace { "Finished LLM call (event id: $eventId) with responses: [${responses.joinToString { "${it.role}: ${it.content}" }}]" }
         context.pipeline.onLLMCallCompleted(
             eventId,
             context.executionInfo,
             context.runId,
-            prompt,
+            effectivePrompt,
             model,
             tools,
             responses,
@@ -86,26 +96,41 @@ public class ContextualPromptExecutor(
 
         logger.debug { "Executing LLM streaming call (event id: $eventId, prompt: $prompt, tools: [${tools.joinToString { it.name }}])" }
 
-        return executor.executeStreaming(prompt, model, tools)
-            .onStart {
-                logger.debug { "Starting LLM streaming call (event id: $eventId)" }
-                context.pipeline.onLLMStreamingStarting(
-                    eventId,
-                    context.executionInfo,
-                    context.runId,
-                    prompt,
-                    model,
-                    tools,
-                    context
-                )
+        var effectivePrompt: Prompt = prompt
+
+        return flow {
+            val promptBeforeInterceptors = context.llm.prompt // because onLLMStreamingStarting might change it
+
+            logger.debug { "Starting LLM streaming call (event id: $eventId)" }
+            context.pipeline.onLLMStreamingStarting(
+                eventId,
+                context.executionInfo,
+                context.runId,
+                prompt,
+                model,
+                tools,
+                context
+            )
+
+            effectivePrompt = if (context.llm.prompt !== promptBeforeInterceptors) {
+                logger.debug { "Executing LLM streaming call with modified prompt (event id: $eventId, prompt: ${context.llm.prompt}, tools: [${tools.joinToString { it.name }}])" }
+                context.llm.prompt
+            } else {
+                logger.debug { "Executing LLM streaming call (event id: $eventId, prompt: $prompt, tools: [${tools.joinToString { it.name }}])" }
+                prompt
             }
+
+            executor.executeStreaming(effectivePrompt, model, tools).collect { frame ->
+                emit(frame)
+            }
+        }
             .onEach { frame ->
-                logger.debug { "Received frame from LLM streaming call (event id: $eventId): $frame" }
+                logger.trace { "Received frame from LLM streaming call (event id: $eventId): $frame" }
                 context.pipeline.onLLMStreamingFrameReceived(
                     eventId,
                     context.executionInfo,
                     context.runId,
-                    prompt,
+                    effectivePrompt,
                     model,
                     frame,
                     context
@@ -117,7 +142,7 @@ public class ContextualPromptExecutor(
                     eventId,
                     context.executionInfo,
                     context.runId,
-                    prompt,
+                    effectivePrompt,
                     model,
                     error,
                     context
@@ -126,11 +151,11 @@ public class ContextualPromptExecutor(
             }
             .onCompletion { error ->
                 logger.debug(error) { "Finished LLM streaming call (event id: $eventId): $error" }
-                context.pipeline.onLLMStreamingCompleted(
+                context.pipeline.onLLMStreamingCompleted( // Note: it will be executed in any case (even if error is null)
                     eventId,
                     context.executionInfo,
                     context.runId,
-                    prompt,
+                    effectivePrompt,
                     model,
                     tools,
                     context
@@ -138,7 +163,7 @@ public class ContextualPromptExecutor(
             }
     }
 
-    // TODO: Add Pipeline interceptors for this method
+    // TODO: Add Pipeline interceptors for this method. Without them features cannot modify prompts before calls to LLMs.
     override suspend fun executeMultipleChoices(
         prompt: Prompt,
         model: LLModel,
@@ -171,7 +196,9 @@ public class ContextualPromptExecutor(
         @OptIn(ExperimentalUuidApi::class)
         val eventId = Uuid.random().toString()
 
-        logger.debug { "Executing moderation LLM request (event id: $eventId, prompt: $prompt)" }
+        val promptBeforeInterceptors = context.llm.prompt
+
+        logger.debug { "Starting moderation LLM request (event id: $eventId, prompt: $prompt)" }
 
         context.pipeline.onLLMCallStarting(
             eventId,
@@ -183,14 +210,22 @@ public class ContextualPromptExecutor(
             context
         )
 
-        val result = executor.moderate(prompt, model)
+        val effectivePrompt = if (context.llm.prompt !== promptBeforeInterceptors) {
+            logger.debug { "Executing moderation LLM request with modified prompt (event id: $eventId, prompt: ${context.llm.prompt})" }
+            context.llm.prompt
+        } else {
+            logger.debug { "Executing moderation LLM request (event id: $eventId, prompt: $prompt)" }
+            prompt
+        }
+
+        val result = executor.moderate(effectivePrompt, model)
         logger.trace { "Finished moderation LLM request (event id: $eventId) with response: $result" }
 
         context.pipeline.onLLMCallCompleted(
             eventId,
             context.executionInfo,
             context.runId,
-            prompt,
+            effectivePrompt,
             model,
             tools = emptyList(),
             responses = emptyList(),

--- a/agents/agents-features/Module.md
+++ b/agents/agents-features/Module.md
@@ -72,3 +72,4 @@ See each feature’s Module/README in its submodule for concrete examples and ad
 - Memory
 - OpenTelemetry
 - Snapshot
+- LongTermMemory

--- a/agents/agents-features/agents-features-longterm-memory/Module.md
+++ b/agents/agents-features/agents-features-longterm-memory/Module.md
@@ -1,0 +1,27 @@
+# Module agents-features-longterm-memory
+
+Provides the `LongTermMemory` feature for AI agents, enabling persistent storage and retrieval of memory records (documents) across agent runs via vector databases or other storage backends. Supports Retrieval-Augmented Generation (RAG) and message ingestion as two independently configurable flows.
+
+### Overview
+
+The agents-features-longterm-memory module adds long-term memory capabilities to Koog AI agents:
+
+- **Retrieval (RAG)**: Searches a memory store for context relevant to the user's query and augments the LLM prompt before each call
+- **Ingestion**: Extracts and persists conversation messages into a memory store for future retrieval
+- **Flexible storage**: Plug any backend via `RetrievalStorage` / `IngestionStorage` interfaces; an in-memory `InMemoryRecordStorage` is included for testing
+- **Configurable timing**: Ingest per-LLM-call or on agent completion
+- **Prompt augmentation modes**: System prompt or user prompt or custom implementation
+
+### Key Components
+
+| Component                                                                                                                    | Description                                                            |
+|------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------|
+| [`LongTermMemory`](src/commonMain/kotlin/ai/koog/agents/longtermmemory/feature/LongTermMemory.kt)                            | Agent feature with DSL config for retrieval & ingestion                |
+| [`RetrievalStorage`](src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/RetrievalStorage.kt)                      | Interface for searching memory records                                 |
+| [`IngestionStorage`](src/commonMain/kotlin/ai/koog/agents/longtermmemory/ingestion/IngestionStorage.kt)                      | Interface for adding memory records                                    |
+| [`SearchStrategy`](src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/SearchStrategy.kt)              | Converts user query into a `SearchRequest` (similarity or keyword)     |
+| [`MemoryRecordExtractor`](src/commonMain/kotlin/ai/koog/agents/longtermmemory/ingestion/extraction/MemoryRecordExtractor.kt) | Transforms messages into `MemoryRecord`s for storage                   |
+| [`PromptAugmenter`](src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/augmentation/PromptAugmenter.kt)           | Interface for augmenting prompts with relevant context                 |
+| [`SystemPromptAugmenter`](src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/augmentation/SystemPromptAugmenter.kt)               | Inserts retrieved context as a system message                          |
+| [`UserPromptAugmenter`](src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/augmentation/UserPromptAugmenter.kt)                   | Inserts retrieved context as a user message                            |
+| [`InMemoryRecordStorage`](src/commonMain/kotlin/ai/koog/agents/longtermmemory/storage/InMemoryRecordStorage.kt)              | In-memory storage implementing both retrieval and ingestion interfaces |

--- a/agents/agents-features/agents-features-longterm-memory/build.gradle.kts
+++ b/agents/agents-features/agents-features-longterm-memory/build.gradle.kts
@@ -1,0 +1,42 @@
+import ai.koog.gradle.publish.maven.Publishing.publishToMaven
+
+group = rootProject.group
+version = rootProject.version
+
+plugins {
+    id("ai.kotlin.multiplatform")
+    alias(libs.plugins.kotlin.serialization)
+}
+
+kotlin {
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(project(":agents:agents-core"))
+                api(project(":prompt:prompt-markdown"))
+
+                api(libs.kotlinx.serialization.json)
+                api(libs.ktor.client.content.negotiation)
+                api(libs.ktor.serialization.kotlinx.json)
+            }
+        }
+
+        commonTest {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(libs.kotlinx.coroutines.test)
+            }
+        }
+
+        jvmTest {
+            dependencies {
+                implementation(kotlin("test-junit5"))
+                implementation(project(":agents:agents-test"))
+            }
+        }
+    }
+
+    explicitApi()
+}
+
+publishToMaven()

--- a/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/feature/LongTermMemory.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/feature/LongTermMemory.kt
@@ -1,0 +1,538 @@
+package ai.koog.agents.longtermmemory.feature
+
+import ai.koog.agents.core.agent.context.AIAgentContext
+import ai.koog.agents.core.agent.context.featureOrThrow
+import ai.koog.agents.core.agent.entity.AIAgentStorageKey
+import ai.koog.agents.core.agent.entity.createStorageKey
+import ai.koog.agents.core.annotation.ExperimentalAgentsApi
+import ai.koog.agents.core.feature.AIAgentFunctionalFeature
+import ai.koog.agents.core.feature.AIAgentGraphFeature
+import ai.koog.agents.core.feature.AIAgentPlannerFeature
+import ai.koog.agents.core.feature.config.FeatureConfig
+import ai.koog.agents.core.feature.pipeline.AIAgentFunctionalPipeline
+import ai.koog.agents.core.feature.pipeline.AIAgentGraphPipeline
+import ai.koog.agents.core.feature.pipeline.AIAgentPipeline
+import ai.koog.agents.core.feature.pipeline.AIAgentPlannerPipeline
+import ai.koog.agents.longtermmemory.ingestion.IngestionSettings
+import ai.koog.agents.longtermmemory.ingestion.IngestionStorage
+import ai.koog.agents.longtermmemory.ingestion.IngestionTiming
+import ai.koog.agents.longtermmemory.ingestion.extraction.MemoryRecordExtractor
+import ai.koog.agents.longtermmemory.retrieval.RetrievalSettings
+import ai.koog.agents.longtermmemory.retrieval.RetrievalStorage
+import ai.koog.agents.longtermmemory.retrieval.SearchStrategy
+import ai.koog.agents.longtermmemory.retrieval.augmentation.PromptAugmenter
+import ai.koog.agents.longtermmemory.retrieval.augmentation.SystemPromptAugmenter
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.streaming.toMessageResponses
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Memory feature that incorporates persistent storage of memory records (documents) in vector databases.
+ *
+ * This feature provides two main capabilities that can be configured independently:
+ * 1. **Retrieval (RAG)**: Retrieves relevant context from the memory record repository using a
+ *    configured search request builder and inserts it into the prompt before sending to the LLM.
+ *    Configured via [retrievalSettings]. When null, no retrieval/augmentation is performed.
+ * 2. **Ingestion**: Saves messages to the memory record repository for future retrieval.
+ *    Configured via [ingestionSettings]. When null, no messages are persisted.
+ *
+ * @see RetrievalSettings
+ * @see IngestionSettings
+ */
+@ExperimentalAgentsApi
+public class LongTermMemory(
+    private val retrievalSettings: RetrievalSettings? = null,
+    private val ingestionSettings: IngestionSettings? = null,
+) {
+    /**
+     * Buffer to accumulate streaming frames by runId.
+     * Frames are accumulated during streaming and saved when streaming completes.
+     */
+    private val streamingFramesBuffer: MutableMap<String, MutableList<StreamFrame>> = mutableMapOf()
+    private val streamingFramesBufferMutex = Mutex()
+
+    /**
+     * Configuration for the LongTermMemory feature.
+     *
+     * This class allows configuring:
+     * - Retrieval settings for RAG (prompt augmentation with context from the repository)
+     * - Ingestion settings for persisting messages to the repository
+     *
+     * Both [retrievalSettings] and [ingestionSettings] are null by default, meaning neither
+     * retrieval nor ingestion is active unless explicitly configured.
+     */
+    public class Config : FeatureConfig() {
+        /**
+         * Settings for retrieval-augmented generation (RAG).
+         * When null (default), no context augmentation from the memory record repository is performed.
+         *
+         * Can be set directly or configured via the [retrieval] DSL block.
+         */
+        public var retrievalSettings: RetrievalSettings? = null
+
+        /**
+         * Settings for ingesting (persisting) messages into the memory record repository.
+         * When null (default), no messages are persisted.
+         *
+         * Can be set directly or configured via the [ingestion] DSL block.
+         */
+        public var ingestionSettings: IngestionSettings? = null
+
+        /**
+         * Configure retrieval (RAG) settings via DSL block.
+         *
+         * Example usage:
+         * ```kotlin
+         * retrieval {
+         *     searchStrategy = SimilaritySearchStrategy(topK = 5)
+         *     promptAugmenter = UserPromptAugmenter()
+         * }
+         * ```
+         */
+        public fun retrieval(block: RetrievalSettingsBuilder.() -> Unit) {
+            retrievalSettings = RetrievalSettingsBuilder().apply(block).build()
+        }
+
+        /**
+         * Set pre-built retrieval settings directly.
+         */
+        public fun retrieval(settings: RetrievalSettings) {
+            retrievalSettings = settings
+        }
+
+        /**
+         * Configure ingestion settings via DSL block.
+         *
+         * Example usage:
+         * ```kotlin
+         * ingestion {
+         *     extractor = FilteringMemoryRecordExtractor(setOf(Message.Role.User))
+         * }
+         * ```
+         */
+        public fun ingestion(block: IngestionSettingsBuilder.() -> Unit) {
+            ingestionSettings = IngestionSettingsBuilder().apply(block).build()
+        }
+
+        /**
+         * Set pre-built ingestion settings directly.
+         */
+        public fun ingestion(settings: IngestionSettings) {
+            ingestionSettings = settings
+        }
+    }
+
+    /**
+     * Builder for [RetrievalSettings] used in the [Config.retrieval] DSL block.
+     */
+    public class RetrievalSettingsBuilder {
+        /**
+         * The retrieval storage to search for relevant memory records.
+         * Must be set explicitly in the retrieval { } block.
+         */
+        public var storage: RetrievalStorage? = null
+
+        /**
+         * The search strategy that defines how to search the retrieval storage.
+         *
+         * @see SearchStrategy
+         */
+        public var searchStrategy: SearchStrategy? = null
+
+        /**
+         * The augmenter that defines how retrieved context is inserted into the prompt.
+         * Defaults to [SystemPromptAugmenter].
+         *
+         * @see SystemPromptAugmenter
+         * @see ai.koog.agents.longtermmemory.retrieval.augmentation.UserPromptAugmenter
+         */
+        public var promptAugmenter: PromptAugmenter = SystemPromptAugmenter()
+
+        /**
+         * Fluent setter for [storage].
+         */
+        public fun withStorage(storage: RetrievalStorage): RetrievalSettingsBuilder = apply { this.storage = storage }
+
+        /**
+         * Fluent setter for [searchStrategy].
+         */
+        public fun withSearchStrategy(searchStrategy: SearchStrategy): RetrievalSettingsBuilder =
+            apply { this.searchStrategy = searchStrategy }
+
+        /**
+         * Fluent setter for [promptAugmenter].
+         */
+        public fun withPromptAugmenter(augmenter: PromptAugmenter): RetrievalSettingsBuilder =
+            apply { this.promptAugmenter = augmenter }
+
+        /**
+         * RetrievalSettings builder.
+         */
+        public fun build(): RetrievalSettings {
+            val retrievalStorage = storage ?: error("storage must be set in retrieval { } block")
+            return RetrievalSettings(
+                retrievalStorage,
+                searchStrategy,
+                promptAugmenter
+            )
+        }
+    }
+
+    /**
+     * Builder for [IngestionSettings] used in the [Config.ingestion] DSL block.
+     */
+    public class IngestionSettingsBuilder {
+        /**
+         * The ingestion storage where memory records will be persisted.
+         * Must be set explicitly in the ingestion { } block.
+         */
+        public var storage: IngestionStorage? = null
+
+        /**
+         * The extractor that defines how to transform messages into memory records.
+         *
+         * Pre-built ingesters are available:
+         * - [ai.koog.agents.longtermmemory.ingestion.extraction.FilteringMemoryRecordExtractor] - Filters messages by role
+         *
+         * Example usage:
+         * ```kotlin
+         * // Use pre-built extractor with parameters
+         * extractor = FilteringMemoryRecordExtractor(
+         *     messageRolesToExtract = setOf(Message.Role.User)
+         * )
+         *
+         * // Or use lambda for custom logic
+         * extractor = MemoryRecordExtractor { messages ->
+         *     messages.map { MemoryRecord.Plain(content = it.content) }
+         * }
+         * ```
+         */
+        public var extractor: MemoryRecordExtractor? = null
+
+        /**
+         * When to mapMessages messages. Defaults to [IngestionTiming.ON_LLM_CALL].
+         */
+        public var timing: IngestionTiming = IngestionTiming.ON_LLM_CALL
+
+        /**
+         * Fluent setter for [storage].
+         */
+        public fun withStorage(storage: IngestionStorage): IngestionSettingsBuilder = apply { this.storage = storage }
+
+        /**
+         * Fluent setter for [extractor].
+         */
+        public fun withExtractor(extractor: MemoryRecordExtractor): IngestionSettingsBuilder =
+            apply { this.extractor = extractor }
+
+        /**
+         * Fluent setter for [timing].
+         */
+        public fun withTiming(timing: IngestionTiming): IngestionSettingsBuilder = apply { this.timing = timing }
+
+        /**
+         * IngestionSettings builder.
+         */
+        public fun build(): IngestionSettings {
+            val ingestionStorage = storage ?: error("storage must be set in ingestion { } block")
+            return IngestionSettings(ingestionStorage, extractor, timing)
+        }
+    }
+
+    /**
+     * Companion object implementing agent feature, handling [LongTermMemory] creation and installation.
+     */
+    public companion object Feature :
+        AIAgentGraphFeature<Config, LongTermMemory>,
+        AIAgentFunctionalFeature<Config, LongTermMemory>,
+        AIAgentPlannerFeature<Config, LongTermMemory> {
+        private val logger = KotlinLogging.logger { }
+
+        override val key: AIAgentStorageKey<LongTermMemory> =
+            createStorageKey("long-term-memory-feature")
+
+        override fun createInitialConfig(): Config = Config()
+
+        /**
+         * Create a feature implementation using the provided configuration.
+         */
+        private fun createFeature(
+            config: Config,
+            pipeline: AIAgentPipeline,
+        ): LongTermMemory {
+            val ltmFeature = LongTermMemory(
+                retrievalSettings = config.retrievalSettings,
+                ingestionSettings = config.ingestionSettings,
+            )
+
+            val ingestionExtractor = config.ingestionSettings?.memoryRecordExtractor
+            val searchStrategy = config.retrievalSettings?.searchStrategy
+
+            if (ingestionExtractor == null && searchStrategy == null) {
+                return ltmFeature
+            }
+
+            // Note: ingestion interceptors on "Starting" events must be registered before
+            // retrieval interceptors so that messages are ingested before prompt augmentation.
+            if (ingestionExtractor != null) {
+                installIngestionInterceptors(ltmFeature, pipeline)
+            }
+            if (searchStrategy != null) {
+                installRetrievalInterceptors(ltmFeature, pipeline)
+            }
+            installCleanupInterceptors(ltmFeature, pipeline)
+
+            return ltmFeature
+        }
+
+        /**
+         * Install interceptors for ingesting messages into the memory record repository.
+         *
+         * Depending on [IngestionTiming], interceptors are installed either on individual LLM
+         * calls/streams ([IngestionTiming.ON_LLM_CALL]) or on agent completion
+         * ([IngestionTiming.ON_AGENT_COMPLETION]).
+         */
+        private fun installIngestionInterceptors(
+            ltmFeature: LongTermMemory,
+            pipeline: AIAgentPipeline,
+        ) {
+            val ingestion = ltmFeature.ingestionSettings ?: return
+
+            when (ingestion.timing) {
+                IngestionTiming.ON_LLM_CALL -> installOnLLMCallIngestion(ltmFeature, ingestion, pipeline)
+                IngestionTiming.ON_AGENT_COMPLETION -> installOnAgentCompletionIngestion(ingestion, pipeline)
+            }
+        }
+
+        /**
+         * Install ingestion interceptors for [IngestionTiming.ON_LLM_CALL] mode.
+         * Covers both regular and streaming LLM calls.
+         */
+        private fun installOnLLMCallIngestion(
+            ltmFeature: LongTermMemory,
+            ingestion: IngestionSettings,
+            pipeline: AIAgentPipeline,
+        ) {
+            // Ingest original (not yet augmented) prompt messages before regular LLM call
+            pipeline.interceptLLMCallStarting(this) { ctx ->
+                ingestMessages(ingestion, ctx.prompt.messages)
+            }
+
+            // Ingest assistant responses after regular LLM call
+            pipeline.interceptLLMCallCompleted(this) { ctx ->
+                ingestMessages(ingestion, ctx.responses)
+            }
+
+            // Ingest original (not yet augmented) prompt messages before streaming LLM call
+            pipeline.interceptLLMStreamingStarting(this) { ctx ->
+                ingestMessages(ingestion, ctx.prompt.messages)
+            }
+
+            // Accumulate streaming frames in buffer
+            pipeline.interceptLLMStreamingFrameReceived(this) { ctx ->
+                ltmFeature.streamingFramesBufferMutex.withLock {
+                    ltmFeature.streamingFramesBuffer.getOrPut(ctx.runId) { mutableListOf() }
+                        .add(ctx.streamFrame)
+                }
+            }
+
+            // Clean up the buffer on streaming failure
+            pipeline.interceptLLMStreamingFailed(this) { ctx ->
+                ltmFeature.streamingFramesBufferMutex.withLock {
+                    ltmFeature.streamingFramesBuffer.remove(ctx.runId)
+                }
+            }
+
+            // Ingest accumulated streaming response on streaming completion
+            pipeline.interceptLLMStreamingCompleted(this) { ctx ->
+                val frames = ltmFeature.streamingFramesBufferMutex.withLock {
+                    ltmFeature.streamingFramesBuffer.remove(ctx.runId)
+                }
+                if (!frames.isNullOrEmpty()) {
+                    ingestMessages(ingestion, frames.toMessageResponses())
+                }
+            }
+        }
+
+        /**
+         * Install ingestion interceptors for [IngestionTiming.ON_AGENT_COMPLETION] mode.
+         * All messages are saved at once when the agent completes.
+         */
+        private fun installOnAgentCompletionIngestion(
+            ingestion: IngestionSettings,
+            pipeline: AIAgentPipeline,
+        ) {
+            pipeline.interceptAgentCompleted(this) { ctx ->
+                ctx.context.llm.readSession {
+                    ingestMessages(ingestion, prompt.messages)
+                }
+            }
+        }
+
+        /**
+         * Install interceptors for retrieval-augmented generation (RAG).
+         * Augments prompts with relevant context from the memory record repository
+         * before both regular and streaming LLM calls.
+         */
+        private fun installRetrievalInterceptors(
+            ltmFeature: LongTermMemory,
+            pipeline: AIAgentPipeline,
+        ) {
+            val retrieval = ltmFeature.retrievalSettings ?: return
+
+            // Augment prompt before regular LLM call
+            pipeline.interceptLLMCallStarting(this) { ctx ->
+                val augmentedPrompt = getAugmentedPromptOrNull(ctx.prompt, retrieval)
+                if (augmentedPrompt != null) {
+                    ctx.context.llm.prompt = augmentedPrompt // TODO: switch to writeSession after the KG-688
+                }
+            }
+
+            // Augment prompt before streaming LLM call
+            pipeline.interceptLLMStreamingStarting(this) { ctx ->
+                val augmentedPrompt = getAugmentedPromptOrNull(ctx.prompt, retrieval)
+                if (augmentedPrompt != null) {
+                    ctx.context.llm.writeSession {
+                        prompt = augmentedPrompt
+                    }
+                }
+            }
+        }
+
+        /**
+         * Install safety-net interceptors to clean up any leaked streaming buffer entries
+         * when the agent completes or fails.
+         */
+        private fun installCleanupInterceptors(
+            ltmFeature: LongTermMemory,
+            pipeline: AIAgentPipeline,
+        ) {
+            pipeline.interceptAgentCompleted(this) { ctx ->
+                ltmFeature.streamingFramesBufferMutex.withLock {
+                    ltmFeature.streamingFramesBuffer.remove(ctx.runId)
+                }
+            }
+
+            pipeline.interceptAgentExecutionFailed(this) { ctx ->
+                ltmFeature.streamingFramesBufferMutex.withLock {
+                    ltmFeature.streamingFramesBuffer.remove(ctx.runId)
+                }
+            }
+        }
+
+        private suspend fun ingestMessages(
+            ingestion: IngestionSettings,
+            messages: List<Message>,
+        ) {
+            val records = ingestion.memoryRecordExtractor?.extract(messages) ?: return
+            if (records.isEmpty()) {
+                return
+            }
+
+            try {
+                ingestion.storage.add(records, ingestion.namespace)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.error(e) { "Failed to ingest ${records.size} memory records." }
+            }
+        }
+
+        /**
+         * Returns an augmented prompt only if there are relevant memory records for the last user's message.
+         */
+        private suspend fun getAugmentedPromptOrNull(
+            prompt: Prompt,
+            retrieval: RetrievalSettings,
+        ): Prompt? {
+            // TODO: the input for retrieval (last user message or custom) must be configurable via QueryExtractor.
+            val lastUserMessage = prompt.messages.lastOrNull { it.role == Message.Role.User } ?: return null
+
+            val searchStrategy = retrieval.searchStrategy ?: return null
+            val searchResults = try {
+                val request = searchStrategy.create(lastUserMessage.content)
+                retrieval.storage.search(request, retrieval.namespace)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.error(e) { "Failed to search memory records for $searchStrategy." }
+                emptyList()
+            }
+            if (searchResults.isEmpty()) {
+                return null
+            }
+
+            return retrieval.promptAugmenter.augment(
+                originalPrompt = prompt,
+                relevantContext = searchResults
+            )
+        }
+
+        override fun install(
+            config: Config,
+            pipeline: AIAgentGraphPipeline,
+        ): LongTermMemory = createFeature(config, pipeline)
+
+        override fun install(
+            config: Config,
+            pipeline: AIAgentFunctionalPipeline,
+        ): LongTermMemory = createFeature(config, pipeline)
+
+        override fun install(
+            config: Config,
+            pipeline: AIAgentPlannerPipeline,
+        ): LongTermMemory = createFeature(config, pipeline)
+    }
+
+    /**
+     * Property getter for [RetrievalStorage] for usage inside strategy nodes
+     */
+    public val retrievalStorage: RetrievalStorage?
+        get() = retrievalSettings?.storage
+
+    /**
+     * Property getter for [IngestionStorage] for usage inside strategy nodes
+     */
+    public val ingestionStorage: IngestionStorage?
+        get() = ingestionSettings?.storage
+}
+
+/**
+ * Returns the [LongTermMemory] feature instance installed on this agent.
+ *
+ * @throws IllegalStateException if the [LongTermMemory] feature is not installed.
+ * @see withLongTermMemory
+ */
+@OptIn(ExperimentalAgentsApi::class)
+public fun AIAgentContext.longTermMemory(): LongTermMemory = featureOrThrow(LongTermMemory)
+
+/**
+ * Executes the given [action] in the context of the [LongTermMemory] feature installed on this agent.
+ *
+ * This is the primary way to access long-term memory storages from within strategy nodes.
+ * Inside the [action] block, you can use [LongTermMemory.retrievalSettings] and
+ * [LongTermMemory.ingestionSettings] to search and add memory records.
+ *
+ * Example usage:
+ * ```kotlin
+ * val myNode by node<String, Unit> {
+ *     withLongTermMemory {
+ *         this.getIngestionStorage()?.add(records, namespace)
+ *         val results = this.getRetrievalStorage()?.search(request, namespace)
+ *     }
+ * }
+ * ```
+ *
+ * @param action the block to execute with [LongTermMemory] as the receiver.
+ * @return the result of the [action] block.
+ * @throws IllegalStateException if the [LongTermMemory] feature is not installed.
+ * @see longTermMemory
+ */
+@OptIn(ExperimentalAgentsApi::class)
+public suspend fun <T> AIAgentContext.withLongTermMemory(action: suspend LongTermMemory.() -> T): T =
+    longTermMemory().action()

--- a/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/ingestion/IngestionSettings.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/ingestion/IngestionSettings.kt
@@ -1,0 +1,23 @@
+package ai.koog.agents.longtermmemory.ingestion
+
+import ai.koog.agents.core.annotation.ExperimentalAgentsApi
+import ai.koog.agents.longtermmemory.ingestion.extraction.MemoryRecordExtractor
+
+/**
+ * Settings controlling how messages are persisted (ingested) into the memory repository.
+ *
+ * @param storage The ingestion storage where memory records will be persisted.
+ * @param memoryRecordExtractor The extractor that defines how to transform messages into memory records.
+ *   Pre-built ingesters are available:
+ *   - [ai.koog.agents.longtermmemory.ingestion.extraction.FilteringMemoryRecordExtractor] - Filters messages by role
+ *   Custom ingesters can be provided as lambdas via the [ai.koog.agents.longtermmemory.ingestion.extraction.MemoryRecordExtractor] SAM interface.
+ * @param timing When to mapMessages messages. Defaults to [IngestionTiming.ON_LLM_CALL].
+ * @param namespace Namespace (table/collection name) for a request
+ */
+@ExperimentalAgentsApi
+public data class IngestionSettings(
+    val storage: IngestionStorage,
+    val memoryRecordExtractor: MemoryRecordExtractor? = null,
+    val timing: IngestionTiming = IngestionTiming.ON_LLM_CALL,
+    val namespace: String? = null
+)

--- a/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/ingestion/IngestionStorage.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/ingestion/IngestionStorage.kt
@@ -1,0 +1,23 @@
+package ai.koog.agents.longtermmemory.ingestion
+
+import ai.koog.agents.longtermmemory.model.MemoryRecord
+
+/**
+ * An interface for ingesting (adding) memory records into a store.
+ *
+ * All methods accept an optional `namespace` parameter that can override the default
+ * namespace (table name or collection name) configured in the constructor.
+ * When `namespace` is `null`, the implementation uses its default namespace.
+ */
+public fun interface IngestionStorage {
+
+    /**
+     * Adds memory records to the store.
+     * If a record with the same ID exists, behavior depends on implementation (insert or upsert).
+     *
+     * @param records The records to add
+     * @param namespace Optional namespace (table/collection name) to override the default.
+     *                  If null, uses the default namespace from constructor.
+     */
+    public suspend fun add(records: List<MemoryRecord>, namespace: String?)
+}

--- a/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/ingestion/IngestionTiming.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/ingestion/IngestionTiming.kt
@@ -1,0 +1,21 @@
+package ai.koog.agents.longtermmemory.ingestion
+
+import ai.koog.agents.core.annotation.ExperimentalAgentsApi
+
+/**
+ * Defines when messages should be extracted and ingested into the memory repository.
+ */
+@ExperimentalAgentsApi
+public enum class IngestionTiming {
+    /**
+     * Ingest each message as soon as the LLM call completes.
+     * Enables intra-session RAG and provides crash resilience.
+     */
+    ON_LLM_CALL,
+
+    /**
+     * Ingest all messages at once when the agent run completes.
+     * Enables holistic extraction/summarization and avoids critical-path latency.
+     */
+    ON_AGENT_COMPLETION,
+}

--- a/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/ingestion/extraction/FilteringMemoryRecordExtractor.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/ingestion/extraction/FilteringMemoryRecordExtractor.kt
@@ -1,0 +1,89 @@
+package ai.koog.agents.longtermmemory.ingestion.extraction
+
+import ai.koog.agents.longtermmemory.model.MemoryRecord
+import ai.koog.prompt.message.Message
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * Default extractor that filters messages by role.
+ *
+ * This extractor filters messages to only include those with roles in
+ * [messageRolesToExtract], then converts each message's content into [MemoryRecord]s.
+ *
+ * When [lastMessageOnly] is `true`, only the last message for each role in [messageRolesToExtract]
+ * is extracted. This is useful with [ai.koog.agents.longtermmemory.ingestion.IngestionTiming.ON_LLM_CALL] to avoid re-ingesting
+ * messages that were already stored in previous calls.
+ *
+ * @property messageRolesToExtract The set of message roles to extract and persist.
+ *   Defaults to `setOf(Message.Role.User, Message.Role.Assistant)`.
+ * @property lastMessageOnly When `true`, only the last message for each matching role is extracted.
+ *   Defaults to `false`.
+ */
+public class FilteringMemoryRecordExtractor(
+    public val messageRolesToExtract: Set<Message.Role> = setOf(Message.Role.User, Message.Role.Assistant),
+    public val lastMessageOnly: Boolean = false,
+) : MemoryRecordExtractor {
+
+    private val messageRoleFieldNameInMetadata = "messageRole"
+
+    /**
+     * Builder for [FilteringMemoryRecordExtractor].
+     *
+     * Provides a fluent API for constructing a [FilteringMemoryRecordExtractor],
+     * which is convenient for Java users.
+     *
+     * Example usage (Java):
+     * ```java
+     * new FilteringMemoryRecordExtractor.Builder()
+     *     .withExtractRoles(new HashSet<>(Arrays.asList(Message.Role.User, Message.Role.Assistant)))
+     *     .withLastMessageOnly(true)
+     *     .build()
+     * ```
+     */
+    public class Builder {
+        /**
+         * The set of message roles to extract. Defaults to User and Assistant.
+         */
+        public var extractRoles: Set<Message.Role> = setOf(Message.Role.User, Message.Role.Assistant)
+
+        /**
+         * When true, only the last message for each matching role is extracted.
+         * Defaults to false.
+         */
+        public var lastMessageOnly: Boolean = false
+
+        /** Fluent setter for [extractRoles]. */
+        public fun withExtractRoles(roles: Set<Message.Role>): Builder =
+            apply { this.extractRoles = roles }
+
+        /** Fluent setter for [lastMessageOnly]. */
+        public fun withLastMessageOnly(lastMessageOnly: Boolean): Builder =
+            apply { this.lastMessageOnly = lastMessageOnly }
+
+        /** Builds a [FilteringMemoryRecordExtractor] from the current settings. */
+        public fun build(): FilteringMemoryRecordExtractor =
+            FilteringMemoryRecordExtractor(extractRoles, lastMessageOnly)
+    }
+
+    override suspend fun extract(messages: List<Message>): List<MemoryRecord> {
+        val filtered: List<Message> = if (lastMessageOnly) {
+            messageRolesToExtract.mapNotNull { role ->
+                messages.lastOrNull { it.role == role }
+            }
+        } else {
+            messages.filter { it.role in messageRolesToExtract }
+        }
+        return filtered.map { messageToMemoryRecord(it) }
+    }
+
+    private fun messageToMemoryRecord(message: Message): MemoryRecord = MemoryRecord(
+        content = message.content,
+        metadata = JsonObject(
+            mapOf(
+                messageRoleFieldNameInMetadata to JsonPrimitive(message.role.name),
+            )
+        ),
+        timestamp = message.metaInfo.timestamp
+    )
+}

--- a/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/ingestion/extraction/MemoryRecordExtractor.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/ingestion/extraction/MemoryRecordExtractor.kt
@@ -1,0 +1,86 @@
+package ai.koog.agents.longtermmemory.ingestion.extraction
+
+import ai.koog.agents.longtermmemory.model.MemoryRecord
+import ai.koog.prompt.message.Message
+
+/**
+ * Extractor of memory records during message ingestion.
+ *
+ * This is a functional interface (SAM) that defines how a list of messages
+ * should be transformed into a list of [MemoryRecord]s for storage.
+ * It provides flexibility in how messages are filtered, transformed, and
+ * converted into memory records while maintaining type safety.
+ *
+ * Pre-built implementations are available for common ingestion patterns:
+ * - [FilteringMemoryRecordExtractor] - Filters messages by role
+ *
+ * ### Usage Examples
+ *
+ * **Using pre-built extractors (Kotlin):**
+ * ```kotlin
+ * // Extract User and Assistant messages (default)
+ * val extractor = FilteringMemoryRecordExtractor()
+ *
+ * // Extract only User messages
+ * val extractor = FilteringMemoryRecordExtractor(
+ *     messageRolesToExtract = setOf(Message.Role.User)
+ * )
+ * ```
+ *
+ * **Custom implementation as lambda (Kotlin):**
+ * ```kotlin
+ * val customExtractor = MemoryRecordExtractor { messages ->
+ *     messages
+ *         .filter { it.role == Message.Role.Assistant }
+ *         .extract { MemoryRecord.Plain(content = summarize(it.content)) }
+ * }
+ * ```
+ *
+ * **Custom implementation as lambda (Java):**
+ * ```java
+ * MemoryRecordExtractor customExtractor = (messages) ->
+ *     messages.stream()
+ *         .filter(m -> m.getRole() == Message.Role.Assistant)
+ *         .extract(m -> new MemoryRecord.Plain(m.getContent()))
+ *         .collect(Collectors.toList());
+ * ```
+ */
+public fun interface MemoryRecordExtractor {
+    /**
+     * Transforms a list of messages into a list of memory records for storage.
+     *
+     * @param messages The messages to transform into memory records
+     * @return List of memory records to be stored
+     */
+    public suspend fun extract(messages: List<Message>): List<MemoryRecord>
+
+    /**
+     * Companion object with a builder method.
+     */
+    public companion object {
+        /**
+         * Returns a builder that lets you choose a default [MemoryRecordExtractor] implementation.
+         *
+         * Example usage (Java):
+         * ```java
+         * MemoryRecordExtractor.builder()
+         *     .filtering()
+         *     .withExtractRoles(new HashSet<>(Arrays.asList(Message.Role.User, Message.Role.Assistant)))
+         *     .build()
+         * ```
+         */
+        @kotlin.jvm.JvmStatic
+        public fun builder(): MemoryRecordExtractorBuilder = MemoryRecordExtractorBuilder()
+    }
+}
+
+/**
+ * Intermediate builder that lets callers select a [MemoryRecordExtractor] implementation.
+ */
+public class MemoryRecordExtractorBuilder {
+    /**
+     * Select the [FilteringMemoryRecordExtractor] implementation.
+     * Returns its [FilteringMemoryRecordExtractor.Builder] for further configuration.
+     */
+    public fun filtering(): FilteringMemoryRecordExtractor.Builder = FilteringMemoryRecordExtractor.Builder()
+}

--- a/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/model/MemoryRecord.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/model/MemoryRecord.kt
@@ -1,0 +1,35 @@
+package ai.koog.agents.longtermmemory.model
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+import kotlin.time.Instant
+
+/**
+ * Represents a memory record that can be stored in a vector database.
+ *
+ * @property content The main textual content to be embedded and searched
+ * @property id Unique identifier for the record
+ * @property metadata Flexible key-value metadata for filtering and custom fields
+ */
+@Serializable
+public data class MemoryRecord(
+    /**
+     * The main textual content to be embedded and searched
+     */
+    val content: String,
+
+    /**
+     * Unique identifier for the record
+     */
+    val id: String? = null,
+
+    /**
+     * Flexible key-value metadata for filtering and custom fields
+     */
+    val metadata: JsonObject? = null,
+
+    /**
+     * Timestamp indicating when the memory record was created
+     */
+    val timestamp: Instant? = null,
+)

--- a/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/RetrievalSettings.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/RetrievalSettings.kt
@@ -1,0 +1,21 @@
+package ai.koog.agents.longtermmemory.retrieval
+
+import ai.koog.agents.core.annotation.ExperimentalAgentsApi
+import ai.koog.agents.longtermmemory.retrieval.augmentation.PromptAugmenter
+import ai.koog.agents.longtermmemory.retrieval.augmentation.SystemPromptAugmenter
+
+/**
+ * Settings controlling how memory records are retrieved and injected into prompts (RAG).
+ *
+ * @param storage The retrieval storage to search for relevant memory records.
+ * @param searchStrategy The strategy that defines how to search the retrieval store.
+ * @param promptAugmenter The augmenter that defines how retrieved context is inserted into the prompt.
+ * @param namespace Namespace (table/collection name) for a request.
+ */
+@ExperimentalAgentsApi
+public data class RetrievalSettings(
+    val storage: RetrievalStorage,
+    val searchStrategy: SearchStrategy? = null,
+    val promptAugmenter: PromptAugmenter = SystemPromptAugmenter(),
+    val namespace: String? = null
+)

--- a/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/RetrievalStorage.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/RetrievalStorage.kt
@@ -1,0 +1,96 @@
+package ai.koog.agents.longtermmemory.retrieval
+
+import ai.koog.agents.longtermmemory.model.MemoryRecord
+import kotlinx.serialization.Serializable
+
+/**
+ * An interface for retrieving (searching) memory records from a storage.
+ * An implementation of this interface is responsible for embedding.
+ *
+ * All methods accept an optional `namespace` parameter that can override the default
+ * namespace (table name or collection name) configured in the constructor.
+ * When `namespace` is `null`, the implementation uses its default namespace.
+ */
+public fun interface RetrievalStorage {
+
+    /**
+     * Performs a search and returns results with similarity scores.
+     *
+     * @param request The search request with all parameters
+     * @param namespace Optional namespace (table/collection name) to override the default.
+     *                  If null, uses the default namespace from constructor.
+     * @return List of scored records, sorted by similarity (highest first)
+     */
+    public suspend fun search(request: SearchRequest, namespace: String?): List<SearchResult>
+}
+
+/**
+ * Base interface for search requests.
+ *
+ * @property limit Maximum number of results to return (topK)
+ * @property similarityThreshold Minimum similarity score for results (0.0 to 1.0)
+ * @property filterExpression Metadata filter expression for pre-filtering
+ */
+public interface SearchRequest {
+    /**
+     * Maximum number of results to return (topK)
+     */
+    public val limit: Int
+
+    /**
+     * Minimum similarity score for results (0.0 to 1.0)
+     */
+    public val similarityThreshold: Double
+
+    /**
+     * Metadata filter expression for pre-filtering
+     */
+    public val filterExpression: String? // TODO: it's unsafe and not portable; add FilterExpressionDsl in the next PR
+}
+
+/**
+ * Search request for pure vector similarity search using text query.
+ * The text will be embedded and used for vector similarity search.
+ *
+ * @property query Text query to be embedded and searched
+ * @property limit Maximum number of results to return (topK)
+ * @property similarityThreshold Minimum similarity score for results (0.0 to 1.0)
+ * @property filterExpression Metadata filter expression for pre-filtering
+ */
+@Serializable
+public data class SimilaritySearchRequest(
+    val query: String,
+    override val limit: Int = 10,
+    override val similarityThreshold: Double = 0.0,
+    override val filterExpression: String? = null
+) : SearchRequest
+
+/**
+ * Search request for keyword/full-text search.
+ * Uses traditional text matching instead of vector similarity.
+ *
+ * @property query Text query for keyword matching
+ * @property limit Maximum number of results to return (topK)
+ * @property similarityThreshold Minimum similarity score for results (0.0 to 1.0)
+ * @property filterExpression Metadata filter expression for pre-filtering
+ */
+@Serializable
+public data class KeywordSearchRequest(
+    val query: String,
+    override val limit: Int = 10,
+    override val similarityThreshold: Double = 0.0,
+    override val filterExpression: String? = null
+) : SearchRequest
+// TODO: add HybridSearchRequest
+
+/**
+ * Represents a result of a [SearchRequest].
+ *
+ * @property record The actual record data
+ * @property similarity The similarity/relevance score (0.0 to 1.0, higher is more relevant)
+ */
+@Serializable
+public data class SearchResult(
+    val record: MemoryRecord,
+    val similarity: Double
+)

--- a/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/SearchStrategy.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/SearchStrategy.kt
@@ -1,0 +1,174 @@
+package ai.koog.agents.longtermmemory.retrieval
+
+/**
+ * Search strategy for creating search requests during prompt augmentation.
+ *
+ * This is a functional interface (SAM) that defines how a user query string
+ * should be transformed into a [SearchRequest] for storage.
+ *
+ * Pre-built implementations are available for common search types:
+ * - [SimilaritySearchStrategy] - Vector similarity search (semantic search)
+ * - [KeywordSearchStrategy] - Full-text/keyword search
+ *
+ * ### Usage Examples
+ *
+ * **Using pre-built strategies (Kotlin):**
+ * ```kotlin
+ * retrieval {
+ *     searchStrategy = SimilaritySearchStrategy(topK = 5, similarityThreshold = 0.7)
+ * }
+ * ```
+ *
+ * **Custom implementation as lambda (Java):
+ * ```java
+ * SearchStrategy customStrategy = (query) ->
+ *     new SimilaritySearchRequest(query, 5, 0.8, null);
+ * ```
+ */
+public fun interface SearchStrategy {
+    /**
+     * Maps a query string into a [SearchRequest] for the storage.
+     *
+     * @param query The user's query string (typically the last user message content)
+     * @return The search request to be executed
+     */
+    public fun create(query: String): SearchRequest
+
+    /**
+     * Companion object with a builder method.
+     */
+    public companion object {
+        /**
+         * Returns a builder that lets you choose a default [SearchStrategy] implementation.
+         *
+         * Example usage (Java):
+         * ```java
+         * SearchStrategy.builder()
+         *     .similarity()
+         *     .withTopK(5)
+         *     .withSimilarityThreshold(0.7)
+         *     .build()
+         * ```
+         */
+        @kotlin.jvm.JvmStatic
+        public fun builder(): SearchStrategyBuilder = SearchStrategyBuilder()
+    }
+}
+
+/**
+ * Intermediate builder that lets callers select a [SearchStrategy] implementation.
+ */
+public class SearchStrategyBuilder {
+    /**
+     * Select the [SimilaritySearchStrategy] implementation.
+     * Returns its [SimilaritySearchStrategy.Builder] for further configuration.
+     */
+    public fun similarity(): SimilaritySearchStrategy.Builder = SimilaritySearchStrategy.Builder()
+
+    /**
+     * Select the [KeywordSearchStrategy] implementation.
+     * Returns its [KeywordSearchStrategy.Builder] for further configuration.
+     */
+    public fun keyword(): KeywordSearchStrategy.Builder = KeywordSearchStrategy.Builder()
+}
+
+/**
+ * Keyword search mode using full-text/lexical matching.
+ *
+ * This mode uses traditional text matching instead of vector similarity,
+ * which can be useful for exact term matching or when semantic search
+ * is not needed.
+ *
+ * @property topK Maximum number of results to return
+ * @property similarityThreshold Minimum similarity score (0.0 to 1.0)
+ * @property filterExpression Optional metadata filter expression for pre-filtering
+ */
+public class KeywordSearchStrategy(
+    public val topK: Int = 10,
+    public val similarityThreshold: Double = 0.0,
+    public val filterExpression: String? = null
+) : SearchStrategy {
+    override fun create(query: String): SearchRequest =
+        KeywordSearchRequest(query, topK, similarityThreshold, filterExpression)
+
+    /**
+     * Builder for [KeywordSearchStrategy].
+     *
+     * @see KeywordSearchStrategy
+     */
+    public class Builder {
+        /** Maximum number of results to return. */
+        public var topK: Int = 10
+
+        /** Minimum similarity score (0.0 to 1.0). */
+        public var similarityThreshold: Double = 0.0
+
+        /** Optional metadata filter expression for pre-filtering. */
+        public var filterExpression: String? = null
+
+        /** Fluent setter for [topK]. */
+        public fun withTopK(topK: Int): Builder = apply { this.topK = topK }
+
+        /** Fluent setter for [similarityThreshold]. */
+        public fun withSimilarityThreshold(similarityThreshold: Double): Builder =
+            apply { this.similarityThreshold = similarityThreshold }
+
+        /** Fluent setter for [filterExpression]. */
+        public fun withFilterExpression(filterExpression: String?): Builder =
+            apply { this.filterExpression = filterExpression }
+
+        /** Builds a [KeywordSearchStrategy] from the current settings. */
+        public fun build(): KeywordSearchStrategy =
+            KeywordSearchStrategy(topK, similarityThreshold, filterExpression)
+    }
+}
+
+/**
+ * Similarity search mode using vector embeddings for semantic search.
+ *
+ * This mode converts the query to a vector embedding and finds records
+ * with similar embeddings in the vector database.
+ *
+ * @property topK Maximum number of results to return
+ * @property similarityThreshold Minimum similarity score (0.0 to 1.0)
+ * @property filterExpression Optional metadata filter expression for pre-filtering
+ */
+public class SimilaritySearchStrategy(
+    public val topK: Int = 10,
+    public val similarityThreshold: Double = 0.0,
+    public val filterExpression: String? = null
+) : SearchStrategy {
+    override fun create(query: String): SearchRequest =
+        SimilaritySearchRequest(query, topK, similarityThreshold, filterExpression)
+
+    /**
+     * Builder for [SimilaritySearchStrategy].
+     *
+     * @see SimilaritySearchStrategy
+     */
+    public class Builder {
+        /** Maximum number of results to return. */
+        public var topK: Int = 10
+
+        /** Minimum similarity score (0.0 to 1.0). */
+        public var similarityThreshold: Double = 0.0
+
+        /** Optional metadata filter expression for pre-filtering. */
+        public var filterExpression: String? = null
+
+        /** Fluent setter for [topK]. */
+        public fun withTopK(topK: Int): Builder = apply { this.topK = topK }
+
+        /** Fluent setter for [similarityThreshold]. */
+        public fun withSimilarityThreshold(similarityThreshold: Double): Builder =
+            apply { this.similarityThreshold = similarityThreshold }
+
+        /** Fluent setter for [filterExpression]. */
+        public fun withFilterExpression(filterExpression: String?): Builder =
+            apply { this.filterExpression = filterExpression }
+
+        /** Builds a [SimilaritySearchStrategy] from the current settings. */
+        public fun build(): SimilaritySearchStrategy =
+            SimilaritySearchStrategy(topK, similarityThreshold, filterExpression)
+    }
+}

--- a/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/augmentation/PromptAugmenter.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/augmentation/PromptAugmenter.kt
@@ -1,0 +1,103 @@
+package ai.koog.agents.longtermmemory.retrieval.augmentation
+
+import ai.koog.agents.longtermmemory.retrieval.SearchResult
+import ai.koog.prompt.dsl.Prompt
+
+/**
+ * Interface for augmenting prompts with relevant context retrieved from memory.
+ *
+ * Implementations define how retrieved context is inserted into the prompt.
+ * Two built-in implementations are provided:
+ * - [SystemPromptAugmenter] — inserts context as a system message
+ * - [UserPromptAugmenter] — inserts context as a user message
+ *
+ * Can also be implemented as a lambda thanks to the `fun interface` declaration:
+ * ```kotlin
+ * val custom = PromptAugmenter { prompt, context ->
+ *     // custom augmentation logic
+ *     prompt
+ * }
+ * ```
+ *
+ * @see SystemPromptAugmenter
+ * @see UserPromptAugmenter
+ * @see ai.koog.agents.longtermmemory.feature.LongTermMemory
+ */
+public fun interface PromptAugmenter {
+
+    /**
+     * Augments the given prompt with relevant context.
+     *
+     * @param originalPrompt The original prompt to augment.
+     * @param relevantContext The list of search results containing relevant context.
+     * @return A new [Prompt] with the context inserted, or the original prompt if no augmentation is needed.
+     */
+    public fun augment(originalPrompt: Prompt, relevantContext: List<SearchResult>): Prompt
+
+    /**
+     * Companion object with constants, static methods, and builder entry point.
+     */
+    public companion object {
+        /**
+         * Returns a builder that lets you choose a default [PromptAugmenter] implementation.
+         *
+         * Example usage (Java):
+         * ```java
+         * PromptAugmenter.builder()
+         *     .system()
+         *     .withTemplate("Use this context: {relevant_context}")
+         *     .build()
+         * ```
+         */
+        @kotlin.jvm.JvmStatic
+        public fun builder(): PromptAugmenterBuilder = PromptAugmenterBuilder()
+
+        /**
+         * Placeholder in prompt templates for insertion of relevant context.
+         */
+        public const val RELEVANT_CONTEXT_PLACEHOLDER: String = "{relevant_context}"
+
+        /**
+         * The prefix to add before relevant context.
+         */
+        public const val DEFAULT_CONTEXT_PREFIX: String = "Relevant information:\n"
+
+        /**
+         * Formats a list of search results into a numbered text block with the given prefix.
+         */
+        public fun formatContext(
+            relevantContext: List<SearchResult>,
+            contextPrefix: String = DEFAULT_CONTEXT_PREFIX
+        ): String {
+            return contextPrefix + relevantContext.mapIndexed { index, result ->
+                "[${index + 1}] ${result.record.content}"
+            }.joinToString("\n\n")
+        }
+
+        /**
+         * Formats the template by replacing placeholders with actual content.
+         */
+        public fun formatTemplate(template: String, relevantContextText: String): String {
+            return template
+                .replace(RELEVANT_CONTEXT_PLACEHOLDER, relevantContextText)
+                .trim()
+        }
+    }
+}
+
+/**
+ * Intermediate builder that lets callers select a [PromptAugmenter] implementation.
+ */
+public class PromptAugmenterBuilder {
+    /**
+     * Select the [SystemPromptAugmenter] implementation.
+     * Returns its [SystemPromptAugmenter.Builder] for further configuration.
+     */
+    public fun system(): SystemPromptAugmenter.Builder = SystemPromptAugmenter.Builder()
+
+    /**
+     * Select the [UserPromptAugmenter] implementation.
+     * Returns its [UserPromptAugmenter.Builder] for further configuration.
+     */
+    public fun user(): UserPromptAugmenter.Builder = UserPromptAugmenter.Builder()
+}

--- a/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/augmentation/SystemPromptAugmenter.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/augmentation/SystemPromptAugmenter.kt
@@ -1,0 +1,87 @@
+package ai.koog.agents.longtermmemory.retrieval.augmentation
+
+import ai.koog.agents.longtermmemory.retrieval.SearchResult
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.RequestMetaInfo
+
+/**
+ * A [PromptAugmenter] that inserts retrieved context as a system message at the beginning of the prompt.
+ *
+ * If an existing system message is present, the new context system message is inserted
+ * before it, keeping each system message focused on a single concern.
+ * If there is no system message in the prompt, the prompt is returned unchanged.
+ *
+ * @param template The template for the system message. Use [PromptAugmenter.RELEVANT_CONTEXT_PLACEHOLDER] placeholder.
+ * @param contextPrefix The prefix to add before relevant context.
+ * @see PromptAugmenter
+ */
+public class SystemPromptAugmenter(
+    private val template: String = DEFAULT_SYSTEM_PROMPT_TEMPLATE,
+    private val contextPrefix: String = PromptAugmenter.DEFAULT_CONTEXT_PREFIX
+) : PromptAugmenter {
+
+    /**
+     * Companion object with default templates.
+     */
+    public companion object {
+        /**
+         * Default template for the system message.
+         * Use [PromptAugmenter.RELEVANT_CONTEXT_PLACEHOLDER] placeholder.
+         */
+        public val DEFAULT_SYSTEM_PROMPT_TEMPLATE: String =
+            """
+            |Use the following information to answer the user's question.
+            |
+            |${PromptAugmenter.RELEVANT_CONTEXT_PLACEHOLDER}
+            |
+            |Answer the user's question based on the above context. If the context doesn't contain relevant information, say so.
+            """.trimMargin().trim()
+    }
+
+    /**
+     * Builder for [SystemPromptAugmenter].
+     *
+     * Provides a fluent API for constructing a [SystemPromptAugmenter],
+     * which is convenient for Java users.
+     *
+     * Example usage (Java):
+     * ```java
+     * new SystemPromptAugmenter.Builder()
+     *     .withTemplate("Use this context: {relevant_context}")
+     *     .build()
+     * ```
+     */
+    public class Builder {
+        /** The template for the system message. */
+        public var template: String = DEFAULT_SYSTEM_PROMPT_TEMPLATE
+
+        /** The prefix to add before relevant context. */
+        public var contextPrefix: String = PromptAugmenter.DEFAULT_CONTEXT_PREFIX
+
+        /** Fluent setter for [template]. */
+        public fun withTemplate(template: String): Builder =
+            apply { this.template = template }
+
+        /** Fluent setter for [contextPrefix]. */
+        public fun withContextPrefix(contextPrefix: String): Builder =
+            apply { this.contextPrefix = contextPrefix }
+
+        /** Builds a [SystemPromptAugmenter] from the current settings. */
+        public fun build(): SystemPromptAugmenter = SystemPromptAugmenter(template, contextPrefix)
+    }
+
+    override fun augment(originalPrompt: Prompt, relevantContext: List<SearchResult>): Prompt {
+        if (relevantContext.isEmpty()) return originalPrompt
+        if (originalPrompt.messages.none { it is Message.System }) return originalPrompt
+
+        val relevantContextText = PromptAugmenter.formatContext(relevantContext, contextPrefix)
+        val contextMessage = PromptAugmenter.formatTemplate(template, relevantContextText)
+        if (contextMessage.isBlank()) return originalPrompt
+
+        return originalPrompt.withMessages { messages ->
+            val systemMessage = Message.System(contextMessage, RequestMetaInfo.Empty)
+            listOf<Message>(systemMessage) + messages
+        }
+    }
+}

--- a/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/augmentation/UserPromptAugmenter.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/augmentation/UserPromptAugmenter.kt
@@ -1,0 +1,91 @@
+package ai.koog.agents.longtermmemory.retrieval.augmentation
+
+import ai.koog.agents.longtermmemory.retrieval.SearchResult
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.RequestMetaInfo
+
+/**
+ * A [PromptAugmenter] that inserts retrieved context as a user message before the last user message.
+ *
+ * If the prompt contains no user messages, the original prompt is returned unchanged.
+ *
+ * @param template The template for user context insertion. Use [PromptAugmenter.RELEVANT_CONTEXT_PLACEHOLDER] placeholder.
+ * @param contextPrefix The prefix to add before relevant context.
+ * @see PromptAugmenter
+ */
+public class UserPromptAugmenter(
+    private val template: String = DEFAULT_USER_PROMPT_TEMPLATE,
+    private val contextPrefix: String = PromptAugmenter.DEFAULT_CONTEXT_PREFIX
+) : PromptAugmenter {
+
+    /**
+     * Companion object with default templates.
+     */
+    public companion object {
+        /**
+         * Default template for user context insertion.
+         * Use [PromptAugmenter.RELEVANT_CONTEXT_PLACEHOLDER] placeholder.
+         */
+        public val DEFAULT_USER_PROMPT_TEMPLATE: String =
+            """
+            |Here is some relevant context:
+            |
+            |${PromptAugmenter.RELEVANT_CONTEXT_PLACEHOLDER}
+            |
+            |Based on the above context, please answer the following question:
+            """.trimMargin().trim()
+    }
+
+    /**
+     * Builder for [UserPromptAugmenter].
+     *
+     * Provides a fluent API for constructing a [UserPromptAugmenter],
+     * which is convenient for Java users.
+     *
+     * Example usage (Java):
+     * ```java
+     * new UserPromptAugmenter.Builder()
+     *     .withTemplate("Context: {relevant_context}")
+     *     .build()
+     * ```
+     */
+    public class Builder {
+        /** The template for user context insertion. */
+        public var template: String = DEFAULT_USER_PROMPT_TEMPLATE
+
+        /** The prefix to add before relevant context. */
+        public var contextPrefix: String = PromptAugmenter.DEFAULT_CONTEXT_PREFIX
+
+        /** Fluent setter for [template]. */
+        public fun withTemplate(template: String): Builder =
+            apply { this.template = template }
+
+        /** Fluent setter for [contextPrefix]. */
+        public fun withContextPrefix(contextPrefix: String): Builder =
+            apply { this.contextPrefix = contextPrefix }
+
+        /** Builds a [UserPromptAugmenter] from the current settings. */
+        public fun build(): UserPromptAugmenter = UserPromptAugmenter(template, contextPrefix)
+    }
+
+    override fun augment(originalPrompt: Prompt, relevantContext: List<SearchResult>): Prompt {
+        if (relevantContext.isEmpty()) return originalPrompt
+        if (originalPrompt.messages.none { it is Message.User }) return originalPrompt
+
+        val relevantContextText = PromptAugmenter.formatContext(relevantContext, contextPrefix)
+        val formattedContext = PromptAugmenter.formatTemplate(template, relevantContextText)
+        if (formattedContext.isBlank()) return originalPrompt
+
+        return originalPrompt.withMessages { messages ->
+            val lastUserIndex = messages.indexOfLast { it is Message.User }
+            if (lastUserIndex >= 0) {
+                messages.toMutableList().apply {
+                    add(lastUserIndex, Message.User(formattedContext, RequestMetaInfo.Empty))
+                }
+            } else {
+                messages
+            }
+        }
+    }
+}

--- a/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/storage/InMemoryRecordStorage.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/storage/InMemoryRecordStorage.kt
@@ -1,0 +1,92 @@
+package ai.koog.agents.longtermmemory.storage
+
+import ai.koog.agents.longtermmemory.ingestion.IngestionStorage
+import ai.koog.agents.longtermmemory.model.MemoryRecord
+import ai.koog.agents.longtermmemory.retrieval.KeywordSearchRequest
+import ai.koog.agents.longtermmemory.retrieval.RetrievalStorage
+import ai.koog.agents.longtermmemory.retrieval.SearchRequest
+import ai.koog.agents.longtermmemory.retrieval.SearchResult
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * In-memory implementation of [ai.koog.agents.longtermmemory.retrieval.RetrievalStorage]
+ * and [ai.koog.agents.longtermmemory.ingestion.IngestionStorage] that stores records in a map.
+ *
+ * This implementation is useful for testing, development, and scenarios where persistence
+ * is not required. All data is stored in memory and will be lost when the application stops.
+ *
+ * ## Limitations:
+ * - Data is not persisted and will be lost on application restart
+ * - Supports only keyword search using simple substring matching
+ * - Filter expressions are not supported
+ *
+ * @param defaultNamespace The default namespace to use when none is specified in method calls.
+ *                         Defaults to "default".
+ */
+public open class InMemoryRecordStorage(
+    private val defaultNamespace: String = "default"
+) : RetrievalStorage, IngestionStorage {
+
+    private val mutex = Mutex()
+    private val namespaceRecords = mutableMapOf<String, MutableMap<String, MemoryRecord>>()
+
+    private fun getRecordsForNamespace(namespace: String? = null): MutableMap<String, MemoryRecord> {
+        val ns = namespace ?: defaultNamespace
+        return namespaceRecords.getOrPut(ns) { mutableMapOf() }
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    override suspend fun add(records: List<MemoryRecord>, namespace: String?) {
+        mutex.withLock {
+            val nsRecords = getRecordsForNamespace(namespace)
+            for (record in records) {
+                val recordId = record.id ?: Uuid.random().toString()
+                val recordWithId = if (record.id == null) {
+                    record.copy(id = recordId)
+                } else {
+                    record
+                }
+                nsRecords[recordId] = recordWithId
+            }
+        }
+    }
+
+    override suspend fun search(request: SearchRequest, namespace: String?): List<SearchResult> {
+        return when (request) {
+            is KeywordSearchRequest -> searchByText( // TODO: use filterExpression after switching to Filter DSL
+                request.query,
+                request.limit,
+                request.similarityThreshold,
+                namespace
+            )
+
+            else -> throw UnsupportedOperationException("InMemoryRecordStorage supports only KeywordSearchRequest.")
+        }
+    }
+
+    private suspend fun searchByText(
+        query: String,
+        limit: Int,
+        similarityThreshold: Double,
+        namespace: String?
+    ): List<SearchResult> {
+        val allRecords = mutex.withLock { getRecordsForNamespace(namespace).values.toList() }
+        val queryLower = query.lowercase()
+
+        return allRecords
+            .filter { it.content.lowercase().contains(queryLower) }
+            .map { record -> SearchResult(record, 1.0) }
+            .filter { it.similarity >= similarityThreshold }
+            .take(limit)
+    }
+
+    /**
+     * Returns the number of records in the repository for the specified namespace.
+     *
+     * @param namespace Optional namespace to count records for. If null, counts the default namespace.
+     */
+    public suspend fun size(namespace: String? = null): Int = mutex.withLock { getRecordsForNamespace(namespace).size }
+}

--- a/agents/agents-features/agents-features-longterm-memory/src/jvmTest/java/ai/koog/agents/longtermmemory/feature/LongTermMemoryIngestionJavaTest.java
+++ b/agents/agents-features/agents-features-longterm-memory/src/jvmTest/java/ai/koog/agents/longtermmemory/feature/LongTermMemoryIngestionJavaTest.java
@@ -1,0 +1,177 @@
+package ai.koog.agents.longtermmemory.feature;
+
+import ai.koog.agents.core.agent.AIAgent;
+import ai.koog.agents.core.annotation.ExperimentalAgentsApi;
+import ai.koog.agents.core.tools.ToolRegistry;
+import ai.koog.agents.longtermmemory.ingestion.IngestionTiming;
+import ai.koog.agents.longtermmemory.ingestion.extraction.MemoryRecordExtractor;
+import ai.koog.agents.longtermmemory.retrieval.KeywordSearchRequest;
+import ai.koog.agents.longtermmemory.storage.InMemoryRecordStorage;
+import ai.koog.agents.testing.tools.MockExecutor;
+import ai.koog.prompt.executor.clients.openai.OpenAIModels;
+import ai.koog.prompt.message.Message;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Java tests for configuring {@link LongTermMemory} ingestion settings from Java code.
+ * Each test case demonstrates a different ingestion configuration using builders.
+ */
+@ExperimentalAgentsApi
+public class LongTermMemoryIngestionJavaTest {
+
+    private static final ToolRegistry EMPTY_REGISTRY = ToolRegistry.builder().build();
+
+    @Test
+    public void testIngestionWithFilteringExtractorAndOnLlmCallTiming() {
+        InMemoryRecordStorage storage = new InMemoryRecordStorage();
+
+        var agent = AIAgent.builder()
+            .promptExecutor(
+                MockExecutor.builder()
+                    .toolRegistry(EMPTY_REGISTRY)
+                    .mockLLMAnswer("The capital of France is Paris.").asDefaultResponse()
+                    .build()
+            )
+            .llmModel(OpenAIModels.Chat.GPT4o)
+            .systemPrompt("You are a helpful assistant.")
+            .install(LongTermMemory.Feature, config ->
+                config.ingestion(
+                    new LongTermMemory.IngestionSettingsBuilder()
+                        .withStorage(storage)
+                        .withExtractor(
+                            MemoryRecordExtractor.builder()
+                                .filtering()
+                                .withExtractRoles(new HashSet<>(Arrays.asList(Message.Role.User, Message.Role.Assistant)))
+                                .withLastMessageOnly(false)
+                                .build()
+                        )
+                        .withTiming(IngestionTiming.ON_LLM_CALL)
+                        .build()
+                )
+            )
+            .build();
+
+        String result = (String) agent.run("What is the capital of France?");
+
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+    }
+
+    @Test
+    public void testIngestionWithFilteringExtractorAndOnAgentCompletionTiming() {
+        InMemoryRecordStorage storage = new InMemoryRecordStorage();
+
+        var agent = AIAgent.builder()
+            .promptExecutor(
+                MockExecutor.builder()
+                    .toolRegistry(EMPTY_REGISTRY)
+                    .mockLLMAnswer("answer").asDefaultResponse()
+                    .build()
+            )
+            .llmModel(OpenAIModels.Chat.GPT4o)
+            .systemPrompt("You are a helpful assistant.")
+            .install(LongTermMemory.Feature, config ->
+                config.ingestion(
+                    new LongTermMemory.IngestionSettingsBuilder()
+                        .withStorage(storage)
+                        .withExtractor(
+                            MemoryRecordExtractor.builder()
+                                .filtering()
+                                .withExtractRoles(new HashSet<>(Arrays.asList(Message.Role.User, Message.Role.Assistant)))
+                                .build()
+                        )
+                        .withTiming(IngestionTiming.ON_AGENT_COMPLETION)
+                        .build()
+                )
+            )
+            .build();
+
+        String result = (String) agent.run("Hello");
+
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+    }
+
+    @Test
+    public void testIngestionWithLastMessageOnlyExtractor() {
+        InMemoryRecordStorage storage = new InMemoryRecordStorage();
+
+        var agent = AIAgent.builder()
+            .promptExecutor(
+                MockExecutor.builder()
+                    .toolRegistry(EMPTY_REGISTRY)
+                    .mockLLMAnswer("answer").asDefaultResponse()
+                    .build()
+            )
+            .llmModel(OpenAIModels.Chat.GPT4o)
+            .systemPrompt("You are a helpful assistant.")
+            .install(LongTermMemory.Feature, config ->
+                config.ingestion(
+                    new LongTermMemory.IngestionSettingsBuilder()
+                        .withStorage(storage)
+                        .withExtractor(
+                            MemoryRecordExtractor.builder()
+                                .filtering()
+                                .withExtractRoles(new HashSet<>(Arrays.asList(Message.Role.Assistant)))
+                                .withLastMessageOnly(true)
+                                .build()
+                        )
+                        .withTiming(IngestionTiming.ON_LLM_CALL)
+                        .build()
+                )
+            )
+            .build();
+
+        String result = (String) agent.run("Hello");
+
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+    }
+
+    @Test
+    public void testFullConfigurationWithIngestionAndRetrieval() {
+        InMemoryRecordStorage storage = new InMemoryRecordStorage();
+
+        var agent = AIAgent.builder()
+            .promptExecutor(
+                MockExecutor.builder()
+                    .toolRegistry(EMPTY_REGISTRY)
+                    .mockLLMAnswer("full config answer").asDefaultResponse()
+                    .build()
+            )
+            .llmModel(OpenAIModels.Chat.GPT4o)
+            .systemPrompt("You are a helpful assistant.")
+            .install(LongTermMemory.Feature, config -> {
+                config.ingestion(
+                    new LongTermMemory.IngestionSettingsBuilder()
+                        .withStorage(storage)
+                        .withExtractor(
+                            MemoryRecordExtractor.builder()
+                                .filtering()
+                                .withExtractRoles(new HashSet<>(Arrays.asList(Message.Role.User, Message.Role.Assistant)))
+                                .build()
+                        )
+                        .withTiming(IngestionTiming.ON_AGENT_COMPLETION)
+                        .build()
+                );
+                config.retrieval(
+                    new LongTermMemory.RetrievalSettingsBuilder()
+                        .withStorage(storage)
+                        .withSearchStrategy(query ->
+                            new KeywordSearchRequest(query, 15, 0.5, null)
+                        )
+                        .build()
+                );
+            })
+            .build();
+
+        String result = (String) agent.run("Hello");
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+    }
+}

--- a/agents/agents-features/agents-features-longterm-memory/src/jvmTest/java/ai/koog/agents/longtermmemory/feature/LongTermMemoryRetrievalJavaTest.java
+++ b/agents/agents-features/agents-features-longterm-memory/src/jvmTest/java/ai/koog/agents/longtermmemory/feature/LongTermMemoryRetrievalJavaTest.java
@@ -1,0 +1,147 @@
+package ai.koog.agents.longtermmemory.feature;
+
+import ai.koog.agents.core.agent.AIAgent;
+import ai.koog.agents.core.annotation.ExperimentalAgentsApi;
+import ai.koog.agents.core.tools.ToolRegistry;
+import ai.koog.agents.longtermmemory.retrieval.KeywordSearchRequest;
+import ai.koog.agents.longtermmemory.retrieval.RetrievalSettings;
+import ai.koog.agents.longtermmemory.retrieval.SearchStrategy;
+import ai.koog.agents.longtermmemory.retrieval.augmentation.PromptAugmenter;
+import ai.koog.agents.longtermmemory.storage.InMemoryRecordStorage;
+import ai.koog.agents.testing.tools.MockExecutor;
+import ai.koog.prompt.executor.clients.openai.OpenAIModels;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Java tests for configuring {@link LongTermMemory} retrieval settings from Java code.
+ * Each test case demonstrates a different retrieval configuration using builders.
+ */
+@ExperimentalAgentsApi
+public class LongTermMemoryRetrievalJavaTest {
+
+    private static final ToolRegistry EMPTY_REGISTRY = ToolRegistry.builder().build();
+
+    private AIAgent buildAgentWithRetrieval(RetrievalSettings retrievalSettings) {
+        return AIAgent.builder()
+            .promptExecutor(
+                MockExecutor.builder()
+                    .toolRegistry(EMPTY_REGISTRY)
+                    .mockLLMAnswer("answer").asDefaultResponse()
+                    .build()
+            )
+            .llmModel(OpenAIModels.Chat.GPT4o)
+            .systemPrompt("system")
+            .install(LongTermMemory.Feature, config ->
+                config.retrieval(retrievalSettings)
+            )
+            .build();
+    }
+
+    @Test
+    public void testKeywordSearchViaSearchStrategy() {
+        InMemoryRecordStorage storage = new InMemoryRecordStorage();
+
+        var retrievalSettings = new LongTermMemory.RetrievalSettingsBuilder()
+            .withStorage(storage)
+            .withSearchStrategy(SearchStrategy.builder().keyword().withTopK(10).build())
+            .build();
+
+        var agent = buildAgentWithRetrieval(retrievalSettings);
+
+        String result = (String) agent.run("test query");
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+    }
+
+    @Test
+    public void testKeywordSearchViaLambda() {
+        InMemoryRecordStorage storage = new InMemoryRecordStorage();
+
+        var retrievalSettings = new LongTermMemory.RetrievalSettingsBuilder()
+            .withStorage(storage)
+            .withSearchStrategy(query -> new KeywordSearchRequest(query, 20, 0.0, null))
+            .build();
+
+        var agent = buildAgentWithRetrieval(retrievalSettings);
+
+        String result = (String) agent.run("test query");
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+    }
+
+    @Test
+    public void testSimilaritySearchWithSystemPromptAugmenter() {
+        InMemoryRecordStorage storage = new InMemoryRecordStorage();
+
+        var retrievalSettings = new LongTermMemory.RetrievalSettingsBuilder()
+            .withStorage(storage)
+            .withSearchStrategy(
+                SearchStrategy.builder().similarity().withTopK(10).withSimilarityThreshold(0.7).build()
+            )
+            .withPromptAugmenter(PromptAugmenter.builder().system().build())
+            .build();
+
+        var agent = buildAgentWithRetrieval(retrievalSettings);
+
+        String result = (String) agent.run("test query");
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+    }
+
+    @Test
+    public void testKeywordSearchWithUserPromptAugmenter() {
+        InMemoryRecordStorage storage = new InMemoryRecordStorage();
+
+        var retrievalSettings = new LongTermMemory.RetrievalSettingsBuilder()
+            .withStorage(storage)
+            .withSearchStrategy(
+                SearchStrategy.builder().keyword().withTopK(5).withSimilarityThreshold(0.1).build()
+            )
+            .withPromptAugmenter(PromptAugmenter.builder().user().build())
+            .build();
+
+        var agent = buildAgentWithRetrieval(retrievalSettings);
+
+        String result = (String) agent.run("test query");
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+    }
+
+    @Test
+    public void testSimilaritySearchViaSearchStrategy() {
+        InMemoryRecordStorage storage = new InMemoryRecordStorage();
+
+        var retrievalSettings = new LongTermMemory.RetrievalSettingsBuilder()
+            .withStorage(storage)
+            .withSearchStrategy(
+                SearchStrategy.builder().similarity().withTopK(10).withSimilarityThreshold(0.7).build()
+            )
+            .build();
+
+        var agent = buildAgentWithRetrieval(retrievalSettings);
+
+        String result = (String) agent.run("test query");
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+    }
+
+    @Test
+    public void testKeywordSearchViaSearchStrategyWithThreshold() {
+        InMemoryRecordStorage storage = new InMemoryRecordStorage();
+
+        var retrievalSettings = new LongTermMemory.RetrievalSettingsBuilder()
+            .withStorage(storage)
+            .withSearchStrategy(
+                SearchStrategy.builder().keyword().withTopK(5).withSimilarityThreshold(0.1).build()
+            )
+            .build();
+
+        var agent = buildAgentWithRetrieval(retrievalSettings);
+
+        String result = (String) agent.run("test query");
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+    }
+}

--- a/agents/agents-features/agents-features-longterm-memory/src/jvmTest/kotlin/ai/koog/agents/longtermmemory/feature/LongTermMemoryIngestionTest.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/jvmTest/kotlin/ai/koog/agents/longtermmemory/feature/LongTermMemoryIngestionTest.kt
@@ -1,0 +1,627 @@
+package ai.koog.agents.longtermmemory.feature
+
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.agent.entity.ToolSelectionStrategy
+import ai.koog.agents.core.annotation.ExperimentalAgentsApi
+import ai.koog.agents.core.dsl.builder.forwardTo
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.core.dsl.extension.nodeLLMRequest
+import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreaming
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.longtermmemory.ingestion.IngestionTiming
+import ai.koog.agents.longtermmemory.ingestion.extraction.FilteringMemoryRecordExtractor
+import ai.koog.agents.longtermmemory.ingestion.extraction.MemoryRecordExtractor
+import ai.koog.agents.longtermmemory.model.MemoryRecord
+import ai.koog.agents.longtermmemory.retrieval.KeywordSearchRequest
+import ai.koog.agents.longtermmemory.storage.InMemoryRecordStorage
+import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.executor.ollama.client.OllamaModels
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.prompt.streaming.StreamFrame
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for LongTermMemory ingestion (IngestionSettings): persisting messages into memory storage.
+ */
+@OptIn(ExperimentalAgentsApi::class)
+class LongTermMemoryIngestionTest {
+    private val defaultNamespace = "default"
+
+    private val defaultAgentConfig = AIAgentConfig(
+        prompt = prompt("test") { system("You are a helpful assistant") },
+        model = OllamaModels.Meta.LLAMA_3_2,
+        maxAgentIterations = 10
+    )
+
+    private val nonStreamingStrategy =
+        strategy<String, String>("ingestion-test", toolSelectionStrategy = ToolSelectionStrategy.NONE) {
+            val llmNode by nodeLLMRequest(name = "llm-node", allowToolCalls = false)
+            edge(nodeStart forwardTo llmNode)
+            edge(llmNode forwardTo nodeFinish transformed { it.content })
+        }
+
+    private val streamingStrategy =
+        strategy<String, String>("ingestion-streaming-test", toolSelectionStrategy = ToolSelectionStrategy.NONE) {
+            val llmNode by nodeLLMRequestStreaming(name = "llm-node")
+            edge(nodeStart forwardTo llmNode)
+            edge(
+                llmNode forwardTo nodeFinish transformed { flow ->
+                    flow.toList().filterIsInstance<StreamFrame.TextDelta>().joinToString("") { it.text }
+                }
+            )
+        }
+
+    private fun streamingExecutor(vararg frames: String): PromptExecutor = object : PromptExecutor {
+        override suspend fun execute(
+            prompt: Prompt,
+            model: LLModel,
+            tools: List<ToolDescriptor>
+        ): List<Message.Response> {
+            return listOf(Message.Assistant("non-streaming", ResponseMetaInfo.Empty))
+        }
+
+        override fun executeStreaming(prompt: Prompt, model: LLModel, tools: List<ToolDescriptor>): Flow<StreamFrame> =
+            flow {
+                for (frame in frames) emit(StreamFrame.TextDelta(frame))
+                emit(StreamFrame.TextComplete(frames.joinToString("")))
+                emit(StreamFrame.End("stop"))
+            }
+
+        override suspend fun moderate(prompt: Prompt, model: LLModel) =
+            throw UnsupportedOperationException("Not needed")
+
+        override fun close() {}
+    }
+
+    // ==========================================
+    // Default FilteringMemoryRecordExtractor (User + Assistant)
+    // ==========================================
+
+    @Test
+    fun `default extractor stores both user and assistant messages`() = runTest {
+        val storage = InMemoryRecordStorage()
+
+        val executor = getMockExecutor {
+            mockLLMAnswer("Assistant knows about Kotlin coroutines").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = nonStreamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                ingestion {
+                    this.storage = storage
+                    extractor = FilteringMemoryRecordExtractor()
+                }
+            }
+        }
+
+        agent.run("Tell me about coroutines")
+
+        assertTrue(storage.size() >= 2, "Both user and assistant messages should be stored")
+        val results = storage.search(KeywordSearchRequest(query = "coroutines"), defaultNamespace)
+        assertTrue(
+            results.any { it.record.content.contains("Kotlin coroutines") },
+            "Assistant message should be stored"
+        )
+        val userResults = storage.search(KeywordSearchRequest(query = "Tell me about"), defaultNamespace)
+        assertTrue(
+            userResults.any { it.record.content.contains("Tell me about coroutines") },
+            "User message should be stored"
+        )
+    }
+
+    // ==========================================
+    // Role filtering
+    // ==========================================
+
+    @Test
+    fun `assistant-only extractor stores only assistant messages`() = runTest {
+        val storage = InMemoryRecordStorage()
+
+        val executor = getMockExecutor {
+            mockLLMAnswer("This is the assistant response to store").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = nonStreamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                ingestion {
+                    this.storage = storage
+                    extractor = FilteringMemoryRecordExtractor(setOf(Message.Role.Assistant))
+                }
+            }
+        }
+
+        agent.run("Hello")
+
+        assertTrue(storage.size() > 0, "At least one record should be stored")
+        val results = storage.search(KeywordSearchRequest(query = "assistant response"), defaultNamespace)
+        assertTrue(
+            results.any { it.record.content.contains("assistant response to store") },
+            "Assistant response should be stored"
+        )
+    }
+
+    @Test
+    fun `user-only extractor stores only user messages`() = runTest {
+        val storage = InMemoryRecordStorage()
+
+        val executor = getMockExecutor {
+            mockLLMAnswer("Assistant reply").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = nonStreamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                ingestion {
+                    this.storage = storage
+                    extractor = FilteringMemoryRecordExtractor(setOf(Message.Role.User))
+                    timing = IngestionTiming.ON_LLM_CALL
+                }
+            }
+        }
+
+        agent.run("User question about Kotlin")
+
+        assertTrue(storage.size() > 0, "At least one user message should be stored")
+        val results = storage.search(KeywordSearchRequest(query = "Kotlin"), defaultNamespace)
+        assertTrue(
+            results.any { it.record.content.contains("User question about Kotlin") },
+            "User message should be stored"
+        )
+        val assistantResults = storage.search(KeywordSearchRequest(query = "Assistant"), defaultNamespace)
+        assertTrue(
+            assistantResults.none { it.record.content.contains("Assistant reply") },
+            "Assistant messages should NOT be stored"
+        )
+    }
+
+    @Test
+    fun `assistant-only extractor excludes user messages`() = runTest {
+        val storage = InMemoryRecordStorage()
+
+        val executor = getMockExecutor {
+            mockLLMAnswer("Kotlin is a modern language").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = nonStreamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                ingestion {
+                    this.storage = storage
+                    extractor = FilteringMemoryRecordExtractor(messageRolesToExtract = setOf(Message.Role.Assistant))
+                }
+            }
+        }
+
+        agent.run("What is Kotlin?")
+
+        val allResults = storage.search(KeywordSearchRequest(query = "Kotlin"), defaultNamespace)
+        assertTrue(
+            allResults.none { it.record.content.contains("What is Kotlin") },
+            "User message should NOT be stored"
+        )
+        assertTrue(
+            allResults.any { it.record.content.contains("Kotlin is a modern language") },
+            "Assistant message should be stored"
+        )
+    }
+
+    // ==========================================
+    // No ingestion when not configured
+    // ==========================================
+
+    @Test
+    fun `no messages stored when ingestion is not configured`() = runTest {
+        val storage = InMemoryRecordStorage()
+
+        val executor = getMockExecutor {
+            mockLLMAnswer("This response should NOT be stored").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = nonStreamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                // No ingestion configured
+            }
+        }
+
+        agent.run("Hello")
+
+        assertEquals(0, storage.size(), "No records should be stored when ingestion is not configured")
+    }
+
+    @Test
+    fun `no messages stored in streaming mode when ingestion is not configured`() = runTest {
+        val storage = InMemoryRecordStorage()
+
+        val executor = streamingExecutor("This should NOT be stored")
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = streamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {}
+        }
+
+        agent.run("Hello")
+
+        assertEquals(
+            0,
+            storage.size(),
+            "No records should be stored in streaming mode when ingestion is not configured"
+        )
+    }
+
+    // ==========================================
+    // Streaming ingestion
+    // ==========================================
+
+    @Test
+    fun `streaming frames are ingested when configured`() = runTest {
+        val storage = InMemoryRecordStorage()
+
+        val executor = streamingExecutor("Hello ", "world", "!")
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = streamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                ingestion {
+                    this.storage = storage
+                    extractor = FilteringMemoryRecordExtractor(setOf(Message.Role.Assistant))
+                }
+            }
+        }
+
+        agent.run("Hello")
+
+        assertEquals(1, storage.size(), "Streaming frames should be stored as a memory record")
+        val results = storage.search(KeywordSearchRequest(query = "Hello world"), defaultNamespace)
+        assertEquals(1, results.size)
+        assertTrue(
+            results.first().record.content.contains("Hello world!"),
+            "Concatenated streaming content should be stored"
+        )
+    }
+
+    @Test
+    fun `user messages are ingested during streaming with ON_LLM_CALL timing`() = runTest {
+        val storage = InMemoryRecordStorage()
+
+        val executor = streamingExecutor("Streaming reply")
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = streamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                ingestion {
+                    this.storage = storage
+                    extractor = FilteringMemoryRecordExtractor(setOf(Message.Role.User))
+                    timing = IngestionTiming.ON_LLM_CALL
+                }
+            }
+        }
+
+        agent.run("User streaming question about Kotlin")
+
+        assertTrue(storage.size() > 0, "User message should be stored during streaming")
+        val results = storage.search(KeywordSearchRequest(query = "Kotlin"), defaultNamespace)
+        assertTrue(results.any { it.record.content.contains("User streaming question about Kotlin") })
+        val streamResults = storage.search(KeywordSearchRequest(query = "Streaming reply"), defaultNamespace)
+        assertTrue(
+            streamResults.none { it.record.content.contains("Streaming reply") },
+            "Streaming assistant response should NOT be stored"
+        )
+    }
+
+    // ==========================================
+    // IngestionTiming.ON_AGENT_COMPLETION
+    // ==========================================
+
+    @Test
+    fun `ON_AGENT_COMPLETION stores messages after agent run completes`() = runTest {
+        val storage = InMemoryRecordStorage()
+
+        val executor = getMockExecutor {
+            mockLLMAnswer("This is the assistant response stored on completion").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = nonStreamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                ingestion {
+                    this.storage = storage
+                    extractor = FilteringMemoryRecordExtractor(setOf(Message.Role.Assistant))
+                    timing = IngestionTiming.ON_AGENT_COMPLETION
+                }
+            }
+        }
+
+        agent.run("Hello")
+
+        assertTrue(storage.size() > 0, "Records should be stored after agent completion")
+        val results =
+            storage.search(KeywordSearchRequest(query = "assistant response stored on completion"), defaultNamespace)
+        assertTrue(results.any { it.record.content.contains("assistant response stored on completion") })
+    }
+
+    @Test
+    @Timeout(5)
+    fun `ON_AGENT_COMPLETION does not store messages during LLM call`() = runTest {
+        val storage = InMemoryRecordStorage()
+        var storageSizeDuringLLMCall = -1
+
+        val executor = object : PromptExecutor {
+            override suspend fun execute(
+                prompt: Prompt,
+                model: LLModel,
+                tools: List<ToolDescriptor>
+            ): List<Message.Response> {
+                storageSizeDuringLLMCall = storage.size()
+                return listOf(Message.Assistant("Response that should not be stored yet", ResponseMetaInfo.Empty))
+            }
+
+            override fun executeStreaming(
+                prompt: Prompt,
+                model: LLModel,
+                tools: List<ToolDescriptor>
+            ): Flow<StreamFrame> =
+                throw UnsupportedOperationException("Not needed")
+
+            override suspend fun moderate(prompt: Prompt, model: LLModel) =
+                throw UnsupportedOperationException("Not needed")
+
+            override fun close() {}
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = nonStreamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                ingestion {
+                    this.storage = storage
+                    extractor = FilteringMemoryRecordExtractor(setOf(Message.Role.Assistant))
+                    timing = IngestionTiming.ON_AGENT_COMPLETION
+                }
+            }
+        }
+
+        agent.run("Hello")
+
+        assertEquals(
+            0,
+            storageSizeDuringLLMCall,
+            "No records should be stored during LLM call with ON_COMPLETION timing"
+        )
+        assertTrue(storage.size() > 0, "Records should be stored after agent completion")
+    }
+
+    @Test
+    fun `ON_AGENT_COMPLETION stores user messages`() = runTest {
+        val storage = InMemoryRecordStorage()
+
+        val executor = getMockExecutor {
+            mockLLMAnswer("Assistant reply").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = nonStreamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                ingestion {
+                    this.storage = storage
+                    extractor = FilteringMemoryRecordExtractor(setOf(Message.Role.User))
+                    timing = IngestionTiming.ON_AGENT_COMPLETION
+                }
+            }
+        }
+
+        agent.run("User question about Kotlin")
+
+        assertTrue(storage.size() > 0, "User message should be stored on completion")
+        val results = storage.search(KeywordSearchRequest(query = "Kotlin"), defaultNamespace)
+        assertTrue(results.any { it.record.content.contains("User question about Kotlin") })
+        assertTrue(
+            results.none { it.record.content.contains("Assistant reply") },
+            "Assistant messages should NOT be stored"
+        )
+    }
+
+    @Test
+    fun `ON_AGENT_COMPLETION stores both user and assistant messages`() = runTest {
+        val storage = InMemoryRecordStorage()
+
+        val executor = getMockExecutor {
+            mockLLMAnswer("Assistant response about Kotlin").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = nonStreamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                ingestion {
+                    this.storage = storage
+                    extractor = FilteringMemoryRecordExtractor(setOf(Message.Role.User, Message.Role.Assistant))
+                    timing = IngestionTiming.ON_AGENT_COMPLETION
+                }
+            }
+        }
+
+        agent.run("User question about Kotlin")
+
+        assertTrue(storage.size() >= 2, "Both user and assistant records should be stored")
+        val results = storage.search(KeywordSearchRequest(query = "Kotlin"), defaultNamespace)
+        assertTrue(
+            results.any { it.record.content.contains("User question about Kotlin") },
+            "User message should be stored"
+        )
+        assertTrue(
+            results.any { it.record.content.contains("Assistant response about Kotlin") },
+            "Assistant message should be stored"
+        )
+    }
+
+    // ==========================================
+    // Custom MemoryRecordExtractor
+    // ==========================================
+
+    @Test
+    fun `custom extractor transforms content before storing`() = runTest {
+        val storage = InMemoryRecordStorage()
+
+        val executor = getMockExecutor {
+            mockLLMAnswer("First sentence. Second sentence. Third sentence.").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = nonStreamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                ingestion {
+                    this.storage = storage
+                    extractor = MemoryRecordExtractor { messages ->
+                        messages.filter { it.role == Message.Role.Assistant }
+                            .flatMap { it.content.split(". ") }
+                            .map { it.trim().removeSuffix(".") }
+                            .filter { it.isNotBlank() }
+                            .map { MemoryRecord(content = it) }
+                    }
+                }
+            }
+        }
+
+        agent.run("Hello")
+
+        assertEquals(3, storage.size(), "Custom extractor should split into 3 separate records")
+        val results = storage.search(KeywordSearchRequest(query = "sentence"), defaultNamespace)
+        assertTrue(results.any { it.record.content.contains("First sentence") })
+        assertTrue(results.any { it.record.content.contains("Second sentence") })
+        assertTrue(results.any { it.record.content.contains("Third sentence") })
+    }
+
+    @Test
+    fun `custom extractor that uppercases content`() = runTest {
+        val storage = InMemoryRecordStorage()
+
+        val executor = getMockExecutor {
+            mockLLMAnswer("The answer is 42").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = nonStreamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                ingestion {
+                    this.storage = storage
+                    extractor = MemoryRecordExtractor { messages ->
+                        messages
+                            .filter { it.role == Message.Role.Assistant }
+                            .map { MemoryRecord(content = it.content.uppercase()) }
+                    }
+                }
+            }
+        }
+
+        agent.run("What is the answer?")
+
+        assertTrue(storage.size() > 0, "At least one record should be stored")
+        val results = storage.search(KeywordSearchRequest(query = "ANSWER"), defaultNamespace)
+        assertTrue(
+            results.any { it.record.content == "THE ANSWER IS 42" },
+            "Custom extractor should have uppercased the content"
+        )
+    }
+
+    // ==========================================
+    // Edge case: extractor returns empty list
+    // ==========================================
+
+    @Test
+    fun `extractor returning empty list stores nothing`() = runTest {
+        val storage = InMemoryRecordStorage()
+
+        val executor = getMockExecutor {
+            mockLLMAnswer("Some response").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = nonStreamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                ingestion {
+                    this.storage = storage
+                    extractor = MemoryRecordExtractor { emptyList() }
+                }
+            }
+        }
+
+        agent.run("Hello")
+
+        assertEquals(0, storage.size(), "No records should be stored when extractor returns empty list")
+    }
+}

--- a/agents/agents-features/agents-features-longterm-memory/src/jvmTest/kotlin/ai/koog/agents/longtermmemory/feature/LongTermMemoryRetrievalTest.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/jvmTest/kotlin/ai/koog/agents/longtermmemory/feature/LongTermMemoryRetrievalTest.kt
@@ -1,0 +1,509 @@
+package ai.koog.agents.longtermmemory.feature
+
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.agent.entity.ToolSelectionStrategy
+import ai.koog.agents.core.annotation.ExperimentalAgentsApi
+import ai.koog.agents.core.dsl.builder.forwardTo
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.core.dsl.extension.nodeLLMRequest
+import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreaming
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.longtermmemory.ingestion.IngestionTiming
+import ai.koog.agents.longtermmemory.ingestion.extraction.FilteringMemoryRecordExtractor
+import ai.koog.agents.longtermmemory.model.MemoryRecord
+import ai.koog.agents.longtermmemory.retrieval.KeywordSearchRequest
+import ai.koog.agents.longtermmemory.retrieval.KeywordSearchStrategy
+import ai.koog.agents.longtermmemory.retrieval.SearchStrategy
+import ai.koog.agents.longtermmemory.retrieval.augmentation.UserPromptAugmenter
+import ai.koog.agents.longtermmemory.storage.InMemoryRecordStorage
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.executor.ollama.client.OllamaModels
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.prompt.streaming.StreamFrame
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for LongTermMemory retrieval (RetrievalSettings): prompt augmentation via storage search.
+ */
+@OptIn(ExperimentalAgentsApi::class)
+class LongTermMemoryRetrievalTest {
+    private val defaultNamespace = "default"
+
+    private val defaultAgentConfig = AIAgentConfig(
+        prompt = prompt("test") { system("You are a helpful assistant") },
+        model = OllamaModels.Meta.LLAMA_3_2,
+        maxAgentIterations = 10
+    )
+
+    private val nonStreamingStrategy =
+        strategy<String, String>("retrieval-test", toolSelectionStrategy = ToolSelectionStrategy.NONE) {
+            val llmNode by nodeLLMRequest(name = "llm-node", allowToolCalls = false)
+            edge(nodeStart forwardTo llmNode)
+            edge(llmNode forwardTo nodeFinish transformed { it.content })
+        }
+
+    private val streamingStrategy =
+        strategy<String, String>("retrieval-streaming-test", toolSelectionStrategy = ToolSelectionStrategy.NONE) {
+            val llmNode by nodeLLMRequestStreaming(name = "llm-node")
+            edge(nodeStart forwardTo llmNode)
+            edge(
+                llmNode forwardTo nodeFinish transformed { flow ->
+                    flow.toList().filterIsInstance<StreamFrame.TextDelta>().joinToString("") { it.text }
+                }
+            )
+        }
+
+    /**
+     * Creates a PromptExecutor that captures the full prompt content for inspection.
+     * [onPrompt] receives the joined content of all prompt messages and returns the response text.
+     */
+    private fun promptCapturingExecutor(onPrompt: (String) -> String): PromptExecutor = object : PromptExecutor {
+        override suspend fun execute(
+            prompt: Prompt,
+            model: LLModel,
+            tools: List<ToolDescriptor>
+        ): List<Message.Response> {
+            val allContent = prompt.messages.joinToString("\n") { it.content }
+            return listOf(Message.Assistant(onPrompt(allContent), ResponseMetaInfo.Empty))
+        }
+
+        override fun executeStreaming(prompt: Prompt, model: LLModel, tools: List<ToolDescriptor>): Flow<StreamFrame> =
+            flow {
+                val allContent = prompt.messages.joinToString("\n") { it.content }
+                emit(StreamFrame.TextDelta(onPrompt(allContent)))
+                emit(StreamFrame.End("stop"))
+            }
+
+        override suspend fun moderate(prompt: Prompt, model: LLModel) =
+            throw UnsupportedOperationException("Not needed")
+
+        override fun close() {}
+    }
+
+    // ==========================================
+    // Prompt augmentation with search request builder
+    // ==========================================
+
+    @Test
+    @Timeout(5)
+    fun `prompt is augmented with storage results via search request builder`() = runTest {
+        var searchCalled = false
+        val storage = InMemoryRecordStorage()
+        storage.add(
+            listOf(
+                MemoryRecord(content = "Kotlin was developed by JetBrains"),
+                MemoryRecord(content = "Kotlin is 100% interoperable with Java")
+            ),
+            defaultNamespace
+        )
+
+        var augmented = false
+        val executor = promptCapturingExecutor { content ->
+            augmented = content.contains("Kotlin was developed by JetBrains") && content.contains("Relevant information")
+            if (augmented) "AUGMENTED" else "NOT_AUGMENTED"
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = nonStreamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                retrieval {
+                    this.storage = storage
+                    searchStrategy = SearchStrategy { _ ->
+                        searchCalled = true
+                        KeywordSearchRequest(query = "Kotlin")
+                    }
+                }
+            }
+        }
+
+        val result = agent.run("Tell me about Kotlin")
+
+        assertTrue(searchCalled, "Search function should have been called")
+        assertTrue(augmented, "Prompt should be augmented with storage context")
+        assertEquals("AUGMENTED", result)
+    }
+
+    @Test
+    @Timeout(5)
+    fun `streaming prompt is augmented with storage results`() = runTest {
+        val storage = InMemoryRecordStorage()
+        storage.add(
+            listOf(
+                MemoryRecord(content = "Kotlin was developed by JetBrains"),
+                MemoryRecord(content = "Kotlin is 100% interoperable with Java")
+            ),
+            defaultNamespace
+        )
+
+        var augmented = false
+        val executor = promptCapturingExecutor { content ->
+            augmented = content.contains("Kotlin was developed by JetBrains") && content.contains("Relevant information")
+            if (augmented) "AUGMENTED" else "NOT_AUGMENTED"
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = streamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                retrieval {
+                    this.storage = storage
+                    searchStrategy = SearchStrategy { _ -> KeywordSearchRequest(query = "Kotlin") }
+                }
+            }
+        }
+
+        val result = agent.run("Tell me about Kotlin")
+
+        assertTrue(augmented, "Streaming prompt should be augmented with storage context")
+        assertEquals("AUGMENTED", result)
+    }
+
+    // ==========================================
+    // No augmentation when retrieval is not configured
+    // ==========================================
+
+    @Test
+    @Timeout(5)
+    fun `prompt is not augmented when retrieval is not configured`() = runTest {
+        var augmented = false
+        val executor = promptCapturingExecutor { content ->
+            augmented = content.contains("Relevant information")
+            if (augmented) "AUGMENTED" else "NOT_AUGMENTED"
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = nonStreamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                // No retrieval configured
+            }
+        }
+
+        val result = agent.run("Hello")
+
+        assertFalse(augmented, "Prompt should NOT be augmented when retrieval is not configured")
+        assertEquals("NOT_AUGMENTED", result)
+    }
+
+    @Test
+    @Timeout(5)
+    fun `streaming prompt is not augmented when retrieval is not configured`() = runTest {
+        var augmented = false
+        val executor = promptCapturingExecutor { content ->
+            augmented = content.contains("Relevant information")
+            if (augmented) "AUGMENTED" else "NOT_AUGMENTED"
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = streamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {}
+        }
+
+        val result = agent.run("Hello")
+
+        assertFalse(augmented, "Streaming prompt should NOT be augmented when retrieval is not configured")
+        assertEquals("NOT_AUGMENTED", result)
+    }
+
+    // ==========================================
+    // Search request builder receives the user query
+    // ==========================================
+
+    @Test
+    @Timeout(5)
+    fun `search request strategy receives the user query`() = runTest {
+        var capturedQuery: String? = null
+
+        val storage = InMemoryRecordStorage()
+        storage.add(
+            listOf(
+                MemoryRecord(content = "The weather in Paris is sunny today"),
+                MemoryRecord(content = "Kotlin is a programming language")
+            ),
+            defaultNamespace
+        )
+
+        val executor = promptCapturingExecutor { "OK" }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = nonStreamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                retrieval {
+                    this.storage = storage
+                    searchStrategy = SearchStrategy { query ->
+                        capturedQuery = query
+                        KeywordSearchRequest(query)
+                    }
+                }
+            }
+        }
+
+        agent.run("weather")
+
+        assertEquals("weather", capturedQuery, "Search strategy should receive the user's query")
+    }
+
+    // ==========================================
+    // Keyword search builder integration
+    // ==========================================
+
+    @Test
+    @Timeout(5)
+    fun `keywordSearch builder retrieves matching records`() = runTest {
+        val storage = InMemoryRecordStorage()
+        storage.add(
+            listOf(
+                MemoryRecord(content = "Kotlin was developed by JetBrains"),
+                MemoryRecord(content = "Java is a popular programming language"),
+                MemoryRecord(content = "Kotlin coroutines simplify async programming"),
+            ),
+            defaultNamespace
+        )
+
+        var augmented = false
+        val executor = promptCapturingExecutor { content ->
+            augmented = content.contains("Kotlin was developed by JetBrains")
+            if (augmented) "AUGMENTED" else "NOT_AUGMENTED"
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = nonStreamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                retrieval {
+                    this.storage = storage
+                    searchStrategy = KeywordSearchStrategy(topK = 5)
+                }
+            }
+        }
+
+        val result = agent.run("Kotlin")
+
+        assertTrue(augmented, "Prompt should be augmented with keyword search results")
+        assertEquals("AUGMENTED", result)
+    }
+
+    @Test
+    @Timeout(5)
+    fun `keywordSearch builder returns no augmentation when query does not match`() = runTest {
+        val storage = InMemoryRecordStorage()
+        storage.add(
+            listOf(
+                MemoryRecord(content = "Kotlin was developed by JetBrains"),
+                MemoryRecord(content = "Kotlin coroutines simplify async programming"),
+            ),
+            defaultNamespace
+        )
+
+        var augmented = false
+        val executor = promptCapturingExecutor { content ->
+            augmented = content.contains("Kotlin") && content.contains("JetBrains")
+            if (augmented) "AUGMENTED" else "NOT_AUGMENTED"
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = nonStreamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                retrieval {
+                    this.storage = storage
+                    searchStrategy = KeywordSearchStrategy(topK = 5)
+                }
+            }
+        }
+
+        val result = agent.run("Tell me about Python and Django")
+
+        assertFalse(augmented, "Prompt should NOT be augmented when no records match")
+        assertEquals("NOT_AUGMENTED", result)
+    }
+
+    // ==========================================
+    // Empty storage returns no augmentation
+    // ==========================================
+
+    @Test
+    @Timeout(5)
+    fun `empty storage produces no augmentation`() = runTest {
+        val storage = InMemoryRecordStorage()
+
+        var augmented = false
+        val executor = promptCapturingExecutor { content ->
+            augmented = content.contains("Relevant information")
+            if (augmented) "AUGMENTED" else "NOT_AUGMENTED"
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = nonStreamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                retrieval {
+                    this.storage = storage
+                    searchStrategy = KeywordSearchStrategy(topK = 5)
+                }
+            }
+        }
+
+        val result = agent.run("Tell me something")
+
+        assertFalse(augmented, "Empty storage should produce no augmentation")
+        assertEquals("NOT_AUGMENTED", result)
+    }
+
+    // ==========================================
+    // End-to-end: ingestion then retrieval
+    // ==========================================
+
+    @Test
+    @Timeout(5)
+    fun `ingested data is retrievable in subsequent agent run`() = runTest {
+        val storage = InMemoryRecordStorage()
+
+        // First agent run: ingest data
+        val ingestExecutor = promptCapturingExecutor { "Kotlin supports coroutines for async programming" }
+
+        val ingestAgent = AIAgent(
+            promptExecutor = ingestExecutor,
+            strategy = nonStreamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                ingestion {
+                    this.storage = storage
+                    extractor = FilteringMemoryRecordExtractor()
+                }
+            }
+        }
+
+        ingestAgent.run("Tell me about Kotlin")
+
+        assertTrue(storage.size() > 0, "Data should have been ingested")
+
+        // Second agent run: retrieve the ingested data
+        var augmented = false
+        val retrieveExecutor = promptCapturingExecutor { content ->
+            augmented = content.contains("coroutines")
+            if (augmented) "FOUND_CONTEXT" else "NO_CONTEXT"
+        }
+
+        val retrieveAgent = AIAgent(
+            promptExecutor = retrieveExecutor,
+            strategy = nonStreamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                retrieval {
+                    this.storage = storage
+                    searchStrategy = KeywordSearchStrategy(topK = 5)
+                }
+            }
+        }
+
+        val result = retrieveAgent.run("coroutines")
+
+        assertTrue(augmented, "Previously ingested data should be retrievable")
+        assertEquals("FOUND_CONTEXT", result)
+    }
+
+    // ==========================================
+    // Ingestion + Retrieval: ingestion stores original (non-augmented) prompt
+    // ==========================================
+
+    @Test
+    @Timeout(5)
+    fun `ingestion stores original prompt when both ingestion and retrieval are configured`() = runTest {
+        val retrievalStorage = InMemoryRecordStorage()
+        retrievalStorage.add(
+            listOf(MemoryRecord(content = "Context about Kotlin coroutines")),
+            defaultNamespace
+        )
+
+        val ingestionStorage = InMemoryRecordStorage()
+
+        var promptSeenByLLM: String? = null
+        val executor = promptCapturingExecutor { content ->
+            promptSeenByLLM = content
+            "LLM response"
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = nonStreamingStrategy,
+            agentConfig = defaultAgentConfig,
+            toolRegistry = ToolRegistry.EMPTY
+        ) {
+            install(LongTermMemory.Feature) {
+                retrieval {
+                    storage = retrievalStorage
+                    searchStrategy = SearchStrategy { _ ->
+                        KeywordSearchRequest(query = "Kotlin")
+                    }
+                    promptAugmenter = UserPromptAugmenter()
+                }
+                ingestion {
+                    storage = ingestionStorage
+                    extractor = FilteringMemoryRecordExtractor(setOf(Message.Role.User))
+                    timing = IngestionTiming.ON_LLM_CALL
+                }
+            }
+        }
+
+        val originalUserMessage = "Tell me about Kotlin"
+
+        agent.run(originalUserMessage)
+
+        // Verify the LLM saw the augmented prompt (retrieval worked)
+        assertTrue(
+            promptSeenByLLM!!.contains("Context about Kotlin coroutines"),
+            "LLM should see augmented prompt with retrieved context"
+        )
+
+        // Verify ingestion stored the ORIGINAL user message, not the augmented one
+        val ingestedRecords = ingestionStorage.search(KeywordSearchRequest(query = "Kotlin"), defaultNamespace)
+        assertEquals(1, ingestedRecords.size)
+        assertEquals(originalUserMessage, ingestedRecords.first().record.content)
+    }
+}

--- a/agents/agents-features/agents-features-longterm-memory/src/jvmTest/kotlin/ai/koog/agents/longtermmemory/feature/LongTermMemoryStrategyTest.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/jvmTest/kotlin/ai/koog/agents/longtermmemory/feature/LongTermMemoryStrategyTest.kt
@@ -1,0 +1,100 @@
+package ai.koog.agents.longtermmemory.feature
+
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.agent.entity.ToolSelectionStrategy
+import ai.koog.agents.core.annotation.ExperimentalAgentsApi
+import ai.koog.agents.core.dsl.builder.forwardTo
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.longtermmemory.model.MemoryRecord
+import ai.koog.agents.longtermmemory.retrieval.KeywordSearchRequest
+import ai.koog.agents.longtermmemory.retrieval.SearchResult
+import ai.koog.agents.longtermmemory.storage.InMemoryRecordStorage
+import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.ollama.client.OllamaModels
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Basic test for LongTermMemory feature installation with InMemoryRecordStorage.
+ * Verifies that users can install the feature, provide their own storage implementations,
+ * and call `search` and `add` methods from those storages within strategy nodes.
+ */
+@OptIn(ExperimentalAgentsApi::class)
+class LongTermMemoryStrategyTest {
+    private val myNamespace = "ns"
+
+    @Test
+    @Timeout(30)
+    fun `install LongTermMemory with custom storages and use search and add in strategy`() = runTest {
+        val mockExecutor = getMockExecutor {
+            mockLLMAnswer("Done").asDefaultResponse
+        }
+
+        val memoryStorage = InMemoryRecordStorage(myNamespace)
+
+        val searchResults = mutableListOf<SearchResult>()
+
+        val strategy = strategy<String, String>(
+            "ltm-basic-test",
+            toolSelectionStrategy = ToolSelectionStrategy.NONE
+        ) {
+            val addRecords by node<String, Unit> {
+                withLongTermMemory {
+                    this.ingestionStorage?.add(
+                        listOf(
+                            MemoryRecord(content = "Kotlin is a modern programming language"),
+                            MemoryRecord(content = "Java is a widely used language"),
+                            MemoryRecord(content = "Kotlin runs on the JVM")
+                        ),
+                        myNamespace
+                    )
+                }
+            }
+
+            val searchRecords by node<Unit, Unit> {
+                searchResults += withLongTermMemory {
+                    this.retrievalStorage?.search(
+                        KeywordSearchRequest(query = "Kotlin", limit = 10),
+                        myNamespace
+                    ) ?: emptyList()
+                }
+            }
+
+            edge(nodeStart forwardTo addRecords)
+            edge(addRecords forwardTo searchRecords)
+            edge(searchRecords forwardTo nodeFinish transformed { "Done" })
+        }
+
+        val agentConfig = AIAgentConfig(
+            prompt = prompt("test") { system("You are a helpful assistant") },
+            model = OllamaModels.Meta.LLAMA_3_2,
+            maxAgentIterations = 10
+        )
+
+        val agent = AIAgent(
+            promptExecutor = mockExecutor,
+            strategy = strategy,
+            agentConfig = agentConfig
+        ) {
+            install(LongTermMemory) {
+                retrieval {
+                    storage = memoryStorage
+                }
+                ingestion {
+                    storage = memoryStorage
+                }
+            }
+        }
+
+        agent.run("test input", null)
+
+        assertEquals(3, memoryStorage.size())
+        assertEquals(2, searchResults.size)
+        assertTrue(searchResults.all { it.record.content.contains("Kotlin") })
+    }
+}

--- a/agents/agents-features/agents-features-longterm-memory/src/jvmTest/kotlin/ai/koog/agents/longtermmemory/retrieval/augmentation/PromptAugmenterTest.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/jvmTest/kotlin/ai/koog/agents/longtermmemory/retrieval/augmentation/PromptAugmenterTest.kt
@@ -1,0 +1,194 @@
+package ai.koog.agents.longtermmemory.retrieval.augmentation
+
+import ai.koog.agents.longtermmemory.model.MemoryRecord
+import ai.koog.agents.longtermmemory.retrieval.SearchResult
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.message.Message
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Test class for PromptAugmenter implementations
+ */
+class PromptAugmenterTest {
+
+    private fun searchResults(vararg contents: String): List<SearchResult> =
+        contents.map { SearchResult(record = MemoryRecord(content = it), similarity = 1.0) }
+
+    @Test
+    fun testAugmentWithSystemMessageMode() {
+        val originalPrompt = prompt("test") {
+            system("You are a helpful assistant")
+            user("What is Kotlin?")
+        }
+
+        val relevantContext = searchResults(
+            "Kotlin was developed by JetBrains",
+            "Kotlin is 100% interoperable with Java"
+        )
+
+        val augmenter = SystemPromptAugmenter()
+        val augmentedPrompt = augmenter.augment(
+            originalPrompt = originalPrompt,
+            relevantContext = relevantContext
+        )
+
+        // Verify a new system message with context was prepended, keeping the original intact
+        val systemMessages = augmentedPrompt.messages.filter { it is Message.System }
+        assertEquals(2, systemMessages.size)
+        // First system message should contain the context
+        assertTrue(systemMessages[0].content.contains("Kotlin was developed by JetBrains"))
+        assertTrue(systemMessages[0].content.contains("Kotlin is 100% interoperable with Java"))
+        assertTrue(systemMessages[0].content.contains("Relevant information"))
+        // Second system message should be the original
+        assertEquals("You are a helpful assistant", systemMessages[1].content)
+    }
+
+    @Test
+    fun testAugmentWithUserMessageBeforeLastMode() {
+        val originalPrompt = prompt("test") {
+            system("You are a helpful assistant")
+            user("What is Kotlin?")
+        }
+
+        val relevantContext = searchResults("Kotlin was developed by JetBrains")
+
+        val augmenter = UserPromptAugmenter()
+        val augmentedPrompt = augmenter.augment(
+            originalPrompt = originalPrompt,
+            relevantContext = relevantContext
+        )
+
+        // Verify a new user message was inserted before the last user message
+        val userMessages = augmentedPrompt.messages.filter { it is Message.User }
+        assertEquals(2, userMessages.size)
+
+        // First user message should contain the context
+        assertTrue(userMessages[0].content.contains("Kotlin was developed by JetBrains"))
+        // Second user message should be the original
+        assertEquals("What is Kotlin?", userMessages[1].content)
+    }
+
+    @Test
+    fun testUserPromptAugmenterReturnsOriginalWhenNoUserMessages() {
+        val originalPrompt = prompt("test") {
+            system("You are a helpful assistant")
+        }
+
+        val relevantContext = searchResults("Kotlin was developed by JetBrains")
+
+        val augmenter = UserPromptAugmenter()
+        val augmentedPrompt = augmenter.augment(
+            originalPrompt = originalPrompt,
+            relevantContext = relevantContext
+        )
+
+        // With no user messages, the prompt should remain unchanged
+        assertEquals(originalPrompt.messages.size, augmentedPrompt.messages.size)
+        assertEquals(originalPrompt.messages, augmentedPrompt.messages)
+    }
+
+    @Test
+    fun testAugmentWithEmptyContext() {
+        val originalPrompt = prompt("test") {
+            system("You are a helpful assistant")
+            user("What is Kotlin?")
+        }
+
+        val augmenter = SystemPromptAugmenter()
+        val augmentedPrompt = augmenter.augment(
+            originalPrompt = originalPrompt,
+            relevantContext = emptyList()
+        )
+
+        // With empty context, the prompt should remain unchanged
+        assertEquals(originalPrompt.messages.size, augmentedPrompt.messages.size)
+    }
+
+    @Test
+    fun testAugmentWithCustomTemplates() {
+        val originalPrompt = prompt("test") {
+            system("You are a helpful assistant")
+            user("What is Kotlin?")
+        }
+
+        val relevantContext = searchResults("Kotlin was developed by JetBrains")
+        val customSystemTemplate = "CUSTOM CONTEXT: {relevant_context}"
+
+        val augmenter = SystemPromptAugmenter(template = customSystemTemplate)
+        val augmentedPrompt = augmenter.augment(
+            originalPrompt = originalPrompt,
+            relevantContext = relevantContext
+        )
+
+        // Verify a new system message with the custom template was prepended
+        val systemMessages = augmentedPrompt.messages.filter { it is Message.System }
+        assertEquals(2, systemMessages.size)
+        assertTrue(systemMessages[0].content.contains("CUSTOM CONTEXT:"))
+        assertTrue(systemMessages[0].content.contains("Kotlin was developed by JetBrains"))
+        // Original system message should remain unchanged
+        assertEquals("You are a helpful assistant", systemMessages[1].content)
+    }
+
+    @Test
+    fun testSystemPromptAugmenterReturnsOriginalWhenNoSystemMessages() {
+        val originalPrompt = prompt("test") {
+            user("What is Kotlin?")
+        }
+
+        val relevantContext = searchResults("Kotlin was developed by JetBrains")
+
+        val augmenter = SystemPromptAugmenter()
+        val augmentedPrompt = augmenter.augment(
+            originalPrompt = originalPrompt,
+            relevantContext = relevantContext
+        )
+
+        // With no system messages, the prompt should remain unchanged
+        assertEquals(originalPrompt.messages.size, augmentedPrompt.messages.size)
+        assertEquals(originalPrompt.messages, augmentedPrompt.messages)
+    }
+
+    @Test
+    fun testContextNumbering() {
+        val originalPrompt = prompt("test") {
+            system("You are a helpful assistant")
+            user("Tell me about programming languages")
+        }
+
+        val relevantContext = searchResults(
+            "First context item",
+            "Second context item",
+            "Third context item"
+        )
+
+        val augmenter = SystemPromptAugmenter()
+        val augmentedPrompt = augmenter.augment(
+            originalPrompt = originalPrompt,
+            relevantContext = relevantContext
+        )
+
+        val systemMessages = augmentedPrompt.messages.filter { it is Message.System }
+        assertEquals(2, systemMessages.size)
+        assertTrue(systemMessages[0].content.contains("[1] First context item"))
+        assertTrue(systemMessages[0].content.contains("[2] Second context item"))
+        assertTrue(systemMessages[0].content.contains("[3] Third context item"))
+        // Original system message should remain unchanged
+        assertEquals("You are a helpful assistant", systemMessages[1].content)
+    }
+
+    @Test
+    fun testFunInterfaceLambdaUsage() {
+        val originalPrompt = prompt("test") {
+            user("Hello")
+        }
+
+        val customAugmenter = PromptAugmenter { prompt, context ->
+            prompt // no-op augmenter
+        }
+
+        val result = customAugmenter.augment(originalPrompt, searchResults("some context"))
+        assertEquals(originalPrompt.messages.size, result.messages.size)
+    }
+}

--- a/agents/agents-features/agents-features-longterm-memory/src/jvmTest/kotlin/ai/koog/agents/longtermmemory/storage/InMemoryRecordStorageTest.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/jvmTest/kotlin/ai/koog/agents/longtermmemory/storage/InMemoryRecordStorageTest.kt
@@ -1,0 +1,97 @@
+package ai.koog.agents.longtermmemory.storage
+
+import ai.koog.agents.longtermmemory.model.MemoryRecord
+import ai.koog.agents.longtermmemory.retrieval.KeywordSearchRequest
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class InMemoryRecordStorageTest {
+    private val defaultNamespace = "default"
+
+    @Test
+    fun testAddRecordsWithoutId() = runTest {
+        val repository = InMemoryRecordStorage()
+
+        repository.add(
+            listOf(
+                MemoryRecord(content = "Test content 1"),
+                MemoryRecord(content = "Test content 2")
+            ),
+            defaultNamespace,
+        )
+
+        assertEquals(2, repository.size())
+    }
+
+    @Test
+    fun testAddRecordsWithId() = runTest {
+        val repository = InMemoryRecordStorage()
+
+        repository.add(
+            listOf(
+                MemoryRecord(id = "id-1", content = "Test content 1"),
+                MemoryRecord(id = "id-2", content = "Test content 2")
+            ),
+            defaultNamespace,
+        )
+
+        val searchResults = repository.search(KeywordSearchRequest(query = "content"), defaultNamespace).map { it.record.id }
+        assertEquals(2, searchResults.size)
+        assertContains(searchResults, "id-1")
+        assertContains(searchResults, "id-2")
+    }
+
+    @Test
+    fun testSearchByKeyword() = runTest {
+        val repository = InMemoryRecordStorage()
+        repository.add(
+            listOf(
+                MemoryRecord(id = "id-1", content = "Kotlin is a programming language"),
+                MemoryRecord(id = "id-2", content = "Java is also a programming language"),
+                MemoryRecord(id = "id-3", content = "Python is popular for data science")
+            ),
+            defaultNamespace,
+        )
+
+        val results = repository.search(KeywordSearchRequest(query = "programming"), defaultNamespace)
+
+        assertEquals(2, results.size)
+        assertTrue(results.all { it.record.content.contains("programming") })
+    }
+
+    @Test
+    fun testSearchWithLimit() = runTest {
+        val repository = InMemoryRecordStorage()
+        repository.add(
+            listOf(
+                MemoryRecord(id = "id-1", content = "Test content 1"),
+                MemoryRecord(id = "id-2", content = "Test content 2"),
+                MemoryRecord(id = "id-3", content = "Test content 3")
+            ),
+            defaultNamespace,
+        )
+
+        val results = repository.search(KeywordSearchRequest(query = "Test", limit = 2), defaultNamespace)
+
+        assertEquals(2, results.size)
+    }
+
+    @Test
+    fun testSearchCaseInsensitive() = runTest {
+        val repository = InMemoryRecordStorage()
+        repository.add(
+            listOf(
+                MemoryRecord(id = "id-1", content = "KOTLIN is great"),
+                MemoryRecord(id = "id-2", content = "kotlin is awesome")
+            ),
+            defaultNamespace,
+        )
+
+        val results = repository.search(KeywordSearchRequest(query = "Kotlin"), defaultNamespace)
+
+        assertEquals(2, results.size)
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -210,6 +210,7 @@ dependencies {
     dokka(project(":agents:agents-core"))
     dokka(project(":agents:agents-ext"))
     dokka(project(":agents:agents-features:agents-features-event-handler"))
+    dokka(project(":agents:agents-features:agents-features-longterm-memory"))
     dokka(project(":agents:agents-features:agents-features-memory"))
     dokka(project(":agents:agents-features:agents-features-opentelemetry"))
     dokka(project(":agents:agents-features:agents-features-snapshot"))

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -127,6 +127,12 @@ Learn about the core components of Koog agents in detail:
 
     Debug and monitor agent execution with detailed, configurable tracing
 
+-   :material-timeline-text:{ .lg .middle } [**Long Term Memory**](long-term-memory.md)
+
+    ---
+
+    Integrate vector databases and memory providers for RAG and persistent memory.
+
 </div>
 
 ## Integrations

--- a/docs/docs/long-term-memory.md
+++ b/docs/docs/long-term-memory.md
@@ -1,0 +1,170 @@
+# Long Term Memory Feature (Experimental)
+
+The `LongTermMemory` feature adds persistent memory to Koog AI agents via two independent group of settings:
+- **Retrieval** — augments LLM prompts with relevant context from a memory storage (Retrieval-Augmented Generation or RAG)
+- **Ingestion** — persists conversation messages into a memory storage for future retrieval
+
+## Quick Start
+
+> **Note:** `LongTermMemory` is an experimental API. Annotate your code with `@OptIn(ExperimentalAgentsApi::class)` or add `@file:OptIn(ExperimentalAgentsApi::class)` at the top of your file.
+
+```kotlin
+@OptIn(ExperimentalAgentsApi::class)
+val storage = InMemoryRecordStorage() // or your vector DB adapter
+
+@OptIn(ExperimentalAgentsApi::class)
+val agent = AIAgent(
+    promptExecutor = executor,
+    strategy = singleRunStrategy(),
+    agentConfig = agentConfig,
+    toolRegistry = ToolRegistry.EMPTY
+) {
+    install(LongTermMemory) {
+        retrieval {
+            storage = storage
+            searchStrategy = KeywordSearchStrategy(topK = 5)
+        }
+        ingestion {
+            storage = storage
+        }
+    }
+}
+
+agent.run("What did we discuss yesterday?")
+```
+
+## Retrieval Only (RAG)
+
+Use retrieval without ingestion when you have a pre-populated knowledge base:
+
+```kotlin
+@OptIn(ExperimentalAgentsApi::class)
+install(LongTermMemory) {
+    retrieval {
+        storage = myVectorDbStorage
+        namespace = "my-collection"  // optional: scope to a specific namespace/collection
+        searchStrategy = SimilaritySearchStrategy(topK = 3, similarityThreshold = 0.7)
+        promptAugmenter = SystemPromptAugmenter()
+    }
+}
+```
+
+### Prompt Augmenters
+
+| Augmenter | Behavior |
+|---|---|
+| `SystemPromptAugmenter()` | Inserts context as a system message at the start of the prompt (no-op if there is no system message) |
+| `UserPromptAugmenter()` | Inserts context as a separate user message before the last user message |
+| `PromptAugmenter { prompt, context -> ... }` | Custom augmentation via lambda |
+
+## Ingestion Only
+
+Use ingestion without retrieval to build up a memory storage over time:
+
+```kotlin
+@OptIn(ExperimentalAgentsApi::class)
+install(LongTermMemory) {
+    ingestion {
+        storage = myVectorDbStorage
+        namespace = "my-collection"  // optional: scope to a specific namespace/collection
+        extractor = FilteringMemoryRecordExtractor(
+            messageRolesToExtract = setOf(Message.Role.User, Message.Role.Assistant)
+        )
+        timing = IngestionTiming.ON_LLM_CALL
+    }
+}
+```
+
+### Ingestion Timing
+
+| Timing | Behavior |
+|---|---|
+| `ON_LLM_CALL` | Ingests messages on each LLM call/stream (enables intra-session RAG) |
+| `ON_AGENT_COMPLETION` | Ingests all messages at once when the agent run completes |
+
+## Accessing Long-Term Memory from Strategy Nodes
+
+Use `withLongTermMemory { }` inside a strategy node to directly search or add records:
+
+```kotlin
+@OptIn(ExperimentalAgentsApi::class)
+val myNode by node<String, Unit> {
+    withLongTermMemory {
+        // Manually add records
+        val record = MemoryRecord(content = "important fact")
+        this.getIngestionStorage()?.add(listOf(record), ingestionSettings?.namespace)
+
+        // Manually search
+        val request = SimilaritySearchRequest(query = input, limit = 5)
+        val results = this.getRetrievalStorage()?.search(request, retrievalSettings?.namespace)
+    }
+}
+```
+
+Use `longTermMemory()` to get the feature instance directly:
+
+```kotlin
+@OptIn(ExperimentalAgentsApi::class)
+val myNode by node<String, Unit> {
+    val memory = longTermMemory()
+    val storage = memory.getIngestionStorage()
+}
+```
+
+## Custom Memory Record Extractor
+
+Implement `MemoryRecordExtractor` to control how messages are transformed before storage:
+
+```kotlin
+@OptIn(ExperimentalAgentsApi::class)
+val summarizingExtractor = MemoryRecordExtractor { messages ->
+    messages
+        .filter { it.role == Message.Role.Assistant }
+        .map { MemoryRecord(content = summarize(it.content)) }
+}
+
+install(LongTermMemory) {
+    ingestion {
+        storage = myStorage
+        extractor = summarizingExtractor
+    }
+}
+```
+
+## Custom Search Request
+
+Use `searchStrategy` with a lambda to control how user queries are turned into search requests:
+
+```kotlin
+@OptIn(ExperimentalAgentsApi::class)
+install(LongTermMemory) {
+    retrieval {
+        storage = myStorage
+        searchStrategy = SearchStrategy { query ->
+            SimilaritySearchRequest(query = rephrase(query), limit = 10)
+        }
+    }
+}
+```
+
+## Implementing Custom Storage
+
+Implement `RetrievalStorage` and/or `IngestionStorage` to connect to your vector database:
+
+```kotlin
+class MyVectorDbStorage : RetrievalStorage, IngestionStorage {
+    override suspend fun search(
+        request: SearchRequest, namespace: String?
+    ): List<SearchResult> {
+        // Query your vector DB
+    }
+
+    override suspend fun add(
+        records: List<MemoryRecord>, namespace: String?
+    ) {
+        // Upsert into your vector DB
+    }
+}
+```
+
+For testing, use the built-in `InMemoryRecordStorage` which keeps records in memory with keyword-based search.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
           - Event handlers: agent-event-handlers.md
           - Tracing: tracing.md
           - Memory: agent-memory.md
+          - Long Term Memory: long-term-memory.md
           - Agent Persistence: agent-persistence.md
           - OpenTelemetry:
               - Overview: opentelemetry-support.md

--- a/koog-agents/build.gradle.kts
+++ b/koog-agents/build.gradle.kts
@@ -44,6 +44,7 @@ val excluded = setOf(
 val included = setOf(
     ":agents:agents-core",
     ":agents:agents-features:agents-features-event-handler",
+    ":agents:agents-features:agents-features-longterm-memory",
     ":agents:agents-features:agents-features-memory",
     ":agents:agents-features:agents-features-opentelemetry",
     ":agents:agents-features:agents-features-trace",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,7 @@ include(":agents:agents-ext")
 
 include(":agents:agents-features:agents-features-acp")
 include(":agents:agents-features:agents-features-event-handler")
+include(":agents:agents-features:agents-features-longterm-memory")
 include(":agents:agents-features:agents-features-memory")
 include(":agents:agents-features:agents-features-opentelemetry")
 include(":agents:agents-features:agents-features-sql")


### PR DESCRIPTION
This PR introduces a new feature with pipeline interceptors that can:
* augment prompts before sending them to an LLM with memory records from a provided storage;
* extract memory records from messages and ingest them into the provided storage.
