### PR TITLE
docs: CHANGELOG and README version bump for 0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.6.4
+> Published 4 March 2026
+
+## Major Features
+- **LLM Client Router**: Added support for routing requests across multiple LLM clients with pluggable load balancing strategies. Includes a built-in round-robin router and fallback handling when a provider is unavailable (#1503)
+
+## Improvements
+- **Anthropic models list**: Implemented `models()` for the Anthropic LLM client, consistent with other supported providers ([KG-527](https://youtrack.jetbrains.com/issue/KG-527), #1460)
+- **Dependency updates**: Updated `io.lettuce:lettuce-core` from `6.5.5.RELEASE` to `7.2.1.RELEASE` (#1304)
+
+## Breaking Changes
+- **OllamaModels relocation**: `OllamaModels` and `OllamaEmbeddingModels` moved from `prompt-llm` to `prompt-executor-ollama-client` module ([KG-121](https://youtrack.jetbrains.com/issue/KG-121), #1470)
+ 
 # 0.6.3
 > Published 24 February 2026
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Currently, the framework supports the JVM, JS, WasmJS and iOS targets.
 
     ```
     dependencies {
-        implementation("ai.koog:koog-agents:0.6.3")
+        implementation("ai.koog:koog-agents:0.6.4")
     }
     ```
 2. Make sure that you have `mavenCentral()` in the list of repositories.
@@ -103,7 +103,7 @@ Currently, the framework supports the JVM, JS, WasmJS and iOS targets.
 
     ```
     dependencies {
-        implementation 'ai.koog:koog-agents:0.6.3'
+        implementation 'ai.koog:koog-agents:0.6.4'
     }
     ```
 2. Make sure that you have `mavenCentral()` in the list of repositories.
@@ -115,7 +115,7 @@ Currently, the framework supports the JVM, JS, WasmJS and iOS targets.
     <dependency>
         <groupId>ai.koog</groupId>
         <artifactId>koog-agents-jvm</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </dependency>
     ```
 2. Make sure that you have `mavenCentral` in the list of repositories.

--- a/docs/docs/snippets/quickstart-snippets.md
+++ b/docs/docs/snippets/quickstart-snippets.md
@@ -18,7 +18,7 @@ Add the [Koog package](https://central.sonatype.com/artifact/ai.koog/koog-agents
 
     ``` kotlin title="build.gradle.kts"
     dependencies {
-        implementation("ai.koog:koog-agents:0.6.3")
+        implementation("ai.koog:koog-agents:0.6.4")
     }
     ```
 
@@ -26,7 +26,7 @@ Add the [Koog package](https://central.sonatype.com/artifact/ai.koog/koog-agents
 
     ``` groovy title="build.gradle"
     dependencies {
-        implementation 'ai.koog:koog-agents:0.6.3'
+        implementation 'ai.koog:koog-agents:0.6.4'
     }
     ```
 
@@ -36,7 +36,7 @@ Add the [Koog package](https://central.sonatype.com/artifact/ai.koog/koog-agents
     <dependency>
         <groupId>ai.koog</groupId>
         <artifactId>koog-agents-jvm</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </dependency>
     ```
 # --8<-- [end:dependencies]


### PR DESCRIPTION
Release-specific changes for 0.6.4: CHANGELOG, README and gradle.properties