### PR TITLE
feat(agents): add planner-specific interceptors to the planner pipeline

### DIFF
--- a/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
+++ b/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
@@ -1,0 +1,36 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "MissingKDocForPublicAPI")
+
+package ai.koog.agents.core.feature.pipeline
+
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.feature.AIAgentPlannerFeature
+import ai.koog.agents.core.feature.config.FeatureConfig
+import kotlinx.datetime.Clock
+
+public actual open class AIAgentPlannerPipeline actual constructor(
+    agentConfig: AIAgentConfig,
+    clock: Clock,
+    private val basePipelineDelegate: AIAgentPipelineImpl
+) : AIAgentPipeline(agentConfig, clock), AIAgentPlannerPipelineAPI by AIAgentPlannerPipelineImpl(agentConfig, clock, basePipelineDelegate) {
+
+    /**
+     * Installs a non-graph feature into the pipeline with the provided configuration.
+     *
+     * @param TConfig The type of the feature configuration
+     * @param TFeature The type of the feature being installed
+     * @param feature The feature implementation to be installed
+     * @param configure A lambda to customize the feature configuration
+     */
+    public actual fun <TConfig : FeatureConfig, TFeature : Any> install(
+        feature: AIAgentPlannerFeature<TConfig, TFeature>,
+        configure: TConfig.() -> Unit,
+    ) {
+        val featureConfig = feature.createInitialConfig().apply { configure() }
+        val featureImpl = feature.install(
+            config = featureConfig,
+            pipeline = this,
+        )
+
+        basePipelineDelegate.install(feature.key, featureConfig, featureImpl)
+    }
+}

--- a/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
+++ b/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
@@ -5,7 +5,7 @@ package ai.koog.agents.core.feature.pipeline
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.feature.AIAgentPlannerFeature
 import ai.koog.agents.core.feature.config.FeatureConfig
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual open class AIAgentPlannerPipeline actual constructor(
     agentConfig: AIAgentConfig,

--- a/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
+++ b/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
@@ -1,0 +1,36 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "MissingKDocForPublicAPI")
+
+package ai.koog.agents.core.feature.pipeline
+
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.feature.AIAgentPlannerFeature
+import ai.koog.agents.core.feature.config.FeatureConfig
+import kotlinx.datetime.Clock
+
+public actual open class AIAgentPlannerPipeline actual constructor(
+    agentConfig: AIAgentConfig,
+    clock: Clock,
+    private val basePipelineDelegate: AIAgentPipelineImpl
+) : AIAgentPipeline(agentConfig, clock), AIAgentPlannerPipelineAPI by AIAgentPlannerPipelineImpl(agentConfig, clock, basePipelineDelegate) {
+
+    /**
+     * Installs a non-graph feature into the pipeline with the provided configuration.
+     *
+     * @param TConfig The type of the feature configuration
+     * @param TFeature The type of the feature being installed
+     * @param feature The feature implementation to be installed
+     * @param configure A lambda to customize the feature configuration
+     */
+    public actual fun <TConfig : FeatureConfig, TFeature : Any> install(
+        feature: AIAgentPlannerFeature<TConfig, TFeature>,
+        configure: TConfig.() -> Unit,
+    ) {
+        val featureConfig = feature.createInitialConfig().apply { configure() }
+        val featureImpl = feature.install(
+            config = featureConfig,
+            pipeline = this,
+        )
+
+        basePipelineDelegate.install(feature.key, featureConfig, featureImpl)
+    }
+}

--- a/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
+++ b/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
@@ -5,7 +5,7 @@ package ai.koog.agents.core.feature.pipeline
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.feature.AIAgentPlannerFeature
 import ai.koog.agents.core.feature.config.FeatureConfig
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual open class AIAgentPlannerPipeline actual constructor(
     agentConfig: AIAgentConfig,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/AgentLifecycleEventType.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/AgentLifecycleEventType.kt
@@ -150,4 +150,38 @@ public sealed interface AgentLifecycleEventType {
     public object LLMStreamingCompleted : AgentLifecycleEventType
 
     //endregion LLM Streaming
+
+    //region Planner
+
+    /**
+     * Represents an event triggered when building a plan starts.
+     */
+    public object BuildPlanStarting : AgentLifecycleEventType
+
+    /**
+     * Represents an event triggered when building a plan completes.
+     */
+    public object BuildPlanCompleted : AgentLifecycleEventType
+
+    /**
+     * Represents an event triggered when executing a plan step starts.
+     */
+    public object ExecuteStepStarting : AgentLifecycleEventType
+
+    /**
+     * Represents an event triggered when executing a plan step completes.
+     */
+    public object ExecuteStepCompleted : AgentLifecycleEventType
+
+    /**
+     * Represents an event triggered when checking plan completion starts.
+     */
+    public object IsPlanCompletedStarting : AgentLifecycleEventType
+
+    /**
+     * Represents an event triggered when checking plan completion completes.
+     */
+    public object IsPlanCompletedCompleted : AgentLifecycleEventType
+
+    //endregion Planner
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/planner/PlannerEventContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/planner/PlannerEventContext.kt
@@ -1,0 +1,137 @@
+package ai.koog.agents.core.feature.handler.planner
+
+import ai.koog.agents.core.agent.context.AIAgentContext
+import ai.koog.agents.core.agent.execution.AgentExecutionInfo
+import ai.koog.agents.core.feature.handler.AgentLifecycleEventContext
+import ai.koog.agents.core.feature.handler.AgentLifecycleEventType
+
+/**
+ * Defines the context specifically for handling planner-related events within the AI agent framework.
+ * Extends the base event handler context to include functionality and behavior dedicated to managing
+ * the lifecycle and operations of planner agents.
+ */
+public interface PlannerEventContext : AgentLifecycleEventContext
+
+/**
+ * Represents the context for a buildPlan operation starting event.
+ *
+ * @property eventId The unique identifier for the event;
+ * @property executionInfo The execution information containing parentId and current execution path;
+ * @property context The context associated with the planner's execution;
+ * @property state The current state;
+ * @property currentPlan The current plan (null on first call).
+ */
+public class PlanCreationStartingContext(
+    override val eventId: String,
+    override val executionInfo: AgentExecutionInfo,
+    public val context: AIAgentContext,
+    public val state: Any,
+    public val currentPlan: Any?,
+    public val stepIndex: Int,
+) : PlannerEventContext {
+    override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.BuildPlanStarting
+}
+
+/**
+ * Represents the context for a buildPlan operation completed event.
+ *
+ * @property eventId The unique identifier for the event;
+ * @property executionInfo The execution information containing parentId and current execution path;
+ * @property context The context associated with the planner's execution;
+ * @property state The current state;
+ * @property currentPlan The previous plan (null on first call);
+ * @property newPlan The newly built plan.
+ */
+public class PlanCreationCompletedContext(
+    override val eventId: String,
+    override val executionInfo: AgentExecutionInfo,
+    public val context: AIAgentContext,
+    public val state: Any,
+    public val currentPlan: Any?,
+    public val newPlan: Any,
+    public val stepIndex: Int,
+) : PlannerEventContext {
+    override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.BuildPlanCompleted
+}
+
+/**
+ * Represents the context for an executeStep operation starting event.
+ *
+ * @property eventId The unique identifier for the event;
+ * @property executionInfo The execution information containing parentId and current execution path;
+ * @property context The context associated with the planner's execution;
+ * @property state The current state;
+ * @property plan The current plan.
+ */
+public class StepExecutionStartingContext(
+    override val eventId: String,
+    override val executionInfo: AgentExecutionInfo,
+    public val context: AIAgentContext,
+    public val state: Any,
+    public val plan: Any,
+    public val stepIndex: Int,
+) : PlannerEventContext {
+    override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.ExecuteStepStarting
+}
+
+/**
+ * Represents the context for an executeStep operation completed event.
+ *
+ * @property eventId The unique identifier for the event;
+ * @property executionInfo The execution information containing parentId and current execution path;
+ * @property context The context associated with the planner's execution;
+ * @property state The state after step execution;
+ * @property plan The current plan;
+ */
+public class StepExecutionCompletedContext(
+    override val eventId: String,
+    override val executionInfo: AgentExecutionInfo,
+    public val context: AIAgentContext,
+    public val state: Any,
+    public val plan: Any,
+    public val stepIndex: Int,
+) : PlannerEventContext {
+    override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.ExecuteStepCompleted
+}
+
+/**
+ * Represents the context for an isPlanCompleted check starting event.
+ *
+ * @property eventId The unique identifier for the event;
+ * @property executionInfo The execution information containing parentId and current execution path;
+ * @property context The context associated with the planner's execution;
+ * @property state The current state;
+ * @property plan The current plan.
+ */
+public class PlanCompletionEvaluationStartingContext(
+    override val eventId: String,
+    override val executionInfo: AgentExecutionInfo,
+    public val context: AIAgentContext,
+    public val state: Any,
+    public val plan: Any,
+    public val stepIndex: Int,
+) : PlannerEventContext {
+    override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.IsPlanCompletedStarting
+}
+
+/**
+ * Represents the context for an isPlanCompleted check completed event.
+ *
+ * @property eventId The unique identifier for the event;
+ * @property executionInfo The execution information containing parentId and current execution path;
+ * @property context The context associated with the planner's execution;
+ * @property state The current state;
+ * @property plan The current plan;
+ * @property isCompleted The result of the completion check.
+ */
+public class PlanCompletionEvaluationCompletedContext(
+    override val eventId: String,
+    override val executionInfo: AgentExecutionInfo,
+    public val context: AIAgentContext,
+    public val state: Any,
+    public val plan: Any,
+    public val isCompleted: Boolean,
+    public val stepIndex: Int,
+) : PlannerEventContext {
+    override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.IsPlanCompletedCompleted
+}

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
@@ -1,8 +1,20 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
 package ai.koog.agents.core.feature.pipeline
 
 import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.agent.context.AIAgentContext
+import ai.koog.agents.core.agent.execution.AgentExecutionInfo
+import ai.koog.agents.core.annotation.InternalAgentsApi
+import ai.koog.agents.core.feature.AIAgentFeature
 import ai.koog.agents.core.feature.AIAgentPlannerFeature
 import ai.koog.agents.core.feature.config.FeatureConfig
+import ai.koog.agents.core.feature.handler.planner.PlanCompletionEvaluationCompletedContext
+import ai.koog.agents.core.feature.handler.planner.PlanCompletionEvaluationStartingContext
+import ai.koog.agents.core.feature.handler.planner.PlanCreationCompletedContext
+import ai.koog.agents.core.feature.handler.planner.PlanCreationStartingContext
+import ai.koog.agents.core.feature.handler.planner.StepExecutionCompletedContext
+import ai.koog.agents.core.feature.handler.planner.StepExecutionStartingContext
 import kotlin.time.Clock
 
 /**
@@ -10,8 +22,11 @@ import kotlin.time.Clock
  *
  * @property clock The clock used for time-based operations within the pipeline
  */
-public class AIAgentPlannerPipeline(agentConfig: AIAgentConfig, clock: Clock = Clock.System) :
-    AIAgentPipeline(agentConfig, clock) {
+public expect open class AIAgentPlannerPipeline(
+    agentConfig: AIAgentConfig,
+    clock: Clock = Clock.System,
+    basePipelineDelegate: AIAgentPipelineImpl = AIAgentPipelineImpl(agentConfig, clock)
+) : AIAgentPipeline, AIAgentPlannerPipelineAPI {
     /**
      * Installs a non-graph feature into the pipeline with the provided configuration.
      *
@@ -23,13 +38,96 @@ public class AIAgentPlannerPipeline(agentConfig: AIAgentConfig, clock: Clock = C
     public fun <TConfig : FeatureConfig, TFeature : Any> install(
         feature: AIAgentPlannerFeature<TConfig, TFeature>,
         configure: TConfig.() -> Unit,
-    ) {
-        val featureConfig = feature.createInitialConfig().apply { configure() }
-        val featureImpl = feature.install(
-            config = featureConfig,
-            pipeline = this,
-        )
+    )
 
-        super.install(feature.key, featureConfig, featureImpl)
-    }
+    @InternalAgentsApi
+    public override suspend fun onPlanCreationStarting(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any?,
+        stepIndex: Int,
+    )
+
+    @InternalAgentsApi
+    public override suspend fun onPlanCreationCompleted(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int,
+    )
+
+    @InternalAgentsApi
+    public override suspend fun onStepExecutionStarting(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int
+    )
+
+    @InternalAgentsApi
+    public override suspend fun onStepExecutionCompleted(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int,
+    )
+
+    @InternalAgentsApi
+    public override suspend fun onPlanCompletionEvaluationStarting(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int,
+    )
+
+    @InternalAgentsApi
+    public override suspend fun onPlanCompletionEvaluationCompleted(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        isCompleted: Boolean,
+        stepIndex: Int,
+    )
+
+    public override fun interceptPlanCreationStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCreationStartingContext) -> Unit
+    )
+
+    public override fun interceptPlanCreationCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCreationCompletedContext) -> Unit
+    )
+
+    public override fun interceptStepExecutionStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (StepExecutionStartingContext) -> Unit
+    )
+
+    public override fun interceptStepExecutionCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (StepExecutionCompletedContext) -> Unit
+    )
+
+    public override fun interceptPlanCompletionEvaluationStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCompletionEvaluationStartingContext) -> Unit
+    )
+
+    public override fun interceptPlanCompletionEvaluationCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCompletionEvaluationCompletedContext) -> Unit
+    )
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipelineAPI.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipelineAPI.kt
@@ -1,0 +1,233 @@
+@file:Suppress("MissingKDocForPublicAPI")
+
+package ai.koog.agents.core.feature.pipeline
+
+import ai.koog.agents.core.agent.context.AIAgentContext
+import ai.koog.agents.core.agent.execution.AgentExecutionInfo
+import ai.koog.agents.core.annotation.InternalAgentsApi
+import ai.koog.agents.core.feature.AIAgentFeature
+import ai.koog.agents.core.feature.handler.planner.PlanCompletionEvaluationCompletedContext
+import ai.koog.agents.core.feature.handler.planner.PlanCompletionEvaluationStartingContext
+import ai.koog.agents.core.feature.handler.planner.PlanCreationCompletedContext
+import ai.koog.agents.core.feature.handler.planner.PlanCreationStartingContext
+import ai.koog.agents.core.feature.handler.planner.StepExecutionCompletedContext
+import ai.koog.agents.core.feature.handler.planner.StepExecutionStartingContext
+
+/**
+ * Platform-agnostic API for planner agent pipelines, extending the base pipeline API
+ * with planner-specific functionality.
+ */
+public interface AIAgentPlannerPipelineAPI : AIAgentPipelineAPI {
+
+    //region Trigger Planner Handlers
+
+    /**
+     * Notifies all registered planner handlers that a plan creation has started.
+     *
+     * @param eventId The unique identifier for the event group;
+     * @param executionInfo The execution information for the plan creation event;
+     * @param context The context of the plan creation;
+     * @param plan The plan that is starting creation;
+     */
+    @InternalAgentsApi
+    public suspend fun onPlanCreationStarting(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any?,
+        stepIndex: Int,
+    )
+
+    /**
+     * Notifies all registered planner handlers that a plan creation has completed.
+     *
+     * @param eventId The unique identifier for the event group;
+     * @param executionInfo The execution information for the plan creation event;
+     * @param context The context of the plan creation;
+     * @param state The current state;
+     * @param plan The plan that completed creation;
+     */
+    @InternalAgentsApi
+    public suspend fun onPlanCreationCompleted(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int,
+    )
+
+    /**
+     * Notifies all registered planner handlers that a plan step execution has started.
+     *
+     * @param eventId The unique identifier for the event group;
+     * @param executionInfo The execution information for the step execution event;
+     * @param context The context of the step execution;
+     * @param state The current state;
+     * @param plan The plan that is starting execution;
+     * @param stepIndex The index of the step in the plan.
+     */
+    @InternalAgentsApi
+    public suspend fun onStepExecutionStarting(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int
+    )
+
+    /**
+     * Notifies all registered planner handlers that a plan step execution has completed.
+     *
+     * @param eventId The unique identifier for the event group;
+     * @param executionInfo The execution information for the step execution event;
+     * @param context The context of the step execution;
+     * @param state The state after step execution;
+     * @param plan The plan that completed execution;
+     * @param stepIndex The index of the step in the plan;
+     */
+    @InternalAgentsApi
+    public suspend fun onStepExecutionCompleted(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int,
+    )
+
+    /**
+     * Notifies all registered planner handlers when evaluating whether a plan is completed.
+     *
+     * @param eventId The unique identifier for the event group;
+     * @param executionInfo The execution information for the evaluation event;
+     * @param context The context of the plan execution;
+     * @param state The current state;
+     * @param plan The plan being evaluated for completion;
+     */
+    @InternalAgentsApi
+    public suspend fun onPlanCompletionEvaluationStarting(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int,
+    )
+
+    /**
+     * Notifies all registered planner handlers when evaluating whether a plan is completed.
+     *
+     * @param eventId The unique identifier for the event group;
+     * @param executionInfo The execution information for the evaluation event;
+     * @param context The context of the plan execution;
+     * @param state The current state;
+     * @param plan The plan being evaluated for completion;
+     * @param isCompleted The result of the completion check.
+     */
+    @InternalAgentsApi
+    public suspend fun onPlanCompletionEvaluationCompleted(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        isCompleted: Boolean,
+        stepIndex: Int,
+    )
+
+    //endregion Trigger Planner Handlers
+
+    //region Planner Interceptors
+
+    /**
+     * Intercepts plan creation starting event to perform actions when a plan begins creation.
+     *
+     * @param feature The feature associated with this handler;
+     * @param handle A suspend function that processes the start of a plan creation.
+     */
+    public fun interceptPlanCreationStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCreationStartingContext) -> Unit
+    )
+
+    /**
+     * Intercepts plan creation completed event to perform actions when a plan completes creation.
+     *
+     * @param feature The feature associated with this handler;
+     * @param handle A suspend function that processes the completion of a plan creation.
+     */
+    public fun interceptPlanCreationCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCreationCompletedContext) -> Unit
+    )
+
+    /**
+     * Intercepts step execution starting event to perform actions when a plan step begins execution.
+     *
+     * @param feature The feature associated with this handler;
+     * @param handle A suspend function that processes the start of a step execution.
+     *
+     * Example:
+     * ```
+     * pipeline.interceptStepExecutionStarting(feature) { event ->
+     *     logger.info("Step ${event.stepIndex} execution has started")
+     * }
+     * ```
+     */
+    public fun interceptStepExecutionStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (StepExecutionStartingContext) -> Unit
+    )
+
+    /**
+     * Intercepts step execution completed event to perform actions when a plan step completes execution.
+     *
+     * @param feature The feature associated with this handler;
+     * @param handle A suspend function that processes the completion of a step execution.
+     *
+     * Example:
+     * ```
+     * pipeline.interceptStepExecutionCompleted(feature) { event ->
+     *     logger.info("Step ${event.stepIndex} execution has completed")
+     * }
+     * ```
+     */
+    public fun interceptStepExecutionCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (StepExecutionCompletedContext) -> Unit
+    )
+
+    /**
+     * Intercepts plan completion evaluation starting event to perform actions when a plan is about to be evaluated for completion.
+     *
+     * @param feature The feature associated with this handler;
+     * @param handle A suspend function that processes the start of a plan completion evaluation.
+     */
+    public fun interceptPlanCompletionEvaluationStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCompletionEvaluationStartingContext) -> Unit
+    )
+
+    /**
+     * Intercepts plan completion evaluation completed event to perform actions when a plan is evaluated for completion.
+     *
+     * @param feature The feature associated with this handler;
+     * @param handle A suspend function that processes the completion of a plan completion evaluation.
+     *
+     * Example:
+     * ```
+     * pipeline.interceptPlanCompletionEvaluationCompleted(feature) { event ->
+     *     logger.info("Plan completion evaluated as: ${event.isCompleted}")
+     * }
+     * ```
+     */
+    public fun interceptPlanCompletionEvaluationCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCompletionEvaluationCompletedContext) -> Unit
+    )
+
+    //endregion Planner Interceptors
+}

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipelineAPI.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipelineAPI.kt
@@ -1,5 +1,3 @@
-@file:Suppress("MissingKDocForPublicAPI")
-
 package ai.koog.agents.core.feature.pipeline
 
 import ai.koog.agents.core.agent.context.AIAgentContext

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipelineImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipelineImpl.kt
@@ -1,0 +1,197 @@
+package ai.koog.agents.core.feature.pipeline
+
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.agent.context.AIAgentContext
+import ai.koog.agents.core.agent.execution.AgentExecutionInfo
+import ai.koog.agents.core.annotation.InternalAgentsApi
+import ai.koog.agents.core.feature.AIAgentFeature
+import ai.koog.agents.core.feature.handler.AgentLifecycleEventType
+import ai.koog.agents.core.feature.handler.planner.PlanCompletionEvaluationCompletedContext
+import ai.koog.agents.core.feature.handler.planner.PlanCompletionEvaluationStartingContext
+import ai.koog.agents.core.feature.handler.planner.PlanCreationCompletedContext
+import ai.koog.agents.core.feature.handler.planner.PlanCreationStartingContext
+import ai.koog.agents.core.feature.handler.planner.StepExecutionCompletedContext
+import ai.koog.agents.core.feature.handler.planner.StepExecutionStartingContext
+import kotlinx.datetime.Clock
+
+/**
+ * Default implementation of [AIAgentPlannerPipelineAPI] that delegates base pipeline operations
+ * to [AIAgentPipelineImpl] and implements planner-specific functionality.
+ */
+public class AIAgentPlannerPipelineImpl(
+    config: AIAgentConfig,
+    clock: Clock = kotlin.time.Clock.System,
+    private val basePipelineDelegate: AIAgentPipelineImpl
+) : AIAgentPlannerPipelineAPI, AIAgentPipelineAPI by basePipelineDelegate {
+
+    //region Invoke Planner Handlers
+
+    @InternalAgentsApi
+    public override suspend fun onPlanCreationStarting(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any?,
+        stepIndex: Int,
+    ) {
+        basePipelineDelegate.invokeRegisteredHandlersForEvent(
+            eventType = AgentLifecycleEventType.BuildPlanStarting,
+            context = PlanCreationStartingContext(eventId, executionInfo, context, state, plan, stepIndex)
+        )
+    }
+
+    @InternalAgentsApi
+    public override suspend fun onPlanCreationCompleted(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int,
+    ) {
+        basePipelineDelegate.invokeRegisteredHandlersForEvent(
+            eventType = AgentLifecycleEventType.BuildPlanCompleted,
+            context = PlanCreationCompletedContext(eventId, executionInfo, context, state, null, plan, stepIndex)
+        )
+    }
+
+    @InternalAgentsApi
+    public override suspend fun onStepExecutionStarting(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int
+    ) {
+        basePipelineDelegate.invokeRegisteredHandlersForEvent(
+            eventType = AgentLifecycleEventType.ExecuteStepStarting,
+            context = StepExecutionStartingContext(eventId, executionInfo, context, state, plan, stepIndex)
+        )
+    }
+
+    @InternalAgentsApi
+    public override suspend fun onStepExecutionCompleted(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int,
+    ) {
+        basePipelineDelegate.invokeRegisteredHandlersForEvent(
+            eventType = AgentLifecycleEventType.ExecuteStepCompleted,
+            context = StepExecutionCompletedContext(eventId, executionInfo, context, state, plan, stepIndex)
+        )
+    }
+
+    @InternalAgentsApi
+    public override suspend fun onPlanCompletionEvaluationStarting(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int,
+    ) {
+        basePipelineDelegate.invokeRegisteredHandlersForEvent(
+            eventType = AgentLifecycleEventType.IsPlanCompletedStarting,
+            context = PlanCompletionEvaluationStartingContext(eventId, executionInfo, context, state, plan, stepIndex)
+        )
+    }
+
+    @InternalAgentsApi
+    public override suspend fun onPlanCompletionEvaluationCompleted(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        isCompleted: Boolean,
+        stepIndex: Int,
+    ) {
+        basePipelineDelegate.invokeRegisteredHandlersForEvent(
+            eventType = AgentLifecycleEventType.IsPlanCompletedCompleted,
+            context = PlanCompletionEvaluationCompletedContext(eventId, executionInfo, context, state, plan, isCompleted, stepIndex)
+        )
+    }
+
+    //endregion Invoke Planner Handlers
+
+    //region Planner Interceptors
+
+    @OptIn(InternalAgentsApi::class)
+    public override fun interceptPlanCreationStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCreationStartingContext) -> Unit
+    ) {
+        basePipelineDelegate.addHandlerForFeature(
+            featureKey = feature.key,
+            eventType = AgentLifecycleEventType.BuildPlanStarting,
+            handler = basePipelineDelegate.createConditionalHandler(feature, handle)
+        )
+    }
+
+    @OptIn(InternalAgentsApi::class)
+    public override fun interceptPlanCreationCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCreationCompletedContext) -> Unit
+    ) {
+        basePipelineDelegate.addHandlerForFeature(
+            featureKey = feature.key,
+            eventType = AgentLifecycleEventType.BuildPlanCompleted,
+            handler = basePipelineDelegate.createConditionalHandler(feature, handle)
+        )
+    }
+
+    @OptIn(InternalAgentsApi::class)
+    public override fun interceptStepExecutionStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (StepExecutionStartingContext) -> Unit
+    ) {
+        basePipelineDelegate.addHandlerForFeature(
+            featureKey = feature.key,
+            eventType = AgentLifecycleEventType.ExecuteStepStarting,
+            handler = basePipelineDelegate.createConditionalHandler(feature, handle)
+        )
+    }
+
+    @OptIn(InternalAgentsApi::class)
+    public override fun interceptStepExecutionCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (StepExecutionCompletedContext) -> Unit
+    ) {
+        basePipelineDelegate.addHandlerForFeature(
+            featureKey = feature.key,
+            eventType = AgentLifecycleEventType.ExecuteStepCompleted,
+            handler = basePipelineDelegate.createConditionalHandler(feature, handle)
+        )
+    }
+
+    @OptIn(InternalAgentsApi::class)
+    public override fun interceptPlanCompletionEvaluationStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCompletionEvaluationStartingContext) -> Unit
+    ) {
+        basePipelineDelegate.addHandlerForFeature(
+            featureKey = feature.key,
+            eventType = AgentLifecycleEventType.IsPlanCompletedStarting,
+            handler = basePipelineDelegate.createConditionalHandler(feature, handle)
+        )
+    }
+
+    @OptIn(InternalAgentsApi::class)
+    public override fun interceptPlanCompletionEvaluationCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCompletionEvaluationCompletedContext) -> Unit
+    ) {
+        basePipelineDelegate.addHandlerForFeature(
+            featureKey = feature.key,
+            eventType = AgentLifecycleEventType.IsPlanCompletedCompleted,
+            handler = basePipelineDelegate.createConditionalHandler(feature, handle)
+        )
+    }
+
+    //endregion Planner Interceptors
+}

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipelineImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipelineImpl.kt
@@ -12,7 +12,7 @@ import ai.koog.agents.core.feature.handler.planner.PlanCreationCompletedContext
 import ai.koog.agents.core.feature.handler.planner.PlanCreationStartingContext
 import ai.koog.agents.core.feature.handler.planner.StepExecutionCompletedContext
 import ai.koog.agents.core.feature.handler.planner.StepExecutionStartingContext
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 /**
  * Default implementation of [AIAgentPlannerPipelineAPI] that delegates base pipeline operations

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/AIAgentPlanner.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/AIAgentPlanner.kt
@@ -2,7 +2,9 @@ package ai.koog.agents.planner
 
 import ai.koog.agents.core.agent.context.AIAgentContext
 import ai.koog.agents.core.agent.context.AIAgentPlannerContext
+import ai.koog.agents.core.agent.context.with
 import ai.koog.agents.core.agent.exception.AIAgentMaxNumberOfIterationsReachedException
+import ai.koog.agents.core.annotation.InternalAgentsApi
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
@@ -19,7 +21,7 @@ import kotlin.reflect.typeOf
  *
  * @param stateType [KType] of the [State].
  */
-public abstract class AIAgentPlanner<State, Plan>(
+public abstract class AIAgentPlanner<State : Any, Plan : Any>(
     // FIXME: require the type explicitly when we decide, what to do with it in Java API
     stateType: KType? = null,
 ) {
@@ -71,16 +73,47 @@ public abstract class AIAgentPlanner<State, Plan>(
      * @throws AIAgentMaxNumberOfIterationsReachedException If the maximum number of iterations defined in the agent's
      * configuration is exceeded.
      */
-    public suspend fun execute(
+    @OptIn(InternalAgentsApi::class)
+    internal suspend fun execute(
         context: AIAgentPlannerContext,
         input: State
     ): State {
         logger.debug { formatLog(context, "Starting planner execution") }
         var state = input
-        var plan: Plan = buildPlan(context, state, null)
+        var previousPlan: Plan? = null
 
-        while (!isPlanCompleted(context, state, plan)) {
-            val iterations = context.stateManager.withStateLock { state ->
+        while (true) {
+            val stepIndex = context.stateManager.withStateLock { state ->
+                state.iterations
+            }
+
+            val plan = context.with(partName = "buildPlan-${stepIndex + 1}") { executionInfo, eventId ->
+                context.pipeline.onPlanCreationStarting(eventId, executionInfo, context, state, previousPlan, stepIndex + 1)
+                val newPlan = buildPlan(context, state, previousPlan)
+                context.pipeline.onPlanCreationCompleted(eventId, executionInfo, context, state, newPlan, stepIndex + 1)
+                newPlan
+            }
+
+            logger.debug { formatLog(context, "Executing plan step #${stepIndex + 1}") }
+
+            // Execute step
+            context.with(partName = "executeStep-${stepIndex + 1}") { stepExecutionInfo, stepEventId ->
+                context.pipeline.onStepExecutionStarting(stepEventId, stepExecutionInfo, context, state, plan, stepIndex + 1)
+                state = executeStep(context, state, plan)
+                context.pipeline.onStepExecutionCompleted(stepEventId, stepExecutionInfo, context, state, plan, stepIndex + 1)
+            }
+
+            logger.debug { formatLog(context, "Finished executing plan step #${stepIndex + 1}") }
+
+            // Check if plan is completed
+            val isCompleted = context.with(partName = "isPlanCompleted-${stepIndex + 1}") { executionInfo, eventId ->
+                context.pipeline.onPlanCompletionEvaluationStarting(eventId, executionInfo, context, state, plan, stepIndex + 1)
+                val completed = isPlanCompleted(context, state, plan)
+                context.pipeline.onPlanCompletionEvaluationCompleted(eventId, executionInfo, context, state, plan, completed, stepIndex + 1)
+                completed
+            }
+
+            context.stateManager.withStateLock { state ->
                 if (++state.iterations > context.config.maxAgentIterations) {
                     logger.error {
                         formatLog(
@@ -90,14 +123,11 @@ public abstract class AIAgentPlanner<State, Plan>(
                     }
                     throw AIAgentMaxNumberOfIterationsReachedException(context.config.maxAgentIterations)
                 }
-
-                state.iterations
             }
 
-            logger.debug { formatLog(context, "Executing plan step #$iterations") }
-            state = executeStep(context, state, plan)
-            plan = buildPlan(context, state, plan)
-            logger.debug { formatLog(context, "Finished executing plan step #$iterations") }
+            if (isCompleted) break
+
+            previousPlan = plan
         }
 
         logger.debug { formatLog(context, "Finished planner execution") }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/AIAgentPlannerStrategy.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/AIAgentPlannerStrategy.kt
@@ -1,7 +1,6 @@
 package ai.koog.agents.planner
 
 import ai.koog.agents.core.agent.context.AIAgentPlannerContext
-import ai.koog.agents.core.agent.context.with
 import ai.koog.agents.core.agent.entity.AIAgentStrategy
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.planner.goap.GoapAgentState
@@ -22,7 +21,7 @@ import kotlin.jvm.JvmStatic
  * @property initializeState A function that initializes the planner state based on the given input.
  * @property provideOutput A function that produces the strategy's output based on the final planner state.
  */
-public class AIAgentPlannerStrategy<Input, Output, State>(
+public class AIAgentPlannerStrategy<Input, Output, State : Any>(
     override val name: String,
     private val planner: AIAgentPlanner<State, *>,
     private val initializeState: (Input) -> State,
@@ -33,15 +32,9 @@ public class AIAgentPlannerStrategy<Input, Output, State>(
         context: AIAgentPlannerContext,
         input: Input
     ): Output {
-        val state = initializeState(input)
         return try {
-            context.with(partName = name) { executionInfo, eventId ->
-                context.pipeline.onStrategyStarting(eventId, executionInfo, this, context)
-                val result = planner.execute(context, initializeState(input))
-                context.pipeline.onStrategyCompleted(eventId, executionInfo, this, context, result, planner.stateType)
-
-                provideOutput(result)
-            }
+            val result = planner.execute(context, initializeState(input))
+            provideOutput(result)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -61,7 +54,7 @@ public class AIAgentPlannerStrategy<Input, Output, State>(
          * @param planner The planner instance that defines the specific planning logic.
          * @return A new [AIAgentPlannerStrategy] instance where the input, output, and state types are the same.
          */
-        public operator fun <State> invoke(
+        public operator fun <State : Any> invoke(
             name: String,
             planner: AIAgentPlanner<State, *>,
         ): AIAgentPlannerStrategy<State, State, State> = AIAgentPlannerStrategy(name, planner, { it }, { it })

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/goap/GOAPPlanner.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/goap/GOAPPlanner.kt
@@ -15,7 +15,7 @@ import kotlin.reflect.KType
  * @param goals The list of defined goals.
  */
 @Deprecated("Use AIAgentStrategy.builder(name).goap() DSL instead.")
-public open class GOAPPlanner<State> internal constructor(
+public open class GOAPPlanner<State : Any> internal constructor(
     private val actions: List<Action<State>>,
     private val goals: List<Goal<State>>,
     stateType: KType? = null,

--- a/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
+++ b/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
@@ -1,0 +1,36 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "MissingKDocForPublicAPI")
+
+package ai.koog.agents.core.feature.pipeline
+
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.feature.AIAgentPlannerFeature
+import ai.koog.agents.core.feature.config.FeatureConfig
+import kotlinx.datetime.Clock
+
+public actual open class AIAgentPlannerPipeline actual constructor(
+    agentConfig: AIAgentConfig,
+    clock: Clock,
+    private val basePipelineDelegate: AIAgentPipelineImpl
+) : AIAgentPipeline(agentConfig, clock), AIAgentPlannerPipelineAPI by AIAgentPlannerPipelineImpl(agentConfig, clock, basePipelineDelegate) {
+
+    /**
+     * Installs a non-graph feature into the pipeline with the provided configuration.
+     *
+     * @param TConfig The type of the feature configuration
+     * @param TFeature The type of the feature being installed
+     * @param feature The feature implementation to be installed
+     * @param configure A lambda to customize the feature configuration
+     */
+    public actual fun <TConfig : FeatureConfig, TFeature : Any> install(
+        feature: AIAgentPlannerFeature<TConfig, TFeature>,
+        configure: TConfig.() -> Unit,
+    ) {
+        val featureConfig = feature.createInitialConfig().apply { configure() }
+        val featureImpl = feature.install(
+            config = featureConfig,
+            pipeline = this,
+        )
+
+        basePipelineDelegate.install(feature.key, featureConfig, featureImpl)
+    }
+}

--- a/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
+++ b/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
@@ -5,7 +5,7 @@ package ai.koog.agents.core.feature.pipeline
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.feature.AIAgentPlannerFeature
 import ai.koog.agents.core.feature.config.FeatureConfig
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual open class AIAgentPlannerPipeline actual constructor(
     agentConfig: AIAgentConfig,

--- a/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/feature/pipeline/AIAgentGraphPipeline.kt
+++ b/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/feature/pipeline/AIAgentGraphPipeline.kt
@@ -52,7 +52,6 @@ public actual open class AIAgentGraphPipeline @JvmOverloads actual constructor(
      * ```
      */
     @JavaAPI
-    @InternalAgentsApi
     @JvmName("interceptNodeExecutionStarting")
     public fun javaApiInterceptNodeExecutionStarting(
         feature: AIAgentGraphFeature<*, *>,
@@ -80,7 +79,6 @@ public actual open class AIAgentGraphPipeline @JvmOverloads actual constructor(
      * ```
      */
     @JavaAPI
-    @InternalAgentsApi
     @JvmName("interceptNodeExecutionCompleted")
     public fun javaApiInterceptNodeExecutionCompleted(
         feature: AIAgentGraphFeature<*, *>,
@@ -108,7 +106,6 @@ public actual open class AIAgentGraphPipeline @JvmOverloads actual constructor(
      * ```
      */
     @JavaAPI
-    @InternalAgentsApi
     @JvmName("interceptNodeExecutionFailed")
     public fun javaApiInterceptNodeExecutionFailed(
         feature: AIAgentGraphFeature<*, *>,
@@ -136,7 +133,6 @@ public actual open class AIAgentGraphPipeline @JvmOverloads actual constructor(
      * ```
      */
     @JavaAPI
-    @InternalAgentsApi
     @JvmName("interceptSubgraphExecutionStarting")
     public fun javaApiInterceptSubgraphExecutionStarting(
         feature: AIAgentGraphFeature<*, *>,
@@ -164,7 +160,6 @@ public actual open class AIAgentGraphPipeline @JvmOverloads actual constructor(
      * ```
      */
     @JavaAPI
-    @InternalAgentsApi
     @JvmName("interceptSubgraphExecutionCompleted")
     public fun javaApiInterceptSubgraphExecutionCompleted(
         feature: AIAgentGraphFeature<*, *>,
@@ -192,7 +187,6 @@ public actual open class AIAgentGraphPipeline @JvmOverloads actual constructor(
      * ```
      */
     @JavaAPI
-    @InternalAgentsApi
     @JvmName("interceptSubgraphExecutionFailed")
     public fun javaApiInterceptSubgraphExecutionFailed(
         feature: AIAgentGraphFeature<*, *>,

--- a/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
+++ b/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
@@ -1,0 +1,183 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "MissingKDocForPublicAPI")
+@file:OptIn(InternalAgentsApi::class)
+
+package ai.koog.agents.core.feature.pipeline
+
+import ai.koog.agents.annotations.JavaAPI
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.annotation.InternalAgentsApi
+import ai.koog.agents.core.feature.AIAgentFeature
+import ai.koog.agents.core.feature.AIAgentPlannerFeature
+import ai.koog.agents.core.feature.config.FeatureConfig
+import ai.koog.agents.core.feature.handler.planner.PlanCompletionEvaluationCompletedContext
+import ai.koog.agents.core.feature.handler.planner.PlanCompletionEvaluationStartingContext
+import ai.koog.agents.core.feature.handler.planner.PlanCreationCompletedContext
+import ai.koog.agents.core.feature.handler.planner.PlanCreationStartingContext
+import ai.koog.agents.core.feature.handler.planner.StepExecutionCompletedContext
+import ai.koog.agents.core.feature.handler.planner.StepExecutionStartingContext
+import ai.koog.agents.core.utils.submitToMainDispatcher
+import kotlinx.datetime.Clock
+
+public actual open class AIAgentPlannerPipeline @JvmOverloads actual constructor(
+    agentConfig: AIAgentConfig,
+    clock: Clock,
+    private val basePipelineDelegate: AIAgentPipelineImpl
+) : AIAgentPipeline(agentConfig, clock), AIAgentPlannerPipelineAPI by AIAgentPlannerPipelineImpl(agentConfig, clock, basePipelineDelegate) {
+
+    /**
+     * Installs a non-graph feature into the pipeline with the provided configuration.
+     *
+     * @param TConfig The type of the feature configuration
+     * @param TFeature The type of the feature being installed
+     * @param feature The feature implementation to be installed
+     * @param configure A lambda to customize the feature configuration
+     */
+    public actual fun <TConfig : FeatureConfig, TFeature : Any> install(
+        feature: AIAgentPlannerFeature<TConfig, TFeature>,
+        configure: TConfig.() -> Unit,
+    ) {
+        val featureConfig = feature.createInitialConfig().apply { configure() }
+        val featureImpl = feature.install(
+            config = featureConfig,
+            pipeline = this,
+        )
+
+        basePipelineDelegate.install(feature.key, featureConfig, featureImpl)
+    }
+
+    //region JVM Planner Interceptors
+
+    /**
+     * Intercepts plan creation starting event to perform actions when a plan begins creation.
+     *
+     * JVM-friendly overload that accepts an async interceptor.
+     */
+    @JavaAPI
+    @InternalAgentsApi
+    @JvmName("interceptPlanCreationStarting")
+    public fun javaApiInterceptPlanCreationStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: Interceptor<PlanCreationStartingContext>
+    ) {
+        interceptPlanCreationStarting(feature) { ctx ->
+            config.submitToMainDispatcher {
+                handle.intercept(ctx)
+            }
+        }
+    }
+
+    /**
+     * Intercepts plan creation completed event to perform actions when a plan completes creation.
+     *
+     * JVM-friendly overload that accepts an async interceptor.
+     */
+    @JavaAPI
+    @InternalAgentsApi
+    @JvmName("interceptPlanCreationCompleted")
+    public fun javaApiInterceptPlanCreationCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: Interceptor<PlanCreationCompletedContext>
+    ) {
+        interceptPlanCreationCompleted(feature) { ctx ->
+            config.submitToMainDispatcher {
+                handle.intercept(ctx)
+            }
+        }
+    }
+
+    /**
+     * Intercepts step execution starting event to perform actions when a plan step begins execution.
+     *
+     * JVM-friendly overload that accepts an async interceptor.
+     *
+     * Example (Java):
+     * pipeline.interceptStepExecutionStarting(feature, event -> {
+     *     // Step execution started
+     *     return java.util.concurrent.CompletableFuture.completedFuture(null);
+     * });
+     */
+    @JavaAPI
+    @InternalAgentsApi
+    @JvmName("interceptStepExecutionStarting")
+    public fun javaApiInterceptStepExecutionStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: Interceptor<StepExecutionStartingContext>
+    ) {
+        interceptStepExecutionStarting(feature) { ctx ->
+            config.submitToMainDispatcher {
+                handle.intercept(ctx)
+            }
+        }
+    }
+
+    /**
+     * Intercepts step execution completed event to perform actions when a plan step completes execution.
+     *
+     * JVM-friendly overload that accepts an async interceptor.
+     *
+     * Example (Java):
+     * pipeline.interceptStepExecutionCompleted(feature, event -> {
+     *     // Step execution completed
+     *     return java.util.concurrent.CompletableFuture.completedFuture(null);
+     * });
+     */
+    @JavaAPI
+    @InternalAgentsApi
+    @JvmName("interceptStepExecutionCompleted")
+    public fun javaApiInterceptStepExecutionCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: Interceptor<StepExecutionCompletedContext>
+    ) {
+        interceptStepExecutionCompleted(feature) { ctx ->
+            config.submitToMainDispatcher {
+                handle.intercept(ctx)
+            }
+        }
+    }
+
+    /**
+     * Intercepts plan completion evaluation starting event to perform actions when a plan is about to be evaluated for completion.
+     *
+     * JVM-friendly overload that accepts an async interceptor.
+     */
+    @JavaAPI
+    @InternalAgentsApi
+    @JvmName("interceptPlanCompletionEvaluationStarting")
+    public fun javaApiInterceptPlanCompletionEvaluationStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: Interceptor<PlanCompletionEvaluationStartingContext>
+    ) {
+        interceptPlanCompletionEvaluationStarting(feature) { ctx ->
+            config.submitToMainDispatcher {
+                handle.intercept(ctx)
+            }
+        }
+    }
+
+    /**
+     * Intercepts plan completion evaluation completed event to perform actions when evaluating if a plan is completed.
+     *
+     * JVM-friendly overload that accepts an async interceptor.
+     *
+     * Example (Java):
+     * pipeline.interceptPlanCompletionEvaluationCompleted(feature, event -> {
+     *     // Plan completion evaluated
+     *     return java.util.concurrent.CompletableFuture.completedFuture(null);
+     * });
+     */
+    @JavaAPI
+    @InternalAgentsApi
+    @JvmName("interceptPlanCompletionEvaluationCompleted")
+    public fun javaApiInterceptPlanCompletionEvaluationCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: Interceptor<PlanCompletionEvaluationCompletedContext>
+    ) {
+        interceptPlanCompletionEvaluationCompleted(feature) { ctx ->
+            config.submitToMainDispatcher {
+                handle.intercept(ctx)
+            }
+        }
+    }
+
+    //endregion JVM Planner Interceptors
+}

--- a/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
+++ b/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
@@ -53,7 +53,6 @@ public actual open class AIAgentPlannerPipeline @JvmOverloads actual constructor
      * JVM-friendly overload that accepts an async interceptor.
      */
     @JavaAPI
-    @InternalAgentsApi
     @JvmName("interceptPlanCreationStarting")
     public fun javaApiInterceptPlanCreationStarting(
         feature: AIAgentFeature<*, *>,
@@ -72,7 +71,6 @@ public actual open class AIAgentPlannerPipeline @JvmOverloads actual constructor
      * JVM-friendly overload that accepts an async interceptor.
      */
     @JavaAPI
-    @InternalAgentsApi
     @JvmName("interceptPlanCreationCompleted")
     public fun javaApiInterceptPlanCreationCompleted(
         feature: AIAgentFeature<*, *>,
@@ -97,7 +95,6 @@ public actual open class AIAgentPlannerPipeline @JvmOverloads actual constructor
      * });
      */
     @JavaAPI
-    @InternalAgentsApi
     @JvmName("interceptStepExecutionStarting")
     public fun javaApiInterceptStepExecutionStarting(
         feature: AIAgentFeature<*, *>,
@@ -122,7 +119,6 @@ public actual open class AIAgentPlannerPipeline @JvmOverloads actual constructor
      * });
      */
     @JavaAPI
-    @InternalAgentsApi
     @JvmName("interceptStepExecutionCompleted")
     public fun javaApiInterceptStepExecutionCompleted(
         feature: AIAgentFeature<*, *>,
@@ -141,7 +137,6 @@ public actual open class AIAgentPlannerPipeline @JvmOverloads actual constructor
      * JVM-friendly overload that accepts an async interceptor.
      */
     @JavaAPI
-    @InternalAgentsApi
     @JvmName("interceptPlanCompletionEvaluationStarting")
     public fun javaApiInterceptPlanCompletionEvaluationStarting(
         feature: AIAgentFeature<*, *>,
@@ -166,7 +161,6 @@ public actual open class AIAgentPlannerPipeline @JvmOverloads actual constructor
      * });
      */
     @JavaAPI
-    @InternalAgentsApi
     @JvmName("interceptPlanCompletionEvaluationCompleted")
     public fun javaApiInterceptPlanCompletionEvaluationCompleted(
         feature: AIAgentFeature<*, *>,

--- a/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
+++ b/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
@@ -16,7 +16,7 @@ import ai.koog.agents.core.feature.handler.planner.PlanCreationStartingContext
 import ai.koog.agents.core.feature.handler.planner.StepExecutionCompletedContext
 import ai.koog.agents.core.feature.handler.planner.StepExecutionStartingContext
 import ai.koog.agents.core.utils.submitToMainDispatcher
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual open class AIAgentPlannerPipeline @JvmOverloads actual constructor(
     agentConfig: AIAgentConfig,

--- a/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
+++ b/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
@@ -1,0 +1,36 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "MissingKDocForPublicAPI")
+
+package ai.koog.agents.core.feature.pipeline
+
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.feature.AIAgentPlannerFeature
+import ai.koog.agents.core.feature.config.FeatureConfig
+import kotlinx.datetime.Clock
+
+public actual open class AIAgentPlannerPipeline actual constructor(
+    agentConfig: AIAgentConfig,
+    clock: Clock,
+    private val basePipelineDelegate: AIAgentPipelineImpl
+) : AIAgentPipeline(agentConfig, clock), AIAgentPlannerPipelineAPI by AIAgentPlannerPipelineImpl(agentConfig, clock, basePipelineDelegate) {
+
+    /**
+     * Installs a non-graph feature into the pipeline with the provided configuration.
+     *
+     * @param TConfig The type of the feature configuration
+     * @param TFeature The type of the feature being installed
+     * @param feature The feature implementation to be installed
+     * @param configure A lambda to customize the feature configuration
+     */
+    public actual fun <TConfig : FeatureConfig, TFeature : Any> install(
+        feature: AIAgentPlannerFeature<TConfig, TFeature>,
+        configure: TConfig.() -> Unit,
+    ) {
+        val featureConfig = feature.createInitialConfig().apply { configure() }
+        val featureImpl = feature.install(
+            config = featureConfig,
+            pipeline = this,
+        )
+
+        basePipelineDelegate.install(feature.key, featureConfig, featureImpl)
+    }
+}

--- a/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
+++ b/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
@@ -5,7 +5,7 @@ package ai.koog.agents.core.feature.pipeline
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.feature.AIAgentPlannerFeature
 import ai.koog.agents.core.feature.config.FeatureConfig
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 public actual open class AIAgentPlannerPipeline actual constructor(
     agentConfig: AIAgentConfig,


### PR DESCRIPTION
added the following methods to the planning pipeline:
* `onPlanCreationStarting`
* `onPlanCreationCompleted`
* `onStepExecutionStarting`
* `onStepExecutionCompleted`
* `onPlanCompletionEvaluationStarting`
* `onPlanCompletionEvaluationCompleted`

closes KG-672