### PR TITLE
fix(examples): disabling step 5 for 'examples/code-agents'

### DIFF
--- a/.github/workflows/code-agent-examples.yml
+++ b/.github/workflows/code-agent-examples.yml
@@ -52,7 +52,9 @@ jobs:
           - step-02-add-execution-tool
           - step-03-add-observability
           - step-04-add-subagent
-          - step-05-history
+          # TODO: KG-697 Re-enable history step in code-agents examples workflow
+          #       This step should be included along with release for 0.7.0
+          # - step-05-history
 
     steps:
       - name: Configure Git


### PR DESCRIPTION
`step-05-history` depends on `singleRunStrategyWithHistoryCompression` which doesn't exist in `release/0.6.3` — backporting it would mean partially pulling in the Java API work (#1185) which is intentionally held back for `0.7.0.` For now, we should remove `step-05-history` from the CI matrix in `code-agent-examples.yml` on `release/0.6.3`. Once `0.7.0` ships with #1185, we should add it back