### PR TITLE
fix(prompt): Stream Ollama response with preparePost.execute

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -45,13 +45,16 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.get
 import io.ktor.client.request.post
+import io.ktor.client.request.preparePost
 import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsChannel
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.readUTF8Line
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
@@ -287,31 +290,31 @@ public class OllamaClient @JvmOverloads constructor(
             )
         )
 
-        val response = client.post(DEFAULT_MESSAGE_PATH) {
+        client.preparePost(DEFAULT_MESSAGE_PATH) {
+            contentType(ContentType.Application.Json)
             setBody(request)
-        }
+        }.execute { response: HttpResponse ->
+            val channel: ByteReadChannel = response.bodyAsChannel()
 
-        val channel = response.bodyAsChannel()
+            while (!channel.isClosedForRead) {
+                val line = channel.readUTF8Line() ?: break
+                if (line.isBlank()) continue
 
-        while (!channel.isClosedForRead) {
-            val line = channel.readUTF8Line() ?: break
-            if (line.isBlank()) continue
-
-            try {
-                val chunk = ollamaJson.decodeFromString<OllamaChatResponseDTO>(line)
-                chunk.message?.let { message ->
-                    emitAppend(message.content)
-                    message.toolCalls?.forEach { toolCall ->
-                        emitToolCall(
-                            id = null,
-                            name = toolCall.function.name,
-                            content = toolCall.function.arguments.toString()
-                        )
+                try {
+                    val chunk = ollamaJson.decodeFromString<OllamaChatResponseDTO>(line)
+                    chunk.message?.let { message ->
+                        emitAppend(message.content)
+                        message.toolCalls?.forEach { toolCall ->
+                            emitToolCall(
+                                id = null,
+                                name = toolCall.function.name,
+                                content = toolCall.function.arguments.toString()
+                            )
+                        }
                     }
+                } catch (_: Exception) {
+                    // Skip malformed JSON lines
                 }
-            } catch (_: Exception) {
-                // Skip malformed JSON lines
-                continue
             }
         }
     }


### PR DESCRIPTION
Switch from client.post to client.preparePost(...).execute to stream and process the response body using HttpResponse and ByteReadChannel. Explicitly set Content-Type for the request, move the channel-reading loop into the execute block, and simplify malformed-JSON handling. Added necessary imports (HttpResponse, ByteReadChannel, preparePost) and removed the previous response variable usage.

This is needed because else the body is fully downloaded and then streamed. See https://api.ktor.io/ktor-client-core/io.ktor.client/-http-client.html section streaming
 