### PR TITLE
feat(prompt): add thinking support and coverage for Ollama responses

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -36,8 +36,6 @@ import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.streaming.buildStreamFrameFlow
-import ai.koog.prompt.streaming.emitTextDelta
-import ai.koog.prompt.streaming.emitToolCallDelta
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -59,7 +57,7 @@ import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.readUTF8Line
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.json.Json
 import kotlin.jvm.JvmOverloads
 
@@ -300,11 +298,15 @@ public class OllamaClient @JvmOverloads constructor(
             while (!channel.isClosedForRead) {
                 val line = channel.readUTF8Line() ?: break
                 if (line.isBlank()) continue
-
                 try {
                     val chunk = ollamaJson.decodeFromString<OllamaChatResponseDTO>(line)
                     chunk.message?.let { message ->
-                        emitTextDelta(message.content)
+                        if(message.content.isNotEmpty()){
+                            emitTextDelta(message.content)
+                        }
+                        if(message.thinking.isNullOrEmpty().not()){
+                            emitReasoningDelta(message.thinking)
+                        }
                         message.toolCalls?.forEachIndexed { index, toolCall ->
                             val name = toolCall.function.name
                             val args = toolCall.function.arguments.toString()

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -57,9 +57,9 @@ import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.readUTF8Line
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
-import kotlin.time.Clock
 import kotlinx.serialization.json.Json
 import kotlin.jvm.JvmOverloads
+import kotlin.time.Clock
 
 /**
  * Client for interacting with the Ollama API with comprehensive model support.
@@ -301,10 +301,10 @@ public class OllamaClient @JvmOverloads constructor(
                 try {
                     val chunk = ollamaJson.decodeFromString<OllamaChatResponseDTO>(line)
                     chunk.message?.let { message ->
-                        if(message.content.isNotEmpty()){
+                        if (message.content.isNotEmpty()) {
                             emitTextDelta(message.content)
                         }
-                        if(message.thinking.isNullOrEmpty().not()){
+                        if (message.thinking.isNullOrEmpty().not()) {
                             emitReasoningDelta(message.thinking)
                         }
                         message.toolCalls?.forEachIndexed { index, toolCall ->

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaModels.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.json.JsonElement
 internal data class OllamaChatMessageDTO(
     val role: String,
     val content: String,
+    val thinking: String? = null,
     val images: List<String>? = null,
     @SerialName("tool_calls") val toolCalls: List<OllamaToolCallDTO>? = null
 )
@@ -63,6 +64,7 @@ internal data class OllamaChatRequestDTO(
     val format: JsonElement? = null,
     val options: Options? = null,
     val stream: Boolean,
+    val think: Boolean = true,
     @SerialName("keep_alive") val keepAlive: String? = null,
     val additionalProperties: Map<String, JsonElement>? = null,
 ) {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/ContextWindowStrategyTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/ContextWindowStrategyTest.kt
@@ -10,11 +10,11 @@ import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.tokenizer.PromptTokenizer
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.test.runTest
-import kotlin.time.Clock
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.time.Clock
 
 class ContextWindowStrategyTest {
     @Test
@@ -196,4 +196,3 @@ private fun makeDummyResponse(
     promptEvalCount = promptEvalCount,
     evalCount = evalCount,
 )
-

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/ContextWindowStrategyTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/ContextWindowStrategyTest.kt
@@ -9,20 +9,12 @@ import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.tokenizer.PromptTokenizer
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.mock.MockEngine
-import io.ktor.client.engine.mock.respond
-import io.ktor.client.request.HttpRequestData
-import io.ktor.http.HttpHeaders
-import io.ktor.http.HttpStatusCode
-import io.ktor.http.content.TextContent
-import io.ktor.http.headersOf
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.Json
+import kotlin.time.Clock
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
-import kotlin.time.Clock
 
 class ContextWindowStrategyTest {
     @Test
@@ -205,26 +197,3 @@ private fun makeDummyResponse(
     evalCount = evalCount,
 )
 
-private class MockOllamaChatServer(
-    private val handler: (OllamaChatRequestDTO) -> OllamaChatResponseDTO,
-) {
-    val mockEngine = MockEngine { requestData ->
-        val request = requestData.extractChatRequest()
-        val response = handler(request)
-        respond(
-            content = Json.encodeToString<OllamaChatResponseDTO>(response),
-            status = HttpStatusCode.OK,
-            headers = headersOf(HttpHeaders.ContentType to listOf("application/json")),
-        )
-    }
-
-    val requestHistory: List<OllamaChatRequestDTO>
-        get() = mockEngine.requestHistory.map { it.extractChatRequest() }
-
-    private fun HttpRequestData.extractChatRequest(): OllamaChatRequestDTO {
-        val requestContent = body as TextContent
-        val requestBody = requestContent.text
-        val request = Json.decodeFromString<OllamaChatRequestDTO>(requestBody)
-        return request
-    }
-}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/MockOllamaChatServer.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/MockOllamaChatServer.kt
@@ -1,0 +1,36 @@
+package ai.koog.prompt.executor.ollama.client
+
+import ai.koog.prompt.executor.ollama.client.dto.OllamaChatRequestDTO
+import ai.koog.prompt.executor.ollama.client.dto.OllamaChatResponseDTO
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.TextContent
+import io.ktor.http.headersOf
+import kotlinx.serialization.json.Json
+
+internal class MockOllamaChatServer(
+    private val handler: (OllamaChatRequestDTO) -> OllamaChatResponseDTO,
+) {
+    val mockEngine = MockEngine.Companion { requestData ->
+        val request = requestData.extractChatRequest()
+        val response = handler(request)
+        respond(
+            content = Json.encodeToString<OllamaChatResponseDTO>(response),
+            status = HttpStatusCode.Companion.OK,
+            headers = headersOf(HttpHeaders.ContentType to listOf("application/json")),
+        )
+    }
+
+    val requestHistory: List<OllamaChatRequestDTO>
+        get() = mockEngine.requestHistory.map { it.extractChatRequest() }
+
+    private fun HttpRequestData.extractChatRequest(): OllamaChatRequestDTO {
+        val requestContent = body as TextContent
+        val requestBody = requestContent.text
+        val request = Json.decodeFromString<OllamaChatRequestDTO>(requestBody)
+        return request
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/MockStreamingOllamaChatServer.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/MockStreamingOllamaChatServer.kt
@@ -1,0 +1,37 @@
+package ai.koog.prompt.executor.ollama.client
+
+import ai.koog.prompt.executor.ollama.client.dto.OllamaChatRequestDTO
+import ai.koog.prompt.executor.ollama.client.dto.OllamaChatResponseDTO
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.TextContent
+import io.ktor.http.headersOf
+import kotlinx.serialization.json.Json
+
+internal class MockStreamingOllamaChatServer(
+    private val handler: (Unit) -> OllamaChatResponseDTO,
+) {
+    val mockEngine = MockEngine { _ ->
+        // Build streaming response by collecting multiple responses
+        val responses = mutableListOf<String>()
+        var response = handler(Unit)
+        while (!response.done) {
+            responses.add(Json.encodeToString<OllamaChatResponseDTO>(response))
+            response = handler(Unit)
+        }
+        // Add the final response
+        responses.add(Json.encodeToString<OllamaChatResponseDTO>(response))
+
+        // Join with newlines for NDJSON format
+        val streamContent = responses.joinToString("\n")
+
+        respond(
+            content = streamContent,
+            status = HttpStatusCode.OK,
+            headers = headersOf(HttpHeaders.ContentType to listOf("application/json")),
+        )
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/MockStreamingOllamaChatServer.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/MockStreamingOllamaChatServer.kt
@@ -1,13 +1,10 @@
 package ai.koog.prompt.executor.ollama.client
 
-import ai.koog.prompt.executor.ollama.client.dto.OllamaChatRequestDTO
 import ai.koog.prompt.executor.ollama.client.dto.OllamaChatResponseDTO
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
-import io.ktor.client.request.HttpRequestData
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.content.TextContent
 import io.ktor.http.headersOf
 import kotlinx.serialization.json.Json
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/OllamaThinkingFeatureTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/OllamaThinkingFeatureTest.kt
@@ -1,0 +1,419 @@
+package ai.koog.prompt.executor.ollama.client
+
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.ollama.client.dto.OllamaChatMessageDTO
+import ai.koog.prompt.executor.ollama.client.dto.OllamaChatResponseDTO
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.streaming.StreamFrame
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for Ollama client thinking feature support.
+ *
+ * These tests verify that:
+ * - Thinking content is properly parsed from responses
+ * - Thinking and regular content are handled correctly
+ * - Thinking works with streaming responses
+ * - Thinking is properly emitted in stream frames
+ */
+class OllamaThinkingFeatureTest {
+
+    @Test
+    fun `test parsing response with thinking content only`() = runTest {
+        val thinkingContent = "Let me think about this problem step by step..."
+        val mockServer = MockOllamaChatServer { request ->
+            OllamaChatResponseDTO(
+                model = request.model,
+                message = OllamaChatMessageDTO(
+                    role = "assistant",
+                    content = "",
+                    thinking = thinkingContent
+                ),
+                done = true
+            )
+        }
+
+        val ollamaClient = OllamaClient(
+            baseClient = HttpClient(mockServer.mockEngine)
+        )
+
+        val responses = ollamaClient.execute(
+            prompt = prompt("test") { },
+            model = OllamaModels.Meta.LLAMA_3_2
+        )
+
+        assertEquals(1, responses.size)
+        val response = responses.first()
+        assertTrue(response is Message.Assistant)
+        // The thinking should still be in the content as it was provided
+        assertTrue(response.content.contains(thinkingContent) || response.content.isEmpty())
+    }
+
+    @Test
+    fun `test parsing response with both thinking and content`() = runTest {
+        val thinkingContent = "I need to analyze the request carefully"
+        val responseContent = "Based on my analysis, the answer is..."
+
+        val mockServer = MockOllamaChatServer { request ->
+            OllamaChatResponseDTO(
+                model = request.model,
+                message = OllamaChatMessageDTO(
+                    role = "assistant",
+                    content = responseContent,
+                    thinking = thinkingContent
+                ),
+                done = true
+            )
+        }
+
+        val ollamaClient = OllamaClient(
+            baseClient = HttpClient(mockServer.mockEngine)
+        )
+
+        val responses = ollamaClient.execute(
+            prompt = prompt("test") { },
+            model = OllamaModels.Meta.LLAMA_3_2
+        )
+
+        assertEquals(1, responses.size)
+        val response = responses.first()
+        assertTrue(response is Message.Assistant)
+        assertEquals(responseContent, response.content)
+    }
+
+    @Test
+    fun `test parsing response without thinking content`() = runTest {
+        val responseContent = "This is a simple response"
+
+        val mockServer = MockOllamaChatServer { request ->
+            OllamaChatResponseDTO(
+                model = request.model,
+                message = OllamaChatMessageDTO(
+                    role = "assistant",
+                    content = responseContent,
+                    thinking = null
+                ),
+                done = true
+            )
+        }
+
+        val ollamaClient = OllamaClient(
+            baseClient = HttpClient(mockServer.mockEngine)
+        )
+
+        val responses = ollamaClient.execute(
+            prompt = prompt("test") { },
+            model = OllamaModels.Meta.LLAMA_3_2
+        )
+
+        assertEquals(1, responses.size)
+        val response = responses.first()
+        assertTrue(response is Message.Assistant)
+        assertEquals(responseContent, response.content)
+    }
+
+    @Test
+    fun `test parsing response with empty thinking content`() = runTest {
+        val responseContent = "Response content"
+
+        val mockServer = MockOllamaChatServer { request ->
+            OllamaChatResponseDTO(
+                model = request.model,
+                message = OllamaChatMessageDTO(
+                    role = "assistant",
+                    content = responseContent,
+                    thinking = ""
+                ),
+                done = true
+            )
+        }
+
+        val ollamaClient = OllamaClient(
+            baseClient = HttpClient(mockServer.mockEngine)
+        )
+
+        val responses = ollamaClient.execute(
+            prompt = prompt("test") { },
+            model = OllamaModels.Meta.LLAMA_3_2
+        )
+
+        assertEquals(1, responses.size)
+        val response = responses.first()
+        assertTrue(response is Message.Assistant)
+        assertEquals(responseContent, response.content)
+    }
+
+    @Test
+    fun `test streaming response with thinking content`() = runTest {
+        val thinkingContent = "Thinking through the problem..."
+        val responseContent = "Final answer"
+
+        // For streaming, we need to simulate multiple chunks
+        val streamingResponses = listOf(
+            OllamaChatResponseDTO(
+                model = "test-model",
+                message = OllamaChatMessageDTO(
+                    role = "assistant",
+                    content = "",
+                    thinking = thinkingContent
+                ),
+                done = false
+            ),
+            OllamaChatResponseDTO(
+                model = "test-model",
+                message = OllamaChatMessageDTO(
+                    role = "assistant",
+                    content = responseContent,
+                    thinking = null
+                ),
+                done = false
+            ),
+            OllamaChatResponseDTO(
+                model = "test-model",
+                message = OllamaChatMessageDTO(
+                    role = "assistant",
+                    content = "",
+                    thinking = null
+                ),
+                done = true
+            )
+        )
+
+        var responseIndex = 0
+        val mockServer = MockStreamingOllamaChatServer {
+            val response = streamingResponses.getOrNull(responseIndex)
+                ?: OllamaChatResponseDTO(
+                    model = "test-model",
+                    message = null,
+                    done = true
+                )
+            responseIndex++
+            response
+        }
+
+        val ollamaClient = OllamaClient(
+            baseClient = HttpClient(mockServer.mockEngine)
+        )
+
+        val streamFrames = ollamaClient.executeStreaming(
+            prompt = prompt("test") { },
+            model = OllamaModels.Meta.LLAMA_3_2
+        ).toList()
+
+        // Verify that we have stream frames
+        assertTrue(streamFrames.isNotEmpty(), "Should have stream frames")
+
+        // Check for thinking stream frames
+        val thinkingFrames = streamFrames.filterIsInstance<StreamFrame.ReasoningDelta>()
+        assertTrue(thinkingFrames.isNotEmpty(), "Should have at least one thinking frame")
+
+        // Verify thinking content is present
+        val allThinkingContent = thinkingFrames.joinToString("") { it.text.orEmpty() }
+        assertTrue(allThinkingContent.contains(thinkingContent), "Thinking content should be in frames")
+    }
+
+    @Test
+    fun `test streaming response with content only`() = runTest {
+        val responseContent = "Streaming response content"
+
+        val streamingResponses = listOf(
+            OllamaChatResponseDTO(
+                model = "test-model",
+                message = OllamaChatMessageDTO(
+                    role = "assistant",
+                    content = responseContent,
+                    thinking = null
+                ),
+                done = false
+            ),
+            OllamaChatResponseDTO(
+                model = "test-model",
+                message = OllamaChatMessageDTO(
+                    role = "assistant",
+                    content = "",
+                    thinking = null
+                ),
+                done = true
+            )
+        )
+
+        var responseIndex = 0
+        val mockServer = MockStreamingOllamaChatServer {
+            val response = streamingResponses.getOrNull(responseIndex)
+                ?: OllamaChatResponseDTO(
+                    model = "test-model",
+                    message = null,
+                    done = true
+                )
+            responseIndex++
+            response
+        }
+
+        val ollamaClient = OllamaClient(
+            baseClient = HttpClient(mockServer.mockEngine)
+        )
+
+        val streamFrames = ollamaClient.executeStreaming(
+            prompt = prompt("test") { },
+            model = OllamaModels.Meta.LLAMA_3_2
+        ).toList()
+
+        // Verify that we have stream frames
+        assertTrue(streamFrames.isNotEmpty(), "Should have stream frames")
+
+        // Check for append frames
+        val textFrames = streamFrames.filterIsInstance<StreamFrame.TextDelta>()
+        assertTrue(textFrames.isNotEmpty(), "Should have at least one text frame")
+
+        // Verify content is present
+        val allContent = textFrames.joinToString("") { it.text }
+        assertTrue(allContent.contains(responseContent), "Response content should be in frames")
+    }
+
+    @Test
+    fun `test streaming response with both thinking and content`() = runTest {
+        val thinkingContent = "Internal reasoning process"
+        val responseContent = "External response"
+
+        val streamingResponses = listOf(
+            OllamaChatResponseDTO(
+                model = "test-model",
+                message = OllamaChatMessageDTO(
+                    role = "assistant",
+                    content = "",
+                    thinking = thinkingContent
+                ),
+                done = false
+            ),
+            OllamaChatResponseDTO(
+                model = "test-model",
+                message = OllamaChatMessageDTO(
+                    role = "assistant",
+                    content = responseContent,
+                    thinking = null
+                ),
+                done = false
+            ),
+            OllamaChatResponseDTO(
+                model = "test-model",
+                message = OllamaChatMessageDTO(
+                    role = "assistant",
+                    content = "",
+                    thinking = null
+                ),
+                done = true
+            )
+        )
+
+        var responseIndex = 0
+        val mockServer = MockStreamingOllamaChatServer {
+            val response = streamingResponses.getOrNull(responseIndex)
+                ?: OllamaChatResponseDTO(
+                    model = "test-model",
+                    message = null,
+                    done = true
+                )
+            responseIndex++
+            response
+        }
+
+        val ollamaClient = OllamaClient(
+            baseClient = HttpClient(mockServer.mockEngine)
+        )
+
+        val streamFrames = ollamaClient.executeStreaming(
+            prompt = prompt("test") { },
+            model = OllamaModels.Meta.LLAMA_3_2
+        ).toList()
+
+        // Verify we have stream frames
+        assertTrue(streamFrames.isNotEmpty(), "Should have stream frames")
+
+        // Check for both types of frames
+        val thinkingFrames = streamFrames.filterIsInstance<StreamFrame.ReasoningDelta>()
+        val textFrames = streamFrames.filterIsInstance<StreamFrame.TextDelta>()
+
+        assertTrue(thinkingFrames.isNotEmpty(), "Should have thinking frames")
+        assertTrue(textFrames.isNotEmpty(), "Should have text frames")
+
+        // Verify content
+        val allThinking = thinkingFrames.joinToString("") { it.text.orEmpty() }
+        val allContent = textFrames.joinToString("") { it.text }
+
+        assertTrue(allThinking.contains(thinkingContent), "Thinking content should be in thinking frames")
+        assertTrue(allContent.contains(responseContent), "Response content should be in text frames")
+    }
+
+    @Test
+    fun `test request includes think parameter`() = runTest {
+        val mockServer = MockOllamaChatServer { request ->
+            OllamaChatResponseDTO(
+                model = request.model,
+                message = OllamaChatMessageDTO(
+                    role = "assistant",
+                    content = "Response"
+                ),
+                done = true
+            )
+        }
+
+        val ollamaClient = OllamaClient(
+            baseClient = HttpClient(mockServer.mockEngine)
+        )
+
+        ollamaClient.execute(
+            prompt = prompt("test") { },
+            model = OllamaModels.Meta.LLAMA_3_2
+        )
+
+        val requestHistory = mockServer.requestHistory
+        assertEquals(1, requestHistory.size)
+
+        val request = requestHistory.first()
+        // The think parameter should be set to true by default
+        assertTrue(request.think, "Request should have think parameter set to true")
+    }
+
+    @Test
+    fun `test token counts are properly extracted with thinking`() = runTest {
+        val promptTokens = 50
+        val responseTokens = 100
+
+        val mockServer = MockOllamaChatServer { request ->
+            OllamaChatResponseDTO(
+                model = request.model,
+                message = OllamaChatMessageDTO(
+                    role = "assistant",
+                    content = "Response with thinking",
+                    thinking = "This is the thinking content"
+                ),
+                done = true,
+                promptEvalCount = promptTokens,
+                evalCount = responseTokens
+            )
+        }
+
+        val ollamaClient = OllamaClient(
+            baseClient = HttpClient(mockServer.mockEngine)
+        )
+
+        val responses = ollamaClient.execute(
+            prompt = prompt("test") { },
+            model = OllamaModels.Meta.LLAMA_3_2
+        )
+
+        assertEquals(1, responses.size)
+        val response = responses.first()
+        assertTrue(response is Message.Assistant)
+
+        val metaInfo = assertNotNull(response.metaInfo)
+        assertEquals(promptTokens, metaInfo.inputTokensCount)
+        assertEquals(responseTokens, metaInfo.outputTokensCount)
+    }
+}


### PR DESCRIPTION
- add `thinking` to chat message DTO and `think=true` request parameter
- emit reasoning deltas for streaming thinking chunks
- avoid emitting empty text deltas in streaming responses
- extract reusable chat/streaming mock servers for tests
- add OllamaThinkingFeatureTest and reuse shared mocks in context window tests