### PR TITLE
ci: disable fail-fast for Checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -114,6 +114,7 @@ jobs:
       contents: read
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
 


### PR DESCRIPTION
This also has to be applied to the active release branch (cherry-pick or just copy)