### PR TITLE
fix(koog-ktor): parsing timeouts configuration (#1505)

### DIFF
--- a/examples/simple-examples/src/main/resources/application.yaml
+++ b/examples/simple-examples/src/main/resources/application.yaml
@@ -5,11 +5,11 @@ ktor:
 
 koog:
   openai:
-  apikey: "your-openai-api-key"
-  timeout:
-    requestTimeoutMillis: 900000
-    connectTimeoutMillis: 60000
-    socketTimeoutMillis: 900000
+    apikey: "your-openai-api-key"
+    timeout:
+      requestTimeoutMillis: 900000
+      connectTimeoutMillis: 60000
+      socketTimeoutMillis: 900000
   anthropic:
     apikey: "your-anthropic-api-key"
     timeout:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -78,6 +78,7 @@ ktor-server-sse = { module = "io.ktor:ktor-server-sse", version.ref = "ktor3" }
 ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor3" }
 ktor-server-cors = { module = "io.ktor:ktor-server-cors", version.ref = "ktor3" }
 ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor3" }
+ktor-server-config-yaml = { module = "io.ktor:ktor-server-config-yaml", version.ref = "ktor3" }
 lettuce-core = { module = "io.lettuce:lettuce-core", version.ref = "lettuce" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 oshai-kotlin-logging = { module = "io.github.oshai:kotlin-logging", version.ref = "oshai-logging" }

--- a/koog-ktor/build.gradle.kts
+++ b/koog-ktor/build.gradle.kts
@@ -53,6 +53,7 @@ kotlin {
                 implementation(kotlin("test-junit5"))
                 implementation(libs.kotlinx.coroutines.test)
                 implementation(libs.ktor.client.cio)
+                implementation(libs.ktor.server.config.yaml)
             }
         }
 

--- a/koog-ktor/src/commonMain/kotlin/ai/koog/ktor/utils/EnvConfigLoader.kt
+++ b/koog-ktor/src/commonMain/kotlin/ai/koog/ktor/utils/EnvConfigLoader.kt
@@ -145,17 +145,20 @@ private inline fun KoogAgentsConfig.config(
 }
 
 private fun KoogAgentsConfig.TimeoutConfiguration.configure(key: String, config: ApplicationConfig) {
-    if (config.propertyOrNull(key) == null) {
-        config.propertyOrNull("requestTimeoutMillis")
+    if (config.propertyOrNull(key) != null) {
+        val providerTimeoutSection = config.config(key)
+
+        providerTimeoutSection.propertyOrNull("requestTimeoutMillis")
             ?.getString()
             ?.toLongOrNull()
             ?.let { requestTimeout = it.milliseconds }
 
-        config.propertyOrNull("connectTimeoutMillis")
+        providerTimeoutSection.propertyOrNull("connectTimeoutMillis")
             ?.getString()
             ?.toLongOrNull()
             ?.let { connectTimeout = it.milliseconds }
-        config.propertyOrNull("socketTimeoutMillis")
+
+        providerTimeoutSection.propertyOrNull("socketTimeoutMillis")
             ?.getString()
             ?.toLongOrNull()
             ?.let { socketTimeout = it.milliseconds }

--- a/koog-ktor/src/commonTest/kotlin/ai/koog/ktor/ConfigurationLoadingTest.kt
+++ b/koog-ktor/src/commonTest/kotlin/ai/koog/ktor/ConfigurationLoadingTest.kt
@@ -299,6 +299,13 @@ class ConfigurationLoadingTest {
         )
     }
 
+    @Test
+    fun testConfigWithoutSpecificTimeouts() = testApplication {
+        environment { config = buildConfigWithoutSpecificTimeouts() }
+        install(Koog)
+        startApplication()
+    }
+
     private fun buildCompleteConfig() =
         buildOpenAIConfig()
             .mergeWith(buildAnthropicConfig())
@@ -379,6 +386,11 @@ class ConfigurationLoadingTest {
         "koog.anthropic.timeout.requestTimeoutMillis" to "invalid-timeout",
         // Invalid fallback configuration - missing model
         "koog.llm.fallback.provider" to "google"
+    )
+
+    private fun buildConfigWithoutSpecificTimeouts() = MapApplicationConfig(
+        "koog.openai.apikey" to "test-openai-api-key",
+        "koog.openai.baseUrl" to "https://api.openai.com/v1"
     )
 
     private fun buildTimeoutConfig() = MapApplicationConfig(

--- a/koog-ktor/src/jvmTest/kotlin/ai/koog/ktor/YamlConfigurationLoadingTest.kt
+++ b/koog-ktor/src/jvmTest/kotlin/ai/koog/ktor/YamlConfigurationLoadingTest.kt
@@ -1,0 +1,26 @@
+package ai.koog.ktor
+
+import io.ktor.server.config.yaml.YamlConfig
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+
+class YamlConfigurationLoadingTest {
+
+    @Test
+    fun testYamlConfigWithoutTimeout() = testApplication {
+        environment {
+            config = YamlConfig("application-no-timeout.yaml")!!
+        }
+        install(Koog)
+        startApplication()
+    }
+
+    @Test
+    fun testYamlConfigWithTimeout() = testApplication {
+        environment {
+            config = YamlConfig("application-with-timeout.yaml")!!
+        }
+        install(Koog)
+        startApplication()
+    }
+}

--- a/koog-ktor/src/jvmTest/resources/application-no-timeout.yaml
+++ b/koog-ktor/src/jvmTest/resources/application-no-timeout.yaml
@@ -1,0 +1,4 @@
+koog:
+  openai:
+    apikey: test-openai-api-key
+    baseUrl: https://api.openai.com

--- a/koog-ktor/src/jvmTest/resources/application-with-timeout.yaml
+++ b/koog-ktor/src/jvmTest/resources/application-with-timeout.yaml
@@ -1,0 +1,8 @@
+koog:
+  openai:
+    apikey: test-openai-api-key
+    baseUrl: https://api.openai.com
+    timeout:
+      requestTimeoutMillis: 900000
+      connectTimeoutMillis: 60000
+      socketTimeoutMillis: 900000


### PR DESCRIPTION
The `configure` function in `EnvConfigLoader` had an inverted condition and read from the root config instead of the provider's timeout sub-section, causing custom timeout values to be silently ignored. This fixes both issues and adds YAML-based tests covering the exact scenario reported in the issue.

The fix was originally proposed by community:
https://github.com/JetBrains/koog/issues/807
This PR cherry picked these changes and added tests on top of it. Additionally it also fixes `application.yaml` example

Closes:
- https://youtrack.jetbrains.com/issue/KTOR-8881
- https://github.com/JetBrains/koog/issues/807