### PR TITLE
fix(agents)!: KG-533. readfiletool empty files as binary (#1340)

### DIFF
--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/ReadFileTool.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/ReadFileTool.kt
@@ -92,7 +92,9 @@ public class ReadFileTool<Path>(private val fs: FileSystemProvider.ReadOnly<Path
         validate(metadata.type == FileMetadata.FileType.File) { "Not a file: ${args.path}" }
 
         val type = fs.getFileContentType(path)
-        validate(type == FileMetadata.FileContentType.Text) { "File is not a text file: ${args.path}" }
+        val isEmpty = fs.size(path) == 0L
+        val isText = isEmpty || (type == FileMetadata.FileContentType.Text)
+        validate(isText) { "File is not a text file: ${args.path}" }
 
         return runCatching {
             var warningMessage: String? = null

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/ReadFileUtil.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/file/ReadFileUtil.kt
@@ -52,10 +52,12 @@ private fun buildContent(
     endLine: Int,
     onEndLineExceedsFileLength: ((requestedEndLine: Int, fileLineCount: Int) -> Unit)?
 ): FileSystemEntry.File.Content {
-    val lineCount = content.lineSequence().count()
+    val lineCount = if (content.isEmpty()) 0 else content.lineSequence().count()
 
     require(startLine >= 0) { "startLine=$startLine must be >= 0" }
-    require(startLine < lineCount) { "startLine=$startLine must be < lineCount=$lineCount" }
+    if (lineCount > 0) {
+        require(startLine < lineCount) { "startLine=$startLine must be < lineCount=$lineCount" }
+    }
 
     require(endLine >= -1) { "endLine=$endLine must be >= -1" }
     require(endLine == -1 || endLine > startLine) { "endLine=$endLine must be > startLine=$startLine or -1" }

--- a/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/ReadFileToolJvmTest.kt
+++ b/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/file/ReadFileToolJvmTest.kt
@@ -205,11 +205,17 @@ class ReadFileToolJvmTest {
     }
 
     @Test
-    fun `throws ValidationFailure when reading empty markdown file`() {
+    fun `reading empty markdown file renders empty fenced block`() = runBlocking {
         val f = createTestFile("empty.md", "")
-        assertThrows<ToolException.ValidationFailure> {
-            runBlocking { readFile(f) }
-        }
+        val result = readFile(f)
+        val expected = """
+            ${"${f.toAbsolutePath().toString().norm()} (0 bytes, 0 lines)"}
+            Content:
+            ```markdown
+            ```
+        """.trimIndent()
+
+        assertEquals(expected, tool.encodeResultToString(result))
     }
 
     @Test
@@ -249,11 +255,17 @@ class ReadFileToolJvmTest {
     }
 
     @Test
-    fun `throws ValidationFailure when reading empty kotlin file`() {
+    fun `reading empty kotlin file renders empty fenced block`() = runBlocking {
         val f = createTestFile("Empty.kt", "")
-        assertThrows<ToolException.ValidationFailure> {
-            runBlocking { readFile(f) }
-        }
+        val result = readFile(f)
+        val expected = """
+            ${"${f.toAbsolutePath().toString().norm()} (0 bytes, 0 lines)"}
+            Content:
+            ```kotlin
+            ```
+        """.trimIndent()
+
+        assertEquals(expected, tool.encodeResultToString(result))
     }
 
     @Test

--- a/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/model/FileSystemEntryBuilders.kt
+++ b/rag/rag-base/src/commonMain/kotlin/ai/koog/rag/base/files/model/FileSystemEntryBuilders.kt
@@ -118,5 +118,7 @@ public suspend fun <Path> buildFileSize(
         return listOf(bytes)
     }
 
-    return listOf(bytes, FileSize.Lines(fs.readText(path).lineSequence().count()))
+    val text = fs.readText(path)
+    val lineCount = if (text.isEmpty()) 0 else text.lineSequence().count()
+    return listOf(bytes, FileSize.Lines(lineCount))
 }


### PR DESCRIPTION
[KG-533](https://youtrack.jetbrains.com/issue/KG-533) ReadFileTool incorrectly reports empty files as binary

closes [KG-533](https://youtrack.jetbrains.com/issue/KG-533)
