### PR TITLE
fix(agents): KG-703 add trace attributes to all Langfuse spans, not j…

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapter.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapter.kt
@@ -86,6 +86,8 @@ internal class LangfuseSpanAdapter(
 
             else -> {}
         }
+        // adding attributes to all spans as per Langfuse recommendation for OTEL instrumentation:
+        // https://langfuse.com/integrations/native/opentelemetry#propagating-attributes
         traceAttributes.forEach { attribute ->
             span.addAttribute(attribute)
         }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapter.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapter.kt
@@ -44,10 +44,6 @@ internal class LangfuseSpanAdapter(
                 runId?.let { runId ->
                     span.addAttribute(CustomAttribute("langfuse.session.id", runId))
                 }
-
-                traceAttributes.forEach { attribute ->
-                    span.addAttribute(attribute)
-                }
             }
 
             SpanType.INFERENCE -> {
@@ -89,6 +85,9 @@ internal class LangfuseSpanAdapter(
             }
 
             else -> {}
+        }
+        traceAttributes.forEach { attribute ->
+            span.addAttribute(attribute)
         }
     }
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapterTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapterTest.kt
@@ -55,6 +55,12 @@ class LangfuseSpanAdapterTest {
             messages = emptyList()
         )
 
+        adapter.onBeforeSpanStarted(createAgentSpan)
+
+        traceAttributes.forEach { attribute ->
+            assertEquals(attribute.value, createAgentSpan.attributes.requireValue(attribute.key))
+        }
+
         val invokeAgentSpanId = "invoke-agent-span-id"
         val runId = "run-id"
 


### PR DESCRIPTION
…ust invoke_agent

LangFuse trace attributes are currently not set on all spans but only set on invoke_agent span.
This leads to incorrectly labelled traces in LangFuse.
e.g. when setting "langfuse.environment" attribute the trace is still labelled as `env:default`.
This is becase the top level create_agent span (and all the remaining spans) is missing the "langfuse.environment" attribute and defaults environment to "default".

Screenshots showing the issue here: https://youtrack.jetbrains.com/issue/KG-703

closes KG-703
