### PR TITLE
build: publish XCFramework binary for SPM (#1485)

### DIFF
--- a/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
+++ b/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
@@ -2,6 +2,7 @@
 
 import ai.koog.gradle.publish.maven.configureJvmJarManifest
 import ai.koog.gradle.tests.configureTests
+import ai.koog.gradle.xcframework.XCFrameworkConfig.configureXCFrameworkIfRequested
 import jetbrains.sign.GpgSignSignatoryProvider
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
@@ -18,12 +19,15 @@ kotlin {
     // Tiers are in accordance with <https://kotlinlang.org/docs/native-target-support.html>
     // Tier 1
     iosSimulatorArm64()
-    iosX64()
-
-    // Tier 2
     iosArm64()
 
+    // Tier 2
+
     // Tier 3
+    iosX64()
+
+    // Configure XCFramework for iOS targets (opt-in via -Pkoog.build.xcframework=true)
+    configureXCFrameworkIfRequested(project)
 
     // Android
     androidTarget()

--- a/convention-plugin-ai/src/main/kotlin/ai/koog/gradle/xcframework/XCFrameworkConfig.kt
+++ b/convention-plugin-ai/src/main/kotlin/ai/koog/gradle/xcframework/XCFrameworkConfig.kt
@@ -1,0 +1,73 @@
+package ai.koog.gradle.xcframework
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
+
+/**
+ * Helper object for configuring XCFramework builds in Kotlin Multiplatform projects.
+ *
+ * XCFramework building is opt-in via the Gradle property `koog.build.xcframework=true`.
+ * This prevents slow framework compilation during regular CI runs (assemble, test, etc.).
+ *
+ * Usage:
+ * ```
+ * ./gradlew {module} assembleKoogXCFramework -Pkoog.build.xcframework=true
+ * ```
+ */
+object XCFrameworkConfig {
+
+    private const val PROPERTY_NAME = "koog.build.xcframework"
+
+    /**
+     * Checks if XCFramework building is enabled via the Gradle property.
+     */
+    fun isEnabled(project: Project): Boolean =
+        project.findProperty(PROPERTY_NAME)?.toString()?.toBoolean() ?: false
+
+    /**
+     * Configures XCFramework for iOS targets if enabled.
+     * Creates framework binaries for all targets defined for the project.
+     *
+     * @param project The Gradle project
+     */
+    fun KotlinMultiplatformExtension.configureXCFrameworkIfRequested(project: Project) {
+        if (isEnabled(project)) {
+            val xcf = project.XCFramework("Koog")
+            targets.withType<KotlinNativeTarget>()
+                .matching { it.konanTarget.family.isAppleFamily }
+                .configureEach {
+                    binaries.framework {
+                        baseName = "Koog"
+                        binaryOption("bundleId", "ai.koog")
+                        xcf.add(this)
+                    }
+                }
+        }
+    }
+
+    /**
+     * Configures framework exports for all native targets if XCFramework building is enabled.
+     * This exports all specified projects to the iOS framework, making them available to Swift.
+     *
+     * @param project The Gradle project
+     * @param projectPaths Set of project paths to export (e.g., ":agents:agents-core")
+     */
+    fun KotlinMultiplatformExtension.configureFrameworkExportsIfRequested(
+        project: Project,
+        projectPaths: Set<String>
+    ) {
+        if (isEnabled(project)) {
+            targets.withType<KotlinNativeTarget>().configureEach {
+                binaries.withType(Framework::class.java).configureEach {
+                    projectPaths.forEach {
+                        export(project.project(it))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/koog-agents/build.gradle.kts
+++ b/koog-agents/build.gradle.kts
@@ -1,4 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
+import ai.koog.gradle.xcframework.XCFrameworkConfig.configureFrameworkExportsIfRequested
 
 group = rootProject.group
 version = rootProject.version
@@ -87,14 +88,16 @@ val included = setOf(
 )
 
 kotlin {
+    val projects = rootProject.subprojects
+        .filterNot { it.path in excluded }
+        .filter { it.buildFile.exists() }
+    val projectsPaths = projects.mapTo(sortedSetOf()) { it.path }
+
+    configureFrameworkExportsIfRequested(project, projectsPaths)
+
     sourceSets {
         commonMain {
             dependencies {
-                val projects = rootProject.subprojects
-                    .filterNot { it.path in excluded }
-                    .filter { it.buildFile.exists() }
-
-                val projectsPaths = projects.mapTo(sortedSetOf()) { it.path }
 
                 val obsoleteIncluded = included - projectsPaths
                 require(obsoleteIncluded.isEmpty()) {

--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/generator/JsonSchemaConsts.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/generator/JsonSchemaConsts.kt
@@ -1,5 +1,8 @@
 package ai.koog.prompt.structure.json.generator
 
+import kotlin.experimental.ExperimentalObjCName
+import kotlin.native.ObjCName
+
 /**
  * Collection of special constants, such as keys and data types, from JSON schema definition.
  */
@@ -46,6 +49,9 @@ public object JsonSchemaConsts {
         public const val BOOLEAN: String = "boolean"
         public const val ARRAY: String = "array"
         public const val OBJECT: String = "object"
+
+        @OptIn(ExperimentalObjCName::class)
+        @ObjCName("JSON_NULL")
         public const val NULL: String = "null"
     }
 }


### PR DESCRIPTION
# Add Swift Package Manager (SPM) Support via XCFramework

## Summary
Adds infrastructure to build and distribute Koog as an XCFramework for iOS/macOS development via Swift Package Manager.

## Changes
1. **XCFramework Build Configuration** (`.github/workflows/build-xcframework.yml`)
- New CI workflow that builds XCFramework on releases and manual trigger
   - Runs on macOS with Xcode support
   - Creates versioned zip archives with SHA-256 checksums
   - Uploads artifacts to GitHub releases

2. **iOS Target Support** (`ai.kotlin.multiplatform.gradle.kts`)
- Configure iOS targets (arm64, simulator arm64, x64) to produce Framework binaries
   - Set up XCFramework assembly from individual frameworks
   - Use 'Koog' as framework name (follows Swift PascalCase convention)

3. **Module Export** (`koog-agents/build.gradle.kts`)
   - Export all included modules through Framework binaries
   - Makes Koog APIs accessible to Swift consumers

## Architecture
- **Single XCFramework**: `Koog.xcframework` contains all Koog modules
- **Distribution**: GitHub Releases (binary artifacts)
- **Consumption**: Separate SPM repository will reference these artifacts via Package.swift

## Testing
- [x] Manual: Verified XCFramework builds locally
- [x] Manual: Framework structure validated
- [x] Manual: Tested import in sample Xcode project 
- [ ] CI: Automated testing (future work)

## Next Steps (Follow-up Work)
1. Create separate SPM repository with Package.swift
2. Add modular framework distribution (separate frameworks per module)
3. Add automated Swift compilation tests

## Related Issues
KG-682