### PR TITLE
test: reasoning streaming for OpenAI

### DIFF
--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
@@ -218,6 +218,7 @@ abstract class ExecutorIntegrationTestBase {
 
     open fun integration_testExecuteStreaming(model: LLModel) = runTest(timeout = 300.seconds) {
         Models.assumeAvailable(model.provider)
+        assumeTrue(model.capabilities!!.contains(LLMCapability.Tools), "Model $model does not support tools")
 
         val executor = getExecutor(model)
 
@@ -1127,6 +1128,83 @@ abstract class ExecutorIntegrationTestBase {
             val answer = response2.filter { it is Message.Assistant || it is Message.Reasoning }
                 .joinToString("") { it.content }
             answer.shouldContain("20")
+        }
+    }
+
+    open fun integration_testReasoningStreamingSummaryDeltas(model: LLModel) = runTest(timeout = 300.seconds) {
+        Models.assumeAvailable(model.provider)
+        assumeTrue(
+            model.provider == LLMProvider.OpenAI,
+            "This test is specific to OpenAI Responses API reasoning streaming"
+        )
+
+        val params = createReasoningParams(model)
+        val prompt = Prompt.build("reasoning-streaming-test", params = params) {
+            system("You are a helpful assistant.")
+            user("Think about this step by step: What is 12 * 15?")
+        }
+
+        val executor = getExecutor(model)
+
+        withRetry(times = 3, testName = "integration_testReasoningStreamingSummaryDeltas[${model.id}]") {
+            val reasoningDeltaFrames = mutableListOf<StreamFrame.ReasoningDelta>()
+            val reasoningCompleteFrames = mutableListOf<StreamFrame.ReasoningComplete>()
+            val textDeltaFrames = mutableListOf<StreamFrame.TextDelta>()
+            val endFrames = mutableListOf<StreamFrame.End>()
+
+            executor.executeStreamAndCollect(
+                prompt = prompt,
+                model = model,
+                reasoningDeltaFrames = reasoningDeltaFrames,
+                reasoningCompleteFrames = reasoningCompleteFrames,
+                textDeltaFrames = textDeltaFrames,
+                endFrame = endFrames
+            )
+
+            reasoningDeltaFrames.shouldNotBeEmpty()
+
+            val reasoningText = reasoningDeltaFrames.mapNotNull { it.text }.joinToString("")
+            val reasoningSummary = reasoningDeltaFrames.mapNotNull { it.summary }.joinToString("")
+            (reasoningText + reasoningSummary).length shouldBeGreaterThan 0
+
+            val finalAnswer = textDeltaFrames.joinToString("") { it.text }
+            finalAnswer.shouldContain("180")
+        }
+    }
+
+    open fun integration_testReasoningStreamingWithEncryptedContent(model: LLModel) = runTest(timeout = 300.seconds) {
+        Models.assumeAvailable(model.provider)
+        assumeTrue(
+            model.provider == LLMProvider.OpenAI,
+            "This test is specific to OpenAI Responses API encrypted reasoning in stateless mode"
+        )
+
+        val params = createReasoningParams(model)
+        val prompt = Prompt.build("reasoning-streaming-encryption-test", params = params) {
+            system("You are a helpful assistant.")
+            user("Think about this step by step: What is 8 * 9?")
+        }
+
+        val executor = getExecutor(model)
+
+        withRetry(times = 3, testName = "integration_testReasoningStreamingWithEncryptedContent[${model.id}]") {
+            val reasoningCompleteFrames = mutableListOf<StreamFrame.ReasoningComplete>()
+            val textDeltaFrames = mutableListOf<StreamFrame.TextDelta>()
+
+            executor.executeStreamAndCollect(
+                prompt = prompt,
+                model = model,
+                reasoningCompleteFrames = reasoningCompleteFrames,
+                textDeltaFrames = textDeltaFrames
+            )
+
+            reasoningCompleteFrames.shouldNotBeEmpty()
+            val reasoningComplete = reasoningCompleteFrames.first()
+            reasoningComplete.encrypted.shouldNotBeNull()
+            reasoningComplete.encrypted!!.length shouldBeGreaterThan 0
+
+            val finalAnswer = textDeltaFrames.joinToString("") { it.text }
+            finalAnswer.shouldContain("72")
         }
     }
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/MultipleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/MultipleLLMPromptExecutorIntegrationTest.kt
@@ -39,30 +39,10 @@ class MultipleLLMPromptExecutorIntegrationTest : ExecutorIntegrationTestBase() {
         fun audioScenarioModelCombinations(): Stream<Arguments> {
             return MediaTestScenarios.audioScenarioModelCombinations()
         }
-
-        @JvmStatic
-        fun moderationModels(): Stream<Arguments> {
-            return Models.moderationModels().map { model -> Arguments.of(model) }
-        }
-
-        @JvmStatic
-        fun embeddingModels(): Stream<Arguments> {
-            return Models.embeddingModels().map { model -> Arguments.of(model) }
-        }
-
-        @JvmStatic
-        fun reasoningCapableModels(): Stream<Arguments> {
-            return Models.reasoningCapableModels().map { model -> Arguments.of(model) }
-        }
-
-        @JvmStatic
-        fun allCompletionModels(): Stream<Arguments> {
-            return Models.allCompletionModels().map { model -> Arguments.of(model) }
-        }
     }
 
     private val executor: MultiLLMPromptExecutor = run {
-        val providers = allCompletionModels()
+        val providers = Models.allCompletionModels().map { model -> Arguments.of(model) }
             .toList()
             .map { it.get().single() as LLModel }
             .map { it.provider }
@@ -104,97 +84,97 @@ class MultipleLLMPromptExecutorIntegrationTest : ExecutorIntegrationTestBase() {
 
     // Core integration test methods
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testExecute(model: LLModel) {
         super.integration_testExecute(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testExecuteStreaming(model: LLModel) {
         super.integration_testExecuteStreaming(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testExecuteStreamingWithTools(model: LLModel) {
         super.integration_testExecuteStreamingWithTools(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolWithRequiredParams(model: LLModel) {
         super.integration_testToolWithRequiredParams(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolWithNotRequiredOptionalParams(model: LLModel) {
         super.integration_testToolWithNotRequiredOptionalParams(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolWithOptionalParams(model: LLModel) {
         super.integration_testToolWithOptionalParams(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolWithNoParams(model: LLModel) {
         super.integration_testToolWithNoParams(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolWithListEnumParams(model: LLModel) {
         super.integration_testToolWithListEnumParams(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolWithNestedListParams(model: LLModel) {
         super.integration_testToolWithNestedListParams(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolsWithNullParams(model: LLModel) {
         super.integration_testToolsWithNullParams(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolsWithAnyOfParams(model: LLModel) {
         super.integration_testToolsWithAnyOfParams(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testMarkdownStructuredDataStreaming(model: LLModel) {
         super.integration_testMarkdownStructuredDataStreaming(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolChoiceRequired(model: LLModel) {
         super.integration_testToolChoiceRequired(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolChoiceNone(model: LLModel) {
         super.integration_testToolChoiceNone(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolChoiceNamed(model: LLModel) {
         super.integration_testToolChoiceNamed(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testBase64EncodedAttachment(model: LLModel) {
         assumeTrue(
             model.provider != LLMProvider.Bedrock,
@@ -205,7 +185,7 @@ class MultipleLLMPromptExecutorIntegrationTest : ExecutorIntegrationTestBase() {
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testUrlBasedAttachment(model: LLModel) {
         assumeTrue(
             model.provider != LLMProvider.Bedrock,
@@ -216,68 +196,74 @@ class MultipleLLMPromptExecutorIntegrationTest : ExecutorIntegrationTestBase() {
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testStructuredOutputNative(model: LLModel) {
         super.integration_testStructuredOutputNative(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testStructuredOutputNativeWithFixingParser(model: LLModel) {
         super.integration_testStructuredOutputNativeWithFixingParser(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testStructuredOutputManual(model: LLModel) {
         super.integration_testStructuredOutputManual(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testStructuredOutputManualWithFixingParser(model: LLModel) {
         super.integration_testStructuredOutputManualWithFixingParser(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testMultipleSystemMessages(model: LLModel) {
         super.integration_testMultipleSystemMessages(model)
     }
 
     @ParameterizedTest
-    @MethodSource("embeddingModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#embeddingModels")
     override fun integration_testEmbed(model: LLModel) {
         super.integration_testEmbed(model)
     }
 
     @ParameterizedTest
-    @MethodSource("moderationModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#moderationModels")
     override fun integration_testSingleMessageModeration(model: LLModel) {
         super.integration_testSingleMessageModeration(model)
     }
 
     @ParameterizedTest
-    @MethodSource("moderationModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#moderationModels")
     override fun integration_testMultipleMessagesModeration(model: LLModel) {
         super.integration_testMultipleMessagesModeration(model)
     }
 
     @ParameterizedTest
-    @MethodSource("reasoningCapableModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#reasoningCapableModels")
     override fun integration_testReasoningCapability(model: LLModel) {
         super.integration_testReasoningCapability(model)
     }
 
     @ParameterizedTest
-    @MethodSource("reasoningCapableModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#reasoningCapableModels")
     override fun integration_testReasoningWithEncryption(model: LLModel) {
         super.integration_testReasoningWithEncryption(model)
     }
 
     @ParameterizedTest
-    @MethodSource("reasoningCapableModels")
-    override fun integration_testReasoningMultiStep(model: LLModel) {
-        super.integration_testReasoningMultiStep(model)
+    @MethodSource("ai.koog.integration.tests.utils.Models#openAIReasoningModels")
+    override fun integration_testReasoningStreamingSummaryDeltas(model: LLModel) {
+        super.integration_testReasoningStreamingSummaryDeltas(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("ai.koog.integration.tests.utils.Models#openAIReasoningModels")
+    override fun integration_testReasoningStreamingWithEncryptedContent(model: LLModel) {
+        super.integration_testReasoningStreamingWithEncryptedContent(model)
     }
 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SingleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SingleLLMPromptExecutorIntegrationTest.kt
@@ -20,21 +20,6 @@ import java.util.stream.Stream
 class SingleLLMPromptExecutorIntegrationTest : ExecutorIntegrationTestBase() {
     companion object {
         @JvmStatic
-        fun allCompletionModels(): Stream<Arguments> {
-            return Models.allCompletionModels().map { model -> Arguments.of(model) }
-        }
-
-        @JvmStatic
-        fun moderationModels(): Stream<Arguments> {
-            return Models.moderationModels().map { model -> Arguments.of(model) }
-        }
-
-        @JvmStatic
-        fun embeddingModels(): Stream<Arguments> {
-            return Models.embeddingModels().map { model -> Arguments.of(model) }
-        }
-
-        @JvmStatic
         fun bedrockMarkdownScenarioModelCombinations(): Stream<Arguments> {
             return Models.bedrockModels().flatMap { model ->
                 listOf(
@@ -86,11 +71,6 @@ class SingleLLMPromptExecutorIntegrationTest : ExecutorIntegrationTestBase() {
                 LLMProvider.Anthropic
             ).map { provider -> Arguments.of(provider) }
         }
-
-        @JvmStatic
-        fun reasoningCapableModels(): Stream<Arguments> {
-            return Models.reasoningCapableModels().map { model -> Arguments.of(model) }
-        }
     }
 
     override fun getExecutor(model: LLModel): PromptExecutor {
@@ -98,91 +78,91 @@ class SingleLLMPromptExecutorIntegrationTest : ExecutorIntegrationTestBase() {
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testExecute(model: LLModel) {
         super.integration_testExecute(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testExecuteStreaming(model: LLModel) {
         super.integration_testExecuteStreaming(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testExecuteStreamingWithTools(model: LLModel) {
         super.integration_testExecuteStreamingWithTools(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolWithRequiredParams(model: LLModel) {
         super.integration_testToolWithRequiredParams(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolWithNotRequiredOptionalParams(model: LLModel) {
         super.integration_testToolWithNotRequiredOptionalParams(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolWithOptionalParams(model: LLModel) {
         super.integration_testToolWithOptionalParams(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolWithNoParams(model: LLModel) {
         super.integration_testToolWithNoParams(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolWithListEnumParams(model: LLModel) {
         super.integration_testToolWithListEnumParams(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolWithNestedListParams(model: LLModel) {
         super.integration_testToolWithNestedListParams(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolsWithNullParams(model: LLModel) {
         super.integration_testToolsWithNullParams(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolsWithAnyOfParams(model: LLModel) {
         super.integration_testToolsWithAnyOfParams(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testMarkdownStructuredDataStreaming(model: LLModel) {
         super.integration_testMarkdownStructuredDataStreaming(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolChoiceRequired(model: LLModel) {
         super.integration_testToolChoiceRequired(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolChoiceNone(model: LLModel) {
         super.integration_testToolChoiceNone(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testToolChoiceNamed(model: LLModel) {
         super.integration_testToolChoiceNamed(model)
     }
@@ -235,7 +215,7 @@ class SingleLLMPromptExecutorIntegrationTest : ExecutorIntegrationTestBase() {
      * Checking just images to make sure the file is uploaded in base64 format
      * */
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testBase64EncodedAttachment(model: LLModel) {
         assumeTrue(
             model.provider != LLMProvider.Bedrock,
@@ -249,7 +229,7 @@ class SingleLLMPromptExecutorIntegrationTest : ExecutorIntegrationTestBase() {
      * Checking just images to make sure the file is uploaded by URL
      * */
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testUrlBasedAttachment(model: LLModel) {
         assumeTrue(
             model.provider != LLMProvider.Bedrock,
@@ -264,49 +244,49 @@ class SingleLLMPromptExecutorIntegrationTest : ExecutorIntegrationTestBase() {
      * */
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testStructuredOutputNative(model: LLModel) {
         super.integration_testStructuredOutputNative(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testStructuredOutputNativeWithFixingParser(model: LLModel) {
         super.integration_testStructuredOutputNativeWithFixingParser(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testStructuredOutputManual(model: LLModel) {
         super.integration_testStructuredOutputManual(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testStructuredOutputManualWithFixingParser(model: LLModel) {
         super.integration_testStructuredOutputManualWithFixingParser(model)
     }
 
     @ParameterizedTest
-    @MethodSource("allCompletionModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#allCompletionModels")
     override fun integration_testMultipleSystemMessages(model: LLModel) {
         super.integration_testMultipleSystemMessages(model)
     }
 
     @ParameterizedTest
-    @MethodSource("embeddingModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#embeddingModels")
     override fun integration_testEmbed(model: LLModel) {
         super.integration_testEmbed(model)
     }
 
     @ParameterizedTest
-    @MethodSource("moderationModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#moderationModels")
     override fun integration_testSingleMessageModeration(model: LLModel) {
         super.integration_testSingleMessageModeration(model)
     }
 
     @ParameterizedTest
-    @MethodSource("moderationModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#moderationModels")
     override fun integration_testMultipleMessagesModeration(model: LLModel) {
         super.integration_testMultipleMessagesModeration(model)
     }
@@ -318,20 +298,32 @@ class SingleLLMPromptExecutorIntegrationTest : ExecutorIntegrationTestBase() {
     }
 
     @ParameterizedTest
-    @MethodSource("reasoningCapableModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#reasoningCapableModels")
     override fun integration_testReasoningCapability(model: LLModel) {
         super.integration_testReasoningCapability(model)
     }
 
     @ParameterizedTest
-    @MethodSource("reasoningCapableModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#reasoningCapableModels")
     override fun integration_testReasoningWithEncryption(model: LLModel) {
         super.integration_testReasoningWithEncryption(model)
     }
 
     @ParameterizedTest
-    @MethodSource("reasoningCapableModels")
+    @MethodSource("ai.koog.integration.tests.utils.Models#reasoningCapableModels")
     override fun integration_testReasoningMultiStep(model: LLModel) {
         super.integration_testReasoningMultiStep(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("ai.koog.integration.tests.utils.Models#openAIReasoningModels")
+    override fun integration_testReasoningStreamingSummaryDeltas(model: LLModel) {
+        super.integration_testReasoningStreamingSummaryDeltas(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("ai.koog.integration.tests.utils.Models#openAIReasoningModels")
+    override fun integration_testReasoningStreamingWithEncryptedContent(model: LLModel) {
+        super.integration_testReasoningStreamingWithEncryptedContent(model)
     }
 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
@@ -113,6 +113,14 @@ object Models {
     }
 
     @JvmStatic
+    fun openAIReasoningModels(): Stream<LLModel> {
+        return Stream.of(
+            OpenAIModels.Chat.GPT5_1Codex,
+            OpenAIModels.Chat.GPT5_2,
+        )
+    }
+
+    @JvmStatic
     fun modelsWithVisionCapability(): Stream<Arguments> {
         return Stream.concat(
             openAIModels()


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

1. Add reasoning-streaming-specific integration tests for OpenAI; 
2. Refactor method source mappings for Single- and Multiple LLM executor integration tests.


<!-- Include BREAKING section below only if this PR introduces breaking changes. Otherwise, delete it. -->
BREAKING:
* none

<!-- Include DEPRECATED section below only if this PR deprecates any public APIs. Otherwise, delete it. -->
DEPRECATED:
* none
