### PR TITLE
feat(agents): Used StreamFrame.End to improve exception and undexpected stream finish handling in executeStreaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,33 @@ env.properties
 local.properties
 **/kotlin-js-store
 docs/src/main/kotlin/*.kt
-**/.env
+**/.env*
 .venv
 .DS_Store
 /.claude/
 /.junie/memory
+
+# Logs
+/.taskmaster
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+dev-debug.log
+# Dependency directories
+node_modules/
+# Environment variables
+.env
+# Editor directories and files
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+# OS specific
+
+# Task files
+# tasks.json
+# tasks/ 

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/StreamingConnectionExceptionTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/StreamingConnectionExceptionTest.kt
@@ -10,13 +10,13 @@ import ai.koog.agents.testing.tools.getMockExecutor
 import ai.koog.prompt.dsl.ModerationResult
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.LLMClientException
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.streaming.IncompleteStreamException
 import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.streaming.collectText
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/StreamingConnectionExceptionTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/StreamingConnectionExceptionTest.kt
@@ -1,0 +1,394 @@
+package ai.koog.agents.core.agent
+
+import ai.koog.agents.core.dsl.builder.forwardTo
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreaming
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.features.eventHandler.feature.EventHandler
+import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.prompt.dsl.ModerationResult
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.executor.clients.LLMClientException
+import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.streaming.IncompleteStreamException
+import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.streaming.collectText
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Tests for agent behavior when connection exceptions are thrown during streaming LLM calls.
+ *
+ * These tests verify that [IncompleteStreamException], [LLMClientException], and other
+ * connection-related errors propagate correctly through the agent pipeline when using
+ * the streaming API (requestLLMStreaming).
+ */
+class StreamingConnectionExceptionTest {
+
+    /**
+     * A [PromptExecutor] that overrides [executeStreaming] with custom behavior
+     * for simulating streaming failures (connection drops, incomplete streams, etc.).
+     */
+    private class StreamOverrideExecutor(
+        private val delegate: PromptExecutor,
+        private val streamingBehavior: () -> Flow<StreamFrame>
+    ) : PromptExecutor() {
+
+        override suspend fun execute(
+            prompt: Prompt,
+            model: LLModel,
+            tools: List<ToolDescriptor>
+        ): List<Message.Response> = delegate.execute(prompt, model, tools)
+
+        override fun executeStreaming(
+            prompt: Prompt,
+            model: LLModel,
+            tools: List<ToolDescriptor>
+        ): Flow<StreamFrame> = streamingBehavior()
+
+        override suspend fun moderate(prompt: Prompt, model: LLModel): ModerationResult =
+            delegate.moderate(prompt, model)
+
+        override fun close() = delegate.close()
+    }
+
+    private val model = OpenAIModels.Chat.GPT4oMini
+
+    private fun baseMockExecutor(): PromptExecutor = getMockExecutor {
+        mockLLMAnswer("fallback").asDefaultResponse
+    }
+
+    // -- Functional agent tests --
+
+    @Test
+    fun testIncompleteStreamExceptionPropagatesThroughAgent() = runTest {
+        val errors = mutableListOf<Throwable>()
+
+        val executor = StreamOverrideExecutor(baseMockExecutor()) {
+            flow {
+                emit(StreamFrame.TextDelta("partial"))
+                throw IncompleteStreamException()
+            }
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            llmModel = model,
+            strategy = functionalStrategy<String, String> { input ->
+                requestLLMStreaming(input).collectText()
+            },
+            systemPrompt = "You are helpful"
+        ) {
+            install(EventHandler) {
+                onAgentExecutionFailed { ctx -> errors.add(ctx.throwable) }
+            }
+        }
+
+        val exception = assertFailsWith<Exception> {
+            agent.run("test input")
+        }
+
+        assertIs<IncompleteStreamException>(exception)
+        assertTrue(errors.isNotEmpty(), "Agent should have reported execution failure")
+    }
+
+    @Test
+    fun testLLMClientExceptionDuringStreamingPropagatesThroughAgent() = runTest {
+        val errors = mutableListOf<Throwable>()
+
+        val executor = StreamOverrideExecutor(baseMockExecutor()) {
+            flow {
+                throw LLMClientException("test-client", "Connection refused")
+            }
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            llmModel = model,
+            strategy = functionalStrategy<String, String> { input ->
+                requestLLMStreaming(input).collectText()
+            },
+            systemPrompt = "You are helpful"
+        ) {
+            install(EventHandler) {
+                onAgentExecutionFailed { ctx -> errors.add(ctx.throwable) }
+            }
+        }
+
+        val exception = assertFailsWith<LLMClientException> {
+            agent.run("test input")
+        }
+
+        assertTrue(exception.message!!.contains("test-client"), "Exception should identify the client")
+        assertTrue(errors.isNotEmpty(), "Agent should have reported execution failure")
+    }
+
+    @Test
+    fun testConnectionExceptionAfterPartialStreamData() = runTest {
+        val errors = mutableListOf<Throwable>()
+
+        val executor = StreamOverrideExecutor(baseMockExecutor()) {
+            flow {
+                emit(StreamFrame.TextDelta("Hello "))
+                emit(StreamFrame.TextDelta("World"))
+                throw LLMClientException("test-client", "Connection reset by peer")
+            }
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            llmModel = model,
+            strategy = functionalStrategy<String, String> { input ->
+                requestLLMStreaming(input).toList()
+                "should not reach here"
+            },
+            systemPrompt = "You are helpful"
+        ) {
+            install(EventHandler) {
+                onAgentExecutionFailed { ctx -> errors.add(ctx.throwable) }
+            }
+        }
+
+        val exception = assertFailsWith<LLMClientException> {
+            agent.run("test input")
+        }
+
+        assertTrue(exception.message!!.contains("Connection reset"), "Should carry original error message")
+        assertTrue(errors.isNotEmpty(), "Agent should have reported execution failure")
+    }
+
+    @Test
+    fun testRuntimeExceptionDuringStreamingPropagatesThroughAgent() = runTest {
+        val errors = mutableListOf<Throwable>()
+
+        val executor = StreamOverrideExecutor(baseMockExecutor()) {
+            flow {
+                throw RuntimeException("Unexpected network error")
+            }
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            llmModel = model,
+            strategy = functionalStrategy<String, String> { input ->
+                requestLLMStreaming(input).collectText()
+            },
+            systemPrompt = "You are helpful"
+        ) {
+            install(EventHandler) {
+                onAgentExecutionFailed { ctx -> errors.add(ctx.throwable) }
+            }
+        }
+
+        val exception = assertFailsWith<RuntimeException> {
+            agent.run("test input")
+        }
+
+        assertEquals("Unexpected network error", exception.message)
+        assertTrue(errors.isNotEmpty(), "Agent should have reported execution failure")
+    }
+
+    @Test
+    fun testStreamingExceptionWithPartialToolCallData() = runTest {
+        val errors = mutableListOf<Throwable>()
+        val toolCallsStarted = mutableListOf<String>()
+
+        val toolRegistry = ToolRegistry {
+            tool(CreateTool)
+        }
+
+        val executor = StreamOverrideExecutor(baseMockExecutor()) {
+            flow {
+                // Emit a partial tool call delta, then drop connection
+                emit(StreamFrame.ToolCallDelta(id = "call_1", name = "create", content = "{\"na", index = 0))
+                throw IncompleteStreamException("Stream dropped during tool call")
+            }
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            llmModel = model,
+            toolRegistry = toolRegistry,
+            strategy = functionalStrategy<String, String> { input ->
+                requestLLMStreaming(input).toList()
+                "should not reach here"
+            },
+            systemPrompt = "You are helpful"
+        ) {
+            install(EventHandler) {
+                onAgentExecutionFailed { ctx -> errors.add(ctx.throwable) }
+                onToolCallStarting { ctx -> toolCallsStarted.add(ctx.toolName) }
+            }
+        }
+
+        assertFailsWith<IncompleteStreamException> {
+            agent.run("test input")
+        }
+
+        assertTrue(errors.isNotEmpty(), "Agent should have reported execution failure")
+        assertTrue(toolCallsStarted.isEmpty(), "No tool should have been started since stream was incomplete")
+    }
+
+    // -- Streaming pipeline event tests --
+
+    @Test
+    fun testStreamingFailedEventFiredOnException() = runTest {
+        val streamingFailedErrors = mutableListOf<Throwable>()
+
+        val executor = StreamOverrideExecutor(baseMockExecutor()) {
+            flow {
+                throw IncompleteStreamException()
+            }
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            llmModel = model,
+            strategy = functionalStrategy<String, String> { input ->
+                requestLLMStreaming(input).collectText()
+            },
+            systemPrompt = "You are helpful"
+        ) {
+            install(EventHandler) {
+                onLLMStreamingFailed { ctx ->
+                    streamingFailedErrors.add(ctx.error)
+                }
+            }
+        }
+
+        assertFailsWith<IncompleteStreamException> {
+            agent.run("test input")
+        }
+
+        assertTrue(
+            streamingFailedErrors.isNotEmpty(),
+            "onLLMStreamingFailed event should have been fired"
+        )
+        assertIs<IncompleteStreamException>(streamingFailedErrors.first())
+    }
+
+    @Test
+    fun testStreamingFailedEventFiredForLLMClientException() = runTest {
+        val streamingFailedErrors = mutableListOf<Throwable>()
+
+        val executor = StreamOverrideExecutor(baseMockExecutor()) {
+            flow {
+                emit(StreamFrame.TextDelta("partial data"))
+                throw LLMClientException("anthropic", "502 Bad Gateway")
+            }
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            llmModel = model,
+            strategy = functionalStrategy<String, String> { input ->
+                requestLLMStreaming(input).collectText()
+            },
+            systemPrompt = "You are helpful"
+        ) {
+            install(EventHandler) {
+                onLLMStreamingFailed { ctx ->
+                    streamingFailedErrors.add(ctx.error)
+                }
+            }
+        }
+
+        assertFailsWith<LLMClientException> {
+            agent.run("test input")
+        }
+
+        assertTrue(
+            streamingFailedErrors.isNotEmpty(),
+            "onLLMStreamingFailed event should have been fired"
+        )
+        assertIs<LLMClientException>(streamingFailedErrors.first())
+        assertTrue(streamingFailedErrors.first().message!!.contains("anthropic"))
+    }
+
+    // -- Graph-based agent streaming exception test --
+
+    @Test
+    fun testGraphAgentStreamingExceptionPropagates() = runTest {
+        val streamingFailedErrors = mutableListOf<Throwable>()
+
+        val executor = StreamOverrideExecutor(baseMockExecutor()) {
+            flow {
+                throw IncompleteStreamException("Connection dropped")
+            }
+        }
+
+        val agentStrategy = strategy<String, String>("streaming-error-test") {
+            val streamNode by nodeLLMRequestStreaming { stream ->
+                stream
+            }
+
+            val collectNode by node<Flow<StreamFrame>, String> { stream ->
+                stream.collectText()
+            }
+
+            edge(nodeStart forwardTo streamNode)
+            edge(streamNode forwardTo collectNode)
+            edge(collectNode forwardTo nodeFinish)
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            strategy = agentStrategy,
+            llmModel = model,
+            systemPrompt = "You are helpful"
+        ) {
+            install(EventHandler) {
+                onLLMStreamingFailed { ctx ->
+                    streamingFailedErrors.add(ctx.error)
+                }
+            }
+        }
+
+        assertFailsWith<IncompleteStreamException> {
+            agent.run("test input")
+        }
+
+        assertTrue(
+            streamingFailedErrors.isNotEmpty(),
+            "onLLMStreamingFailed event should have been fired for graph agent"
+        )
+        assertIs<IncompleteStreamException>(streamingFailedErrors.first())
+    }
+
+    // -- Baseline: successful streaming --
+
+    @Test
+    fun testSuccessfulStreamingWorksEndToEnd() = runTest {
+        val executor = StreamOverrideExecutor(baseMockExecutor()) {
+            flow {
+                emit(StreamFrame.TextDelta("Hello "))
+                emit(StreamFrame.TextDelta("World"))
+                emit(StreamFrame.TextComplete("Hello World", index = 0))
+                emit(StreamFrame.End(finishReason = "stop"))
+            }
+        }
+
+        val agent = AIAgent(
+            promptExecutor = executor,
+            llmModel = model,
+            strategy = functionalStrategy<String, String> { input ->
+                requestLLMStreaming(input).collectText()
+            },
+            systemPrompt = "You are helpful"
+        )
+
+        val result = agent.run("test input")
+        assertEquals("Hello World", result)
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
@@ -36,6 +36,7 @@ import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.streaming.buildStreamFrameFlow
+import ai.koog.prompt.streaming.requireEndFrame
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpTimeout
@@ -334,7 +335,7 @@ public open class AnthropicLLMClient @JvmOverloads constructor(
                     cause = e
                 )
             }
-        }
+        }.requireEndFrame()
     }
 
     @OptIn(ExperimentalUuidApi::class)

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -41,6 +41,7 @@ import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.streaming.buildStreamFrameFlow
+import ai.koog.prompt.streaming.requireEndFrame
 import ai.koog.prompt.structure.annotations.InternalStructuredOutputApi
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
@@ -222,7 +223,7 @@ public open class GoogleLLMClient @JvmOverloads constructor(
                 cause = e
             )
         }
-    }
+    }.requireEndFrame()
 
     override suspend fun executeMultipleChoices(
         prompt: Prompt,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
@@ -31,6 +31,7 @@ import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.streaming.requireEndFrame
 import io.github.oshai.kotlinlogging.KLogger
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpTimeout
@@ -193,7 +194,7 @@ public abstract class AbstractOpenAILLMClient<TResponse : OpenAIBaseLLMResponse,
                     decodeStreamingResponse = ::decodeStreamingResponse,
                     processStreamingChunk = { it }
                 ).collect { send(it) }
-            }.let { processStreamingResponse(it) }
+            }.let { processStreamingResponse(it) }.requireEndFrame()
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -53,6 +53,7 @@ import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.streaming.buildStreamFrameFlow
+import ai.koog.prompt.streaming.requireEndFrame
 import ai.koog.utils.io.SuitableForIO
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
@@ -342,7 +343,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                 request = request,
                 requestBodyType = String::class,
                 decodeStreamingResponse = { json.decodeFromString<OpenAIStreamEvent>(it) },
-                processStreamingChunk = { it ->
+                processStreamingChunk = {
                     when (it) {
                         is OpenAIStreamEvent.ResponseOutputTextDelta -> {
                             StreamFrame.TextDelta(text = it.delta, index = it.outputIndex)
@@ -400,7 +401,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                         else -> null
                     }
                 }
-            ).filterNotNull()
+            ).filterNotNull().requireEndFrame()
         } catch (e: Exception) {
             throw LLMClientException(
                 clientName = clientName,

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClient.kt
@@ -8,6 +8,7 @@ import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.LLMChoice
 import ai.koog.prompt.message.Message
+import ai.koog.prompt.streaming.IncompleteStreamException
 import ai.koog.prompt.streaming.StreamFrame
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
@@ -150,6 +151,8 @@ public class RetryingLLMClient @JvmOverloads constructor(
     }
 
     private fun shouldRetry(error: Throwable): Boolean {
+        if (error is IncompleteStreamException) return true
+
         val message = error.message ?: return false
 
         // Check if error matches any retry pattern

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClientTest.kt
@@ -11,6 +11,7 @@ import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.LLMChoice
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.prompt.streaming.IncompleteStreamException
 import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.streaming.emitTextDelta
 import ai.koog.prompt.streaming.streamFrameFlow
@@ -382,6 +383,61 @@ class RetryingLLMClientTest {
 
         assertEquals(moderationResult, result)
         assertEquals(2, mockClient.moderateCalls)
+    }
+
+    @Test
+    fun testIncompleteStreamExceptionBeforeFirstFrameTriggersRetry() = runTest {
+        var callCount = 0
+        val mockClient = MockLLMClient(
+            streamResponse = flow {
+                callCount++
+                if (callCount == 1) {
+                    throw IncompleteStreamException()
+                }
+                emit(StreamFrame.TextDelta("success"))
+                emit(StreamFrame.End(finishReason = "stop"))
+            }
+        )
+
+        val retryingClient = RetryingLLMClient(
+            mockClient,
+            RetryConfig(
+                maxAttempts = 3,
+                initialDelay = 10.milliseconds
+            )
+        )
+
+        val result = retryingClient.executeStreaming(testPrompt, testModel).toList()
+
+        assertEquals(
+            listOf(StreamFrame.TextDelta("success"), StreamFrame.End(finishReason = "stop")),
+            result
+        )
+        assertEquals(2, mockClient.streamCalls)
+    }
+
+    @Test
+    fun testIncompleteStreamExceptionAfterFirstFramePropagates() = runTest {
+        val mockClient = MockLLMClient(
+            streamResponse = streamFrameFlow {
+                emitTextDelta("first-token")
+                throw IncompleteStreamException()
+            }
+        )
+
+        val retryingClient = RetryingLLMClient(
+            mockClient,
+            RetryConfig(
+                maxAttempts = 3,
+                initialDelay = 10.milliseconds
+            )
+        )
+
+        assertFailsWith<IncompleteStreamException> {
+            retryingClient.executeStreaming(testPrompt, testModel).collect()
+        }
+
+        assertEquals(1, mockClient.streamCalls) // No retry after first frame
     }
 
     // Mock LLMClient for testing

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowExt.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowExt.kt
@@ -4,6 +4,40 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.fold
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
+
+/**
+ * Signals that a streaming response terminated without receiving a [StreamFrame.End] frame.
+ *
+ * This typically indicates a dropped network connection during SSE streaming,
+ * where the underlying transport (e.g., Ktor SSE) completes the flow normally
+ * instead of propagating an error.
+ */
+public class IncompleteStreamException(
+    message: String = "Stream completed without receiving an End frame",
+    cause: Throwable? = null
+) : Exception(message, cause)
+
+/**
+ * Ensures that the stream contains a [StreamFrame.End] frame before completing.
+ *
+ * If the flow completes normally without emitting a [StreamFrame.End] frame,
+ * an [IncompleteStreamException] is thrown. This detects dropped connections
+ * during SSE streaming where the transport silently completes the flow.
+ *
+ * If the flow already terminates with an exception, that exception is propagated
+ * without additionally throwing [IncompleteStreamException].
+ */
+public fun Flow<StreamFrame>.requireEndFrame(): Flow<StreamFrame> {
+    var endFrameReceived = false
+    return onEach { frame -> if (frame is StreamFrame.End) endFrameReceived = true }
+        .onCompletion { error ->
+            if (error == null && !endFrameReceived) {
+                throw IncompleteStreamException()
+            }
+        }
+}
 
 /**
  * Returns a transformed flow of [StreamFrame.TextDelta] objects that contains only the textual content.

--- a/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowExtTest.kt
+++ b/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowExtTest.kt
@@ -1,0 +1,90 @@
+package ai.koog.prompt.streaming
+
+import ai.koog.prompt.message.ResponseMetaInfo
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+
+class StreamFrameFlowExtTest {
+
+    @Test
+    fun testRequireEndFrameWithEndFrameCompletesNormally() = runTest {
+        val frames = flowOf(
+            StreamFrame.TextDelta("Hello"),
+            StreamFrame.End(finishReason = "stop")
+        ).requireEndFrame().toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.TextDelta("Hello"),
+                StreamFrame.End(finishReason = "stop")
+            ),
+            frames
+        )
+    }
+
+    @Test
+    fun testRequireEndFrameWithoutEndFrameThrowsIncompleteStreamException() = runTest {
+        val flow = flowOf(
+            StreamFrame.TextDelta("Hello"),
+            StreamFrame.TextDelta(" World")
+        ).requireEndFrame()
+
+        assertFailsWith<IncompleteStreamException> {
+            flow.toList()
+        }
+    }
+
+    @Test
+    fun testRequireEndFrameOnEmptyFlowThrowsIncompleteStreamException() = runTest {
+        val flow = emptyFlow<StreamFrame>().requireEndFrame()
+
+        assertFailsWith<IncompleteStreamException> {
+            flow.toList()
+        }
+    }
+
+    @Test
+    fun testRequireEndFrameDoesNotMaskExistingErrors() = runTest {
+        val flow = flow<StreamFrame> {
+            emit(StreamFrame.TextDelta("Hello"))
+            throw RuntimeException("Connection lost")
+        }.requireEndFrame()
+
+        val exception = assertFailsWith<RuntimeException> {
+            flow.toList()
+        }
+
+        assertFalse(
+            exception is IncompleteStreamException,
+            "Should propagate original exception, not IncompleteStreamException"
+        )
+    }
+
+    @Test
+    fun testRequireEndFrameWithEndFrameAmongMultipleFrames() = runTest {
+        val meta = ResponseMetaInfo.Empty
+        val frames = flowOf(
+            StreamFrame.TextDelta("Hello", 0),
+            StreamFrame.TextDelta(" World", 0),
+            StreamFrame.TextComplete("Hello World", 0),
+            StreamFrame.End(finishReason = "stop", metaInfo = meta)
+        ).requireEndFrame().toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.TextDelta("Hello", 0),
+                StreamFrame.TextDelta(" World", 0),
+                StreamFrame.TextComplete("Hello World", 0),
+                StreamFrame.End(finishReason = "stop", metaInfo = meta)
+            ),
+            frames
+        )
+    }
+}


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

`executeStreaming` not swallowing exceptions from llm client. Used `StreamFrame.End` to require to have it when finishing the stream.

<!-- Include references to related issues below, e.g., closes #1, closes KG-1. Otherwise, delete it. -->
closes 
KG-550
