### PR TITLE
ci: Update the regex for release branch names

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,7 +75,7 @@ version = run {
     "$baseVersion$feat"
 }
 
-fun isCustomReleaseBranch(branchName: String): Boolean = branchName.matches(Regex("""^\d+\.\d+\.\d+$"""))
+fun isCustomReleaseBranch(branchName: String): Boolean = branchName.matches(Regex("""^(release\/)?\d+\.\d+\.\d+$"""))
 
 buildscript {
     dependencies {


### PR DESCRIPTION
Update the regex for release branch names to match the `release` prefix.