### PR TITLE
docs(agents)!: Update description of singleRunStrategy

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentSimpleStrategies.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentSimpleStrategies.kt
@@ -24,11 +24,11 @@ import ai.koog.agents.core.dsl.extension.onToolCall
  * 3. Execute a tool based on the LLM's response.
  * 4. Send the tool result back to the LLM.
  * 5. Repeat until LLM indicates no further tool calls are needed or the agent finishes.
- * @param runMode The mode in which the single-run strategy should operate. Defaults to SingleRunMode.SINGLE.
- *                - SingleRunMode.SINGLE: Executes without allowing multiple simultaneous tool calls.
- *                - SingleRunMode.SEQUENTIAL: Executes simultaneous tool calls sequentially.
- *                - SingleRunMode.PARALLEL: Executes multiple tool calls in parallel.
- * @return An instance of AIAgentStrategy configured according to the specified single-run mode.
+ * @param runMode The mode in which the single-run strategy should operate. Defaults to [ToolCalls.SEQUENTIAL].
+ *                - [ToolCalls.SEQUENTIAL]: Executes multiple tool calls sequentially.
+ *                - [ToolCalls.PARALLEL]: Executes multiple tool calls in parallel.
+ *                - [ToolCalls.SINGLE_RUN_SEQUENTIAL]: Executes a single tool call per step.
+ * @return An instance of AIAgentStrategy configured according to the specified run mode.
  */
 public fun singleRunStrategy(runMode: ToolCalls = ToolCalls.SEQUENTIAL): AIAgentGraphStrategy<String, String> =
     when (runMode) {


### PR DESCRIPTION
Updated KDoc for singleRunStrategy to correctly reflect that the default mode is ToolCalls.SEQUENTIAL and swapped outdated SingleRunMode references for the ToolCalls enum.

Related to: [KG-156](https://youtrack.jetbrains.com/issue/KG-156)
