### PR TITLE
fix: deprecated import of kotlinx.datetime

### DIFF
--- a/a2a/a2a-core/build.gradle.kts
+++ b/a2a/a2a-core/build.gradle.kts
@@ -20,7 +20,6 @@ kotlin {
             dependencies {
                 api(libs.kotlinx.serialization.json)
                 api(libs.kotlinx.coroutines.core)
-                api(libs.kotlinx.datetime)
             }
         }
 

--- a/a2a/a2a-core/src/commonMain/kotlin/ai/koog/a2a/model/Task.kt
+++ b/a2a/a2a-core/src/commonMain/kotlin/ai/koog/a2a/model/Task.kt
@@ -1,11 +1,11 @@
 package ai.koog.a2a.model
 
-import kotlin.time.Instant
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 import kotlin.time.Clock
+import kotlin.time.Instant
 
 /**
  * Represents a single, stateful operation or conversation between a client and an agent.

--- a/a2a/a2a-core/src/commonMain/kotlin/ai/koog/a2a/model/Task.kt
+++ b/a2a/a2a-core/src/commonMain/kotlin/ai/koog/a2a/model/Task.kt
@@ -1,6 +1,6 @@
 package ai.koog.a2a.model
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/agents/agents-core/build.gradle.kts
+++ b/agents/agents-core/build.gradle.kts
@@ -32,7 +32,6 @@ kotlin {
                 api(project(":prompt:prompt-executor:prompt-executor-model"))
                 api(project(":prompt:prompt-markdown"))
 
-                api(libs.kotlinx.datetime)
                 api(libs.kotlinx.io.core)
                 api(libs.kotlinx.serialization.json)
                 api(libs.ktor.client.content.negotiation)

--- a/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
+++ b/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
@@ -13,7 +13,7 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
 import ai.koog.utils.io.Closeable
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
 
 @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT")

--- a/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
+++ b/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
@@ -9,7 +9,7 @@ import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual abstract class AIAgentService<Input, Output, TAgent : AIAgent<Input, Output>> actual constructor() {
     public actual abstract val promptExecutor: PromptExecutor

--- a/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
+++ b/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
@@ -12,7 +12,7 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual open class AIAgentLLMContext internal actual constructor(
     internal actual val delegate: AIAgentLLMContextImpl

--- a/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
+++ b/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
@@ -15,7 +15,7 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
 import ai.koog.prompt.structure.StructuredResponse
 import kotlinx.coroutines.flow.Flow
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.reflect.KClass
 
 public actual class AIAgentLLMWriteSession internal constructor(

--- a/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
+++ b/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
@@ -15,8 +15,8 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
 import ai.koog.prompt.structure.StructuredResponse
 import kotlinx.coroutines.flow.Flow
-import kotlin.time.Clock
 import kotlin.reflect.KClass
+import kotlin.time.Clock
 
 public actual class AIAgentLLMWriteSession internal constructor(
     @PublishedApi internal actual val delegate: AIAgentLLMWriteSessionImpl

--- a/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
+++ b/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
@@ -7,7 +7,7 @@ import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.feature.AIAgentGraphFeature
 import ai.koog.agents.core.feature.config.FeatureConfig
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual open class AIAgentGraphPipeline actual constructor(
     agentConfig: AIAgentConfig,

--- a/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
+++ b/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
@@ -3,7 +3,7 @@
 package ai.koog.agents.core.feature.pipeline
 
 import ai.koog.agents.core.agent.config.AIAgentConfig
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual abstract class AIAgentPipeline actual constructor(
     agentConfig: AIAgentConfig,

--- a/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
+++ b/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
@@ -13,7 +13,7 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
 import ai.koog.utils.io.Closeable
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
 
 @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT")

--- a/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
+++ b/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
@@ -9,7 +9,7 @@ import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual abstract class AIAgentService<Input, Output, TAgent : AIAgent<Input, Output>> actual constructor() {
     public actual abstract val promptExecutor: PromptExecutor

--- a/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
+++ b/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
@@ -12,7 +12,7 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual open class AIAgentLLMContext internal actual constructor(
     internal actual val delegate: AIAgentLLMContextImpl

--- a/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
+++ b/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
@@ -15,7 +15,7 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
 import ai.koog.prompt.structure.StructuredResponse
 import kotlinx.coroutines.flow.Flow
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.reflect.KClass
 
 public actual class AIAgentLLMWriteSession internal constructor(

--- a/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
+++ b/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
@@ -15,8 +15,8 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
 import ai.koog.prompt.structure.StructuredResponse
 import kotlinx.coroutines.flow.Flow
-import kotlin.time.Clock
 import kotlin.reflect.KClass
+import kotlin.time.Clock
 
 public actual class AIAgentLLMWriteSession internal constructor(
     @PublishedApi internal actual val delegate: AIAgentLLMWriteSessionImpl

--- a/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
+++ b/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
@@ -7,7 +7,7 @@ import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.feature.AIAgentGraphFeature
 import ai.koog.agents.core.feature.config.FeatureConfig
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual open class AIAgentGraphPipeline actual constructor(
     agentConfig: AIAgentConfig,

--- a/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
+++ b/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
@@ -3,7 +3,7 @@
 package ai.koog.agents.core.feature.pipeline
 
 import ai.koog.agents.core.agent.config.AIAgentConfig
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual abstract class AIAgentPipeline actual constructor(
     agentConfig: AIAgentConfig,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
@@ -14,7 +14,7 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
 import ai.koog.utils.io.Closeable
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.jvm.JvmStatic
 import kotlin.uuid.ExperimentalUuidApi
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
@@ -14,8 +14,8 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
 import ai.koog.utils.io.Closeable
-import kotlin.time.Clock
 import kotlin.jvm.JvmStatic
+import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
 
 /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
@@ -87,7 +87,7 @@ public expect abstract class AIAgent<Input, Output> constructor() : Closeable {
             strategy: AIAgentGraphStrategy<Input, Output>,
             toolRegistry: ToolRegistry = ToolRegistry.EMPTY,
             id: String? = null,
-            clock: Clock = kotlin.time.Clock.System,
+            clock: Clock = Clock.System,
             noinline installFeatures: FeatureContext.() -> Unit = {},
         ): AIAgent<Input, Output>
 
@@ -133,7 +133,7 @@ public expect abstract class AIAgent<Input, Output> constructor() : Closeable {
             strategy: AIAgentFunctionalStrategy<Input, Output>,
             toolRegistry: ToolRegistry = ToolRegistry.EMPTY,
             id: String? = null,
-            clock: Clock = kotlin.time.Clock.System,
+            clock: Clock = Clock.System,
             installFeatures: FunctionalAIAgent.FeatureContext.() -> Unit = {},
         ): FunctionalAIAgent<Input, Output>
 
@@ -195,7 +195,7 @@ public expect abstract class AIAgent<Input, Output> constructor() : Closeable {
             responseProcessor: ResponseProcessor? = null,
             toolRegistry: ToolRegistry = ToolRegistry.EMPTY,
             id: String? = null,
-            clock: Clock = kotlin.time.Clock.System,
+            clock: Clock = Clock.System,
             systemPrompt: String? = null,
             temperature: Double? = null,
             numberOfChoices: Int = 1,
@@ -284,7 +284,7 @@ public expect abstract class AIAgent<Input, Output> constructor() : Closeable {
             strategy: AIAgentPlannerStrategy<Input, Output, *>,
             toolRegistry: ToolRegistry = ToolRegistry.EMPTY,
             id: String? = null,
-            clock: Clock = kotlin.time.Clock.System,
+            clock: Clock = Clock.System,
             installFeatures: PlannerAIAgent.FeatureContext.() -> Unit = {},
         ): AIAgent<Input, Output>
     }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilder.kt
@@ -21,8 +21,8 @@ import ai.koog.agents.planner.TypedAgentPlannerStrategyBuilder
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
-import kotlin.time.Clock
 import kotlin.reflect.KType
+import kotlin.time.Clock
 
 /**
  * Represents a configurational builder for setting up and customizing the execution parameters and

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilder.kt
@@ -131,7 +131,7 @@ public expect class AIAgentBuilder internal constructor() : AIAgentBuilderAPI {
      * Represents the clock used to determine the current time in the builder.
      * By default, it is set to the system clock, but can be customized for testing or specific time-related behaviors*/
     @property:PublishedApi
-    internal var clock: kotlin.time.Clock
+    internal var clock: Clock
 
     public override fun promptExecutor(promptExecutor: PromptExecutor): AIAgentBuilder
 
@@ -203,7 +203,7 @@ public class GraphAgentBuilder<Input, Output>(
     private var missingToolsConversionStrategy: MissingToolsConversionStrategy =
         MissingToolsConversionStrategy.Missing(ToolCallDescriber.JSON),
     private var maxIterations: Int = 50,
-    private var clock: Clock = kotlin.time.Clock.System,
+    private var clock: Clock = Clock.System,
     private var featureInstallers: MutableList<FeatureContext.() -> Unit> = mutableListOf(),
 ) {
 
@@ -404,7 +404,7 @@ public class FunctionalAgentBuilder<Input, Output>(
     private var missingToolsConversionStrategy: MissingToolsConversionStrategy =
         MissingToolsConversionStrategy.Missing(ToolCallDescriber.JSON),
     private var maxIterations: Int = 50,
-    private var clock: Clock = kotlin.time.Clock.System,
+    private var clock: Clock = Clock.System,
     private var featureInstallers: MutableList<FunctionalAIAgent.FeatureContext.() -> Unit> = mutableListOf(),
 ) {
 
@@ -596,7 +596,7 @@ public class PlannerAgentBuilder<Input, Output>(
     private var missingToolsConversionStrategy: MissingToolsConversionStrategy =
         MissingToolsConversionStrategy.Missing(ToolCallDescriber.JSON),
     private var maxIterations: Int = 50,
-    private var clock: Clock = kotlin.time.Clock.System,
+    private var clock: Clock = Clock.System,
     private var featureInstallers: MutableList<PlannerAIAgent.FeatureContext.() -> Unit> = mutableListOf(),
 ) {
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilder.kt
@@ -21,7 +21,7 @@ import ai.koog.agents.planner.TypedAgentPlannerStrategyBuilder
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.reflect.KType
 
 /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentHelper.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentHelper.kt
@@ -11,7 +11,7 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.processor.ResponseProcessor
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.jvm.JvmStatic
 import kotlin.reflect.typeOf
 import kotlin.uuid.ExperimentalUuidApi

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentHelper.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentHelper.kt
@@ -50,7 +50,7 @@ internal object AIAgentHelper {
         strategy: AIAgentGraphStrategy<Input, Output>,
         toolRegistry: ToolRegistry = ToolRegistry.EMPTY,
         id: String? = null,
-        clock: Clock = kotlin.time.Clock.System,
+        clock: Clock = Clock.System,
         noinline installFeatures: FeatureContext.() -> Unit = {},
     ): AIAgent<Input, Output> {
         return GraphAIAgent(
@@ -94,7 +94,7 @@ internal object AIAgentHelper {
         toolRegistry = toolRegistry,
         strategy = strategy,
         id = id,
-        clock = kotlin.time.Clock.System,
+        clock = Clock.System,
         installFeatures = installFeatures
     )
 
@@ -117,7 +117,7 @@ internal object AIAgentHelper {
         strategy: AIAgentFunctionalStrategy<Input, Output>,
         toolRegistry: ToolRegistry = ToolRegistry.EMPTY,
         id: String? = null,
-        clock: Clock = kotlin.time.Clock.System,
+        clock: Clock = Clock.System,
         installFeatures: FunctionalAIAgent.FeatureContext.() -> Unit = {},
     ): FunctionalAIAgent<Input, Output> {
         return FunctionalAIAgent(
@@ -208,7 +208,7 @@ internal object AIAgentHelper {
         responseProcessor: ResponseProcessor? = null,
         toolRegistry: ToolRegistry = ToolRegistry.EMPTY,
         id: String? = null,
-        clock: Clock = kotlin.time.Clock.System,
+        clock: Clock = Clock.System,
         systemPrompt: String? = null,
         temperature: Double? = null,
         numberOfChoices: Int = 1,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentHelper.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentHelper.kt
@@ -11,9 +11,9 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.processor.ResponseProcessor
-import kotlin.time.Clock
 import kotlin.jvm.JvmStatic
 import kotlin.reflect.typeOf
+import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
 
 @PublishedApi

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
@@ -198,7 +198,7 @@ public expect abstract class AIAgentService<Input, Output, TAgent : AIAgent<Inpu
         id: String? = null,
         additionalToolRegistry: ToolRegistry = ToolRegistry.EMPTY,
         agentConfig: AIAgentConfig = this.agentConfig,
-        clock: Clock = kotlin.time.Clock.System,
+        clock: Clock = Clock.System,
     ): TAgent
 
     /**
@@ -216,7 +216,7 @@ public expect abstract class AIAgentService<Input, Output, TAgent : AIAgent<Inpu
         id: String? = null,
         additionalToolRegistry: ToolRegistry = this.toolRegistry,
         agentConfig: AIAgentConfig = this.agentConfig,
-        clock: Clock = kotlin.time.Clock.System,
+        clock: Clock = Clock.System,
     ): Output
 }
 
@@ -264,7 +264,7 @@ public abstract class AIAgentServiceBase<Input, Output, TAgent : AIAgent<Input, 
         id: String? = null,
         additionalToolRegistry: ToolRegistry,
         agentConfig: AIAgentConfig,
-        clock: Clock = kotlin.time.Clock.System,
+        clock: Clock = Clock.System,
     ): TAgent
 
     /**
@@ -459,7 +459,7 @@ public inline fun <reified Input, reified Output> AIAgentService<Input, Output, 
     inputSerializer: KSerializer<Input> = serializer(),
     outputSerializer: KSerializer<Output> = serializer(),
     parentAgentId: String? = null,
-    clock: Clock = kotlin.time.Clock.System
+    clock: Clock = Clock.System
 ): Tool<Input, AIAgentTool.AgentToolResult<Output>> = AIAgentTool(
     agentService = this,
     agentName = agentName,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
@@ -14,12 +14,12 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlin.time.Clock
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 import kotlin.jvm.JvmStatic
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
+import kotlin.time.Clock
 
 /**
  * [AIAgentService] is a core interface for managing AI agents. The service allows creation, removal, and

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
@@ -14,7 +14,7 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 import kotlin.jvm.JvmStatic

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
@@ -19,8 +19,8 @@ import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.params.LLMParams
-import kotlin.time.Clock
 import kotlin.reflect.KType
+import kotlin.time.Clock
 
 /**
  * Builder for creating AIAgentService instances.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
@@ -94,7 +94,7 @@ public class GraphAgentServiceBuilder<Input, Output> internal constructor(
     private var missingToolsConversionStrategy: MissingToolsConversionStrategy = MissingToolsConversionStrategy.Missing(
         ToolCallDescriber.JSON
     ),
-    private var clock: Clock = kotlin.time.Clock.System,
+    private var clock: Clock = Clock.System,
     private var featureInstallers: MutableList<FeatureContext.() -> Unit> = mutableListOf(),
 ) {
 
@@ -292,7 +292,7 @@ public class FunctionalAgentServiceBuilder<Input, Output> internal constructor(
     private var missingToolsConversionStrategy: MissingToolsConversionStrategy = MissingToolsConversionStrategy.Missing(
         ToolCallDescriber.JSON
     ),
-    private var clock: Clock = kotlin.time.Clock.System,
+    private var clock: Clock = Clock.System,
     private var featureInstallers: MutableList<FunctionalAIAgent.FeatureContext.() -> Unit> = mutableListOf(),
 ) {
     /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
@@ -19,7 +19,7 @@ import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.params.LLMParams
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.reflect.KType
 
 /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/FunctionalAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/FunctionalAIAgent.kt
@@ -42,7 +42,7 @@ public class FunctionalAIAgent<Input, Output>(
     override val strategy: AIAgentFunctionalStrategy<Input, Output>,
     public val toolRegistry: ToolRegistry = ToolRegistry.EMPTY,
     id: String? = null,
-    public val clock: Clock = kotlin.time.Clock.System,
+    public val clock: Clock = Clock.System,
     @property:InternalAgentsApi
     public val installFeatures: FeatureContext.() -> Unit = {}
 ) : AIAgentBase<Input, Output, AIAgentFunctionalContext>(

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/FunctionalAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/FunctionalAIAgent.kt
@@ -18,7 +18,7 @@ import ai.koog.agents.core.feature.pipeline.AIAgentFunctionalPipeline
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.prompt.executor.model.PromptExecutor
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 /**
  * Represents the core AI agent for processing input and generating output using

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/GraphAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/GraphAIAgent.kt
@@ -20,7 +20,7 @@ import ai.koog.agents.core.feature.pipeline.AIAgentGraphPipeline
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.prompt.executor.model.PromptExecutor
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.reflect.KType
 
 /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/GraphAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/GraphAIAgent.kt
@@ -20,8 +20,8 @@ import ai.koog.agents.core.feature.pipeline.AIAgentGraphPipeline
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.prompt.executor.model.PromptExecutor
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlin.time.Clock
 import kotlin.reflect.KType
+import kotlin.time.Clock
 
 /**
  * Represents an implementation of an AI agent that provides functionalities to execute prompts,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/GraphAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/GraphAIAgent.kt
@@ -55,7 +55,7 @@ public open class GraphAIAgent<Input, Output>(
     override val strategy: AIAgentGraphStrategy<Input, Output>,
     public val toolRegistry: ToolRegistry = ToolRegistry.EMPTY,
     id: String? = null,
-    public val clock: Clock = kotlin.time.Clock.System,
+    public val clock: Clock = Clock.System,
     @property:InternalAgentsApi
     public val installFeatures: FeatureContext.() -> Unit = {}
 ) : AIAgentBase<Input, Output, AIAgentGraphContextBase>(

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
@@ -14,7 +14,7 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.jvm.JvmName
 
 /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
@@ -14,8 +14,8 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
-import kotlin.time.Clock
 import kotlin.jvm.JvmName
+import kotlin.time.Clock
 
 /**
  * Represents the context for an AI agent LLM, managing tools, prompt handling, and interaction with the

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContextAPI.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContextAPI.kt
@@ -14,7 +14,7 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 /**
  * Annotation for marking APIs as detached prompt executors within the `AIAgentLLMContext`.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContextImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContextImpl.kt
@@ -15,7 +15,7 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 internal class AIAgentLLMContextImpl(
     override var tools: List<ToolDescriptor>,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
@@ -25,10 +25,10 @@ import ai.koog.prompt.structure.StructureDefinition
 import ai.koog.prompt.structure.StructuredRequestConfig
 import ai.koog.prompt.structure.StructuredResponse
 import kotlinx.coroutines.flow.Flow
-import kotlin.time.Clock
 import kotlinx.serialization.KSerializer
 import kotlin.jvm.JvmName
 import kotlin.reflect.KClass
+import kotlin.time.Clock
 
 /**
  * A session for managing interactions with a language learning model (LLM)

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
@@ -25,7 +25,7 @@ import ai.koog.prompt.structure.StructureDefinition
 import ai.koog.prompt.structure.StructuredRequestConfig
 import ai.koog.prompt.structure.StructuredResponse
 import kotlinx.coroutines.flow.Flow
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.KSerializer
 import kotlin.jvm.JvmName
 import kotlin.reflect.KClass

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionAPI.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionAPI.kt
@@ -19,9 +19,9 @@ import ai.koog.prompt.structure.StructureDefinition
 import ai.koog.prompt.structure.StructuredRequestConfig
 import ai.koog.prompt.structure.StructuredResponse
 import kotlinx.coroutines.flow.Flow
-import kotlin.time.Clock
 import kotlinx.serialization.KSerializer
 import kotlin.reflect.KClass
+import kotlin.time.Clock
 
 /**
  * API of the [AIAgentLLMWriteSession]

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionAPI.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionAPI.kt
@@ -19,7 +19,7 @@ import ai.koog.prompt.structure.StructureDefinition
 import ai.koog.prompt.structure.StructuredRequestConfig
 import ai.koog.prompt.structure.StructuredResponse
 import kotlinx.coroutines.flow.Flow
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.KSerializer
 import kotlin.reflect.KClass
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionImpl.kt
@@ -28,11 +28,11 @@ import ai.koog.prompt.structure.StructuredResponse
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flow
-import kotlin.time.Clock
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 import kotlin.jvm.JvmName
 import kotlin.reflect.KClass
+import kotlin.time.Clock
 
 @PublishedApi
 internal class AIAgentLLMWriteSessionImpl internal constructor(

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionImpl.kt
@@ -28,7 +28,7 @@ import ai.koog.prompt.structure.StructuredResponse
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flow
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 import kotlin.jvm.JvmName

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentLLMActions.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentLLMActions.kt
@@ -3,7 +3,7 @@ package ai.koog.agents.core.dsl.extension
 import ai.koog.agents.core.agent.session.AIAgentLLMWriteSession
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.params.LLMParams
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 /**
  * Clears the history of messages in the current AI Agent LLM Write Session.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/DefaultHistoryCompressionStrategies.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/DefaultHistoryCompressionStrategies.kt
@@ -2,7 +2,7 @@ package ai.koog.agents.core.dsl.extension
 
 import ai.koog.agents.core.agent.session.AIAgentLLMWriteSession
 import ai.koog.prompt.message.Message
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlin.collections.chunked
 
 /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/DefaultHistoryCompressionStrategies.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/DefaultHistoryCompressionStrategies.kt
@@ -2,8 +2,8 @@ package ai.koog.agents.core.dsl.extension
 
 import ai.koog.agents.core.agent.session.AIAgentLLMWriteSession
 import ai.koog.prompt.message.Message
-import kotlin.time.Instant
 import kotlin.collections.chunked
+import kotlin.time.Instant
 
 /**
  * WholeHistory is a concrete implementation of the HistoryCompressionStrategy

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/HistoryCompressionStrategy.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/HistoryCompressionStrategy.kt
@@ -4,7 +4,7 @@ import ai.koog.agents.annotations.KtLintIgnoreNaming
 import ai.koog.agents.core.agent.session.AIAgentLLMWriteSession
 import ai.koog.agents.core.prompt.Prompts.summarizeInTLDR
 import ai.koog.prompt.message.Message
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/HistoryCompressionStrategy.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/HistoryCompressionStrategy.kt
@@ -4,9 +4,9 @@ import ai.koog.agents.annotations.KtLintIgnoreNaming
 import ai.koog.agents.core.agent.session.AIAgentLLMWriteSession
 import ai.koog.agents.core.prompt.Prompts.summarizeInTLDR
 import ai.koog.prompt.message.Message
-import kotlin.time.Instant
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
+import kotlin.time.Instant
 
 /**
  * Represents an abstract strategy for compressing the history of messages in a `AIAgentLLMWriteSession`.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/ReceivedToolResult.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/ReceivedToolResult.kt
@@ -36,7 +36,7 @@ public data class ReceivedToolResult(
      * @param clock The clock to use for generating the timestamp in the metadata. Defaults to `Clock.System`.
      * @return A `Message.Tool.Result` instance representing the tool result with the current data and metadata.
      */
-    public fun toMessage(clock: Clock = kotlin.time.Clock.System): Message.Tool.Result = Message.Tool.Result(
+    public fun toMessage(clock: Clock = Clock.System): Message.Tool.Result = Message.Tool.Result(
         id = id,
         tool = tool,
         content = content,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/ReceivedToolResult.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/ReceivedToolResult.kt
@@ -4,7 +4,7 @@ import ai.koog.agents.core.tools.ToolResult
 import ai.koog.prompt.dsl.PromptBuilder
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/ReceivedToolResult.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/ReceivedToolResult.kt
@@ -4,10 +4,10 @@ import ai.koog.agents.core.tools.ToolResult
 import ai.koog.prompt.dsl.PromptBuilder
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
-import kotlin.time.Clock
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlin.time.Clock
 
 /**
  * Represents the result or response received from a tool operation.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/SafeTool.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/SafeTool.kt
@@ -5,8 +5,8 @@ package ai.koog.agents.core.environment
 import ai.koog.agents.core.tools.Tool
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
-import kotlin.time.Clock
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Clock
 
 /**
  * A wrapper class designed to safely execute a tool within a given AI agent environment.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/SafeTool.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/SafeTool.kt
@@ -5,7 +5,7 @@ package ai.koog.agents.core.environment
 import ai.koog.agents.core.tools.Tool
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.coroutines.cancellation.CancellationException
 
 /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/FeatureStringMessage.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/FeatureStringMessage.kt
@@ -2,6 +2,7 @@ package ai.koog.agents.core.feature.model
 
 import ai.koog.agents.core.feature.message.FeatureMessage
 import kotlinx.serialization.Serializable
+import kotlin.time.Clock
 
 /**
  * Represents a detailed implementation of [ai.koog.agents.core.feature.message.FeatureMessage] that encapsulates a string message.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/FeatureStringMessage.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/FeatureStringMessage.kt
@@ -21,7 +21,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 public data class FeatureStringMessage(
     val message: String,
-    override val timestamp: Long = kotlin.time.Clock.System.now().toEpochMilliseconds()
+    override val timestamp: Long = Clock.System.now().toEpochMilliseconds()
 ) : FeatureMessage {
 
     /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentFunctionalPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentFunctionalPipeline.kt
@@ -3,7 +3,7 @@ package ai.koog.agents.core.feature.pipeline
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.feature.AIAgentFunctionalFeature
 import ai.koog.agents.core.feature.config.FeatureConfig
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 /**
  * Represents a specific implementation of an AI agent pipeline

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentFunctionalPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentFunctionalPipeline.kt
@@ -16,7 +16,7 @@ import kotlin.time.Clock
  */
 public class AIAgentFunctionalPipeline(
     agentConfig: AIAgentConfig,
-    clock: Clock = kotlin.time.Clock.System
+    clock: Clock = Clock.System
 ) : AIAgentPipeline(agentConfig, clock) {
     /**
      * Installs a non-graph feature into the pipeline with the provided configuration.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
@@ -17,8 +17,8 @@ import ai.koog.agents.core.feature.handler.node.NodeExecutionStartingContext
 import ai.koog.agents.core.feature.handler.subgraph.SubgraphExecutionCompletedContext
 import ai.koog.agents.core.feature.handler.subgraph.SubgraphExecutionFailedContext
 import ai.koog.agents.core.feature.handler.subgraph.SubgraphExecutionStartingContext
-import kotlin.time.Clock
 import kotlin.reflect.KType
+import kotlin.time.Clock
 
 /**
  * Represents a pipeline for AI agent graph execution, extending the functionality of `AIAgentPipeline`.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
@@ -28,7 +28,7 @@ import kotlin.time.Clock
  */
 public expect open class AIAgentGraphPipeline(
     agentConfig: AIAgentConfig,
-    clock: Clock = kotlin.time.Clock.System,
+    clock: Clock = Clock.System,
     basePipelineDelegate: AIAgentPipelineImpl = AIAgentPipelineImpl(agentConfig, clock)
 ) : AIAgentPipeline, AIAgentGraphPipelineAPI {
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
@@ -17,7 +17,7 @@ import ai.koog.agents.core.feature.handler.node.NodeExecutionStartingContext
 import ai.koog.agents.core.feature.handler.subgraph.SubgraphExecutionCompletedContext
 import ai.koog.agents.core.feature.handler.subgraph.SubgraphExecutionFailedContext
 import ai.koog.agents.core.feature.handler.subgraph.SubgraphExecutionStartingContext
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.reflect.KType
 
 /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
@@ -37,11 +37,11 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.streaming.StreamFrame
-import kotlin.time.Clock
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
+import kotlin.time.Clock
 
 /**
  * Pipeline for AI agent features that provides interception points for various agent lifecycle events.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
@@ -37,7 +37,7 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.streaming.StreamFrame
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlin.reflect.KClass

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineAPI.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineAPI.kt
@@ -37,11 +37,11 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.streaming.StreamFrame
-import kotlin.time.Clock
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
+import kotlin.time.Clock
 
 /**
  * Platform-agnostic API for agent pipelines. Implemented by both the expect/actual AIAgentPipeline

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineAPI.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineAPI.kt
@@ -37,7 +37,7 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.streaming.StreamFrame
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlin.reflect.KClass

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineImpl.kt
@@ -46,12 +46,12 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.streaming.StreamFrame
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlin.time.Clock
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.safeCast
+import kotlin.time.Clock
 
 /**
  * Default implementation of [AIAgentPipelineAPI]

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineImpl.kt
@@ -46,7 +46,7 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.streaming.StreamFrame
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlin.reflect.KClass

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
@@ -3,7 +3,7 @@ package ai.koog.agents.core.feature.pipeline
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.feature.AIAgentPlannerFeature
 import ai.koog.agents.core.feature.config.FeatureConfig
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 /**
  * Represents a specific implementation of an AI agent pipeline that uses a planner approach.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
@@ -10,7 +10,7 @@ import kotlin.time.Clock
  *
  * @property clock The clock used for time-based operations within the pipeline
  */
-public class AIAgentPlannerPipeline(agentConfig: AIAgentConfig, clock: Clock = kotlin.time.Clock.System) :
+public class AIAgentPlannerPipeline(agentConfig: AIAgentConfig, clock: Clock = Clock.System) :
     AIAgentPipeline(agentConfig, clock) {
     /**
      * Installs a non-graph feature into the pipeline with the provided configuration.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/PlannerAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/PlannerAIAgent.kt
@@ -18,8 +18,8 @@ import ai.koog.agents.core.feature.pipeline.AIAgentPlannerPipeline
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.prompt.executor.model.PromptExecutor
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlin.time.Clock
 import kotlin.jvm.JvmStatic
+import kotlin.time.Clock
 
 /**
  * Represents an instance of planner agent using [AIAgentPlannerStrategy].

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/PlannerAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/PlannerAIAgent.kt
@@ -41,7 +41,7 @@ public class PlannerAIAgent<Input, Output>(
     override val strategy: AIAgentPlannerStrategy<Input, Output, *>,
     public val toolRegistry: ToolRegistry = ToolRegistry.EMPTY,
     id: String? = null,
-    public val clock: Clock = kotlin.time.Clock.System,
+    public val clock: Clock = Clock.System,
     @property:InternalAgentsApi
     public val installFeatures: FeatureContext.() -> Unit = {}
 ) : AIAgentBase<Input, Output, AIAgentPlannerContext>(

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/PlannerAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/PlannerAIAgent.kt
@@ -18,7 +18,7 @@ import ai.koog.agents.core.feature.pipeline.AIAgentPlannerPipeline
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.prompt.executor.model.PromptExecutor
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.jvm.JvmStatic
 
 /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/PlannerAIAgentBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/PlannerAIAgentBuilder.kt
@@ -30,7 +30,7 @@ public class PlannerAIAgentBuilder<Input, Output>(
     private var missingToolsConversionStrategy: MissingToolsConversionStrategy =
         MissingToolsConversionStrategy.Missing(ToolCallDescriber.JSON)
     private var maxIterations: Int = 50
-    private var clock: Clock = kotlin.time.Clock.System
+    private var clock: Clock = Clock.System
     private var featureInstallers: MutableList<(PlannerAIAgent.FeatureContext.() -> Unit)> = mutableListOf()
 
     /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/PlannerAIAgentBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/PlannerAIAgentBuilder.kt
@@ -12,7 +12,7 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 /**
  * A builder for creating [PlannerAIAgent] instances.

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/dsl/extension/TestLLMExecutor.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/dsl/extension/TestLLMExecutor.kt
@@ -12,11 +12,12 @@ import ai.koog.prompt.streaming.toStreamFrames
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlin.time.Clock
+import kotlin.time.Instant
 
 class TestLLMExecutor : PromptExecutor() {
     companion object {
         val testClock: Clock = object : Clock {
-            override fun now(): kotlin.time.Instant = kotlin.time.Instant.parse("2023-01-01T00:00:00Z")
+            override fun now(): Instant = Instant.parse("2023-01-01T00:00:00Z")
         }
 
         const val DEFAULT_ASSISTANT_RESPONSE = "Default test response"

--- a/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
+++ b/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
@@ -13,7 +13,7 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
 import ai.koog.utils.io.Closeable
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
 
 @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT")

--- a/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilder.kt
+++ b/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilder.kt
@@ -16,7 +16,7 @@ import ai.koog.agents.planner.TypedAgentPlannerStrategyBuilder
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual class AIAgentBuilder internal actual constructor() : AIAgentBuilderAPI by AIAgentBuilderImpl() {
     private val delegate: AIAgentBuilderImpl = AIAgentBuilderImpl()

--- a/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
+++ b/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
@@ -9,7 +9,7 @@ import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual abstract class AIAgentService<Input, Output, TAgent : AIAgent<Input, Output>> actual constructor() {
     public actual abstract val promptExecutor: PromptExecutor

--- a/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
+++ b/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
@@ -12,7 +12,7 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual open class AIAgentLLMContext internal actual constructor(
     internal actual val delegate: AIAgentLLMContextImpl

--- a/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
+++ b/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
@@ -15,7 +15,7 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
 import ai.koog.prompt.structure.StructuredResponse
 import kotlinx.coroutines.flow.Flow
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.reflect.KClass
 
 public actual class AIAgentLLMWriteSession internal constructor(

--- a/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
+++ b/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
@@ -15,8 +15,8 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
 import ai.koog.prompt.structure.StructuredResponse
 import kotlinx.coroutines.flow.Flow
-import kotlin.time.Clock
 import kotlin.reflect.KClass
+import kotlin.time.Clock
 
 public actual class AIAgentLLMWriteSession internal constructor(
     @PublishedApi internal actual val delegate: AIAgentLLMWriteSessionImpl

--- a/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
+++ b/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
@@ -7,7 +7,7 @@ import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.feature.AIAgentGraphFeature
 import ai.koog.agents.core.feature.config.FeatureConfig
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual open class AIAgentGraphPipeline actual constructor(
     agentConfig: AIAgentConfig,

--- a/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
+++ b/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
@@ -3,7 +3,7 @@
 package ai.koog.agents.core.feature.pipeline
 
 import ai.koog.agents.core.agent.config.AIAgentConfig
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual abstract class AIAgentPipeline actual constructor(
     agentConfig: AIAgentConfig,

--- a/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
+++ b/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
@@ -17,7 +17,7 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
 import ai.koog.utils.io.Closeable
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import java.util.concurrent.ExecutorService
 import kotlin.uuid.ExperimentalUuidApi
 

--- a/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
+++ b/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
@@ -17,8 +17,8 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
 import ai.koog.utils.io.Closeable
-import kotlin.time.Clock
 import java.util.concurrent.ExecutorService
+import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
 
 @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT")

--- a/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
+++ b/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
@@ -12,7 +12,7 @@ import ai.koog.agents.core.utils.runOnStrategyDispatcher
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import java.util.concurrent.ExecutorService
 
 public actual abstract class AIAgentService<Input, Output, TAgent : AIAgent<Input, Output>> {

--- a/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
+++ b/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
@@ -12,8 +12,8 @@ import ai.koog.agents.core.utils.runOnStrategyDispatcher
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
-import kotlin.time.Clock
 import java.util.concurrent.ExecutorService
+import kotlin.time.Clock
 
 public actual abstract class AIAgentService<Input, Output, TAgent : AIAgent<Input, Output>> {
     public actual abstract val promptExecutor: PromptExecutor

--- a/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
+++ b/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
@@ -55,7 +55,7 @@ public actual abstract class AIAgentService<Input, Output, TAgent : AIAgent<Inpu
         additionalToolRegistry: ToolRegistry = ToolRegistry.EMPTY,
         agentConfig: AIAgentConfig = this.agentConfig,
         executorService: ExecutorService? = null,
-        clock: Clock = kotlin.time.Clock.System
+        clock: Clock = Clock.System
     ): TAgent = agentConfig.runOnStrategyDispatcher(executorService) {
         createAgent(id, additionalToolRegistry, agentConfig, clock)
     }

--- a/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
+++ b/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
@@ -17,8 +17,8 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
-import kotlin.time.Clock
 import java.util.function.Function
+import kotlin.time.Clock
 
 public actual open class AIAgentLLMContext internal actual constructor(
     internal actual val delegate: AIAgentLLMContextImpl

--- a/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
+++ b/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
@@ -17,7 +17,7 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import java.util.function.Function
 
 public actual open class AIAgentLLMContext internal actual constructor(

--- a/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/feature/pipeline/AIAgentGraphPipeline.kt
+++ b/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/feature/pipeline/AIAgentGraphPipeline.kt
@@ -15,7 +15,7 @@ import ai.koog.agents.core.feature.handler.subgraph.SubgraphExecutionCompletedCo
 import ai.koog.agents.core.feature.handler.subgraph.SubgraphExecutionFailedContext
 import ai.koog.agents.core.feature.handler.subgraph.SubgraphExecutionStartingContext
 import ai.koog.agents.core.utils.submitToMainDispatcher
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual open class AIAgentGraphPipeline @JvmOverloads actual constructor(
     agentConfig: AIAgentConfig,

--- a/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/feature/pipeline/AIAgentPipeline.kt
+++ b/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/feature/pipeline/AIAgentPipeline.kt
@@ -26,7 +26,7 @@ import ai.koog.agents.core.feature.handler.tool.ToolCallFailedContext
 import ai.koog.agents.core.feature.handler.tool.ToolCallStartingContext
 import ai.koog.agents.core.feature.handler.tool.ToolValidationFailedContext
 import ai.koog.agents.core.utils.submitToMainDispatcher
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual abstract class AIAgentPipeline actual constructor(
     agentConfig: AIAgentConfig,

--- a/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
+++ b/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
@@ -24,7 +24,7 @@ import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.structure.StructuredRequestConfig
 import ai.koog.prompt.structure.StructuredResponse
 import kotlinx.coroutines.flow.Flow
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.KSerializer
 import java.util.concurrent.ExecutorService
 import kotlin.reflect.KClass

--- a/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
+++ b/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
@@ -24,10 +24,10 @@ import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.structure.StructuredRequestConfig
 import ai.koog.prompt.structure.StructuredResponse
 import kotlinx.coroutines.flow.Flow
-import kotlin.time.Clock
 import kotlinx.serialization.KSerializer
 import java.util.concurrent.ExecutorService
 import kotlin.reflect.KClass
+import kotlin.time.Clock
 
 @Suppress("DELEGATED_MEMBER_HIDES_SUPERTYPE_OVERRIDE")
 public actual class AIAgentLLMWriteSession internal constructor(

--- a/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/environment/SafeTool.jvm.kt
+++ b/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/environment/SafeTool.jvm.kt
@@ -7,9 +7,9 @@ import ai.koog.agents.core.tools.reflect.ToolFromCallable
 import ai.koog.agents.core.tools.reflect.asTool
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
-import kotlin.time.Clock
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.reflect.KFunction
+import kotlin.time.Clock
 
 /**
  * A wrapper class that creates a safer abstraction for executing a tool function alongside an associated environment.

--- a/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/environment/SafeTool.jvm.kt
+++ b/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/environment/SafeTool.jvm.kt
@@ -7,7 +7,7 @@ import ai.koog.agents.core.tools.reflect.ToolFromCallable
 import ai.koog.agents.core.tools.reflect.asTool
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.reflect.KFunction
 

--- a/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
+++ b/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt
@@ -13,7 +13,7 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
 import ai.koog.utils.io.Closeable
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
 
 @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT")

--- a/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilder.kt
+++ b/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilder.kt
@@ -16,7 +16,7 @@ import ai.koog.agents.planner.TypedAgentPlannerStrategyBuilder
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual class AIAgentBuilder internal actual constructor() : AIAgentBuilderAPI {
     private val delegate: AIAgentBuilderImpl = AIAgentBuilderImpl()

--- a/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
+++ b/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
@@ -9,7 +9,7 @@ import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual abstract class AIAgentService<Input, Output, TAgent : AIAgent<Input, Output>> actual constructor() {
     public actual abstract val promptExecutor: PromptExecutor

--- a/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
+++ b/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
@@ -12,7 +12,7 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual open class AIAgentLLMContext internal actual constructor(
     internal actual val delegate: AIAgentLLMContextImpl

--- a/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
+++ b/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
@@ -15,7 +15,7 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
 import ai.koog.prompt.structure.StructuredResponse
 import kotlinx.coroutines.flow.Flow
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.reflect.KClass
 
 public actual class AIAgentLLMWriteSession internal constructor(

--- a/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
+++ b/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSession.kt
@@ -15,8 +15,8 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
 import ai.koog.prompt.structure.StructuredResponse
 import kotlinx.coroutines.flow.Flow
-import kotlin.time.Clock
 import kotlin.reflect.KClass
+import kotlin.time.Clock
 
 public actual class AIAgentLLMWriteSession internal constructor(
     @PublishedApi internal actual val delegate: AIAgentLLMWriteSessionImpl

--- a/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
+++ b/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
@@ -7,7 +7,7 @@ import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.feature.AIAgentGraphFeature
 import ai.koog.agents.core.feature.config.FeatureConfig
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual open class AIAgentGraphPipeline actual constructor(
     agentConfig: AIAgentConfig,

--- a/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
+++ b/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
@@ -3,7 +3,7 @@
 package ai.koog.agents.core.feature.pipeline
 
 import ai.koog.agents.core.agent.config.AIAgentConfig
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual abstract class AIAgentPipeline actual constructor(
     agentConfig: AIAgentConfig,

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/StructuredOutputWithToolsIntegrationTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/StructuredOutputWithToolsIntegrationTest.kt
@@ -197,7 +197,7 @@ class StructuredOutputWithToolsIntegrationTest {
         }
 
         val toolCallTimestamps = mutableMapOf<String, Long>()
-        val currentTime = kotlin.time.Clock.System.now().toEpochMilliseconds()
+        val currentTime = Clock.System.now().toEpochMilliseconds()
 
         val mockExecutor = getMockExecutor {
             // Return structured output

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/StructuredOutputWithToolsIntegrationTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/StructuredOutputWithToolsIntegrationTest.kt
@@ -17,6 +17,7 @@ import kotlinx.serialization.Serializable
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.time.Clock
 
 class StructuredOutputWithToolsIntegrationTest {
 

--- a/agents/agents-features/agents-features-a2a-core/src/commonMain/kotlin/ai/koog/agents/a2a/core/MessageConverters.kt
+++ b/agents/agents-features/agents-features-a2a-core/src/commonMain/kotlin/ai/koog/agents/a2a/core/MessageConverters.kt
@@ -31,7 +31,7 @@ public typealias A2AMessage = ai.koog.a2a.model.Message
  * @param clock The clock to use for the timestamp. Defaults to [Clock.System].
  */
 public fun A2AMessage.toKoogMessage(
-    clock: Clock = kotlin.time.Clock.System,
+    clock: Clock = Clock.System,
 ): Message {
     // Create metadata
     val metadata = JsonObject(emptyMap()).withA2AMetadata(

--- a/agents/agents-features/agents-features-a2a-core/src/commonMain/kotlin/ai/koog/agents/a2a/core/MessageConverters.kt
+++ b/agents/agents-features/agents-features-a2a-core/src/commonMain/kotlin/ai/koog/agents/a2a/core/MessageConverters.kt
@@ -12,7 +12,7 @@ import ai.koog.prompt.message.ContentPart
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.message.ResponseMetaInfo
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.json.JsonObject
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid

--- a/agents/agents-features/agents-features-a2a-core/src/commonMain/kotlin/ai/koog/agents/a2a/core/MessageConverters.kt
+++ b/agents/agents-features/agents-features-a2a-core/src/commonMain/kotlin/ai/koog/agents/a2a/core/MessageConverters.kt
@@ -12,8 +12,8 @@ import ai.koog.prompt.message.ContentPart
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.message.ResponseMetaInfo
-import kotlin.time.Clock
 import kotlinx.serialization.json.JsonObject
+import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 

--- a/agents/agents-features/agents-features-acp/src/jvmMain/kotlin/ai/koog/agents/features/acp/MessageConverters.kt
+++ b/agents/agents-features/agents-features-acp/src/jvmMain/kotlin/ai/koog/agents/features/acp/MessageConverters.kt
@@ -12,7 +12,7 @@ import com.agentclientprotocol.model.SessionUpdate
 import com.agentclientprotocol.model.SessionUpdate.AgentMessageChunk
 import com.agentclientprotocol.model.ToolCallId
 import com.agentclientprotocol.model.ToolCallStatus
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 /** Constant to use for an unknown content part format */
 public const val UNKNOWN_FORMAT: String = "unknown"

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerTest.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerTest.kt
@@ -27,13 +27,13 @@ import ai.koog.utils.io.use
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
-import kotlin.time.Instant
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.time.Instant
 
 class EventHandlerTest {
 

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerTest.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerTest.kt
@@ -27,7 +27,7 @@ import ai.koog.utils.io.use
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.Test

--- a/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/AgentMemory.kt
+++ b/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/AgentMemory.kt
@@ -36,7 +36,7 @@ import ai.koog.prompt.structure.StructuredRequest
 import ai.koog.prompt.structure.StructuredRequestConfig
 import ai.koog.prompt.structure.json.JsonStructure
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.Serializable
 
 /**

--- a/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/AgentMemory.kt
+++ b/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/AgentMemory.kt
@@ -36,8 +36,8 @@ import ai.koog.prompt.structure.StructuredRequest
 import ai.koog.prompt.structure.StructuredRequestConfig
 import ai.koog.prompt.structure.json.JsonStructure
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlin.time.Clock
 import kotlinx.serialization.Serializable
+import kotlin.time.Clock
 
 /**
  * Memory implementation for AI agents that provides persistent storage and retrieval of facts.

--- a/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/AgentMemory.kt
+++ b/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/AgentMemory.kt
@@ -458,7 +458,7 @@ public class AgentMemory(
 @OptIn(InternalAgentsApi::class)
 public suspend fun AIAgentLLMWriteSession.retrieveFactsFromHistory(
     concept: Concept,
-    clock: Clock = kotlin.time.Clock.System,
+    clock: Clock = Clock.System,
 ): Fact {
     @Serializable
     @LLMDescription("Fact text")

--- a/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/nodes/MemoryNodes.kt
+++ b/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/nodes/MemoryNodes.kt
@@ -14,7 +14,7 @@ import ai.koog.agents.memory.model.MultipleFacts
 import ai.koog.agents.memory.model.SingleFact
 import ai.koog.agents.memory.prompts.MemoryPrompts
 import ai.koog.prompt.llm.LLModel
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 

--- a/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/nodes/MemoryNodes.kt
+++ b/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/nodes/MemoryNodes.kt
@@ -14,9 +14,9 @@ import ai.koog.agents.memory.model.MultipleFacts
 import ai.koog.agents.memory.model.SingleFact
 import ai.koog.agents.memory.prompts.MemoryPrompts
 import ai.koog.prompt.llm.LLModel
-import kotlin.time.Clock
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlin.time.Clock
 
 // ==========
 // Memory nodes

--- a/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/nodes/MemoryNodes.kt
+++ b/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/memory/feature/nodes/MemoryNodes.kt
@@ -208,7 +208,7 @@ internal data class SubjectWithFact(
 @InternalAgentsApi
 public fun parseFactsFromResponse(
     content: String,
-    clock: Clock = kotlin.time.Clock.System,
+    clock: Clock = Clock.System,
 ): List<Pair<MemorySubject, Fact>> {
     val parsedFacts = Json.decodeFromString<List<SubjectWithFact>>(content)
     val groupedFacts = parsedFacts.groupBy { it.subject to it.keyword }

--- a/agents/agents-features/agents-features-memory/src/jvmTest/kotlin/ai/koog/agents/chatMemory/ChatMemoryTest.kt
+++ b/agents/agents-features/agents-features-memory/src/jvmTest/kotlin/ai/koog/agents/chatMemory/ChatMemoryTest.kt
@@ -11,11 +11,11 @@ import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.message.ResponseMetaInfo
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Instant
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
+import kotlin.time.Instant
 
 class ChatMemoryTest {
 

--- a/agents/agents-features/agents-features-memory/src/jvmTest/kotlin/ai/koog/agents/chatMemory/JavaTestHelpers.kt
+++ b/agents/agents-features/agents-features-memory/src/jvmTest/kotlin/ai/koog/agents/chatMemory/JavaTestHelpers.kt
@@ -12,7 +12,6 @@ object JavaTestHelpers {
 
     /**
      * Creates a [MockLLMBuilder] using the system clock.
-     * This avoids Java tests needing to import [kotlinx.datetime.Clock] directly.
      */
     @JvmStatic
     fun createMockLLMBuilder(): MockLLMBuilder = MockLLMBuilder(Clock.System)

--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/AgentCheckpointData.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/AgentCheckpointData.kt
@@ -8,11 +8,11 @@ import ai.koog.agents.core.agent.context.RollbackStrategy
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.snapshot.providers.PersistenceUtils
 import ai.koog.prompt.message.Message
-import kotlin.time.Instant
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonPrimitive
+import kotlin.time.Instant
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 

--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/AgentCheckpointData.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/AgentCheckpointData.kt
@@ -8,7 +8,7 @@ import ai.koog.agents.core.agent.context.RollbackStrategy
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.snapshot.providers.PersistenceUtils
 import ai.koog.prompt.message.Message
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull

--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/Persistence.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/Persistence.kt
@@ -19,7 +19,7 @@ import ai.koog.agents.core.utils.SerializationUtils
 import ai.koog.agents.snapshot.providers.PersistenceStorageProvider
 import ai.koog.prompt.message.Message
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.json.JsonElement
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.reflect.KType

--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/Persistence.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/Persistence.kt
@@ -19,12 +19,12 @@ import ai.koog.agents.core.utils.SerializationUtils
 import ai.koog.agents.snapshot.providers.PersistenceStorageProvider
 import ai.koog.prompt.message.Message
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlin.time.Instant
 import kotlinx.serialization.json.JsonElement
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.reflect.KType
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 

--- a/agents/agents-features/agents-features-sql/src/commonMain/kotlin/ai/koog/agents/features/sql/providers/SQLPersistencyStorageProvider.kt
+++ b/agents/agents-features/agents-features-sql/src/commonMain/kotlin/ai/koog/agents/features/sql/providers/SQLPersistencyStorageProvider.kt
@@ -1,7 +1,7 @@
 package ai.koog.agents.features.sql.providers
 
 import ai.koog.agents.snapshot.providers.PersistenceStorageProvider
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlin.jvm.JvmOverloads
 
 /**

--- a/agents/agents-features/agents-features-sql/src/commonMain/kotlin/ai/koog/agents/features/sql/providers/SQLPersistencyStorageProvider.kt
+++ b/agents/agents-features/agents-features-sql/src/commonMain/kotlin/ai/koog/agents/features/sql/providers/SQLPersistencyStorageProvider.kt
@@ -1,8 +1,8 @@
 package ai.koog.agents.features.sql.providers
 
 import ai.koog.agents.snapshot.providers.PersistenceStorageProvider
-import kotlin.time.Instant
 import kotlin.jvm.JvmOverloads
+import kotlin.time.Instant
 
 /**
  * Abstract base class for SQL-based implementations of [PersistenceStorageProvider].

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/feature/TestingFeature.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/feature/TestingFeature.kt
@@ -419,7 +419,7 @@ public class Testing {
          * This enables test scenarios that require precise control over time
          * by allowing the use of custom clock instances, such as mock or fixed clocks.
          */
-        public var clock: Clock = kotlin.time.Clock.System
+        public var clock: Clock = Clock.System
 
         /**
          * Defines the tokenizer to be used for estimating token counts in text strings.

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMBuilder.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMBuilder.kt
@@ -1032,7 +1032,7 @@ public open class DefaultResponseReceiver(
  */
 public fun getMockExecutor(
     toolRegistry: ToolRegistry? = null,
-    clock: Clock = kotlin.time.Clock.System,
+    clock: Clock = Clock.System,
     tokenizer: Tokenizer? = null,
     handleLastAssistantMessage: Boolean = false,
     init: MockLLMBuilder.() -> Unit

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMExecutor.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMExecutor.kt
@@ -65,7 +65,7 @@ internal class MockLLMExecutor(
     private val toolRegistry: ToolRegistry? = null,
     private val logger: KLogger = KotlinLogging.logger(MockLLMExecutor::class.simpleName.toString()),
     val toolActions: List<ToolCondition<*, *>> = emptyList(),
-    private val clock: Clock = kotlin.time.Clock.System,
+    private val clock: Clock = Clock.System,
     private val tokenizer: Tokenizer? = null
 ) : PromptExecutor() {
 

--- a/agents/agents-test/src/jvmMain/kotlin/ai/koog/agents/testing/tools/MockExecutorBuilder.kt
+++ b/agents/agents-test/src/jvmMain/kotlin/ai/koog/agents/testing/tools/MockExecutorBuilder.kt
@@ -43,7 +43,7 @@ public class MockExecutorBuilder internal constructor() {
      * facilitate fine-grained control over time during executions, enabling scenarios such as testing
      * time-sensitive logic or simulating specific timestamps.
      */
-    private var clock: kotlin.time.Clock = kotlin.time.Clock.System
+    private var clock: kotlin.time.Clock = Clock.System
 
     /**
      * Holds the instance of the `Tokenizer` interface used for tokenizing text and counting tokens.

--- a/agents/agents-tools/build.gradle.kts
+++ b/agents/agents-tools/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(kotlin("test"))
+                implementation(libs.kotlinx.datetime)
                 implementation(libs.kotlinx.coroutines.test)
             }
         }

--- a/examples/acp-agent/src/main/kotlin/ai/coding/agent/AcpAgent.kt
+++ b/examples/acp-agent/src/main/kotlin/ai/coding/agent/AcpAgent.kt
@@ -8,7 +8,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.io.asSink
 import kotlinx.io.asSource
 import kotlinx.io.buffered

--- a/examples/acp-agent/src/main/kotlin/ai/coding/agent/KoogAgentSupport.kt
+++ b/examples/acp-agent/src/main/kotlin/ai/coding/agent/KoogAgentSupport.kt
@@ -31,7 +31,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.json.JsonElement
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid

--- a/examples/acp-agent/src/main/kotlin/ai/coding/app/PipeApp.kt
+++ b/examples/acp-agent/src/main/kotlin/ai/coding/app/PipeApp.kt
@@ -9,7 +9,7 @@ import com.agentclientprotocol.transport.StdioTransport
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.io.asSink
 import kotlinx.io.asSource
 import kotlinx.io.buffered

--- a/examples/code-agent/step-04-add-subagent/gradle/libs.versions.toml
+++ b/examples/code-agent/step-04-add-subagent/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.2.20"
+kotlin = "2.3.10"
 kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.8.1"
 logback = "1.5.13"

--- a/examples/code-agent/step-05-history/gradle/libs.versions.toml
+++ b/examples/code-agent/step-05-history/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.2.20"
+kotlin = "2.3.10"
 kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.8.1"
 logback = "1.5.13"

--- a/examples/devoxx-belgium-2025/src/main/kotlin/ai/koog/spring/sandwich/agents/KoogAgentService.kt
+++ b/examples/devoxx-belgium-2025/src/main/kotlin/ai/koog/spring/sandwich/agents/KoogAgentService.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newFixedThreadPoolContext
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.Serializable
 import org.springframework.boot.info.BuildProperties
 import org.springframework.stereotype.Service

--- a/examples/spring-boot-java/pom.xml
+++ b/examples/spring-boot-java/pom.xml
@@ -33,6 +33,7 @@
         <koog.version>0.4.3-develop-20250927-0204</koog.version>
         <!-- Kotlinx-serialization version must be aligned -->
         <kotlinx-serialization.version>1.8.1</kotlinx-serialization.version>
+        <kotlinx-datetime.version>0.7.1</kotlinx-datetime.version>
         <ktor.version>3.2.3</ktor.version>
     </properties>
     <dependencyManagement>
@@ -41,6 +42,13 @@
                 <groupId>org.jetbrains.kotlinx</groupId>
                 <artifactId>kotlinx-serialization-bom</artifactId>
                 <version>${kotlinx-serialization.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlinx</groupId>
+                <artifactId>kotlinx-datetime-jvm</artifactId>
+                <version>${kotlinx-datetime.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/examples/spring-boot-java/src/main/java/com/example/AIService.java
+++ b/examples/spring-boot-java/src/main/java/com/example/AIService.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 @Service
 record AIService(
     @NonNull JavaPromptExecutor executor,
-    kotlinx.datetime.Clock clock
+    kotlin.time.Clock clock
 ) {
 
     private static final Logger log = LoggerFactory.getLogger(AIService.class);

--- a/examples/spring-boot-java/src/main/java/com/example/AIService.java
+++ b/examples/spring-boot-java/src/main/java/com/example/AIService.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 @Service
 record AIService(
     @NonNull JavaPromptExecutor executor,
-    kotlin.time.Clock clock
+    kotlinx.datetime.Clock clock
 ) {
 
     private static final Logger log = LoggerFactory.getLogger(AIService.class);

--- a/examples/spring-boot-java/src/main/java/com/example/Application.java
+++ b/examples/spring-boot-java/src/main/java/com/example/Application.java
@@ -9,8 +9,8 @@ public class Application {
 
     // TODO: Make it work without requiring Kotlin Clock
     @Bean
-    kotlin.time.Clock kotlinClock() {
-        return kotlin.time.Clock.System.INSTANCE;
+    kotlinx.datetime.Clock kotlinClock() {
+        return kotlinx.datetime.Clock.System.INSTANCE;
     }
 
     public static void main(String[] args) {

--- a/examples/spring-boot-java/src/main/java/com/example/Application.java
+++ b/examples/spring-boot-java/src/main/java/com/example/Application.java
@@ -9,8 +9,8 @@ public class Application {
 
     // TODO: Make it work without requiring Kotlin Clock
     @Bean
-    kotlinx.datetime.Clock kotlinClock() {
-        return kotlinx.datetime.Clock.System.INSTANCE;
+    kotlin.time.Clock kotlinClock() {
+        return kotlin.time.Clock.System.INSTANCE;
     }
 
     public static void main(String[] args) {

--- a/examples/trip-planning-example/build.gradle.kts
+++ b/examples/trip-planning-example/build.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
 
     implementation(libs.kotlinx.coroutines.core)
-    implementation(libs.kotlinx.datetime)
 
     implementation(libs.ktor.client.core)
     implementation(libs.ktor.client.cio)

--- a/examples/trip-planning-example/build.gradle.kts
+++ b/examples/trip-planning-example/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
 
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.datetime)
 
     implementation(libs.ktor.client.core)
     implementation(libs.ktor.client.cio)

--- a/examples/trip-planning-example/gradle/libs.versions.toml
+++ b/examples/trip-planning-example/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.1.20"
+kotlin = "2.3.10"
 ktor = "3.1.2"
 coroutines = "1.10.2"
 koog = "0.4.2-feat-1-3"

--- a/examples/trip-planning-example/gradle/libs.versions.toml
+++ b/examples/trip-planning-example/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 kotlin = "2.3.10"
 ktor = "3.1.2"
 coroutines = "1.10.2"
+kotlinx-datetime = "0.7.1"
 koog = "0.4.2-feat-1-3"
 logback = "1.5.13"
 oshai-logging = "7.0.7"
@@ -24,6 +25,9 @@ koog-all = { module = "ai.koog:koog-agents", version.ref = "koog" }
 
 # Coroutines
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
+
+# Datetime
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 
 # Logging
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }

--- a/examples/trip-planning-example/gradle/libs.versions.toml
+++ b/examples/trip-planning-example/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 kotlin = "2.3.10"
 ktor = "3.1.2"
 coroutines = "1.10.2"
-kotlinx-datetime = "0.7.1"
 koog = "0.4.2-feat-1-3"
 logback = "1.5.13"
 oshai-logging = "7.0.7"
@@ -25,9 +24,6 @@ koog-all = { module = "ai.koog:koog-agents", version.ref = "koog" }
 
 # Coroutines
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
-
-# Datetime
-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 
 # Logging
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }

--- a/examples/trip-planning-example/src/main/kotlin/ai/koog/agents/examples/tripplanning/Main.kt
+++ b/examples/trip-planning-example/src/main/kotlin/ai/koog/agents/examples/tripplanning/Main.kt
@@ -9,7 +9,7 @@ import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.llm.LLMProvider
 import io.modelcontextprotocol.kotlin.sdk.client.StdioClientTransport
 import kotlinx.coroutines.delay
-import kotlin.time.Clock
+import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 

--- a/examples/trip-planning-example/src/main/kotlin/ai/koog/agents/examples/tripplanning/Main.kt
+++ b/examples/trip-planning-example/src/main/kotlin/ai/koog/agents/examples/tripplanning/Main.kt
@@ -9,7 +9,7 @@ import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.llm.LLMProvider
 import io.modelcontextprotocol.kotlin.sdk.client.StdioClientTransport
 import kotlinx.coroutines.delay
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 

--- a/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentServiceIntegrationTest.java
+++ b/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentServiceIntegrationTest.java
@@ -9,6 +9,7 @@ import ai.koog.integration.tests.utils.JavaUtils;
 import ai.koog.integration.tests.utils.Models;
 import ai.koog.prompt.llm.LLModel;
 import ai.koog.prompt.message.Message;
+import kotlin.time.Clock;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 

--- a/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentServiceIntegrationTest.java
+++ b/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentServiceIntegrationTest.java
@@ -96,7 +96,7 @@ public class JavaAIAgentServiceIntegrationTest extends KoogJavaTestBase {
 
         ToolRegistry emptyRegistry = ToolRegistry.builder().build();
         String result = service.createAgentAndRun("What is 2+2?", "one-shot-agent",
-            emptyRegistry, service.getAgentConfig(), null,  Clock.System .INSTANCE);
+            emptyRegistry, service.getAgentConfig(), null,  Clock.System.INSTANCE);
 
         assertNotNull(result);
         assertFalse(result.isEmpty());

--- a/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentServiceIntegrationTest.java
+++ b/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentServiceIntegrationTest.java
@@ -95,7 +95,7 @@ public class JavaAIAgentServiceIntegrationTest extends KoogJavaTestBase {
 
         ToolRegistry emptyRegistry = ToolRegistry.builder().build();
         String result = service.createAgentAndRun("What is 2+2?", "one-shot-agent",
-            emptyRegistry, service.getAgentConfig(), null, kotlin.time.Clock.System.INSTANCE);
+            emptyRegistry, service.getAgentConfig(), null,  Clock.System .INSTANCE);
 
         assertNotNull(result);
         assertFalse(result.isEmpty());

--- a/koog-ktor/src/jvmMain/kotlin/ai/koog/ktor/BedrockConfig.kt
+++ b/koog-ktor/src/jvmMain/kotlin/ai/koog/ktor/BedrockConfig.kt
@@ -26,7 +26,7 @@ public class BedrockClientConfig {
     /**
      * Override the clock used for time-based operations.
      */
-    public var clock: Clock = kotlin.time.Clock.System
+    public var clock: Clock = Clock.System
 }
 
 /**
@@ -39,7 +39,7 @@ public class BedrockClientConfig {
  */
 public fun KoogAgentsConfig.bedrock(
     apiKey: String,
-    clock: Clock = kotlin.time.Clock.System,
+    clock: Clock = Clock.System,
     moderationGuardrailsSettings: BedrockGuardrailsSettings? = null,
     configure: BedrockRuntimeClient.Config.Builder.() -> Unit = {}
 ) {
@@ -65,7 +65,7 @@ public fun KoogAgentsConfig.bedrock(
  * @param configure A lambda receiver to customize the OpenAI configuration such as base URL, timeout settings, and paths.
  */
 public fun KoogAgentsConfig.bedrock(
-    clock: Clock = kotlin.time.Clock.System,
+    clock: Clock = Clock.System,
     moderationGuardrailsSettings: BedrockGuardrailsSettings? = null,
     configure: BedrockRuntimeClient.Config.Builder.() -> Unit
 ) {

--- a/koog-ktor/src/jvmMain/kotlin/ai/koog/ktor/BedrockConfig.kt
+++ b/koog-ktor/src/jvmMain/kotlin/ai/koog/ktor/BedrockConfig.kt
@@ -6,7 +6,7 @@ import ai.koog.prompt.executor.clients.bedrock.BedrockLLMClient
 import ai.koog.prompt.executor.clients.bedrock.StaticBearerTokenProvider
 import ai.koog.prompt.llm.LLMProvider
 import aws.sdk.kotlin.services.bedrockruntime.BedrockRuntimeClient
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 /**
  * Configuration to create a new Bedrock LLM client configured with the specified identity provider and settings.

--- a/prompt/prompt-cache/prompt-cache-model/build.gradle.kts
+++ b/prompt/prompt-cache/prompt-cache-model/build.gradle.kts
@@ -14,7 +14,6 @@ kotlin {
             dependencies {
                 api(project(":agents:agents-tools"))
                 api(project(":prompt:prompt-model"))
-                api(libs.kotlinx.datetime)
             }
         }
 

--- a/prompt/prompt-cache/prompt-cache-model/src/commonMain/kotlin/ai/koog/prompt/cache/model/PromptCache.kt
+++ b/prompt/prompt-cache/prompt-cache-model/src/commonMain/kotlin/ai/koog/prompt/cache/model/PromptCache.kt
@@ -5,13 +5,13 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.message.ResponseMetaInfo
-import kotlin.time.Clock
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlin.math.absoluteValue
+import kotlin.time.Clock
 
 private val defaultJson = Json {
     ignoreUnknownKeys = true

--- a/prompt/prompt-cache/prompt-cache-model/src/commonMain/kotlin/ai/koog/prompt/cache/model/PromptCache.kt
+++ b/prompt/prompt-cache/prompt-cache-model/src/commonMain/kotlin/ai/koog/prompt/cache/model/PromptCache.kt
@@ -5,7 +5,7 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.message.ResponseMetaInfo
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject

--- a/prompt/prompt-cache/prompt-cache-model/src/commonMain/kotlin/ai/koog/prompt/cache/model/PromptCache.kt
+++ b/prompt/prompt-cache/prompt-cache-model/src/commonMain/kotlin/ai/koog/prompt/cache/model/PromptCache.kt
@@ -216,7 +216,7 @@ public interface PromptCache {
 public suspend fun PromptCache.get(
     prompt: Prompt,
     tools: List<ToolDescriptor>,
-    clock: Clock = kotlin.time.Clock.System
+    clock: Clock = Clock.System
 ): List<Message.Response>? {
     return get(PromptCache.Request.create(prompt, tools))?.let { messages ->
         val metaInfo = prompt

--- a/prompt/prompt-executor/prompt-executor-cached/src/commonMain/kotlin/ai/koog/prompt/executor/cached/CachedPromptExecutor.kt
+++ b/prompt/prompt-executor/prompt-executor-cached/src/commonMain/kotlin/ai/koog/prompt/executor/cached/CachedPromptExecutor.kt
@@ -15,7 +15,7 @@ import ai.koog.prompt.structure.json.generator.BasicJsonSchemaGenerator
 import ai.koog.prompt.structure.json.generator.StandardJsonSchemaGenerator
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 /**
  * A CodePromptExecutor that caches responses from a nested executor.

--- a/prompt/prompt-executor/prompt-executor-cached/src/commonMain/kotlin/ai/koog/prompt/executor/cached/CachedPromptExecutor.kt
+++ b/prompt/prompt-executor/prompt-executor-cached/src/commonMain/kotlin/ai/koog/prompt/executor/cached/CachedPromptExecutor.kt
@@ -26,7 +26,7 @@ import kotlin.time.Clock
 public class CachedPromptExecutor(
     private val cache: PromptCache,
     private val nested: PromptExecutor,
-    private val clock: Clock = kotlin.time.Clock.System
+    private val clock: Clock = Clock.System
 ) : PromptExecutor() {
 
     override suspend fun execute(

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/build.gradle.kts
@@ -20,7 +20,6 @@ kotlin {
                 api(project(":prompt:prompt-model"))
                 api(project(":http-client:http-client-ktor"))
                 api(libs.kotlinx.coroutines.core)
-                api(libs.kotlinx.datetime)
                 api(libs.ktor.client.content.negotiation)
                 api(libs.ktor.serialization.kotlinx.json)
                 implementation(libs.oshai.kotlin.logging)

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
@@ -48,7 +48,7 @@ import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.CancellationException
 import kotlinx.coroutines.flow.Flow
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
@@ -48,7 +48,6 @@ import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.CancellationException
 import kotlinx.coroutines.flow.Flow
-import kotlin.time.Clock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -57,6 +56,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import kotlin.jvm.JvmOverloads
+import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
@@ -94,7 +94,7 @@ public open class AnthropicLLMClient @JvmOverloads constructor(
     private val apiKey: String,
     private val settings: AnthropicClientSettings = AnthropicClientSettings(),
     baseClient: HttpClient = HttpClient(),
-    private val clock: Clock = kotlin.time.Clock.System
+    private val clock: Clock = Clock.System
 ) : LLMClient() {
 
     private companion object {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/build.gradle.kts
@@ -21,7 +21,6 @@ kotlin {
                 api(project(":prompt:prompt-llm"))
                 api(project(":prompt:prompt-model"))
                 api(libs.kotlinx.coroutines.core)
-                api(libs.kotlinx.datetime)
                 api(libs.ktor.client.content.negotiation)
                 api(libs.ktor.serialization.kotlinx.json)
                 implementation(libs.oshai.kotlin.logging)

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
@@ -138,7 +138,7 @@ public class BedrockLLMClient @JvmOverloads constructor(
     private val apiMethod: BedrockAPIMethod = BedrockAPIMethod.InvokeModel,
     private val moderationGuardrailsSettings: BedrockGuardrailsSettings? = null,
     private val fallbackModelFamily: BedrockModelFamilies? = null,
-    private val clock: Clock = kotlin.time.Clock.System,
+    private val clock: Clock = Clock.System,
 ) : LLMClient(), LLMEmbeddingProvider {
 
     private val logger = KotlinLogging.logger {}
@@ -155,7 +155,7 @@ public class BedrockLLMClient @JvmOverloads constructor(
     public constructor(
         identityProvider: IdentityProvider,
         settings: BedrockClientSettings = BedrockClientSettings(),
-        clock: Clock = kotlin.time.Clock.System,
+        clock: Clock = Clock.System,
     ) : this(
         bedrockClient = BedrockRuntimeClient {
             this.region = settings.region

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
@@ -57,9 +57,9 @@ import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.withContext
-import kotlin.time.Clock
 import kotlinx.serialization.json.Json
 import org.jetbrains.annotations.VisibleForTesting
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.milliseconds
 
 /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
@@ -57,7 +57,7 @@ import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.json.Json
 import org.jetbrains.annotations.VisibleForTesting
 import kotlin.time.Duration.Companion.milliseconds

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseConverters.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseConverters.kt
@@ -343,7 +343,7 @@ internal object BedrockConverseConverters {
      */
     fun transformConverseStreamChunks(
         chunkFlow: Flow<ConverseStreamOutput>,
-        clock: Clock = kotlin.time.Clock.System,
+        clock: Clock = Clock.System,
     ) = buildStreamFrameFlow {
         var finishReason: String? = null
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseConverters.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseConverters.kt
@@ -48,13 +48,13 @@ import aws.sdk.kotlin.services.bedrockruntime.model.VideoSource
 import aws.smithy.kotlin.runtime.content.Document
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
-import kotlin.time.Clock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import kotlin.time.Clock
 import aws.sdk.kotlin.services.bedrockruntime.model.Message as BedrockMessage
 import aws.sdk.kotlin.services.bedrockruntime.model.Tool as BedrockTool
 import aws.sdk.kotlin.services.bedrockruntime.model.ToolChoice as BedrockToolChoice

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseConverters.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseConverters.kt
@@ -48,7 +48,7 @@ import aws.sdk.kotlin.services.bedrockruntime.model.VideoSource
 import aws.smithy.kotlin.runtime.content.Document
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.add

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/dashscope/DashscopeLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/dashscope/DashscopeLLMClient.kt
@@ -54,7 +54,7 @@ public class DashscopeLLMClient @JvmOverloads constructor(
     apiKey: String,
     private val settings: DashscopeClientSettings = DashscopeClientSettings(),
     baseClient: HttpClient = HttpClient(),
-    clock: Clock = kotlin.time.Clock.System,
+    clock: Clock = Clock.System,
     toolsConverter: OpenAICompatibleToolDescriptorSchemaGenerator = OpenAICompatibleToolDescriptorSchemaGenerator()
 ) : AbstractOpenAILLMClient<DashscopeChatCompletionResponse, DashscopeChatCompletionStreamResponse>(
     apiKey = apiKey,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/dashscope/DashscopeLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/dashscope/DashscopeLLMClient.kt
@@ -23,7 +23,7 @@ import ai.koog.prompt.streaming.buildStreamFrameFlow
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.flow.Flow
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.jvm.JvmOverloads
 
 /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/dashscope/DashscopeLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/dashscope/DashscopeLLMClient.kt
@@ -23,8 +23,8 @@ import ai.koog.prompt.streaming.buildStreamFrameFlow
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.flow.Flow
-import kotlin.time.Clock
 import kotlin.jvm.JvmOverloads
+import kotlin.time.Clock
 
 /**
  * Configuration settings for connecting to the DashScope API using OpenAI-compatible endpoints.

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
@@ -28,7 +28,7 @@ import ai.koog.prompt.streaming.buildStreamFrameFlow
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.flow.Flow
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.jvm.JvmOverloads
 
 /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
@@ -58,7 +58,7 @@ public class DeepSeekLLMClient @JvmOverloads constructor(
     apiKey: String,
     private val settings: DeepSeekClientSettings = DeepSeekClientSettings(),
     baseClient: HttpClient = HttpClient(),
-    clock: Clock = kotlin.time.Clock.System,
+    clock: Clock = Clock.System,
     toolsConverter: OpenAICompatibleToolDescriptorSchemaGenerator = OpenAICompatibleToolDescriptorSchemaGenerator()
 ) : AbstractOpenAILLMClient<DeepSeekChatCompletionResponse, DeepSeekChatCompletionStreamResponse>(
     apiKey = apiKey,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
@@ -28,8 +28,8 @@ import ai.koog.prompt.streaming.buildStreamFrameFlow
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.flow.Flow
-import kotlin.time.Clock
 import kotlin.jvm.JvmOverloads
+import kotlin.time.Clock
 
 /**
  * Configuration settings for connecting to the DeepSeek API.

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/build.gradle.kts
@@ -21,7 +21,6 @@ kotlin {
                 api(project(":prompt:prompt-structure"))
                 api(project(":http-client:http-client-ktor"))
                 api(libs.kotlinx.coroutines.core)
-                api(libs.kotlinx.datetime)
                 api(libs.ktor.client.content.negotiation)
                 api(libs.ktor.serialization.kotlinx.json)
                 implementation(libs.oshai.kotlin.logging)

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -53,7 +53,6 @@ import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.CancellationException
 import kotlinx.coroutines.flow.Flow
-import kotlin.time.Clock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonObjectBuilder
@@ -64,6 +63,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlin.jvm.JvmOverloads
+import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -97,7 +97,7 @@ public open class GoogleLLMClient @JvmOverloads constructor(
     private val apiKey: String,
     private val settings: GoogleClientSettings = GoogleClientSettings(),
     baseClient: HttpClient = HttpClient(),
-    private val clock: Clock = kotlin.time.Clock.System
+    private val clock: Clock = Clock.System
 ) : LLMClient(), LLMEmbeddingProvider {
 
     @OptIn(InternalStructuredOutputApi::class)

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -53,7 +53,7 @@ import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.CancellationException
 import kotlinx.coroutines.flow.Flow
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonObjectBuilder

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAILLMClient.kt
@@ -71,7 +71,7 @@ public open class MistralAILLMClient(
     apiKey: String,
     private val settings: MistralAIClientSettings = MistralAIClientSettings(),
     baseClient: HttpClient = HttpClient(),
-    clock: Clock = kotlin.time.Clock.System,
+    clock: Clock = Clock.System,
     toolsConverter: OpenAICompatibleToolDescriptorSchemaGenerator = OpenAICompatibleToolDescriptorSchemaGenerator()
 ) : AbstractOpenAILLMClient<MistralAIChatCompletionResponse, MistralAIChatCompletionStreamResponse>(
     apiKey = apiKey,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAILLMClient.kt
@@ -41,7 +41,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 /**
  * Represents the settings for configuring a Mistral AI client.

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/build.gradle.kts
@@ -24,7 +24,6 @@ kotlin {
                 api(project(":embeddings:embeddings-base"))
 
                 api(libs.ktor.client.logging)
-                api(libs.kotlinx.datetime)
                 api(libs.kotlinx.coroutines.core)
                 api(libs.ktor.client.content.negotiation)
                 api(libs.ktor.serialization.kotlinx.json)

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -79,7 +79,7 @@ public class OllamaClient @JvmOverloads constructor(
     public val baseUrl: String = "http://localhost:11434",
     baseClient: HttpClient = HttpClient(),
     timeoutConfig: ConnectionTimeoutConfig = ConnectionTimeoutConfig(),
-    private val clock: Clock = kotlin.time.Clock.System,
+    private val clock: Clock = Clock.System,
     private val contextWindowStrategy: ContextWindowStrategy = ContextWindowStrategy.Companion.None,
     private val toolDescriptorConverter: ToolDescriptorSchemaGenerator = OllamaToolDescriptorSchemaGenerator()
 ) : LLMClient(), LLMEmbeddingProvider {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
@@ -80,7 +80,7 @@ public abstract class AbstractOpenAILLMClient<TResponse : OpenAIBaseLLMResponse,
     private val apiKey: String,
     settings: OpenAIBaseSettings,
     baseClient: HttpClient = HttpClient(),
-    protected val clock: Clock = kotlin.time.Clock.System,
+    protected val clock: Clock = Clock.System,
     protected val logger: KLogger,
     private val toolsConverter: OpenAICompatibleToolDescriptorSchemaGenerator,
 ) : LLMClient() {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
@@ -44,7 +44,7 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNamingStrategy
 import kotlin.io.encoding.ExperimentalEncodingApi

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
@@ -44,11 +44,11 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
-import kotlin.time.Clock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNamingStrategy
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.jvm.JvmOverloads
+import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 import ai.koog.prompt.executor.clients.openai.base.models.Content as OpenAIContent

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -104,7 +104,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
     apiKey: String,
     private val settings: OpenAIClientSettings = OpenAIClientSettings(),
     baseClient: HttpClient = HttpClient(),
-    clock: Clock = kotlin.time.Clock.System,
+    clock: Clock = Clock.System,
     private val toolsConverter: OpenAICompatibleToolDescriptorSchemaGenerator = OpenAICompatibleToolDescriptorSchemaGenerator(),
 ) : AbstractOpenAILLMClient<OpenAIChatCompletionResponse, OpenAIChatCompletionStreamResponse>(
     apiKey,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -64,7 +64,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.jvm.JvmOverloads
 import kotlin.uuid.ExperimentalUuidApi

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -64,9 +64,9 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.withContext
-import kotlin.time.Clock
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.jvm.JvmOverloads
+import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 import ai.koog.prompt.executor.clients.openai.base.models.Content as OpenAIContent

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
@@ -34,8 +34,8 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
-import kotlin.time.Clock
 import kotlin.jvm.JvmOverloads
+import kotlin.time.Clock
 
 /**
  * Configuration settings for connecting to the OpenRouter API.

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
@@ -66,7 +66,7 @@ public class OpenRouterLLMClient @JvmOverloads constructor(
     apiKey: String,
     private val settings: OpenRouterClientSettings = OpenRouterClientSettings(),
     baseClient: HttpClient = HttpClient(),
-    clock: Clock = kotlin.time.Clock.System,
+    clock: Clock = Clock.System,
     toolsConverter: OpenAICompatibleToolDescriptorSchemaGenerator = OpenAICompatibleToolDescriptorSchemaGenerator(),
 ) : AbstractOpenAILLMClient<OpenRouterChatCompletionResponse, OpenRouterChatCompletionStreamResponse>(
     apiKey = apiKey,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
@@ -34,7 +34,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlin.jvm.JvmOverloads
 
 /**

--- a/prompt/prompt-model/build.gradle.kts
+++ b/prompt/prompt-model/build.gradle.kts
@@ -16,7 +16,6 @@ kotlin {
                 api(project(":utils"))
                 api(libs.kotlinx.coroutines.core)
                 api(libs.kotlinx.serialization.json)
-                api(libs.kotlinx.datetime)
                 api(libs.kotlinx.io.core)
             }
         }

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/Prompt.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/Prompt.kt
@@ -5,7 +5,7 @@ import ai.koog.prompt.message.Message
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.params.LLMParams.Schema
 import ai.koog.prompt.params.LLMParams.ToolChoice
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmName

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/Prompt.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/Prompt.kt
@@ -5,12 +5,12 @@ import ai.koog.prompt.message.Message
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.params.LLMParams.Schema
 import ai.koog.prompt.params.LLMParams.ToolChoice
-import kotlin.time.Clock
 import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmName
 import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
+import kotlin.time.Clock
 import kotlin.time.Duration
 
 /**

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/Prompt.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/Prompt.kt
@@ -43,7 +43,7 @@ public data class Prompt @JvmOverloads constructor(
         @JvmStatic
         @JvmOverloads
         @JavaAPI
-        public fun builder(id: String, clock: Clock = kotlin.time.Clock.System): PromptBuilder = PromptBuilder(id, clock = clock)
+        public fun builder(id: String, clock: Clock = Clock.System): PromptBuilder = PromptBuilder(id, clock = clock)
 
         /**
          * Represents an empty state for a [Prompt] object. This variable is initialized
@@ -68,7 +68,7 @@ public data class Prompt @JvmOverloads constructor(
         public fun build(
             id: String,
             params: LLMParams = LLMParams(),
-            clock: Clock = kotlin.time.Clock.System,
+            clock: Clock = Clock.System,
             init: PromptBuilder.() -> Unit
         ): Prompt {
             val builder = PromptBuilder(id, params, clock)
@@ -84,7 +84,7 @@ public data class Prompt @JvmOverloads constructor(
          * @param init The initialization block applied to configure the [PromptBuilder].
          * @return A new [Prompt] instance configured with the specified initialization logic.
          */
-        public fun build(prompt: Prompt, clock: Clock = kotlin.time.Clock.System, init: PromptBuilder.() -> Unit): Prompt {
+        public fun build(prompt: Prompt, clock: Clock = Clock.System, init: PromptBuilder.() -> Unit): Prompt {
             return PromptBuilder.from(prompt, clock).also(init).build()
         }
     }

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/PromptBuilder.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/PromptBuilder.kt
@@ -32,12 +32,12 @@ import kotlin.time.Clock
 public class PromptBuilder internal constructor(
     private val id: String,
     private val params: LLMParams = LLMParams(),
-    private val clock: Clock = kotlin.time.Clock.System
+    private val clock: Clock = Clock.System
 ) {
     private val messages = mutableListOf<Message>()
 
     internal companion object {
-        internal fun from(prompt: Prompt, clock: Clock = kotlin.time.Clock.System): PromptBuilder = PromptBuilder(
+        internal fun from(prompt: Prompt, clock: Clock = Clock.System): PromptBuilder = PromptBuilder(
             prompt.id,
             prompt.params,
             clock

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/PromptBuilder.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/PromptBuilder.kt
@@ -7,7 +7,7 @@ import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.text.TextContentBuilder
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 /**
  * A builder class for creating prompts using a DSL approach.

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/PromptDSL.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/PromptDSL.kt
@@ -1,7 +1,7 @@
 package ai.koog.prompt.dsl
 
 import ai.koog.prompt.params.LLMParams
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 /**
  * Marker annotation for the Prompt DSL.

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/PromptDSL.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/PromptDSL.kt
@@ -34,7 +34,7 @@ public annotation class PromptDSL
 public fun prompt(
     id: String,
     params: LLMParams = LLMParams(),
-    clock: Clock = kotlin.time.Clock.System,
+    clock: Clock = Clock.System,
     build: PromptBuilder.() -> Unit
 ): Prompt {
     return Prompt.build(id, params, clock, build)
@@ -72,7 +72,7 @@ public fun emptyPrompt(): Prompt = Prompt.build("") { }
  */
 public fun prompt(
     existing: Prompt,
-    clock: Clock = kotlin.time.Clock.System,
+    clock: Clock = Clock.System,
     build: PromptBuilder.() -> Unit
 ): Prompt {
     return Prompt.build(existing, clock, build)

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
@@ -1,7 +1,7 @@
 package ai.koog.prompt.message
 
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Clock
+import kotlin.time.Instant
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
@@ -1,12 +1,12 @@
 package ai.koog.prompt.message
 
-import kotlin.time.Clock
-import kotlin.time.Instant
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlin.jvm.JvmOverloads
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 public typealias LLMChoice = List<Message.Response>
 

--- a/prompt/prompt-tokenizer/build.gradle.kts
+++ b/prompt/prompt-tokenizer/build.gradle.kts
@@ -15,7 +15,6 @@ kotlin {
                 api(project(":prompt:prompt-llm"))
                 api(project(":prompt:prompt-model"))
                 api(libs.kotlinx.serialization.json)
-                api(libs.kotlinx.datetime)
             }
         }
 


### PR DESCRIPTION
I just fixed the deprecated import of kotlinx.datetime.x

- kotlinx.datetime.Instant -> kotlin.time.Instant
- kotlinx.datetime.Clock -> kotlin.time.Clock

I think it is a good idea to do this in one PR.