### PR TITLE
fix(agents): KG-704 AIAgentError populated incorrectly for reflective…

### DIFF
--- a/agents/agents-tools/src/jvmCommonMain/kotlin/ai/koog/agents/core/tools/reflect/ToolFromCallable.kt
+++ b/agents/agents-tools/src/jvmCommonMain/kotlin/ai/koog/agents/core/tools/reflect/ToolFromCallable.kt
@@ -8,6 +8,7 @@ import ai.koog.serialization.JSONObject
 import ai.koog.serialization.JSONSerializer
 import ai.koog.serialization.KotlinTypeToken
 import ai.koog.serialization.typeToken
+import java.lang.reflect.InvocationTargetException
 import kotlin.reflect.KCallable
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.callSuspendBy
@@ -91,7 +92,11 @@ public class ToolFromCallable<TResult>(
             putAll(args.parameters)
         }
 
-        return callable.callSuspendBy(argsMap)
+        return try {
+            callable.callSuspendBy(argsMap)
+        } catch (e: InvocationTargetException) {
+            throw e.cause ?: e
+        }
     }
 }
 

--- a/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/core/tools/reflect/ToolsFromCallableTest.kt
+++ b/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/core/tools/reflect/ToolsFromCallableTest.kt
@@ -15,6 +15,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -28,6 +29,12 @@ suspend fun globalTool(
     @LLMDescription("Count parameter") count: Int,
 ): String {
     return "Global tool called: $count"
+}
+
+@Tool
+@LLMDescription("Global tool that always throws a RuntimeException")
+suspend fun globalToolThatThrows(): String {
+    throw RuntimeException("test exception")
 }
 
 object ObjectArgumentTool {
@@ -515,6 +522,12 @@ class ToolsFromCallableTest {
             tool.encodeResultToStringUnsafe(result, serializer),
             "Incorrect result for $callable with argument $argumentJson"
         )
+    }
+
+    @Test
+    fun testCorrectExceptionThrown(): Unit = runBlocking {
+        val exception = assertThrows<RuntimeException> { ::globalToolThatThrows.asTool().execute(ToolFromCallable.Args(emptyMap())) }
+        assertEquals("test exception", exception.message)
     }
 
     @ParameterizedTest


### PR DESCRIPTION
… tool call failures

When a tool defined via reflection throws an exception, the AIAgentError is incorrectly populated, becase the exception thrown from the reflective call is wrapped in an InvocationTargetException with null message:

```
Tool with name 'exceptionTool' failed to execute with arguments: VarArgs(args={})
java.lang.reflect.InvocationTargetException: null
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:119)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at kotlin.reflect.jvm.internal.calls.CallerImpl$Method.callMethod(CallerImpl.kt:97)
	at kotlin.reflect.jvm.internal.calls.CallerImpl$Method$Static.call(CallerImpl.kt:106)
	at kotlin.reflect.jvm.internal.KCallableImpl.callDefaultMethod$kotlin_reflection(KCallableImpl.kt:159)
	at kotlin.reflect.jvm.internal.KCallableImpl.callBy(KCallableImpl.kt:112)
	at kotlin.jvm.internal.CallableReference.callBy(CallableReference.java:166)
	at kotlin.reflect.full.KCallables.callSuspendBy(KCallables.kt:71)
	at ai.koog.agents.core.tools.reflect.ToolFromCallable.execute(ToolFromCallable.kt:110)
	...
Caused by: java.lang.RuntimeException: This is a test exception
```

The AIAgentError is then populated with the default message "Unknown error":

`AIAgentError(message=Unknown error, stackTrace=java.lang.reflect.InvocationTargetException ...`



This results in the agent receiving the tool call result without the exception message.
```
{
    content: "Tool with name 'exceptionTool' failed to execute due to the error: null!"
    role: "tool"
}
```

closes KG-704
