### PR TITLE
feat(koog-agents): add open telemetry metric support in Koog

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/GenAIAttributes.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/GenAIAttributes.kt
@@ -16,7 +16,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.putJsonArray
 
 /**
- * The class describe Attributes related to a Spans in GenAI system.
+ * The class describe Attributes in GenAI system.
  *
  * The list of supported attributes according to Open Telemetry Semantic Convention
  * (https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/)
@@ -48,8 +48,9 @@ import kotlinx.serialization.json.putJsonArray
  * - gen_ai.tool.call.id (recommended)
  * - gen_ai.tool.description (recommended)
  * - gen_ai.tool.name (recommended)
+ * - gen_ai.token.type (required)
  */
-internal object SpanAttributes {
+internal object GenAIAttributes {
 
     // gen_ai.operation
     sealed interface Operation : GenAIAttribute {
@@ -275,21 +276,27 @@ internal object SpanAttributes {
 
         sealed interface FinishReasonType {
             val id: String
+
             object ContentFilter : FinishReasonType {
                 override val id = "content_filter"
             }
+
             object Error : FinishReasonType {
                 override val id = "error"
             }
+
             object Length : FinishReasonType {
                 override val id = "length"
             }
+
             object Stop : FinishReasonType {
                 override val id = "stop"
             }
+
             object ToolCalls : FinishReasonType {
                 override val id = "tool_calls"
             }
+
             data class Custom(override val id: String) : FinishReasonType
         }
 
@@ -303,6 +310,23 @@ internal object SpanAttributes {
         data class Model(private val model: LLModel) : Response {
             override val key: String = super.key.concatKey("model")
             override val value: String = model.id
+        }
+    }
+
+    // gen_ai.token
+    sealed interface Token : GenAIAttribute {
+        override val key: String
+            get() = super.key.concatKey("token")
+
+        // gen_ai.token.type
+        data class Type(private val type: TokenType) : Token {
+            override val key: String = super.key.concatKey("type")
+            override val value: String = type.str
+        }
+
+        enum class TokenType(val str: String) {
+            INPUT("input"),
+            OUTPUT("output")
         }
     }
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/KoogAttributes.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/KoogAttributes.kt
@@ -73,5 +73,27 @@ internal object KoogAttributes {
                 override val value: HiddenString = HiddenString(output)
             }
         }
+
+        sealed interface Tool : Koog {
+            override val key: String
+                get() = super.key.concatKey("tool")
+
+            sealed interface Call : Tool {
+                override val key: String
+                    get() = super.key.concatKey("call")
+
+                // koog.tool.call.status
+                data class Status(private val status: StatusType) : Call {
+                    override val key: String = super.key.concatKey("status")
+                    override val value: String = status.str
+                }
+
+                enum class StatusType(val str: String) {
+                    SUCCESS("success"),
+                    ERROR("error"),
+                    VALIDATION_FAILED("validation_failed")
+                }
+            }
+        }
     }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/attributes.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/attributes.kt
@@ -4,7 +4,6 @@ import ai.koog.agents.utils.HiddenString
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.common.AttributesBuilder
-import java.util.function.BiConsumer
 
 internal fun AttributesBuilder.addAttributes(attributes: Map<AttributeKey<*>, Any>): AttributesBuilder {
     attributes.forEach { (key, value) ->
@@ -16,26 +15,7 @@ internal fun AttributesBuilder.addAttributes(attributes: Map<AttributeKey<*>, An
 
 internal fun List<Attribute>.toSdkAttributes(verbose: Boolean): Attributes {
     val sdkAttributesMap = this.associate { it.toSdkAttribute(verbose) }
-
-    return object : Attributes {
-
-        @Suppress("UNCHECKED_CAST")
-        override fun <T : Any?> get(key: AttributeKey<T?>): T? = sdkAttributesMap[key] as T?
-
-        override fun forEach(consumer: BiConsumer<in AttributeKey<*>, in Any>) {
-            sdkAttributesMap.forEach { attribute ->
-                consumer.accept(attribute.key, attribute.value)
-            }
-        }
-
-        override fun size(): Int = sdkAttributesMap.size
-
-        override fun isEmpty(): Boolean = sdkAttributesMap.isEmpty()
-
-        override fun asMap(): Map<AttributeKey<*>, Any> = sdkAttributesMap
-
-        override fun toBuilder(): AttributesBuilder = Attributes.builder().addAttributes(sdkAttributesMap)
-    }
+    return Attributes.builder().addAttributes(sdkAttributesMap).build()
 }
 
 private fun Attribute.toSdkAttribute(verbose: Boolean): Pair<AttributeKey<*>, Any> {
@@ -47,25 +27,32 @@ private fun Attribute.toSdkAttribute(verbose: Boolean): Pair<AttributeKey<*>, An
             val unwrappedValue = if (verbose) value.value else value.toString()
             Pair(AttributeKey.stringKey(key), unwrappedValue)
         }
+
         is CharSequence,
         is Char -> {
             Pair(AttributeKey.stringKey(key), value)
         }
+
         is Boolean -> {
             Pair(AttributeKey.booleanKey(key), value)
         }
+
         is Int -> {
             Pair(AttributeKey.longKey(key), value.toLong())
         }
+
         is Long -> {
             Pair(AttributeKey.longKey(key), value)
         }
+
         is Float -> {
             Pair(AttributeKey.doubleKey(key), value)
         }
+
         is Double -> {
             Pair(AttributeKey.doubleKey(key), value)
         }
+
         is List<*> -> {
             if (value.all { it is HiddenString }) {
                 val unwrappedValue = value.map {
@@ -87,12 +74,15 @@ private fun Attribute.toSdkAttribute(verbose: Boolean): Pair<AttributeKey<*>, An
                 Pair(AttributeKey.doubleArrayKey(key), value.map { (it as Float).toDouble() })
             } else {
                 error(
-                    "Attribute '$key' has unsupported type for List values: ${value.firstOrNull()?.let {
-                        it::class.simpleName
-                    } }"
+                    "Attribute '$key' has unsupported type for List values: ${
+                        value.firstOrNull()?.let {
+                            it::class.simpleName
+                        }
+                    }"
                 )
             }
         }
+
         else -> {
             error("Attribute '$key' has unsupported type for value: ${value::class.simpleName}")
         }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEvent.kt
@@ -1,7 +1,7 @@
 package ai.koog.agents.features.opentelemetry.event
 
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.message.Message
 import kotlinx.serialization.json.JsonObject
@@ -43,7 +43,7 @@ internal class ChoiceEvent(
             is Message.Tool.Call -> {
                 addBodyField(EventBodyFields.Role(role = message.role))
                 addBodyField(EventBodyFields.ToolCalls(tools = listOf(message)))
-                addBodyField(EventBodyFields.FinishReason(SpanAttributes.Response.FinishReasonType.ToolCalls.id))
+                addBodyField(EventBodyFields.FinishReason(GenAIAttributes.Response.FinishReasonType.ToolCalls.id))
             }
         }
     }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
@@ -12,7 +12,8 @@ import ai.koog.agents.core.feature.pipeline.AIAgentGraphPipeline
 import ai.koog.agents.core.feature.pipeline.AIAgentPipeline
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.utils.SerializationUtils
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
+import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
 import ai.koog.agents.features.opentelemetry.event.AssistantMessageEvent
 import ai.koog.agents.features.opentelemetry.event.ChoiceEvent
 import ai.koog.agents.features.opentelemetry.event.ModerationResponseEvent
@@ -21,6 +22,13 @@ import ai.koog.agents.features.opentelemetry.event.ToolMessageEvent
 import ai.koog.agents.features.opentelemetry.event.UserMessageEvent
 import ai.koog.agents.features.opentelemetry.integration.SpanAdapter
 import ai.koog.agents.features.opentelemetry.integration.mcp.McpMethod
+import ai.koog.agents.features.opentelemetry.metric.MetricCollector
+import ai.koog.agents.features.opentelemetry.metric.events.createExecuteToolDurationHistogramMetricEvent
+import ai.koog.agents.features.opentelemetry.metric.events.createLLMCallDurationHistogramMetricEvent
+import ai.koog.agents.features.opentelemetry.metric.events.createLLMInputTokensMetricEvent
+import ai.koog.agents.features.opentelemetry.metric.events.createLLMOutputTokensMetricEvent
+import ai.koog.agents.features.opentelemetry.metric.events.createToolCallCounterMetricEvent
+import ai.koog.agents.features.opentelemetry.metric.events.toMetricEvent
 import ai.koog.agents.features.opentelemetry.span.GenAIAgentSpan
 import ai.koog.agents.features.opentelemetry.span.SpanCollector
 import ai.koog.agents.features.opentelemetry.span.SpanType
@@ -42,6 +50,7 @@ import ai.koog.agents.features.opentelemetry.span.startSubgraphExecuteSpan
 import ai.koog.agents.mcp.metadata.McpMetadataKeys
 import ai.koog.prompt.message.Message
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.datetime.Clock
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlin.reflect.KType
@@ -264,6 +273,9 @@ public class OpenTelemetry {
         ) {
             val spanAdapter = config.spanAdapter
             val tracer = config.tracer
+            val meter = config.meter
+
+            val metricCollector = MetricCollector(meter, config)
 
             //region Agent
 
@@ -354,8 +366,8 @@ public class OpenTelemetry {
                 ) ?: return@intercept
 
                 invokeAgentSpan.addAttribute(
-                    attribute = SpanAttributes.Response.FinishReasons(
-                        listOf(SpanAttributes.Response.FinishReasonType.Error)
+                    attribute = GenAIAttributes.Response.FinishReasons(
+                        listOf(GenAIAttributes.Response.FinishReasonType.Error)
                     )
                 )
 
@@ -517,6 +529,9 @@ public class OpenTelemetry {
                     span = inferenceSpan,
                     path = patchedExecutionInfo
                 )
+
+                // Metrics
+                metricCollector.storeMetricEvent(eventContext.toMetricEvent())
             }
 
             pipeline.interceptLLMCallCompleted(this) intercept@{ eventContext ->
@@ -567,11 +582,11 @@ public class OpenTelemetry {
                 eventContext.responses.lastOrNull()?.let { message ->
                     val finishReasonsAttribute = when (message) {
                         is Message.Assistant, is Message.Reasoning -> {
-                            SpanAttributes.Response.FinishReasons(reasons = listOf(SpanAttributes.Response.FinishReasonType.Stop))
+                            GenAIAttributes.Response.FinishReasons(reasons = listOf(GenAIAttributes.Response.FinishReasonType.Stop))
                         }
 
                         is Message.Tool.Call -> {
-                            SpanAttributes.Response.FinishReasons(reasons = listOf(SpanAttributes.Response.FinishReasonType.ToolCalls))
+                            GenAIAttributes.Response.FinishReasons(reasons = listOf(GenAIAttributes.Response.FinishReasonType.ToolCalls))
                         }
                     }
 
@@ -590,6 +605,37 @@ public class OpenTelemetry {
                     span = inferenceSpan,
                     path = patchedExecutionInfo
                 )
+
+                eventContext.responses.lastOrNull()?.metaInfo?.inputTokensCount?.toLong()?.let { inputTokens ->
+                    metricCollector.addCounterMetricEvent(
+                        metricEvent = createLLMInputTokensMetricEvent(
+                            id = eventContext.eventId,
+                            model = eventContext.model,
+                            inputTokens = inputTokens,
+                        )
+                    )
+                }
+
+                eventContext.responses.lastOrNull()?.metaInfo?.outputTokensCount?.toLong()?.let { outputTokens ->
+                    metricCollector.addCounterMetricEvent(
+                        metricEvent = createLLMOutputTokensMetricEvent(
+                            id = eventContext.eventId,
+                            model = eventContext.model,
+                            outputTokens = outputTokens,
+                        )
+                    )
+                }
+
+                // Metrics
+                metricCollector.getMetricEvent(eventContext.eventId)?.let { storedMetricEvent ->
+                    metricCollector.recordHistogramMetricEvent(
+                        metricEvent = createLLMCallDurationHistogramMetricEvent(
+                            id = eventContext.eventId,
+                            model = eventContext.model,
+                            duration = Clock.System.now() - storedMetricEvent.timestamp
+                        )
+                    )
+                }
             }
 
             //endregion LLM Call
@@ -639,6 +685,9 @@ public class OpenTelemetry {
 
                 spanAdapter?.onBeforeSpanStarted(executeToolSpan)
                 spanCollector.collectSpan(executeToolSpan, path)
+
+                // Metrics
+                metricCollector.storeMetricEvent(eventContext.toMetricEvent())
             }
 
             pipeline.interceptToolCallCompleted(this) intercept@{ eventContext ->
@@ -651,6 +700,26 @@ public class OpenTelemetry {
                     spanCollector = spanCollector,
                     eventContext = eventContext,
                 )
+
+                // Metrics
+                metricCollector.addCounterMetricEvent(
+                    metricEvent = createToolCallCounterMetricEvent(
+                        id = eventContext.eventId,
+                        toolName = eventContext.toolName,
+                        toolCallStatus = KoogAttributes.Koog.Tool.Call.StatusType.SUCCESS
+                    )
+                )
+
+                metricCollector.getMetricEvent(eventContext.eventId)?.let { storedMetricEvent ->
+                    metricCollector.recordHistogramMetricEvent(
+                        metricEvent = createExecuteToolDurationHistogramMetricEvent(
+                            id = eventContext.eventId,
+                            duration = Clock.System.now() - storedMetricEvent.timestamp,
+                            toolName = eventContext.toolName,
+                            toolCallStatus = KoogAttributes.Koog.Tool.Call.StatusType.VALIDATION_FAILED
+                        )
+                    )
+                }
             }
 
             pipeline.interceptToolCallFailed(this) intercept@{ eventContext ->
@@ -663,6 +732,26 @@ public class OpenTelemetry {
                     eventContext = eventContext,
                     error = eventContext.error,
                 )
+
+                // Metrics
+                metricCollector.addCounterMetricEvent(
+                    metricEvent = createToolCallCounterMetricEvent(
+                        id = eventContext.eventId,
+                        toolName = eventContext.toolName,
+                        toolCallStatus = KoogAttributes.Koog.Tool.Call.StatusType.ERROR
+                    )
+                )
+
+                metricCollector.getMetricEvent(eventContext.eventId)?.let { storedMetricEvent ->
+                    metricCollector.recordHistogramMetricEvent(
+                        metricEvent = createExecuteToolDurationHistogramMetricEvent(
+                            id = eventContext.eventId,
+                            duration = Clock.System.now() - storedMetricEvent.timestamp,
+                            toolName = eventContext.toolName,
+                            toolCallStatus = KoogAttributes.Koog.Tool.Call.StatusType.VALIDATION_FAILED
+                        )
+                    )
+                }
             }
 
             pipeline.interceptToolValidationFailed(this) intercept@{ eventContext ->
@@ -675,6 +764,26 @@ public class OpenTelemetry {
                     eventContext = eventContext,
                     error = eventContext.error,
                 )
+
+                // Metrics
+                metricCollector.addCounterMetricEvent(
+                    metricEvent = createToolCallCounterMetricEvent(
+                        id = eventContext.eventId,
+                        toolName = eventContext.toolName,
+                        toolCallStatus = KoogAttributes.Koog.Tool.Call.StatusType.VALIDATION_FAILED
+                    )
+                )
+
+                metricCollector.getMetricEvent(eventContext.eventId)?.let { storedMetricEvent ->
+                    metricCollector.recordHistogramMetricEvent(
+                        metricEvent = createExecuteToolDurationHistogramMetricEvent(
+                            id = eventContext.eventId,
+                            duration = Clock.System.now() - storedMetricEvent.timestamp,
+                            toolName = eventContext.toolName,
+                            toolCallStatus = KoogAttributes.Koog.Tool.Call.StatusType.VALIDATION_FAILED
+                        )
+                    )
+                }
             }
 
             //endregion Tool Call

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryConfig.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryConfig.kt
@@ -4,14 +4,24 @@ import ai.koog.agents.core.feature.config.FeatureConfig
 import ai.koog.agents.core.feature.handler.AgentLifecycleEventContext
 import ai.koog.agents.features.opentelemetry.attribute.addAttributes
 import ai.koog.agents.features.opentelemetry.integration.SpanAdapter
+import ai.koog.agents.features.opentelemetry.metric.MetricFilter
+import ai.koog.agents.features.opentelemetry.metric.adapter.MetricAdapter
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.metrics.Meter
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.propagation.ContextPropagators
+import io.opentelemetry.exporter.logging.LoggingMetricExporter
 import io.opentelemetry.exporter.logging.LoggingSpanExporter
 import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.metrics.InstrumentSelector
+import io.opentelemetry.sdk.metrics.SdkMeterProvider
+import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder
+import io.opentelemetry.sdk.metrics.View
+import io.opentelemetry.sdk.metrics.export.MetricExporter
+import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader
 import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.sdk.trace.SdkTracerProvider
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder
@@ -22,6 +32,9 @@ import io.opentelemetry.sdk.trace.samplers.Sampler
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 import java.util.Properties
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
 
 /**
  * Configuration class for OpenTelemetry integration.
@@ -40,6 +53,11 @@ public class OpenTelemetryConfig : FeatureConfig() {
         private val osVersion = System.getProperty("os.version")
 
         private val osArch = System.getProperty("os.arch")
+
+        /**
+         * The default interval for metric reading, which can be overridden when adding a custom exporter.
+         */
+        val DEFAULT_METER_INTERVAL: Duration = 1.seconds
     }
 
     private val productProperties = run {
@@ -56,6 +74,8 @@ public class OpenTelemetryConfig : FeatureConfig() {
 
     private val customResourceAttributes = mutableMapOf<AttributeKey<*>, Any>()
 
+    private val customMetricExporters = mutableListOf<Pair<MetricExporter, Duration>>()
+
     private var _sdk: OpenTelemetrySdk? = null
 
     private var _serviceName: String = productProperties.getProperty("name") ?: "ai.koog"
@@ -71,6 +91,10 @@ public class OpenTelemetryConfig : FeatureConfig() {
     private var _verbose: Boolean = false
 
     private var _spanAdapter: SpanAdapter? = null
+
+    private var _metricAdapter: MetricAdapter? = null
+
+    private val _metricFilters = mutableListOf<MetricFilter>()
 
     override fun setEventFilter(filter: (AgentLifecycleEventContext) -> Boolean) {
         // Do not allow events filtering for the OpenTelemetry feature
@@ -121,6 +145,45 @@ public class OpenTelemetryConfig : FeatureConfig() {
         get() = sdk.getTracer(_instrumentationScopeName, _instrumentationScopeVersion)
 
     /**
+     * The `Meter` can be utilized to create metric instruments such as counters, histograms, and gauges,
+     * which can then be used to track application-specific metrics.
+     */
+    public val meter: Meter
+        get() = sdk.getMeter(_instrumentationScopeName)
+
+    /**
+     * Adds a MetricExporter to the OpenTelemetry configuration.
+     * This exporter will be used to export metrics collected during the application's execution.
+     *
+     * @param exporter The MetricExporter instance to be added to the list of custom metric exporters.
+     */
+    public fun addMetricExporter(exporter: MetricExporter, meterInterval: Duration = DEFAULT_METER_INTERVAL) {
+        customMetricExporters.add(exporter to meterInterval)
+    }
+
+    /**
+     * Adds a metric filter to the OpenTelemetry configuration. This filter is used to specify
+     * which attribute keys should be retained for a specific metric during telemetry data processing.
+     *
+     * @param metricName The name of the metric to which the filter will be applied.
+     * @param keysToRetain A set of attribute keys that should be retained for the specified metric.
+     */
+    public fun addMetricFilter(metricName: String, keysToRetain: Set<String>) {
+        _metricFilters.add(MetricFilter(metricName, keysToRetain))
+    }
+
+    /**
+     * Adds a custom metric adapter to the OpenTelemetry configuration.
+     * The adapter can be used to process or modify metric events during telemetry data handling.
+     *
+     * @param adapter The MetricAdapter implementation that will handle
+     *                processing of metric events.
+     */
+    internal fun addMetricAdapter(adapter: MetricAdapter) {
+        _metricAdapter = adapter
+    }
+
+    /**
      * The name of the service associated with this OpenTelemetry configuration.
      */
     public val serviceName: String
@@ -134,6 +197,9 @@ public class OpenTelemetryConfig : FeatureConfig() {
 
     internal val spanAdapter: SpanAdapter?
         get() = _spanAdapter
+
+    internal val metricAdapter: MetricAdapter?
+        get() = _metricAdapter
 
     /**
      * Sets the service information for the OpenTelemetry configuration.
@@ -240,7 +306,7 @@ public class OpenTelemetryConfig : FeatureConfig() {
         // Tracing
         val sampler = createSampler()
         val resource = createResources()
-        val exporters: List<SpanExporter> = createExporters()
+        val exporters: List<SpanExporter> = createSpanExporters()
 
         val traceProviderBuilder = SdkTracerProvider.builder()
             .setSampler(sampler)
@@ -250,8 +316,25 @@ public class OpenTelemetryConfig : FeatureConfig() {
             traceProviderBuilder.addProcessors(exporter)
         }
 
+        val metricProvider = SdkMeterProvider.builder()
+            .setResource(resource)
+
+        val metricExporters = createMetricExporters()
+
+        metricExporters.forEach { (exporter, meterInterval) ->
+            val reader = PeriodicMetricReader
+                .builder(exporter)
+                .setInterval(meterInterval.toJavaDuration())
+                .build()
+
+            metricProvider.registerMetricReader(reader)
+        }
+
+        _metricFilters.forEach { filter -> metricProvider.registerView(filter) }
+
         val sdk = builder
             .setTracerProvider(traceProviderBuilder.build())
+            .setMeterProvider(metricProvider.build())
             .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
             .build()
 
@@ -285,7 +368,7 @@ public class OpenTelemetryConfig : FeatureConfig() {
         return resource
     }
 
-    private fun createExporters(): List<SpanExporter> = buildList {
+    private fun createSpanExporters(): List<SpanExporter> = buildList {
         if (customSpanExporters.isEmpty()) {
             logger.debug { "No custom span exporters configured. Use log span exporter by default." }
             add(LoggingSpanExporter.create())
@@ -294,6 +377,18 @@ public class OpenTelemetryConfig : FeatureConfig() {
         customSpanExporters.forEach { exporter ->
             logger.debug { "Adding span exporter: ${exporter::class.simpleName}" }
             add(exporter)
+        }
+    }
+
+    private fun createMetricExporters(): List<Pair<MetricExporter, Duration>> = buildList {
+        if (customMetricExporters.isEmpty()) {
+            logger.debug { "No custom metric exporters configured. Use log metric exporter by default." }
+            add(LoggingMetricExporter.create() to DEFAULT_METER_INTERVAL)
+        }
+
+        customMetricExporters.forEach { (exporter, interval) ->
+            logger.debug { "Adding metric exporter: ${exporter::class.simpleName}" }
+            add(exporter to interval)
         }
     }
 
@@ -311,6 +406,13 @@ public class OpenTelemetryConfig : FeatureConfig() {
             logger.debug { "Adding span processor: ${spanProcessor::class.simpleName}" }
             addSpanProcessor(spanProcessor)
         }
+    }
+
+    private fun SdkMeterProviderBuilder.registerView(filter: MetricFilter) {
+        val selector = InstrumentSelector.builder().setName(filter.metricName).build()
+        val view = View.builder().setAttributeFilter(filter.attributesKeysToRetain).build()
+
+        this.registerView(selector, view)
     }
 
     //endregion Private Methods

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapter.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapter.kt
@@ -1,8 +1,8 @@
 package ai.koog.agents.features.opentelemetry.integration.langfuse
 
 import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
 import ai.koog.agents.features.opentelemetry.event.AssistantMessageEvent
 import ai.koog.agents.features.opentelemetry.event.ChoiceEvent
 import ai.koog.agents.features.opentelemetry.event.EventBodyFields
@@ -39,7 +39,7 @@ internal class LangfuseSpanAdapter(
         when (span.type) {
             SpanType.INVOKE_AGENT -> {
                 val runId =
-                    span.attributes.find { attribute -> attribute.key == SpanAttributes.Conversation.Id("").key }?.value
+                    span.attributes.find { attribute -> attribute.key == GenAIAttributes.Conversation.Id("").key }?.value
 
                 runId?.let { runId ->
                     span.addAttribute(CustomAttribute("langfuse.session.id", runId))

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/weave/WeaveSpanAdapter.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/weave/WeaveSpanAdapter.kt
@@ -1,7 +1,7 @@
 package ai.koog.agents.features.opentelemetry.integration.weave
 
 import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.event.AssistantMessageEvent
 import ai.koog.agents.features.opentelemetry.event.ChoiceEvent
 import ai.koog.agents.features.opentelemetry.event.EventBodyFields
@@ -142,11 +142,11 @@ internal class WeaveSpanAdapter(private val openTelemetryConfig: OpenTelemetryCo
 
     private fun AssistantMessageEvent.convertToCompletion(span: GenAIAgentSpan, index: Int) {
         // Convert token attributes to Weave format
-        span.replaceAttributes<SpanAttributes.Usage.InputTokens> { attribute ->
+        span.replaceAttributes<GenAIAttributes.Usage.InputTokens> { attribute ->
             CustomAttribute("gen_ai.usage.prompt_tokens", attribute.value)
         }
 
-        span.replaceAttributes<SpanAttributes.Usage.OutputTokens> { attribute ->
+        span.replaceAttributes<GenAIAttributes.Usage.OutputTokens> { attribute ->
             CustomAttribute("gen_ai.usage.completion_tokens", attribute.value)
         }
 
@@ -190,11 +190,11 @@ internal class WeaveSpanAdapter(private val openTelemetryConfig: OpenTelemetryCo
 
     private fun ChoiceEvent.convertToCompletion(span: GenAIAgentSpan, index: Int) {
         // Convert tokens attributes to Weave format
-        span.replaceAttributes<SpanAttributes.Usage.InputTokens> { attribute ->
+        span.replaceAttributes<GenAIAttributes.Usage.InputTokens> { attribute ->
             CustomAttribute("gen_ai.usage.prompt_tokens", attribute.value)
         }
 
-        span.replaceAttributes<SpanAttributes.Usage.OutputTokens> { attribute ->
+        span.replaceAttributes<GenAIAttributes.Usage.OutputTokens> { attribute ->
             CustomAttribute("gen_ai.usage.completion_tokens", attribute.value)
         }
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/GenAIMetric.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/GenAIMetric.kt
@@ -1,0 +1,6 @@
+package ai.koog.agents.features.opentelemetry.metric
+
+internal sealed interface GenAIMetric : Metric {
+    override val name: String
+        get() = "gen_ai"
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/GenAIMetrics.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/GenAIMetrics.kt
@@ -1,0 +1,40 @@
+package ai.koog.agents.features.opentelemetry.metric
+
+internal object GenAIMetrics {
+
+    sealed interface Client : GenAIMetric {
+
+        override val name: String
+            get() = super.name.concatKey("client")
+
+        sealed interface Token : Client {
+
+            override val name: String
+                get() = super.name.concatKey("token")
+
+            object Usage : Token {
+
+                override val name: String
+                    get() = super.name.concatKey("usage")
+
+                override val description: String = "Total token count"
+                override val unit: String = "token"
+            }
+        }
+
+        sealed interface Operation : Client {
+
+            override val name: String
+                get() = super.name.concatKey("operation")
+
+            object Duration : Operation {
+
+                override val name: String
+                    get() = super.name.concatKey("duration")
+
+                override val description: String = "Operation duration"
+                override val unit: String = "s"
+            }
+        }
+    }
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/KoogMetric.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/KoogMetric.kt
@@ -1,0 +1,7 @@
+package ai.koog.agents.features.opentelemetry.metric
+
+internal sealed interface KoogMetric : Metric {
+
+    override val name: String
+        get() = "koog"
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/KoogMetrics.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/KoogMetrics.kt
@@ -1,0 +1,19 @@
+package ai.koog.agents.features.opentelemetry.metric
+
+internal object KoogMetrics {
+
+    sealed interface Tool : KoogMetric {
+
+        override val name: String
+            get() = super.name.concatKey("tool")
+
+        object Count : Tool {
+
+            override val name: String
+                get() = super.name.concatKey("count")
+
+            override val description: String = "Tool calls count"
+            override val unit: String = "tool call"
+        }
+    }
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/Metric.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/Metric.kt
@@ -1,0 +1,15 @@
+package ai.koog.agents.features.opentelemetry.metric
+
+internal sealed interface Metric {
+    val name: String
+    val description: String
+    val unit: String
+
+    fun String.concatKey(other: String) = this.plus(".$other")
+}
+
+internal interface CounterMetric : Metric
+
+internal interface HistogramMetric : Metric {
+    val boundariesAdvice: List<Double>
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/MetricCollector.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/MetricCollector.kt
@@ -1,0 +1,103 @@
+package ai.koog.agents.features.opentelemetry.metric
+
+import ai.koog.agents.features.opentelemetry.attribute.toSdkAttributes
+import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryConfig
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.opentelemetry.api.metrics.DoubleHistogram
+import io.opentelemetry.api.metrics.LongCounter
+import io.opentelemetry.api.metrics.Meter
+import java.util.concurrent.ConcurrentHashMap
+
+internal class MetricCollector(private val meter: Meter, private val config: OpenTelemetryConfig) {
+
+    private val counters = ConcurrentHashMap<String, LongCounter>()
+
+    private val histograms = ConcurrentHashMap<String, DoubleHistogram>()
+
+    private val metricEvents = ConcurrentHashMap<String, MetricEvent<*>>()
+
+    companion object {
+        private val logger = KotlinLogging.logger { }
+    }
+
+    init {
+        MetricFactory.createTokenCounterMetric().let {
+            counters[it.name] = addCounterMetric(it)
+        }
+
+        MetricFactory.createToolCallCounterMetric().let {
+            counters[it.name] = addCounterMetric(it)
+        }
+
+        MetricFactory.createOperationDurationHistogramMetric().let {
+            histograms[it.name] = addHistogramMetric(it)
+        }
+    }
+
+    fun addCounterMetric(metric: CounterMetric): LongCounter {
+        val counter = meter.counterBuilder(metric.name)
+            .setDescription(metric.description)
+            .setUnit(metric.unit)
+            .build()
+            .also { it.add(0) }
+
+        counters[metric.name] = counter
+
+        return counter
+    }
+
+    fun addHistogramMetric(metric: HistogramMetric): DoubleHistogram {
+        val counter = meter
+            .histogramBuilder(metric.name)
+            .setDescription(metric.description)
+            .setUnit(metric.unit)
+            .setExplicitBucketBoundariesAdvice(metric.boundariesAdvice)
+            .build()
+
+        histograms[metric.name] = counter
+
+        return counter
+    }
+
+    internal fun storeMetricEvent(metricEvent: MetricEvent<*>) {
+        val result = metricEvents.putIfAbsent(metricEvent.id, metricEvent)
+
+        if (result == null) {
+            logger.warn { "Metric event (id: ${metricEvent.id}) is already stored. Unable to store event with the same id." }
+        }
+    }
+
+    internal fun getMetricEvent(id: String): MetricEvent<*>? {
+        return metricEvents.remove(id)
+    }
+
+    internal fun addCounterMetricEvent(metricEvent: CounterMetricEvent) {
+        val updatedMetricEvent = config.metricAdapter?.process(metricEvent) ?: metricEvent
+
+        val metric = counters[updatedMetricEvent.metricName]
+        if (metric == null) {
+            logger.warn { "Counter metric (name: ${metricEvent.metricName}) not found. Please make sure you register the counter metric before usage." }
+            return
+        }
+
+        metric.add(
+            updatedMetricEvent.value,
+            updatedMetricEvent.attributes.toSdkAttributes(verbose = config.isVerbose)
+        )
+    }
+
+    internal fun recordHistogramMetricEvent(metricEvent: HistogramMetricEvent) {
+        val updatedMetricEvent = config.metricAdapter?.process(metricEvent) ?: metricEvent
+
+        val metric = histograms[updatedMetricEvent.metricName]
+        if (metric == null) {
+            logger.warn { "Histogram metric (name: ${metricEvent.metricName}) not found. Please make sure you register the histogram metric before usage." }
+            return
+        }
+
+        metric.record(
+            updatedMetricEvent.value,
+            updatedMetricEvent.attributes.toSdkAttributes(verbose = config.isVerbose)
+        )
+    }
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/MetricEvent.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/MetricEvent.kt
@@ -1,0 +1,48 @@
+package ai.koog.agents.features.opentelemetry.metric
+
+import ai.koog.agents.features.opentelemetry.attribute.Attribute
+import kotlinx.datetime.Instant
+
+internal sealed interface MetricEvent<T : MetricEvent<T>> {
+    val id: String
+    val timestamp: Instant
+    val metricName: String
+    val attributes: List<Attribute>
+
+    fun withAttributes(attributes: List<Attribute>): T
+}
+
+internal open class BaseMetricEvent(
+    override val id: String,
+    override val timestamp: Instant,
+    override val metricName: String,
+    override val attributes: List<Attribute>
+) : MetricEvent<BaseMetricEvent> {
+    override fun withAttributes(attributes: List<Attribute>): BaseMetricEvent {
+        return BaseMetricEvent(id, timestamp, metricName, attributes)
+    }
+}
+
+internal data class CounterMetricEvent(
+    override val id: String,
+    override val timestamp: Instant,
+    override val metricName: String,
+    override val attributes: List<Attribute>,
+    val value: Long
+) : MetricEvent<CounterMetricEvent> {
+    override fun withAttributes(attributes: List<Attribute>): CounterMetricEvent {
+        return CounterMetricEvent(id, timestamp, metricName, attributes, value)
+    }
+}
+
+internal data class HistogramMetricEvent(
+    override val id: String,
+    override val timestamp: Instant,
+    override val metricName: String,
+    override val attributes: List<Attribute>,
+    val value: Double
+) : MetricEvent<HistogramMetricEvent> {
+    override fun withAttributes(attributes: List<Attribute>): HistogramMetricEvent {
+        return HistogramMetricEvent(id, timestamp, metricName, attributes, value)
+    }
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/MetricFactory.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/MetricFactory.kt
@@ -1,0 +1,68 @@
+package ai.koog.agents.features.opentelemetry.metric
+
+internal object MetricFactory {
+
+    /**
+     * Build and register a Counter instrument for tracking GenAI token usage.
+     *
+     * The instrument name, description, and unit are taken from [GenAIMetrics.Client.Token.Usage].
+     * This counter is created according to the OpenTelemetry Metrics API. It is pre-initialized with
+     * a zero value to make the instrument visible to exporters even if no data points were recorded yet.
+     *
+     * Recommended metric attributes when recording values (aligned with GenAI semantic conventions):
+     * - gen_ai.operation.name (required)
+     * - gen_ai.provider.name (required)
+     * - gen_ai.response.model (recommended)
+     * - gen_ai.token.type (recommended) — INPUT or OUTPUT
+     */
+    internal fun createTokenCounterMetric(): CounterMetric = object : CounterMetric {
+        override val name: String = GenAIMetrics.Client.Token.Usage.name
+        override val description: String = GenAIMetrics.Client.Token.Usage.description
+        override val unit: String = GenAIMetrics.Client.Token.Usage.unit
+    }
+
+    /**
+     * Build and register a Counter instrument for counting GenAI tool calls.
+     *
+     * The instrument name, description and unit are taken from [KoogMetrics.Tool.Count].
+     * This counter is created according to the OpenTelemetry Metrics API and pre-initialized with a
+     * zero value to ensure the instrument appears in the exporter even without recorded data points.
+     *
+     * Recommended metric attributes when recording values (aligned with GenAI semantic conventions):
+     * - gen_ai.operation.name (required)
+     * - gen_ai.tool.name (recommended)
+     *
+     * Custom attributes:
+     * - koog.tool.call.status (recommended)
+     */
+    internal fun createToolCallCounterMetric(): CounterMetric = object : CounterMetric {
+        override val name: String = KoogMetrics.Tool.Count.name
+        override val description: String = KoogMetrics.Tool.Count.description
+        override val unit: String = KoogMetrics.Tool.Count.unit
+    }
+
+    /**
+     * Build and register a Histogram instrument for measuring GenAI operations durations.
+     *
+     * The instrument name, description, and unit are taken from [GenAIMetrics.Client.Operation.Duration].
+     * This metric SHOULD be specified with ExplicitBucketBoundaries of
+     * [0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92] seconds
+     * to provide a meaningful latency distribution for operation durations.
+     *
+     * Recommended metric attributes when recording values (aligned with GenAI semantic conventions):
+     * - gen_ai.operation.name (required)
+     * - gen_ai.tool.name (recommended, if applicable)
+     * - gen_ai.tool.call.status (recommended, if applicable)
+     * - gen_ai.response.model (recommended, if applicable)
+     * - gen_ai.provider.name (recommended, if applicable)
+     */
+    internal fun createOperationDurationHistogramMetric(): HistogramMetric = object : HistogramMetric {
+        override val name: String = GenAIMetrics.Client.Operation.Duration.name
+        override val description: String = GenAIMetrics.Client.Operation.Duration.description
+        override val unit: String = GenAIMetrics.Client.Operation.Duration.unit
+
+        override val boundariesAdvice: List<Double> = listOf(
+            0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92
+        )
+    }
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/MetricFilter.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/MetricFilter.kt
@@ -1,0 +1,3 @@
+package ai.koog.agents.features.opentelemetry.metric
+
+internal data class MetricFilter(val metricName: String, val attributesKeysToRetain: Set<String>)

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/adapter/MetricAdapter.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/adapter/MetricAdapter.kt
@@ -1,0 +1,8 @@
+package ai.koog.agents.features.opentelemetry.metric.adapter
+
+import ai.koog.agents.features.opentelemetry.metric.MetricEvent
+
+internal abstract class MetricAdapter {
+
+    abstract fun <T : MetricEvent<T>> process(metricEvent: T): T
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/adapter/toolNameCardinality.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/adapter/toolNameCardinality.kt
@@ -1,0 +1,40 @@
+package ai.koog.agents.features.opentelemetry.metric.adapter
+
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
+import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryConfig
+import ai.koog.agents.features.opentelemetry.metric.MetricEvent
+
+private const val FALLBACK_TOOL_NAME = "filtered"
+
+/**
+ * Restricts tool names in the attributes' metric and sets the fallback tool name when a tool is not allowed.
+ * Helps to manage cardinality of the metric.
+ *
+ * @param allowedToolNames A set of allowed tool names
+ * @param fallbackToolName The fallback / default tool name if not in the allowed set
+ */
+public fun OpenTelemetryConfig.restrictToolNameCardinality(
+    allowedToolNames: Set<String>,
+    fallbackToolName: String = FALLBACK_TOOL_NAME,
+) {
+    addMetricAdapter(object : MetricAdapter() {
+        override fun <T : MetricEvent<T>> process(metricEvent: T): T {
+            val toolNameKey = GenAIAttributes.Tool.Name("").key
+            val toolName = metricEvent.attributes.find { it.key == toolNameKey }
+
+            if (toolName == null || toolName.value in allowedToolNames) {
+                return metricEvent
+            }
+
+            return metricEvent.withAttributes(
+                metricEvent.attributes.map {
+                    if (it.key == toolNameKey) {
+                        GenAIAttributes.Tool.Name(fallbackToolName)
+                    } else {
+                        it
+                    }
+                }
+            )
+        }
+    })
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/events/counterMetricEvents.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/events/counterMetricEvents.kt
@@ -1,0 +1,71 @@
+package ai.koog.agents.features.opentelemetry.metric.events
+
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
+import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
+import ai.koog.agents.features.opentelemetry.metric.CounterMetricEvent
+import ai.koog.agents.features.opentelemetry.metric.GenAIMetrics
+import ai.koog.agents.features.opentelemetry.metric.KoogMetrics
+import ai.koog.prompt.llm.LLModel
+import kotlinx.datetime.Clock
+
+internal fun createLLMInputTokensMetricEvent(
+    id: String,
+    inputTokens: Long,
+    model: LLModel
+): CounterMetricEvent {
+    val attributes = listOf(
+        GenAIAttributes.Operation.Name(GenAIAttributes.Operation.OperationNameType.TEXT_COMPLETION),
+        GenAIAttributes.Provider.Name(model.provider),
+        GenAIAttributes.Token.Type(GenAIAttributes.Token.TokenType.INPUT),
+        GenAIAttributes.Response.Model(model)
+    )
+
+    return CounterMetricEvent(
+        id = id,
+        timestamp = Clock.System.now(),
+        metricName = GenAIMetrics.Client.Token.Usage.name,
+        value = inputTokens,
+        attributes = attributes
+    )
+}
+
+internal fun createLLMOutputTokensMetricEvent(
+    id: String,
+    outputTokens: Long,
+    model: LLModel
+): CounterMetricEvent {
+    val attributes = listOf(
+        GenAIAttributes.Operation.Name(GenAIAttributes.Operation.OperationNameType.TEXT_COMPLETION),
+        GenAIAttributes.Provider.Name(model.provider),
+        GenAIAttributes.Token.Type(GenAIAttributes.Token.TokenType.OUTPUT),
+        GenAIAttributes.Response.Model(model)
+    )
+
+    return CounterMetricEvent(
+        id = id,
+        timestamp = Clock.System.now(),
+        metricName = GenAIMetrics.Client.Token.Usage.name,
+        value = outputTokens,
+        attributes = attributes
+    )
+}
+
+internal fun createToolCallCounterMetricEvent(
+    id: String,
+    toolName: String,
+    toolCallStatus: KoogAttributes.Koog.Tool.Call.StatusType,
+): CounterMetricEvent {
+    val attributes = listOf(
+        GenAIAttributes.Operation.Name(GenAIAttributes.Operation.OperationNameType.EXECUTE_TOOL),
+        GenAIAttributes.Tool.Name(toolName),
+        KoogAttributes.Koog.Tool.Call.Status(toolCallStatus)
+    )
+
+    return CounterMetricEvent(
+        id = id,
+        timestamp = Clock.System.now(),
+        metricName = KoogMetrics.Tool.Count.name,
+        attributes = attributes,
+        1
+    )
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/events/histogramMetricEvents.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/metric/events/histogramMetricEvents.kt
@@ -1,0 +1,64 @@
+package ai.koog.agents.features.opentelemetry.metric.events
+
+import ai.koog.agents.core.feature.handler.AgentLifecycleEventContext
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
+import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
+import ai.koog.agents.features.opentelemetry.metric.BaseMetricEvent
+import ai.koog.agents.features.opentelemetry.metric.GenAIMetrics
+import ai.koog.agents.features.opentelemetry.metric.HistogramMetricEvent
+import ai.koog.prompt.llm.LLModel
+import kotlinx.datetime.Clock
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+
+internal fun AgentLifecycleEventContext.toMetricEvent(): BaseMetricEvent {
+    return BaseMetricEvent(
+        id = this@toMetricEvent.eventId,
+        timestamp = Clock.System.now(),
+        metricName = GenAIMetrics.Client.Operation.Duration.name,
+        attributes = emptyList()
+    )
+}
+
+internal fun createLLMCallDurationHistogramMetricEvent(
+    id: String,
+    model: LLModel,
+    duration: Duration
+): HistogramMetricEvent {
+    val attributes =
+        listOf(
+            GenAIAttributes.Operation.Name(GenAIAttributes.Operation.OperationNameType.TEXT_COMPLETION),
+            GenAIAttributes.Provider.Name(model.provider),
+            GenAIAttributes.Response.Model(model)
+        )
+
+    return HistogramMetricEvent(
+        id = id,
+        timestamp = Clock.System.now(),
+        metricName = GenAIMetrics.Client.Operation.Duration.name,
+        attributes = attributes,
+        value = duration.toDouble(DurationUnit.SECONDS)
+    )
+}
+
+internal fun createExecuteToolDurationHistogramMetricEvent(
+    id: String,
+    toolName: String,
+    toolCallStatus: KoogAttributes.Koog.Tool.Call.StatusType,
+    duration: Duration
+): HistogramMetricEvent {
+    val attributes =
+        listOf(
+            GenAIAttributes.Operation.Name(GenAIAttributes.Operation.OperationNameType.EXECUTE_TOOL),
+            GenAIAttributes.Tool.Name(toolName),
+            KoogAttributes.Koog.Tool.Call.Status(toolCallStatus)
+        )
+
+    return HistogramMetricEvent(
+        id = id,
+        timestamp = Clock.System.now(),
+        metricName = GenAIMetrics.Client.Operation.Duration.name,
+        attributes = attributes,
+        value = duration.toDouble(DurationUnit.SECONDS)
+    )
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/createAgentSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/createAgentSpan.kt
@@ -1,8 +1,8 @@
 package ai.koog.agents.features.opentelemetry.span
 
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
 import ai.koog.agents.features.opentelemetry.extension.toSpanEndStatus
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
@@ -42,17 +42,17 @@ internal fun startCreateAgentSpan(
         parentSpan = parentSpan,
         id = id,
         kind = SpanKind.CLIENT,
-        name = "${SpanAttributes.Operation.OperationNameType.CREATE_AGENT.id} $agentId",
+        name = "${GenAIAttributes.Operation.OperationNameType.CREATE_AGENT.id} $agentId",
     )
         // gen_ai.operation.name
-        .addAttribute(SpanAttributes.Operation.Name(SpanAttributes.Operation.OperationNameType.CREATE_AGENT))
+        .addAttribute(GenAIAttributes.Operation.Name(GenAIAttributes.Operation.OperationNameType.CREATE_AGENT))
         // gen_ai.provider.name
-        .addAttribute(SpanAttributes.Provider.Name(model.provider))
+        .addAttribute(GenAIAttributes.Provider.Name(model.provider))
         // gen_ai.request.model
-        .addAttribute(SpanAttributes.Request.Model(model))
+        .addAttribute(GenAIAttributes.Request.Model(model))
         // gen_ai.agent.description - Ignore. Not supported in Koog
         // gen_ai.agent.id
-        .addAttribute(SpanAttributes.Agent.Id(agentId))
+        .addAttribute(GenAIAttributes.Agent.Id(agentId))
 
     // gen_ai.agent.name - Ignore. Not supported in Koog
     // server.port - Ignore. Not supported in Koog
@@ -60,7 +60,7 @@ internal fun startCreateAgentSpan(
     // gen_ai.system_instructions
     val systemMessages = messages.filterIsInstance<Message.System>()
     if (systemMessages.isNotEmpty()) {
-        builder.addAttribute(SpanAttributes.SystemInstructions(systemMessages))
+        builder.addAttribute(GenAIAttributes.SystemInstructions(systemMessages))
     }
 
     builder.addAttribute(KoogAttributes.Koog.Event.Id(id))

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/executeToolSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/executeToolSpan.kt
@@ -2,8 +2,8 @@ package ai.koog.agents.features.opentelemetry.span
 
 import ai.koog.agents.core.feature.model.AIAgentError
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
 import ai.koog.agents.features.opentelemetry.extension.toSpanEndStatus
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.Tracer
@@ -40,29 +40,29 @@ internal fun startExecuteToolSpan(
         parentSpan = parentSpan,
         id = id,
         kind = SpanKind.INTERNAL,
-        name = "${SpanAttributes.Operation.OperationNameType.EXECUTE_TOOL.id} $toolName",
+        name = "${GenAIAttributes.Operation.OperationNameType.EXECUTE_TOOL.id} $toolName",
     )
         // gen_ai.operation.name
-        .addAttribute(SpanAttributes.Operation.Name(SpanAttributes.Operation.OperationNameType.EXECUTE_TOOL))
+        .addAttribute(GenAIAttributes.Operation.Name(GenAIAttributes.Operation.OperationNameType.EXECUTE_TOOL))
 
     // gen_ai.tool.call.id
     toolCallId?.let { callId ->
-        builder.addAttribute(SpanAttributes.Tool.Call.Id(id = callId))
+        builder.addAttribute(GenAIAttributes.Tool.Call.Id(id = callId))
     }
 
     // gen_ai.tool.description
     toolDescription?.let { description ->
-        builder.addAttribute(SpanAttributes.Tool.Description(description = description))
+        builder.addAttribute(GenAIAttributes.Tool.Description(description = description))
     }
 
     // gen_ai.tool.name
-    builder.addAttribute(SpanAttributes.Tool.Name(name = toolName))
+    builder.addAttribute(GenAIAttributes.Tool.Name(name = toolName))
 
     // gen_ai.tool.type
     //   Ignore. Not supported in Koog
 
     // gen_ai.tool.call.arguments
-    builder.addAttribute(SpanAttributes.Tool.Call.Arguments(toolArgs))
+    builder.addAttribute(GenAIAttributes.Tool.Call.Arguments(toolArgs))
 
     builder.addAttribute(KoogAttributes.Koog.Event.Id(id))
 
@@ -96,7 +96,7 @@ internal fun endExecuteToolSpan(
 
     // gen_ai.tool.call.result
     toolResult?.let { result ->
-        span.addAttribute(SpanAttributes.Tool.Call.Result(result))
+        span.addAttribute(GenAIAttributes.Tool.Call.Result(result))
     }
 
     span.end(error.toSpanEndStatus(), verbose)

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/inferenceSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/inferenceSpan.kt
@@ -2,8 +2,8 @@ package ai.koog.agents.features.opentelemetry.span
 
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
 import ai.koog.agents.features.opentelemetry.extension.toSpanEndStatus
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
@@ -58,44 +58,44 @@ internal fun startInferenceSpan(
         parentSpan = parentSpan,
         id = id,
         kind = SpanKind.CLIENT,
-        name = "${SpanAttributes.Operation.OperationNameType.CHAT.id} ${model.id}",
+        name = "${GenAIAttributes.Operation.OperationNameType.CHAT.id} ${model.id}",
     )
         // gen_ai.operation.name
-        .addAttribute(SpanAttributes.Operation.Name(SpanAttributes.Operation.OperationNameType.CHAT))
+        .addAttribute(GenAIAttributes.Operation.Name(GenAIAttributes.Operation.OperationNameType.CHAT))
         // gen_ai.provider.name
-        .addAttribute(SpanAttributes.Provider.Name(provider))
+        .addAttribute(GenAIAttributes.Provider.Name(provider))
         // gen_ai.conversation.id
-        .addAttribute(SpanAttributes.Conversation.Id(runId))
+        .addAttribute(GenAIAttributes.Conversation.Id(runId))
         // gen_ai.output.type
         .addAttribute(
-            SpanAttributes.Output.Type(
+            GenAIAttributes.Output.Type(
                 type = if (llmParams.schema != null) {
-                    SpanAttributes.Output.OutputType.JSON
+                    GenAIAttributes.Output.OutputType.JSON
                 } else {
-                    SpanAttributes.Output.OutputType.TEXT
+                    GenAIAttributes.Output.OutputType.TEXT
                 }
             )
         )
 
     // gen_ai.request.choice.count
     llmParams.numberOfChoices?.let { number ->
-        builder.addAttribute(SpanAttributes.Request.Choice.Count(number))
+        builder.addAttribute(GenAIAttributes.Request.Choice.Count(number))
     }
     // gen_ai.request.model
-    builder.addAttribute(SpanAttributes.Request.Model(model))
+    builder.addAttribute(GenAIAttributes.Request.Model(model))
     // gen_ai.request.seed - Ignore. Not supported in Koog
     // server.port - Ignore. Not supported in Koog
     // gen_ai.request.frequency_penalty - Ignore. Not supported in Koog
     // gen_ai.request.max_tokens
     llmParams.maxTokens?.let {
-        builder.addAttribute(SpanAttributes.Request.MaxTokens(it))
+        builder.addAttribute(GenAIAttributes.Request.MaxTokens(it))
     }
 
     // gen_ai.request.presence_penalty - Ignore. Not supported in Koog
     // gen_ai.request.stop_sequences - Ignore. Not supported in Koog
     // gen_ai.request.temperature
     llmParams.temperature?.let {
-        builder.addAttribute(SpanAttributes.Request.Temperature(it))
+        builder.addAttribute(GenAIAttributes.Request.Temperature(it))
     }
 
     // gen_ai.request.top_k - Ignore. Not supported in Koog
@@ -103,18 +103,18 @@ internal fun startInferenceSpan(
     // server.address - Ignore. Not supported in Koog
     // gen_ai.input.messages
     if (messages.isNotEmpty()) {
-        builder.addAttribute(SpanAttributes.Input.Messages(messages))
+        builder.addAttribute(GenAIAttributes.Input.Messages(messages))
     }
 
     // gen_ai.system_instructions
     val systemMessages = messages.filterIsInstance<Message.System>()
     if (systemMessages.isNotEmpty()) {
-        builder.addAttribute(SpanAttributes.SystemInstructions(systemMessages))
+        builder.addAttribute(GenAIAttributes.SystemInstructions(systemMessages))
     }
 
     // gen_ai.tool.definitions
     if (tools.isNotEmpty()) {
-        builder.addAttribute(SpanAttributes.Tool.Definitions(tools))
+        builder.addAttribute(GenAIAttributes.Tool.Definitions(tools))
     }
 
     builder.addAttribute(KoogAttributes.Koog.Event.Id(id))
@@ -156,25 +156,25 @@ internal fun endInferenceSpan(
     // gen_ai.response.finish_reasons - Ignore. Not supported in Koog
     // gen_ai.response.id - Ignore. Not supported in Koog
     // gen_ai.response.model
-    span.addAttribute(SpanAttributes.Response.Model(model))
+    span.addAttribute(GenAIAttributes.Response.Model(model))
 
     // gen_ai.usage.input_tokens
     span.addAttribute(
-        SpanAttributes.Usage.InputTokens(
+        GenAIAttributes.Usage.InputTokens(
             messages.filterIsInstance<Message.Response>().sumOf { message -> message.metaInfo.inputTokensCount ?: 0 }
         )
     )
 
     // gen_ai.usage.output_tokens
     span.addAttribute(
-        SpanAttributes.Usage.OutputTokens(
+        GenAIAttributes.Usage.OutputTokens(
             messages.filterIsInstance<Message.Response>().sumOf { message -> message.metaInfo.outputTokensCount ?: 0 }
         )
     )
 
     // gen_ai.output.messages
     if (messages.isNotEmpty()) {
-        span.addAttribute(SpanAttributes.Output.Messages(messages))
+        span.addAttribute(GenAIAttributes.Output.Messages(messages))
     }
 
     span.end(error.toSpanEndStatus(), verbose)

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/invokeAgentSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/invokeAgentSpan.kt
@@ -2,8 +2,8 @@ package ai.koog.agents.features.opentelemetry.span
 
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
 import ai.koog.agents.features.opentelemetry.extension.toSpanEndStatus
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
@@ -60,70 +60,70 @@ internal fun startInvokeAgentSpan(
         parentSpan = parentSpan,
         id = id,
         kind = SpanKind.CLIENT,
-        name = "${SpanAttributes.Operation.OperationNameType.INVOKE_AGENT.id} $agentId",
+        name = "${GenAIAttributes.Operation.OperationNameType.INVOKE_AGENT.id} $agentId",
     )
 
     // gen_ai.operation.name
-    builder.addAttribute(SpanAttributes.Operation.Name(SpanAttributes.Operation.OperationNameType.INVOKE_AGENT))
+    builder.addAttribute(GenAIAttributes.Operation.Name(GenAIAttributes.Operation.OperationNameType.INVOKE_AGENT))
         // gen_ai.provider.name
-        .addAttribute(SpanAttributes.Provider.Name(model.provider))
+        .addAttribute(GenAIAttributes.Provider.Name(model.provider))
         // gen_ai.agent.description - Ignore. Not supported in Koog
         // gen_ai.agent.id
-        .addAttribute(SpanAttributes.Agent.Id(agentId))
+        .addAttribute(GenAIAttributes.Agent.Id(agentId))
         // gen_ai.agent.name - Ignore. Not supported in Koog
         // gen_ai.conversation.id
-        .addAttribute(SpanAttributes.Conversation.Id(runId))
+        .addAttribute(GenAIAttributes.Conversation.Id(runId))
         // gen_ai.data_source.id - Ignore. Not supported in Koog
         // gen_ai.output.type
         .addAttribute(
-            SpanAttributes.Output.Type(
+            GenAIAttributes.Output.Type(
                 if (llmParams.schema != null) {
-                    SpanAttributes.Output.OutputType.JSON
+                    GenAIAttributes.Output.OutputType.JSON
                 } else {
-                    SpanAttributes.Output.OutputType.TEXT
+                    GenAIAttributes.Output.OutputType.TEXT
                 }
             )
         )
 
     // gen_ai.request.choice.count
     llmParams.numberOfChoices?.let { number ->
-        builder.addAttribute(SpanAttributes.Request.Choice.Count(number))
+        builder.addAttribute(GenAIAttributes.Request.Choice.Count(number))
     }
 
     // gen_ai.request.model
-    builder.addAttribute(SpanAttributes.Request.Model(model))
+    builder.addAttribute(GenAIAttributes.Request.Model(model))
 
     // gen_ai.request.seed - Ignore. Not supported in Koog
     // server.port - Ignore. Not supported in Koog
     // gen_ai.request.frequency_penalty - Ignore. Not supported in Koog
     // gen_ai.request.max_tokens
     llmParams.maxTokens?.let { maxTokens ->
-        builder.addAttribute(SpanAttributes.Request.MaxTokens(maxTokens))
+        builder.addAttribute(GenAIAttributes.Request.MaxTokens(maxTokens))
     }
 
     // gen_ai.request.presence_penalty - Ignore. Not supported in Koog
     // gen_ai.request.stop_sequences - Ignore. Not supported in Koog
     // gen_ai.request.temperature
     llmParams.temperature?.let { temperature ->
-        builder.addAttribute(SpanAttributes.Request.Temperature(temperature))
+        builder.addAttribute(GenAIAttributes.Request.Temperature(temperature))
     }
 
     // gen_ai.request.top_p - Ignore. Not supported in Koog
     // server.address - Ignore. Not supported in Koog
     // gen_ai.input.messages
     if (messages.isNotEmpty()) {
-        builder.addAttribute(SpanAttributes.Input.Messages(messages))
+        builder.addAttribute(GenAIAttributes.Input.Messages(messages))
     }
 
     // gen_ai.system_instructions
     val systemMessages = messages.filterIsInstance<Message.System>()
     if (systemMessages.isNotEmpty()) {
-        builder.addAttribute(SpanAttributes.SystemInstructions(systemMessages))
+        builder.addAttribute(GenAIAttributes.SystemInstructions(systemMessages))
     }
 
     // gen_ai.tool.definitions
     if (tools.isNotEmpty()) {
-        builder.addAttribute(SpanAttributes.Tool.Definitions(tools))
+        builder.addAttribute(GenAIAttributes.Tool.Definitions(tools))
     }
 
     builder.addAttribute(KoogAttributes.Koog.Event.Id(id))
@@ -165,25 +165,25 @@ internal fun endInvokeAgentSpan(
     // gen_ai.response.finish_reasons - Ignore. Not supported in Koog
     // gen_ai.response.id - Ignore. Not supported in Koog
     // gen_ai.response.model
-    span.addAttribute(SpanAttributes.Response.Model(model))
+    span.addAttribute(GenAIAttributes.Response.Model(model))
 
     // gen_ai.usage.input_tokens
     span.addAttribute(
-        SpanAttributes.Usage.InputTokens(
+        GenAIAttributes.Usage.InputTokens(
             messages.filterIsInstance<Message.Response>().sumOf { message -> message.metaInfo.inputTokensCount ?: 0 }
         )
     )
 
     // gen_ai.usage.output_tokens
     span.addAttribute(
-        SpanAttributes.Usage.OutputTokens(
+        GenAIAttributes.Usage.OutputTokens(
             messages.filterIsInstance<Message.Response>().sumOf { message -> message.metaInfo.outputTokensCount ?: 0 }
         )
     )
 
     // gen_ai.output.messages
     if (messages.isNotEmpty()) {
-        span.addAttribute(SpanAttributes.Output.Messages(messages))
+        span.addAttribute(GenAIAttributes.Output.Messages(messages))
     }
 
     span.end(error.toSpanEndStatus(), verbose)

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/mcpClientSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/mcpClientSpan.kt
@@ -1,8 +1,8 @@
 package ai.koog.agents.features.opentelemetry.span
 
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.attribute.McpAttributes
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
 import ai.koog.agents.features.opentelemetry.integration.mcp.McpMethod
 
 /**
@@ -68,10 +68,10 @@ internal fun GenAIAgentSpan.enrichExecuteToolSpanWithMcpAttrs(
     addAttribute(McpAttributes.Mcp.Method.Name(method.methodName))
 
     // gen_ai.operation.name (RECOMMENDED for tool calls)
-    addAttribute(SpanAttributes.Operation.Name(SpanAttributes.Operation.OperationNameType.EXECUTE_TOOL))
+    addAttribute(GenAIAttributes.Operation.Name(GenAIAttributes.Operation.OperationNameType.EXECUTE_TOOL))
 
     // gen_ai.tool.name (CONDITIONALLY REQUIRED)
-    addAttribute(SpanAttributes.Tool.Name(toolName))
+    addAttribute(GenAIAttributes.Tool.Name(toolName))
 
     // mcp.session.id (RECOMMENDED)
     sessionId?.let { session ->

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/nodeExecuteSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/nodeExecuteSpan.kt
@@ -1,8 +1,8 @@
 package ai.koog.agents.features.opentelemetry.span
 
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
 import ai.koog.agents.features.opentelemetry.extension.toSpanEndStatus
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.Tracer
@@ -36,7 +36,7 @@ internal fun startNodeExecuteSpan(
         kind = SpanKind.INTERNAL,
         name = "node $nodeId",
     )
-        .addAttribute(SpanAttributes.Conversation.Id(runId))
+        .addAttribute(GenAIAttributes.Conversation.Id(runId))
         .addAttribute(KoogAttributes.Koog.Node.Id(nodeId))
 
     nodeInput?.let { input ->

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/strategySpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/strategySpan.kt
@@ -1,8 +1,8 @@
 package ai.koog.agents.features.opentelemetry.span
 
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
 import ai.koog.agents.features.opentelemetry.extension.toSpanEndStatus
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.Tracer
@@ -35,7 +35,7 @@ internal fun startStrategySpan(
         kind = SpanKind.INTERNAL,
         name = "strategy $strategyName",
     )
-        .addAttribute(SpanAttributes.Conversation.Id(runId))
+        .addAttribute(GenAIAttributes.Conversation.Id(runId))
         .addAttribute(KoogAttributes.Koog.Strategy.Name(strategyName))
         .addAttribute(KoogAttributes.Koog.Event.Id(id))
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/subgraphExecuteSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/subgraphExecuteSpan.kt
@@ -1,8 +1,8 @@
 package ai.koog.agents.features.opentelemetry.span
 
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
 import ai.koog.agents.features.opentelemetry.extension.toSpanEndStatus
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.Tracer
@@ -36,7 +36,7 @@ internal fun startSubgraphExecuteSpan(
         kind = SpanKind.INTERNAL,
         name = "subgraph $subgraphId",
     )
-        .addAttribute(SpanAttributes.Conversation.Id(runId))
+        .addAttribute(GenAIAttributes.Conversation.Id(runId))
         .addAttribute(KoogAttributes.Koog.Subgraph.Id(subgraphId))
 
     subgraphInput?.let { input ->

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestAPI.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestAPI.kt
@@ -25,7 +25,7 @@ import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.USER
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Parameter.defaultModel
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Strategy.getSingleLLMCallStrategy
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Strategy.getSingleToolCallStrategy
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryConfig
 import ai.koog.agents.features.opentelemetry.mock.MockSpanExporter
@@ -376,11 +376,11 @@ internal object OpenTelemetryTestAPI {
     }
 
     fun getMessagesString(messages: List<Message>): String {
-        return SpanAttributes.Input.Messages(messages).value.value
+        return GenAIAttributes.Input.Messages(messages).value.value
     }
 
     fun getToolDefinitionsString(toolDescriptors: List<ai.koog.agents.core.tools.ToolDescriptor>): String {
-        return SpanAttributes.Tool.Definitions(toolDescriptors).value.value
+        return GenAIAttributes.Tool.Definitions(toolDescriptors).value.value
     }
 
     //endregion Attributes

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestData.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestData.kt
@@ -1,8 +1,8 @@
 package ai.koog.agents.features.opentelemetry
 
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes.Operation.OperationNameType
 import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes.Operation.OperationNameType
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.sdk.trace.data.SpanData
 
@@ -45,10 +45,10 @@ internal data class OpenTelemetryTestData(
     }
 
     fun filterCreateAgentEventIds(agentId: String): List<String> {
-        val operationNameAttribute = SpanAttributes.Operation.Name(OperationNameType.CREATE_AGENT)
+        val operationNameAttribute = GenAIAttributes.Operation.Name(OperationNameType.CREATE_AGENT)
         val expectedOperationNameKey = AttributeKey.stringKey(operationNameAttribute.key)
 
-        val agentIdAttribute = SpanAttributes.Agent.Id(agentId)
+        val agentIdAttribute = GenAIAttributes.Agent.Id(agentId)
         val expectedAgentIdAttributeKey = AttributeKey.stringKey(agentIdAttribute.key)
 
         val eventIdAttribute = KoogAttributes.Koog.Event.Id("")
@@ -107,7 +107,7 @@ internal data class OpenTelemetryTestData(
     }
 
     fun filterToolCallEventIdByToolName(toolName: String): List<String> {
-        val toolNameAttribute = SpanAttributes.Tool.Name(toolName)
+        val toolNameAttribute = GenAIAttributes.Tool.Name(toolName)
         val expectedToolNameKey = AttributeKey.stringKey(toolNameAttribute.key)
 
         val eventIdAttribute = KoogAttributes.Koog.Event.Id("")
@@ -121,7 +121,7 @@ internal data class OpenTelemetryTestData(
     }
 
     fun filterInferenceEventIds(): List<String> {
-        val operationNameAttribute = SpanAttributes.Operation.Name(OperationNameType.CHAT)
+        val operationNameAttribute = GenAIAttributes.Operation.Name(OperationNameType.CHAT)
         val expectedOperationNameKey = AttributeKey.stringKey(operationNameAttribute.key)
 
         val eventIdAttribute = KoogAttributes.Koog.Event.Id("")
@@ -139,7 +139,7 @@ internal data class OpenTelemetryTestData(
     }
 
     fun filterCreateAgentSpans(): List<SpanData> {
-        val createAgentAttribute = SpanAttributes.Operation.Name(OperationNameType.CREATE_AGENT)
+        val createAgentAttribute = GenAIAttributes.Operation.Name(OperationNameType.CREATE_AGENT)
         val attributeKey = AttributeKey.stringKey(createAgentAttribute.key)
 
         return collectedSpans.filter { spanData ->
@@ -148,7 +148,7 @@ internal data class OpenTelemetryTestData(
     }
 
     fun filterAgentInvokeSpans(): List<SpanData> {
-        val invokeAgentAttribute = SpanAttributes.Operation.Name(OperationNameType.INVOKE_AGENT)
+        val invokeAgentAttribute = GenAIAttributes.Operation.Name(OperationNameType.INVOKE_AGENT)
         val attributeKey = AttributeKey.stringKey(invokeAgentAttribute.key)
 
         return collectedSpans.filter { spanData ->
@@ -166,7 +166,7 @@ internal data class OpenTelemetryTestData(
     }
 
     fun filterInferenceSpans(): List<SpanData> {
-        val chatAttribute = SpanAttributes.Operation.Name(OperationNameType.CHAT)
+        val chatAttribute = GenAIAttributes.Operation.Name(OperationNameType.CHAT)
         val attributeKey = AttributeKey.stringKey(chatAttribute.key)
 
         return collectedSpans.filter { spanData ->
@@ -175,7 +175,7 @@ internal data class OpenTelemetryTestData(
     }
 
     fun filterExecuteToolSpans(): List<SpanData> {
-        val executeToolOperationAttribute = SpanAttributes.Operation.Name(OperationNameType.EXECUTE_TOOL)
+        val executeToolOperationAttribute = GenAIAttributes.Operation.Name(OperationNameType.EXECUTE_TOOL)
         val attributeKey = AttributeKey.stringKey(executeToolOperationAttribute.key)
 
         return collectedSpans.filter { spanData ->

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/attribute/GenAIAttributesTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/attribute/GenAIAttributesTest.kt
@@ -8,14 +8,14 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class SpanAttributesTest {
+class GenAIAttributesTest {
 
     //region Tool
 
     @Test
     fun `test tool call arguments with empty object value`() {
         val arguments = JsonObject(emptyMap())
-        val actualAttribute = SpanAttributes.Tool.Call.Arguments(arguments)
+        val actualAttribute = GenAIAttributes.Tool.Call.Arguments(arguments)
         assertEquals("gen_ai.tool.call.arguments", actualAttribute.key)
         assertEquals(arguments.toString(), actualAttribute.value.value)
     }
@@ -28,7 +28,7 @@ class SpanAttributesTest {
                 "key2" to JsonPrimitive("value2")
             )
         )
-        val actualAttribute = SpanAttributes.Tool.Call.Arguments(arguments)
+        val actualAttribute = GenAIAttributes.Tool.Call.Arguments(arguments)
         assertEquals("gen_ai.tool.call.arguments", actualAttribute.key)
         assertEquals(arguments.toString(), actualAttribute.value.value)
     }
@@ -40,7 +40,7 @@ class SpanAttributesTest {
                 "argument" to JsonPrimitive("sensitive user input")
             )
         )
-        val actualAttribute = SpanAttributes.Tool.Call.Arguments(arguments)
+        val actualAttribute = GenAIAttributes.Tool.Call.Arguments(arguments)
 
         assertEquals("gen_ai.tool.call.arguments", actualAttribute.key)
         assertEquals("HIDDEN:non-empty", actualAttribute.value.toString())
@@ -50,7 +50,7 @@ class SpanAttributesTest {
     @Test
     fun `test tool result with empty string value`() {
         val result = JsonObject(emptyMap())
-        val actualAttribute = SpanAttributes.Tool.Call.Result(result)
+        val actualAttribute = GenAIAttributes.Tool.Call.Result(result)
         assertEquals("gen_ai.tool.call.result", actualAttribute.key)
         assertEquals(result.toString(), actualAttribute.value.value)
     }
@@ -63,7 +63,7 @@ class SpanAttributesTest {
                 "key2" to JsonPrimitive("value2")
             )
         )
-        val actualAttribute = SpanAttributes.Tool.Call.Result(result)
+        val actualAttribute = GenAIAttributes.Tool.Call.Result(result)
         assertEquals("gen_ai.tool.call.result", actualAttribute.key)
         assertEquals(result.toString(), actualAttribute.value.value)
     }
@@ -75,7 +75,7 @@ class SpanAttributesTest {
                 "output" to JsonPrimitive("sensitive tool output")
             )
         )
-        val actualAttribute = SpanAttributes.Tool.Call.Result(result)
+        val actualAttribute = GenAIAttributes.Tool.Call.Result(result)
 
         assertEquals("gen_ai.tool.call.result", actualAttribute.key)
         assertEquals("HIDDEN:non-empty", actualAttribute.value.toString())
@@ -84,21 +84,21 @@ class SpanAttributesTest {
 
     @Test
     fun `test tool call id attribute`() {
-        val attribute = SpanAttributes.Tool.Call.Id("call-123")
+        val attribute = GenAIAttributes.Tool.Call.Id("call-123")
         assertEquals("gen_ai.tool.call.id", attribute.key)
         assertEquals("call-123", attribute.value)
     }
 
     @Test
     fun `test tool name attribute`() {
-        val attribute = SpanAttributes.Tool.Name("search")
+        val attribute = GenAIAttributes.Tool.Name("search")
         assertEquals("gen_ai.tool.name", attribute.key)
         assertEquals("search", attribute.value)
     }
 
     @Test
     fun `test tool description attribute`() {
-        val attribute = SpanAttributes.Tool.Description("Performs web search")
+        val attribute = GenAIAttributes.Tool.Description("Performs web search")
         assertEquals("gen_ai.tool.description", attribute.key)
         assertEquals("Performs web search", attribute.value)
     }
@@ -109,21 +109,21 @@ class SpanAttributesTest {
 
     @Test
     fun `test agent id attribute`() {
-        val idAttribute = SpanAttributes.Agent.Id("test-agent")
+        val idAttribute = GenAIAttributes.Agent.Id("test-agent")
         assertEquals("gen_ai.agent.id", idAttribute.key)
         assertEquals("test-agent", idAttribute.value)
     }
 
     @Test
     fun `test agent name attribute`() {
-        val nameAttribute = SpanAttributes.Agent.Name("Test Agent")
+        val nameAttribute = GenAIAttributes.Agent.Name("Test Agent")
         assertEquals("gen_ai.agent.name", nameAttribute.key)
         assertEquals("Test Agent", nameAttribute.value)
     }
 
     @Test
     fun `test agent description attributes`() {
-        val descriptionAttribute = SpanAttributes.Agent.Description("This is a test agent")
+        val descriptionAttribute = GenAIAttributes.Agent.Description("This is a test agent")
         assertEquals("gen_ai.agent.description", descriptionAttribute.key)
         assertEquals("This is a test agent", descriptionAttribute.value)
     }
@@ -134,7 +134,7 @@ class SpanAttributesTest {
 
     @Test
     fun `test conversation id attribute`() {
-        val conversationAttribute = SpanAttributes.Conversation.Id("conversation-id")
+        val conversationAttribute = GenAIAttributes.Conversation.Id("conversation-id")
         assertEquals("gen_ai.conversation.id", conversationAttribute.key)
         assertEquals("conversation-id", conversationAttribute.value)
     }
@@ -145,7 +145,7 @@ class SpanAttributesTest {
 
     @Test
     fun `test data source id attribute`() {
-        val dataSourceAttribute = SpanAttributes.DataSource.Id("data-source-id")
+        val dataSourceAttribute = GenAIAttributes.DataSource.Id("data-source-id")
         assertEquals("gen_ai.data_source.id", dataSourceAttribute.key)
         assertEquals("data-source-id", dataSourceAttribute.value)
     }
@@ -156,21 +156,21 @@ class SpanAttributesTest {
 
     @Test
     fun `test operation name chat attribute`() {
-        val attribute = SpanAttributes.Operation.Name(SpanAttributes.Operation.OperationNameType.CHAT)
+        val attribute = GenAIAttributes.Operation.Name(GenAIAttributes.Operation.OperationNameType.CHAT)
         assertEquals("gen_ai.operation.name", attribute.key)
         assertEquals("chat", attribute.value)
     }
 
     @Test
     fun `test operation name execute tool attribute`() {
-        val attribute = SpanAttributes.Operation.Name(SpanAttributes.Operation.OperationNameType.EXECUTE_TOOL)
+        val attribute = GenAIAttributes.Operation.Name(GenAIAttributes.Operation.OperationNameType.EXECUTE_TOOL)
         assertEquals("gen_ai.operation.name", attribute.key)
         assertEquals("execute_tool", attribute.value)
     }
 
     @Test
     fun `test operation name generate content attribute`() {
-        val attribute = SpanAttributes.Operation.Name(SpanAttributes.Operation.OperationNameType.GENERATE_CONTENT)
+        val attribute = GenAIAttributes.Operation.Name(GenAIAttributes.Operation.OperationNameType.GENERATE_CONTENT)
         assertEquals("gen_ai.operation.name", attribute.key)
         assertEquals("generate_content", attribute.value)
     }
@@ -181,21 +181,21 @@ class SpanAttributesTest {
 
     @Test
     fun `test output type text attribute`() {
-        val attribute = SpanAttributes.Output.Type(SpanAttributes.Output.OutputType.TEXT)
+        val attribute = GenAIAttributes.Output.Type(GenAIAttributes.Output.OutputType.TEXT)
         assertEquals("gen_ai.output.type", attribute.key)
         assertEquals("text", attribute.value)
     }
 
     @Test
     fun `test output type json attribute`() {
-        val attribute = SpanAttributes.Output.Type(SpanAttributes.Output.OutputType.JSON)
+        val attribute = GenAIAttributes.Output.Type(GenAIAttributes.Output.OutputType.JSON)
         assertEquals("gen_ai.output.type", attribute.key)
         assertEquals("json", attribute.value)
     }
 
     @Test
     fun `test output type image attribute`() {
-        val attribute = SpanAttributes.Output.Type(SpanAttributes.Output.OutputType.IMAGE)
+        val attribute = GenAIAttributes.Output.Type(GenAIAttributes.Output.OutputType.IMAGE)
         assertEquals("gen_ai.output.type", attribute.key)
         assertEquals("image", attribute.value)
     }
@@ -206,7 +206,7 @@ class SpanAttributesTest {
 
     @Test
     fun `test request choice count attribute`() {
-        val attribute = SpanAttributes.Request.Choice.Count(3)
+        val attribute = GenAIAttributes.Request.Choice.Count(3)
         assertEquals("gen_ai.request.choice.count", attribute.key)
         assertEquals(3, attribute.value)
     }
@@ -214,35 +214,35 @@ class SpanAttributesTest {
     @Test
     fun `test request model attribute`() {
         val model = LLModel(MockLLMProvider(), "gpt-4o", listOf(LLMCapability.Completion), 8192, 4096)
-        val attribute = SpanAttributes.Request.Model(model)
+        val attribute = GenAIAttributes.Request.Model(model)
         assertEquals("gen_ai.request.model", attribute.key)
         assertEquals("gpt-4o", attribute.value)
     }
 
     @Test
     fun `test request seed attribute`() {
-        val attribute = SpanAttributes.Request.Seed(42)
+        val attribute = GenAIAttributes.Request.Seed(42)
         assertEquals("gen_ai.request.seed", attribute.key)
         assertEquals(42, attribute.value)
     }
 
     @Test
     fun `test request frequency penalty attribute`() {
-        val attribute = SpanAttributes.Request.FrequencyPenalty(0.25)
+        val attribute = GenAIAttributes.Request.FrequencyPenalty(0.25)
         assertEquals("gen_ai.request.frequency_penalty", attribute.key)
         assertEquals(0.25, attribute.value)
     }
 
     @Test
     fun `test request max tokens attribute`() {
-        val attribute = SpanAttributes.Request.MaxTokens(1024)
+        val attribute = GenAIAttributes.Request.MaxTokens(1024)
         assertEquals("gen_ai.request.max_tokens", attribute.key)
         assertEquals(1024, attribute.value)
     }
 
     @Test
     fun `test request presence penalty attribute`() {
-        val attribute = SpanAttributes.Request.PresencePenalty(0.75)
+        val attribute = GenAIAttributes.Request.PresencePenalty(0.75)
         assertEquals("gen_ai.request.presence_penalty", attribute.key)
         assertEquals(0.75, attribute.value)
     }
@@ -250,21 +250,21 @@ class SpanAttributesTest {
     @Test
     fun `test request stop sequences attribute`() {
         val stops = listOf("END", "STOP")
-        val attribute = SpanAttributes.Request.StopSequences(stops)
+        val attribute = GenAIAttributes.Request.StopSequences(stops)
         assertEquals("gen_ai.request.stop_sequences", attribute.key)
         assertEquals(stops, attribute.value)
     }
 
     @Test
     fun `test request temperature attribute`() {
-        val attribute = SpanAttributes.Request.Temperature(0.8)
+        val attribute = GenAIAttributes.Request.Temperature(0.8)
         assertEquals("gen_ai.request.temperature", attribute.key)
         assertEquals(0.8, attribute.value)
     }
 
     @Test
     fun `test request top_p attribute`() {
-        val attribute = SpanAttributes.Request.TopP(0.9)
+        val attribute = GenAIAttributes.Request.TopP(0.9)
         assertEquals("gen_ai.request.top_p", attribute.key)
         assertEquals(0.9, attribute.value)
     }
@@ -276,17 +276,17 @@ class SpanAttributesTest {
     @Test
     fun `test response finish reasons attribute`() {
         val reasons = listOf(
-            SpanAttributes.Response.FinishReasonType.Stop,
-            SpanAttributes.Response.FinishReasonType.Custom("custom-reason"),
+            GenAIAttributes.Response.FinishReasonType.Stop,
+            GenAIAttributes.Response.FinishReasonType.Custom("custom-reason"),
         )
-        val attribute = SpanAttributes.Response.FinishReasons(reasons)
+        val attribute = GenAIAttributes.Response.FinishReasons(reasons)
         assertEquals("gen_ai.response.finish_reasons", attribute.key)
         assertEquals(listOf("stop", "custom-reason"), attribute.value)
     }
 
     @Test
     fun `test response id attribute`() {
-        val attribute = SpanAttributes.Response.Id("resp-001")
+        val attribute = GenAIAttributes.Response.Id("resp-001")
         assertEquals("gen_ai.response.id", attribute.key)
         assertEquals("resp-001", attribute.value)
     }
@@ -294,25 +294,36 @@ class SpanAttributesTest {
     @Test
     fun `test response model attribute`() {
         val model = LLModel(MockLLMProvider(), "gemini-1.5-pro", emptyList(), 32768)
-        val attribute = SpanAttributes.Response.Model(model)
+        val attribute = GenAIAttributes.Response.Model(model)
         assertEquals("gen_ai.response.model", attribute.key)
         assertEquals("gemini-1.5-pro", attribute.value)
     }
 
     //endregion Response
 
+    //region Token
+
+    @Test
+    fun `test token type attribute`() {
+        val attribute = GenAIAttributes.Token.Type(GenAIAttributes.Token.TokenType.INPUT)
+        assertEquals("gen_ai.token.type", attribute.key)
+        assertEquals("input", attribute.value)
+    }
+
+    //endregion Token
+
     //region Usage
 
     @Test
     fun `test usage input tokens attribute`() {
-        val attribute = SpanAttributes.Usage.InputTokens(123)
+        val attribute = GenAIAttributes.Usage.InputTokens(123)
         assertEquals("gen_ai.usage.input_tokens", attribute.key)
         assertEquals(123, attribute.value)
     }
 
     @Test
     fun `test usage output tokens attribute`() {
-        val attribute = SpanAttributes.Usage.OutputTokens(456)
+        val attribute = GenAIAttributes.Usage.OutputTokens(456)
         assertEquals("gen_ai.usage.output_tokens", attribute.key)
         assertEquals(456, attribute.value)
     }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/attribute/KoogAttributesTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/attribute/KoogAttributesTest.kt
@@ -1,0 +1,13 @@
+package ai.koog.agents.features.opentelemetry.attribute
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class KoogAttributesTest {
+    @Test
+    fun `test status attribute`() {
+        val attribute = KoogAttributes.Koog.Tool.Call.Status(KoogAttributes.Koog.Tool.Call.StatusType.SUCCESS)
+        assertEquals("koog.tool.call.status", attribute.key)
+        assertEquals("success", attribute.value)
+    }
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEventTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/event/ChoiceEventTest.kt
@@ -1,7 +1,7 @@
 package ai.koog.agents.features.opentelemetry.event
 
 import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.mock.MockLLMProvider
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
@@ -76,7 +76,7 @@ class ChoiceEventTest {
             EventBodyFields.Index(0),
             EventBodyFields.Role(role = Message.Role.Tool),
             EventBodyFields.ToolCalls(tools = listOf(expectedMessage)),
-            EventBodyFields.FinishReason(reason = SpanAttributes.Response.FinishReasonType.ToolCalls.id)
+            EventBodyFields.FinishReason(reason = GenAIAttributes.Response.FinishReasonType.ToolCalls.id)
         )
 
         assertEquals(expectedBodyFields.size, choiceEvent.bodyFields.size)
@@ -153,7 +153,7 @@ class ChoiceEventTest {
             EventBodyFields.Index(0),
             EventBodyFields.Role(role = Message.Role.Tool),
             EventBodyFields.ToolCalls(tools = listOf(expectedMessage)),
-            EventBodyFields.FinishReason(reason = SpanAttributes.Response.FinishReasonType.ToolCalls.id)
+            EventBodyFields.FinishReason(reason = GenAIAttributes.Response.FinishReasonType.ToolCalls.id)
         )
 
         assertEquals(expectedBodyFields.size, choiceEvent.bodyFields.size)

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryConfigTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryConfigTest.kt
@@ -19,8 +19,8 @@ import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.getSystemInstr
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.testClock
 import ai.koog.agents.features.opentelemetry.assertSpans
 import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes.Operation.OperationNameType
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes.Operation.OperationNameType
 import ai.koog.agents.features.opentelemetry.integration.SpanAdapter
 import ai.koog.agents.features.opentelemetry.mock.MockSpanExporter
 import ai.koog.agents.features.opentelemetry.span.GenAIAgentSpan
@@ -218,8 +218,8 @@ class OpenTelemetryConfigTest : OpenTelemetryTestBase() {
             val collectedSpans = mockExporter.collectedSpans
             assertTrue(collectedSpans.isNotEmpty(), "Spans should be created during agent execution")
 
-            val conversationIdAttribute = SpanAttributes.Conversation.Id(mockExporter.lastRunId)
-            val operationNameAttribute = SpanAttributes.Operation.Name(OperationNameType.INVOKE_AGENT)
+            val conversationIdAttribute = GenAIAttributes.Conversation.Id(mockExporter.lastRunId)
+            val operationNameAttribute = GenAIAttributes.Operation.Name(OperationNameType.INVOKE_AGENT)
 
             fun attributesMatches(attributes: Map<AttributeKey<*>, Any>): Boolean {
                 var conversationIdAttributeExists = false

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryAgentSpanTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryAgentSpanTest.kt
@@ -10,7 +10,7 @@ import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.getSystemInstr
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.runAgentWithStrategy
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.testClock
 import ai.koog.agents.features.opentelemetry.assertSpans
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes.Operation.OperationNameType
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes.Operation.OperationNameType
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryTestBase
 import ai.koog.agents.utils.HiddenString
 import ai.koog.prompt.message.Message

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryExecuteToolSpanTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryExecuteToolSpanTest.kt
@@ -14,7 +14,7 @@ import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.runAgentWithSi
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.runAgentWithStrategy
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.testClock
 import ai.koog.agents.features.opentelemetry.assertSpans
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes.Operation.OperationNameType
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes.Operation.OperationNameType
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryTestBase
 import ai.koog.agents.features.opentelemetry.mock.TestGetWeatherTool
 import ai.koog.agents.testing.tools.getMockExecutor

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryInferenceSpanTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryInferenceSpanTest.kt
@@ -17,8 +17,8 @@ import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.runAgentWithSt
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.testClock
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.toolCallMessage
 import ai.koog.agents.features.opentelemetry.assertSpans
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes.Operation.OperationNameType
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes.Response.FinishReasonType
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes.Operation.OperationNameType
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes.Response.FinishReasonType
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryTestBase
 import ai.koog.agents.features.opentelemetry.mock.TestGetWeatherTool
 import ai.koog.agents.testing.tools.getMockExecutor

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetrySpanTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetrySpanTest.kt
@@ -16,7 +16,7 @@ import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.getMessagesStr
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.getSystemInstructionsString
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestData
 import ai.koog.agents.features.opentelemetry.assertSpans
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes.Operation.OperationNameType
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes.Operation.OperationNameType
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryTestBase
 import ai.koog.agents.features.opentelemetry.mock.MockSpanExporter
 import ai.koog.prompt.llm.LLModel

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/TraceStructureTestBase.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/TraceStructureTestBase.kt
@@ -24,8 +24,8 @@ import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.testClock
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestData
 import ai.koog.agents.features.opentelemetry.assertSpans
 import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes.Response.FinishReasonType
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes.Response.FinishReasonType
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryConfig
 import ai.koog.agents.features.opentelemetry.mock.MockSpanExporter
 import ai.koog.agents.features.opentelemetry.mock.TestGetWeatherTool
@@ -103,7 +103,7 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
             // Assert expected LLM Call Span (InferenceSpan) attributes for Langfuse/Weave
             val expectedLLMSpans = listOf(
                 mapOf(
-                    "${SpanAttributes.Operation.OperationNameType.CHAT.id} ${model.id}" to mapOf(
+                    "${GenAIAttributes.Operation.OperationNameType.CHAT.id} ${model.id}" to mapOf(
                         "attributes" to mapOf(
                             "gen_ai.operation.name" to "chat",
                             "gen_ai.provider.name" to model.provider.id,
@@ -255,13 +255,13 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
 
             val expectedLLMSpans = listOf(
                 mapOf(
-                    "${SpanAttributes.Operation.OperationNameType.CHAT.id} ${model.id}" to mapOf(
+                    "${GenAIAttributes.Operation.OperationNameType.CHAT.id} ${model.id}" to mapOf(
                         "attributes" to expectedInitialLLMSpanAttributes,
                         "events" to emptyMap()
                     )
                 ),
                 mapOf(
-                    "${SpanAttributes.Operation.OperationNameType.CHAT.id} ${model.id}" to mapOf(
+                    "${GenAIAttributes.Operation.OperationNameType.CHAT.id} ${model.id}" to mapOf(
                         "attributes" to expectedFinalLLMSpanAttributes,
                         "events" to emptyMap()
                     )
@@ -274,7 +274,7 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
             val toolEventId = testData.singleAttributeValue(actualToolSpans.single(), "koog.event.id")
             val expectedToolSpans = listOf(
                 mapOf(
-                    "${SpanAttributes.Operation.OperationNameType.EXECUTE_TOOL.id} ${TestGetWeatherTool.name}" to mapOf(
+                    "${GenAIAttributes.Operation.OperationNameType.EXECUTE_TOOL.id} ${TestGetWeatherTool.name}" to mapOf(
                         "attributes" to mapOf(
                             "gen_ai.operation.name" to "execute_tool",
                             "gen_ai.tool.name" to TestGetWeatherTool.name,
@@ -360,7 +360,7 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
             // Assert tool execution spans
             val expectedToolSpans = listOf(
                 mapOf(
-                    "${SpanAttributes.Operation.OperationNameType.EXECUTE_TOOL.id} ${TestGetWeatherTool.name}" to mapOf(
+                    "${GenAIAttributes.Operation.OperationNameType.EXECUTE_TOOL.id} ${TestGetWeatherTool.name}" to mapOf(
                         "attributes" to mapOf(
                             "gen_ai.operation.name" to "execute_tool",
                             "gen_ai.tool.name" to TestGetWeatherTool.name,
@@ -373,7 +373,7 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
                     )
                 ),
                 mapOf(
-                    "${SpanAttributes.Operation.OperationNameType.EXECUTE_TOOL.id} ${TestGetWeatherTool.name}" to mapOf(
+                    "${GenAIAttributes.Operation.OperationNameType.EXECUTE_TOOL.id} ${TestGetWeatherTool.name}" to mapOf(
                         "attributes" to mapOf(
                             "gen_ai.operation.name" to "execute_tool",
                             "gen_ai.tool.name" to TestGetWeatherTool.name,
@@ -439,7 +439,7 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
             val actualSpans = mockSpanExporter.collectedSpans
 
             // Verify that basic spans are present
-            assertTrue { actualSpans.count { it.name == "${SpanAttributes.Operation.OperationNameType.CHAT.id} ${model.id}" } == 1 }
+            assertTrue { actualSpans.count { it.name == "${GenAIAttributes.Operation.OperationNameType.CHAT.id} ${model.id}" } == 1 }
             assertTrue { actualSpans.any { it.name == "subgraph sg" } }
             assertTrue { actualSpans.any { it.name == "strategy subgraph-finish-tool-strategy" } }
         }
@@ -500,7 +500,7 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
             val nodeSpan = spans.first { it.name == "node test-llm-call" }
             val nodeAttrs = nodeSpan.attributes.asMap().asSequence().associate { it.key.key to it.value }
             assertEquals("value-start", nodeAttrs["custom.after.start"])
-            val llmSpan = spans.first { it.name == "${SpanAttributes.Operation.OperationNameType.CHAT.id} ${model.id}" }
+            val llmSpan = spans.first { it.name == "${GenAIAttributes.Operation.OperationNameType.CHAT.id} ${model.id}" }
             val llmAttrs = llmSpan.attributes.asMap().asSequence().associate { it.key.key to it.value }
 
             assertEquals(123L, llmAttrs["custom.before.finish"])
@@ -584,7 +584,7 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
             // Assert expected LLM Call Span attributes for structured output
             val expectedLLMSpans = listOf(
                 mapOf(
-                    "${SpanAttributes.Operation.OperationNameType.CHAT.id} ${model.id}" to mapOf(
+                    "${GenAIAttributes.Operation.OperationNameType.CHAT.id} ${model.id}" to mapOf(
                         "attributes" to mapOf(
                             "gen_ai.operation.name" to "chat",
                             "gen_ai.provider.name" to model.provider.id,
@@ -756,13 +756,13 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
 
             val expectedLLMSpans = listOf(
                 mapOf(
-                    "${SpanAttributes.Operation.OperationNameType.CHAT.id} ${model.id}" to mapOf(
+                    "${GenAIAttributes.Operation.OperationNameType.CHAT.id} ${model.id}" to mapOf(
                         "attributes" to expectedInitialLLMSpanAttributes,
                         "events" to emptyMap()
                     )
                 ),
                 mapOf(
-                    "${SpanAttributes.Operation.OperationNameType.CHAT.id} ${model.id}" to mapOf(
+                    "${GenAIAttributes.Operation.OperationNameType.CHAT.id} ${model.id}" to mapOf(
                         "attributes" to expectedFinalLLMSpanAttributes,
                         "events" to emptyMap()
                     )
@@ -826,9 +826,9 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
             val spans = mockSpanExporter.collectedSpans
             assertTrue(spans.any { it.name == "node moderate-message" })
 
-            val llmSpan = spans.firstOrNull { it.name == "${SpanAttributes.Operation.OperationNameType.CHAT.id} ${model.id}" }
+            val llmSpan = spans.firstOrNull { it.name == "${GenAIAttributes.Operation.OperationNameType.CHAT.id} ${model.id}" }
                 ?: spans.firstOrNull { span -> span.events.any { it.name == "moderation.result" } }
-                ?: error("No LLM span for moderation found (expected '${SpanAttributes.Operation.OperationNameType.CHAT.id} ${model.id}' or a span with 'moderation.result' event)")
+                ?: error("No LLM span for moderation found (expected '${GenAIAttributes.Operation.OperationNameType.CHAT.id} ${model.id}' or a span with 'moderation.result' event)")
 
             val moderationEvent = llmSpan.events.firstOrNull { it.name == "moderation.result" }
             assertNotNull(moderationEvent, "LLM span should contain a moderation.result event")

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapterTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapterTest.kt
@@ -2,7 +2,7 @@ package ai.koog.agents.features.opentelemetry.integration.langfuse
 
 import ai.koog.agents.features.opentelemetry.attribute.Attribute
 import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.event.AssistantMessageEvent
 import ai.koog.agents.features.opentelemetry.event.ChoiceEvent
 import ai.koog.agents.features.opentelemetry.event.EventBodyFields
@@ -168,7 +168,7 @@ class LangfuseSpanAdapterTest {
         assertEquals("assistant", attributes.requireValue("gen_ai.completion.1.role"))
         assertEquals(expectedToolCallJson, attributes.requireValue("gen_ai.completion.1.content"))
         assertEquals(
-            SpanAttributes.Response.FinishReasonType.ToolCalls.id,
+            GenAIAttributes.Response.FinishReasonType.ToolCalls.id,
             attributes.requireValue("gen_ai.completion.1.finish_reason"),
         )
     }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseTraceStructureTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseTraceStructureTest.kt
@@ -1,7 +1,7 @@
 package ai.koog.agents.features.opentelemetry.integration.langfuse
 
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.integration.TraceStructureTestBase
 import ai.koog.agents.features.opentelemetry.mock.TestGetWeatherTool
 import ai.koog.prompt.llm.LLModel
@@ -65,14 +65,14 @@ class LangfuseTraceStructureTest :
             "system_instructions" to systemInstructions,
             "gen_ai.output.messages" to outputMessages,
             "gen_ai.tool.definitions" to toolDefinitions,
-            "gen_ai.response.finish_reasons" to listOf(SpanAttributes.Response.FinishReasonType.ToolCalls.id),
+            "gen_ai.response.finish_reasons" to listOf(GenAIAttributes.Response.FinishReasonType.ToolCalls.id),
             "gen_ai.prompt.0.role" to Message.Role.System.name.lowercase(),
             "gen_ai.prompt.0.content" to systemPrompt,
             "gen_ai.prompt.1.role" to Message.Role.User.name.lowercase(),
             "gen_ai.prompt.1.content" to userPrompt,
             "gen_ai.completion.0.role" to Message.Role.Assistant.name.lowercase(),
             "gen_ai.completion.0.content" to "[{\"function\":{\"name\":\"${TestGetWeatherTool.name}\",\"arguments\":\"{\\\"location\\\":\\\"Paris\\\"}\"},\"id\":\"get-weather-tool-call-id\",\"type\":\"function\"}]",
-            "gen_ai.completion.0.finish_reason" to SpanAttributes.Response.FinishReasonType.ToolCalls.id,
+            "gen_ai.completion.0.finish_reason" to GenAIAttributes.Response.FinishReasonType.ToolCalls.id,
         )
     }
 
@@ -132,7 +132,7 @@ class LangfuseTraceStructureTest :
             "system_instructions" to systemInstructions,
             "gen_ai.output.messages" to outputMessages,
             "gen_ai.tool.definitions" to toolDefinitions,
-            "gen_ai.response.finish_reasons" to listOf(SpanAttributes.Response.FinishReasonType.Stop.id),
+            "gen_ai.response.finish_reasons" to listOf(GenAIAttributes.Response.FinishReasonType.Stop.id),
             "gen_ai.prompt.0.role" to Message.Role.System.name.lowercase(),
             "gen_ai.prompt.0.content" to systemPrompt,
             "gen_ai.prompt.1.role" to Message.Role.User.name.lowercase(),
@@ -186,7 +186,7 @@ class LangfuseTraceStructureTest :
             "system_instructions" to systemInstructions,
             "gen_ai.output.messages" to outputMessages,
             "gen_ai.tool.definitions" to toolDefinitions,
-            "gen_ai.response.finish_reasons" to listOf(SpanAttributes.Response.FinishReasonType.ToolCalls.id),
+            "gen_ai.response.finish_reasons" to listOf(GenAIAttributes.Response.FinishReasonType.ToolCalls.id),
 
             "gen_ai.prompt.0.role" to Message.Role.System.name.lowercase(),
             "gen_ai.prompt.0.content" to systemPrompt,
@@ -194,7 +194,7 @@ class LangfuseTraceStructureTest :
             "gen_ai.prompt.1.content" to userPrompt,
             "gen_ai.completion.0.role" to Message.Role.Assistant.name.lowercase(),
             "gen_ai.completion.0.content" to "[{\"function\":{\"name\":\"${TestGetWeatherTool.name}\",\"arguments\":\"{\\\"location\\\":\\\"Paris\\\"}\"},\"id\":\"get-weather-tool-call-id\",\"type\":\"function\"}]",
-            "gen_ai.completion.0.finish_reason" to SpanAttributes.Response.FinishReasonType.ToolCalls.id,
+            "gen_ai.completion.0.finish_reason" to GenAIAttributes.Response.FinishReasonType.ToolCalls.id,
         )
     }
 
@@ -255,7 +255,7 @@ class LangfuseTraceStructureTest :
             "system_instructions" to systemInstructions,
             "gen_ai.output.messages" to outputMessages,
             "gen_ai.tool.definitions" to toolDefinitions,
-            "gen_ai.response.finish_reasons" to listOf(SpanAttributes.Response.FinishReasonType.Stop.id),
+            "gen_ai.response.finish_reasons" to listOf(GenAIAttributes.Response.FinishReasonType.Stop.id),
 
             "gen_ai.prompt.0.role" to Message.Role.System.name.lowercase(),
             "gen_ai.prompt.0.content" to systemPrompt,

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/weave/WeaveTraceStructureTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/weave/WeaveTraceStructureTest.kt
@@ -1,7 +1,7 @@
 package ai.koog.agents.features.opentelemetry.integration.weave
 
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import ai.koog.agents.features.opentelemetry.integration.TraceStructureTestBase
 import ai.koog.agents.features.opentelemetry.mock.TestGetWeatherTool
 import ai.koog.prompt.llm.LLModel
@@ -57,14 +57,14 @@ class WeaveTraceStructureTest :
             "system_instructions" to systemInstructions,
             "gen_ai.output.messages" to outputMessages,
             "gen_ai.tool.definitions" to toolDefinitions,
-            "gen_ai.response.finish_reasons" to listOf(SpanAttributes.Response.FinishReasonType.ToolCalls.id),
+            "gen_ai.response.finish_reasons" to listOf(GenAIAttributes.Response.FinishReasonType.ToolCalls.id),
 
             "gen_ai.prompt.0.role" to Message.Role.System.name.lowercase(),
             "gen_ai.prompt.0.content" to systemPrompt,
             "gen_ai.prompt.1.role" to Message.Role.User.name.lowercase(),
             "gen_ai.prompt.1.content" to userPrompt,
             "gen_ai.completion.0.role" to Message.Role.Assistant.name.lowercase(),
-            "gen_ai.completion.0.finish_reason" to SpanAttributes.Response.FinishReasonType.ToolCalls.id,
+            "gen_ai.completion.0.finish_reason" to GenAIAttributes.Response.FinishReasonType.ToolCalls.id,
             // Weave-specific: tool_calls attributes without content for initial LLM call
             "gen_ai.completion.0.tool_calls.0.id" to toolCallId,
             "gen_ai.completion.0.tool_calls.0.type" to "function",
@@ -125,7 +125,7 @@ class WeaveTraceStructureTest :
             "system_instructions" to systemInstructions,
             "gen_ai.output.messages" to outputMessages,
             "gen_ai.tool.definitions" to toolDefinitions,
-            "gen_ai.response.finish_reasons" to listOf(SpanAttributes.Response.FinishReasonType.Stop.id),
+            "gen_ai.response.finish_reasons" to listOf(GenAIAttributes.Response.FinishReasonType.Stop.id),
 
             "gen_ai.prompt.0.role" to Message.Role.System.name.lowercase(),
             "gen_ai.prompt.0.content" to systemPrompt,
@@ -133,7 +133,7 @@ class WeaveTraceStructureTest :
             "gen_ai.prompt.1.content" to userPrompt,
             // Weave-specific: tool call appears as assistant message in prompt history
             "gen_ai.prompt.2.role" to Message.Role.Assistant.name.lowercase(),
-            "gen_ai.prompt.2.finish_reason" to SpanAttributes.Response.FinishReasonType.ToolCalls.id,
+            "gen_ai.prompt.2.finish_reason" to GenAIAttributes.Response.FinishReasonType.ToolCalls.id,
             "gen_ai.prompt.2.tool_calls.0.id" to toolCallId,
             "gen_ai.prompt.2.tool_calls.0.type" to "function",
             "gen_ai.prompt.2.tool_calls.0.function" to "{\"name\":\"${TestGetWeatherTool.name}\",\"arguments\":\"{\\\"location\\\":\\\"Paris\\\"}\"}",
@@ -189,14 +189,14 @@ class WeaveTraceStructureTest :
             "system_instructions" to systemInstructions,
             "gen_ai.output.messages" to outputMessages,
             "gen_ai.tool.definitions" to toolDefinitions,
-            "gen_ai.response.finish_reasons" to listOf(SpanAttributes.Response.FinishReasonType.ToolCalls.id),
+            "gen_ai.response.finish_reasons" to listOf(GenAIAttributes.Response.FinishReasonType.ToolCalls.id),
 
             "gen_ai.prompt.0.role" to Message.Role.System.name.lowercase(),
             "gen_ai.prompt.0.content" to systemPrompt,
             "gen_ai.prompt.1.role" to Message.Role.User.name.lowercase(),
             "gen_ai.prompt.1.content" to userPrompt,
             "gen_ai.completion.0.role" to Message.Role.Assistant.name.lowercase(),
-            "gen_ai.completion.0.finish_reason" to SpanAttributes.Response.FinishReasonType.ToolCalls.id,
+            "gen_ai.completion.0.finish_reason" to GenAIAttributes.Response.FinishReasonType.ToolCalls.id,
             // Weave-specific: tool_calls attributes without content for initial LLM call
             "gen_ai.completion.0.tool_calls.0.id" to toolCallId,
             "gen_ai.completion.0.tool_calls.0.type" to "function",
@@ -272,7 +272,7 @@ class WeaveTraceStructureTest :
             "system_instructions" to systemInstructions,
             "gen_ai.output.messages" to outputMessages,
             "gen_ai.tool.definitions" to toolDefinitions,
-            "gen_ai.response.finish_reasons" to listOf(SpanAttributes.Response.FinishReasonType.Stop.id),
+            "gen_ai.response.finish_reasons" to listOf(GenAIAttributes.Response.FinishReasonType.Stop.id),
 
             "gen_ai.prompt.0.role" to Message.Role.System.name.lowercase(),
             "gen_ai.prompt.0.content" to systemPrompt,
@@ -281,7 +281,7 @@ class WeaveTraceStructureTest :
 
             // Weave-specific: tool call appears as assistant message in prompt history
             "gen_ai.prompt.2.role" to Message.Role.Assistant.name.lowercase(),
-            "gen_ai.prompt.2.finish_reason" to SpanAttributes.Response.FinishReasonType.ToolCalls.id,
+            "gen_ai.prompt.2.finish_reason" to GenAIAttributes.Response.FinishReasonType.ToolCalls.id,
             "gen_ai.prompt.2.tool_calls.0.id" to toolCallId,
             "gen_ai.prompt.2.tool_calls.0.type" to "function",
             "gen_ai.prompt.2.tool_calls.0.function" to "{\"name\":\"${TestGetWeatherTool.name}\",\"arguments\":\"{\\\"location\\\":\\\"Paris\\\"}\"}",

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/metrics/AttributesExt.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/metrics/AttributesExt.kt
@@ -1,0 +1,16 @@
+package ai.koog.agents.features.opentelemetry.metrics
+
+import ai.koog.agents.features.opentelemetry.attribute.Attribute
+import io.opentelemetry.api.common.Attributes
+
+internal fun Attributes.contains(searchableAttribute: Attribute): Boolean {
+    var isFound = false
+
+    this.forEach { attrKey, attrValue ->
+        if (searchableAttribute.key == attrKey.toString() && searchableAttribute.value == attrValue) {
+            isFound = true
+        }
+    }
+
+    return isFound
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/metrics/LongExt.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/metrics/LongExt.kt
@@ -1,0 +1,5 @@
+package ai.koog.agents.features.opentelemetry.metrics
+
+import kotlin.math.pow
+
+internal fun Long.toSec() = this.toDouble().div(10.0.pow(6))

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/metrics/MetricAdapterTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/metrics/MetricAdapterTest.kt
@@ -1,0 +1,172 @@
+package ai.koog.agents.features.opentelemetry.metrics
+
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
+import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
+import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryConfig
+import ai.koog.agents.features.opentelemetry.metric.MetricCollector
+import ai.koog.agents.features.opentelemetry.metric.adapter.restrictToolNameCardinality
+import ai.koog.agents.features.opentelemetry.metric.events.createExecuteToolDurationHistogramMetricEvent
+import ai.koog.agents.features.opentelemetry.metric.events.createToolCallCounterMetricEvent
+import ai.koog.agents.features.opentelemetry.metrics.mock.TestMeter
+import ai.koog.agents.features.opentelemetry.metrics.mock.getRecordsByCounterName
+import ai.koog.agents.features.opentelemetry.metrics.mock.getRecordsByHistogramName
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+
+class MetricAdapterTest {
+
+    @Test
+    fun testRestrictToolNameCardinalityWithAllowedTool() {
+        val meter = TestMeter()
+        val config = OpenTelemetryConfig()
+
+        val allowedToolNames = setOf("allowed-tool", "another-allowed-tool")
+        config.restrictToolNameCardinality(allowedToolNames)
+
+        val metricCollector = MetricCollector(meter, config)
+
+        val toolName = "allowed-tool"
+        metricCollector.addCounterMetricEvent(
+            createToolCallCounterMetricEvent(
+                id = "test-id",
+                toolName = toolName,
+                toolCallStatus = KoogAttributes.Koog.Tool.Call.StatusType.SUCCESS
+            )
+        )
+
+        val toolCallCountRecords = meter.getRecordsByCounterName("koog.tool.count")
+        assertEquals(2, toolCallCountRecords.size) // Initial 0 + 1 call
+
+        val attributes = toolCallCountRecords.last().attributes
+        assertTrue { attributes?.contains(GenAIAttributes.Tool.Name(toolName)) == true }
+    }
+
+    @Test
+    fun testRestrictToolNameCardinalityWithDisallowedTool() {
+        val meter = TestMeter()
+        val config = OpenTelemetryConfig()
+
+        val allowedToolNames = setOf("allowed-tool")
+        val fallbackToolName = "filtered"
+        config.restrictToolNameCardinality(allowedToolNames, fallbackToolName)
+
+        val metricCollector = MetricCollector(meter, config)
+
+        val toolName = "disallowed-tool"
+        metricCollector.addCounterMetricEvent(
+            createToolCallCounterMetricEvent(
+                id = "test-id",
+                toolName = toolName,
+                toolCallStatus = KoogAttributes.Koog.Tool.Call.StatusType.SUCCESS
+            )
+        )
+
+        val toolCallCountRecords = meter.getRecordsByCounterName("koog.tool.count")
+        assertEquals(2, toolCallCountRecords.size) // Initial 0 + 1 call
+
+        // Metric adapter should have processed the tool name
+        // The metric should be recorded regardless of filtering
+        assertTrue(toolCallCountRecords.last().value == 1L)
+    }
+
+    @Test
+    fun testRestrictToolNameCardinalityWithHistogram() {
+        val meter = TestMeter()
+        val config = OpenTelemetryConfig()
+
+        val allowedToolNames = setOf("allowed-tool")
+        config.restrictToolNameCardinality(allowedToolNames)
+
+        val metricCollector = MetricCollector(meter, config)
+
+        val toolName = "allowed-tool"
+        val duration = 100.milliseconds
+
+        metricCollector.recordHistogramMetricEvent(
+            createExecuteToolDurationHistogramMetricEvent(
+                id = "test-id",
+                duration = duration,
+                toolName = toolName,
+                toolCallStatus = KoogAttributes.Koog.Tool.Call.StatusType.SUCCESS
+            )
+        )
+
+        val histogramRecords = meter.getRecordsByHistogramName("gen_ai.client.operation.duration")
+        assertEquals(1, histogramRecords.size)
+
+        val attributes = histogramRecords.first().attributes
+        assertTrue { attributes?.contains(GenAIAttributes.Tool.Name(toolName)) == true }
+    }
+
+    @Test
+    fun testRestrictToolNameCardinalityWithMultipleTools() {
+        val meter = TestMeter()
+        val config = OpenTelemetryConfig()
+
+        val allowedToolNames = setOf("tool-a", "tool-b")
+        config.restrictToolNameCardinality(allowedToolNames)
+
+        val metricCollector = MetricCollector(meter, config)
+
+        // Add allowed tools
+        metricCollector.addCounterMetricEvent(
+            createToolCallCounterMetricEvent(
+                id = "test-id",
+                toolName = "tool-a",
+                toolCallStatus = KoogAttributes.Koog.Tool.Call.StatusType.SUCCESS
+            )
+        )
+
+        metricCollector.addCounterMetricEvent(
+            createToolCallCounterMetricEvent(
+                id = "test-id",
+                toolName = "tool-b",
+                toolCallStatus = KoogAttributes.Koog.Tool.Call.StatusType.SUCCESS
+            )
+        )
+
+        // Add disallowed tool
+        metricCollector.addCounterMetricEvent(
+            createToolCallCounterMetricEvent(
+                id = "test-id",
+                toolName = "tool-c",
+                toolCallStatus = KoogAttributes.Koog.Tool.Call.StatusType.SUCCESS
+            )
+        )
+
+        val toolCallCountRecords = meter.getRecordsByCounterName("koog.tool.count")
+        assertEquals(4, toolCallCountRecords.size) // Initial 0 + 3 calls
+
+        // Verify all three calls are recorded
+        assertTrue(toolCallCountRecords.size == 4)
+    }
+
+    @Test
+    fun testRestrictToolNameCardinalityWithDefaultFallbackName() {
+        val meter = TestMeter()
+        val config = OpenTelemetryConfig()
+
+        val allowedToolNames = setOf("allowed-tool")
+        // Using default fallback name "filtered"
+        config.restrictToolNameCardinality(allowedToolNames)
+
+        val metricCollector = MetricCollector(meter, config)
+
+        val toolName = "disallowed-tool"
+        metricCollector.addCounterMetricEvent(
+            createToolCallCounterMetricEvent(
+                id = "test-id",
+                toolName = toolName,
+                toolCallStatus = KoogAttributes.Koog.Tool.Call.StatusType.SUCCESS
+            )
+        )
+
+        val toolCallCountRecords = meter.getRecordsByCounterName("koog.tool.count")
+        assertEquals(2, toolCallCountRecords.size)
+
+        // Verify the metric was recorded (even if tool name might be filtered)
+        assertTrue(toolCallCountRecords.last().value == 1L)
+    }
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/metrics/MetricCollectorTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/metrics/MetricCollectorTest.kt
@@ -1,0 +1,291 @@
+package ai.koog.agents.features.opentelemetry.metrics
+
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes.Token.TokenType
+import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
+import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes.Koog.Tool.Call.StatusType
+import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryConfig
+import ai.koog.agents.features.opentelemetry.metric.MetricCollector
+import ai.koog.agents.features.opentelemetry.metric.events.createExecuteToolDurationHistogramMetricEvent
+import ai.koog.agents.features.opentelemetry.metric.events.createLLMCallDurationHistogramMetricEvent
+import ai.koog.agents.features.opentelemetry.metric.events.createLLMInputTokensMetricEvent
+import ai.koog.agents.features.opentelemetry.metric.events.createLLMOutputTokensMetricEvent
+import ai.koog.agents.features.opentelemetry.metric.events.createToolCallCounterMetricEvent
+import ai.koog.agents.features.opentelemetry.metrics.mock.Metric
+import ai.koog.agents.features.opentelemetry.metrics.mock.TestMeter
+import ai.koog.agents.features.opentelemetry.metrics.mock.getRecordsByCounterName
+import ai.koog.agents.features.opentelemetry.metrics.mock.getRecordsByHistogramName
+import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
+import io.opentelemetry.api.common.Attributes
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class MetricCollectorTest {
+    companion object {
+        private const val tokenCountMetricName = "gen_ai.client.token.usage"
+        private const val toolCallCountMetricName = "koog.tool.count"
+        private const val operationDurationMetricName = "gen_ai.client.operation.duration"
+
+        val model: LLModel = LLModel(
+            provider = LLMProvider.Ollama,
+            id = "llama3-groq-tool-use:8b",
+            capabilities = listOf(
+                LLMCapability.Temperature,
+                LLMCapability.Schema.JSON.Standard,
+                LLMCapability.Tools
+            ),
+            contextLength = 8_192,
+        )
+
+        val countersAmount = 2
+        val histogramsAmount = 1
+    }
+
+    @Test
+    fun testMetricCollectorToInitializeMetrics() {
+        val meter = TestMeter()
+
+        assertEquals(0, meter.counterValues.size)
+        assertEquals(0, meter.histogramValues.size)
+
+        // Initialize MetricCollector to register metrics on the meter
+        val config = OpenTelemetryConfig()
+        MetricCollector(meter, config)
+
+        // Two counters and one histogram should be created
+        assertEquals(countersAmount, meter.buildCounter.size)
+        assertEquals(histogramsAmount, meter.buildHistogram.size)
+
+        // For each counter-metric one starting value should be set
+        assertEquals(countersAmount, meter.counterValues.size)
+        assertEquals(0, meter.histogramValues.size)
+    }
+
+    @Test
+    fun testMetricCollectorToCreateTokenCounter() {
+        val meter = TestMeter()
+        val config = OpenTelemetryConfig()
+        MetricCollector(meter, config)
+
+        assertContains(
+            meter.buildCounter,
+            Metric(tokenCountMetricName, "Total token count", "token")
+        )
+    }
+
+    @Test
+    fun testMetricCollectorToCreateToolCallCounter() {
+        val meter = TestMeter()
+        val config = OpenTelemetryConfig()
+        MetricCollector(meter, config)
+
+        assertContains(
+            meter.buildCounter,
+            Metric(toolCallCountMetricName, "Tool calls count", "tool call")
+        )
+    }
+
+    @Test
+    fun testMetricCollectorToCreateOperationDurationHistogram() {
+        val meter = TestMeter()
+        val config = OpenTelemetryConfig()
+        MetricCollector(meter, config)
+
+        assertContains(
+            meter.buildHistogram,
+            Metric(operationDurationMetricName, "Operation duration", "s")
+        )
+    }
+
+    @Test
+    fun testMetricCollectorToProcessLLMTokens() {
+        val meter = TestMeter()
+        val config = OpenTelemetryConfig()
+        val metricCollector = MetricCollector(meter, config)
+
+        val model = model
+        val inputTokenSpend = 100L
+        val outputTokenSpend = 200L
+
+        metricCollector.addCounterMetricEvent(
+            createLLMInputTokensMetricEvent(
+                id = "test-id",
+                model = model,
+                inputTokens = inputTokenSpend
+            )
+        )
+
+        metricCollector.addCounterMetricEvent(
+            createLLMOutputTokensMetricEvent(
+                id = "test-id",
+                model = model,
+                outputTokens = outputTokenSpend
+            )
+        )
+
+        assertEquals(countersAmount + 2, meter.counterValues.size)
+
+        // Token Count Metric
+        // Check values of the token count metric
+        val tokenCountRecords = meter.getRecordsByCounterName(tokenCountMetricName)
+
+        assertContentEquals(
+            listOf(0, inputTokenSpend, outputTokenSpend),
+            tokenCountRecords.map { it.value }
+        )
+
+        // Check values' attributes of the input count metric
+        val inputTokenAttributes = tokenCountRecords.getOrNull(1)?.attributes
+        assertLlmModelAttributes(inputTokenAttributes, model, model.provider)
+        assertLlmModelTokenAttribute(inputTokenAttributes, TokenType.INPUT)
+
+        val outputTokenAttributes = tokenCountRecords.getOrNull(2)?.attributes
+        assertLlmModelAttributes(outputTokenAttributes, model, model.provider)
+        assertLlmModelTokenAttribute(outputTokenAttributes, TokenType.OUTPUT)
+    }
+
+    @Test
+    fun testMetricCollectorToProcessLLMCallDuration() {
+        val meter = TestMeter()
+        val config = OpenTelemetryConfig()
+        val metricCollector = MetricCollector(meter, config)
+
+        val model = model
+        val duration = 1.seconds
+
+        metricCollector.recordHistogramMetricEvent(
+            createLLMCallDurationHistogramMetricEvent(
+                id = "test-id",
+                model = model,
+                duration = duration
+            )
+        )
+
+        assertEquals(histogramsAmount, meter.buildHistogram.size)
+
+        // Operation Duration Metric
+        // Check values of the operation duration metric
+        assertContentEquals(
+            listOf(duration.inWholeSeconds.toDouble()),
+            meter.getRecordsByHistogramName(operationDurationMetricName).map { it.value }
+        )
+
+        val operationDurationAttributes =
+            meter.getRecordsByHistogramName(operationDurationMetricName).getOrNull(0)?.attributes
+
+        // Check values' attributes of the operation duration metric
+        assertLlmModelAttributes(operationDurationAttributes, model, model.provider)
+    }
+
+    private fun assertLlmModelTokenAttribute(
+        attributes: Attributes?,
+        tokenType: TokenType
+    ) {
+        assertNotNull(attributes)
+        assertTrue { attributes.contains(GenAIAttributes.Token.Type(tokenType)) }
+    }
+
+    private fun assertLlmModelAttributes(
+        attributes: Attributes?,
+        model: LLModel,
+        modelProvider: LLMProvider
+    ) {
+        assertNotNull(attributes)
+        assertTrue {
+            attributes.contains(
+                GenAIAttributes.Operation.Name(GenAIAttributes.Operation.OperationNameType.TEXT_COMPLETION)
+            )
+        }
+        assertTrue { attributes.contains(GenAIAttributes.Provider.Name(modelProvider)) }
+        assertTrue { attributes.contains(GenAIAttributes.Response.Model(model)) }
+    }
+
+    @Test
+    fun testMetricCollectorToProcessToolCall() {
+        val cases = listOf(
+            StatusType.SUCCESS,
+            StatusType.ERROR,
+            StatusType.VALIDATION_FAILED
+        )
+
+        cases.forEach { status ->
+            val meter = TestMeter()
+            val config = OpenTelemetryConfig()
+            val metricCollector = MetricCollector(meter, config)
+
+            val toolCallName = "test-tool"
+            val duration = 100.milliseconds
+
+            metricCollector.addCounterMetricEvent(
+                createToolCallCounterMetricEvent(
+                    id = "test-id",
+                    toolName = toolCallName,
+                    toolCallStatus = status
+                )
+            )
+
+            assertEquals(countersAmount + 1, meter.counterValues.size)
+
+            // Tool Call Count Metric
+            // Check values of the Tool Call Count Metric
+            assertContentEquals(
+                meter.getRecordsByCounterName(toolCallCountMetricName).map { it.value },
+                listOf(0, 1)
+            )
+
+            val toolCallCountAttributes =
+                meter.getRecordsByCounterName(toolCallCountMetricName).getOrNull(1)?.attributes
+
+            // Check values' attributes of the input count metric
+            assertToolCallAttributes(toolCallCountAttributes, toolCallName, status)
+
+            // Record duration
+            metricCollector.recordHistogramMetricEvent(
+                createExecuteToolDurationHistogramMetricEvent(
+                    id = "test-id",
+                    duration = duration,
+                    toolName = toolCallName,
+                    toolCallStatus = status
+                )
+            )
+
+            assertEquals(histogramsAmount, meter.buildHistogram.size)
+
+            // Operation Duration Metric
+            // Check values of the operation duration metric
+            assertContentEquals(
+                listOf(duration.inWholeMilliseconds.toDouble() / 1000),
+                meter.getRecordsByHistogramName(operationDurationMetricName).map { it.value }
+            )
+
+            val operationDurationMetric =
+                meter.getRecordsByHistogramName(operationDurationMetricName).getOrNull(0)
+
+            // Check values' attributes of the operation duration metric
+            assertToolCallAttributes(operationDurationMetric?.attributes, toolCallName, status)
+        }
+    }
+
+    private fun assertToolCallAttributes(
+        attributes: Attributes?,
+        toolCallName: String,
+        status: StatusType,
+    ) {
+        assertNotNull(attributes)
+        assertTrue {
+            attributes.contains(
+                GenAIAttributes.Operation.Name(GenAIAttributes.Operation.OperationNameType.EXECUTE_TOOL)
+            )
+        }
+        assertTrue { attributes.contains(GenAIAttributes.Tool.Name(toolCallName)) }
+        assertTrue { attributes.contains(KoogAttributes.Koog.Tool.Call.Status(status)) }
+    }
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/metrics/MetricEventCreatorsTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/metrics/MetricEventCreatorsTest.kt
@@ -1,0 +1,200 @@
+package ai.koog.agents.features.opentelemetry.metrics
+
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
+import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
+import ai.koog.agents.features.opentelemetry.attribute.toSdkAttributes
+import ai.koog.agents.features.opentelemetry.metric.events.createExecuteToolDurationHistogramMetricEvent
+import ai.koog.agents.features.opentelemetry.metric.events.createLLMCallDurationHistogramMetricEvent
+import ai.koog.agents.features.opentelemetry.metric.events.createLLMInputTokensMetricEvent
+import ai.koog.agents.features.opentelemetry.metric.events.createLLMOutputTokensMetricEvent
+import ai.koog.agents.features.opentelemetry.metric.events.createToolCallCounterMetricEvent
+import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class MetricEventCreatorsTest {
+
+    private val testModel = LLModel(
+        provider = LLMProvider.OpenAI,
+        id = "gpt-4",
+        capabilities = listOf(LLMCapability.Tools, LLMCapability.Temperature),
+        contextLength = 8192
+    )
+
+    @Test
+    fun testCreateLLMInputTokensMetricEvent() {
+        val inputTokens = 100L
+        val event = createLLMInputTokensMetricEvent(
+            id = "test-id",
+            model = testModel,
+            inputTokens = inputTokens
+        )
+
+        assertEquals("gen_ai.client.token.usage", event.metricName)
+        assertEquals(inputTokens, event.value)
+
+        // Verify attributes using toSdkAttributes
+        val sdkAttributes = event.attributes.toSdkAttributes(verbose = true)
+        assertTrue(sdkAttributes.contains(GenAIAttributes.Operation.Name(GenAIAttributes.Operation.OperationNameType.TEXT_COMPLETION)))
+        assertTrue(sdkAttributes.contains(GenAIAttributes.Provider.Name(LLMProvider.OpenAI)))
+        assertTrue(sdkAttributes.contains(GenAIAttributes.Token.Type(GenAIAttributes.Token.TokenType.INPUT)))
+        assertTrue(sdkAttributes.contains(GenAIAttributes.Response.Model(testModel)))
+    }
+
+    @Test
+    fun testCreateLLMOutputTokensMetricEvent() {
+        val outputTokens = 200L
+        val event = createLLMOutputTokensMetricEvent(
+            id = "test-id",
+            model = testModel,
+            outputTokens = outputTokens
+        )
+
+        assertEquals("gen_ai.client.token.usage", event.metricName)
+        assertEquals(outputTokens, event.value)
+
+        // Verify attributes using toSdkAttributes
+        val sdkAttributes = event.attributes.toSdkAttributes(verbose = true)
+        assertTrue(sdkAttributes.contains(GenAIAttributes.Operation.Name(GenAIAttributes.Operation.OperationNameType.TEXT_COMPLETION)))
+        assertTrue(sdkAttributes.contains(GenAIAttributes.Provider.Name(LLMProvider.OpenAI)))
+        assertTrue(sdkAttributes.contains(GenAIAttributes.Token.Type(GenAIAttributes.Token.TokenType.OUTPUT)))
+        assertTrue(sdkAttributes.contains(GenAIAttributes.Response.Model(testModel)))
+    }
+
+    @Test
+    fun testCreateLLMCallDurationHistogramMetricEvent() {
+        val duration = 1.5.seconds
+        val event = createLLMCallDurationHistogramMetricEvent(
+            id = "test-id",
+            model = testModel,
+            duration = duration
+        )
+
+        assertEquals("gen_ai.client.operation.duration", event.metricName)
+        assertEquals(1.5, event.value)
+
+        // Verify attributes using toSdkAttributes
+        val sdkAttributes = event.attributes.toSdkAttributes(verbose = true)
+        assertTrue(sdkAttributes.contains(GenAIAttributes.Operation.Name(GenAIAttributes.Operation.OperationNameType.TEXT_COMPLETION)))
+        assertTrue(sdkAttributes.contains(GenAIAttributes.Provider.Name(LLMProvider.OpenAI)))
+        assertTrue(sdkAttributes.contains(GenAIAttributes.Response.Model(testModel)))
+    }
+
+    @Test
+    fun testCreateToolCallCounterMetricEvent() {
+        val toolName = "test-tool"
+        val status = KoogAttributes.Koog.Tool.Call.StatusType.SUCCESS
+
+        val event = createToolCallCounterMetricEvent(
+            id = "test-id",
+            toolName = toolName,
+            toolCallStatus = status
+        )
+
+        assertEquals("koog.tool.count", event.metricName)
+        assertEquals(1L, event.value)
+
+        // Verify attributes using toSdkAttributes
+        val sdkAttributes = event.attributes.toSdkAttributes(verbose = true)
+        assertTrue(sdkAttributes.contains(GenAIAttributes.Operation.Name(GenAIAttributes.Operation.OperationNameType.EXECUTE_TOOL)))
+        assertTrue(sdkAttributes.contains(GenAIAttributes.Tool.Name(toolName)))
+        assertTrue(sdkAttributes.contains(KoogAttributes.Koog.Tool.Call.Status(status)))
+    }
+
+    @Test
+    fun testCreateExecuteToolDurationHistogramMetricEvent() {
+        val toolName = "test-tool"
+        val status = KoogAttributes.Koog.Tool.Call.StatusType.SUCCESS
+        val duration = 150.milliseconds
+
+        val event = createExecuteToolDurationHistogramMetricEvent(
+            id = "test-id",
+            duration = duration,
+            toolName = toolName,
+            toolCallStatus = status
+        )
+
+        assertEquals("gen_ai.client.operation.duration", event.metricName)
+        assertEquals(0.15, event.value)
+
+        // Verify attributes using toSdkAttributes
+        val sdkAttributes = event.attributes.toSdkAttributes(verbose = true)
+        assertTrue(sdkAttributes.contains(GenAIAttributes.Operation.Name(GenAIAttributes.Operation.OperationNameType.EXECUTE_TOOL)))
+        assertTrue(sdkAttributes.contains(GenAIAttributes.Tool.Name(toolName)))
+        assertTrue(sdkAttributes.contains(KoogAttributes.Koog.Tool.Call.Status(status)))
+    }
+
+    @Test
+    fun testCreateToolCallCounterMetricEventWithDifferentStatuses() {
+        val toolName = "test-tool"
+        val statuses = listOf(
+            KoogAttributes.Koog.Tool.Call.StatusType.SUCCESS,
+            KoogAttributes.Koog.Tool.Call.StatusType.ERROR,
+            KoogAttributes.Koog.Tool.Call.StatusType.VALIDATION_FAILED
+        )
+
+        statuses.forEach { status ->
+            val event = createToolCallCounterMetricEvent(
+                id = "test-id",
+                toolName = toolName,
+                toolCallStatus = status
+            )
+
+            assertEquals("koog.tool.count", event.metricName)
+            assertEquals(1L, event.value)
+
+            val sdkAttributes = event.attributes.toSdkAttributes(verbose = true)
+            assertTrue(sdkAttributes.contains(KoogAttributes.Koog.Tool.Call.Status(status)))
+        }
+    }
+
+    @Test
+    fun testCreateExecuteToolDurationHistogramMetricEventWithDifferentStatuses() {
+        val toolName = "test-tool"
+        val duration = 100.milliseconds
+        val statuses = listOf(
+            KoogAttributes.Koog.Tool.Call.StatusType.SUCCESS,
+            KoogAttributes.Koog.Tool.Call.StatusType.ERROR,
+            KoogAttributes.Koog.Tool.Call.StatusType.VALIDATION_FAILED
+        )
+
+        statuses.forEach { status ->
+            val event = createExecuteToolDurationHistogramMetricEvent(
+                id = "test-id",
+                duration = duration,
+                toolName = toolName,
+                toolCallStatus = status
+            )
+
+            assertEquals("gen_ai.client.operation.duration", event.metricName)
+            assertEquals(0.1, event.value)
+
+            val sdkAttributes = event.attributes.toSdkAttributes(verbose = true)
+            assertTrue(sdkAttributes.contains(KoogAttributes.Koog.Tool.Call.Status(status)))
+        }
+    }
+
+    @Test
+    fun testDurationConversionToSeconds() {
+        val testCases = listOf(
+            1.seconds to 1.0,
+            500.milliseconds to 0.5,
+            1500.milliseconds to 1.5,
+            100.milliseconds to 0.1
+        )
+
+        testCases.forEach { (duration, expectedSeconds) ->
+            val event = createLLMCallDurationHistogramMetricEvent(
+                id = "test-id",
+                model = testModel,
+                duration = duration
+            )
+            assertEquals(expectedSeconds, event.value)
+        }
+    }
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/metrics/MetricFactoryTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/metrics/MetricFactoryTest.kt
@@ -1,0 +1,72 @@
+package ai.koog.agents.features.opentelemetry.metrics
+
+import ai.koog.agents.features.opentelemetry.metric.MetricFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class MetricFactoryTest {
+
+    @Test
+    fun testCreateTokenCounterMetric() {
+        val metric = MetricFactory.createTokenCounterMetric()
+
+        assertEquals("gen_ai.client.token.usage", metric.name)
+        assertEquals("Total token count", metric.description)
+        assertEquals("token", metric.unit)
+    }
+
+    @Test
+    fun testCreateToolCallCounterMetric() {
+        val metric = MetricFactory.createToolCallCounterMetric()
+
+        assertEquals("koog.tool.count", metric.name)
+        assertEquals("Tool calls count", metric.description)
+        assertEquals("tool call", metric.unit)
+    }
+
+    @Test
+    fun testCreateOperationDurationHistogramMetric() {
+        val metric = MetricFactory.createOperationDurationHistogramMetric()
+
+        assertEquals("gen_ai.client.operation.duration", metric.name)
+        assertEquals("Operation duration", metric.description)
+        assertEquals("s", metric.unit)
+
+        // Verify boundaries advice is set according to OpenTelemetry semantic conventions
+        assertNotNull(metric.boundariesAdvice)
+        assertTrue(metric.boundariesAdvice.isNotEmpty())
+
+        val expectedBoundaries = listOf(
+            0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92
+        )
+        assertEquals(expectedBoundaries, metric.boundariesAdvice)
+    }
+
+    @Test
+    fun testOperationDurationHistogramBoundariesAreOrdered() {
+        val metric = MetricFactory.createOperationDurationHistogramMetric()
+
+        val boundaries = metric.boundariesAdvice
+
+        // Verify boundaries are in ascending order
+        for (i in 0 until boundaries.size - 1) {
+            assertTrue(
+                boundaries[i] < boundaries[i + 1],
+                "Boundaries should be in ascending order: ${boundaries[i]} should be less than ${boundaries[i + 1]}"
+            )
+        }
+    }
+
+    @Test
+    fun testOperationDurationHistogramBoundariesCoverReasonableRange() {
+        val metric = MetricFactory.createOperationDurationHistogramMetric()
+
+        val boundaries = metric.boundariesAdvice
+
+        // Verify the range covers from 10ms to ~82 seconds
+        assertTrue(boundaries.first() >= 0.01, "First boundary should be at least 10ms")
+        assertTrue(boundaries.last() <= 100.0, "Last boundary should be at most 100s")
+    }
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/metrics/MetricNamesTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/metrics/MetricNamesTest.kt
@@ -1,0 +1,29 @@
+package ai.koog.agents.features.opentelemetry.metrics
+
+import ai.koog.agents.features.opentelemetry.metric.GenAIMetrics
+import ai.koog.agents.features.opentelemetry.metric.KoogMetrics
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MetricNamesTest {
+    @Test
+    fun `test tool call count metric`() {
+        val metric = KoogMetrics.Tool.Count
+        assertEquals("koog.tool.count", metric.name)
+        assertEquals("tool call", metric.unit)
+    }
+
+    @Test
+    fun `test tool call operation duration metric`() {
+        val metric = GenAIMetrics.Client.Operation.Duration
+        assertEquals("gen_ai.client.operation.duration", metric.name)
+        assertEquals("s", metric.unit)
+    }
+
+    @Test
+    fun `test token usage metric`() {
+        val metric = GenAIMetrics.Client.Token.Usage
+        assertEquals("gen_ai.client.token.usage", metric.name)
+        assertEquals("token", metric.unit)
+    }
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/metrics/TestMeter.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/metrics/TestMeter.kt
@@ -1,0 +1,142 @@
+package ai.koog.agents.features.opentelemetry.metrics
+
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.metrics.DoubleCounterBuilder
+import io.opentelemetry.api.metrics.DoubleGaugeBuilder
+import io.opentelemetry.api.metrics.DoubleHistogram
+import io.opentelemetry.api.metrics.DoubleHistogramBuilder
+import io.opentelemetry.api.metrics.LongCounter
+import io.opentelemetry.api.metrics.LongCounterBuilder
+import io.opentelemetry.api.metrics.LongHistogramBuilder
+import io.opentelemetry.api.metrics.LongUpDownCounterBuilder
+import io.opentelemetry.api.metrics.Meter
+import io.opentelemetry.api.metrics.ObservableLongCounter
+import io.opentelemetry.api.metrics.ObservableLongMeasurement
+import io.opentelemetry.context.Context
+import java.util.function.Consumer
+
+internal data class Metric(val name: String, val description: String?, val unit: String?)
+
+internal data class MetricRecord<T>(val metric: Metric, val value: T, val attributes: Attributes?)
+
+internal class TestMeter : Meter {
+    val buildCounter: MutableList<Metric> = mutableListOf()
+    val buildHistogram: MutableList<Metric> = mutableListOf()
+
+    val counterValues: MutableList<MetricRecord<Long>> = mutableListOf()
+    val histogramValues: MutableList<MetricRecord<Double>> = mutableListOf()
+
+    override fun counterBuilder(name: String): LongCounterBuilder? {
+        return object : LongCounterBuilder {
+            var description: String? = null
+            var unit: String? = null
+
+            override fun setDescription(description: String?): LongCounterBuilder? {
+                this.description = description
+
+                return this
+            }
+
+            override fun setUnit(unit: String?): LongCounterBuilder? {
+                this.unit = unit
+
+                return this
+            }
+
+            override fun ofDoubles(): DoubleCounterBuilder? {
+                TODO("Not yet implemented")
+            }
+
+            override fun build(): LongCounter? {
+                val metric = Metric(name, description, unit)
+                buildCounter.add(metric)
+
+                return object : LongCounter {
+                    override fun add(value: Long) {
+                        counterValues.add(MetricRecord(metric, value, null))
+                    }
+
+                    override fun add(value: Long, attributes: Attributes?) {
+                        counterValues.add(MetricRecord(metric, value, attributes))
+                    }
+
+                    override fun add(
+                        value: Long,
+                        attributes: Attributes?,
+                        context: Context?
+                    ) {
+                        counterValues.add(MetricRecord(metric, value, attributes))
+                    }
+                }
+            }
+
+            override fun buildWithCallback(callback: Consumer<ObservableLongMeasurement?>?): ObservableLongCounter? {
+                TODO("Not yet implemented")
+            }
+        }
+    }
+
+    override fun upDownCounterBuilder(name: String): LongUpDownCounterBuilder? {
+        TODO("Not yet implemented")
+    }
+
+    override fun histogramBuilder(name: String): DoubleHistogramBuilder? {
+        return object : DoubleHistogramBuilder {
+            var description: String? = null
+            var unit: String? = null
+
+            override fun setDescription(description: String?): DoubleHistogramBuilder? {
+                this.description = description
+
+                return this
+            }
+
+            override fun setUnit(unit: String?): DoubleHistogramBuilder? {
+                this.unit = unit
+
+                return this
+            }
+
+            override fun ofLongs(): LongHistogramBuilder? {
+                TODO("Not yet implemented")
+            }
+
+            override fun build(): DoubleHistogram {
+                val metric = Metric(name, description, unit)
+                buildHistogram.add(metric)
+
+                return object : DoubleHistogram {
+                    val currentMetric = metric
+
+                    override fun record(value: Double) {
+                        histogramValues.add(MetricRecord(currentMetric, value, null))
+                    }
+
+                    override fun record(value: Double, attributes: Attributes?) {
+                        histogramValues.add(MetricRecord(currentMetric, value, attributes))
+                    }
+
+                    override fun record(
+                        value: Double,
+                        attributes: Attributes?,
+                        context: Context?
+                    ) {
+                        histogramValues.add(MetricRecord(currentMetric, value, attributes))
+                    }
+                }
+            }
+        }
+    }
+
+    override fun gaugeBuilder(name: String?): DoubleGaugeBuilder? {
+        TODO("Not yet implemented")
+    }
+}
+
+internal fun TestMeter.getRecordsByCounterName(name: String): List<MetricRecord<Long>> {
+    return this.counterValues.filter { it.metric.name == name }
+}
+
+internal fun TestMeter.getRecordsByHistogramName(name: String): List<MetricRecord<Double>> {
+    return this.histogramValues.filter { it.metric.name == name }
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/metrics/mock/TestMeter.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/metrics/mock/TestMeter.kt
@@ -1,0 +1,142 @@
+package ai.koog.agents.features.opentelemetry.metrics.mock
+
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.metrics.DoubleCounterBuilder
+import io.opentelemetry.api.metrics.DoubleGaugeBuilder
+import io.opentelemetry.api.metrics.DoubleHistogram
+import io.opentelemetry.api.metrics.DoubleHistogramBuilder
+import io.opentelemetry.api.metrics.LongCounter
+import io.opentelemetry.api.metrics.LongCounterBuilder
+import io.opentelemetry.api.metrics.LongHistogramBuilder
+import io.opentelemetry.api.metrics.LongUpDownCounterBuilder
+import io.opentelemetry.api.metrics.Meter
+import io.opentelemetry.api.metrics.ObservableLongCounter
+import io.opentelemetry.api.metrics.ObservableLongMeasurement
+import io.opentelemetry.context.Context
+import java.util.function.Consumer
+
+internal data class Metric(val name: String, val description: String?, val unit: String?)
+
+internal data class MetricRecord<T>(val metric: Metric, val value: T, val attributes: Attributes?)
+
+internal class TestMeter : Meter {
+    val buildCounter: MutableList<Metric> = mutableListOf()
+    val buildHistogram: MutableList<Metric> = mutableListOf()
+
+    val counterValues: MutableList<MetricRecord<Long>> = mutableListOf()
+    val histogramValues: MutableList<MetricRecord<Double>> = mutableListOf()
+
+    override fun counterBuilder(name: String): LongCounterBuilder? {
+        return object : LongCounterBuilder {
+            var description: String? = null
+            var unit: String? = null
+
+            override fun setDescription(description: String?): LongCounterBuilder? {
+                this.description = description
+
+                return this
+            }
+
+            override fun setUnit(unit: String?): LongCounterBuilder? {
+                this.unit = unit
+
+                return this
+            }
+
+            override fun ofDoubles(): DoubleCounterBuilder? {
+                TODO("Not yet implemented")
+            }
+
+            override fun build(): LongCounter? {
+                val metric = Metric(name, description, unit)
+                buildCounter.add(metric)
+
+                return object : LongCounter {
+                    override fun add(value: Long) {
+                        counterValues.add(MetricRecord(metric, value, null))
+                    }
+
+                    override fun add(value: Long, attributes: Attributes?) {
+                        counterValues.add(MetricRecord(metric, value, attributes))
+                    }
+
+                    override fun add(
+                        value: Long,
+                        attributes: Attributes?,
+                        context: Context?
+                    ) {
+                        counterValues.add(MetricRecord(metric, value, attributes))
+                    }
+                }
+            }
+
+            override fun buildWithCallback(callback: Consumer<ObservableLongMeasurement?>?): ObservableLongCounter? {
+                TODO("Not yet implemented")
+            }
+        }
+    }
+
+    override fun upDownCounterBuilder(name: String): LongUpDownCounterBuilder? {
+        TODO("Not yet implemented")
+    }
+
+    override fun histogramBuilder(name: String): DoubleHistogramBuilder? {
+        return object : DoubleHistogramBuilder {
+            var description: String? = null
+            var unit: String? = null
+
+            override fun setDescription(description: String?): DoubleHistogramBuilder? {
+                this.description = description
+
+                return this
+            }
+
+            override fun setUnit(unit: String?): DoubleHistogramBuilder? {
+                this.unit = unit
+
+                return this
+            }
+
+            override fun ofLongs(): LongHistogramBuilder? {
+                TODO("Not yet implemented")
+            }
+
+            override fun build(): DoubleHistogram {
+                val metric = Metric(name, description, unit)
+                buildHistogram.add(metric)
+
+                return object : DoubleHistogram {
+                    val currentMetric = metric
+
+                    override fun record(value: Double) {
+                        histogramValues.add(MetricRecord(currentMetric, value, null))
+                    }
+
+                    override fun record(value: Double, attributes: Attributes?) {
+                        histogramValues.add(MetricRecord(currentMetric, value, attributes))
+                    }
+
+                    override fun record(
+                        value: Double,
+                        attributes: Attributes?,
+                        context: Context?
+                    ) {
+                        histogramValues.add(MetricRecord(currentMetric, value, attributes))
+                    }
+                }
+            }
+        }
+    }
+
+    override fun gaugeBuilder(name: String?): DoubleGaugeBuilder? {
+        TODO("Not yet implemented")
+    }
+}
+
+internal fun TestMeter.getRecordsByCounterName(name: String): List<MetricRecord<Long>> {
+    return this.counterValues.filter { it.metric.name == name }
+}
+
+internal fun TestMeter.getRecordsByHistogramName(name: String): List<MetricRecord<Double>> {
+    return this.histogramValues.filter { it.metric.name == name }
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/mock/MockSpanExporter.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/mock/MockSpanExporter.kt
@@ -1,6 +1,6 @@
 package ai.koog.agents.features.opentelemetry.mock
 
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
+import ai.koog.agents.features.opentelemetry.attribute.GenAIAttributes
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.sdk.common.CompletableResultCode
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -19,7 +19,7 @@ internal class MockSpanExporter : SpanExporter {
 
     companion object {
         private val createAgentSpanOperationAttribute =
-            SpanAttributes.Operation.Name(SpanAttributes.Operation.OperationNameType.CREATE_AGENT)
+            GenAIAttributes.Operation.Name(GenAIAttributes.Operation.OperationNameType.CREATE_AGENT)
     }
 
     private val _collectedSpans = mutableListOf<SpanData>()

--- a/docs/docs/opentelemetry-support.md
+++ b/docs/docs/opentelemetry-support.md
@@ -1,12 +1,13 @@
 # OpenTelemetry support
 
-This page provides details about the support for OpenTelemetry with the Koog agentic framework for tracing and 
+This page provides details about the support for OpenTelemetry with the Koog agentic framework for tracing and
 monitoring your AI agents.
 
 ## Overview
 
 OpenTelemetry is an observability framework that provides tools for generating, collecting, and exporting telemetry data
-(traces) from your applications. The Koog OpenTelemetry feature allows you to instrument your AI agents to collect 
+(traces and metrics) from your applications. The Koog OpenTelemetry feature allows you to instrument your AI agents to
+collect
 telemetry data, which can help you:
 
 - Monitor agent performance and behavior
@@ -17,21 +18,24 @@ telemetry data, which can help you:
 
 ## Key OpenTelemetry concepts
 
-- **Spans**: spans represent individual units of work or operations within a distributed trace. They indicate the 
-beginning and end of a specific activity in an application, such as an agent execution, a function call, an LLM call, 
-or a tool call.
-- **Attributes**: attributes provide metadata about a telemetry-related item such as a span. Attributes are represented 
-as key-value pairs.
-- **Events**: events are specific points in time during the lifetime of a span (span-related events) that represent 
-something potentially noteworthy that happened.
-- **Exporters**: exporters are components responsible for sending the collected telemetry data to various backends or 
-destinations.
-- **Collectors**: collectors receive, process, and export telemetry data. They act as intermediaries between your 
-applications and your observability backend.
-- **Samplers**: samplers determine whether a trace should be recorded based on the sampling strategy. They are used to 
-manage the volume of telemetry data.
-- **Resources**: resources represent entities that produce telemetry data. They are identified by resource attributes, 
-which are key-value pairs that provide information about the resource.
+- **Spans**: spans represent individual units of work or operations within a distributed trace. They indicate the
+  beginning and end of a specific activity in an application, such as an agent execution, a function call, an LLM call,
+  or a tool call.
+- **Attributes**: attributes provide metadata about a telemetry-related item such as a span. Attributes are represented
+  as key-value pairs.
+- **Events**: events are specific points in time during the lifetime of a span (span-related events) that represent
+  something potentially noteworthy that happened.
+- **Metrics**: metrics are numerical measurements that represent the system's performance or state over time, such as
+  token usage.
+  They include a name, a value, and attributes for the context.
+- **Exporters**: exporters are components responsible for sending the collected telemetry data to various backends or
+  destinations.
+- **Collectors**: collectors receive, process, and export telemetry data. They act as intermediaries between your
+  applications and your observability backend.
+- **Samplers**: samplers determine whether a trace should be recorded based on the sampling strategy. They are used to
+  manage the volume of telemetry data.
+- **Resources**: resources represent entities that produce telemetry data. They are identified by resource attributes,
+  which are key-value pairs that provide information about the resource.
 
 The OpenTelemetry feature in Koog automatically creates spans for various agent events, including:
 
@@ -39,6 +43,9 @@ The OpenTelemetry feature in Koog automatically creates spans for various agent 
 - Node execution
 - LLM calls
 - Tool calls
+
+Additionally, OpenTelemetry feature sends metrics including token usage consumption,
+operation duration, and number of tool calls
 
 ## Installation
 
@@ -79,9 +86,10 @@ Here is the full list of available properties that you set when configuring the 
 | `isVerbose`      | `Boolean`          | `false`                      | Whether to enable verbose logging for debugging OpenTelemetry configuration. |
 | `sdk`            | `OpenTelemetrySdk` |                              | The OpenTelemetry SDK instance to use for telemetry collection.              |
 | `tracer`         | `Tracer`           |                              | The OpenTelemetry tracer instance used for creating spans.                   |
+| `meter`          | `Meter`            |                              | The OpenTelemetry meter instance used for creating metrics.                  |
 
 !!! note
-    The `sdk` and `tracer` properties are public properties that you can access, but you can only set them using the
+    The `sdk` and `tracer`, and `meter` properties are public properties that you can access, but you can only set them using the
     public methods listed below.
 
 The `OpenTelemetryConfig` class also includes methods that represent actions related to different configuration
@@ -92,6 +100,7 @@ import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+import io.opentelemetry.exporter.logging.LoggingMetricExporter
 import io.opentelemetry.exporter.logging.LoggingSpanExporter
 
 const val apiKey = ""
@@ -109,9 +118,12 @@ val agent = AIAgent(
 install(OpenTelemetry) {
     // Set your service configuration
     setServiceInfo("my-agent-service", "1.0.0")
-    
+
     // Add the Logging exporter
     addSpanExporter(LoggingSpanExporter.create())
+
+    // Add the Metric exporter
+    addMetricExporter(LoggingMetricExporter.create())
 }
 ```
 <!--- KNIT example-opentelemetry-support-02.kt -->
@@ -122,10 +134,10 @@ For a reference of available methods, see the sections below.
 
 Sets the service information including name and version. Takes the following arguments:
 
-| Name               | Data type | Required | Default value | Description                                                 |
-|--------------------|-----------|----------|---------------|-------------------------------------------------------------|
-| `serviceName`      | String    | Yes      |               | The name of the service being instrumented.                 |
-| `serviceVersion`   | String    | Yes      |               | The version of the service being instrumented.              |
+| Name             | Data type | Required | Default value | Description                                    |
+|------------------|-----------|----------|---------------|------------------------------------------------|
+| `serviceName`    | String    | Yes      |               | The name of the service being instrumented.    |
+| `serviceVersion` | String    | Yes      |               | The version of the service being instrumented. |
 
 #### addSpanExporter
 
@@ -135,13 +147,43 @@ Adds a span exporter to send telemetry data to external systems. Takes the follo
 |------------|----------------|----------|---------------|-------------------------------------------------------------------------------|
 | `exporter` | `SpanExporter` | Yes      |               | The `SpanExporter` instance to be added to the list of custom span exporters. |
 
+#### addMetricExporter
+
+Adds a metric exporter to send runtime metrics to external systems. Takes the following arguments:
+
+| Name            | Data type        | Required | Default value           | Description                                                                       |
+|-----------------|------------------|----------|-------------------------|-----------------------------------------------------------------------------------|
+| `exporter`      | `MetricExporter` | Yes      |                         | The `MetricExporter` instance to be added to the list of custom metric exporters. |
+| `meterInterval` | `Duration`       | No       | `Duration.ofSeconds(1)` | The interval for processing metrics.                                              |
+
+#### addMetricFilter
+
+Adds a metric filter to the OpenTelemetry configuration. This filter is used to specify which attribute keys should be
+retained for a specific metric during telemetry data processing. Takes the following arguments:
+
+| Name           | Data type     | Required | Default value | Description                                                               |
+|----------------|---------------|----------|---------------|---------------------------------------------------------------------------|
+| `metricName`   | `String`      | Yes      |               | The name of the metric to which the filter will be applied.               |
+| `keysToRetain` | `Set<String>` | Yes      |               | A set of attribute keys that should be retained for the specified metric. |
+
+#### restrictToolNameCardinality
+
+Adds a configuration that maps tool names to the `gen_ai.tool.name` attribute value.
+Tool names in the allowlist are used as-is. All other tool names are replaced with a single fallback value.
+This reduces attribute cardinality and helps control overall metric cardinality.
+
+| Name                | Data type     | Required | Default value | Description                                                   |
+|---------------------|---------------|----------|---------------|---------------------------------------------------------------|
+| `allowedToolNames`  | `Set<String>` | Yes      |               | A set of allowed tool names.                                  |
+| `fallbackToolName`  | `String`      | No       | `filtered`    | The fallback value if the tool name is not in the allow list. |
+
 #### addSpanProcessor
 
 Adds a span processor factory to process spans before they are exported. Takes the following argument:
 
-| Name        | Data type                         | Required | Default value | Description                                                                                                  |
-|-------------|-----------------------------------|----------|---------------|--------------------------------------------------------------------------------------------------------------|
-| `processor` | `(SpanExporter) -> SpanProcessor` | Yes      |               | A function that creates a span processor for a given exporter. Lets you customize processing per exporter.   |
+| Name        | Data type                         | Required | Default value | Description                                                                                                |
+|-------------|-----------------------------------|----------|---------------|------------------------------------------------------------------------------------------------------------|
+| `processor` | `(SpanExporter) -> SpanProcessor` | Yes      |               | A function that creates a span processor for a given exporter. Lets you customize processing per exporter. |
 
 #### addResourceAttributes
 
@@ -175,7 +217,8 @@ Enables or disables verbose logging. Takes the following argument:
 
 Injects a pre-configured OpenTelemetrySdk instance.
 
-- When you call setSdk(sdk), the provided SDK is used as-is, and any custom configuration applied via addSpanExporter, addSpanProcessor, addResourceAttributes, or setSampler is ignored.
+- When you call setSdk(sdk), the provided SDK is used as-is, and any custom configuration applied via addSpanExporter,
+  addMeterExporter, addSpanProcessor, addResourceAttributes, or setSampler is ignored.
 - The tracer’s instrumentation scope name/version are aligned with your service info.
 
 | Name  | Data type          | Required | Description                           |
@@ -187,16 +230,20 @@ Injects a pre-configured OpenTelemetrySdk instance.
 For more advanced configuration, you can also customize the following configuration options:
 
 - Sampler: configure the sampling strategy to adjust the frequency and amount of collected data.
-- Resource attributes: add more information about the process that is producing telemetry data. 
+- Resource attributes: add more information about the process that is producing telemetry data.
 
 <!--- INCLUDE
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
+import ai.koog.agents.features.opentelemetry.metric.adapter.restrictToolNameCardinality
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
 import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.exporter.logging.LoggingMetricExporter
 import io.opentelemetry.exporter.logging.LoggingSpanExporter
 import io.opentelemetry.sdk.trace.samplers.Sampler
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 const val apiKey = ""
 
@@ -213,12 +260,30 @@ val agent = AIAgent(
 install(OpenTelemetry) {
     // Set your service configuration
     setServiceInfo("my-agent-service", "1.0.0")
-    
+
     // Add the Logging exporter
     addSpanExporter(LoggingSpanExporter.create())
-    
+
+    // Add the Metric exporter
+    addMetricExporter(
+        exporter = LoggingMetricExporter.create(),
+        meterInterval = 30.seconds
+    )
+
+    // Add metric filter
+    addMetricFilter(
+        metricName = "gen_ai.client.token.usage",
+        keysToRetain = setOf("gen_ai.operation.name", "gen_ai.token.type")
+    )
+
+    // Add tool names restriction
+    restrictToolNameCardinality(
+        allowedToolNames = setOf("calculator", "weather_api"),
+        fallbackToolName = "hidden_tool"
+    )
+
     // Set the sampler 
-    setSampler(Sampler.traceIdRatioBased(0.5)) 
+    setSampler(Sampler.traceIdRatioBased(0.5))
 
     // Add resource attributes
     addResourceAttributes(mapOf(
@@ -230,8 +295,8 @@ install(OpenTelemetry) {
 
 #### Sampler
 
-To define a sampler, use a corresponding method of the `Sampler` class (`io.opentelemetry.sdk.trace.samplers.Sampler`) 
-from the `opentelemetry-java` SDK that represents the sampling strategy you want to use. 
+To define a sampler, use a corresponding method of the `Sampler` class (`io.opentelemetry.sdk.trace.samplers.Sampler`)
+from the `opentelemetry-java` SDK that represents the sampling strategy you want to use.
 
 The default sampling strategy is as follows:
 
@@ -351,23 +416,95 @@ The following event types are supported in line with OpenTelemetry's [Semantic c
 - **ModerationResponseEvent**: the model moderation result or signal.
 
 !!! note   
-    The `optentelemetry-java` SDK does not support the event body fields parameter when adding an event. Therefore, in 
-    the OpenTelemetry support in Koog, event body fields are a separate attribute whose key is `body` and value type is 
-    string. The string includes the content or payload for the event body field, which is usually a JSON-like object. For 
-    examples of event body fields, see the [OpenTelemetry documentation](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/#examples). For the state of support for event body 
-    fields in `opentelemetry-java`, see the related [GitHub issue](https://github.com/open-telemetry/semantic-conventions/issues/1870).
+    The `optentelemetry-java` SDK does not support the event body fields parameter when adding an event. Therefore, in
+    the OpenTelemetry support in Koog, event body fields are a separate attribute whose key is `body` and value type is
+    string. The string includes the content or payload for the event body field, which is usually a JSON-like object. For
+    examples of event body fields, see
+    the [OpenTelemetry documentation](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/#examples). For the
+    state of support for event body
+    fields in `opentelemetry-java`, see the
+    related [GitHub issue](https://github.com/open-telemetry/semantic-conventions/issues/1870).
+
+## Metrics
+
+Koog also emits runtime metrics alongside traces to help you monitor agent behavior in real time.
+
+### Available metrics
+
+- gen_ai.client.token.usage
+    - Instrument: Counter (LongCounter)
+    - Unit: `token`
+    - Description: Total token count per operation and token type
+    - When emitted: after an LLM call finishes; recorded separately for input and output tokens
+    - Key attributes:
+        - `gen_ai.operation.name` (required) - `TEXT_COMPLETION`
+        - `gen_ai.provider.name` (required)
+        - `gen_ai.response.model` (recommended)
+        - `gen_ai.token.type` (recommended) — `INPUT` or `OUTPUT`
+    - Spec: see OpenTelemetry semantic
+      conventions, [gen_ai.client.token.usage](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiclienttokenusage)
+
+- gen_ai.client.operation.duration
+    - Instrument: Histogram (DoubleHistogram)
+    - Unit: seconds (`s`)
+    - Description: Operation duration distribution; in Koog it is recorded for tool calls
+    - Recommended explicit bucket boundaries (seconds): 0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12,
+      10.24, 20.48, 40.96, 81.92
+    - Key attributes:
+        - `gen_ai.operation.name` (required) - `TEXT_COMPLETION` or `EXECUTE_TOOL`
+        - `gen_ai.tool.name` (recommended, if `gen_ai.operation.name` is `EXECUTE_TOOL`)
+        - `gen_ai.tool.call.status` (custom, if `gen_ai.operation.name` is `EXECUTE_TOOL`) — `SUCCESS`, `ERROR`, or
+          `VALIDATION_FAILED`
+        - `gen_ai.provider.name` (recommended, if `gen_ai.operation.name` is `TEXT_COMPLETION`)
+        - `gen_ai.response.model` (recommended, if `gen_ai.operation.name` is `TEXT_COMPLETION`)
+        - `gen_ai.token.type` (recommended, if `gen_ai.operation.name` is `TEXT_COMPLETION`)
+    - Spec: see OpenTelemetry semantic
+      conventions, [gen_ai.client.operation.duration](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiclientoperationduration)
+
+- gen_ai.client.tool.count
+    - Instrument: Counter (LongCounter)
+    - Unit: `tool call`
+    - Description: Custom metric that counts tool calls and their statuses
+    - When emitted: on tool completion, failure, or validation failure
+    - Key attributes:
+        - `gen_ai.operation.name` (required) — `EXECUTE_TOOL`
+        - `gen_ai.tool.name` (recommended)
+        - `gen_ai.tool.call.status` (custom) — `SUCCESS`, `ERROR`, or `VALIDATION_FAILED`
+
+!!! note
+
+    `gen_ai.tool.name` is a dynamic attribute. A high number of unique tool names can increase metric cardinality and impact performance. You can use the `restrictToolNameCardinality` method to control this metric by limiting the allowed tool names and mapping others to a fallback value.
+
+!!! note
+Metrics are reported via the OpenTelemetry `Meter` created for your service. If no metric exporters are configured,
+Koog uses a console `LoggingMetricExporter` by default (with a 1-second `PeriodicMetricReader` interval).
+You can customize the metric reading interval when adding a custom exporter using the `meterInterval` parameter.
 
 ## Exporters
 
-Exporters send collected telemetry data to an OpenTelemetry Collector or other types of destinations or backend 
-implementations. To add an exporter, use the `addSpanExporter()` method when installing the OpenTelemetry feature. The 
-method takes the following argument:
+Exporters send collected telemetry data to an OpenTelemetry Collector or other types of destinations or backend
+implementations.
+
+### Span exporters
+
+To export traces, use the `addSpanExporter()` method when installing the OpenTelemetry feature. The method takes the
+following argument:
 
 | Name       | Data type    | Required | Default | Description                                                                 |
 |------------|--------------|----------|---------|-----------------------------------------------------------------------------|
 | `exporter` | SpanExporter | Yes      |         | The SpanExporter instance to be added to the list of custom span exporters. |
 
-The sections below provide information about some of the most commonly used exporters from the `opentelemetry-java` SDK.
+### Metric exporters
+
+To export metrics, use the `addMetricExporter()` method when installing the OpenTelemetry feature. The method takes the
+following argument:
+
+| Name       | Data type        | Required | Default | Description                                                                     |
+|------------|------------------|----------|---------|---------------------------------------------------------------------------------|
+| `exporter` | `MetricExporter` | Yes      |         | The MetricExporter instance to be added to the list of custom metric exporters. |
+
+The sections below provide information about some of the most commonly used span exporters from the `opentelemetry-java`
+SDK.
 
 !!! note
     If you do not configure any custom exporters, Koog will use a console LoggingSpanExporter by default. This helps during local development and debugging.
@@ -417,6 +554,7 @@ import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
+import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter
 import java.util.concurrent.TimeUnit
 
 const val apiKey = ""
@@ -434,17 +572,27 @@ val agent = AIAgent(
 -->
 ```kotlin
 install(OpenTelemetry) {
-   // Add OpenTelemetry HTTP exporter 
-   addSpanExporter(
-      OtlpHttpSpanExporter.builder()
-         // Set the maximum time to wait for the collector to process an exported batch of spans 
-         .setTimeout(30, TimeUnit.SECONDS)
-         // Set the OpenTelemetry endpoint to connect to
-         .setEndpoint("http://localhost:3000/api/public/otel/v1/traces")
-         // Add the authorization header
-         .addHeader("Authorization", "Basic $AUTH_STRING")
-         .build()
-   )
+    // Add OpenTelemetry HTTP Span exporter
+    addSpanExporter(
+        OtlpHttpSpanExporter.builder()
+            // Set the maximum time to wait for the collector to process an exported batch of spans 
+            .setTimeout(30, TimeUnit.SECONDS)
+            // Set the OpenTelemetry endpoint to connect to
+            .setEndpoint("http://localhost:3000/api/public/otel/v1/traces")
+            // Add the authorization header
+            .addHeader("Authorization", "Basic $AUTH_STRING")
+            .build()
+    )
+    addMetricExporter(
+        OtlpHttpMetricExporter.builder()
+            // Set the maximum time to wait for the collector to process an exported batch of metrics 
+            .setTimeout(30, TimeUnit.SECONDS)
+            // Set the OpenTelemetry endpoint to connect to
+            .setEndpoint("http://localhost:17011")
+            // Add the authorization header
+            .addHeader("Authorization", "Basic $AUTH_STRING")
+            .build()
+    )
 }
 ```
 <!--- KNIT example-opentelemetry-support-06.kt -->
@@ -462,6 +610,7 @@ import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter
+import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter
 
 const val apiKey = ""
 
@@ -476,13 +625,20 @@ val agent = AIAgent(
 -->
 ```kotlin
 install(OpenTelemetry) {
-   // Add OpenTelemetry gRPC exporter 
-   addSpanExporter(
-      OtlpGrpcSpanExporter.builder()
-          // Set the host and the port
-         .setEndpoint("http://localhost:4317")
-         .build()
-   )
+    addSpanExporter(
+        // Add OpenTelemetry gRPC exporter
+        OtlpGrpcSpanExporter.builder()
+            // Set the host and the port
+            .setEndpoint("http://localhost:4317")
+            .build()
+    )
+    addMetricExporter(
+        // Add OpenTelemetry gRPC exporter
+        OtlpGrpcMetricExporter.builder()
+            // Set the host and the port
+            .setEndpoint("http://localhost:4317")
+            .build()
+    )
 }
 ```
 <!--- KNIT example-opentelemetry-support-07.kt -->
@@ -607,11 +763,13 @@ import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
 import io.opentelemetry.exporter.logging.LoggingSpanExporter
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter
+import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter
 import kotlinx.coroutines.runBlocking
 
 const val openAIApiKey = "open-ai-api-key"
 
 -->
+
 ```kotlin
 fun main() {
     runBlocking {
@@ -627,6 +785,14 @@ fun main() {
                 // Send traces to OpenTelemetry collector
                 addSpanExporter(
                     OtlpGrpcSpanExporter.builder()
+                        .setEndpoint("http://localhost:4317")
+                        .build()
+                )
+
+                // Send metrics to OpenTelemetry collector
+                addMetricExporter(
+                    OtlpGrpcMetricExporter.builder()
+                        // Set the host and the port
                         .setEndpoint("http://localhost:4317")
                         .build()
                 )

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/calculator/Calculator.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/calculator/Calculator.kt
@@ -3,14 +3,20 @@ package ai.koog.agents.example.calculator
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.tools.ToolRegistry
-import ai.koog.agents.core.tools.reflect.asTools
 import ai.koog.agents.example.ApiKeyService
 import ai.koog.agents.ext.tool.AskUser
 import ai.koog.agents.ext.tool.SayToUser
 import ai.koog.agents.features.eventHandler.feature.handleEvents
+import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
+import ai.koog.agents.features.opentelemetry.metric.adapter.restrictToolNameCardinality
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
 
 suspend fun main() {
     // Create a tool registry with calculator tools
@@ -53,9 +59,37 @@ suspend fun main() {
                     println("Result: ${eventContext.result}")
                 }
             }
+
+            install(OpenTelemetry) {
+                setServiceInfo(
+                    "calculator",
+                    "0.0.1"
+                )
+                addResourceAttributes(
+                    mapOf(AttributeKey.stringKey("service.instance.id") to "run-1")
+                )
+                addMetricExporter(
+                    OtlpGrpcMetricExporter.builder()
+                        .setEndpoint("http://localhost:17011")
+                        .setTimeout(2, TimeUnit.SECONDS)
+                        .build(),
+                    1.seconds
+                )
+                restrictToolNameCardinality(
+                    setOf("plus", "minus", "multiply", "divide"),
+                    "unknown"
+                )
+                addSpanExporter(
+                    OtlpGrpcSpanExporter.builder()
+                        .setEndpoint("http://localhost:17011")
+                        .setTimeout(2, TimeUnit.SECONDS)
+                        .build()
+                )
+            }
         }
 
-        val result = agent.run("(10 + 20) * (5 + 5) / (2 - 11)")
+        val expression = "(10 + 20) * (5 + 5) / (2 - 11) * 445 / 23 + 2334 / 23 + 3"
+        val result = agent.run(expression)
         println("Agent result: $result")
     }
 }


### PR DESCRIPTION
<!--
Thank you for opening a pull request!

Please add a brief description of the proposed change here.
Also, please tick the appropriate points in the checklist below.
-->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
PR introduces metrics support based on OpenTelemetry specification. Such metrics allow their listeners observe the behaviour of agent in run-time. All changes are done within OpenTelemetry feature

[Link to issue](https://youtrack.jetbrains.com/issue/KG-136/Add-Open-Telemetry-metrics-support-in-Koog)

Added configuration:
- `addMeterExporter(MetricExporter)` -- function within OpenTelemetry feature that accept MetricExporter and sent library metrics via such exporter

Example of OpenTelemetry feature configuration:
```
install(OpenTelemetry) {
    setServiceInfo(
        "calculator",
        "0.0.1"
    )
    addResourceAttributes(
        mapOf(AttributeKey.stringKey("service.instance.id") to "run-1")
    )
    addMeterExporter(
        OtlpGrpcMetricExporter.builder()
            .setEndpoint("http://localhost:17011")
            .setTimeout(1, TimeUnit.SECONDS)
            .build()
        )
    }
```

Added metrics:
- gen_ai.client.token.usage -- see [here](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiclienttokenusage)
- gen_ai.client.operation.duration -- see [here](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiclientoperationduration)
- gen_ai.client.tool.count -- custom metric allows observe tool calls and their statuses 

Visualisation (via OpenTelemetry plugin):
![telegram-cloud-photo-size-2-5438313832905380635-y](https://github.com/user-attachments/assets/89188d68-b6ec-45a5-90dd-bc508f77d9de)
<img width="1101" height="384" alt="image" src="https://github.com/user-attachments/assets/b6160aaf-445e-4e48-9a2c-836e5e3e49d8" />


## Breaking Changes
<!-- Will users need to update their code or configurations? -->

---

#### Type of the changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tests improvement
- [ ] Refactoring
- [ ] CI/CD changes
- [ ] Dependencies update

#### Checklist
- [x] The pull request has a description of the proposed change
- [x] I read the [Contributing Guidelines](https://github.com/JetBrains/koog/blob/main/CONTRIBUTING.md) before opening the pull request
- [x] The pull request uses **`develop`** as the base branch
- [x] Tests for the changes have been added
- [x] All new and existing tests passed

##### Additional steps for pull requests adding a new feature
- [x] An issue describing the proposed change exists
- [x] The pull request includes a link to the issue
- [x] The change was discussed and approved in the issue
- [x] Docs have been added / updated
