### PR TITLE
fix(prompt): Add missing fields to OpenRouter streaming response

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/models/OpenRouterChatCompletion.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/models/OpenRouterChatCompletion.kt
@@ -127,12 +127,17 @@ public class OpenRouterStreamChoice(
  * @property content The contents of the chunk message.
  * @property role The role of the author of this message.
  * @property toolCalls The tool calls requested by the model.
+ * @property reasoning The reasoning content for models that support it.
+ * @property reasoningDetails Additional reasoning details in structured format.
  */
 @Serializable
 public class OpenRouterStreamDelta(
     public val content: String? = null,
     public val role: String? = null,
-    public val toolCalls: List<OpenAIToolCall>? = null
+    public val toolCalls: List<OpenAIToolCall>? = null,
+    public val reasoning: String? = null,
+    @SerialName("reasoning_details")
+    public val reasoningDetails: List<JsonElement>? = null
 )
 
 /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openrouter/models/OpenRouterSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openrouter/models/OpenRouterSerializationTest.kt
@@ -739,4 +739,51 @@ class OpenRouterSerializationTest {
         req.provider?.sort shouldBe "price"
         req.provider?.maxPrice shouldBe mapOf("prompt" to "0.002", "completion" to "0.006")
     }
+
+    @Test
+    fun `test OpenRouter streaming response with reasoning fields deserialization`() {
+        val jsonString =
+            // language=json
+            """
+            {
+                "id": "gen-1758662697-qjFTfAqlZh2Qa1vAfoff",
+                "provider": "AtlasCloud",
+                "model": "alibaba/tongyi-deepresearch-30b-a3b",
+                "object": "chat.completion.chunk",
+                "created": 1758662697,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant",
+                            "content": "",
+                            "reasoning": null,
+                            "reasoning_details": []
+                        },
+                        "finish_reason": null,
+                        "native_finish_reason": null,
+                        "logprobs": null
+                    }
+                ]
+            }
+            """.trimIndent()
+
+        val response = json.decodeFromString(OpenRouterChatCompletionStreamResponse.serializer(), jsonString)
+
+        response.id shouldBe "gen-1758662697-qjFTfAqlZh2Qa1vAfoff"
+        response.model shouldBe "alibaba/tongyi-deepresearch-30b-a3b"
+        response.objectType shouldBe "chat.completion.chunk"
+        response.created shouldBe 1758662697L
+        response.choices.size shouldBe 1
+
+        val choice = response.choices.first()
+        choice.finishReason shouldBe null
+        choice.nativeFinishReason shouldBe null
+
+        choice.delta.role shouldBe "assistant"
+        choice.delta.content shouldBe ""
+        choice.delta.reasoning shouldBe null
+        choice.delta.reasoningDetails shouldNotBe null
+        choice.delta.reasoningDetails?.size shouldBe 0
+    }
 }


### PR DESCRIPTION
This PR adds `reasoning` and `reasoningDetails` fields to `OpenRouterStreamDelta` to fix a parsing exception during deserialization

closes #854
