### PR TITLE
feat(agents): support planner-specific opentelemetry

### DIFF
--- a/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
+++ b/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
@@ -6,6 +6,8 @@ import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.planner.AIAgentPlannerStrategy
+import ai.koog.agents.planner.PlannerAIAgent
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
@@ -56,6 +58,16 @@ public actual abstract class AIAgentService<Input, Output, TAgent : AIAgent<Inpu
             toolRegistry: ToolRegistry,
             noinline installFeatures: GraphAIAgent.FeatureContext.() -> Unit
         ): GraphAIAgentService<Input, Output> =
+            AIAgentServiceHelper.invoke(promptExecutor, agentConfig, strategy, toolRegistry, installFeatures)
+
+        @OptIn(markerClass = [InternalAgentsApi::class])
+        public actual operator fun <Input, Output> invoke(
+            promptExecutor: PromptExecutor,
+            agentConfig: AIAgentConfig,
+            strategy: AIAgentPlannerStrategy<Input, Output, *>,
+            toolRegistry: ToolRegistry,
+            installFeatures: PlannerAIAgent.FeatureContext.() -> Unit
+        ): PlannerAIAgentService<Input, Output> =
             AIAgentServiceHelper.invoke(promptExecutor, agentConfig, strategy, toolRegistry, installFeatures)
 
         public actual operator fun invoke(

--- a/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
+++ b/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
@@ -5,6 +5,7 @@ package ai.koog.agents.core.agent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.planner.AIAgentPlannerStrategy
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
@@ -43,6 +44,9 @@ public actual class AIAgentServiceBuilder internal actual constructor() :
 
     actual override fun <Input, Output> functionalStrategy(strategy: AIAgentFunctionalStrategy<Input, Output>): FunctionalAgentServiceBuilder<Input, Output> =
         delegate.functionalStrategy(strategy)
+
+    actual override fun <Input, Output> plannerStrategy(strategy: AIAgentPlannerStrategy<Input, Output, *>): PlannerAgentServiceBuilder<Input, Output> =
+        delegate.plannerStrategy(strategy)
 
     actual override fun build(): GraphAIAgentService<String, String> = delegate.build()
 }

--- a/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
+++ b/agents/agents-core/src/androidMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
@@ -1,0 +1,36 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "MissingKDocForPublicAPI")
+
+package ai.koog.agents.core.feature.pipeline
+
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.feature.AIAgentPlannerFeature
+import ai.koog.agents.core.feature.config.FeatureConfig
+import kotlinx.datetime.Clock
+
+public actual open class AIAgentPlannerPipeline actual constructor(
+    agentConfig: AIAgentConfig,
+    clock: Clock,
+    private val basePipelineDelegate: AIAgentPipelineImpl
+) : AIAgentPipeline(agentConfig, clock), AIAgentPlannerPipelineAPI by AIAgentPlannerPipelineImpl(agentConfig, clock, basePipelineDelegate) {
+
+    /**
+     * Installs a non-graph feature into the pipeline with the provided configuration.
+     *
+     * @param TConfig The type of the feature configuration
+     * @param TFeature The type of the feature being installed
+     * @param feature The feature implementation to be installed
+     * @param configure A lambda to customize the feature configuration
+     */
+    public actual fun <TConfig : FeatureConfig, TFeature : Any> install(
+        feature: AIAgentPlannerFeature<TConfig, TFeature>,
+        configure: TConfig.() -> Unit,
+    ) {
+        val featureConfig = feature.createInitialConfig().apply { configure() }
+        val featureImpl = feature.install(
+            config = featureConfig,
+            pipeline = this,
+        )
+
+        basePipelineDelegate.install(feature.key, featureConfig, featureImpl)
+    }
+}

--- a/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
+++ b/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
@@ -6,6 +6,8 @@ import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.planner.AIAgentPlannerStrategy
+import ai.koog.agents.planner.PlannerAIAgent
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
@@ -56,6 +58,16 @@ public actual abstract class AIAgentService<Input, Output, TAgent : AIAgent<Inpu
             toolRegistry: ToolRegistry,
             noinline installFeatures: GraphAIAgent.FeatureContext.() -> Unit
         ): GraphAIAgentService<Input, Output> =
+            AIAgentServiceHelper.invoke(promptExecutor, agentConfig, strategy, toolRegistry, installFeatures)
+
+        @OptIn(markerClass = [InternalAgentsApi::class])
+        public actual operator fun <Input, Output> invoke(
+            promptExecutor: PromptExecutor,
+            agentConfig: AIAgentConfig,
+            strategy: AIAgentPlannerStrategy<Input, Output, *>,
+            toolRegistry: ToolRegistry,
+            installFeatures: PlannerAIAgent.FeatureContext.() -> Unit
+        ): PlannerAIAgentService<Input, Output> =
             AIAgentServiceHelper.invoke(promptExecutor, agentConfig, strategy, toolRegistry, installFeatures)
 
         public actual operator fun invoke(

--- a/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
+++ b/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
@@ -5,6 +5,7 @@ package ai.koog.agents.core.agent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.planner.AIAgentPlannerStrategy
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
@@ -43,6 +44,9 @@ public actual class AIAgentServiceBuilder internal actual constructor() :
 
     actual override fun <Input, Output> functionalStrategy(strategy: AIAgentFunctionalStrategy<Input, Output>): FunctionalAgentServiceBuilder<Input, Output> =
         delegate.functionalStrategy(strategy)
+
+    actual override fun <Input, Output> plannerStrategy(strategy: AIAgentPlannerStrategy<Input, Output, *>): PlannerAgentServiceBuilder<Input, Output> =
+        delegate.plannerStrategy(strategy)
 
     actual override fun build(): GraphAIAgentService<String, String> = delegate.build()
 }

--- a/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
+++ b/agents/agents-core/src/appleMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
@@ -1,0 +1,36 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "MissingKDocForPublicAPI")
+
+package ai.koog.agents.core.feature.pipeline
+
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.feature.AIAgentPlannerFeature
+import ai.koog.agents.core.feature.config.FeatureConfig
+import kotlinx.datetime.Clock
+
+public actual open class AIAgentPlannerPipeline actual constructor(
+    agentConfig: AIAgentConfig,
+    clock: Clock,
+    private val basePipelineDelegate: AIAgentPipelineImpl
+) : AIAgentPipeline(agentConfig, clock), AIAgentPlannerPipelineAPI by AIAgentPlannerPipelineImpl(agentConfig, clock, basePipelineDelegate) {
+
+    /**
+     * Installs a non-graph feature into the pipeline with the provided configuration.
+     *
+     * @param TConfig The type of the feature configuration
+     * @param TFeature The type of the feature being installed
+     * @param feature The feature implementation to be installed
+     * @param configure A lambda to customize the feature configuration
+     */
+    public actual fun <TConfig : FeatureConfig, TFeature : Any> install(
+        feature: AIAgentPlannerFeature<TConfig, TFeature>,
+        configure: TConfig.() -> Unit,
+    ) {
+        val featureConfig = feature.createInitialConfig().apply { configure() }
+        val featureImpl = feature.install(
+            config = featureConfig,
+            pipeline = this,
+        )
+
+        basePipelineDelegate.install(feature.key, featureConfig, featureImpl)
+    }
+}

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
@@ -9,6 +9,8 @@ import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
+import ai.koog.agents.planner.AIAgentPlannerStrategy
+import ai.koog.agents.planner.PlannerAIAgent
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
@@ -144,6 +146,26 @@ public expect abstract class AIAgentService<Input, Output, TAgent : AIAgent<Inpu
             toolRegistry: ToolRegistry = ToolRegistry.EMPTY,
             noinline installFeatures: FeatureContext.() -> Unit = {},
         ): GraphAIAgentService<Input, Output>
+
+        /**
+         * Invokes the creation of a [PlannerAIAgentService] instance with the provided configuration, strategy,
+         * tool registry, and optional feature installation logic.
+         *
+         * @param promptExecutor The executor responsible for processing AI prompts and responses.
+         * @param agentConfig Configuration parameters for the AI agent.
+         * @param strategy A strategy defining the planner structure for AI agent interactions and processing.
+         * @param toolRegistry The registry containing tools available for the agent.
+         * @param installFeatures A lambda expression to configure and install additional features.
+         * @return An instance of [PlannerAIAgentService] initialized with the given parameters.
+         */
+        @OptIn(InternalAgentsApi::class)
+        public operator fun <Input, Output> invoke(
+            promptExecutor: PromptExecutor,
+            agentConfig: AIAgentConfig,
+            strategy: AIAgentPlannerStrategy<Input, Output, *>,
+            toolRegistry: ToolRegistry = ToolRegistry.EMPTY,
+            installFeatures: PlannerAIAgent.FeatureContext.() -> Unit = {},
+        ): PlannerAIAgentService<Input, Output>
 
         /**
          * Invokes the creation of a [GraphAIAgentService] with the provided dependencies, configuration,
@@ -402,6 +424,54 @@ public constructor(
         agentConfig: AIAgentConfig,
         clock: Clock,
     ): FunctionalAIAgent<Input, Output> = FunctionalAIAgent(
+        promptExecutor = promptExecutor,
+        agentConfig = agentConfig,
+        toolRegistry = toolRegistry + additionalToolRegistry,
+        strategy = strategy,
+        id = id,
+        clock = clock,
+        installFeatures = installFeatures
+    )
+}
+
+/**
+ * A service for managing planner AI agents that operate based on a specified execution strategy.
+ *
+ * This class provides the infrastructure for creating and managing planner AI agents.
+ * It integrates an execution strategy with associated input and output types, a tool registry for
+ * additional functionalities, and a customizable feature installation context.
+ *
+ * @param Input The type of input data that the planner AI agent will process.
+ * @param Output The type of output data produced by the planner AI agent.
+ * @property promptExecutor The executor responsible for handling and executing prompts.
+ * @property agentConfig The configuration settings for the AI agent, including model and prompt behavior.
+ * @property strategy The planner strategy defining the agent's iteration logic and processing behavior.
+ */
+@Suppress("MissingKDocForPublicAPI")
+public class PlannerAIAgentService<Input, Output>
+@InternalAgentsApi
+public constructor(
+    override val promptExecutor: PromptExecutor,
+    override val agentConfig: AIAgentConfig,
+    public val strategy: AIAgentPlannerStrategy<Input, Output, *>,
+    override val toolRegistry: ToolRegistry,
+    public val installFeatures: PlannerAIAgent.FeatureContext.() -> Unit
+) : AIAgentServiceBase<Input, Output, PlannerAIAgent<Input, Output>>() {
+
+    /**
+     * Creates and returns a managed instance of [PlannerAIAgent].
+     *
+     * @param clock The clock instance used for time-related operations within the agent.
+     * @param id The identifier for the agent. Random UUID will be generated if set to null.
+     * @return A managed AI agent instance implementing the AIAgent interface.
+     */
+    @InternalAgentsApi
+    override fun createManagedAgent(
+        id: String?,
+        additionalToolRegistry: ToolRegistry,
+        agentConfig: AIAgentConfig,
+        clock: Clock,
+    ): PlannerAIAgent<Input, Output> = PlannerAIAgent(
         promptExecutor = promptExecutor,
         agentConfig = agentConfig,
         toolRegistry = toolRegistry + additionalToolRegistry,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
@@ -14,10 +14,10 @@ import ai.koog.agents.core.feature.AIAgentGraphFeature
 import ai.koog.agents.core.feature.config.FeatureConfig
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.utils.ConfigureAction
-import ai.koog.prompt.dsl.Prompt
-import ai.koog.prompt.dsl.prompt
 import ai.koog.agents.planner.AIAgentPlannerStrategy
 import ai.koog.agents.planner.PlannerAIAgent
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.params.LLMParams
@@ -494,7 +494,7 @@ public constructor(
     private var temperature: Double? = null,
     private var numberOfChoices: Int = 1,
     private var maxIterations: Int = 50,
-    private var missingToolsConversionStrategy: MissingToolsConversionStrategy = MissingToolsConversionStrategy.Missing( ToolCallDescriber.JSON ),
+    private var missingToolsConversionStrategy: MissingToolsConversionStrategy = MissingToolsConversionStrategy.Missing(ToolCallDescriber.JSON),
     private var clock: Clock = kotlin.time.Clock.System,
     private var featureInstallers: MutableList<PlannerAIAgent.FeatureContext.() -> Unit> = mutableListOf()
 ) {

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
@@ -16,6 +16,8 @@ import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.utils.ConfigureAction
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.dsl.prompt
+import ai.koog.agents.planner.AIAgentPlannerStrategy
+import ai.koog.agents.planner.PlannerAIAgent
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.params.LLMParams
@@ -56,6 +58,13 @@ public expect class AIAgentServiceBuilder internal constructor() : AIAgentServic
     public override fun <Input, Output> functionalStrategy(
         strategy: AIAgentFunctionalStrategy<Input, Output>
     ): FunctionalAgentServiceBuilder<Input, Output>
+
+    /**
+     * Configure a planner strategy and continue with a planner service builder.
+     */
+    public override fun <Input, Output> plannerStrategy(
+        strategy: AIAgentPlannerStrategy<Input, Output, *>
+    ): PlannerAgentServiceBuilder<Input, Output>
 
     public override fun build(): GraphAIAgentService<String, String>
 }
@@ -456,6 +465,119 @@ public class FunctionalAgentServiceBuilder<Input, Output> internal constructor(
         }
 
         return FunctionalAIAgentService(
+            promptExecutor = executor,
+            agentConfig = config,
+            toolRegistry = toolRegistry,
+            strategy = strategy,
+            installFeatures = installCombined
+        )
+    }
+}
+
+/**
+ * A builder class for creating instances of [PlannerAIAgentService].
+ *
+ * This builder provides methods to configure the necessary components for a planner AI agent,
+ * such as the prompt executor, language model, strategy, and feature installation.
+ *
+ * @param Input The input type that the planner AI agent processes.
+ * @param Output The output type that the planner AI agent produces.
+ */
+public class PlannerAgentServiceBuilder<Input, Output>
+@InternalAgentsApi
+public constructor(
+    private val strategy: AIAgentPlannerStrategy<Input, Output, *>,
+    internal var promptExecutor: PromptExecutor? = null,
+    internal var toolRegistry: ToolRegistry = ToolRegistry.EMPTY,
+    private var prompt: Prompt = Prompt.Empty,
+    private var llmModel: LLModel? = null,
+    private var temperature: Double? = null,
+    private var numberOfChoices: Int = 1,
+    private var maxIterations: Int = 50,
+    private var missingToolsConversionStrategy: MissingToolsConversionStrategy = MissingToolsConversionStrategy.Missing( ToolCallDescriber.JSON ),
+    private var clock: Clock = kotlin.time.Clock.System,
+    private var featureInstallers: MutableList<PlannerAIAgent.FeatureContext.() -> Unit> = mutableListOf()
+) {
+
+    public fun promptExecutor(promptExecutor: PromptExecutor): PlannerAgentServiceBuilder<Input, Output> = apply {
+        this.promptExecutor = promptExecutor
+    }
+
+    public fun llmModel(model: LLModel): PlannerAgentServiceBuilder<Input, Output> = apply {
+        this.llmModel = model
+    }
+
+    public fun toolRegistry(toolRegistry: ToolRegistry): PlannerAgentServiceBuilder<Input, Output> = apply {
+        this.toolRegistry = toolRegistry
+    }
+
+    public fun systemPrompt(systemPrompt: String): PlannerAgentServiceBuilder<Input, Output> = apply {
+        this.prompt = prompt(id = "agent") { system(systemPrompt) }
+    }
+
+    public fun prompt(prompt: Prompt): PlannerAgentServiceBuilder<Input, Output> = apply {
+        this.prompt = prompt
+    }
+
+    public fun temperature(temperature: Double): PlannerAgentServiceBuilder<Input, Output> = apply {
+        this.temperature = temperature
+    }
+
+    public fun numberOfChoices(numberOfChoices: Int): PlannerAgentServiceBuilder<Input, Output> = apply {
+        this.numberOfChoices = numberOfChoices
+    }
+
+    public fun maxIterations(maxIterations: Int): PlannerAgentServiceBuilder<Input, Output> = apply {
+        this.maxIterations = maxIterations
+    }
+
+    @JavaAPI
+    public fun agentConfig(config: AIAgentConfig): PlannerAgentServiceBuilder<Input, Output> = apply {
+        this.prompt = config.prompt
+        this.llmModel = config.model
+        this.maxIterations = config.maxAgentIterations
+        this.missingToolsConversionStrategy = config.missingToolsConversionStrategy
+    }
+
+    public fun install(
+        configure: PlannerAIAgent.FeatureContext.() -> Unit
+    ): PlannerAgentServiceBuilder<Input, Output> = apply {
+        featureInstallers.add(configure)
+    }
+
+    /**
+     * Builds and returns a [PlannerAIAgentService] instance using the current configuration.
+     *
+     * @return A configured [PlannerAIAgentService] instance.
+     * @throws IllegalArgumentException if mandatory fields like `promptExecutor` or `llmModel` are not set.
+     */
+    @OptIn(InternalAgentsApi::class)
+    public fun build(): PlannerAIAgentService<Input, Output> {
+        val executor = requireNotNull(promptExecutor) { "PromptExecutor must be provided" }
+        val model = requireNotNull(llmModel) { "LLModel must be provided" }
+
+        val config = AIAgentConfig(
+            prompt = if (prompt === Prompt.Empty) {
+                prompt(
+                    id = "chat",
+                    params = LLMParams(
+                        temperature = temperature,
+                        numberOfChoices = numberOfChoices
+                    )
+                ) {}
+            } else {
+                prompt
+            },
+            model = model,
+            maxAgentIterations = maxIterations,
+            missingToolsConversionStrategy = missingToolsConversionStrategy
+        )
+
+        val installCombined: PlannerAIAgent.FeatureContext.() -> Unit = {
+            featureInstallers.forEach { it(this) }
+        }
+
+        return PlannerAIAgentService(
             promptExecutor = executor,
             agentConfig = config,
             toolRegistry = toolRegistry,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilderAPI.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilderAPI.kt
@@ -6,6 +6,7 @@ import ai.koog.agents.annotations.JavaAPI
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.planner.AIAgentPlannerStrategy
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
@@ -112,6 +113,13 @@ public interface AIAgentServiceBuilderAPI {
     public fun <Input, Output> functionalStrategy(
         strategy: AIAgentFunctionalStrategy<Input, Output>
     ): FunctionalAgentServiceBuilder<Input, Output>
+
+    /**
+     * Configure a planner strategy and continue with a planner service builder.
+     */
+    public fun <Input, Output> plannerStrategy(
+        strategy: AIAgentPlannerStrategy<Input, Output, *>
+    ): PlannerAgentServiceBuilder<Input, Output>
 
     /**
      * Convenience build for GraphAIAgentService<String, String> using singleRunStrategy.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilderImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilderImpl.kt
@@ -9,6 +9,7 @@ import ai.koog.agents.core.agent.config.ToolCallDescriber
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.planner.AIAgentPlannerStrategy
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.model.PromptExecutor
@@ -97,6 +98,21 @@ internal class AIAgentServiceBuilderImpl : AIAgentServiceBuilderAPI {
     public override fun <Input, Output> functionalStrategy(
         strategy: AIAgentFunctionalStrategy<Input, Output>
     ): FunctionalAgentServiceBuilder<Input, Output> = FunctionalAgentServiceBuilder(
+        strategy = strategy,
+        prompt = this.prompt,
+        llmModel = this.llmModel,
+        temperature = this.temperature,
+        numberOfChoices = this.numberOfChoices,
+        maxIterations = this.maxIterations,
+        clock = this.clock,
+    ).also {
+        it.promptExecutor = this.promptExecutor
+        it.toolRegistry = this.toolRegistry
+    }
+
+    public override fun <Input, Output> plannerStrategy(
+        strategy: AIAgentPlannerStrategy<Input, Output, *>
+    ): PlannerAgentServiceBuilder<Input, Output> = PlannerAgentServiceBuilder(
         strategy = strategy,
         prompt = this.prompt,
         llmModel = this.llmModel,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceHelper.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceHelper.kt
@@ -148,6 +148,7 @@ internal object AIAgentServiceHelper {
         strategy = strategy,
         installFeatures = installFeatures
     )
+
     @OptIn(InternalAgentsApi::class)
     internal operator fun <Input, Output> invoke(
         promptExecutor: PromptExecutor,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceHelper.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceHelper.kt
@@ -7,6 +7,8 @@ import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.planner.AIAgentPlannerStrategy
+import ai.koog.agents.planner.PlannerAIAgent
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
@@ -140,6 +142,20 @@ internal object AIAgentServiceHelper {
         toolRegistry: ToolRegistry = ToolRegistry.EMPTY,
         installFeatures: FunctionalAIAgent.FeatureContext.() -> Unit = {},
     ): FunctionalAIAgentService<Input, Output> = FunctionalAIAgentService(
+        promptExecutor = promptExecutor,
+        agentConfig = agentConfig,
+        toolRegistry = toolRegistry,
+        strategy = strategy,
+        installFeatures = installFeatures
+    )
+    @OptIn(InternalAgentsApi::class)
+    internal operator fun <Input, Output> invoke(
+        promptExecutor: PromptExecutor,
+        agentConfig: AIAgentConfig,
+        strategy: AIAgentPlannerStrategy<Input, Output, *>,
+        toolRegistry: ToolRegistry = ToolRegistry.EMPTY,
+        installFeatures: PlannerAIAgent.FeatureContext.() -> Unit = {},
+    ): PlannerAIAgentService<Input, Output> = PlannerAIAgentService(
         promptExecutor = promptExecutor,
         agentConfig = agentConfig,
         toolRegistry = toolRegistry,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentContext.kt
@@ -9,6 +9,7 @@ import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.environment.AIAgentEnvironment
 import ai.koog.agents.core.feature.AIAgentFeature
 import ai.koog.agents.core.feature.pipeline.AIAgentPipeline
+import ai.koog.agents.core.utils.RWLock
 import ai.koog.prompt.message.Message
 import kotlin.reflect.KClass
 import kotlin.uuid.ExperimentalUuidApi
@@ -149,6 +150,52 @@ public interface AIAgentContext {
      * @return `true` if there is at least one `Message.Tool.Call` in the list, otherwise `false`.
      */
     public fun List<Message.Response>.containsToolCalls(): Boolean = this.any { it is Message.Tool.Call }
+}
+
+/**
+ * Mutable wrapper for AI agent context properties.
+ */
+internal class MutableAIAgentContext(
+    var llm: AIAgentLLMContext,
+    var stateManager: AIAgentStateManager,
+    var storage: AIAgentStorage,
+    var environment: AIAgentEnvironment,
+    var executionInfo: AgentExecutionInfo
+) {
+    private val rwLock = RWLock()
+
+    /**
+     * Creates a copy of the current [MutableAIAgentContext].
+     * @return A new instance of [MutableAIAgentContext] with copies of all mutable properties.
+     */
+    suspend fun copy(): MutableAIAgentContext {
+        return rwLock.withReadLock {
+            MutableAIAgentContext(llm.copy(), stateManager.copy(), storage.copy(), environment, executionInfo.copy())
+        }
+    }
+
+    /**
+     * Replaces the current context with the provided context.
+     *
+     * @param llm The LLM context to replace the current context with.
+     * @param stateManager The state manager to replace the current context with.
+     * @param storage The storage to replace the current context with.
+     */
+    suspend fun replace(
+        llm: AIAgentLLMContext?,
+        stateManager: AIAgentStateManager?,
+        storage: AIAgentStorage?,
+        environment: AIAgentEnvironment?,
+        executionInfo: AgentExecutionInfo?,
+    ) {
+        rwLock.withWriteLock {
+            llm?.let { this.llm = it }
+            stateManager?.let { this.stateManager = it }
+            storage?.let { this.storage = it }
+            environment?.let { this.environment = it }
+            executionInfo?.let { this.executionInfo = it }
+        }
+    }
 }
 
 /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBase.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBase.kt
@@ -77,6 +77,8 @@ public expect abstract class AIAgentFunctionalContextBase<Pipeline : AIAgentPipe
 
     override suspend fun getHistory(): List<Message>
 
+    override suspend fun replace(context: AIAgentContext)
+
     public override suspend fun requestLLM(
         message: String,
         allowToolCalls: Boolean

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBaseAPI.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBaseAPI.kt
@@ -66,6 +66,15 @@ public interface AIAgentFunctionalContextBaseAPI<Pipeline : AIAgentPipeline> : A
     override suspend fun getHistory(): List<Message>
 
     /**
+     * Replaces the current context with the provided context.
+     * This method is used to update the current context with values from another context,
+     * particularly useful in scenarios like parallel node execution where contexts need to be merged.
+     *
+     * @param context The context to replace the current context with.
+     */
+    public suspend fun replace(context: AIAgentContext)
+
+    /**
      * Sends a message to a Large Language Model (LLM) and optionally allows the use of tools during the LLM interaction.
      * The message becomes part of the current prompt, and the LLM's response is processed accordingly,
      * either with or without tool integrations based on the provided parameters.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBaseImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBaseImpl.kt
@@ -42,20 +42,40 @@ import kotlin.reflect.KClass
 @Suppress("UNCHECKED_CAST")
 @PublishedApi
 internal class AIAgentFunctionalContextBaseImpl<Pipeline : AIAgentPipeline>(
-    override val environment: AIAgentEnvironment,
+    environment: AIAgentEnvironment,
     override val agentId: String,
     override val runId: String,
     override val agentInput: Any?,
     override val config: AIAgentConfig,
-    override val llm: AIAgentLLMContext,
-    override val stateManager: AIAgentStateManager,
-    override val storage: AIAgentStorage,
+    llm: AIAgentLLMContext,
+    stateManager: AIAgentStateManager,
+    storage: AIAgentStorage,
     override val strategyName: String,
     override val pipeline: Pipeline,
-    override var executionInfo: AgentExecutionInfo,
+    executionInfo: AgentExecutionInfo,
     internal val storeMap: MutableMap<AIAgentStorageKey<*>, Any> = mutableMapOf(),
     override val parentContext: AIAgentContext? = null
 ) : AIAgentFunctionalContextBaseAPI<Pipeline> {
+
+    private val mutableAIAgentContext = MutableAIAgentContext(llm, stateManager, storage, environment, executionInfo)
+
+    override val llm: AIAgentLLMContext
+        get() = mutableAIAgentContext.llm
+
+    override val stateManager: AIAgentStateManager
+        get() = mutableAIAgentContext.stateManager
+
+    override val storage: AIAgentStorage
+        get() = mutableAIAgentContext.storage
+
+    override val environment: AIAgentEnvironment
+        get() = mutableAIAgentContext.environment
+
+    override var executionInfo: AgentExecutionInfo
+        get() = mutableAIAgentContext.executionInfo
+        set(value) {
+            mutableAIAgentContext.executionInfo = value
+        }
 
     override fun store(key: AIAgentStorageKey<*>, value: Any) {
         storeMap[key] = value
@@ -67,6 +87,16 @@ internal class AIAgentFunctionalContextBaseImpl<Pipeline : AIAgentPipeline>(
 
     override suspend fun getHistory(): List<Message> {
         return llm.readSession { prompt.messages }
+    }
+
+    override suspend fun replace(context: AIAgentContext) {
+        mutableAIAgentContext.replace(
+            llm = context.llm,
+            stateManager = context.stateManager,
+            storage = context.storage,
+            environment = context.environment,
+            executionInfo = context.executionInfo
+        )
     }
 
     override suspend fun requestLLM(

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentGraphContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentGraphContext.kt
@@ -10,7 +10,6 @@ import ai.koog.agents.core.environment.AIAgentEnvironment
 import ai.koog.agents.core.feature.pipeline.AIAgentGraphPipeline
 import ai.koog.agents.core.feature.pipeline.AIAgentPipeline
 import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.agents.core.utils.RWLock
 import ai.koog.prompt.message.Message
 import kotlin.reflect.KType
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentGraphContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentGraphContext.kt
@@ -155,52 +155,6 @@ public class AIAgentGraphContext(
             mutableAIAgentContext.executionInfo = value
         }
 
-    /**
-     * Mutable wrapper for AI agent context properties.
-     */
-    internal class MutableAIAgentContext(
-        var llm: AIAgentLLMContext,
-        var stateManager: AIAgentStateManager,
-        var storage: AIAgentStorage,
-        var environment: AIAgentEnvironment,
-        var executionInfo: AgentExecutionInfo
-    ) {
-        private val rwLock = RWLock()
-
-        /**
-         * Creates a copy of the current [MutableAIAgentContext].
-         * @return A new instance of [MutableAIAgentContext] with copies of all mutable properties.
-         */
-        suspend fun copy(): MutableAIAgentContext {
-            return rwLock.withReadLock {
-                MutableAIAgentContext(llm.copy(), stateManager.copy(), storage.copy(), environment, executionInfo.copy())
-            }
-        }
-
-        /**
-         * Replaces the current context with the provided context.
-         *
-         * @param llm The LLM context to replace the current context with.
-         * @param stateManager The state manager to replace the current context with.
-         * @param storage The storage to replace the current context with.
-         */
-        suspend fun replace(
-            llm: AIAgentLLMContext?,
-            stateManager: AIAgentStateManager?,
-            storage: AIAgentStorage?,
-            environment: AIAgentEnvironment?,
-            executionInfo: AgentExecutionInfo?,
-        ) {
-            rwLock.withWriteLock {
-                llm?.let { this.llm = it }
-                stateManager?.let { this.stateManager = it }
-                storage?.let { this.storage = it }
-                environment?.let { this.environment = it }
-                executionInfo?.let { this.executionInfo = it }
-            }
-        }
-    }
-
     private val storeMap: MutableMap<AIAgentStorageKey<*>, Any> = mutableMapOf()
 
     override fun store(key: AIAgentStorageKey<*>, value: Any) {

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/AgentLifecycleEventType.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/AgentLifecycleEventType.kt
@@ -150,4 +150,38 @@ public sealed interface AgentLifecycleEventType {
     public object LLMStreamingCompleted : AgentLifecycleEventType
 
     //endregion LLM Streaming
+
+    //region Planner
+
+    /**
+     * Represents an event triggered when building a plan starts.
+     */
+    public object BuildPlanStarting : AgentLifecycleEventType
+
+    /**
+     * Represents an event triggered when building a plan completes.
+     */
+    public object BuildPlanCompleted : AgentLifecycleEventType
+
+    /**
+     * Represents an event triggered when executing a plan step starts.
+     */
+    public object ExecuteStepStarting : AgentLifecycleEventType
+
+    /**
+     * Represents an event triggered when executing a plan step completes.
+     */
+    public object ExecuteStepCompleted : AgentLifecycleEventType
+
+    /**
+     * Represents an event triggered when checking plan completion starts.
+     */
+    public object IsPlanCompletedStarting : AgentLifecycleEventType
+
+    /**
+     * Represents an event triggered when checking plan completion completes.
+     */
+    public object IsPlanCompletedCompleted : AgentLifecycleEventType
+
+    //endregion Planner
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/planner/PlannerEventContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/planner/PlannerEventContext.kt
@@ -1,0 +1,137 @@
+package ai.koog.agents.core.feature.handler.planner
+
+import ai.koog.agents.core.agent.context.AIAgentContext
+import ai.koog.agents.core.agent.execution.AgentExecutionInfo
+import ai.koog.agents.core.feature.handler.AgentLifecycleEventContext
+import ai.koog.agents.core.feature.handler.AgentLifecycleEventType
+
+/**
+ * Defines the context specifically for handling planner-related events within the AI agent framework.
+ * Extends the base event handler context to include functionality and behavior dedicated to managing
+ * the lifecycle and operations of planner agents.
+ */
+public interface PlannerEventContext : AgentLifecycleEventContext
+
+/**
+ * Represents the context for a buildPlan operation starting event.
+ *
+ * @property eventId The unique identifier for the event;
+ * @property executionInfo The execution information containing parentId and current execution path;
+ * @property context The context associated with the planner's execution;
+ * @property state The current state;
+ * @property currentPlan The current plan (null on first call).
+ */
+public class PlanCreationStartingContext(
+    override val eventId: String,
+    override val executionInfo: AgentExecutionInfo,
+    public val context: AIAgentContext,
+    public val state: Any,
+    public val currentPlan: Any?,
+    public val stepIndex: Int,
+) : PlannerEventContext {
+    override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.BuildPlanStarting
+}
+
+/**
+ * Represents the context for a buildPlan operation completed event.
+ *
+ * @property eventId The unique identifier for the event;
+ * @property executionInfo The execution information containing parentId and current execution path;
+ * @property context The context associated with the planner's execution;
+ * @property state The current state;
+ * @property currentPlan The previous plan (null on first call);
+ * @property newPlan The newly built plan.
+ */
+public class PlanCreationCompletedContext(
+    override val eventId: String,
+    override val executionInfo: AgentExecutionInfo,
+    public val context: AIAgentContext,
+    public val state: Any,
+    public val currentPlan: Any?,
+    public val newPlan: Any,
+    public val stepIndex: Int,
+) : PlannerEventContext {
+    override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.BuildPlanCompleted
+}
+
+/**
+ * Represents the context for an executeStep operation starting event.
+ *
+ * @property eventId The unique identifier for the event;
+ * @property executionInfo The execution information containing parentId and current execution path;
+ * @property context The context associated with the planner's execution;
+ * @property state The current state;
+ * @property plan The current plan.
+ */
+public class StepExecutionStartingContext(
+    override val eventId: String,
+    override val executionInfo: AgentExecutionInfo,
+    public val context: AIAgentContext,
+    public val state: Any,
+    public val plan: Any,
+    public val stepIndex: Int,
+) : PlannerEventContext {
+    override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.ExecuteStepStarting
+}
+
+/**
+ * Represents the context for an executeStep operation completed event.
+ *
+ * @property eventId The unique identifier for the event;
+ * @property executionInfo The execution information containing parentId and current execution path;
+ * @property context The context associated with the planner's execution;
+ * @property state The state after step execution;
+ * @property plan The current plan;
+ */
+public class StepExecutionCompletedContext(
+    override val eventId: String,
+    override val executionInfo: AgentExecutionInfo,
+    public val context: AIAgentContext,
+    public val state: Any,
+    public val plan: Any,
+    public val stepIndex: Int,
+) : PlannerEventContext {
+    override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.ExecuteStepCompleted
+}
+
+/**
+ * Represents the context for an isPlanCompleted check starting event.
+ *
+ * @property eventId The unique identifier for the event;
+ * @property executionInfo The execution information containing parentId and current execution path;
+ * @property context The context associated with the planner's execution;
+ * @property state The current state;
+ * @property plan The current plan.
+ */
+public class PlanCompletionEvaluationStartingContext(
+    override val eventId: String,
+    override val executionInfo: AgentExecutionInfo,
+    public val context: AIAgentContext,
+    public val state: Any,
+    public val plan: Any,
+    public val stepIndex: Int,
+) : PlannerEventContext {
+    override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.IsPlanCompletedStarting
+}
+
+/**
+ * Represents the context for an isPlanCompleted check completed event.
+ *
+ * @property eventId The unique identifier for the event;
+ * @property executionInfo The execution information containing parentId and current execution path;
+ * @property context The context associated with the planner's execution;
+ * @property state The current state;
+ * @property plan The current plan;
+ * @property isCompleted The result of the completion check.
+ */
+public class PlanCompletionEvaluationCompletedContext(
+    override val eventId: String,
+    override val executionInfo: AgentExecutionInfo,
+    public val context: AIAgentContext,
+    public val state: Any,
+    public val plan: Any,
+    public val isCompleted: Boolean,
+    public val stepIndex: Int,
+) : PlannerEventContext {
+    override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.IsPlanCompletedCompleted
+}

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
@@ -1,17 +1,32 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
 package ai.koog.agents.core.feature.pipeline
 
 import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.agent.context.AIAgentContext
+import ai.koog.agents.core.agent.execution.AgentExecutionInfo
+import ai.koog.agents.core.annotation.InternalAgentsApi
+import ai.koog.agents.core.feature.AIAgentFeature
 import ai.koog.agents.core.feature.AIAgentPlannerFeature
 import ai.koog.agents.core.feature.config.FeatureConfig
-import kotlinx.datetime.Clock
+import ai.koog.agents.core.feature.handler.planner.PlanCompletionEvaluationCompletedContext
+import ai.koog.agents.core.feature.handler.planner.PlanCompletionEvaluationStartingContext
+import ai.koog.agents.core.feature.handler.planner.PlanCreationCompletedContext
+import ai.koog.agents.core.feature.handler.planner.PlanCreationStartingContext
+import ai.koog.agents.core.feature.handler.planner.StepExecutionCompletedContext
+import ai.koog.agents.core.feature.handler.planner.StepExecutionStartingContext
+import kotlin.time.Clock
 
 /**
  * Represents a specific implementation of an AI agent pipeline that uses a planner approach.
  *
  * @property clock The clock used for time-based operations within the pipeline
  */
-public class AIAgentPlannerPipeline(agentConfig: AIAgentConfig, clock: Clock = kotlin.time.Clock.System) :
-    AIAgentPipeline(agentConfig, clock) {
+public expect open class AIAgentPlannerPipeline(
+    agentConfig: AIAgentConfig,
+    clock: Clock = Clock.System,
+    basePipelineDelegate: AIAgentPipelineImpl = AIAgentPipelineImpl(agentConfig, clock)
+) : AIAgentPipeline, AIAgentPlannerPipelineAPI {
     /**
      * Installs a non-graph feature into the pipeline with the provided configuration.
      *
@@ -23,13 +38,96 @@ public class AIAgentPlannerPipeline(agentConfig: AIAgentConfig, clock: Clock = k
     public fun <TConfig : FeatureConfig, TFeature : Any> install(
         feature: AIAgentPlannerFeature<TConfig, TFeature>,
         configure: TConfig.() -> Unit,
-    ) {
-        val featureConfig = feature.createInitialConfig().apply { configure() }
-        val featureImpl = feature.install(
-            config = featureConfig,
-            pipeline = this,
-        )
+    )
 
-        super.install(feature.key, featureConfig, featureImpl)
-    }
+    @InternalAgentsApi
+    public override suspend fun onPlanCreationStarting(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any?,
+        stepIndex: Int,
+    )
+
+    @InternalAgentsApi
+    public override suspend fun onPlanCreationCompleted(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int,
+    )
+
+    @InternalAgentsApi
+    public override suspend fun onStepExecutionStarting(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int
+    )
+
+    @InternalAgentsApi
+    public override suspend fun onStepExecutionCompleted(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int,
+    )
+
+    @InternalAgentsApi
+    public override suspend fun onPlanCompletionEvaluationStarting(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int,
+    )
+
+    @InternalAgentsApi
+    public override suspend fun onPlanCompletionEvaluationCompleted(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        isCompleted: Boolean,
+        stepIndex: Int,
+    )
+
+    public override fun interceptPlanCreationStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCreationStartingContext) -> Unit
+    )
+
+    public override fun interceptPlanCreationCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCreationCompletedContext) -> Unit
+    )
+
+    public override fun interceptStepExecutionStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (StepExecutionStartingContext) -> Unit
+    )
+
+    public override fun interceptStepExecutionCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (StepExecutionCompletedContext) -> Unit
+    )
+
+    public override fun interceptPlanCompletionEvaluationStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCompletionEvaluationStartingContext) -> Unit
+    )
+
+    public override fun interceptPlanCompletionEvaluationCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCompletionEvaluationCompletedContext) -> Unit
+    )
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipelineAPI.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipelineAPI.kt
@@ -1,0 +1,233 @@
+@file:Suppress("MissingKDocForPublicAPI")
+
+package ai.koog.agents.core.feature.pipeline
+
+import ai.koog.agents.core.agent.context.AIAgentContext
+import ai.koog.agents.core.agent.execution.AgentExecutionInfo
+import ai.koog.agents.core.annotation.InternalAgentsApi
+import ai.koog.agents.core.feature.AIAgentFeature
+import ai.koog.agents.core.feature.handler.planner.PlanCompletionEvaluationCompletedContext
+import ai.koog.agents.core.feature.handler.planner.PlanCompletionEvaluationStartingContext
+import ai.koog.agents.core.feature.handler.planner.PlanCreationCompletedContext
+import ai.koog.agents.core.feature.handler.planner.PlanCreationStartingContext
+import ai.koog.agents.core.feature.handler.planner.StepExecutionCompletedContext
+import ai.koog.agents.core.feature.handler.planner.StepExecutionStartingContext
+
+/**
+ * Platform-agnostic API for planner agent pipelines, extending the base pipeline API
+ * with planner-specific functionality.
+ */
+public interface AIAgentPlannerPipelineAPI : AIAgentPipelineAPI {
+
+    //region Trigger Planner Handlers
+
+    /**
+     * Notifies all registered planner handlers that a plan creation has started.
+     *
+     * @param eventId The unique identifier for the event group;
+     * @param executionInfo The execution information for the plan creation event;
+     * @param context The context of the plan creation;
+     * @param plan The plan that is starting creation;
+     */
+    @InternalAgentsApi
+    public suspend fun onPlanCreationStarting(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any?,
+        stepIndex: Int,
+    )
+
+    /**
+     * Notifies all registered planner handlers that a plan creation has completed.
+     *
+     * @param eventId The unique identifier for the event group;
+     * @param executionInfo The execution information for the plan creation event;
+     * @param context The context of the plan creation;
+     * @param state The current state;
+     * @param plan The plan that completed creation;
+     */
+    @InternalAgentsApi
+    public suspend fun onPlanCreationCompleted(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int,
+    )
+
+    /**
+     * Notifies all registered planner handlers that a plan step execution has started.
+     *
+     * @param eventId The unique identifier for the event group;
+     * @param executionInfo The execution information for the step execution event;
+     * @param context The context of the step execution;
+     * @param state The current state;
+     * @param plan The plan that is starting execution;
+     * @param stepIndex The index of the step in the plan.
+     */
+    @InternalAgentsApi
+    public suspend fun onStepExecutionStarting(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int
+    )
+
+    /**
+     * Notifies all registered planner handlers that a plan step execution has completed.
+     *
+     * @param eventId The unique identifier for the event group;
+     * @param executionInfo The execution information for the step execution event;
+     * @param context The context of the step execution;
+     * @param state The state after step execution;
+     * @param plan The plan that completed execution;
+     * @param stepIndex The index of the step in the plan;
+     */
+    @InternalAgentsApi
+    public suspend fun onStepExecutionCompleted(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int,
+    )
+
+    /**
+     * Notifies all registered planner handlers when evaluating whether a plan is completed.
+     *
+     * @param eventId The unique identifier for the event group;
+     * @param executionInfo The execution information for the evaluation event;
+     * @param context The context of the plan execution;
+     * @param state The current state;
+     * @param plan The plan being evaluated for completion;
+     */
+    @InternalAgentsApi
+    public suspend fun onPlanCompletionEvaluationStarting(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int,
+    )
+
+    /**
+     * Notifies all registered planner handlers when evaluating whether a plan is completed.
+     *
+     * @param eventId The unique identifier for the event group;
+     * @param executionInfo The execution information for the evaluation event;
+     * @param context The context of the plan execution;
+     * @param state The current state;
+     * @param plan The plan being evaluated for completion;
+     * @param isCompleted The result of the completion check.
+     */
+    @InternalAgentsApi
+    public suspend fun onPlanCompletionEvaluationCompleted(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        isCompleted: Boolean,
+        stepIndex: Int,
+    )
+
+    //endregion Trigger Planner Handlers
+
+    //region Planner Interceptors
+
+    /**
+     * Intercepts plan creation starting event to perform actions when a plan begins creation.
+     *
+     * @param feature The feature associated with this handler;
+     * @param handle A suspend function that processes the start of a plan creation.
+     */
+    public fun interceptPlanCreationStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCreationStartingContext) -> Unit
+    )
+
+    /**
+     * Intercepts plan creation completed event to perform actions when a plan completes creation.
+     *
+     * @param feature The feature associated with this handler;
+     * @param handle A suspend function that processes the completion of a plan creation.
+     */
+    public fun interceptPlanCreationCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCreationCompletedContext) -> Unit
+    )
+
+    /**
+     * Intercepts step execution starting event to perform actions when a plan step begins execution.
+     *
+     * @param feature The feature associated with this handler;
+     * @param handle A suspend function that processes the start of a step execution.
+     *
+     * Example:
+     * ```
+     * pipeline.interceptStepExecutionStarting(feature) { event ->
+     *     logger.info("Step ${event.stepIndex} execution has started")
+     * }
+     * ```
+     */
+    public fun interceptStepExecutionStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (StepExecutionStartingContext) -> Unit
+    )
+
+    /**
+     * Intercepts step execution completed event to perform actions when a plan step completes execution.
+     *
+     * @param feature The feature associated with this handler;
+     * @param handle A suspend function that processes the completion of a step execution.
+     *
+     * Example:
+     * ```
+     * pipeline.interceptStepExecutionCompleted(feature) { event ->
+     *     logger.info("Step ${event.stepIndex} execution has completed")
+     * }
+     * ```
+     */
+    public fun interceptStepExecutionCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (StepExecutionCompletedContext) -> Unit
+    )
+
+    /**
+     * Intercepts plan completion evaluation starting event to perform actions when a plan is about to be evaluated for completion.
+     *
+     * @param feature The feature associated with this handler;
+     * @param handle A suspend function that processes the start of a plan completion evaluation.
+     */
+    public fun interceptPlanCompletionEvaluationStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCompletionEvaluationStartingContext) -> Unit
+    )
+
+    /**
+     * Intercepts plan completion evaluation completed event to perform actions when a plan is evaluated for completion.
+     *
+     * @param feature The feature associated with this handler;
+     * @param handle A suspend function that processes the completion of a plan completion evaluation.
+     *
+     * Example:
+     * ```
+     * pipeline.interceptPlanCompletionEvaluationCompleted(feature) { event ->
+     *     logger.info("Plan completion evaluated as: ${event.isCompleted}")
+     * }
+     * ```
+     */
+    public fun interceptPlanCompletionEvaluationCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCompletionEvaluationCompletedContext) -> Unit
+    )
+
+    //endregion Planner Interceptors
+}

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipelineImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipelineImpl.kt
@@ -1,0 +1,197 @@
+package ai.koog.agents.core.feature.pipeline
+
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.agent.context.AIAgentContext
+import ai.koog.agents.core.agent.execution.AgentExecutionInfo
+import ai.koog.agents.core.annotation.InternalAgentsApi
+import ai.koog.agents.core.feature.AIAgentFeature
+import ai.koog.agents.core.feature.handler.AgentLifecycleEventType
+import ai.koog.agents.core.feature.handler.planner.PlanCompletionEvaluationCompletedContext
+import ai.koog.agents.core.feature.handler.planner.PlanCompletionEvaluationStartingContext
+import ai.koog.agents.core.feature.handler.planner.PlanCreationCompletedContext
+import ai.koog.agents.core.feature.handler.planner.PlanCreationStartingContext
+import ai.koog.agents.core.feature.handler.planner.StepExecutionCompletedContext
+import ai.koog.agents.core.feature.handler.planner.StepExecutionStartingContext
+import kotlinx.datetime.Clock
+
+/**
+ * Default implementation of [AIAgentPlannerPipelineAPI] that delegates base pipeline operations
+ * to [AIAgentPipelineImpl] and implements planner-specific functionality.
+ */
+public class AIAgentPlannerPipelineImpl(
+    config: AIAgentConfig,
+    clock: Clock = kotlin.time.Clock.System,
+    private val basePipelineDelegate: AIAgentPipelineImpl
+) : AIAgentPlannerPipelineAPI, AIAgentPipelineAPI by basePipelineDelegate {
+
+    //region Invoke Planner Handlers
+
+    @InternalAgentsApi
+    public override suspend fun onPlanCreationStarting(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any?,
+        stepIndex: Int,
+    ) {
+        basePipelineDelegate.invokeRegisteredHandlersForEvent(
+            eventType = AgentLifecycleEventType.BuildPlanStarting,
+            context = PlanCreationStartingContext(eventId, executionInfo, context, state, plan, stepIndex)
+        )
+    }
+
+    @InternalAgentsApi
+    public override suspend fun onPlanCreationCompleted(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int,
+    ) {
+        basePipelineDelegate.invokeRegisteredHandlersForEvent(
+            eventType = AgentLifecycleEventType.BuildPlanCompleted,
+            context = PlanCreationCompletedContext(eventId, executionInfo, context, state, null, plan, stepIndex)
+        )
+    }
+
+    @InternalAgentsApi
+    public override suspend fun onStepExecutionStarting(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int
+    ) {
+        basePipelineDelegate.invokeRegisteredHandlersForEvent(
+            eventType = AgentLifecycleEventType.ExecuteStepStarting,
+            context = StepExecutionStartingContext(eventId, executionInfo, context, state, plan, stepIndex)
+        )
+    }
+
+    @InternalAgentsApi
+    public override suspend fun onStepExecutionCompleted(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int,
+    ) {
+        basePipelineDelegate.invokeRegisteredHandlersForEvent(
+            eventType = AgentLifecycleEventType.ExecuteStepCompleted,
+            context = StepExecutionCompletedContext(eventId, executionInfo, context, state, plan, stepIndex)
+        )
+    }
+
+    @InternalAgentsApi
+    public override suspend fun onPlanCompletionEvaluationStarting(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        stepIndex: Int,
+    ) {
+        basePipelineDelegate.invokeRegisteredHandlersForEvent(
+            eventType = AgentLifecycleEventType.IsPlanCompletedStarting,
+            context = PlanCompletionEvaluationStartingContext(eventId, executionInfo, context, state, plan, stepIndex)
+        )
+    }
+
+    @InternalAgentsApi
+    public override suspend fun onPlanCompletionEvaluationCompleted(
+        eventId: String,
+        executionInfo: AgentExecutionInfo,
+        context: AIAgentContext,
+        state: Any,
+        plan: Any,
+        isCompleted: Boolean,
+        stepIndex: Int,
+    ) {
+        basePipelineDelegate.invokeRegisteredHandlersForEvent(
+            eventType = AgentLifecycleEventType.IsPlanCompletedCompleted,
+            context = PlanCompletionEvaluationCompletedContext(eventId, executionInfo, context, state, plan, isCompleted, stepIndex)
+        )
+    }
+
+    //endregion Invoke Planner Handlers
+
+    //region Planner Interceptors
+
+    @OptIn(InternalAgentsApi::class)
+    public override fun interceptPlanCreationStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCreationStartingContext) -> Unit
+    ) {
+        basePipelineDelegate.addHandlerForFeature(
+            featureKey = feature.key,
+            eventType = AgentLifecycleEventType.BuildPlanStarting,
+            handler = basePipelineDelegate.createConditionalHandler(feature, handle)
+        )
+    }
+
+    @OptIn(InternalAgentsApi::class)
+    public override fun interceptPlanCreationCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCreationCompletedContext) -> Unit
+    ) {
+        basePipelineDelegate.addHandlerForFeature(
+            featureKey = feature.key,
+            eventType = AgentLifecycleEventType.BuildPlanCompleted,
+            handler = basePipelineDelegate.createConditionalHandler(feature, handle)
+        )
+    }
+
+    @OptIn(InternalAgentsApi::class)
+    public override fun interceptStepExecutionStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (StepExecutionStartingContext) -> Unit
+    ) {
+        basePipelineDelegate.addHandlerForFeature(
+            featureKey = feature.key,
+            eventType = AgentLifecycleEventType.ExecuteStepStarting,
+            handler = basePipelineDelegate.createConditionalHandler(feature, handle)
+        )
+    }
+
+    @OptIn(InternalAgentsApi::class)
+    public override fun interceptStepExecutionCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (StepExecutionCompletedContext) -> Unit
+    ) {
+        basePipelineDelegate.addHandlerForFeature(
+            featureKey = feature.key,
+            eventType = AgentLifecycleEventType.ExecuteStepCompleted,
+            handler = basePipelineDelegate.createConditionalHandler(feature, handle)
+        )
+    }
+
+    @OptIn(InternalAgentsApi::class)
+    public override fun interceptPlanCompletionEvaluationStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCompletionEvaluationStartingContext) -> Unit
+    ) {
+        basePipelineDelegate.addHandlerForFeature(
+            featureKey = feature.key,
+            eventType = AgentLifecycleEventType.IsPlanCompletedStarting,
+            handler = basePipelineDelegate.createConditionalHandler(feature, handle)
+        )
+    }
+
+    @OptIn(InternalAgentsApi::class)
+    public override fun interceptPlanCompletionEvaluationCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: suspend (PlanCompletionEvaluationCompletedContext) -> Unit
+    ) {
+        basePipelineDelegate.addHandlerForFeature(
+            featureKey = feature.key,
+            eventType = AgentLifecycleEventType.IsPlanCompletedCompleted,
+            handler = basePipelineDelegate.createConditionalHandler(feature, handle)
+        )
+    }
+
+    //endregion Planner Interceptors
+}

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/AIAgentPlanner.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/AIAgentPlanner.kt
@@ -2,7 +2,9 @@ package ai.koog.agents.planner
 
 import ai.koog.agents.core.agent.context.AIAgentContext
 import ai.koog.agents.core.agent.context.AIAgentPlannerContext
+import ai.koog.agents.core.agent.context.with
 import ai.koog.agents.core.agent.exception.AIAgentMaxNumberOfIterationsReachedException
+import ai.koog.agents.core.annotation.InternalAgentsApi
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
@@ -19,7 +21,7 @@ import kotlin.reflect.typeOf
  *
  * @param stateType [KType] of the [State].
  */
-public abstract class AIAgentPlanner<State, Plan>(
+public abstract class AIAgentPlanner<State : Any, Plan : Any>(
     // FIXME: require the type explicitly when we decide, what to do with it in Java API
     stateType: KType? = null,
 ) {
@@ -71,16 +73,47 @@ public abstract class AIAgentPlanner<State, Plan>(
      * @throws AIAgentMaxNumberOfIterationsReachedException If the maximum number of iterations defined in the agent's
      * configuration is exceeded.
      */
-    public suspend fun execute(
+    @OptIn(InternalAgentsApi::class)
+    internal suspend fun execute(
         context: AIAgentPlannerContext,
         input: State
     ): State {
         logger.debug { formatLog(context, "Starting planner execution") }
         var state = input
-        var plan: Plan = buildPlan(context, state, null)
+        var previousPlan: Plan? = null
 
-        while (!isPlanCompleted(context, state, plan)) {
-            val iterations = context.stateManager.withStateLock { state ->
+        while (true) {
+            val stepIndex = context.stateManager.withStateLock { state ->
+                state.iterations
+            }
+
+            val plan = context.with(partName = "buildPlan-${stepIndex + 1}") { executionInfo, eventId ->
+                context.pipeline.onPlanCreationStarting(eventId, executionInfo, context, state, previousPlan, stepIndex + 1)
+                val newPlan = buildPlan(context, state, previousPlan)
+                context.pipeline.onPlanCreationCompleted(eventId, executionInfo, context, state, newPlan, stepIndex + 1)
+                newPlan
+            }
+
+            logger.debug { formatLog(context, "Executing plan step #${stepIndex + 1}") }
+
+            // Execute step
+            context.with(partName = "executeStep-${stepIndex + 1}") { stepExecutionInfo, stepEventId ->
+                context.pipeline.onStepExecutionStarting(stepEventId, stepExecutionInfo, context, state, plan, stepIndex + 1)
+                state = executeStep(context, state, plan)
+                context.pipeline.onStepExecutionCompleted(stepEventId, stepExecutionInfo, context, state, plan, stepIndex + 1)
+            }
+
+            logger.debug { formatLog(context, "Finished executing plan step #${stepIndex + 1}") }
+
+            // Check if plan is completed
+            val isCompleted = context.with(partName = "isPlanCompleted-${stepIndex + 1}") { executionInfo, eventId ->
+                context.pipeline.onPlanCompletionEvaluationStarting(eventId, executionInfo, context, state, plan, stepIndex + 1)
+                val completed = isPlanCompleted(context, state, plan)
+                context.pipeline.onPlanCompletionEvaluationCompleted(eventId, executionInfo, context, state, plan, completed, stepIndex + 1)
+                completed
+            }
+
+            context.stateManager.withStateLock { state ->
                 if (++state.iterations > context.config.maxAgentIterations) {
                     logger.error {
                         formatLog(
@@ -90,14 +123,11 @@ public abstract class AIAgentPlanner<State, Plan>(
                     }
                     throw AIAgentMaxNumberOfIterationsReachedException(context.config.maxAgentIterations)
                 }
-
-                state.iterations
             }
 
-            logger.debug { formatLog(context, "Executing plan step #$iterations") }
-            state = executeStep(context, state, plan)
-            plan = buildPlan(context, state, plan)
-            logger.debug { formatLog(context, "Finished executing plan step #$iterations") }
+            if (isCompleted) break
+
+            previousPlan = plan
         }
 
         logger.debug { formatLog(context, "Finished planner execution") }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/AIAgentPlannerStrategy.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/AIAgentPlannerStrategy.kt
@@ -1,7 +1,6 @@
 package ai.koog.agents.planner
 
 import ai.koog.agents.core.agent.context.AIAgentPlannerContext
-import ai.koog.agents.core.agent.context.with
 import ai.koog.agents.core.agent.entity.AIAgentStrategy
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.planner.goap.GoapAgentState
@@ -22,7 +21,7 @@ import kotlin.jvm.JvmStatic
  * @property initializeState A function that initializes the planner state based on the given input.
  * @property provideOutput A function that produces the strategy's output based on the final planner state.
  */
-public class AIAgentPlannerStrategy<Input, Output, State>(
+public class AIAgentPlannerStrategy<Input, Output, State : Any>(
     override val name: String,
     private val planner: AIAgentPlanner<State, *>,
     private val initializeState: (Input) -> State,
@@ -33,15 +32,9 @@ public class AIAgentPlannerStrategy<Input, Output, State>(
         context: AIAgentPlannerContext,
         input: Input
     ): Output {
-        val state = initializeState(input)
         return try {
-            context.with(partName = name) { executionInfo, eventId ->
-                context.pipeline.onStrategyStarting(eventId, executionInfo, this, context)
-                val result = planner.execute(context, initializeState(input))
-                context.pipeline.onStrategyCompleted(eventId, executionInfo, this, context, result, planner.stateType)
-
-                provideOutput(result)
-            }
+            val result = planner.execute(context, initializeState(input))
+            provideOutput(result)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -61,7 +54,7 @@ public class AIAgentPlannerStrategy<Input, Output, State>(
          * @param planner The planner instance that defines the specific planning logic.
          * @return A new [AIAgentPlannerStrategy] instance where the input, output, and state types are the same.
          */
-        public operator fun <State> invoke(
+        public operator fun <State : Any> invoke(
             name: String,
             planner: AIAgentPlanner<State, *>,
         ): AIAgentPlannerStrategy<State, State, State> = AIAgentPlannerStrategy(name, planner, { it }, { it })

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/PlannerAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/PlannerAIAgent.kt
@@ -147,6 +147,8 @@ public class PlannerAIAgent<Input, Output>(
             parentRootContext = initialAgentContext.parentContext, // Keep the original parent context
         )
 
-        return updatedAgentContext
+        initialAgentContext.replace(updatedAgentContext)
+
+        return initialAgentContext
     }
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/goap/GOAPPlanner.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/goap/GOAPPlanner.kt
@@ -15,7 +15,7 @@ import kotlin.reflect.KType
  * @param goals The list of defined goals.
  */
 @Deprecated("Use AIAgentStrategy.builder(name).goap() DSL instead.")
-public open class GOAPPlanner<State> internal constructor(
+public open class GOAPPlanner<State : Any> internal constructor(
     private val actions: List<Action<State>>,
     private val goals: List<Goal<State>>,
     stateType: KType? = null,

--- a/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
+++ b/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
@@ -6,6 +6,8 @@ import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.planner.AIAgentPlannerStrategy
+import ai.koog.agents.planner.PlannerAIAgent
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
@@ -56,6 +58,16 @@ public actual abstract class AIAgentService<Input, Output, TAgent : AIAgent<Inpu
             toolRegistry: ToolRegistry,
             noinline installFeatures: GraphAIAgent.FeatureContext.() -> Unit
         ): GraphAIAgentService<Input, Output> =
+            AIAgentServiceHelper.invoke(promptExecutor, agentConfig, strategy, toolRegistry, installFeatures)
+
+        @OptIn(markerClass = [InternalAgentsApi::class])
+        public actual operator fun <Input, Output> invoke(
+            promptExecutor: PromptExecutor,
+            agentConfig: AIAgentConfig,
+            strategy: AIAgentPlannerStrategy<Input, Output, *>,
+            toolRegistry: ToolRegistry,
+            installFeatures: PlannerAIAgent.FeatureContext.() -> Unit
+        ): PlannerAIAgentService<Input, Output> =
             AIAgentServiceHelper.invoke(promptExecutor, agentConfig, strategy, toolRegistry, installFeatures)
 
         public actual operator fun invoke(

--- a/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
+++ b/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
@@ -5,6 +5,7 @@ package ai.koog.agents.core.agent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.planner.AIAgentPlannerStrategy
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
@@ -43,6 +44,9 @@ public actual class AIAgentServiceBuilder internal actual constructor() :
 
     actual override fun <Input, Output> functionalStrategy(strategy: AIAgentFunctionalStrategy<Input, Output>): FunctionalAgentServiceBuilder<Input, Output> =
         delegate.functionalStrategy(strategy)
+
+    actual override fun <Input, Output> plannerStrategy(strategy: AIAgentPlannerStrategy<Input, Output, *>): PlannerAgentServiceBuilder<Input, Output> =
+        delegate.plannerStrategy(strategy)
 
     actual override fun build(): GraphAIAgentService<String, String> = delegate.build()
 }

--- a/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
+++ b/agents/agents-core/src/jsMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
@@ -1,0 +1,36 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "MissingKDocForPublicAPI")
+
+package ai.koog.agents.core.feature.pipeline
+
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.feature.AIAgentPlannerFeature
+import ai.koog.agents.core.feature.config.FeatureConfig
+import kotlinx.datetime.Clock
+
+public actual open class AIAgentPlannerPipeline actual constructor(
+    agentConfig: AIAgentConfig,
+    clock: Clock,
+    private val basePipelineDelegate: AIAgentPipelineImpl
+) : AIAgentPipeline(agentConfig, clock), AIAgentPlannerPipelineAPI by AIAgentPlannerPipelineImpl(agentConfig, clock, basePipelineDelegate) {
+
+    /**
+     * Installs a non-graph feature into the pipeline with the provided configuration.
+     *
+     * @param TConfig The type of the feature configuration
+     * @param TFeature The type of the feature being installed
+     * @param feature The feature implementation to be installed
+     * @param configure A lambda to customize the feature configuration
+     */
+    public actual fun <TConfig : FeatureConfig, TFeature : Any> install(
+        feature: AIAgentPlannerFeature<TConfig, TFeature>,
+        configure: TConfig.() -> Unit,
+    ) {
+        val featureConfig = feature.createInitialConfig().apply { configure() }
+        val featureImpl = feature.install(
+            config = featureConfig,
+            pipeline = this,
+        )
+
+        basePipelineDelegate.install(feature.key, featureConfig, featureImpl)
+    }
+}

--- a/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
+++ b/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
@@ -9,6 +9,8 @@ import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.utils.runOnStrategyDispatcher
+import ai.koog.agents.planner.AIAgentPlannerStrategy
+import ai.koog.agents.planner.PlannerAIAgent
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
@@ -208,6 +210,16 @@ public actual abstract class AIAgentService<Input, Output, TAgent : AIAgent<Inpu
             toolRegistry: ToolRegistry,
             noinline installFeatures: GraphAIAgent.FeatureContext.() -> Unit
         ): GraphAIAgentService<Input, Output> =
+            AIAgentServiceHelper.invoke(promptExecutor, agentConfig, strategy, toolRegistry, installFeatures)
+
+        @OptIn(markerClass = [InternalAgentsApi::class])
+        public actual operator fun <Input, Output> invoke(
+            promptExecutor: PromptExecutor,
+            agentConfig: AIAgentConfig,
+            strategy: AIAgentPlannerStrategy<Input, Output, *>,
+            toolRegistry: ToolRegistry,
+            installFeatures: PlannerAIAgent.FeatureContext.() -> Unit
+        ): PlannerAIAgentService<Input, Output> =
             AIAgentServiceHelper.invoke(promptExecutor, agentConfig, strategy, toolRegistry, installFeatures)
 
         public actual operator fun invoke(

--- a/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
+++ b/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
@@ -7,6 +7,7 @@ import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.context.AIAgentFunctionalContext
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.planner.AIAgentPlannerStrategy
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
@@ -46,6 +47,9 @@ public actual class AIAgentServiceBuilder internal actual constructor() :
 
     actual override fun <Input, Output> functionalStrategy(strategy: AIAgentFunctionalStrategy<Input, Output>): FunctionalAgentServiceBuilder<Input, Output> =
         delegate.functionalStrategy(strategy)
+
+    actual override fun <Input, Output> plannerStrategy(strategy: AIAgentPlannerStrategy<Input, Output, *>): PlannerAgentServiceBuilder<Input, Output> =
+        delegate.plannerStrategy(strategy)
 
     /**
      * Creates a functional agent service builder using the provided strategy.

--- a/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
+++ b/agents/agents-core/src/jvmMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
@@ -1,0 +1,183 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "MissingKDocForPublicAPI")
+@file:OptIn(InternalAgentsApi::class)
+
+package ai.koog.agents.core.feature.pipeline
+
+import ai.koog.agents.annotations.JavaAPI
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.annotation.InternalAgentsApi
+import ai.koog.agents.core.feature.AIAgentFeature
+import ai.koog.agents.core.feature.AIAgentPlannerFeature
+import ai.koog.agents.core.feature.config.FeatureConfig
+import ai.koog.agents.core.feature.handler.planner.PlanCompletionEvaluationCompletedContext
+import ai.koog.agents.core.feature.handler.planner.PlanCompletionEvaluationStartingContext
+import ai.koog.agents.core.feature.handler.planner.PlanCreationCompletedContext
+import ai.koog.agents.core.feature.handler.planner.PlanCreationStartingContext
+import ai.koog.agents.core.feature.handler.planner.StepExecutionCompletedContext
+import ai.koog.agents.core.feature.handler.planner.StepExecutionStartingContext
+import ai.koog.agents.core.utils.submitToMainDispatcher
+import kotlinx.datetime.Clock
+
+public actual open class AIAgentPlannerPipeline @JvmOverloads actual constructor(
+    agentConfig: AIAgentConfig,
+    clock: Clock,
+    private val basePipelineDelegate: AIAgentPipelineImpl
+) : AIAgentPipeline(agentConfig, clock), AIAgentPlannerPipelineAPI by AIAgentPlannerPipelineImpl(agentConfig, clock, basePipelineDelegate) {
+
+    /**
+     * Installs a non-graph feature into the pipeline with the provided configuration.
+     *
+     * @param TConfig The type of the feature configuration
+     * @param TFeature The type of the feature being installed
+     * @param feature The feature implementation to be installed
+     * @param configure A lambda to customize the feature configuration
+     */
+    public actual fun <TConfig : FeatureConfig, TFeature : Any> install(
+        feature: AIAgentPlannerFeature<TConfig, TFeature>,
+        configure: TConfig.() -> Unit,
+    ) {
+        val featureConfig = feature.createInitialConfig().apply { configure() }
+        val featureImpl = feature.install(
+            config = featureConfig,
+            pipeline = this,
+        )
+
+        basePipelineDelegate.install(feature.key, featureConfig, featureImpl)
+    }
+
+    //region JVM Planner Interceptors
+
+    /**
+     * Intercepts plan creation starting event to perform actions when a plan begins creation.
+     *
+     * JVM-friendly overload that accepts an async interceptor.
+     */
+    @JavaAPI
+    @InternalAgentsApi
+    @JvmName("interceptPlanCreationStarting")
+    public fun javaApiInterceptPlanCreationStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: Interceptor<PlanCreationStartingContext>
+    ) {
+        interceptPlanCreationStarting(feature) { ctx ->
+            config.submitToMainDispatcher {
+                handle.intercept(ctx)
+            }
+        }
+    }
+
+    /**
+     * Intercepts plan creation completed event to perform actions when a plan completes creation.
+     *
+     * JVM-friendly overload that accepts an async interceptor.
+     */
+    @JavaAPI
+    @InternalAgentsApi
+    @JvmName("interceptPlanCreationCompleted")
+    public fun javaApiInterceptPlanCreationCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: Interceptor<PlanCreationCompletedContext>
+    ) {
+        interceptPlanCreationCompleted(feature) { ctx ->
+            config.submitToMainDispatcher {
+                handle.intercept(ctx)
+            }
+        }
+    }
+
+    /**
+     * Intercepts step execution starting event to perform actions when a plan step begins execution.
+     *
+     * JVM-friendly overload that accepts an async interceptor.
+     *
+     * Example (Java):
+     * pipeline.interceptStepExecutionStarting(feature, event -> {
+     *     // Step execution started
+     *     return java.util.concurrent.CompletableFuture.completedFuture(null);
+     * });
+     */
+    @JavaAPI
+    @InternalAgentsApi
+    @JvmName("interceptStepExecutionStarting")
+    public fun javaApiInterceptStepExecutionStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: Interceptor<StepExecutionStartingContext>
+    ) {
+        interceptStepExecutionStarting(feature) { ctx ->
+            config.submitToMainDispatcher {
+                handle.intercept(ctx)
+            }
+        }
+    }
+
+    /**
+     * Intercepts step execution completed event to perform actions when a plan step completes execution.
+     *
+     * JVM-friendly overload that accepts an async interceptor.
+     *
+     * Example (Java):
+     * pipeline.interceptStepExecutionCompleted(feature, event -> {
+     *     // Step execution completed
+     *     return java.util.concurrent.CompletableFuture.completedFuture(null);
+     * });
+     */
+    @JavaAPI
+    @InternalAgentsApi
+    @JvmName("interceptStepExecutionCompleted")
+    public fun javaApiInterceptStepExecutionCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: Interceptor<StepExecutionCompletedContext>
+    ) {
+        interceptStepExecutionCompleted(feature) { ctx ->
+            config.submitToMainDispatcher {
+                handle.intercept(ctx)
+            }
+        }
+    }
+
+    /**
+     * Intercepts plan completion evaluation starting event to perform actions when a plan is about to be evaluated for completion.
+     *
+     * JVM-friendly overload that accepts an async interceptor.
+     */
+    @JavaAPI
+    @InternalAgentsApi
+    @JvmName("interceptPlanCompletionEvaluationStarting")
+    public fun javaApiInterceptPlanCompletionEvaluationStarting(
+        feature: AIAgentFeature<*, *>,
+        handle: Interceptor<PlanCompletionEvaluationStartingContext>
+    ) {
+        interceptPlanCompletionEvaluationStarting(feature) { ctx ->
+            config.submitToMainDispatcher {
+                handle.intercept(ctx)
+            }
+        }
+    }
+
+    /**
+     * Intercepts plan completion evaluation completed event to perform actions when evaluating if a plan is completed.
+     *
+     * JVM-friendly overload that accepts an async interceptor.
+     *
+     * Example (Java):
+     * pipeline.interceptPlanCompletionEvaluationCompleted(feature, event -> {
+     *     // Plan completion evaluated
+     *     return java.util.concurrent.CompletableFuture.completedFuture(null);
+     * });
+     */
+    @JavaAPI
+    @InternalAgentsApi
+    @JvmName("interceptPlanCompletionEvaluationCompleted")
+    public fun javaApiInterceptPlanCompletionEvaluationCompleted(
+        feature: AIAgentFeature<*, *>,
+        handle: Interceptor<PlanCompletionEvaluationCompletedContext>
+    ) {
+        interceptPlanCompletionEvaluationCompleted(feature) { ctx ->
+            config.submitToMainDispatcher {
+                handle.intercept(ctx)
+            }
+        }
+    }
+
+    //endregion JVM Planner Interceptors
+}

--- a/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
+++ b/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
@@ -6,6 +6,8 @@ import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.planner.AIAgentPlannerStrategy
+import ai.koog.agents.planner.PlannerAIAgent
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
@@ -56,6 +58,16 @@ public actual abstract class AIAgentService<Input, Output, TAgent : AIAgent<Inpu
             toolRegistry: ToolRegistry,
             noinline installFeatures: GraphAIAgent.FeatureContext.() -> Unit
         ): GraphAIAgentService<Input, Output> =
+            AIAgentServiceHelper.invoke(promptExecutor, agentConfig, strategy, toolRegistry, installFeatures)
+
+        @OptIn(markerClass = [InternalAgentsApi::class])
+        public actual operator fun <Input, Output> invoke(
+            promptExecutor: PromptExecutor,
+            agentConfig: AIAgentConfig,
+            strategy: AIAgentPlannerStrategy<Input, Output, *>,
+            toolRegistry: ToolRegistry,
+            installFeatures: PlannerAIAgent.FeatureContext.() -> Unit
+        ): PlannerAIAgentService<Input, Output> =
             AIAgentServiceHelper.invoke(promptExecutor, agentConfig, strategy, toolRegistry, installFeatures)
 
         public actual operator fun invoke(

--- a/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
+++ b/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
@@ -5,6 +5,7 @@ package ai.koog.agents.core.agent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.planner.AIAgentPlannerStrategy
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
@@ -43,6 +44,9 @@ public actual class AIAgentServiceBuilder internal actual constructor() :
 
     actual override fun <Input, Output> functionalStrategy(strategy: AIAgentFunctionalStrategy<Input, Output>): FunctionalAgentServiceBuilder<Input, Output> =
         delegate.functionalStrategy(strategy)
+
+    actual override fun <Input, Output> plannerStrategy(strategy: AIAgentPlannerStrategy<Input, Output, *>): PlannerAgentServiceBuilder<Input, Output> =
+        delegate.plannerStrategy(strategy)
 
     actual override fun build(): GraphAIAgentService<String, String> = delegate.build()
 }

--- a/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
+++ b/agents/agents-core/src/wasmJsMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
@@ -1,0 +1,36 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "MissingKDocForPublicAPI")
+
+package ai.koog.agents.core.feature.pipeline
+
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.feature.AIAgentPlannerFeature
+import ai.koog.agents.core.feature.config.FeatureConfig
+import kotlinx.datetime.Clock
+
+public actual open class AIAgentPlannerPipeline actual constructor(
+    agentConfig: AIAgentConfig,
+    clock: Clock,
+    private val basePipelineDelegate: AIAgentPipelineImpl
+) : AIAgentPipeline(agentConfig, clock), AIAgentPlannerPipelineAPI by AIAgentPlannerPipelineImpl(agentConfig, clock, basePipelineDelegate) {
+
+    /**
+     * Installs a non-graph feature into the pipeline with the provided configuration.
+     *
+     * @param TConfig The type of the feature configuration
+     * @param TFeature The type of the feature being installed
+     * @param feature The feature implementation to be installed
+     * @param configure A lambda to customize the feature configuration
+     */
+    public actual fun <TConfig : FeatureConfig, TFeature : Any> install(
+        feature: AIAgentPlannerFeature<TConfig, TFeature>,
+        configure: TConfig.() -> Unit,
+    ) {
+        val featureConfig = feature.createInitialConfig().apply { configure() }
+        val featureImpl = feature.install(
+            config = featureConfig,
+            pipeline = this,
+        )
+
+        basePipelineDelegate.install(feature.key, featureConfig, featureImpl)
+    }
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/KoogAttributes.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/KoogAttributes.kt
@@ -78,54 +78,34 @@ internal object KoogAttributes {
             override val key: String
                 get() = super.key.concatKey("planner")
 
-            sealed interface Plan : Planner {
-                override val key: String
-                    get() = super.key.concatKey("plan")
-
-                data class Input(private val plan: String) : Plan {
-                    override val key: String = super.key.concatKey("input")
-                    override val value: HiddenString = HiddenString(plan)
-                }
-
-                data class Output(private val plan: String) : Plan {
-                    override val key: String = super.key.concatKey("output")
-                    override val value: HiddenString = HiddenString(plan)
-                }
+            data class StepIndex(private val stepIndex: Int) : Planner {
+                override val key: String = super.key.concatKey("step_index")
+                override val value: Int = stepIndex
             }
 
-            sealed interface Step : Planner {
-                override val key: String
-                    get() = super.key.concatKey("step")
-
-                data class Index(private val index: Int) : Step {
-                    override val key: String = super.key.concatKey("index")
-                    override val value: Long = index.toLong()
-                }
+            data class Plan(private val plan: String) : Planner {
+                override val key: String = super.key.concatKey("plan")
+                override val value: HiddenString = HiddenString(plan)
             }
 
-            sealed interface State : Planner {
-                override val key: String
-                    get() = super.key.concatKey("state")
-
-                data class Input(private val state: String) : State {
-                    override val key: String = super.key.concatKey("input")
-                    override val value: HiddenString = HiddenString(state)
-                }
-
-                data class Output(private val state: String) : State {
-                    override val key: String = super.key.concatKey("output")
-                    override val value: HiddenString = HiddenString(state)
-                }
+            data class NewPlan(private val newPlan: String) : Planner {
+                override val key: String = super.key.concatKey("new_plan")
+                override val value: HiddenString = HiddenString(newPlan)
             }
 
-            sealed interface Completion : Planner {
-                override val key: String
-                    get() = super.key.concatKey("completion")
+            data class State(private val state: String) : Planner {
+                override val key: String = super.key.concatKey("state")
+                override val value: HiddenString = HiddenString(state)
+            }
 
-                data class IsCompleted(private val isCompleted: Boolean) : Completion {
-                    override val key: String = super.key.concatKey("is_completed")
-                    override val value: Boolean = isCompleted
-                }
+            data class NewState(private val newState: String) : Planner {
+                override val key: String = super.key.concatKey("new_state")
+                override val value: HiddenString = HiddenString(newState)
+            }
+
+            data class IsCompleted(private val isCompleted: Boolean) : Planner {
+                override val key: String = super.key.concatKey("is_completed")
+                override val value: Boolean = isCompleted
             }
         }
     }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/KoogAttributes.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/KoogAttributes.kt
@@ -73,5 +73,60 @@ internal object KoogAttributes {
                 override val value: HiddenString = HiddenString(output)
             }
         }
+
+        sealed interface Planner : Koog {
+            override val key: String
+                get() = super.key.concatKey("planner")
+
+            sealed interface Plan : Planner {
+                override val key: String
+                    get() = super.key.concatKey("plan")
+
+                data class Input(private val plan: String) : Plan {
+                    override val key: String = super.key.concatKey("input")
+                    override val value: HiddenString = HiddenString(plan)
+                }
+
+                data class Output(private val plan: String) : Plan {
+                    override val key: String = super.key.concatKey("output")
+                    override val value: HiddenString = HiddenString(plan)
+                }
+            }
+
+            sealed interface Step : Planner {
+                override val key: String
+                    get() = super.key.concatKey("step")
+
+                data class Index(private val index: Int) : Step {
+                    override val key: String = super.key.concatKey("index")
+                    override val value: Long = index.toLong()
+                }
+            }
+
+            sealed interface State : Planner {
+                override val key: String
+                    get() = super.key.concatKey("state")
+
+                data class Input(private val state: String) : State {
+                    override val key: String = super.key.concatKey("input")
+                    override val value: HiddenString = HiddenString(state)
+                }
+
+                data class Output(private val state: String) : State {
+                    override val key: String = super.key.concatKey("output")
+                    override val value: HiddenString = HiddenString(state)
+                }
+            }
+
+            sealed interface Completion : Planner {
+                override val key: String
+                    get() = super.key.concatKey("completion")
+
+                data class IsCompleted(private val isCompleted: Boolean) : Completion {
+                    override val key: String = super.key.concatKey("is_completed")
+                    override val value: Boolean = isCompleted
+                }
+            }
+        }
     }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
@@ -31,6 +31,9 @@ import ai.koog.agents.features.opentelemetry.span.endExecuteToolSpan
 import ai.koog.agents.features.opentelemetry.span.endInferenceSpan
 import ai.koog.agents.features.opentelemetry.span.endInvokeAgentSpan
 import ai.koog.agents.features.opentelemetry.span.endNodeExecuteSpan
+import ai.koog.agents.features.opentelemetry.span.endPlanCompletionEvaluationSpan
+import ai.koog.agents.features.opentelemetry.span.endPlanCreationSpan
+import ai.koog.agents.features.opentelemetry.span.endStepExecutionSpan
 import ai.koog.agents.features.opentelemetry.span.endStrategySpan
 import ai.koog.agents.features.opentelemetry.span.endSubgraphExecuteSpan
 import ai.koog.agents.features.opentelemetry.span.enrichExecuteToolSpanWithMcpAttrs
@@ -39,6 +42,9 @@ import ai.koog.agents.features.opentelemetry.span.startExecuteToolSpan
 import ai.koog.agents.features.opentelemetry.span.startInferenceSpan
 import ai.koog.agents.features.opentelemetry.span.startInvokeAgentSpan
 import ai.koog.agents.features.opentelemetry.span.startNodeExecuteSpan
+import ai.koog.agents.features.opentelemetry.span.startPlanCompletionEvaluationSpan
+import ai.koog.agents.features.opentelemetry.span.startPlanCreationSpan
+import ai.koog.agents.features.opentelemetry.span.startStepExecutionSpan
 import ai.koog.agents.features.opentelemetry.span.startStrategySpan
 import ai.koog.agents.features.opentelemetry.span.startSubgraphExecuteSpan
 import ai.koog.agents.mcp.metadata.McpMetadataKeys
@@ -266,6 +272,145 @@ public class OpenTelemetry {
             val spanCollector = SpanCollector()
 
             installCommon(config, pipeline, spanCollector)
+
+            // Inline install for Planner (no separate installPlanner function)
+            val spanAdapter = config.spanAdapter
+            val tracer = config.tracer
+
+            // Plan Creation
+            pipeline.interceptPlanCreationStarting(this) { eventContext ->
+                logger.debug { "Execute OpenTelemetry before plan creation starting handler" }
+
+                val patchedExecutionInfo = eventContext.executionInfo.appendRunId(eventContext.context.runId)
+                val parentSpan = spanCollector.getParentSpanForEvent(patchedExecutionInfo)
+                val span = startPlanCreationSpan(
+                    tracer = tracer,
+                    parentSpan = parentSpan,
+                    id = eventContext.eventId,
+                    runId = eventContext.context.runId,
+                    stepIndex = eventContext.stepIndex,
+                    state = eventContext.state.toString(),
+                    currentPlan = eventContext.currentPlan?.toString(),
+                )
+
+                spanAdapter?.onBeforeSpanStarted(span)
+                spanCollector.collectSpan(
+                    span = span,
+                    path = patchedExecutionInfo
+                )
+            }
+
+            pipeline.interceptPlanCreationCompleted(this) { eventContext ->
+                logger.debug { "Execute OpenTelemetry after plan creation completed handler" }
+
+                val patchedExecutionInfo = eventContext.executionInfo.appendRunId(eventContext.context.runId)
+                val span = spanCollector.getStartedSpan(
+                    executionInfo = patchedExecutionInfo,
+                    eventId = eventContext.eventId,
+                    spanType = SpanType.PLAN_CREATION
+                ) ?: return@interceptPlanCreationCompleted
+
+                spanAdapter?.onBeforeSpanFinished(span)
+                endPlanCreationSpan(
+                    span = span,
+                    newPlan = eventContext.newPlan.toString(),
+                    verbose = config.isVerbose
+                )
+                spanCollector.removeSpan(
+                    span = span,
+                    path = patchedExecutionInfo
+                )
+            }
+
+            // Step Execution
+            pipeline.interceptStepExecutionStarting(this) { eventContext ->
+                logger.debug { "Execute OpenTelemetry before step execution starting handler" }
+
+                val patchedExecutionInfo = eventContext.executionInfo.appendRunId(eventContext.context.runId)
+                val parentSpan = spanCollector.getParentSpanForEvent(patchedExecutionInfo)
+                val span = startStepExecutionSpan(
+                    tracer = tracer,
+                    parentSpan = parentSpan,
+                    id = eventContext.eventId,
+                    runId = eventContext.context.runId,
+                    stepIndex = eventContext.stepIndex,
+                    state = eventContext.state.toString(),
+                    plan = eventContext.plan.toString(),
+                )
+
+                spanAdapter?.onBeforeSpanStarted(span)
+                spanCollector.collectSpan(
+                    span = span,
+                    path = patchedExecutionInfo
+                )
+            }
+
+            pipeline.interceptStepExecutionCompleted(this) { eventContext ->
+                logger.debug { "Execute OpenTelemetry after step execution completed handler" }
+
+                val patchedExecutionInfo = eventContext.executionInfo.appendRunId(eventContext.context.runId)
+                val span = spanCollector.getStartedSpan(
+                    executionInfo = patchedExecutionInfo,
+                    eventId = eventContext.eventId,
+                    spanType = SpanType.STEP_EXECUTION
+                ) ?: return@interceptStepExecutionCompleted
+
+                spanAdapter?.onBeforeSpanFinished(span)
+                endStepExecutionSpan(
+                    span = span,
+                    state = eventContext.state.toString(),
+                    verbose = config.isVerbose
+                )
+                spanCollector.removeSpan(
+                    span = span,
+                    path = patchedExecutionInfo
+                )
+            }
+
+            // Plan Completion Evaluation
+            pipeline.interceptPlanCompletionEvaluationStarting(this) { eventContext ->
+                logger.debug { "Execute OpenTelemetry before plan completion evaluation starting handler" }
+
+                val patchedExecutionInfo = eventContext.executionInfo.appendRunId(eventContext.context.runId)
+                val parentSpan = spanCollector.getParentSpanForEvent(patchedExecutionInfo)
+                val span = startPlanCompletionEvaluationSpan(
+                    tracer = tracer,
+                    parentSpan = parentSpan,
+                    id = eventContext.eventId,
+                    runId = eventContext.context.runId,
+                    stepIndex = eventContext.stepIndex,
+                    state = eventContext.state.toString(),
+                    plan = eventContext.plan.toString(),
+                )
+
+                spanAdapter?.onBeforeSpanStarted(span)
+                spanCollector.collectSpan(
+                    span = span,
+                    path = patchedExecutionInfo
+                )
+            }
+
+            pipeline.interceptPlanCompletionEvaluationCompleted(this) { eventContext ->
+                logger.debug { "Execute OpenTelemetry after plan completion evaluation completed handler" }
+
+                val patchedExecutionInfo = eventContext.executionInfo.appendRunId(eventContext.context.runId)
+                val span = spanCollector.getStartedSpan(
+                    executionInfo = patchedExecutionInfo,
+                    eventId = eventContext.eventId,
+                    spanType = SpanType.PLAN_COMPLETION_EVALUATION
+                ) ?: return@interceptPlanCompletionEvaluationCompleted
+
+                spanAdapter?.onBeforeSpanFinished(span)
+                endPlanCompletionEvaluationSpan(
+                    span = span,
+                    isCompleted = eventContext.isCompleted,
+                    verbose = config.isVerbose
+                )
+                spanCollector.removeSpan(
+                    span = span,
+                    path = patchedExecutionInfo
+                )
+            }
 
             return openTelemetry
         }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/SpanType.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/SpanType.kt
@@ -8,4 +8,7 @@ internal enum class SpanType {
     SUBGRAPH,
     INFERENCE,
     EXECUTE_TOOL,
+    PLAN_CREATION,
+    STEP_EXECUTION,
+    PLAN_COMPLETION_EVALUATION,
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/plannerSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/plannerSpan.kt
@@ -1,0 +1,162 @@
+package ai.koog.agents.features.opentelemetry.span
+
+import ai.koog.agents.features.opentelemetry.attribute.CommonAttributes
+import ai.koog.agents.features.opentelemetry.attribute.KoogAttributes
+import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
+import ai.koog.agents.features.opentelemetry.extension.toSpanEndStatus
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.Tracer
+
+/**
+ * Build and start a new Plan Creation Span with necessary attributes.
+ */
+internal fun startPlanCreationSpan(
+    tracer: Tracer,
+    parentSpan: GenAIAgentSpan?,
+    id: String,
+    runId: String,
+    stepIndex: Int,
+    state: String,
+    currentPlan: String?,
+): GenAIAgentSpan {
+    val builder = GenAIAgentSpanBuilder(
+        spanType = SpanType.PLAN_CREATION,
+        parentSpan = parentSpan,
+        id = id,
+        kind = SpanKind.INTERNAL,
+        name = "plan creation $stepIndex",
+    )
+        .addAttribute(SpanAttributes.Conversation.Id(runId))
+        .addAttribute(KoogAttributes.Koog.Event.Id(id))
+        .addAttribute(KoogAttributes.Koog.Planner.Step.Index(stepIndex))
+
+    builder.addAttribute(KoogAttributes.Koog.Planner.State.Input(state))
+
+    builder.addAttribute(KoogAttributes.Koog.Planner.Plan.Input(currentPlan ?: "no plan yet"))
+
+    return builder.buildAndStart(tracer)
+}
+
+/**
+ * End Plan Creation Span and set final attributes.
+ */
+internal fun endPlanCreationSpan(
+    span: GenAIAgentSpan,
+    newPlan: String,
+    error: Throwable? = null,
+    verbose: Boolean = false
+) {
+    check(span.type == SpanType.PLAN_CREATION) {
+        "${span.logString} Expected to end span type of type: <${SpanType.PLAN_CREATION}>, but received span of type: <${span.type}>"
+    }
+
+    error?.javaClass?.typeName?.let { typeName ->
+        span.addAttribute(CommonAttributes.Error.Type(typeName))
+    }
+
+    span.addAttribute(KoogAttributes.Koog.Planner.Plan.Output(newPlan))
+
+    span.end(error.toSpanEndStatus(), verbose)
+}
+
+/**
+ * Build and start a new Step Execution Span with necessary attributes.
+ */
+internal fun startStepExecutionSpan(
+    tracer: Tracer,
+    parentSpan: GenAIAgentSpan?,
+    id: String,
+    runId: String,
+    stepIndex: Int,
+    state: String,
+    plan: String,
+): GenAIAgentSpan {
+    val builder = GenAIAgentSpanBuilder(
+        spanType = SpanType.STEP_EXECUTION,
+        parentSpan = parentSpan,
+        id = id,
+        kind = SpanKind.INTERNAL,
+        name = "step execution $stepIndex",
+    )
+        .addAttribute(SpanAttributes.Conversation.Id(runId))
+        .addAttribute(KoogAttributes.Koog.Event.Id(id))
+        .addAttribute(KoogAttributes.Koog.Planner.Step.Index(stepIndex))
+
+    builder.addAttribute(KoogAttributes.Koog.Planner.State.Input(state))
+    builder.addAttribute(KoogAttributes.Koog.Planner.Plan.Input(plan))
+
+    return builder.buildAndStart(tracer)
+}
+
+/**
+ * End Step Execution Span and set final attributes.
+ */
+internal fun endStepExecutionSpan(
+    span: GenAIAgentSpan,
+    state: String,
+    error: Throwable? = null,
+    verbose: Boolean = false
+) {
+    check(span.type == SpanType.STEP_EXECUTION) {
+        "${span.logString} Expected to end span type of type: <${SpanType.STEP_EXECUTION}>, but received span of type: <${span.type}>"
+    }
+
+    error?.javaClass?.typeName?.let { typeName ->
+        span.addAttribute(CommonAttributes.Error.Type(typeName))
+    }
+
+    span.addAttribute(KoogAttributes.Koog.Planner.State.Output(state))
+
+    span.end(error.toSpanEndStatus(), verbose)
+}
+
+/**
+ * Build and start a new Plan Completion Evaluation Span with necessary attributes.
+ */
+internal fun startPlanCompletionEvaluationSpan(
+    tracer: Tracer,
+    parentSpan: GenAIAgentSpan?,
+    id: String,
+    runId: String,
+    stepIndex: Int,
+    state: String,
+    plan: String,
+): GenAIAgentSpan {
+    val builder = GenAIAgentSpanBuilder(
+        spanType = SpanType.PLAN_COMPLETION_EVALUATION,
+        parentSpan = parentSpan,
+        id = id,
+        kind = SpanKind.INTERNAL,
+        name = "plan completion evaluation $stepIndex",
+    )
+        .addAttribute(SpanAttributes.Conversation.Id(runId))
+        .addAttribute(KoogAttributes.Koog.Event.Id(id))
+        .addAttribute(KoogAttributes.Koog.Planner.Step.Index(stepIndex))
+
+    builder.addAttribute(KoogAttributes.Koog.Planner.State.Input(state))
+    builder.addAttribute(KoogAttributes.Koog.Planner.Plan.Input(plan))
+
+    return builder.buildAndStart(tracer)
+}
+
+/**
+ * End Plan Completion Evaluation Span and set final attributes.
+ */
+internal fun endPlanCompletionEvaluationSpan(
+    span: GenAIAgentSpan,
+    isCompleted: Boolean,
+    error: Throwable? = null,
+    verbose: Boolean = false
+) {
+    check(span.type == SpanType.PLAN_COMPLETION_EVALUATION) {
+        "${span.logString} Expected to end span type of type: <${SpanType.PLAN_COMPLETION_EVALUATION}>, but received span of type: <${span.type}>"
+    }
+
+    error?.javaClass?.typeName?.let { typeName ->
+        span.addAttribute(CommonAttributes.Error.Type(typeName))
+    }
+
+    span.addAttribute(KoogAttributes.Koog.Planner.Completion.IsCompleted(isCompleted))
+
+    span.end(error.toSpanEndStatus(), verbose)
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/plannerSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/plannerSpan.kt
@@ -28,11 +28,9 @@ internal fun startPlanCreationSpan(
     )
         .addAttribute(SpanAttributes.Conversation.Id(runId))
         .addAttribute(KoogAttributes.Koog.Event.Id(id))
-        .addAttribute(KoogAttributes.Koog.Planner.Step.Index(stepIndex))
-
-    builder.addAttribute(KoogAttributes.Koog.Planner.State.Input(state))
-
-    builder.addAttribute(KoogAttributes.Koog.Planner.Plan.Input(currentPlan ?: "no plan yet"))
+        .addAttribute(KoogAttributes.Koog.Planner.StepIndex(stepIndex))
+        .addAttribute(KoogAttributes.Koog.Planner.State(state))
+        .addAttribute(KoogAttributes.Koog.Planner.Plan(currentPlan ?: "no plan yet"))
 
     return builder.buildAndStart(tracer)
 }
@@ -54,7 +52,7 @@ internal fun endPlanCreationSpan(
         span.addAttribute(CommonAttributes.Error.Type(typeName))
     }
 
-    span.addAttribute(KoogAttributes.Koog.Planner.Plan.Output(newPlan))
+    span.addAttribute(KoogAttributes.Koog.Planner.NewPlan(newPlan))
 
     span.end(error.toSpanEndStatus(), verbose)
 }
@@ -80,10 +78,9 @@ internal fun startStepExecutionSpan(
     )
         .addAttribute(SpanAttributes.Conversation.Id(runId))
         .addAttribute(KoogAttributes.Koog.Event.Id(id))
-        .addAttribute(KoogAttributes.Koog.Planner.Step.Index(stepIndex))
-
-    builder.addAttribute(KoogAttributes.Koog.Planner.State.Input(state))
-    builder.addAttribute(KoogAttributes.Koog.Planner.Plan.Input(plan))
+        .addAttribute(KoogAttributes.Koog.Planner.StepIndex(stepIndex))
+        .addAttribute(KoogAttributes.Koog.Planner.State(state))
+        .addAttribute(KoogAttributes.Koog.Planner.Plan(plan))
 
     return builder.buildAndStart(tracer)
 }
@@ -105,7 +102,7 @@ internal fun endStepExecutionSpan(
         span.addAttribute(CommonAttributes.Error.Type(typeName))
     }
 
-    span.addAttribute(KoogAttributes.Koog.Planner.State.Output(state))
+    span.addAttribute(KoogAttributes.Koog.Planner.NewState(state))
 
     span.end(error.toSpanEndStatus(), verbose)
 }
@@ -131,10 +128,9 @@ internal fun startPlanCompletionEvaluationSpan(
     )
         .addAttribute(SpanAttributes.Conversation.Id(runId))
         .addAttribute(KoogAttributes.Koog.Event.Id(id))
-        .addAttribute(KoogAttributes.Koog.Planner.Step.Index(stepIndex))
-
-    builder.addAttribute(KoogAttributes.Koog.Planner.State.Input(state))
-    builder.addAttribute(KoogAttributes.Koog.Planner.Plan.Input(plan))
+        .addAttribute(KoogAttributes.Koog.Planner.StepIndex(stepIndex))
+        .addAttribute(KoogAttributes.Koog.Planner.State(state))
+        .addAttribute(KoogAttributes.Koog.Planner.Plan(plan))
 
     return builder.buildAndStart(tracer)
 }
@@ -156,7 +152,7 @@ internal fun endPlanCompletionEvaluationSpan(
         span.addAttribute(CommonAttributes.Error.Type(typeName))
     }
 
-    span.addAttribute(KoogAttributes.Koog.Planner.Completion.IsCompleted(isCompleted))
+    span.addAttribute(KoogAttributes.Koog.Planner.IsCompleted(isCompleted))
 
     span.end(error.toSpanEndStatus(), verbose)
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/AgentTypes.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/AgentTypes.kt
@@ -2,5 +2,6 @@ package ai.koog.agents.features.opentelemetry
 
 enum class AgentType {
     Graph,
-    Functional
+    Functional,
+    Planner
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestAPI.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestAPI.kt
@@ -4,6 +4,7 @@ import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.AIAgentFunctionalStrategy
 import ai.koog.agents.core.agent.AIAgentService
 import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.agent.context.AIAgentPlannerContext
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.agent.entity.AIAgentStrategy
 import ai.koog.agents.core.agent.functionalStrategy
@@ -27,8 +28,11 @@ import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Strategy.getSi
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.Strategy.getSingleToolCallStrategy
 import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
+import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry.Feature.install
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryConfig
 import ai.koog.agents.features.opentelemetry.mock.MockSpanExporter
+import ai.koog.agents.planner.AIAgentPlanner
+import ai.koog.agents.planner.AIAgentPlannerStrategy
 import ai.koog.agents.testing.tools.getMockExecutor
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
@@ -89,9 +93,19 @@ internal object OpenTelemetryTestAPI {
         internal val simpleFunctionalStrategy =
             functionalStrategy<String, String>(Parameter.DEFAULT_STRATEGY_NAME) { it }
 
+        internal val simplePlannerStrategy = AIAgentPlannerStrategy(
+            Parameter.DEFAULT_STRATEGY_NAME,
+            object : AIAgentPlanner<String, String>() {
+                override suspend fun buildPlan(context: AIAgentPlannerContext, state: String, plan: String?): String = "do-nothing"
+                override suspend fun executeStep(context: AIAgentPlannerContext, state: String, plan: String): String = state
+                override suspend fun isPlanCompleted(context: AIAgentPlannerContext, state: String, plan: String): Boolean = true
+            }
+        )
+
         internal fun getSimpleStrategy(agentType: AgentType) = when (agentType) {
             AgentType.Graph -> simpleGraphStrategy
             AgentType.Functional -> simpleFunctionalStrategy
+            AgentType.Planner -> simplePlannerStrategy
         }
 
         internal val singleLLMCallGraphStrategy = strategy(Parameter.DEFAULT_STRATEGY_NAME) {
@@ -105,9 +119,19 @@ internal object OpenTelemetryTestAPI {
                 requestLLM(input).content
             }
 
+        internal val singleLLMCallPlannerStrategy = AIAgentPlannerStrategy(
+            Parameter.DEFAULT_STRATEGY_NAME,
+            object : AIAgentPlanner<String, String>() {
+                override suspend fun buildPlan(context: AIAgentPlannerContext, state: String, plan: String?): String = "call-llm"
+                override suspend fun executeStep(context: AIAgentPlannerContext, state: String, plan: String): String = context.requestLLM(state).content
+                override suspend fun isPlanCompleted(context: AIAgentPlannerContext, state: String, plan: String): Boolean = true
+            }
+        )
+
         fun getSingleLLMCallStrategy(agentType: AgentType) = when (agentType) {
             AgentType.Graph -> singleLLMCallGraphStrategy
             AgentType.Functional -> singleLLMCallFunctionalStrategy
+            AgentType.Planner -> singleLLMCallPlannerStrategy
         }
 
         internal val singleToolCallGraphStrategy = strategy(Parameter.DEFAULT_STRATEGY_NAME) {
@@ -133,9 +157,29 @@ internal object OpenTelemetryTestAPI {
                 result.content
             }
 
+        internal val singleToolCallPlannerStrategy = AIAgentPlannerStrategy(
+            Parameter.DEFAULT_STRATEGY_NAME,
+            object : AIAgentPlanner<String, String>() {
+                override suspend fun buildPlan(context: AIAgentPlannerContext, state: String, plan: String?): String = "call-tool"
+
+                override suspend fun executeStep(context: AIAgentPlannerContext, state: String, plan: String): String {
+                    var result = context.requestLLM(state)
+
+                    while (result is Message.Tool.Call) {
+                        result = context.sendToolResult(context.executeTool(result))
+                    }
+
+                    return result.content
+                }
+
+                override suspend fun isPlanCompleted(context: AIAgentPlannerContext, state: String, plan: String): Boolean = true
+            }
+        )
+
         fun getSingleToolCallStrategy(agentType: AgentType) = when (agentType) {
             AgentType.Graph -> singleToolCallGraphStrategy
             AgentType.Functional -> singleToolCallFunctionalStrategy
+            AgentType.Planner -> singleToolCallPlannerStrategy
         }
     }
 
@@ -336,6 +380,15 @@ internal object OpenTelemetryTestAPI {
             }
 
             is AIAgentFunctionalStrategy -> AIAgentService(
+                promptExecutor = executor ?: getMockExecutor(clock = testClock) { },
+                strategy = strategy,
+                agentConfig = agentConfig,
+                toolRegistry = toolRegistry
+            ) {
+                install(OpenTelemetry) { configureOtel() }
+            }
+
+            is AIAgentPlannerStrategy<String, String, *> -> AIAgentService(
                 promptExecutor = executor ?: getMockExecutor(clock = testClock) { },
                 strategy = strategy,
                 agentConfig = agentConfig,

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestData.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestData.kt
@@ -196,4 +196,11 @@ internal data class OpenTelemetryTestData(
 
         return collectedSpans.filter { spanData -> spanData.attributes.get(expectedSubgraphKey) != null }
     }
+
+    fun filterPlannerSpans(spanType: String): List<SpanData> {
+        val attributeKey = AttributeKey.stringKey("koog.span.type")
+        return collectedSpans.filter { spanData ->
+            spanData.attributes.get(attributeKey) == spanType
+        }
+    }
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestData.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestData.kt
@@ -134,6 +134,30 @@ internal data class OpenTelemetryTestData(
             .mapNotNull { span -> span.attributes?.get(expectedEventIdKey) }
     }
 
+    fun filterPlanCreationEvents(stepIndex: Int = 1): List<String> {
+        val eventIdAttribute = KoogAttributes.Koog.Event.Id("")
+        val expectedEventIdKey = AttributeKey.stringKey(eventIdAttribute.key)
+        return collectedSpans
+            .filter { span -> span.name == "plan creation $stepIndex" }
+            .mapNotNull { span -> span.attributes?.get(expectedEventIdKey) }
+    }
+
+    fun filterStepExecutionEvents(stepIndex: Int = 1): List<String> {
+        val eventIdAttribute = KoogAttributes.Koog.Event.Id("")
+        val expectedEventIdKey = AttributeKey.stringKey(eventIdAttribute.key)
+        return collectedSpans
+            .filter { span -> span.name == "step execution $stepIndex" }
+            .mapNotNull { span -> span.attributes?.get(expectedEventIdKey) }
+    }
+
+    fun filterPlanCompletionEvaluationEvents(stepIndex: Int = 1): List<String> {
+        val eventIdAttribute = KoogAttributes.Koog.Event.Id("")
+        val expectedEventIdKey = AttributeKey.stringKey(eventIdAttribute.key)
+        return collectedSpans
+            .filter { span -> span.name == "plan completion evaluation $stepIndex" }
+            .mapNotNull { span -> span.attributes?.get(expectedEventIdKey) }
+    }
+
     fun singleAttributeValue(spanData: SpanData, key: String): String? {
         return spanData.attributes?.asMap()?.mapKeys { it.key.key }[key]?.toString()
     }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryConfigTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryConfigTest.kt
@@ -169,6 +169,13 @@ class OpenTelemetryConfigTest : OpenTelemetryTestBase() {
                     "${OperationNameType.INVOKE_AGENT.id} $DEFAULT_AGENT_ID",
                     "${OperationNameType.CREATE_AGENT.id} $DEFAULT_AGENT_ID"
                 )
+
+                AgentType.Planner -> listOf(
+                    "${OperationNameType.CHAT.id} ${defaultModel.id}",
+                    "strategy $DEFAULT_STRATEGY_NAME",
+                    "${OperationNameType.INVOKE_AGENT.id} $DEFAULT_AGENT_ID",
+                    "${OperationNameType.CREATE_AGENT.id} $DEFAULT_AGENT_ID"
+                )
             }
 
             assertEquals(expectedSpanNames.size, actualSpanNames.size)

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryConfigTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryConfigTest.kt
@@ -171,7 +171,10 @@ class OpenTelemetryConfigTest : OpenTelemetryTestBase() {
                 )
 
                 AgentType.Planner -> listOf(
+                    "plan creation 1",
                     "${OperationNameType.CHAT.id} ${defaultModel.id}",
+                    "step execution 1",
+                    "plan completion evaluation 1",
                     "strategy $DEFAULT_STRATEGY_NAME",
                     "${OperationNameType.INVOKE_AGENT.id} $DEFAULT_AGENT_ID",
                     "${OperationNameType.CREATE_AGENT.id} $DEFAULT_AGENT_ID"

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetrySpanTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetrySpanTest.kt
@@ -19,6 +19,8 @@ import ai.koog.agents.features.opentelemetry.assertSpans
 import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes.Operation.OperationNameType
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryTestBase
 import ai.koog.agents.features.opentelemetry.mock.MockSpanExporter
+import ai.koog.agents.planner.AIAgentPlanner
+import ai.koog.agents.planner.AIAgentPlannerStrategy
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
@@ -46,7 +48,7 @@ class OpenTelemetrySpanTest : OpenTelemetryTestBase() {
     val agentId = "test-agent-id"
     val promptId = "test-prompt-id"
 
-    val strategyName = "test-strategy"
+    val strategyName = OpenTelemetryTestAPI.Parameter.DEFAULT_STRATEGY_NAME
     val nodeName = "test-node"
 
     private fun getExpectedCommonSpans(
@@ -178,7 +180,9 @@ class OpenTelemetrySpanTest : OpenTelemetryTestBase() {
                     nodeStart then nodeBlank then nodeFinish
                 }
 
-                AgentType.Functional -> functionalStrategy(strategyName) { it }
+                AgentType.Functional -> OpenTelemetryTestAPI.Strategy.simpleFunctionalStrategy
+
+                AgentType.Planner -> OpenTelemetryTestAPI.Strategy.simplePlannerStrategy
             }
 
             val collectedTestData = OpenTelemetryTestData().apply {
@@ -249,6 +253,8 @@ class OpenTelemetrySpanTest : OpenTelemetryTestBase() {
                 }
 
                 AgentType.Functional -> expectedCommonSpansFirstRun + expectedCommonSpansSecondRun
+
+                AgentType.Planner -> expectedCommonSpansFirstRun + expectedCommonSpansSecondRun
             }
 
             assertSpans(expectedSpans, collectedSpans)

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetrySpanTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetrySpanTest.kt
@@ -2,7 +2,6 @@ package ai.koog.agents.features.opentelemetry.feature.span
 
 import ai.koog.agents.core.agent.entity.AIAgentSubgraph.Companion.FINISH_NODE_PREFIX
 import ai.koog.agents.core.agent.entity.AIAgentSubgraph.Companion.START_NODE_PREFIX
-import ai.koog.agents.core.agent.functionalStrategy
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.features.opentelemetry.AgentType
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI
@@ -19,8 +18,6 @@ import ai.koog.agents.features.opentelemetry.assertSpans
 import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes.Operation.OperationNameType
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryTestBase
 import ai.koog.agents.features.opentelemetry.mock.MockSpanExporter
-import ai.koog.agents.planner.AIAgentPlanner
-import ai.koog.agents.planner.AIAgentPlannerStrategy
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
@@ -162,6 +159,54 @@ class OpenTelemetrySpanTest : OpenTelemetryTestBase() {
         )
     )
 
+    private fun getExpectedPlannerSpans(
+        runId: String,
+        userPrompt: String,
+        planCreationEvent: String,
+        executeStepEvent: String,
+        planCompletionAssessmentEvent: String
+    ) = listOf(
+        mapOf(
+            "plan creation 1" to mapOf(
+                "attributes" to mapOf(
+                    "gen_ai.conversation.id" to runId,
+                    "koog.planner.step_index" to 1.toLong(),
+                    "koog.planner.state" to userPrompt,
+                    "koog.planner.plan" to "no plan yet",
+                    "koog.planner.new_plan" to "do-nothing",
+                    "koog.event.id" to planCreationEvent,
+                ),
+                "events" to emptyMap()
+            )
+        ),
+        mapOf(
+            "step execution 1" to mapOf(
+                "attributes" to mapOf(
+                    "gen_ai.conversation.id" to runId,
+                    "koog.planner.step_index" to 1.toLong(),
+                    "koog.planner.state" to userPrompt,
+                    "koog.planner.plan" to "do-nothing",
+                    "koog.planner.new_state" to userPrompt,
+                    "koog.event.id" to executeStepEvent,
+                ),
+                "events" to emptyMap()
+            )
+        ),
+        mapOf(
+            "plan completion evaluation 1" to mapOf(
+                "attributes" to mapOf(
+                    "gen_ai.conversation.id" to runId,
+                    "koog.planner.step_index" to 1.toLong(),
+                    "koog.planner.state" to userPrompt,
+                    "koog.planner.plan" to "do-nothing",
+                    "koog.planner.is_completed" to true,
+                    "koog.event.id" to planCompletionAssessmentEvent,
+                ),
+                "events" to emptyMap()
+            )
+        )
+    )
+
     @ParameterizedTest
     @EnumSource(AgentType::class)
     fun `test spans for same agent run multiple times`(agentType: AgentType) = runTest {
@@ -254,7 +299,29 @@ class OpenTelemetrySpanTest : OpenTelemetryTestBase() {
 
                 AgentType.Functional -> expectedCommonSpansFirstRun + expectedCommonSpansSecondRun
 
-                AgentType.Planner -> expectedCommonSpansFirstRun + expectedCommonSpansSecondRun
+                AgentType.Planner -> {
+                    val planCreationEvents = collectedTestData.filterPlanCreationEvents()
+                    val stepExecutionEvents = collectedTestData.filterStepExecutionEvents()
+                    val planCompletionEvaluationEvents = collectedTestData.filterPlanCompletionEvaluationEvents()
+
+                    val expectedNodeSpansFirstRun = getExpectedPlannerSpans(
+                        mockExporter.runIds[0],
+                        userPrompt0,
+                        planCreationEvents[0],
+                        stepExecutionEvents[0],
+                        planCompletionEvaluationEvents[0]
+                    )
+
+                    val expectedNodeSpansSecondRun = getExpectedPlannerSpans(
+                        mockExporter.runIds[1],
+                        userPrompt1,
+                        planCreationEvents[1],
+                        stepExecutionEvents[1],
+                        planCompletionEvaluationEvents[1]
+                    )
+
+                    expectedNodeSpansFirstRun + expectedCommonSpansFirstRun + expectedNodeSpansSecondRun + expectedCommonSpansSecondRun
+                }
             }
 
             assertSpans(expectedSpans, collectedSpans)


### PR DESCRIPTION
Added planner-specific interceptors in the opentelemetry feature, so that it creates spans for
* plan creation
* step execution
* plan completion evaluation