### PR TITLE
fix(prompt): added LLMCapability.Document to DevstralMedium (#1496)

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAIModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAIModels.kt
@@ -164,7 +164,8 @@ public object MistralAIModels : LLModelDefinitions {
                 LLMCapability.Tools,
                 LLMCapability.ToolChoice,
                 LLMCapability.Schema.JSON.Basic,
-                LLMCapability.Schema.JSON.Standard
+                LLMCapability.Schema.JSON.Standard,
+                LLMCapability.Document,
             ),
             contextLength = 128_000
         )


### PR DESCRIPTION
Adds a missing capability (`LLMCapability.Document`) to a model (`DevstralMedium`).

closes #1482