### PR TITLE
fix(prompt): fix type inference in round robin test for ios

### DIFF
--- a/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/RoundRobinBasedExecutorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-llms/src/commonTest/kotlin/ai/koog/prompt/executor/llms/RoundRobinBasedExecutorTest.kt
@@ -64,11 +64,12 @@ class RoundRobinBasedExecutorTest {
         val secondOpenAI = MockLLMClient(provider = LLMProvider.OpenAI, executeContent = "Second OpenAI")
         val firstAnthropicClient = MockLLMClient(provider = LLMProvider.Anthropic, executeContent = "First Anthropic")
         val secondAnthropicClient = MockLLMClient(provider = LLMProvider.Anthropic, executeContent = "Second Anthropic")
-        val clientsMap = mapOf(
-            LLMProvider.OpenAI to listOf(firstOpenAI, secondOpenAI),
-            LLMProvider.Anthropic to listOf(firstAnthropicClient, secondAnthropicClient)
+        val executor = RoutingLLMPromptExecutor(
+            mapOf(
+                LLMProvider.OpenAI to listOf(firstOpenAI, secondOpenAI),
+                LLMProvider.Anthropic to listOf(firstAnthropicClient, secondAnthropicClient)
+            )
         )
-        val executor = RoutingLLMPromptExecutor(clientsMap)
 
         // When
         val openAIResponses = (1..3).map {


### PR DESCRIPTION
This PR bypasses the type inference issue for `RoundRobinBasedExecutorTest` that happens only for iOS target on branches that follow old `LLMProvider` model (ie  `release/0.6.4`).
The old `LLMProvider` model was based on nested data classes but that was changed to simple static fields in this PR: https://github.com/JetBrains/koog/pull/1439/

With the old model of LLMProvider, the iOS had issue inferring types when `LLMProvider` was invariant of a generic type.

See the snippet below
```
val clientsMap = mapOf(
    LLMProvider.OpenAI to listOf(firstOpenAI, secondOpenAI),
    LLMProvider.Anthropic to listOf(firstAnthropicClient, secondAnthropicClient)
)
val executor = RoutingLLMPromptExecutor(clientsMap)
```

This compiles correctly
- on all platforms on `develop`
- on all platforms except ios on branches based from `release/0.6.4 `


The compiler thinks that the type of `clientsMap` is `Map<LLMProvider & SerializerFactory, List<LLMClient>>`
The executor expects `Map<LLMProvider,  List<LLMCLient>>`


This failure could have been observed on PR to `release/0.6.4`: https://github.com/JetBrains/koog/actions/runs/22484337654/job/65130114197?pr=1556#step:6:9625
This kind of problem will not be present on branches with new model of `LLMProvider` (so we should be totally safe starting `0.7.0`)