### PR TITLE
deps!: Update min Java version to 11->17. Use JDK 21 on CI instead of JDK 17

### DIFF
--- a/.github/workflows/a2a-tck-test.yml
+++ b/.github/workflows/a2a-tck-test.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
 
 env:
-  JAVA_VERSION: 17
+  JAVA_VERSION: 21
   JAVA_DISTRIBUTION: 'corretto'
 
 jobs:

--- a/.github/workflows/build-xcframework.yml
+++ b/.github/workflows/build-xcframework.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: # Manual trigger
 
 env:
-  JAVA_VERSION: 17
+  JAVA_VERSION: 21
   JAVA_DISTRIBUTION: 'corretto'
   JAVA_OPTS: "-Xms8g -Xmx8g -Dfile.encoding=UTF-8 -Djava.awt.headless=true -Dkotlin.daemon.jvm.options=-Xmx6g"
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' || github.ref != 'refs/heads/develop' }}
 
 env:
-  JAVA_VERSION: 17
+  JAVA_VERSION: 21
   JAVA_DISTRIBUTION: 'corretto'
   JAVA_OPTS: "-Xms8g -Xmx8g -Dfile.encoding=UTF-8 -Djava.awt.headless=true -Dkotlin.daemon.jvm.options=-Xmx6g"
 

--- a/.github/workflows/code-agent-examples.yml
+++ b/.github/workflows/code-agent-examples.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
 
 env:
-  JAVA_VERSION: 17
+  JAVA_VERSION: 21
   JAVA_DISTRIBUTION: 'corretto'
 
 jobs:

--- a/.github/workflows/demo-compose-app.yml
+++ b/.github/workflows/demo-compose-app.yml
@@ -10,7 +10,7 @@ on:
       - 'examples/demo-compose-app/**'
 
 env:
-  JAVA_VERSION: 17
+  JAVA_VERSION: 21
   JAVA_DISTRIBUTION: 'corretto'
 
 jobs:

--- a/.github/workflows/deploy-all-docs.yml
+++ b/.github/workflows/deploy-all-docs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Build Dokka docs

--- a/.github/workflows/deploy-dokka-docs.yml
+++ b/.github/workflows/deploy-dokka-docs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Build Dokka docs

--- a/.github/workflows/heavy-tests.yml
+++ b/.github/workflows/heavy-tests.yml
@@ -82,10 +82,10 @@ jobs:
 
       - uses: actions/checkout@v6
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: 17
+          java-version: 21
           distribution: corretto
 
       # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.

--- a/.github/workflows/java-api-example.yml
+++ b/.github/workflows/java-api-example.yml
@@ -26,10 +26,10 @@ jobs:
         run: |
           git config --global core.autocrlf input
       - uses: actions/checkout@v6
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'corretto'
 
       # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.

--- a/.github/workflows/ollama-tests.yml
+++ b/.github/workflows/ollama-tests.yml
@@ -77,10 +77,10 @@ jobs:
           df -h
 
       - uses: actions/checkout@v6
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'corretto'
           cache: gradle
 

--- a/.github/workflows/simple-examples.yml
+++ b/.github/workflows/simple-examples.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
 
 env:
-  JAVA_VERSION: 17
+  JAVA_VERSION: 21
   JAVA_DISTRIBUTION: 'corretto'
 
 jobs:

--- a/.github/workflows/spring-boot-java-example.yml
+++ b/.github/workflows/spring-boot-java-example.yml
@@ -26,10 +26,10 @@ jobs:
         run: |
           git config --global core.autocrlf input
       - uses: actions/checkout@v6
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
           cache: maven
 

--- a/.github/workflows/trip-planning-example.yml
+++ b/.github/workflows/trip-planning-example.yml
@@ -21,10 +21,10 @@ jobs:
         run: |
           git config --global core.autocrlf input
       - uses: actions/checkout@v6
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'corretto'
 
       # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.

--- a/convention-plugin-ai/src/main/kotlin/ai.kotlin.configuration.gradle.kts
+++ b/convention-plugin-ai/src/main/kotlin/ai.kotlin.configuration.gradle.kts
@@ -57,7 +57,7 @@ tasks.withType<KotlinCompilationTask<*>>().configureEach {
 
 tasks.withType<KotlinJvmCompile>().configureEach {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_11)
+        jvmTarget.set(JvmTarget.JVM_17)
         jvmDefault = JvmDefaultMode.ENABLE
         javaParameters = true
     }
@@ -65,8 +65,8 @@ tasks.withType<KotlinJvmCompile>().configureEach {
 
 tasks.withType<JavaCompile>().configureEach {
     this.options.compilerArgs.addAll(listOf("-parameters", "-g"))
-    sourceCompatibility = JavaVersion.VERSION_11.toString()
-    targetCompatibility = JavaVersion.VERSION_11.toString()
+    sourceCompatibility = JavaVersion.VERSION_17.toString()
+    targetCompatibility = JavaVersion.VERSION_17.toString()
 }
 
 configurations.all {


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

Update workflows and configurations to use Java 21 instead of Java 17. 
It's a prequel for the upcoming update to JUnit 6.0.3 (see #1557).


<!-- Include BREAKING section below only if this PR introduces breaking changes. Otherwise, delete it. -->
BREAKING:
* Update min Java version from 11 to 17; See #571
* Use JDK 21 on CI instead of JDK 17.

<!-- Include DEPRECATED section below only if this PR deprecates any public APIs. Otherwise, delete it. -->
DEPRECATED:
* none
