### PR TITLE
docs(agents): KG-696. Add KDoc and InternalAgentsApi annotations to agent pipeline

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/ContextualAgentEnvironment.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/ContextualAgentEnvironment.kt
@@ -2,6 +2,7 @@ package ai.koog.agents.core.environment
 
 import ai.koog.agents.core.agent.context.AIAgentContext
 import ai.koog.agents.core.agent.execution.AgentExecutionInfo
+import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.feature.model.toAgentError
 import ai.koog.prompt.message.Message
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -10,7 +11,19 @@ import kotlin.coroutines.cancellation.CancellationException
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
-@Suppress("MissingKDocForPublicAPI")
+/**
+ * Represents an AI agent environment that operates within the context of a specific agent framework.
+ *
+ * This class acts as a decorator over an existing [AIAgentEnvironment], augmenting operations with contextual
+ * processing using the provided [AIAgentContext].
+ *
+ * @constructor Constructs a new instance of [ContextualAgentEnvironment] with a decorated [environment] and a
+ * contextual [context].
+ *
+ * @param environment The underlying agent environment responsible for managing tool execution.
+ * @param context The context that augments the environment with additional behavioral and execution information.
+ */
+@InternalAgentsApi
 public class ContextualAgentEnvironment(
     private val environment: AIAgentEnvironment,
     private val context: AIAgentContext,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/ContextualPromptExecutor.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/ContextualPromptExecutor.kt
@@ -1,6 +1,7 @@
 package ai.koog.agents.core.feature
 
 import ai.koog.agents.core.agent.context.AIAgentContext
+import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.prompt.dsl.ModerationResult
 import ai.koog.prompt.dsl.Prompt
@@ -25,6 +26,7 @@ import kotlin.uuid.Uuid
  * @property executor The [ai.koog.prompt.executor.model.PromptExecutor] to wrap;
  * @property context The [AIAgentContext] associated with the agent that is executing the prompt.
  */
+@InternalAgentsApi
 public class ContextualPromptExecutor(
     private val executor: PromptExecutor,
     private val context: AIAgentContext,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/AgentLifecycleHandlersCollector.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/AgentLifecycleHandlersCollector.kt
@@ -2,8 +2,21 @@ package ai.koog.agents.core.feature.handler
 
 import ai.koog.agents.core.agent.entity.AIAgentStorageKey
 
+/**
+ * Collects and manages lifecycle event handlers associated with AI agents and features.
+ *
+ * This class serves as a centralized registry for associating handlers with specific
+ * lifecycle event types and their corresponding features. Handlers are grouped by the
+ * associated feature key and further categorized by the event type they handle.
+ */
 internal class AgentLifecycleHandlersCollector {
 
+    /**
+     * The internal class maintains a mapping between event types and their corresponding handlers, enabling
+     * the addition and retrieval of event handlers for different agent lifecycle events.
+     *
+     * @property featureKey The key representing the feature associated with these event handlers.
+     */
     private class FeatureEventHandlers(
         val featureKey: AIAgentStorageKey<*>
     ) {
@@ -27,8 +40,7 @@ internal class AgentLifecycleHandlersCollector {
         }
     }
 
-    private val featureToHandlersMap =
-        mutableMapOf<AIAgentStorageKey<*>, FeatureEventHandlers>()
+    private val featureToHandlersMap = mutableMapOf<AIAgentStorageKey<*>, FeatureEventHandlers>()
 
     internal fun <TContext : AgentLifecycleEventContext, TReturn : Any> addHandlerForFeature(
         featureKey: AIAgentStorageKey<*>,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
@@ -60,6 +60,7 @@ public expect open class AIAgentGraphPipeline(
      * @param input The input data for the node execution
      * @param inputType The type of the input data provided to the node
      */
+    @InternalAgentsApi
     public open override suspend fun onNodeExecutionStarting(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -81,6 +82,7 @@ public expect open class AIAgentGraphPipeline(
      * @param output The output data produced by the node execution
      * @param outputType The type of the output data produced by the node execution
      */
+    @InternalAgentsApi
     public open override suspend fun onNodeExecutionCompleted(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -103,6 +105,7 @@ public expect open class AIAgentGraphPipeline(
      * @param inputType The type of the input data provided to the node.
      * @param throwable The exception or error that occurred during node execution.
      */
+    @InternalAgentsApi
     public open override suspend fun onNodeExecutionFailed(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -127,6 +130,7 @@ public expect open class AIAgentGraphPipeline(
      * @param input The input data for the subgraph execution.
      * @param inputType The type of the input data provided to the subgraph.
      */
+    @InternalAgentsApi
     public open override suspend fun onSubgraphExecutionStarting(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -148,6 +152,7 @@ public expect open class AIAgentGraphPipeline(
      * @param output The output data produced by the subgraph execution.
      * @param outputType The type of the output data produced by the subgraph execution.
      */
+    @InternalAgentsApi
     public open override suspend fun onSubgraphExecutionCompleted(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -170,6 +175,7 @@ public expect open class AIAgentGraphPipeline(
      * @param inputType The type of the input data provided to the subgraph.
      * @param throwable The exception or error that caused the subgraph execution to fail.
      */
+    @InternalAgentsApi
     public open override suspend fun onSubgraphExecutionFailed(
         eventId: String,
         executionInfo: AgentExecutionInfo,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipelineAPI.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipelineAPI.kt
@@ -6,6 +6,7 @@ import ai.koog.agents.core.agent.context.AIAgentGraphContextBase
 import ai.koog.agents.core.agent.entity.AIAgentNodeBase
 import ai.koog.agents.core.agent.entity.AIAgentSubgraph
 import ai.koog.agents.core.agent.execution.AgentExecutionInfo
+import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.feature.AIAgentGraphFeature
 import ai.koog.agents.core.feature.handler.node.NodeExecutionCompletedContext
 import ai.koog.agents.core.feature.handler.node.NodeExecutionFailedContext
@@ -24,6 +25,8 @@ import kotlin.reflect.KType
 public interface AIAgentGraphPipelineAPI : AIAgentPipelineAPI {
 
     //region Trigger Node Handlers
+
+    @InternalAgentsApi
     public suspend fun onNodeExecutionStarting(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -33,6 +36,7 @@ public interface AIAgentGraphPipelineAPI : AIAgentPipelineAPI {
         inputType: KType
     )
 
+    @InternalAgentsApi
     public suspend fun onNodeExecutionCompleted(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -44,6 +48,7 @@ public interface AIAgentGraphPipelineAPI : AIAgentPipelineAPI {
         outputType: KType,
     )
 
+    @InternalAgentsApi
     public suspend fun onNodeExecutionFailed(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -53,9 +58,12 @@ public interface AIAgentGraphPipelineAPI : AIAgentPipelineAPI {
         inputType: KType,
         throwable: Throwable
     )
-    //endregion
+
+    //endregion Trigger Node Handlers
 
     //region Trigger Subgraph Handlers
+
+    @InternalAgentsApi
     public suspend fun onSubgraphExecutionStarting(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -65,6 +73,7 @@ public interface AIAgentGraphPipelineAPI : AIAgentPipelineAPI {
         inputType: KType
     )
 
+    @InternalAgentsApi
     public suspend fun onSubgraphExecutionCompleted(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -76,6 +85,7 @@ public interface AIAgentGraphPipelineAPI : AIAgentPipelineAPI {
         outputType: KType,
     )
 
+    @InternalAgentsApi
     public suspend fun onSubgraphExecutionFailed(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -85,9 +95,11 @@ public interface AIAgentGraphPipelineAPI : AIAgentPipelineAPI {
         inputType: KType,
         throwable: Throwable
     )
-    //endregion
+
+    //endregion Trigger Subgraph Handlers
 
     //region Interceptors
+
     public fun interceptNodeExecutionStarting(
         feature: AIAgentGraphFeature<*, *>,
         handle: suspend (eventContext: NodeExecutionStartingContext) -> Unit
@@ -117,5 +129,5 @@ public interface AIAgentGraphPipelineAPI : AIAgentPipelineAPI {
         feature: AIAgentGraphFeature<*, *>,
         handle: suspend (eventContext: SubgraphExecutionFailedContext) -> Unit
     )
-    //endregion
+    //endregion Interceptors
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
@@ -124,8 +124,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param agent The agent instance for which the execution has started
      * @param context The context of the agent execution, providing access to the agent environment and context features
      */
-    // TODO: SD -- make this methods internal
-    @OptIn(InternalAgentsApi::class)
+    @InternalAgentsApi
     public override suspend fun <TInput, TOutput> onAgentStarting(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -143,6 +142,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param runId The unique identifier of the agent run
      * @param result The result produced by the agent, or null if no result was produced
      */
+    @InternalAgentsApi
     public override suspend fun onAgentCompleted(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -161,6 +161,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param runId The unique identifier of the agent run
      * @param throwable The [Throwable] exception instance that was thrown during agent execution
      */
+    @InternalAgentsApi
     public override suspend fun onAgentExecutionFailed(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -177,6 +178,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param executionInfo The execution information for the agent environment transformation event
      * @param agentId The unique identifier of the agent that will be closed.
      */
+    @InternalAgentsApi
     public override suspend fun onAgentClosing(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -195,6 +197,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param baseEnvironment The initial environment to be transformed
      * @return The transformed environment after all handlers have been applied
      */
+    @InternalAgentsApi
     public override suspend fun onAgentEnvironmentTransforming(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -214,7 +217,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param strategy The strategy that has started execution
      * @param context The context of the strategy execution
      */
-    @OptIn(InternalAgentsApi::class)
+    @InternalAgentsApi
     public override suspend fun onStrategyStarting(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -231,7 +234,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param context The context of the strategy execution
      * @param result The result produced by the strategy execution
      */
-    @OptIn(InternalAgentsApi::class)
+    @InternalAgentsApi
     public override suspend fun onStrategyCompleted(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -255,6 +258,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param model The language model instance that will process the request
      * @param tools The list of tool descriptors available for the LLM call
      */
+    @InternalAgentsApi
     public override suspend fun onLLMCallStarting(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -277,6 +281,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param responses The response messages received from the language model
      * @param moderationResponse The moderation response, if any, received from the language model
      */
+    @InternalAgentsApi
     public override suspend fun onLLMCallCompleted(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -304,6 +309,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param toolDescription The description of the tool that is being called.
      * @param toolArgs The arguments provided to the tool
      */
+    @InternalAgentsApi
     public override suspend fun onToolCallStarting(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -328,6 +334,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param message The validation error message;
      * @param error The [AIAgentError] validation error.
      */
+    @InternalAgentsApi
     public override suspend fun onToolValidationFailed(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -354,6 +361,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param message A message describing the failure.
      * @param error The [AIAgentError] that caused the failure.
      */
+    @InternalAgentsApi
     public override suspend fun onToolCallFailed(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -379,6 +387,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param toolArgs The arguments that were provided to the tool;
      * @param toolResult The result produced by the tool, or null if no result was produced.
      */
+    @InternalAgentsApi
     public override suspend fun onToolCallCompleted(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -408,6 +417,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param model The language model being used for streaming;
      * @param tools The list of available tool descriptors for this streaming session.
      */
+    @InternalAgentsApi
     public override suspend fun onLLMStreamingStarting(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -431,6 +441,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param model The language model being used for streaming;
      * @param streamFrame The individual stream frame containing partial response data.
      */
+    @InternalAgentsApi
     public override suspend fun onLLMStreamingFrameReceived(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -454,6 +465,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param model The language model being used for streaming;
      * @param throwable The exception that occurred during streaming if applicable.
      */
+    @InternalAgentsApi
     public override suspend fun onLLMStreamingFailed(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -477,6 +489,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param model The language model that was used for streaming;
      * @param tools The list of tool descriptors that were available for this streaming session.
      */
+    @InternalAgentsApi
     public override suspend fun onLLMStreamingCompleted(
         eventId: String,
         executionInfo: AgentExecutionInfo,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineAPI.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineAPI.kt
@@ -67,8 +67,7 @@ public interface AIAgentPipelineAPI {
 
     //region Trigger Agent Handlers
 
-    // TODO: SD -- delete from public API
-    //  this should be an internal methods
+    @InternalAgentsApi
     public suspend fun <TInput, TOutput> onAgentStarting(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -77,6 +76,7 @@ public interface AIAgentPipelineAPI {
         context: AIAgentContext
     )
 
+    @InternalAgentsApi
     public suspend fun onAgentCompleted(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -86,6 +86,7 @@ public interface AIAgentPipelineAPI {
         context: AIAgentContext
     )
 
+    @InternalAgentsApi
     public suspend fun onAgentExecutionFailed(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -95,12 +96,14 @@ public interface AIAgentPipelineAPI {
         context: AIAgentContext
     )
 
+    @InternalAgentsApi
     public suspend fun onAgentClosing(
         eventId: String,
         executionInfo: AgentExecutionInfo,
         agentId: String
     )
 
+    @InternalAgentsApi
     public suspend fun onAgentEnvironmentTransforming(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -108,10 +111,11 @@ public interface AIAgentPipelineAPI {
         baseEnvironment: AIAgentEnvironment
     ): AIAgentEnvironment
 
-    //endregion
+    //endregion Trigger Agent Handlers
 
     //region Trigger Strategy Handlers
 
+    @InternalAgentsApi
     public suspend fun onStrategyStarting(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -119,6 +123,7 @@ public interface AIAgentPipelineAPI {
         context: AIAgentContext
     )
 
+    @InternalAgentsApi
     public suspend fun onStrategyCompleted(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -127,10 +132,12 @@ public interface AIAgentPipelineAPI {
         result: Any?,
         resultType: KType
     )
-    //endregion
+
+    //endregion Trigger Strategy Handlers
 
     //region Trigger LLM Handlers
 
+    @InternalAgentsApi
     public suspend fun onLLMCallStarting(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -141,6 +148,7 @@ public interface AIAgentPipelineAPI {
         context: AIAgentContext
     )
 
+    @InternalAgentsApi
     public suspend fun onLLMCallCompleted(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -153,9 +161,11 @@ public interface AIAgentPipelineAPI {
         context: AIAgentContext
     )
 
-    //endregion
+    //endregion Trigger LLM Handlers
 
     //region Trigger Tool Handlers
+
+    @InternalAgentsApi
     public suspend fun onToolCallStarting(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -167,6 +177,7 @@ public interface AIAgentPipelineAPI {
         context: AIAgentContext
     )
 
+    @InternalAgentsApi
     public suspend fun onToolValidationFailed(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -180,6 +191,7 @@ public interface AIAgentPipelineAPI {
         context: AIAgentContext
     )
 
+    @InternalAgentsApi
     public suspend fun onToolCallFailed(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -193,6 +205,7 @@ public interface AIAgentPipelineAPI {
         context: AIAgentContext
     )
 
+    @InternalAgentsApi
     public suspend fun onToolCallCompleted(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -205,10 +218,11 @@ public interface AIAgentPipelineAPI {
         context: AIAgentContext
     )
 
-    //endregion
+    //endregion Trigger Tool Handlers
 
     //region Trigger Streaming Handlers
 
+    @InternalAgentsApi
     public suspend fun onLLMStreamingStarting(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -219,6 +233,7 @@ public interface AIAgentPipelineAPI {
         context: AIAgentContext
     )
 
+    @InternalAgentsApi
     public suspend fun onLLMStreamingFrameReceived(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -229,6 +244,7 @@ public interface AIAgentPipelineAPI {
         context: AIAgentContext
     )
 
+    @InternalAgentsApi
     public suspend fun onLLMStreamingFailed(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -239,6 +255,7 @@ public interface AIAgentPipelineAPI {
         context: AIAgentContext
     )
 
+    @InternalAgentsApi
     public suspend fun onLLMStreamingCompleted(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -249,7 +266,7 @@ public interface AIAgentPipelineAPI {
         context: AIAgentContext
     )
 
-    //endregion
+    //endregion Trigger Streaming Handlers
 
     //region Interceptors
 
@@ -259,6 +276,7 @@ public interface AIAgentPipelineAPI {
     )
 
     public fun interceptAgentStarting(feature: AIAgentFeature<*, *>, handle: suspend (AgentStartingContext) -> Unit)
+
     public fun interceptAgentCompleted(
         feature: AIAgentFeature<*, *>,
         handle: suspend (eventContext: AgentCompletedContext) -> Unit
@@ -390,7 +408,7 @@ public interface AIAgentPipelineAPI {
         handle: suspend (eventContext: ToolValidationFailedContext) -> Unit
     )
 
-    //endregion
+    //endregion Interceptors
 
     @InternalAgentsApi
     public suspend fun prepareFeatures()

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineImpl.kt
@@ -92,7 +92,6 @@ public class AIAgentPipelineImpl(
         Debugger.key
     )
 
-    // TODO: SD -- add comment
     private val agentLifecycleHandlersCollector = AgentLifecycleHandlersCollector()
 
     public override fun <TFeature : Any> feature(
@@ -168,8 +167,7 @@ public class AIAgentPipelineImpl(
 
     //region Invoke Agent Handlers
 
-    // TODO: SD -- rename all to invokeOnAgentStarting
-    @OptIn(InternalAgentsApi::class)
+    @InternalAgentsApi
     public override suspend fun <TInput, TOutput> onAgentStarting(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -183,7 +181,7 @@ public class AIAgentPipelineImpl(
         )
     }
 
-    @OptIn(InternalAgentsApi::class)
+    @InternalAgentsApi
     public override suspend fun onAgentCompleted(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -198,7 +196,7 @@ public class AIAgentPipelineImpl(
         )
     }
 
-    @OptIn(InternalAgentsApi::class)
+    @InternalAgentsApi
     public override suspend fun onAgentExecutionFailed(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -213,7 +211,7 @@ public class AIAgentPipelineImpl(
         )
     }
 
-    @OptIn(InternalAgentsApi::class)
+    @InternalAgentsApi
     public override suspend fun onAgentClosing(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -225,13 +223,13 @@ public class AIAgentPipelineImpl(
         )
     }
 
+    @InternalAgentsApi
     public override suspend fun onAgentEnvironmentTransforming(
         eventId: String,
         executionInfo: AgentExecutionInfo,
         agent: GraphAIAgent<*, *>,
         baseEnvironment: AIAgentEnvironment
     ): AIAgentEnvironment {
-        @OptIn(InternalAgentsApi::class)
         return invokeRegisteredHandlersForEvent(
             eventType = AgentLifecycleEventType.AgentEnvironmentTransforming,
             context = AgentEnvironmentTransformingContext(eventId, executionInfo, agent, config),
@@ -243,7 +241,7 @@ public class AIAgentPipelineImpl(
 
     //region Invoke Strategy Handlers
 
-    @OptIn(InternalAgentsApi::class)
+    @InternalAgentsApi
     public override suspend fun onStrategyStarting(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -256,7 +254,7 @@ public class AIAgentPipelineImpl(
         )
     }
 
-    @OptIn(InternalAgentsApi::class)
+    @InternalAgentsApi
     public override suspend fun onStrategyCompleted(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -275,7 +273,7 @@ public class AIAgentPipelineImpl(
 
     //region Invoke LLM Call Handlers
 
-    @OptIn(InternalAgentsApi::class)
+    @InternalAgentsApi
     public override suspend fun onLLMCallStarting(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -291,7 +289,7 @@ public class AIAgentPipelineImpl(
         )
     }
 
-    @OptIn(InternalAgentsApi::class)
+    @InternalAgentsApi
     public override suspend fun onLLMCallCompleted(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -313,7 +311,7 @@ public class AIAgentPipelineImpl(
 
     //region Invoke Tool Call Handlers
 
-    @OptIn(InternalAgentsApi::class)
+    @InternalAgentsApi
     public override suspend fun onToolCallStarting(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -339,7 +337,7 @@ public class AIAgentPipelineImpl(
         )
     }
 
-    @OptIn(InternalAgentsApi::class)
+    @InternalAgentsApi
     public override suspend fun onToolValidationFailed(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -369,7 +367,7 @@ public class AIAgentPipelineImpl(
         )
     }
 
-    @OptIn(InternalAgentsApi::class)
+    @InternalAgentsApi
     public override suspend fun onToolCallFailed(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -399,7 +397,7 @@ public class AIAgentPipelineImpl(
         )
     }
 
-    @OptIn(InternalAgentsApi::class)
+    @InternalAgentsApi
     public override suspend fun onToolCallCompleted(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -431,7 +429,7 @@ public class AIAgentPipelineImpl(
 
     //region Invoke LLM Streaming
 
-    @OptIn(InternalAgentsApi::class)
+    @InternalAgentsApi
     public override suspend fun onLLMStreamingStarting(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -447,7 +445,7 @@ public class AIAgentPipelineImpl(
         )
     }
 
-    @OptIn(InternalAgentsApi::class)
+    @InternalAgentsApi
     public override suspend fun onLLMStreamingFrameReceived(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -463,7 +461,7 @@ public class AIAgentPipelineImpl(
         )
     }
 
-    @OptIn(InternalAgentsApi::class)
+    @InternalAgentsApi
     public override suspend fun onLLMStreamingFailed(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -479,7 +477,7 @@ public class AIAgentPipelineImpl(
         )
     }
 
-    @OptIn(InternalAgentsApi::class)
+    @InternalAgentsApi
     public override suspend fun onLLMStreamingCompleted(
         eventId: String,
         executionInfo: AgentExecutionInfo,
@@ -511,8 +509,6 @@ public class AIAgentPipelineImpl(
         )
     }
 
-    // TODO: SD -- rename all to
-    //  onAgentStarting(...)
     @OptIn(InternalAgentsApi::class)
     public override fun interceptAgentStarting(
         feature: AIAgentFeature<*, *>,

--- a/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/AIAgentPlannerStrategy.kt
+++ b/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/AIAgentPlannerStrategy.kt
@@ -3,6 +3,7 @@ package ai.koog.agents.planner
 import ai.koog.agents.core.agent.context.AIAgentFunctionalContext
 import ai.koog.agents.core.agent.context.with
 import ai.koog.agents.core.agent.entity.AIAgentStrategy
+import ai.koog.agents.core.annotation.InternalAgentsApi
 import kotlin.coroutines.cancellation.CancellationException
 
 /**
@@ -21,6 +22,7 @@ public class AIAgentPlannerStrategy<State, Plan>(
         input: State
     ): State {
         return try {
+            @OptIn(InternalAgentsApi::class)
             context.with(partName = name) { executionInfo, eventId ->
                 context.pipeline.onStrategyStarting(eventId, executionInfo, this, context)
                 val result = planner.execute(context, input)


### PR DESCRIPTION
[KG-696](https://youtrack.jetbrains.com/issue/KG-696/Cleanup-Agent-pipeline-API).

1. Marking lifecycle methods as internal - Added @InternalAgentsApi annotations to pipeline methods (onAgentStarting, onToolCallCompleted, etc.) to indicate framework internals API
2. Adding documentation - Added KDoc to key classes like `ContextualAgentEnvironment` and `AgentLifecycleHandlersCollector` for better code readability.
