### PR TITLE
refactor(agents)!: JBAI-18822. Refactor `ai.koog:agents-ext` extract files-related abstractions from agents

### DIFF
--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/ListDirectoryTool.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/ListDirectoryTool.kt
@@ -5,12 +5,12 @@ import ai.koog.agents.core.tools.ToolException
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.core.tools.validate
 import ai.koog.agents.core.tools.validateNotNull
-import ai.koog.agents.ext.tool.file.filter.GlobPattern
-import ai.koog.agents.ext.tool.file.model.FileSystemEntry
 import ai.koog.agents.ext.tool.file.render.folder
 import ai.koog.prompt.text.text
 import ai.koog.rag.base.files.FileMetadata
 import ai.koog.rag.base.files.FileSystemProvider
+import ai.koog.rag.base.files.filter.GlobPattern
+import ai.koog.rag.base.files.model.FileSystemEntry
 import kotlinx.serialization.Serializable
 
 /**

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/ListDirectoryUtil.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/ListDirectoryUtil.kt
@@ -1,12 +1,12 @@
 package ai.koog.agents.ext.tool.file
 
-import ai.koog.agents.ext.tool.file.filter.GlobPattern
-import ai.koog.agents.ext.tool.file.model.FileSystemEntry
-import ai.koog.agents.ext.tool.file.model.buildFileEntry
-import ai.koog.agents.ext.tool.file.model.buildFolderEntry
 import ai.koog.agents.ext.tool.file.render.norm
 import ai.koog.rag.base.files.FileMetadata
 import ai.koog.rag.base.files.FileSystemProvider
+import ai.koog.rag.base.files.filter.GlobPattern
+import ai.koog.rag.base.files.model.FileSystemEntry
+import ai.koog.rag.base.files.model.buildFileEntry
+import ai.koog.rag.base.files.model.buildFolderEntry
 import kotlin.collections.plusAssign
 
 /**

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/ReadFileTool.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/ReadFileTool.kt
@@ -5,11 +5,11 @@ import ai.koog.agents.core.tools.ToolException
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.core.tools.validate
 import ai.koog.agents.core.tools.validateNotNull
-import ai.koog.agents.ext.tool.file.model.FileSystemEntry
 import ai.koog.agents.ext.tool.file.render.file
 import ai.koog.prompt.text.text
 import ai.koog.rag.base.files.FileMetadata
 import ai.koog.rag.base.files.FileSystemProvider
+import ai.koog.rag.base.files.model.FileSystemEntry
 import kotlinx.serialization.Serializable
 
 /**

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/ReadFileUtil.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/ReadFileUtil.kt
@@ -1,11 +1,10 @@
 package ai.koog.agents.ext.tool.file
 
-import ai.koog.agents.ext.tool.file.model.FileSystemEntry.File
-import ai.koog.agents.ext.tool.file.model.FileSystemEntry.File.Content
-import ai.koog.agents.ext.tool.file.model.buildFileSize
 import ai.koog.rag.base.files.DocumentProvider
 import ai.koog.rag.base.files.FileMetadata
 import ai.koog.rag.base.files.FileSystemProvider
+import ai.koog.rag.base.files.model.FileSystemEntry
+import ai.koog.rag.base.files.model.buildFileSize
 import ai.koog.rag.base.files.readText
 
 /**
@@ -35,8 +34,8 @@ internal suspend fun <Path> buildTextFileEntry(
     startLine: Int,
     endLine: Int,
     onEndLineExceedsFileLength: ((endLine: Int, fileLineCount: Int) -> Unit)? = null
-): File {
-    return File(
+): FileSystemEntry.File {
+    return FileSystemEntry.File(
         name = fs.name(path),
         extension = fs.extension(path),
         path = fs.toAbsolutePathString(path),
@@ -52,7 +51,7 @@ private fun buildContent(
     startLine: Int,
     endLine: Int,
     onEndLineExceedsFileLength: ((requestedEndLine: Int, fileLineCount: Int) -> Unit)?
-): Content {
+): FileSystemEntry.File.Content {
     val lineCount = content.lineSequence().count()
 
     require(startLine >= 0) { "startLine=$startLine must be >= 0" }
@@ -68,7 +67,7 @@ private fun buildContent(
     }
 
     if (startLine == 0 && clampedEndLine == lineCount) {
-        return Content.Text(content)
+        return FileSystemEntry.File.Content.Text(content)
     }
 
     val range = DocumentProvider.DocumentRange(
@@ -76,9 +75,9 @@ private fun buildContent(
         DocumentProvider.Position(clampedEndLine, 0)
     )
 
-    return Content.Excerpt(
+    return FileSystemEntry.File.Content.Excerpt(
         listOf(
-            Content.Excerpt.Snippet(
+            FileSystemEntry.File.Content.Excerpt.Snippet(
                 text = range.substring(content),
                 range = range,
             )

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/WriteFileTool.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/WriteFileTool.kt
@@ -5,12 +5,12 @@ import ai.koog.agents.core.tools.ToolException
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.core.tools.validate
 import ai.koog.agents.core.tools.validateNotNull
-import ai.koog.agents.ext.tool.file.model.FileSystemEntry
-import ai.koog.agents.ext.tool.file.model.buildFileSystemEntry
 import ai.koog.agents.ext.tool.file.render.entry
 import ai.koog.prompt.text.text
 import ai.koog.rag.base.files.FileMetadata
 import ai.koog.rag.base.files.FileSystemProvider
+import ai.koog.rag.base.files.model.FileSystemEntry
+import ai.koog.rag.base.files.model.buildFileSystemEntry
 import ai.koog.rag.base.files.writeText
 import kotlinx.serialization.Serializable
 

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/render/Text.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/render/Text.kt
@@ -1,8 +1,8 @@
 package ai.koog.agents.ext.tool.file.render
 
-import ai.koog.agents.ext.tool.file.model.FileSystemEntry
 import ai.koog.prompt.text.TextContentBuilder
 import ai.koog.rag.base.files.FileMetadata
+import ai.koog.rag.base.files.model.FileSystemEntry
 
 private const val FOLDER_INDENTATION = "  "
 

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/search/RegexSearchTool.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/search/RegexSearchTool.kt
@@ -2,13 +2,13 @@ package ai.koog.agents.ext.tool.search
 
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.annotations.LLMDescription
-import ai.koog.agents.ext.tool.file.model.FileSystemEntry
-import ai.koog.agents.ext.tool.file.model.buildFileSize
 import ai.koog.prompt.text.text
 import ai.koog.rag.base.files.DocumentProvider
 import ai.koog.rag.base.files.FileMetadata
 import ai.koog.rag.base.files.FileSystemProvider
 import ai.koog.rag.base.files.extendRangeByLines
+import ai.koog.rag.base.files.model.FileSystemEntry
+import ai.koog.rag.base.files.model.buildFileSize
 import ai.koog.rag.base.files.readText
 import ai.koog.rag.base.files.toPosition
 import kotlinx.coroutines.CancellationException

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/render/TextTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/file/render/TextTest.kt
@@ -1,10 +1,10 @@
 package ai.koog.agents.ext.tool.file.render
 
-import ai.koog.agents.ext.tool.file.model.FileSize
-import ai.koog.agents.ext.tool.file.model.FileSystemEntry
 import ai.koog.prompt.text.text
 import ai.koog.rag.base.files.DocumentProvider
 import ai.koog.rag.base.files.FileMetadata
+import ai.koog.rag.base.files.model.FileSize
+import ai.koog.rag.base.files.model.FileSystemEntry
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/ListDirectoryUtilJvmTest.kt
+++ b/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/ListDirectoryUtilJvmTest.kt
@@ -1,8 +1,8 @@
 package ai.koog.agents.ext.tool.file
 
-import ai.koog.agents.ext.tool.file.filter.GlobPattern
-import ai.koog.agents.ext.tool.file.model.FileSystemEntry
 import ai.koog.rag.base.files.JVMFileSystemProvider
+import ai.koog.rag.base.files.filter.GlobPattern
+import ai.koog.rag.base.files.model.FileSystemEntry
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
@@ -210,8 +210,8 @@ class ListDirectoryUtilJvmTest {
         assertEquals("root", entry.name)
         val singleChild = assertNotNull(entry.entries).single() as FileSystemEntry.Folder
         assertEquals("single", singleChild.name)
-        assertNotNull(singleChild.entries)
-        assertTrue(singleChild.entries.isEmpty())
+        val entries = assertNotNull(singleChild.entries)
+        assertTrue(entries.isEmpty())
     }
 
     @Test

--- a/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/ReadFileUtilJvmTest.kt
+++ b/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/ReadFileUtilJvmTest.kt
@@ -1,7 +1,7 @@
 package ai.koog.agents.ext.tool.file
 
-import ai.koog.agents.ext.tool.file.model.FileSystemEntry
 import ai.koog.rag.base.files.JVMFileSystemProvider
+import ai.koog.rag.base.files.model.FileSystemEntry
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
@@ -30,8 +30,9 @@ class ReadFileUtilJvmTest {
 
         val entry = buildTextFileEntry(fs, file, metadata, 0, -1)
 
-        assertIs<FileSystemEntry.File.Content.Text>(entry.content)
-        assertEquals("line1\nline2\nline3", entry.content.text)
+        val content = entry.content
+        assertIs<FileSystemEntry.File.Content.Text>(content)
+        assertEquals("line1\nline2\nline3", content.text)
     }
 
     @Test
@@ -41,8 +42,9 @@ class ReadFileUtilJvmTest {
 
         val entry = buildTextFileEntry(fs, file, metadata, 0, 3)
 
-        assertIs<FileSystemEntry.File.Content.Text>(entry.content)
-        assertEquals("line1\nline2\nline3", entry.content.text)
+        val content = entry.content
+        assertIs<FileSystemEntry.File.Content.Text>(content)
+        assertEquals("line1\nline2\nline3", content.text)
     }
 
     @Test
@@ -52,8 +54,9 @@ class ReadFileUtilJvmTest {
 
         val entry = buildTextFileEntry(fs, file, metadata, 1, 3)
 
-        assertIs<FileSystemEntry.File.Content.Excerpt>(entry.content)
-        val snippet = entry.content.snippets.single()
+        val content = entry.content
+        assertIs<FileSystemEntry.File.Content.Excerpt>(content)
+        val snippet = content.snippets.single()
         assertEquals("line1\nline2", snippet.text.trim())
         assertEquals(1, snippet.range.start.line)
         assertEquals(3, snippet.range.end.line)
@@ -66,8 +69,9 @@ class ReadFileUtilJvmTest {
 
         val entry = buildTextFileEntry(fs, file, metadata, 0, -1)
 
-        assertIs<FileSystemEntry.File.Content.Text>(entry.content)
-        assertEquals("single line", entry.content.text)
+        val content = entry.content
+        assertIs<FileSystemEntry.File.Content.Text>(content)
+        assertEquals("single line", content.text)
     }
 
     @Test
@@ -146,8 +150,9 @@ class ReadFileUtilJvmTest {
             invokedWithFileLineCount = fileLineCount
         }
 
-        assertIs<FileSystemEntry.File.Content.Text>(entry.content)
-        assertEquals("line1\nline2", entry.content.text)
+        val content = entry.content
+        assertIs<FileSystemEntry.File.Content.Text>(content)
+        assertEquals("line1\nline2", content.text)
         assertEquals(50, invokedWithRequestedEndLine)
         assertEquals(2, invokedWithFileLineCount)
     }

--- a/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/model/FileSystemEntryBuildersJvmTest.kt
+++ b/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/model/FileSystemEntryBuildersJvmTest.kt
@@ -2,6 +2,12 @@ package ai.koog.agents.ext.tool.file.model
 
 import ai.koog.rag.base.files.FileMetadata
 import ai.koog.rag.base.files.JVMFileSystemProvider
+import ai.koog.rag.base.files.model.FileSize
+import ai.koog.rag.base.files.model.FileSystemEntry
+import ai.koog.rag.base.files.model.buildFileEntry
+import ai.koog.rag.base.files.model.buildFileSize
+import ai.koog.rag.base.files.model.buildFileSystemEntry
+import ai.koog.rag.base.files.model.buildFolderEntry
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir

--- a/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/search/RegexSearchToolTest.kt
+++ b/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/search/RegexSearchToolTest.kt
@@ -1,8 +1,8 @@
 package ai.koog.agents.ext.tool.search
 
-import ai.koog.agents.ext.tool.file.model.FileSystemEntry
 import ai.koog.rag.base.files.FileSystemProvider
 import ai.koog.rag.base.files.JVMFileSystemProvider
+import ai.koog.rag.base.files.model.FileSystemEntry
 import kotlinx.coroutines.runBlocking
 import java.nio.file.Files
 import java.nio.file.Path

--- a/rag/rag-base/build.gradle.kts
+++ b/rag/rag-base/build.gradle.kts
@@ -18,6 +18,12 @@ kotlin {
             }
         }
 
+        commonTest {
+            dependencies {
+                implementation(project(":test-utils"))
+            }
+        }
+
         jvmTest {
             dependencies {
                 implementation(kotlin("test-junit5"))

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/filter/GlobPattern.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/filter/GlobPattern.kt
@@ -1,4 +1,4 @@
-package ai.koog.agents.ext.tool.file.filter
+package ai.koog.rag.base.files.filter
 
 /**
  * A pattern for matching file paths using glob syntax.

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/model/FileSize.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/model/FileSize.kt
@@ -1,4 +1,4 @@
-package ai.koog.agents.ext.tool.file.model
+package ai.koog.rag.base.files.model
 
 import kotlinx.serialization.Serializable
 import kotlin.math.pow

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/model/FileSystemEntry.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/model/FileSystemEntry.kt
@@ -1,4 +1,4 @@
-package ai.koog.agents.ext.tool.file.model
+package ai.koog.rag.base.files.model
 
 import ai.koog.rag.base.files.DocumentProvider
 import ai.koog.rag.base.files.FileMetadata

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/model/FileSystemEntryBuilders.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/model/FileSystemEntryBuilders.kt
@@ -1,8 +1,5 @@
-package ai.koog.agents.ext.tool.file.model
+package ai.koog.rag.base.files.model
 
-import ai.koog.agents.ext.tool.file.model.FileSystemEntry.File
-import ai.koog.agents.ext.tool.file.model.FileSystemEntry.File.Content
-import ai.koog.agents.ext.tool.file.model.FileSystemEntry.Folder
 import ai.koog.rag.base.files.FileMetadata
 import ai.koog.rag.base.files.FileSystemProvider
 import ai.koog.rag.base.files.readText
@@ -20,16 +17,16 @@ public suspend fun <Path> buildFileEntry(
     fs: FileSystemProvider.ReadOnly<Path>,
     path: Path,
     metadata: FileMetadata
-): File {
+): FileSystemEntry.File {
     val type = fs.getFileContentType(path)
-    return File(
+    return FileSystemEntry.File(
         name = fs.name(path),
         extension = fs.extension(path),
         path = fs.toAbsolutePathString(path),
         hidden = metadata.hidden,
         size = buildFileSize(fs, path, type),
         contentType = type,
-        content = Content.None,
+        content = FileSystemEntry.File.Content.None,
     )
 }
 
@@ -48,8 +45,8 @@ public fun <Path> buildFolderEntry(
     path: Path,
     metadata: FileMetadata,
     entries: List<FileSystemEntry>?
-): Folder {
-    return Folder(
+): FileSystemEntry.Folder {
+    return FileSystemEntry.Folder(
         name = fs.name(path),
         path = fs.toAbsolutePathString(path),
         hidden = metadata.hidden,

--- a/rag/rag-base/src/commonTest/kotlin/ai/koog/rag/base/files/filter/GlobPatternTest.kt
+++ b/rag/rag-base/src/commonTest/kotlin/ai/koog/rag/base/files/filter/GlobPatternTest.kt
@@ -1,4 +1,4 @@
-package ai.koog.agents.ext.tool.file.filter
+package ai.koog.rag.base.files.filter
 
 import kotlin.test.Test
 import kotlin.test.assertFalse

--- a/rag/rag-base/src/commonTest/kotlin/ai/koog/rag/base/files/model/FileSizeTest.kt
+++ b/rag/rag-base/src/commonTest/kotlin/ai/koog/rag/base/files/model/FileSizeTest.kt
@@ -1,4 +1,4 @@
-package ai.koog.agents.ext.tool.file.model
+package ai.koog.rag.base.files.model
 
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/rag/rag-base/src/commonTest/kotlin/ai/koog/rag/base/files/model/FileSystemEntryTest.kt
+++ b/rag/rag-base/src/commonTest/kotlin/ai/koog/rag/base/files/model/FileSystemEntryTest.kt
@@ -1,4 +1,4 @@
-package ai.koog.agents.ext.tool.file.model
+package ai.koog.rag.base.files.model
 
 import ai.koog.rag.base.files.DocumentProvider
 import ai.koog.rag.base.files.FileMetadata


### PR DESCRIPTION
Currently, we (EmbArk) have a dependency on Code Engine's module `ai.jetbrains.code.files:code-files-model`, which is rather small module for working with files and filesystem. But the problem is that it has dependencies on one class from koog:
`ai.koog.agents.ext.tool.file.filter.GlobPattern` which is located in `ai.koog:agents-ext` and adds dependencies on many various koog-related modules (and even on `ktor-server`).

So I moved `GlobPattern.kt`, `FileSize.kt`, `FileSystemEntry.kt` and `FileSystemEntryBuilders.kt` from `ai.koog:agents-ext` to `rag:rag-base` module.

closes JBAI-18822.