### PR TITLE
test(a2a): pin a2a-tck test suite to A2A protocol version 0.3.x

### DIFF
--- a/a2a/test-tck/README.md
+++ b/a2a/test-tck/README.md
@@ -25,7 +25,7 @@ official [A2A protocol specification](https://a2a-protocol.org/latest/specificat
 
 3. **In another terminal, run the TCK tests:**
    ```bash
-    ./run_tck.sh --sut-url http://localhost:9999/a2a --category all --report   
+    ./run_tck.sh --sut-url http://localhost:9999/a2a --category all --report
     ```
 
 ## More information

--- a/a2a/test-tck/setup_tck.sh
+++ b/a2a/test-tck/setup_tck.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="${SCRIPT_DIR}/a2a-tck"
 REPO_URL="https://github.com/a2aproject/a2a-tck.git"
+COMMIT_HASH="b03fefcae9767dad0e978e11573192f74252dfe3" # A2A version 0.3.x
 
 # 1) Check if a2a-tck already exists
 if [ -d "${REPO_DIR}" ]; then
@@ -13,8 +14,13 @@ if [ -d "${REPO_DIR}" ]; then
   echo "[setup_tck] Will skip cloning but still run 'uv sync'."
 else
   echo "[setup_tck] 'a2a-tck' directory not found in ${SCRIPT_DIR}."
-  echo "[setup_tck] Cloning repository into: ${REPO_DIR}"
+  echo "[setup_tck] Cloning repository into ${REPO_DIR} at commit ${COMMIT_HASH}"
+
   git clone "${REPO_URL}" "${REPO_DIR}" --depth=1
+  cd "${REPO_DIR}"
+  git config advice.detachedHead false
+  git fetch --depth=1 origin "${COMMIT_HASH}"
+  git checkout FETCH_HEAD
 fi
 
 # 2) Always run uv sync in the repo directory


### PR DESCRIPTION
There's a new 1.0 specification which introduces breaking changes to the protocol.
We don't support 1.0 yet.
