### PR TITLE
feat(prompt)!: Support streaming reasoning messages (#1479)

### DIFF
--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/CalculatorPromptExecutor.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/CalculatorPromptExecutor.kt
@@ -8,7 +8,7 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.streaming.StreamFrame
-import ai.koog.prompt.streaming.toStreamFrame
+import ai.koog.prompt.streaming.toStreamFrames
 import io.ktor.utils.io.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -60,9 +60,7 @@ object CalculatorChatExecutor : PromptExecutor {
     ): Flow<StreamFrame> =
         flow {
             try {
-                execute(prompt, model, tools).forEach {
-                    emit(it.toStreamFrame())
-                }
+                execute(prompt, model, tools).toStreamFrames().forEach { emit(it) }
             } catch (t: CancellationException) {
                 throw t
             } catch (t: Throwable) {

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/dsl/extension/TestLLMExecutor.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/dsl/extension/TestLLMExecutor.kt
@@ -8,9 +8,9 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.streaming.StreamFrame
-import ai.koog.prompt.streaming.toStreamFrame
+import ai.koog.prompt.streaming.toStreamFrames
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flow
 import kotlin.time.Clock
 
 class TestLLMExecutor : PromptExecutor {
@@ -43,8 +43,9 @@ class TestLLMExecutor : PromptExecutor {
         prompt: Prompt,
         model: LLModel,
         tools: List<ToolDescriptor>
-    ): Flow<StreamFrame> =
-        flowOf(handlePrompt(prompt).toStreamFrame())
+    ): Flow<StreamFrame> = flow {
+        handlePrompt(prompt).toStreamFrames().forEach { emit(it) }
+    }
 
     override suspend fun moderate(
         prompt: Prompt,

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/feature/AIAgentFeatureTestAPI.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/feature/AIAgentFeatureTestAPI.kt
@@ -349,7 +349,7 @@ internal object AIAgentFeatureTestAPI {
             params = LLMParams()
         ),
         model = mockLLModel.toModelInfo(),
-        frame = StreamFrame.Append("test-frame"),
+        frame = StreamFrame.TextDelta("test-frame"),
         timestamp = testClock.now().toEpochMilliseconds(),
     )
 

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerStreamingTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerStreamingTest.kt
@@ -196,7 +196,7 @@ class DebuggerStreamingTest {
                             runId = clientEventsCollector.runId,
                             prompt = expectedLLMCallPrompt,
                             model = mockLLModel.toModelInfo(),
-                            frame = StreamFrame.Append(testLLMResponse),
+                            frame = StreamFrame.TextDelta(testLLMResponse),
                             timestamp = testClock.now().toEpochMilliseconds(),
                         ),
                         LLMStreamingCompletedEvent(

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerTest.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerTest.kt
@@ -27,6 +27,7 @@ import ai.koog.utils.io.use
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.Test
@@ -560,7 +561,9 @@ class EventHandlerTest {
 
         val expectedEvents = listOf(
             "OnLLMStreamingStarting (run id: $runId, prompt: $expectedPromptString, temperature: $temperature, model: ${model.eventString}, tools: [${toolRegistry.tools.joinToString { it.name }}])",
-            "OnLLMStreamingFrameReceived (run id: $runId, frame: Append(text=$testLLMResponse))",
+            "OnLLMStreamingFrameReceived (run id: $runId, frame: TextDelta(text=$testLLMResponse, index=0))",
+            "OnLLMStreamingFrameReceived (run id: $runId, frame: TextComplete(text=$testLLMResponse, index=0))",
+            "OnLLMStreamingFrameReceived (run id: $runId, frame: End(finishReason=null, metaInfo=ResponseMetaInfo(timestamp=${Instant.DISTANT_PAST}, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, additionalInfo={}, metadata=null)))",
             "OnLLMStreamingCompleted (run id: $runId, prompt: $expectedPromptString, temperature: $temperature, model: ${model.eventString}, tools: [${toolRegistry.tools.joinToString { it.name }}])",
         )
 

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/TestLLMExecutor.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/TestLLMExecutor.kt
@@ -8,9 +8,9 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.streaming.StreamFrame
-import ai.koog.prompt.streaming.toStreamFrame
+import ai.koog.prompt.streaming.toStreamFrames
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flow
 import kotlin.time.Clock
 
 class TestLLMExecutor(val clock: Clock) : PromptExecutor {
@@ -22,8 +22,9 @@ class TestLLMExecutor(val clock: Clock) : PromptExecutor {
         prompt: Prompt,
         model: LLModel,
         tools: List<ToolDescriptor>
-    ): Flow<StreamFrame> =
-        flowOf(handlePrompt(prompt).toStreamFrame())
+    ): Flow<StreamFrame> = flow {
+        handlePrompt(prompt).toStreamFrames().forEach { emit(it) }
+    }
 
     private fun handlePrompt(prompt: Prompt): Message.Response {
         // For a compression test, return a summary

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/mock/MockLLMExecutor.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/mock/MockLLMExecutor.kt
@@ -8,7 +8,7 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.streaming.StreamFrame
-import ai.koog.prompt.streaming.toStreamFrame
+import ai.koog.prompt.streaming.toStreamFrames
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlin.time.Clock
@@ -29,7 +29,7 @@ class MockLLMExecutor : PromptExecutor {
         model: LLModel,
         tools: List<ToolDescriptor>
     ): Flow<StreamFrame> =
-        flow { emit(handlePrompt(prompt).toStreamFrame()) }
+        flow { handlePrompt(prompt).toStreamFrames().forEach { emit(it) } }
 
     private fun handlePrompt(prompt: Prompt): Message.Response {
         val lastMessage = prompt.messages.last()

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
@@ -414,7 +414,25 @@ class TraceFeatureMessageTestWriterTest {
                         runId = writer.runId,
                         prompt = expectedPrompt,
                         model = model.toModelInfo(),
-                        frame = StreamFrame.Append(testLLMResponse),
+                        frame = StreamFrame.TextDelta(testLLMResponse, index = 0),
+                        timestamp = testClock.now().toEpochMilliseconds()
+                    ),
+                    LLMStreamingFrameReceivedEvent(
+                        eventId = actualStreamingStartingEvent.eventId,
+                        executionInfo = agentExecutionInfo(agentId, strategyName, nodeLLMRequestStreamingName),
+                        runId = writer.runId,
+                        prompt = expectedPrompt,
+                        model = model.toModelInfo(),
+                        frame = StreamFrame.TextComplete(testLLMResponse, index = 0),
+                        timestamp = testClock.now().toEpochMilliseconds()
+                    ),
+                    LLMStreamingFrameReceivedEvent(
+                        eventId = actualStreamingStartingEvent.eventId,
+                        executionInfo = agentExecutionInfo(agentId, strategyName, nodeLLMRequestStreamingName),
+                        runId = writer.runId,
+                        prompt = expectedPrompt,
+                        model = model.toModelInfo(),
+                        frame = StreamFrame.End(null, ResponseMetaInfo.Empty),
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
                     LLMStreamingCompletedEvent(

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMExecutor.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockLLMExecutor.kt
@@ -9,7 +9,7 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.streaming.StreamFrame
-import ai.koog.prompt.streaming.toStreamFrame
+import ai.koog.prompt.streaming.toStreamFrames
 import ai.koog.prompt.tokenizer.Tokenizer
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -98,9 +98,7 @@ internal class MockLLMExecutor(
         model: LLModel,
         tools: List<ToolDescriptor>
     ): Flow<StreamFrame> = flow {
-        execute(prompt = prompt, model = model).forEach {
-            emit(it.toStreamFrame())
-        }
+        execute(prompt = prompt, model = model).toStreamFrames().forEach { emit(it) }
     }
 
     /**

--- a/docs/docs/prompts/llm-clients.md
+++ b/docs/docs/prompts/llm-clients.md
@@ -71,7 +71,15 @@ fun main() = runBlocking {
     Available for all LLM clients.
 
 When you need to process responses as they are generated,
-you can use the `executeStreaming()` method to stream the model output:
+you can use the `executeStreaming()` method to stream the model output.
+
+The streaming API provides different frame types:
+- **Delta frames** (`TextDelta`, `ReasoningDelta`, `ToolCallDelta`) — incremental content that arrives in chunks
+- **Complete frames** (`TextComplete`, `ReasoningComplete`, `ToolCallComplete`) — full content after all deltas are received
+- **End frame** (`End`) — signals stream completion with finish reason
+
+For models that support reasoning (such as Claude Sonnet 4.5 or GPT-o1), reasoning frames will be emitted during streaming.
+See the [Streaming API documentation](../streaming-api.md) for more details on working with frames.
 
 <!--- INCLUDE
 import ai.koog.prompt.dsl.prompt
@@ -95,11 +103,13 @@ val response = client.executeStreaming(
     model = OpenAIModels.Chat.GPT4_1
 )
 
-response.collect { event ->
-    when (event) {
-        is StreamFrame.Append -> println(event.text)
-        is StreamFrame.ToolCall -> println("\nTool call: ${event.name}")
-        is StreamFrame.End -> println("\n[done] Reason: ${event.finishReason}")
+response.collect { frame ->
+    when (frame) {
+        is StreamFrame.TextDelta -> print(frame.text)
+        is StreamFrame.ReasoningDelta -> print("[Reasoning] ${frame.text}")
+        is StreamFrame.ToolCallComplete -> println("\nTool call: ${frame.name}")
+        is StreamFrame.End -> println("\n[done] Reason: ${frame.finishReason}")
+        else -> {} // Handle other frame types if needed
     }
 }
 ```

--- a/docs/docs/streaming-api.md
+++ b/docs/docs/streaming-api.md
@@ -9,10 +9,19 @@ Koog’s **Streaming API** lets you consume **LLM output incrementally** as a `F
 - detect **tool calls** live and act on them,
 - know when a stream **ends** and why.
 
-The stream carries **typed frames**:
+The stream carries **typed frames** organized into two categories:
 
-- `StreamFrame.Append(text: String)` — incremental assistant text
-- `StreamFrame.ToolCall(id: String?, name: String, content: String)` — tool invocation (combined safely)
+**Delta frames** (incremental/partial content):
+- `StreamFrame.TextDelta(text: String, index: Int?)` — incremental assistant text
+- `StreamFrame.ReasoningDelta(text: String?, summary: String?, index: Int?)` — incremental reasoning text and summary
+- `StreamFrame.ToolCallDelta(id: String?, name: String?, content: String?, index: Int?)` — partial tool invocation
+
+**Complete frames** (full content):
+- `StreamFrame.TextComplete(text: String)` — complete assistant text
+- `StreamFrame.ReasoningComplete(text: List<String>, summary: List<String>?)` — complete reasoning with optional summary
+- `StreamFrame.ToolCallComplete(id: String?, name: String, content: String)` — complete tool invocation
+
+**End marker**:
 - `StreamFrame.End(finishReason: String?)` — end-of-stream marker
 
 Helpers are provided to extract plain text, convert frames to `Message.Response` objects, and safely **combine chunked tool calls**.
@@ -27,8 +36,19 @@ With streaming you can:
 - Parse structured info on the fly (Markdown/JSON/etc.)
 - Emit objects as they complete
 - Trigger tools in real time
+- Access model reasoning in real-time (for supported models)
 
 You can operate either on the **frames** themselves or on **plain text** derived from frames.
+
+### Delta vs Complete Frames
+
+The streaming API distinguishes between two types of frames:
+
+- **Delta frames** (`DeltaFrame`) — Incremental/partial content that arrives in chunks. These are ideal for real-time display as content streams in. Examples: `TextDelta`, `ReasoningDelta`, `ToolCallDelta`.
+
+- **Complete frames** (`CompleteFrame`) — Full content emitted after all deltas for that content type have been received. These are useful for final processing and conversion to `Message.Response` objects. Examples: `TextComplete`, `ReasoningComplete`, `ToolCallComplete`.
+
+Typically, you'll work with delta frames for UI updates and complete frames for extracting final structured data.
 
 ---
 ## Usage
@@ -56,13 +76,15 @@ llm.writeSession {
 
     stream.collect { frame ->
         when (frame) {
-            is StreamFrame.Append -> print(frame.text)
-            is StreamFrame.ToolCall -> {
+            is StreamFrame.TextDelta -> print(frame.text)
+            is StreamFrame.ReasoningDelta -> print("[Reasoning] text=${frame.text} summary=${frame.summary}")
+            is StreamFrame.ToolCallComplete -> {
                 println("\n🔧 Tool call: ${frame.name} args=${frame.content}")
                 // Optionally parse lazily:
                 // val json = frame.contentJson
             }
             is StreamFrame.End -> println("\n[END] reason=${frame.finishReason}")
+            else -> {} // Handle other frame types (TextComplete, ToolCallDelta, etc.)
         }
     }
 }
@@ -103,9 +125,58 @@ llm.writeSession {
 ```
 <!--- KNIT example-streaming-api-02.kt -->
 
+### Working with reasoning frames
+
+Models that support reasoning (such as Claude Sonnet 4.5 or GPT-o1) emit reasoning frames during streaming. You can access both the reasoning process and its summary:
+
+<!--- INCLUDE
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.prompt.streaming.StreamFrame
+
+val strategy = strategy<String, String>("strategy_name") {
+    val node by node<Unit, Unit> {
+-->
+<!--- SUFFIX
+   }
+}
+-->
+```kotlin
+llm.writeSession {
+    appendPrompt { user("Solve this complex problem: ...") }
+
+    val stream = requestLLMStreaming()
+    val reasoningSteps = mutableListOf<String>()
+    val summarySteps = mutableListOf<String>()
+
+    stream.collect { frame ->
+        when (frame) {
+            is StreamFrame.ReasoningDelta -> {
+                frame.text?.let { 
+                    reasoningSteps.add(it)
+                    print(frame.text) // Display reasoning as it arrives
+                }
+                frame.summary?.let {
+                    summarySteps.add(it)
+                    print(frame.summary) // Display reasoning summary as it arrives
+                }
+            }
+            is StreamFrame.ReasoningComplete -> {
+                // Access complete reasoning
+                println("\nComplete reasoning: ${frame.text.joinToString("")}")
+                println("Summary: ${frame.summary?.joinToString("") ?: "N/A"}")
+            }
+            is StreamFrame.TextDelta -> print(frame.text)
+            is StreamFrame.End -> println("\n[END]")
+            else -> {}
+        }
+    }
+}
+```
+<!--- KNIT example-streaming-api-reasoning-01.kt -->
+
 ### Working with a raw text stream (derived)
 
-If you have existing streaming parsers that expect `Flow<String>`, 
+If you have existing streaming parsers that expect `Flow<String>`,
 derive text chunks via `filterTextOnly()` or collect them with `collectText()`.
 
 <!--- INCLUDE
@@ -156,11 +227,13 @@ handleEvents {
         println("\n🔧 Using ${context.toolName} with ${context.toolArgs}... ")
     }
     onLLMStreamingFrameReceived { context ->
-        (context.streamFrame as? StreamFrame.Append)?.let { frame ->
-            print(frame.text)
+        when (val frame = context.streamFrame) {
+            is StreamFrame.TextDelta -> print(frame.text)
+            is StreamFrame.ReasoningDelta -> print("[Reasoning] text=${frame.text} summary=${frame.summary}")
+            else -> {} // Handle other frame types if needed
         }
     }
-    onLLMStreamingFailed { context -> 
+    onLLMStreamingFailed { context ->
         println("❌ Error: ${context.error}")
     }
     onLLMStreamingCompleted {
@@ -173,9 +246,10 @@ handleEvents {
 ### Converting frames to `Message.Response`
 
 You can transform a collected list of frames to standard message objects:
-- `toAssistantMessageOrNull()`
-- `toToolCallMessages()`
-- `toMessageResponses()`
+- `toAssistantMessageOrNull()` — extracts `Message.Assistant` from text frames
+- `toReasoningMessageOrNull()` — extracts `Message.Reasoning` from reasoning frames
+- `toToolCallMessages()` — extracts `Message.Tool.Call` from tool call frames
+- `toMessageResponses()` — converts all complete frames to their corresponding `Message.Response` objects
 
 ---
 

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/streaming/StreamingAgentWithTools.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/streaming/StreamingAgentWithTools.kt
@@ -36,7 +36,7 @@ suspend fun main() {
                     println("\n🔧 Using ${context.toolName} with ${context.toolArgs}... ")
                 }
                 onLLMStreamingFrameReceived { context ->
-                    (context.streamFrame as? StreamFrame.Append)?.let { frame ->
+                    (context.streamFrame as? StreamFrame.TextDelta)?.let { frame ->
                         print(frame.text)
                     }
                 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
@@ -78,7 +78,6 @@ import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
@@ -225,43 +224,44 @@ abstract class ExecutorIntegrationTestBase {
         }
 
         withRetry(times = 3, testName = "integration_testExecuteStreaming[${model.id}]") {
-            with(StringBuilder()) {
-                val endMessages = mutableListOf<StreamFrame.End>()
-                val toolMessages = mutableListOf<StreamFrame.ToolCall>()
+            val endMessages = mutableListOf<StreamFrame.End>()
+            val toolMessages = mutableListOf<StreamFrame.ToolCallDelta>()
+            val textFrames = mutableListOf<StreamFrame.TextDelta>()
+            val reasoningFrames = mutableListOf<StreamFrame.ReasoningDelta>()
 
-                executor.executeStreamAndCollect(
-                    prompt = prompt,
-                    model = model,
-                    appendable = this,
-                    endMessages = endMessages,
-                    toolMessages = toolMessages
-                )
+            executor.executeStreamAndCollect(
+                prompt = prompt,
+                model = model,
+                tools = listOf(SimpleCalculatorTool.descriptor),
+                textFrames = textFrames,
+                reasoningFrames = reasoningFrames,
+                endFrame = endMessages,
+                toolFrames = toolMessages
+            )
 
-                length shouldNotBe (0)
-                toolMessages.shouldBeEmpty()
-                when (model.provider) {
-                    is LLMProvider.Ollama -> endMessages.size shouldBe 0
+            toolMessages.shouldBeEmpty()
+            when (model.provider) {
+                is LLMProvider.Ollama -> endMessages.size shouldBe 0
 
-                    else -> {
-                        endMessages.size shouldBe 1
-                        endMessages.first() should { end ->
-                            end.metaInfo should { meta ->
-                                withClue("ResponseMetaInfo should contain at least some non-nullable token count info") {
-                                    listOf(meta.inputTokensCount, meta.outputTokensCount, meta.totalTokensCount)
-                                        .shouldForAny { it != null }
-                                }
+                else -> {
+                    endMessages.size shouldBe 1
+                    endMessages.first() should { end ->
+                        end.metaInfo should { meta ->
+                            withClue("ResponseMetaInfo should contain at least some non-nullable token count info") {
+                                listOf(meta.inputTokensCount, meta.outputTokensCount, meta.totalTokensCount)
+                                    .shouldForAny { it != null }
                             }
                         }
                     }
                 }
+            }
 
-                toString() shouldNotBeNull {
-                    shouldContain("1")
-                    shouldContain("2")
-                    shouldContain("3")
-                    shouldContain("4")
-                    shouldContain("5")
-                }
+            textFrames.joinToString { it.text } shouldNotBeNull {
+                shouldContain("1")
+                shouldContain("2")
+                shouldContain("3")
+                shouldContain("4")
+                shouldContain("5")
             }
         }
     }
@@ -1153,26 +1153,27 @@ abstract class ExecutorIntegrationTestBase {
         }
 
         withRetry(times = 3, testName = "integration_testExecuteStreamingWithTools[${model.id}]") {
-            with(StringBuilder()) {
-                val endMessages = mutableListOf<StreamFrame.End>()
-                val toolMessages = mutableListOf<StreamFrame.ToolCall>()
+            val endMessages = mutableListOf<StreamFrame.End>()
+            val toolMessages = mutableListOf<StreamFrame.ToolCallDelta>()
+            val textFrames = mutableListOf<StreamFrame.TextDelta>()
+            val reasoningFrames = mutableListOf<StreamFrame.ReasoningDelta>()
 
-                executor.executeStreamAndCollect(
-                    prompt = prompt,
-                    model = model,
-                    tools = listOf(SimpleCalculatorTool.descriptor),
-                    appendable = this,
-                    endMessages = endMessages,
-                    toolMessages = toolMessages
-                )
+            executor.executeStreamAndCollect(
+                prompt = prompt,
+                model = model,
+                tools = listOf(SimpleCalculatorTool.descriptor),
+                textFrames = textFrames,
+                reasoningFrames = reasoningFrames,
+                endFrame = endMessages,
+                toolFrames = toolMessages
+            )
 
-                toolMessages.shouldNotBeEmpty()
-                withClue("Expected calculator tool call but got: [$toolMessages]") {
-                    toolMessages.any {
-                        it.name == SimpleCalculatorTool.name &&
-                            it.content.contains(CalculatorOperation.MULTIPLY.name, ignoreCase = true)
-                    } shouldBe true
-                }
+            toolMessages.shouldNotBeEmpty()
+            withClue("Expected calculator tool call but got: [$toolMessages]") {
+                toolMessages.any {
+                    it.name == SimpleCalculatorTool.name &&
+                        it.content!!.contains(CalculatorOperation.MULTIPLY.name, ignoreCase = true)
+                } shouldBe true
             }
         }
     }
@@ -1182,15 +1183,26 @@ private suspend fun PromptExecutor.executeStreamAndCollect(
     prompt: Prompt,
     model: LLModel,
     tools: List<ToolDescriptor> = emptyList(),
-    appendable: Appendable,
-    endMessages: MutableList<StreamFrame.End>,
-    toolMessages: MutableList<StreamFrame.ToolCall>
+    textFrames: MutableList<StreamFrame.TextDelta>,
+    endFrame: MutableList<StreamFrame.End>,
+    toolFrames: MutableList<StreamFrame.ToolCallDelta>,
+    reasoningFrames: MutableList<StreamFrame.ReasoningDelta>,
 ) {
     this.executeStreaming(prompt, model, tools).collect { frame ->
         when (frame) {
-            is StreamFrame.Append -> appendable.append(frame.text)
-            is StreamFrame.End -> endMessages.add(frame)
-            is StreamFrame.ToolCall -> toolMessages.add(frame)
+            is StreamFrame.DeltaFrame -> {
+                when (val delta: StreamFrame.DeltaFrame = frame) {
+                    is StreamFrame.TextDelta -> textFrames.add(delta)
+                    is StreamFrame.ToolCallDelta -> toolFrames.add(delta)
+                    is StreamFrame.ReasoningDelta -> reasoningFrames.add(delta)
+                }
+            }
+
+            is StreamFrame.End -> {
+                endFrame.add(frame)
+            }
+
+            is StreamFrame.CompleteFrame -> {}
         }
     }
 }

--- a/prompt/prompt-executor/prompt-executor-cached/src/commonMain/kotlin/ai/koog/prompt/executor/cached/CachedPromptExecutor.kt
+++ b/prompt/prompt-executor/prompt-executor-cached/src/commonMain/kotlin/ai/koog/prompt/executor/cached/CachedPromptExecutor.kt
@@ -10,7 +10,7 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.streaming.StreamFrame
-import ai.koog.prompt.streaming.toStreamFrame
+import ai.koog.prompt.streaming.toStreamFrames
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.datetime.Clock
@@ -41,9 +41,7 @@ public class CachedPromptExecutor(
         tools: List<ToolDescriptor>
     ): Flow<StreamFrame> =
         flow {
-            getOrPut(prompt, tools, model).forEach {
-                emit(it.toStreamFrame())
-            }
+            getOrPut(prompt, tools, model).toStreamFrames().forEach { emit(it) }
         }
 
     private suspend fun getOrPut(prompt: Prompt, model: LLModel): Message.Assistant {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
@@ -210,15 +210,30 @@ public open class AnthropicLLMClient(
                         AnthropicStreamEventType.CONTENT_BLOCK_START.value -> {
                             when (val contentBlock = response.contentBlock) {
                                 is AnthropicContent.Text -> {
-                                    emitAppend(contentBlock.text)
+                                    emitTextDelta(
+                                        text = contentBlock.text,
+                                        index = response.index
+                                            ?: throw LLMClientException(
+                                                clientName,
+                                                "Text index is missing"
+                                            )
+                                    )
                                 }
 
                                 is AnthropicContent.ToolUse -> {
-                                    upsertToolCall(
-                                        index = response.index
-                                            ?: throw LLMClientException(clientName, "Tool index is missing"),
+                                    emitToolCallDelta(
                                         id = contentBlock.id,
                                         name = contentBlock.name,
+                                        index = response.index
+                                            ?: throw LLMClientException(clientName, "Tool index is missing"),
+                                    )
+                                }
+
+                                is AnthropicContent.Thinking -> {
+                                    emitReasoningDelta(
+                                        text = contentBlock.thinking,
+                                        index = response.index
+                                            ?: throw LLMClientException(clientName, "Thinking index is missing")
                                     )
                                 }
 
@@ -234,19 +249,29 @@ public open class AnthropicLLMClient(
                                 // Handles deltas for tool calls and text
 
                                 when (delta.type) {
-                                    AnthropicStreamDeltaContentType.INPUT_JSON_DELTA.value -> {
-                                        upsertToolCall(
+                                    AnthropicStreamDeltaContentType.TEXT_DELTA.value -> {
+                                        emitTextDelta(
+                                            delta.text
+                                                ?: throw LLMClientException(clientName, "Text delta is missing"),
                                             index = response.index
-                                                ?: throw LLMClientException(clientName, "Tool index is missing"),
-                                            args = delta.partialJson
-                                                ?: throw LLMClientException(clientName, "Tool args are missing")
                                         )
                                     }
 
-                                    AnthropicStreamDeltaContentType.TEXT_DELTA.value -> {
-                                        emitAppend(
-                                            delta.text
-                                                ?: throw LLMClientException(clientName, "Text delta is missing")
+                                    AnthropicStreamDeltaContentType.INPUT_JSON_DELTA.value -> {
+                                        emitToolCallDelta(
+                                            args = delta.partialJson
+                                                ?: throw LLMClientException(clientName, "Tool args are missing"),
+                                            index = response.index
+                                                ?: throw LLMClientException(clientName, "Tool index is missing"),
+                                        )
+                                    }
+
+                                    AnthropicStreamDeltaContentType.THINKING_DELTA.value -> {
+                                        emitReasoningDelta(
+                                            text = delta.thinking
+                                                ?: throw LLMClientException(clientName, "Reasoning delta is missing"),
+                                            index = response.index
+                                                ?: throw LLMClientException(clientName, "Reasoning index is missing")
                                         )
                                     }
 
@@ -258,7 +283,21 @@ public open class AnthropicLLMClient(
                         }
 
                         AnthropicStreamEventType.CONTENT_BLOCK_STOP.value -> {
-                            tryEmitPendingToolCall()
+                            response.delta?.let { delta ->
+                                when (delta.type) {
+                                    AnthropicStreamDeltaContentType.TEXT_DELTA.value -> {
+                                        tryEmitPendingText()
+                                    }
+
+                                    AnthropicStreamDeltaContentType.INPUT_JSON_DELTA.value -> {
+                                        tryEmitPendingToolCall()
+                                    }
+
+                                    AnthropicStreamDeltaContentType.THINKING_DELTA.value -> {
+                                        tryEmitPendingReasoning()
+                                    }
+                                }
+                            }
                         }
 
                         AnthropicStreamEventType.MESSAGE_DELTA.value -> {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/models/AnthropicChatMessages.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/models/AnthropicChatMessages.kt
@@ -550,6 +550,7 @@ public enum class AnthropicStreamEventType(public val value: String) {
 public enum class AnthropicStreamDeltaContentType(public val value: String) {
     TEXT_DELTA("text_delta"),
     INPUT_JSON_DELTA("input_json_delta"),
+    THINKING_DELTA("thinking_delta"),
 }
 
 /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseConverters.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseConverters.kt
@@ -355,7 +355,7 @@ internal object BedrockConverseConverters {
 
                 is ConverseStreamOutput.ContentBlockStart -> when (val start = chunk.value.start) {
                     is ContentBlockStart.ToolUse -> {
-                        upsertToolCall(
+                        emitToolCallDelta(
                             index = chunk.value.contentBlockIndex,
                             id = start.value.toolUseId,
                             name = start.value.name,
@@ -377,11 +377,11 @@ internal object BedrockConverseConverters {
 
                 is ConverseStreamOutput.ContentBlockDelta -> when (val delta = chunk.value.delta) {
                     is ContentBlockDelta.Text -> {
-                        emitAppend(delta.value)
+                        emitTextDelta(delta.value)
                     }
 
                     is ContentBlockDelta.ToolUse -> {
-                        upsertToolCall(
+                        emitToolCallDelta(
                             index = chunk.value.contentBlockIndex,
                             args = delta.value.input
                         )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/BedrockAI21JambaSerialization.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/BedrockAI21JambaSerialization.kt
@@ -177,9 +177,9 @@ internal object BedrockAI21JambaSerialization {
         return buildList {
             val choice = streamResponse.choices.firstOrNull()
             choice?.delta?.let { delta ->
-                delta.content?.let(StreamFrame::Append)?.let(::add)
+                delta.content?.let(StreamFrame::TextDelta)?.let(::add)
                 delta.toolCalls?.map { jambaToolCall ->
-                    StreamFrame.ToolCall(
+                    StreamFrame.ToolCallDelta(
                         id = jambaToolCall.id,
                         name = jambaToolCall.function.name,
                         content = jambaToolCall.function.arguments

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/amazon/BedrockAmazonNovaSerialization.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/amazon/BedrockAmazonNovaSerialization.kt
@@ -142,7 +142,7 @@ internal object BedrockAmazonNovaSerialization {
     internal fun parseNovaStreamChunk(chunkJsonString: String, clock: Clock = Clock.System): List<StreamFrame> {
         val chunk = json.decodeFromString<NovaStreamChunk>(chunkJsonString)
         return buildList {
-            chunk.contentBlockDelta?.delta?.text?.let(StreamFrame::Append)?.let(::add)
+            chunk.contentBlockDelta?.delta?.text?.let(StreamFrame::TextDelta)?.let(::add)
             chunk.messageStop?.let { stop ->
                 add(
                     StreamFrame.End(

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/anthropic/BedrockAnthropicClaudeSerialization.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/anthropic/BedrockAnthropicClaudeSerialization.kt
@@ -255,11 +255,11 @@ internal object BedrockAnthropicClaudeSerialization {
                 AnthropicStreamEventType.CONTENT_BLOCK_START.value -> {
                     when (val contentBlock = response.contentBlock) {
                         is AnthropicContent.Text -> {
-                            emitAppend(contentBlock.text)
+                            emitTextDelta(contentBlock.text)
                         }
 
                         is AnthropicContent.ToolUse -> {
-                            upsertToolCall(
+                            emitToolCallDelta(
                                 index = response.index ?: error("Tool index is missing"),
                                 id = contentBlock.id,
                                 name = contentBlock.name,
@@ -279,14 +279,14 @@ internal object BedrockAnthropicClaudeSerialization {
 
                         when (delta.type) {
                             AnthropicStreamDeltaContentType.INPUT_JSON_DELTA.value -> {
-                                upsertToolCall(
+                                emitToolCallDelta(
                                     index = response.index ?: error("Tool index is missing"),
                                     args = delta.partialJson ?: error("Tool args are missing")
                                 )
                             }
 
                             AnthropicStreamDeltaContentType.TEXT_DELTA.value -> {
-                                emitAppend(
+                                emitTextDelta(
                                     delta.text ?: error("Text delta is missing")
                                 )
                             }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/meta/BedrockMetaLlamaSerialization.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/meta/BedrockMetaLlamaSerialization.kt
@@ -64,7 +64,7 @@ internal object BedrockMetaLlamaSerialization {
     internal fun parseLlamaStreamChunk(chunkJsonString: String, clock: Clock = Clock.System): List<StreamFrame> {
         val chunk = json.decodeFromString<LlamaStreamChunk>(chunkJsonString)
         return buildList {
-            chunk.generation?.let(StreamFrame::Append)?.let(::add)
+            chunk.generation?.let(StreamFrame::TextDelta)?.let(::add)
             if (chunk.stopReason != null) {
                 add(
                     StreamFrame.End(

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/BedrockAI21JambaSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/ai21/BedrockAI21JambaSerializationTest.kt
@@ -343,7 +343,7 @@ class BedrockAI21JambaSerializationTest {
         """.trimIndent()
 
         val content = BedrockAI21JambaSerialization.parseJambaStreamChunk(chunkJson)
-        assertEquals(listOf("Paris is ").map(StreamFrame::Append), content)
+        assertEquals(listOf("Paris is ").map(StreamFrame::TextDelta), content)
     }
 
     @Test
@@ -363,7 +363,7 @@ class BedrockAI21JambaSerializationTest {
         """.trimIndent()
 
         val content = BedrockAI21JambaSerialization.parseJambaStreamChunk(chunkJson)
-        assertEquals(listOf("").map(StreamFrame::Append), content)
+        assertEquals(listOf("").map(StreamFrame::TextDelta), content)
     }
 
     @Test

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/amazon/BedrockAmazonNovaSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/amazon/BedrockAmazonNovaSerializationTest.kt
@@ -215,7 +215,7 @@ class BedrockAmazonNovaSerializationTest {
         """.trimIndent()
 
         val content = BedrockAmazonNovaSerialization.parseNovaStreamChunk(chunkJson)
-        assertEquals(listOf(chunkContent).map(StreamFrame::Append), content)
+        assertEquals(listOf(chunkContent).map(StreamFrame::TextDelta), content)
     }
 
     @Test
@@ -231,7 +231,7 @@ class BedrockAmazonNovaSerializationTest {
         """.trimIndent()
 
         val content = BedrockAmazonNovaSerialization.parseNovaStreamChunk(chunkJson)
-        assertEquals(listOf("").map(StreamFrame::Append), content)
+        assertEquals(listOf("").map(StreamFrame::TextDelta), content)
     }
 
     @Test

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/anthropic/BedrockAnthropicClaudeSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/anthropic/BedrockAnthropicClaudeSerializationTest.kt
@@ -327,8 +327,8 @@ class BedrockAnthropicClaudeSerializationTest {
         val content =
             BedrockAnthropicClaudeSerialization.transformAnthropicStreamChunks(chunkJsonStringFlow, mockClock).toList()
         val expected = listOf(
-            StreamFrame.Append("hello"),
-            StreamFrame.Append("world"),
+            StreamFrame.TextDelta("hello"),
+            StreamFrame.TextDelta("world"),
         )
         assertEquals(expected, content)
     }
@@ -444,10 +444,29 @@ class BedrockAnthropicClaudeSerializationTest {
         val content =
             BedrockAnthropicClaudeSerialization.transformAnthropicStreamChunks(chunkJsonStringFlow, mockClock).toList()
         val expected = listOf(
-            StreamFrame.ToolCall(
+            StreamFrame.ToolCallDelta(
                 id = toolId,
                 name = toolName,
-                content = "{\"location\":\"Paris\"}"
+                content = null,
+                index = 0
+            ),
+            StreamFrame.ToolCallDelta(
+                id = null,
+                name = null,
+                content = "{\"location\":",
+                index = 0
+            ),
+            StreamFrame.ToolCallDelta(
+                id = null,
+                name = null,
+                content = "\"Paris\"}",
+                index = 0
+            ),
+            StreamFrame.ToolCallComplete(
+                id = toolId,
+                name = toolName,
+                content = "{\"location\":\"Paris\"}",
+                index = 0
             )
         )
         assertEquals(expected, content)

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/meta/BedrockMetaLlamaSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/meta/BedrockMetaLlamaSerializationTest.kt
@@ -154,7 +154,7 @@ class BedrockMetaLlamaSerializationTest {
         """.trimIndent()
 
         val content = BedrockMetaLlamaSerialization.parseLlamaStreamChunk(chunkJson)
-        assertEquals(listOf("Hello, ").map(StreamFrame::Append), content)
+        assertEquals(listOf("Hello, ").map(StreamFrame::TextDelta), content)
     }
 
     @Test
@@ -166,7 +166,7 @@ class BedrockMetaLlamaSerializationTest {
         """.trimIndent()
 
         val content = BedrockMetaLlamaSerialization.parseLlamaStreamChunk(chunkJson)
-        assertEquals(listOf("").map(StreamFrame::Append), content)
+        assertEquals(listOf("").map(StreamFrame::TextDelta), content)
     }
 
     @Test

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/dashscope/DashscopeLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/dashscope/DashscopeLLMClient.kt
@@ -133,14 +133,14 @@ public class DashscopeLLMClient(
 
         response.collect { chunk ->
             chunk.choices.firstOrNull()?.let { choice ->
-                choice.delta.content?.let { emitAppend(it) }
+                choice.delta.content?.let { emitTextDelta(it) }
 
                 choice.delta.toolCalls?.forEach { toolCall ->
-                    val index = toolCall.index
                     val id = toolCall.id
                     val name = toolCall.function?.name
                     val arguments = toolCall.function?.arguments
-                    upsertToolCall(index, id, name, arguments)
+                    val index = toolCall.index
+                    emitToolCallDelta(id, name, arguments, index)
                 }
 
                 choice.finishReason?.let { finishReason = it }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
@@ -151,14 +151,14 @@ public class DeepSeekLLMClient(
 
         response.collect { chunk ->
             chunk.choices.firstOrNull()?.let { choice ->
-                choice.delta.content?.let { emitAppend(it) }
+                choice.delta.content?.let { emitTextDelta(it) }
 
                 choice.delta.toolCalls?.forEach { toolCall ->
-                    val index = toolCall.index
                     val id = toolCall.id
                     val name = toolCall.function?.name
                     val arguments = toolCall.function?.arguments
-                    upsertToolCall(index, id, name, arguments)
+                    val index = toolCall.index
+                    emitToolCallDelta(id, name, arguments, index)
                 }
 
                 choice.finishReason?.let { finishReason = it }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -40,9 +40,9 @@ import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.streaming.StreamFrame
-import ai.koog.prompt.streaming.emitAppend
 import ai.koog.prompt.streaming.emitEnd
-import ai.koog.prompt.streaming.emitToolCall
+import ai.koog.prompt.streaming.emitTextDelta
+import ai.koog.prompt.streaming.emitToolCallComplete
 import ai.koog.prompt.streaming.streamFrameFlow
 import ai.koog.prompt.structure.RegisteredBasicJsonSchemaGenerators
 import ai.koog.prompt.structure.RegisteredStandardJsonSchemaGenerators
@@ -196,13 +196,16 @@ public open class GoogleLLMClient(
                 response.candidates.firstOrNull()?.let { candidate ->
                     candidate.content?.parts?.forEach { part ->
                         when (part) {
-                            is GooglePart.FunctionCall -> emitToolCall(
+                            is GooglePart.FunctionCall -> emitToolCallComplete(
                                 id = part.functionCall.id,
                                 name = part.functionCall.name,
                                 content = part.functionCall.args?.toString() ?: "{}"
                             )
 
-                            is GooglePart.Text -> emitAppend(part.text)
+                            is GooglePart.Text -> {
+                                emitTextDelta(part.text)
+                            }
+
                             else -> Unit
                         }
                     }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAILLMClient.kt
@@ -165,14 +165,14 @@ public open class MistralAILLMClient(
 
         response.collect { chunk ->
             chunk.choices.firstOrNull()?.let { choice ->
-                choice.delta.content?.let { emitAppend(it) }
+                choice.delta.content?.let { emitTextDelta(it) }
 
                 choice.delta.toolCalls?.forEach { toolCall ->
-                    val index = toolCall.index
                     val id = toolCall.id
                     val name = toolCall.function?.name
                     val arguments = toolCall.function?.arguments
-                    upsertToolCall(index, id, name, arguments)
+                    val index = toolCall.index
+                    emitToolCallDelta(id, name, arguments, index)
                 }
 
                 choice.finishReason?.let { finishReason = it }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -24,6 +24,7 @@ import ai.koog.prompt.executor.ollama.client.dto.OllamaShowModelResponseDTO
 import ai.koog.prompt.executor.ollama.client.dto.OllamaToolDTO
 import ai.koog.prompt.executor.ollama.client.dto.OllamaToolDTO.Definition
 import ai.koog.prompt.executor.ollama.client.dto.extractOllamaJsonFormat
+import ai.koog.prompt.executor.ollama.client.dto.generateToolCallId
 import ai.koog.prompt.executor.ollama.client.dto.getToolCalls
 import ai.koog.prompt.executor.ollama.client.dto.toOllamaChatMessages
 import ai.koog.prompt.executor.ollama.client.dto.toOllamaModelCard
@@ -34,9 +35,9 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.streaming.StreamFrame
-import ai.koog.prompt.streaming.emitAppend
-import ai.koog.prompt.streaming.emitToolCall
-import ai.koog.prompt.streaming.streamFrameFlow
+import ai.koog.prompt.streaming.buildStreamFrameFlow
+import ai.koog.prompt.streaming.emitTextDelta
+import ai.koog.prompt.streaming.emitToolCallDelta
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -272,7 +273,7 @@ public class OllamaClient(
         prompt: Prompt,
         model: LLModel,
         tools: List<ToolDescriptor>
-    ): Flow<StreamFrame> = streamFrameFlow {
+    ): Flow<StreamFrame> = buildStreamFrameFlow {
         require(model.provider == LLMProvider.Ollama) { "Model not supported by Ollama" }
 
         val request = ollamaJson.encodeToString(
@@ -299,13 +300,17 @@ public class OllamaClient(
             try {
                 val chunk = ollamaJson.decodeFromString<OllamaChatResponseDTO>(line)
                 chunk.message?.let { message ->
-                    emitAppend(message.content)
-                    message.toolCalls?.forEach { toolCall ->
-                        emitToolCall(
-                            id = null,
+                    emitTextDelta(message.content)
+                    message.toolCalls?.forEachIndexed { index, toolCall ->
+                        val name = toolCall.function.name
+                        val args = toolCall.function.arguments.toString()
+                        emitToolCallDelta(
+                            id = generateToolCallId(name, args, index),
                             name = toolCall.function.name,
-                            content = toolCall.function.arguments.toString()
+                            args = args,
+                            index = index
                         )
+                        tryEmitPendingToolCall()
                     }
                 }
             } catch (_: Exception) {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaConverters.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaConverters.kt
@@ -173,7 +173,7 @@ internal fun OllamaChatMessageDTO.getToolCalls(responseMetadata: ResponseMetaInf
  * @param index Optional index for multiple tool calls in the same message
  * @return A unique identifier for this specific tool call
  */
-private fun generateToolCallId(toolName: String, content: String, index: Int = 0): String {
+internal fun generateToolCallId(toolName: String, content: String, index: Int = 0): String {
     // Create a deterministic ID using tool name, content hash, and index
     val combined = "$toolName:$content:$index"
     val hashCode = combined.hashCode()

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -271,14 +271,14 @@ public open class OpenAILLMClient(
 
         response.collect { chunk ->
             chunk.choices.firstOrNull()?.let { choice ->
-                choice.delta.content?.let { emitAppend(it) }
+                choice.delta.content?.let { emitTextDelta(it, choice.index) }
 
                 choice.delta.toolCalls?.forEach { openAIToolCall ->
                     val index = openAIToolCall.index
                     val id = openAIToolCall.id
                     val functionName = openAIToolCall.function?.name
                     val functionArgs = openAIToolCall.function?.arguments
-                    upsertToolCall(index, id, functionName, functionArgs)
+                    emitToolCallDelta(id, functionName, functionArgs, index)
                 }
 
                 choice.finishReason?.let { finishReason = it }
@@ -346,11 +346,43 @@ public open class OpenAILLMClient(
                 request = request,
                 requestBodyType = String::class,
                 decodeStreamingResponse = { json.decodeFromString<OpenAIStreamEvent>(it) },
-                processStreamingChunk = {
+                processStreamingChunk = { it ->
                     when (it) {
+                        is OpenAIStreamEvent.ResponseOutputTextDelta -> {
+                            StreamFrame.TextDelta(text = it.delta, index = it.outputIndex)
+                        }
+
+                        is OpenAIStreamEvent.ResponseReasoningTextDelta -> {
+                            StreamFrame.ReasoningDelta(text = it.delta, index = it.outputIndex)
+                        }
+
+                        is OpenAIStreamEvent.ResponseReasoningSummaryTextDelta -> {
+                            StreamFrame.ReasoningDelta(summary = it.delta, index = it.outputIndex)
+                        }
+
+                        is OpenAIStreamEvent.ResponseFunctionCallArgumentsDelta -> {
+                            StreamFrame.ToolCallDelta(id = it.itemId, name = null, content = it.delta, index = it.outputIndex)
+                        }
+
                         is OpenAIStreamEvent.ResponseOutputItemDone -> {
                             when (val item = it.item) {
-                                is Item.FunctionToolCall -> StreamFrame.ToolCall(item.id, item.name, item.arguments)
+                                is Item.Text -> StreamFrame.TextComplete(item.value, it.outputIndex)
+                                is Item.Reasoning -> {
+                                    StreamFrame.ReasoningComplete(
+                                        text = item.content?.map { content -> content.text } ?: emptyList(),
+                                        summary = item.summary.map { content -> content.text },
+                                        encrypted = item.encryptedContent,
+                                        index = it.outputIndex
+                                    )
+                                }
+
+                                is Item.FunctionToolCall -> StreamFrame.ToolCallComplete(
+                                    id = item.id,
+                                    name = item.name,
+                                    content = item.arguments,
+                                    index = it.outputIndex
+                                )
+
                                 else -> null
                             }
                         }
@@ -367,10 +399,6 @@ public open class OpenAILLMClient(
                                     )
                                 }
                             )
-                        }
-
-                        is OpenAIStreamEvent.ResponseOutputTextDelta -> {
-                            StreamFrame.Append(it.delta)
                         }
 
                         else -> null

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
@@ -163,13 +163,13 @@ public class OpenRouterLLMClient(
 
         response.collect { chunk ->
             chunk.choices.firstOrNull()?.let { choice ->
-                choice.delta.content?.let { emitAppend(it) }
+                choice.delta.content?.let { emitTextDelta(it) }
 
                 choice.delta.toolCalls?.forEachIndexed { index, openAIToolCall ->
                     val id = openAIToolCall.id
                     val name = openAIToolCall.function.name
                     val arguments = openAIToolCall.function.arguments
-                    upsertToolCall(index, id, name, arguments)
+                    emitToolCallDelta(id, name, arguments, index)
                 }
 
                 choice.finishReason?.let { finishReason = it }

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClientTest.kt
@@ -12,7 +12,7 @@ import ai.koog.prompt.message.LLMChoice
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.streaming.StreamFrame
-import ai.koog.prompt.streaming.emitAppend
+import ai.koog.prompt.streaming.emitTextDelta
 import ai.koog.prompt.streaming.streamFrameFlow
 import ai.koog.prompt.streaming.streamFrameFlowOf
 import kotlinx.coroutines.CancellationException
@@ -278,7 +278,7 @@ class RetryingLLMClientTest {
 
         val result = retryingClient.executeStreaming(testPrompt, testModel).toList()
 
-        assertEquals(listOf("chunk1", "chunk2").map(StreamFrame::Append), result)
+        assertEquals(listOf("chunk1", "chunk2").map(StreamFrame::TextDelta), result)
         assertEquals(1, mockClient.streamCalls)
     }
 
@@ -300,7 +300,7 @@ class RetryingLLMClientTest {
 
         val result = retryingClient.executeStreaming(testPrompt, testModel).toList()
 
-        assertEquals(listOf("chunk1", "chunk2").map(StreamFrame::Append), result)
+        assertEquals(listOf("chunk1", "chunk2").map(StreamFrame::TextDelta), result)
         assertEquals(2, mockClient.streamCalls)
     }
 
@@ -309,7 +309,7 @@ class RetryingLLMClientTest {
         // Mock that emits one token then fails
         val mockClient = MockLLMClient(
             streamResponse = streamFrameFlow {
-                emitAppend("first-token")
+                emitTextDelta("first-token")
                 throw RuntimeException("Connection lost after first token")
             }
         )

--- a/prompt/prompt-executor/prompt-executor-llms-all/src/jvmTest/kotlin/ai/koog/prompt/executor/llms/all/MultipleLLMPromptExecutorMockTest.kt
+++ b/prompt/prompt-executor/prompt-executor-llms-all/src/jvmTest/kotlin/ai/koog/prompt/executor/llms/all/MultipleLLMPromptExecutorMockTest.kt
@@ -49,7 +49,7 @@ class MultipleLLMPromptExecutorMockTest {
             model: LLModel,
             tools: List<ToolDescriptor>
         ): Flow<StreamFrame> =
-            flowOf("OpenAI", " streaming", " response").map(StreamFrame::Append)
+            flowOf("OpenAI", " streaming", " response").map(StreamFrame::TextDelta)
     }
 
     // Mock client for Anthropic
@@ -67,7 +67,7 @@ class MultipleLLMPromptExecutorMockTest {
             model: LLModel,
             tools: List<ToolDescriptor>
         ): Flow<StreamFrame> =
-            flowOf("Anthropic", " streaming", " response").map(StreamFrame::Append)
+            flowOf("Anthropic", " streaming", " response").map(StreamFrame::TextDelta)
     }
 
     // Mock client for Anthropic
@@ -85,7 +85,7 @@ class MultipleLLMPromptExecutorMockTest {
             model: LLModel,
             tools: List<ToolDescriptor>
         ): Flow<StreamFrame> =
-            flowOf("Gemini", " streaming", " response").map(StreamFrame::Append)
+            flowOf("Gemini", " streaming", " response").map(StreamFrame::TextDelta)
     }
 
     private lateinit var executor: DefaultMultiLLMPromptExecutor

--- a/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/MockOpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/MockOpenAILLMClient.kt
@@ -45,7 +45,7 @@ internal class MockOpenAILLMClient @JvmOverloads constructor(
         model: LLModel,
         tools: List<ToolDescriptor>
     ): Flow<StreamFrame> =
-        flowOf("OpenAI", " streaming", " response").map(StreamFrame::Append)
+        flowOf("OpenAI", " streaming", " response").map(StreamFrame::TextDelta)
 
     override suspend fun moderate(prompt: Prompt, model: LLModel): ModerationResult {
         throw UnsupportedOperationException("Moderation is not supported by mock client.")

--- a/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/MultiLLMPromptExecutorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/MultiLLMPromptExecutorTest.kt
@@ -48,7 +48,7 @@ class MultiLLMPromptExecutorTest {
             model: LLModel,
             tools: List<ToolDescriptor>
         ): Flow<StreamFrame> =
-            flowOf("Anthropic", " streaming", " response").map(StreamFrame::Append)
+            flowOf("Anthropic", " streaming", " response").map(StreamFrame::TextDelta)
 
         override suspend fun moderate(prompt: Prompt, model: LLModel): ModerationResult {
             throw UnsupportedOperationException("Moderation is not supported by mock client.")
@@ -76,7 +76,7 @@ class MultiLLMPromptExecutorTest {
             model: LLModel,
             tools: List<ToolDescriptor>
         ): Flow<StreamFrame> =
-            flowOf("Gemini", " streaming", " response").map(StreamFrame::Append)
+            flowOf("Gemini", " streaming", " response").map(StreamFrame::TextDelta)
 
         override suspend fun moderate(prompt: Prompt, model: LLModel): ModerationResult {
             throw UnsupportedOperationException("Moderation is not supported by mock client.")

--- a/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/SingleLLMPromptExecutorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/SingleLLMPromptExecutorTest.kt
@@ -59,7 +59,7 @@ class SingleLLMPromptExecutorTest {
 
     @Test
     fun testExecuteStreaming() = runTest {
-        val chunks = listOf("hello", " ", "world").map(StreamFrame::Append)
+        val chunks = listOf("hello", " ", "world").map(StreamFrame::TextDelta)
         val client = CapturingLLMClient(streamingChunks = chunks)
         val executor = SingleLLMPromptExecutor(client)
         val prompt = Prompt.build("p2") { user("Hello!") }

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
@@ -168,6 +168,8 @@ public sealed interface Message {
      *
      * @property id An optional identifier for the reasoning process.
      * @property encrypted The encrypted content of the reasoning message.
+     * @property parts The parts of the reasoning message. Only the [ContentPart.Text] part is allowed.
+     * @property summary An optional summary of the reasoning process. Only the [ContentPart.Text] part is allowed.
      * @property content The content of the message as a string.
      * @property role The [Role] of the message, indicating its source or function in the chat (e.g., assistant, user).
      *                Defaults to [Role.Assistant].
@@ -179,14 +181,26 @@ public sealed interface Message {
         public val id: String? = null,
         public val encrypted: String? = null,
         override val parts: List<ContentPart.Text>,
+        public val summary: List<ContentPart.Text>? = null,
         override val metaInfo: ResponseMetaInfo
     ) : Response {
 
         /**
          * Single content part reasoning message constructor
          */
-        public constructor(id: String? = null, encrypted: String? = null, content: String, metaInfo: ResponseMetaInfo) :
-            this(id, encrypted, listOf(ContentPart.Text(content)), metaInfo)
+        public constructor(
+            id: String? = null,
+            encrypted: String? = null,
+            summary: String? = null,
+            content: String,
+            metaInfo: ResponseMetaInfo
+        ) : this(
+            id = id,
+            encrypted = encrypted,
+            parts = listOf(ContentPart.Text(content)),
+            summary = summary?.let { listOf(ContentPart.Text(it)) },
+            metaInfo = metaInfo
+        )
 
         override val role: Role = Role.Reasoning
 

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrame.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrame.kt
@@ -13,14 +13,65 @@ import kotlinx.serialization.json.jsonObject
 public sealed interface StreamFrame {
 
     /**
-     * Represents a frame of a streaming response from a LLM that appends some text.
+     * The interface representing a complete frame of a streaming response from a LLM.
+     */
+    public sealed interface CompleteFrame : StreamFrame {
+        public val index: Int?
+    }
+
+    /**
+     * The interface representing a delta or partial frame of a streaming response from a LLM.
+     */
+    public sealed interface DeltaFrame : StreamFrame {
+        public val index: Int?
+    }
+
+    /**
+     * Represents a frame of a streaming response from a LLM with text delta.
      *
      * @property text The text to append to the response.
      */
     @Serializable
-    public data class Append(
-        val text: String
-    ) : StreamFrame
+    public data class TextDelta(
+        val text: String,
+        override val index: Int? = null
+    ) : DeltaFrame, StreamFrame
+
+    /**
+     * Represents a completion of a streaming response text part.
+     *
+     * @property text The complete text of the response.
+     */
+    @Serializable
+    public data class TextComplete(
+        val text: String,
+        override val index: Int? = null
+    ) : CompleteFrame, StreamFrame
+
+    /**
+     * Represents a frame of a streaming response from a LLM with reasoning text delta.
+     *
+     * @property text The text to append to the reasoning text.
+     */
+    @Serializable
+    public data class ReasoningDelta(
+        val text: String? = null,
+        val summary: String? = null,
+        override val index: Int? = null
+    ) : DeltaFrame, StreamFrame
+
+    /**
+     * Represents a frame of a streaming response from a LLM with reasoning text delta.
+     *
+     * @property text The text to append to the reasoning text.
+     */
+    @Serializable
+    public data class ReasoningComplete(
+        val text: List<String>,
+        val summary: List<String>? = null,
+        public val encrypted: String? = null,
+        override val index: Int? = null
+    ) : CompleteFrame, StreamFrame
 
     /**
      * Represents a frame of a streaming response from a LLM that contains a tool call.
@@ -30,11 +81,27 @@ public sealed interface StreamFrame {
      * @property content The content/arguments of the tool call. Can be null for partial frames.
      */
     @Serializable
-    public data class ToolCall(
+    public data class ToolCallDelta(
+        val id: String?,
+        val name: String?,
+        val content: String?,
+        override val index: Int? = null
+    ) : DeltaFrame, StreamFrame
+
+    /**
+     * Represents a frame of a streaming response from a LLM that contains a tool call.
+     *
+     * @property id The ID of the tool call. Can be null for partial frames.
+     * @property name The name of the tool being called. Can be null for partial frames.
+     * @property content The complete content/arguments of the tool call..
+     */
+    @Serializable
+    public data class ToolCallComplete(
         val id: String?,
         val name: String,
-        val content: String
-    ) : StreamFrame {
+        val content: String,
+        override val index: Int? = null
+    ) : CompleteFrame, StreamFrame {
 
         /**
          * Lazily parses and caches the result of parsing [content] as a JSON object.

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameExt.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameExt.kt
@@ -1,56 +1,99 @@
 package ai.koog.prompt.streaming
 
+import ai.koog.prompt.message.ContentPart
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
 
 /**
- * Converts a [Message.Response] to a [StreamFrame].
+ * Converts a list of [Message.Response] to a list of [StreamFrame].
+ * Final [StreamFrame.End] is also emitted.
  */
-public fun Message.Response.toStreamFrame(): StreamFrame =
-    when (this) {
-        is Message.Assistant -> StreamFrame.Append(content)
-        is Message.Reasoning -> StreamFrame.Append(content)
-        is Message.Tool.Call -> StreamFrame.ToolCall(id, tool, content)
+public fun List<Message.Response>.toStreamFrames(): List<StreamFrame> =
+    flatMapIndexed { index, response -> response.toStreamFrames(index) }.plus(StreamFrame.End(null, ResponseMetaInfo.Empty))
+
+/**
+ * Converts a [Message.Response] to a list of [StreamFrame].
+ * First it emits the delta frames for each content part for each message, then complete frame with the full message content.
+ */
+public fun Message.Response.toStreamFrames(index: Int? = null): List<StreamFrame> {
+    val response = this
+    return buildList {
+        when (response) {
+            is Message.Assistant -> {
+                parts.filterIsInstance<ContentPart.Text>().forEach { add(StreamFrame.TextDelta(it.text, index)) }
+                add(StreamFrame.TextComplete(content, index))
+            }
+
+            is Message.Reasoning -> {
+                parts.forEach { add(StreamFrame.ReasoningDelta(it.text, null, index)) }
+                summary?.forEach { add(StreamFrame.ReasoningDelta(null, it.text, index)) }
+                add(
+                    StreamFrame.ReasoningComplete(
+                        parts.map { it.text },
+                        summary?.map { it.text },
+                        encrypted,
+                        index
+                    )
+                )
+            }
+
+            is Message.Tool.Call -> {
+                add(StreamFrame.ToolCallDelta(id, tool, content, index))
+                add(StreamFrame.ToolCallComplete(id, tool, content, index))
+            }
+        }
     }
+}
 
 /**
  * Converts frames into [Message.Response] objects.
  *
- * - Collects all assistant text (`Append`) into one [Message.Assistant].
- * - Preserves all [StreamFrame.ToolCall] as [Message.Tool.Call].
- * - Uses the last [StreamFrame.End] (if any) for finishReason/metaInfo.
+ * Collects all complete frames into one [Message.Response] objects.
  *
  * @return A list of [Message.Response] objects.
  */
 public fun Iterable<StreamFrame>.toMessageResponses(): List<Message.Response> {
-    var assistantContent: String? = null
-    val toolCalls = mutableListOf<StreamFrame.ToolCall>()
+    val textMessagesCompleteFrames = mutableListOf<StreamFrame.TextComplete>()
+    val reasoningCompleteFrames = mutableListOf<StreamFrame.ReasoningComplete>()
+    val toolCallCompleteFrames = mutableListOf<StreamFrame.ToolCallComplete>()
     var end: StreamFrame.End? = null
 
     forEach { frame ->
         when (frame) {
-            is StreamFrame.Append -> assistantContent = (assistantContent ?: "") + frame.text
-            is StreamFrame.ToolCall -> toolCalls += frame
+            is StreamFrame.TextComplete -> textMessagesCompleteFrames.add(frame)
+            is StreamFrame.ReasoningComplete -> reasoningCompleteFrames.add(frame)
+            is StreamFrame.ToolCallComplete -> toolCallCompleteFrames.add(frame)
             is StreamFrame.End -> end = frame
+            else -> {}
         }
     }
 
     return buildList {
-        toolCalls.forEach {
+        reasoningCompleteFrames.forEach {
+            add(
+                Message.Reasoning(
+                    parts = it.text.map { textPart -> ContentPart.Text(textPart) },
+                    summary = it.summary?.map { summaryPart -> ContentPart.Text(summaryPart) },
+                    encrypted = it.encrypted,
+                    metaInfo = end?.metaInfo ?: ResponseMetaInfo.Empty
+                )
+            )
+        }
+        textMessagesCompleteFrames.forEach {
+            add(
+                Message.Assistant(
+                    content = it.text,
+                    finishReason = end?.finishReason,
+                    metaInfo = end?.metaInfo ?: ResponseMetaInfo.Empty
+                )
+            )
+        }
+        toolCallCompleteFrames.forEach {
             add(
                 Message.Tool.Call(
                     id = it.id,
                     tool = it.name,
                     content = it.content,
-                    metaInfo = end?.metaInfo ?: ResponseMetaInfo.Empty
-                )
-            )
-        }
-        assistantContent?.let {
-            add(
-                Message.Assistant(
-                    content = it,
-                    finishReason = end?.finishReason,
                     metaInfo = end?.metaInfo ?: ResponseMetaInfo.Empty
                 )
             )
@@ -73,3 +116,11 @@ public fun Iterable<StreamFrame>.toToolCallMessages(): List<Message.Tool.Call> =
  */
 public fun Iterable<StreamFrame>.toAssistantMessageOrNull(): Message.Assistant? =
     toMessageResponses().filterIsInstance<Message.Assistant>().singleOrNull()
+
+/**
+ * Extracts the reasoning response from frames, if any.
+ *
+ * @return A [Message.Reasoning] object, or `null` if not found.
+ */
+public fun Iterable<StreamFrame>.toReasoningMessageOrNull(): Message.Reasoning? =
+    toMessageResponses().filterIsInstance<Message.Reasoning>().singleOrNull()

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
@@ -11,16 +11,21 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.experimental.ExperimentalTypeInference
 
 /**
- * Create a [Flow] of [StreamFrame.Append] objects from a list of [String] content.
+ * Create a [Flow] of [StreamFrame.TextDelta] objects from a list of [String] content.
  */
-public fun streamFrameFlowOf(vararg content: String): Flow<StreamFrame.Append> =
-    content.asFlow().map(StreamFrame::Append)
+public fun streamFrameFlowOf(vararg content: String): Flow<StreamFrame.TextDelta> =
+    content.asFlow().map(StreamFrame::TextDelta)
 
 /**
  * Builds a [Flow] of [StreamFrame] objects.
  *
- * @see emitAppend for emitting a [StreamFrame.Append] object.
- * @see emitToolCall for emitting a [StreamFrame.ToolCall] object.
+ * @see emitTextDelta for emitting a [StreamFrame.TextDelta] object.
+ * @see emitTextComplete for emitting a [StreamFrame.TextComplete] object.
+ * @see emitReasoningDelta for emitting a [StreamFrame.ReasoningDelta] object.
+ * @see emitReasoningComplete for emitting a [StreamFrame.ReasoningComplete] object.
+ * @see emitToolCallDelta for emitting a [StreamFrame.ToolCallDelta] object.
+ * @see emitToolCallComplete for emitting a [StreamFrame.ToolCallComplete] object.
+
  * @see emitEnd for emitting a [StreamFrame.End] object.
  */
 @OptIn(ExperimentalTypeInference::class)
@@ -28,10 +33,48 @@ public fun streamFrameFlow(@BuilderInference block: suspend FlowCollector<Stream
     flow(block)
 
 /**
- * Emits a [StreamFrame.Append] with the given [text].
+ * Emits a [StreamFrame.TextDelta] with the given [text].
  */
-public suspend fun FlowCollector<StreamFrame>.emitAppend(text: String): Unit =
-    emit(StreamFrame.Append(text))
+public suspend fun FlowCollector<StreamFrame>.emitTextDelta(text: String, index: Int? = null): Unit =
+    emit(StreamFrame.TextDelta(text, index))
+
+/**
+ * Emits a [StreamFrame.TextComplete] with the given [text].
+ */
+public suspend fun FlowCollector<StreamFrame>.emitTextComplete(text: String, index: Int? = null): Unit =
+    emit(StreamFrame.TextComplete(text, index))
+
+/**
+ * Emits a [StreamFrame.ReasoningDelta] with the given [text] and [summary].
+ */
+public suspend fun FlowCollector<StreamFrame>.emitReasoningDelta(
+    text: String? = null,
+    summary: String? = null,
+    index: Int? = null
+): Unit =
+    emit(StreamFrame.ReasoningDelta(text, summary, index))
+
+/**
+ * Emits a [StreamFrame.ReasoningComplete] with the given [text].
+ */
+public suspend fun FlowCollector<StreamFrame>.emitReasoningComplete(
+    text: String,
+    summary: String? = null,
+    encrypted: String? = null,
+    index: Int? = null
+): Unit =
+    emitReasoningComplete(listOf(text), summary?.let { listOf(it) }, encrypted, index)
+
+/**
+ * Emits a [StreamFrame.ReasoningComplete] with the given [text].
+ */
+public suspend fun FlowCollector<StreamFrame>.emitReasoningComplete(
+    text: List<String>,
+    summary: List<String>? = null,
+    encrypted: String? = null,
+    index: Int? = null
+): Unit =
+    emit(StreamFrame.ReasoningComplete(text, summary, encrypted, index))
 
 /**
  * Emits a [StreamFrame.End] with the given [finishReason].
@@ -43,13 +86,30 @@ public suspend fun FlowCollector<StreamFrame>.emitEnd(
     emit(StreamFrame.End(finishReason, metaInfo ?: ResponseMetaInfo.Empty))
 
 /**
- * Emits a [StreamFrame.ToolCall] with the given [id], [name] and [content].
+ * Emits a [StreamFrame.ToolCallDelta] with the given [id], [name] and [content].
  */
-public suspend fun FlowCollector<StreamFrame>.emitToolCall(id: String?, name: String, content: String): Unit =
-    emit(StreamFrame.ToolCall(id, name, content))
+public suspend fun FlowCollector<StreamFrame>.emitToolCallDelta(
+    id: String?,
+    name: String?,
+    content: String?,
+    index: Int? = null
+): Unit =
+    emit(StreamFrame.ToolCallDelta(id, name, content, index))
+
+/**
+ * Emits a [StreamFrame.ToolCallComplete] with the given [id], [name] and [content].
+ */
+public suspend fun FlowCollector<StreamFrame>.emitToolCallComplete(
+    id: String?,
+    name: String,
+    content: String,
+    index: Int? = null
+): Unit =
+    emit(StreamFrame.ToolCallComplete(id, name, content, index))
 
 /**
  * Builds a [Flow] of [StreamFrame] objects.
+ * Should be used only in case model does not produce completion events.
  */
 public fun buildStreamFrameFlow(block: suspend StreamFrameFlowBuilder.() -> Unit): Flow<StreamFrame> =
     streamFrameFlow {
@@ -70,13 +130,37 @@ public class StreamFrameFlowBuilder(
 ) {
 
     private val pendingToolCallRef = AtomicReference<PendingToolCall?>(null)
+    private val pendingTextRef = AtomicReference<PendingText?>(null)
+    private val pendingReasoningRef = AtomicReference<PendingReasoning?>(null)
 
     /**
-     * Emits a [StreamFrame.Append] with the given [text].
+     * Emits a [StreamFrame.TextDelta] with the given [text].
      */
-    public suspend fun emitAppend(text: String) {
+    public suspend fun emitTextDelta(text: String, index: Int? = null) {
         tryEmitPendingToolCall()
-        flowCollector.emitAppend(text)
+        tryEmitPendingReasoning()
+        val previous: PendingText? = pendingTextRef.load()
+        if (previous == null) {
+            pendingTextRef.store(PendingText(textDelta = text, index = index))
+        } else {
+            pendingTextRef.store(previous.appendTextDelta(text, index))
+        }
+        flowCollector.emitTextDelta(text, index)
+    }
+
+    /**
+     * Emits a [StreamFrame.ReasoningDelta] with the given [text].
+     */
+    public suspend fun emitReasoningDelta(text: String? = null, summary: String? = null, index: Int? = null) {
+        tryEmitPendingToolCall()
+        tryEmitPendingText()
+        val previous: PendingReasoning? = pendingReasoningRef.load()
+        if (previous == null) {
+            pendingReasoningRef.store(PendingReasoning(textDelta = text, summaryDelta = summary, index = index))
+        } else {
+            pendingReasoningRef.store(previous.appendDelta(text, summary, index))
+        }
+        flowCollector.emitReasoningDelta(text, summary, index)
     }
 
     /**
@@ -84,21 +168,9 @@ public class StreamFrameFlowBuilder(
      */
     public suspend fun emitEnd(finishReason: String? = null, metaInfo: ResponseMetaInfo? = null) {
         tryEmitPendingToolCall()
+        tryEmitPendingText()
+        tryEmitPendingReasoning()
         flowCollector.emitEnd(finishReason, metaInfo)
-    }
-
-    /**
-     * Emits a [pendingToolCallRef] if it exists and then clears it.
-     */
-    public suspend fun tryEmitPendingToolCall() {
-        val pendingToolCall = pendingToolCallRef.exchange(null)
-        if (pendingToolCall != null) {
-            flowCollector.emitToolCall(
-                id = pendingToolCall.id,
-                name = pendingToolCall.name ?: "",
-                content = pendingToolCall.argumentsDelta ?: "{}"
-            )
-        }
     }
 
     /**
@@ -107,15 +179,17 @@ public class StreamFrameFlowBuilder(
      *
      * @throws StreamFrameFlowBuilderError if there is
      */
-    public suspend fun upsertToolCall(
-        index: Int,
+    public suspend fun emitToolCallDelta(
         id: String? = null,
         name: String? = null,
-        args: String? = null
+        args: String? = null,
+        index: Int? = null
     ) {
+        tryEmitPendingText()
+        tryEmitPendingReasoning()
         val new: PendingToolCall = if (id != null) {
             tryEmitPendingToolCall()
-            PendingToolCall(index, id, name, args)
+            PendingToolCall(id, name, args, index)
         } else {
             val previous: PendingToolCall? = pendingToolCallRef.load()
             when {
@@ -130,15 +204,83 @@ public class StreamFrameFlowBuilder(
             }
         }
         pendingToolCallRef.store(new)
+        flowCollector.emitToolCallDelta(id, name, args, index)
+    }
+
+    /**
+     * Emits a [pendingTextRef] if it exists and then clears it.
+     */
+    public suspend fun tryEmitPendingText() {
+        val pendingText = pendingTextRef.exchange(null)
+        if (pendingText != null) {
+            flowCollector.emitTextComplete(
+                text = pendingText.textDelta ?: "",
+                index = pendingText.index
+            )
+        }
+    }
+
+    /**
+     * Emits a [pendingReasoningRef] if it exists and then clears it.
+     */
+    public suspend fun tryEmitPendingReasoning() {
+        val pendingReasoning = pendingReasoningRef.exchange(null)
+        if (pendingReasoning != null) {
+            flowCollector.emitReasoningComplete(
+                text = pendingReasoning.textDelta ?: "",
+                summary = pendingReasoning.summaryDelta,
+                index = pendingReasoning.index
+            )
+        }
+    }
+
+    /**
+     * Emits a [pendingToolCallRef] if it exists and then clears it.
+     */
+    public suspend fun tryEmitPendingToolCall() {
+        val pendingToolCall = pendingToolCallRef.exchange(null)
+        if (pendingToolCall != null) {
+            flowCollector.emitToolCallComplete(
+                id = pendingToolCall.id,
+                name = pendingToolCall.name ?: "",
+                content = pendingToolCall.argumentsDelta ?: "{}",
+                index = pendingToolCall.index
+            )
+        }
     }
 
     private data class PendingToolCall(
-        val index: Int,
         val id: String,
         val name: String?,
-        val argumentsDelta: String?
+        val argumentsDelta: String?,
+        val index: Int?,
     ) {
-        fun appendArgumentsDelta(argumentsDelta: String?): PendingToolCall =
-            copy(argumentsDelta = (this.argumentsDelta ?: "") + argumentsDelta)
+        fun appendArgumentsDelta(argumentsDelta: String?): PendingToolCall {
+            require(this.index == index)
+            return copy(argumentsDelta = (this.argumentsDelta ?: "") + argumentsDelta)
+        }
+    }
+
+    private data class PendingText(
+        val textDelta: String?,
+        val index: Int?,
+    ) {
+        fun appendTextDelta(textDelta: String?, index: Int?): PendingText {
+            require(this.index == index)
+            return copy(textDelta = (this.textDelta ?: "") + textDelta)
+        }
+    }
+
+    private data class PendingReasoning(
+        val textDelta: String?,
+        val summaryDelta: String?,
+        val index: Int?
+    ) {
+        fun appendDelta(textDelta: String?, summaryDelta: String?, index: Int?): PendingReasoning {
+            require(this.index == index)
+            val textDelta = if (textDelta == null) this.textDelta else (this.textDelta ?: "") + textDelta
+            val summaryDelta = if (summaryDelta == null) this.summaryDelta else (this.summaryDelta ?: "") + summaryDelta
+            return copy(textDelta = textDelta, summaryDelta = summaryDelta)
+        }
     }
 }

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderError.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderError.kt
@@ -21,6 +21,6 @@ public sealed class StreamFrameFlowBuilderError(message: String) : Throwable(mes
      * @property expectedIndex The expected index of the partial tool call.
      * @property actualIndex The actual index of the partial tool call.
      */
-    public class UnexpectedPartialToolCallIndex(expectedIndex: Int, actualIndex: Int) :
+    public class UnexpectedPartialToolCallIndex(expectedIndex: Int?, actualIndex: Int?) :
         StreamFrameFlowBuilderError("Error constructing tool call, expected index $expectedIndex but was $actualIndex")
 }

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowExt.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowExt.kt
@@ -6,10 +6,10 @@ import kotlinx.coroutines.flow.fold
 import kotlinx.coroutines.flow.map
 
 /**
- * Returns a transformed flow of [StreamFrame.Append] objects that contains only the textual content.
+ * Returns a transformed flow of [StreamFrame.TextDelta] objects that contains only the textual content.
  */
 public fun Flow<StreamFrame>.filterTextOnly(): Flow<String> =
-    filterIsInstance<StreamFrame.Append>()
+    filterIsInstance<StreamFrame.TextDelta>()
         .map { frame -> frame.text }
 
 /**

--- a/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameExtTest.kt
+++ b/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameExtTest.kt
@@ -1,99 +1,337 @@
 package ai.koog.prompt.streaming
 
+import ai.koog.prompt.message.ContentPart
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
-import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
-import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
-import kotlin.time.Clock
+import kotlin.test.assertIs
+import kotlin.test.assertNull
 
 internal class StreamFrameExtTest {
 
     @Test
-    fun `convert Assistant Message to Append StreamFrame`() {
-        assertEquals(
-            expected = appendFrame("test"),
-            actual = assistantMessage("test")
-                .toStreamFrame()
+    fun testMessageAssistantToStreamFrames() {
+        val message = Message.Assistant(
+            content = "Hello, World!",
+            metaInfo = ResponseMetaInfo.Empty,
+            finishReason = "stop"
         )
+
+        val expectedFrames = listOf(
+            StreamFrame.TextDelta("Hello, World!"),
+            StreamFrame.TextComplete("Hello, World!"),
+        )
+
+        assertEquals(expectedFrames, message.toStreamFrames())
     }
 
     @Test
-    fun `convert Call Tool Message to ToolCall StreamFrame`() {
-        assertEquals(
-            expected = toolCallFrame("123", "tool", "{}"),
-            actual = toolCallMessage("123", "tool", "{}")
-                .toStreamFrame()
-        )
-    }
-
-    @Test
-    fun `convert StreamFrame Iterable to Message List`() = runTest {
-        val meta = ResponseMetaInfo.create(
-            clock = Clock.System,
-            inputTokensCount = 1337,
-            outputTokensCount = 69,
-            totalTokensCount = 420,
-        )
-        assertContentEquals(
-            expected = listOf(
-                toolCallMessage("123", "tool", "{}", meta),
-                assistantMessage("test", null, meta),
+    fun testMessageAssistantWithMultiplePartsToStreamFrames() {
+        val message = Message.Assistant(
+            parts = listOf(
+                ContentPart.Text("Hello"),
+                ContentPart.Text("World")
             ),
-            actual = listOf(
-                appendFrame("te"),
-                toolCallFrame("123", "tool", "{}"),
-                appendFrame("st"),
-                endFrame(null, meta),
-            ).toMessageResponses()
+            metaInfo = ResponseMetaInfo.Empty
         )
-        assertContentEquals(
-            expected = listOf(assistantMessage("test", "end", meta)),
-            actual = listOf(
-                appendFrame("test"),
-                endFrame("end", meta),
-            ).toMessageResponses()
+
+        val expectedFrames = listOf(
+            StreamFrame.TextDelta("Hello"),
+            StreamFrame.TextDelta("World"),
+            StreamFrame.TextComplete("Hello\nWorld"),
         )
+
+        assertEquals(expectedFrames, message.toStreamFrames())
     }
 
     @Test
-    fun `convert StreamFrame Iterable to Tool Call Message List`() {
-        assertContentEquals(
-            expected = listOf(toolCallMessage("456", "tool2", "{ a: 1 }")),
-            actual = listOf(toolCallFrame("456", "tool2", "{ a: 1 }"))
-                .toToolCallMessages()
+    fun testMessageReasoningToStreamFrames() {
+        val message = Message.Reasoning(
+            parts = listOf(
+                ContentPart.Text("Thinking step 1"),
+                ContentPart.Text("Thinking step 2")
+            ),
+            summary = listOf(
+                ContentPart.Text("Summary")
+            ),
+            encrypted = "encrypted_content",
+            metaInfo = ResponseMetaInfo.Empty
         )
+
+        val expectedFrames = listOf(
+            StreamFrame.ReasoningDelta(text = "Thinking step 1"),
+            StreamFrame.ReasoningDelta(text = "Thinking step 2"),
+            StreamFrame.ReasoningDelta(summary = "Summary"),
+            StreamFrame.ReasoningComplete(
+                listOf("Thinking step 1", "Thinking step 2"),
+                listOf("Summary"),
+                "encrypted_content"
+            ),
+        )
+
+        assertEquals(expectedFrames, message.toStreamFrames())
     }
 
     @Test
-    fun `convert StreamFrame Iterable to Assistant Message`() {
-        assertEquals(
-            expected = assistantMessage("test"),
-            actual = listOf(appendFrame("test")).toAssistantMessageOrNull()
+    fun testMessageToolCallToStreamFrames() {
+        val message = Message.Tool.Call(
+            id = "call_123",
+            tool = "calculator",
+            content = """{"operation": "add", "a": 1, "b": 2}""",
+            metaInfo = ResponseMetaInfo.Empty
         )
+
+        val expectedFrames = listOf(
+            StreamFrame.ToolCallDelta("call_123", "calculator", """{"operation": "add", "a": 1, "b": 2}"""),
+            StreamFrame.ToolCallComplete("call_123", "calculator", """{"operation": "add", "a": 1, "b": 2}"""),
+        )
+
+        assertEquals(expectedFrames, message.toStreamFrames())
     }
 
     @Test
-    fun `no Assistant Message in StreamFrame Iterable`() {
-        assertEquals(
-            expected = null,
-            actual = listOf(endFrame()).toAssistantMessageOrNull()
+    fun testListOfMessageResponsesToStreamFrames() {
+        val messages = listOf(
+            Message.Reasoning(
+                parts = listOf(
+                    ContentPart.Text("Thinking step 1"),
+                    ContentPart.Text("Thinking step 2")
+                ),
+                summary = listOf(
+                    ContentPart.Text("Summary")
+                ),
+                encrypted = "encrypted_content",
+                metaInfo = ResponseMetaInfo.Empty
+            ),
+            Message.Assistant(
+                parts = listOf(
+                    ContentPart.Text("Hello"),
+                    ContentPart.Text("World")
+                ),
+                metaInfo = ResponseMetaInfo.Empty
+            ),
+            Message.Tool.Call(
+                id = "call_123",
+                tool = "calculator",
+                content = """{"operation": "add", "a": 1, "b": 2}""",
+                metaInfo = ResponseMetaInfo.Empty
+            )
         )
+
+        val expectedFrames = listOf(
+            StreamFrame.ReasoningDelta(text = "Thinking step 1", index = 0),
+            StreamFrame.ReasoningDelta(text = "Thinking step 2", index = 0),
+            StreamFrame.ReasoningDelta(summary = "Summary", index = 0),
+            StreamFrame.ReasoningComplete(
+                listOf("Thinking step 1", "Thinking step 2"),
+                listOf("Summary"),
+                "encrypted_content",
+                0
+            ),
+            StreamFrame.TextDelta("Hello", 1),
+            StreamFrame.TextDelta("World", 1),
+            StreamFrame.TextComplete("Hello\nWorld", 1),
+            StreamFrame.ToolCallDelta("call_123", "calculator", """{"operation": "add", "a": 1, "b": 2}""", 2),
+            StreamFrame.ToolCallComplete("call_123", "calculator", """{"operation": "add", "a": 1, "b": 2}""", 2),
+            StreamFrame.End(null, ResponseMetaInfo.Empty)
+        )
+
+        assertEquals(expectedFrames, messages.toStreamFrames())
+    }
+
+    @Test
+    fun testStreamFramesToMessageAssistant() {
+        val frames = listOf(
+            StreamFrame.TextDelta("Hello, World!"),
+            StreamFrame.TextComplete("Hello, World!"),
+            StreamFrame.End("stop", ResponseMetaInfo.Empty)
+        )
+
+        val expectedMessages = listOf(
+            Message.Assistant(
+                parts = listOf(ContentPart.Text("Hello, World!")),
+                finishReason = "stop",
+                metaInfo = ResponseMetaInfo.Empty
+            )
+        )
+        val messages = frames.toMessageResponses()
+
+        assertEquals(expectedMessages, messages)
+    }
+
+    @Test
+    fun testStreamFramesToMessageAssistantWithMultipleParts() {
+        val frames = listOf(
+            StreamFrame.TextDelta("Hello"),
+            StreamFrame.TextDelta("World"),
+            StreamFrame.TextComplete("Hello\nWorld"),
+            StreamFrame.End(null, ResponseMetaInfo.Empty)
+        )
+
+        val expectedMessages = listOf(
+            Message.Assistant(
+                parts = listOf(ContentPart.Text("Hello\nWorld")),
+                metaInfo = ResponseMetaInfo.Empty
+            )
+        )
+        val messages = frames.toMessageResponses()
+
+        assertEquals(expectedMessages, messages)
+    }
+
+    @Test
+    fun testStreamFramesToMessageReasoning() {
+        val frames = listOf(
+            StreamFrame.ReasoningDelta("Thinking step 1"),
+            StreamFrame.ReasoningDelta("Thinking step 2"),
+            StreamFrame.ReasoningDelta(summary = "Summary"),
+            StreamFrame.ReasoningComplete(
+                listOf("Thinking step 1", "Thinking step 2"),
+                listOf("Summary"),
+                "encrypted_content"
+            ),
+            StreamFrame.End(null, ResponseMetaInfo.Empty)
+        )
+
+        val expectedMessages = listOf(
+            Message.Reasoning(
+                parts = listOf(ContentPart.Text("Thinking step 1"), ContentPart.Text("Thinking step 2")),
+                summary = listOf(ContentPart.Text("Summary")),
+                encrypted = "encrypted_content",
+                metaInfo = ResponseMetaInfo.Empty
+            )
+        )
+
+        val messages = frames.toMessageResponses()
+
+        assertEquals(expectedMessages, messages)
+    }
+
+    @Test
+    fun testStreamFramesToMessageToolCall() {
+        val frames = listOf(
+            StreamFrame.ToolCallDelta("call_123", "calculator", """{"operation": "add", "a": 1, "b": 2}"""),
+            StreamFrame.ToolCallComplete("call_123", "calculator", """{"operation": "add", "a": 1, "b": 2}"""),
+            StreamFrame.End(null, ResponseMetaInfo.Empty)
+        )
+
+        val expectedMessages = listOf(
+            Message.Tool.Call(
+                id = "call_123",
+                tool = "calculator",
+                content = """{"operation": "add", "a": 1, "b": 2}""",
+                metaInfo = ResponseMetaInfo.Empty
+            )
+        )
+
+        val messages = frames.toMessageResponses()
+
+        assertEquals(expectedMessages, messages)
+    }
+
+    @Test
+    fun testStreamFramesToListOfMessageResponses() {
+        val frames = listOf(
+            StreamFrame.ReasoningDelta(text = "Thinking step 1", index = 0),
+            StreamFrame.ReasoningDelta(text = "Thinking step 2", index = 0),
+            StreamFrame.ReasoningDelta(summary = "Summary", index = 0),
+            StreamFrame.ReasoningComplete(
+                listOf("Thinking step 1", "Thinking step 2"),
+                listOf("Summary"),
+                "encrypted_content",
+                0
+            ),
+            StreamFrame.TextDelta("Hello", 1),
+            StreamFrame.TextDelta("World", 1),
+            StreamFrame.TextComplete("Hello\nWorld", 1),
+            StreamFrame.ToolCallDelta("call_123", "calculator", """{"operation": "add", "a": 1, "b": 2}""", 2),
+            StreamFrame.ToolCallComplete("call_123", "calculator", """{"operation": "add", "a": 1, "b": 2}""", 2),
+            StreamFrame.End("stop", ResponseMetaInfo.Empty)
+        )
+
+        val expectedMessages = listOf(
+            Message.Reasoning(
+                parts = listOf(ContentPart.Text("Thinking step 1"), ContentPart.Text("Thinking step 2")),
+                summary = listOf(ContentPart.Text("Summary")),
+                encrypted = "encrypted_content",
+                metaInfo = ResponseMetaInfo.Empty
+            ),
+            Message.Assistant(
+                parts = listOf(ContentPart.Text("Hello\nWorld")),
+                finishReason = "stop",
+                metaInfo = ResponseMetaInfo.Empty
+            ),
+            Message.Tool.Call(
+                id = "call_123",
+                tool = "calculator",
+                content = """{"operation": "add", "a": 1, "b": 2}""",
+                metaInfo = ResponseMetaInfo.Empty
+            )
+        )
+
+        val messages = frames.toMessageResponses()
+
+        assertEquals(expectedMessages, messages)
+    }
+
+    @Test
+    fun testToAssistantMessageOrNull() {
+        val framesWithAssistant = listOf(
+            StreamFrame.TextDelta("Hello"),
+            StreamFrame.TextComplete("Hello"),
+            StreamFrame.End(null, ResponseMetaInfo.Empty)
+        )
+
+        val assistant = framesWithAssistant.toAssistantMessageOrNull()
+
+        assertIs<Message.Assistant>(assistant)
+        assertEquals("Hello", assistant.content)
+    }
+
+    @Test
+    fun testToAssistantMessageOrNullReturnsNull() {
+        val framesWithoutAssistant = listOf(
+            StreamFrame.ToolCallComplete("call_1", "tool", "{}"),
+            StreamFrame.End(null, ResponseMetaInfo.Empty)
+        )
+
+        val assistant = framesWithoutAssistant.toAssistantMessageOrNull()
+
+        assertNull(assistant)
+    }
+
+    @Test
+    fun testToReasoningMessageOrNull() {
+        val framesWithReasoning = listOf(
+            StreamFrame.ReasoningComplete(listOf("Thinking")),
+            StreamFrame.End(null, ResponseMetaInfo.Empty)
+        )
+
+        val reasoning = framesWithReasoning.toReasoningMessageOrNull()
+
+        assertIs<Message.Reasoning>(reasoning)
+        assertEquals("Thinking", reasoning.content)
+    }
+
+    @Test
+    fun testToReasoningMessageOrNullReturnsNull() {
+        val framesWithoutReasoning = listOf(
+            StreamFrame.TextComplete("Hello"),
+            StreamFrame.End(null, ResponseMetaInfo.Empty)
+        )
+
+        val reasoning = framesWithoutReasoning.toReasoningMessageOrNull()
+
+        assertNull(reasoning)
+    }
+
+    @Test
+    fun testToMessageResponsesWithEmptyFrames() {
+        val frames = emptyList<StreamFrame>()
+
+        val messages = frames.toMessageResponses()
+
+        assertEquals(0, messages.size)
     }
 }
-
-private fun toolCallFrame(id: String, name: String, content: String) =
-    StreamFrame.ToolCall(id, name, content)
-
-private fun appendFrame(content: String) =
-    StreamFrame.Append(content)
-
-private fun endFrame(finishReason: String? = null, metaInfo: ResponseMetaInfo = ResponseMetaInfo.Empty) =
-    StreamFrame.End(finishReason, metaInfo)
-
-private fun toolCallMessage(id: String, name: String, content: String, info: ResponseMetaInfo = ResponseMetaInfo.Empty) =
-    Message.Tool.Call(id, name, content, info)
-
-private fun assistantMessage(content: String, finishReason: String? = null, metaInfo: ResponseMetaInfo = ResponseMetaInfo.Empty) =
-    Message.Assistant(content, metaInfo, finishReason = finishReason)

--- a/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderTest.kt
+++ b/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderTest.kt
@@ -1,9 +1,7 @@
 package ai.koog.prompt.streaming
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.FlowCollector
+import ai.koog.prompt.message.ResponseMetaInfo
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -12,87 +10,251 @@ import kotlin.test.assertFailsWith
 
 class StreamFrameFlowBuilderTest {
 
-    private val weatherCallId = "call_get_weather_1"
-    private val weatherFunName = "get_weather"
-    private val weatherArgList = listOf("{\"", "location", "\":\"", "Netherlands", "\"}")
-    private val weatherArgString = weatherArgList.joinToString("")
-
     @Test
-    fun `combine partial tool calls and manually emit as full tool call`() = runTest {
-        buildStreamFrameFlow {
-            upsertWeatherToolCallParts(0)
-            tryEmitPendingToolCall()
-        } assertContentEquals {
-            emitWeatherToolCall()
-        }
+    fun testEmitTextDelta() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitTextDelta("Hello", 0)
+            emitTextDelta(" World", 0)
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.TextDelta("Hello", 0),
+                StreamFrame.TextDelta(" World", 0)
+            ),
+            frames
+        )
     }
 
     @Test
-    fun `combine partial tool calls and automatically emit on append text`() = runTest {
-        buildStreamFrameFlow {
-            upsertWeatherToolCallParts(0)
-            emitAppend("emitted tool?")
-        } assertContentEquals {
-            emitWeatherToolCall()
-            emitAppend("emitted tool?")
-        }
+    fun testEmitReasoningDelta() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitReasoningDelta(text = "Thinking...", index = 0)
+            emitReasoningDelta(text = " step 2", index = 0)
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.ReasoningDelta(text = "Thinking...", index = 0),
+                StreamFrame.ReasoningDelta(text = " step 2", index = 0)
+            ),
+            frames
+        )
     }
 
     @Test
-    fun `combine partial tool calls and automatically emit on end`() = runTest {
-        buildStreamFrameFlow {
-            upsertWeatherToolCallParts(0)
+    fun testEmitReasoningSummaryDelta() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitReasoningDelta(summary = "Summary part 1", index = 0)
+            emitReasoningDelta(summary = " part 2", index = 0)
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.ReasoningDelta(summary = "Summary part 1", index = 0),
+                StreamFrame.ReasoningDelta(summary = " part 2", index = 0)
+            ),
+            frames
+        )
+    }
+
+    @Test
+    fun testEmitToolCallDelta() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitToolCallDelta(id = "call_1", name = "calculator", args = "{\"a\":", 0)
+            emitToolCallDelta(args = " 5}", index = 0)
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.ToolCallDelta("call_1", "calculator", "{\"a\":", 0),
+                StreamFrame.ToolCallDelta(null, null, " 5}", 0),
+            ),
+            frames
+        )
+    }
+
+    @Test
+    fun testEmitEnd() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitEnd("stop")
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.End("stop", ResponseMetaInfo.Empty)
+            ),
+            frames
+        )
+    }
+
+    @Test
+    fun testEmitToolCallDeltaWithoutIdAppendsToExisting() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitToolCallDelta(id = "call_1", name = "search", args = "{\"q")
+            emitToolCallDelta(args = "uery\":")
+            emitToolCallDelta(args = "\"test\"}")
             emitEnd()
-        } assertContentEquals {
-            emitWeatherToolCall()
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.ToolCallDelta("call_1", "search", "{\"q"),
+                StreamFrame.ToolCallDelta(null, null, "uery\":"),
+                StreamFrame.ToolCallDelta(null, null, "\"test\"}"),
+                StreamFrame.ToolCallComplete("call_1", "search", "{\"query\":\"test\"}"),
+                StreamFrame.End(null, ResponseMetaInfo.Empty)
+            ),
+            frames
+        )
+    }
+
+    @Test
+    fun testEmitToolCallDeltaWithIdCreatesNewPendingToolCall() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitToolCallDelta(id = "call_1", name = "calculator", args = "{\"a\":", index = 0)
+            emitToolCallDelta(args = " 5}", index = 0)
+            emitToolCallDelta(id = "call_2", name = "calculator", args = "{\"b\":", index = 1)
+            emitToolCallDelta(args = " 6}", index = 1)
             emitEnd()
-        }
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.ToolCallDelta("call_1", "calculator", "{\"a\":", 0),
+                StreamFrame.ToolCallDelta(null, null, " 5}", 0),
+                StreamFrame.ToolCallComplete("call_1", "calculator", "{\"a\": 5}", 0),
+                StreamFrame.ToolCallDelta("call_2", "calculator", "{\"b\":", 1),
+                StreamFrame.ToolCallDelta(null, null, " 6}", 1),
+                StreamFrame.ToolCallComplete("call_2", "calculator", "{\"b\": 6}", 1),
+                StreamFrame.End(null, ResponseMetaInfo.Empty),
+            ),
+            frames
+        )
     }
 
     @Test
-    fun `combine partial tool calls and automatically emit on other tool call`() = runTest {
-        buildStreamFrameFlow {
-            upsertToolCall(index = 0, id = "some_other_id", name = "some_other_tool", args = "")
-            upsertWeatherToolCallParts(index = 1)
-            tryEmitPendingToolCall()
-        } assertContentEquals {
-            emitToolCall(id = "some_other_id", name = "some_other_tool", content = "")
-            emitWeatherToolCall()
-        }
-    }
-
-    @Test
-    fun `throw when upserting partial tool call without an id`() = runTest {
+    fun testEmitToolCallDeltaWithoutPreviousCallThrowsError() = runTest {
         assertFailsWith<StreamFrameFlowBuilderError.NoPartialToolCallToComplete> {
             buildStreamFrameFlow {
-                upsertToolCall(index = 0, id = null, name = "test_error", "")
+                emitToolCallDelta(args = "{\"a\": 5}")
             }.collect()
         }
     }
 
     @Test
-    fun `throw when upserting partial tool call with index mismatch`() = runTest {
+    fun testEmitToolCallDeltaWithMismatchedIndexThrowsError() = runTest {
         assertFailsWith<StreamFrameFlowBuilderError.UnexpectedPartialToolCallIndex> {
             buildStreamFrameFlow {
-                upsertToolCall(index = 0, id = "test", name = "test_error", "")
-                upsertToolCall(index = 1, id = null, name = "test_error", "")
+                emitToolCallDelta(id = "call_1", name = "tool", args = "{", index = 0)
+                emitToolCallDelta(args = "}", index = 1)
             }.collect()
         }
     }
 
-    private suspend fun StreamFrameFlowBuilder.upsertWeatherToolCallParts(index: Int) {
-        upsertToolCall(index = index, id = weatherCallId, name = weatherFunName, args = "")
-        weatherArgList.forEach {
-            upsertToolCall(index = index, args = it)
-        }
+    @Test
+    fun testSwitchingFromToolCallToTextEmitsPendingToolCall() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitToolCallDelta(id = "call_1", name = "calculator", args = "{\"a\": 5}", 0)
+            emitTextDelta("Result: ", 1)
+            emitEnd()
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.ToolCallDelta("call_1", "calculator", "{\"a\": 5}", 0),
+                StreamFrame.ToolCallComplete("call_1", "calculator", "{\"a\": 5}", 0),
+                StreamFrame.TextDelta("Result: ", 1),
+                StreamFrame.TextComplete("Result: ", 1),
+                StreamFrame.End(null, ResponseMetaInfo.Empty)
+            ),
+            frames
+        )
     }
 
-    private suspend fun FlowCollector<StreamFrame>.emitWeatherToolCall() =
-        emitToolCall(id = weatherCallId, name = weatherFunName, content = weatherArgString)
-}
+    @Test
+    fun testSwitchingFromToolCallToReasoningEmitsPendingToolCall() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitToolCallDelta(id = "call_1", name = "search", args = "{}", 0)
+            emitReasoningDelta(text = "Now thinking...", index = 1)
+            emitEnd()
+        }.toList()
 
-private suspend infix fun Flow<StreamFrame>.assertContentEquals(expected: suspend FlowCollector<StreamFrame>.() -> Unit) =
-    assertContentEquals(
-        expected = flow(expected).toList(),
-        actual = toList()
-    )
+        assertContentEquals(
+            listOf(
+                StreamFrame.ToolCallDelta("call_1", "search", "{}", 0),
+                StreamFrame.ToolCallComplete("call_1", "search", "{}", 0),
+                StreamFrame.ReasoningDelta(text = "Now thinking...", index = 1),
+                StreamFrame.ReasoningComplete(listOf("Now thinking..."), null, null, 1),
+                StreamFrame.End(null, ResponseMetaInfo.Empty)
+            ),
+            frames
+        )
+    }
+
+    @Test
+    fun testSwitchingDifferentFramesEmitsPendingFrame() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitTextDelta("Start with text", 0)
+            emitToolCallDelta(id = "call_1", name = "calculator", args = "{\"a\": 5}", 1)
+            emitTextDelta("Continue after tool with text", 2)
+            emitReasoningDelta(text = "Now switch from text to thinking...", index = 3)
+            emitReasoningDelta(summary = "Summary thinking", index = 3)
+            emitToolCallDelta(id = "call_2", name = "search", args = "{}", 4)
+            emitReasoningDelta(text = "Now switch from tool to thinking...", index = 5)
+            emitReasoningDelta(summary = "Summary thinking", index = 5)
+            emitTextDelta("Finally switch from reasoning to text ", 6)
+            emitEnd()
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.TextDelta("Start with text", 0),
+                StreamFrame.TextComplete("Start with text", 0),
+                StreamFrame.ToolCallDelta("call_1", "calculator", "{\"a\": 5}", 1),
+                StreamFrame.ToolCallComplete("call_1", "calculator", "{\"a\": 5}", 1),
+                StreamFrame.TextDelta("Continue after tool with text", 2),
+                StreamFrame.TextComplete("Continue after tool with text", 2),
+                StreamFrame.ReasoningDelta(text = "Now switch from text to thinking...", index = 3),
+                StreamFrame.ReasoningDelta(summary = "Summary thinking", index = 3),
+                StreamFrame.ReasoningComplete(
+                    listOf("Now switch from text to thinking..."),
+                    listOf("Summary thinking"),
+                    null,
+                    3
+                ),
+                StreamFrame.ToolCallDelta("call_2", "search", "{}", 4),
+                StreamFrame.ToolCallComplete("call_2", "search", "{}", 4),
+                StreamFrame.ReasoningDelta(text = "Now switch from tool to thinking...", index = 5),
+                StreamFrame.ReasoningDelta(summary = "Summary thinking", index = 5),
+                StreamFrame.ReasoningComplete(
+                    listOf("Now switch from tool to thinking..."),
+                    listOf("Summary thinking"),
+                    null,
+                    5
+                ),
+                StreamFrame.TextDelta("Finally switch from reasoning to text ", 6),
+                StreamFrame.TextComplete("Finally switch from reasoning to text ", 6),
+                StreamFrame.End(null, ResponseMetaInfo.Empty)
+            ),
+            frames
+        )
+    }
+
+    @Test
+    fun testEmitEndFlushesAllPendingFrames() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitToolCallDelta(id = "call_1", name = "tool", args = "{}")
+            emitEnd("stop")
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.ToolCallDelta("call_1", "tool", "{}"),
+                StreamFrame.ToolCallComplete("call_1", "tool", "{}"),
+                StreamFrame.End("stop", ResponseMetaInfo.Empty)
+            ),
+            frames
+        )
+    }
+}

--- a/prompt/prompt-model/src/jvmTest/kotlin/ai/koog/prompt/PromptTest.kt
+++ b/prompt/prompt-model/src/jvmTest/kotlin/ai/koog/prompt/PromptTest.kt
@@ -420,7 +420,7 @@ class PromptTest {
 
     @Test
     fun testInvalidToolCallJsonContent() {
-        // contentJson property is now on StreamFrame.ToolCall, not Message.Tool.Call
+        // contentJson property is now on StreamFrame.ToolCallComplete, not Message.Tool.Call
         // This test is no longer applicable for Message.Tool.Call
         val toolCallWithInvalidJson = Message.Tool.Call(toolCallId, toolName, "invalid json", testRespMetaInfo)
         // Just verify the content is stored as-is


### PR DESCRIPTION
Reasoning messages have been previously ignored while streaming. This PR introduces the way to have them as separate objects of `StreamFrame` (including the summary and encrypted version)
`StreamFrame` now has 3 types of events: `DeltaFrame` (for partial messages) and `CompleteFrame`, (for complete messages, merged marts for partial, arrives after the message was completed), and `End` (after all messages are delivered)

BREAKING:
* The whole streaming API, including `StreamFrame` contains breaking changes

closes: #1264 KG-592