### PR TITLE
fix(agents): moved agents-ext from commonMain api to jvmTest implementation in agents-test

### DIFF
--- a/agents/agents-test/build.gradle.kts
+++ b/agents/agents-test/build.gradle.kts
@@ -13,7 +13,6 @@ kotlin {
         commonMain {
             dependencies {
                 api(project(":agents:agents-core"))
-                api(project(":agents:agents-ext"))
                 api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client"))
                 api(project(":prompt:prompt-executor:prompt-executor-llms-all"))
                 api(project(":prompt:prompt-tokenizer"))
@@ -38,6 +37,7 @@ kotlin {
             dependencies {
                 implementation(project(":agents:agents-features:agents-features-event-handler"))
                 implementation(libs.ktor.client.cio)
+                implementation(project(":agents:agents-ext"))
             }
         }
     }


### PR DESCRIPTION
The `agents-ext` module was declared as an `api` dependency in `agents-test`'s `commonMain`, causing it to leak as a transitive compile-time dependency for all consumers of `agents-test` on all platforms.
Moved it to `implementation` in `jvmTest` where it is only used.