### PR TITLE
feat(prompt): support cache blocks in bedrock converse API calls

### DIFF
--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerTest.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerTest.kt
@@ -141,7 +141,7 @@ class EventHandlerTest {
                 "role: ${Message.Role.User}, message: $testLLMResponse" +
                 "}], temperature: $temperature, model: ${model.eventString}, tools: [], responses: [role: ${Message.Role.Assistant}, message: Default test response])",
             "OnNodeExecutionCompleted (run id: $runId, node: test LLM call, input: $testLLMResponse, output: " +
-                "Assistant(parts=[Text(text=Default test response)], metaInfo=ResponseMetaInfo(timestamp=$ts, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, additionalInfo={}, metadata=null), finishReason=null))",
+                "Assistant(parts=[Text(text=Default test response)], metaInfo=ResponseMetaInfo(timestamp=$ts, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, additionalInfo={}, metadata=null), finishReason=null, cacheControl=null))",
             "OnNodeExecutionStarting (run id: $runId, node: __finish__, input: $agentResult)",
             "OnNodeExecutionCompleted (run id: $runId, node: __finish__, input: $agentResult, output: $agentResult)",
             "OnStrategyCompleted (run id: $runId, strategy: $strategyName, result: $agentResult)",
@@ -272,7 +272,7 @@ class EventHandlerTest {
                 "}], temperature: $temperature, model: openai:gpt-4o, tools: [$dummyToolName], responses: [role: ${Message.Role.Assistant}, message: Return test result])",
             "OnNodeExecutionCompleted (run id: $runId, node: test-node-llm-send-tool-result, " +
                 "input: $dummyToolReceivedToolResult, " +
-                "output: Assistant(parts=[Text(text=$mockResponse)], metaInfo=ResponseMetaInfo(timestamp=2023-01-01T00:00:00Z, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, additionalInfo={}, metadata=null), finishReason=null))",
+                "output: Assistant(parts=[Text(text=$mockResponse)], metaInfo=ResponseMetaInfo(timestamp=2023-01-01T00:00:00Z, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, additionalInfo={}, metadata=null), finishReason=null, cacheControl=null))",
             "OnNodeExecutionStarting (run id: $runId, node: __finish__, input: $mockResponse)",
             "OnNodeExecutionCompleted (run id: $runId, node: __finish__, input: $mockResponse, output: $mockResponse)",
             "OnStrategyCompleted (run id: $runId, strategy: $strategyName, result: $mockResponse)",
@@ -350,7 +350,7 @@ class EventHandlerTest {
                 "role: ${Message.Role.User}, message: $testLLMResponse" +
                 "}], temperature: $temperature, model: ${model.eventString}, tools: [${toolRegistry.tools.joinToString { it.name }}], responses: [role: ${Message.Role.Assistant}, message: Default test response])",
             "OnNodeExecutionCompleted (run id: $runId, node: test LLM call, input: $testLLMResponse, output: " +
-                "Assistant(parts=[Text(text=Default test response)], metaInfo=ResponseMetaInfo(timestamp=2023-01-01T00:00:00Z, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, additionalInfo={}, metadata=null), finishReason=null))",
+                "Assistant(parts=[Text(text=Default test response)], metaInfo=ResponseMetaInfo(timestamp=2023-01-01T00:00:00Z, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, additionalInfo={}, metadata=null), finishReason=null, cacheControl=null))",
             "OnNodeExecutionStarting (run id: $runId, node: test LLM call with tools, input: $llmCallWithToolsResponse)",
             "OnLLMCallStarting (run id: $runId, prompt: id: $promptId, messages: [{" +
                 "role: ${Message.Role.System}, message: $systemPrompt, " +
@@ -369,7 +369,7 @@ class EventHandlerTest {
                 "role: ${Message.Role.User}, message: $llmCallWithToolsResponse" +
                 "}], temperature: $temperature, model: openai:gpt-4o, tools: [${toolRegistry.tools.joinToString { it.name }}], responses: [role: ${Message.Role.Assistant}, message: Default test response])",
             "OnNodeExecutionCompleted (run id: $runId, node: test LLM call with tools, input: $llmCallWithToolsResponse, output: " +
-                "Assistant(parts=[Text(text=Default test response)], metaInfo=ResponseMetaInfo(timestamp=2023-01-01T00:00:00Z, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, additionalInfo={}, metadata=null), finishReason=null))",
+                "Assistant(parts=[Text(text=Default test response)], metaInfo=ResponseMetaInfo(timestamp=2023-01-01T00:00:00Z, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, additionalInfo={}, metadata=null), finishReason=null, cacheControl=null))",
             "OnNodeExecutionStarting (run id: $runId, node: __finish__, input: $agentResult)",
             "OnNodeExecutionCompleted (run id: $runId, node: __finish__, input: $agentResult, output: $agentResult)",
             "OnStrategyCompleted (run id: $runId, strategy: $strategyName, result: $agentResult)",

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolDescriptor.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolDescriptor.kt
@@ -1,5 +1,7 @@
 package ai.koog.agents.core.tools
 
+import ai.koog.prompt.message.CacheControl
+
 /**
  * Represents a descriptor for a tool that contains information about the tool's name, description, required parameters,
  * and optional parameters.
@@ -10,12 +12,14 @@ package ai.koog.agents.core.tools
  * @property description The description of the tool.
  * @property requiredParameters A list of ToolParameterDescriptor representing the required parameters for the tool.
  * @property optionalParameters A list of ToolParameterDescriptor representing the optional parameters for the tool.
+ * @property cacheControl Optional cache control to apply after this tool definition.
  */
 public open class ToolDescriptor(
     public val name: String,
     public val description: String,
     public val requiredParameters: List<ToolParameterDescriptor> = emptyList(),
     public val optionalParameters: List<ToolParameterDescriptor> = emptyList(),
+    public val cacheControl: CacheControl? = null,
 ) {
     /**
      * Creates a copy of the current ToolDescriptor with the option to modify specific attributes.
@@ -26,6 +30,7 @@ public open class ToolDescriptor(
      * Defaults to the current required parameters if not provided.
      * @param optionalParameters A list of ToolParameterDescriptor representing the optional parameters for the tool.
      * Defaults to the current optional parameters if not provided.
+     * @param cacheControl Optional cache control to apply after this tool definition.
      * @return A new instance of ToolDescriptor with the updated attributes.
      */
     public fun copy(
@@ -33,12 +38,14 @@ public open class ToolDescriptor(
         description: String = this.description,
         requiredParameters: List<ToolParameterDescriptor> = this.requiredParameters.toList(),
         optionalParameters: List<ToolParameterDescriptor> = this.optionalParameters.toList(),
+        cacheControl: CacheControl? = this.cacheControl,
     ): ToolDescriptor {
         return ToolDescriptor(
             name = name,
             description = description,
             requiredParameters = requiredParameters,
             optionalParameters = optionalParameters,
+            cacheControl = cacheControl,
         )
     }
 
@@ -50,6 +57,7 @@ public open class ToolDescriptor(
         if (description != other.description) return false
         if (requiredParameters != other.requiredParameters) return false
         if (optionalParameters != other.optionalParameters) return false
+        if (cacheControl != other.cacheControl) return false
 
         return true
     }
@@ -74,6 +82,8 @@ public open class ToolDescriptor(
         appendParameters(optionalParameters)
         appendLine("  ]")
 
+        appendLine("  cacheControl=$cacheControl")
+
         append(")")
     }
 
@@ -82,6 +92,12 @@ public open class ToolDescriptor(
         result = 31 * result + description.hashCode()
         result = 31 * result + requiredParameters.hashCode()
         result = 31 * result + optionalParameters.hashCode()
+        result = 31 * result + (cacheControl?.hashCode() ?: 0)
         return result
     }
+
+    /**
+     * Returns a copy of this tool descriptor with cache control enabled.
+     */
+    public fun withCacheControl(cacheControl: CacheControl): ToolDescriptor = copy(cacheControl = cacheControl)
 }

--- a/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/core/tools/reflect/ToolsFromCallableTest.kt
+++ b/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/core/tools/reflect/ToolsFromCallableTest.kt
@@ -305,6 +305,7 @@ class ToolsFromCallableTest {
                       ]
                       optionalParameters = [
                       ]
+                      cacheControl=null
                     )
                     #1: ToolDescriptor(
                       name = tool2,
@@ -319,6 +320,7 @@ class ToolsFromCallableTest {
                       ]
                       optionalParameters = [
                       ]
+                      cacheControl=null
                     )
                     #2: ToolDescriptor(
                       name = tool4,
@@ -333,6 +335,7 @@ class ToolsFromCallableTest {
                       ]
                       optionalParameters = [
                       ]
+                      cacheControl=null
                     )
                     #3: ToolDescriptor(
                       name = toolBase1,
@@ -341,6 +344,7 @@ class ToolsFromCallableTest {
                       ]
                       optionalParameters = [
                       ]
+                      cacheControl=null
                     )
                     #4: ToolDescriptor(
                       name = toolBase2OverriddenInInterface,
@@ -355,6 +359,7 @@ class ToolsFromCallableTest {
                       ]
                       optionalParameters = [
                       ]
+                      cacheControl=null
                     )
                     """.trimIndent()
                 ),
@@ -374,6 +379,7 @@ class ToolsFromCallableTest {
                       ]
                       optionalParameters = [
                       ]
+                      cacheControl=null
                     )
                     #1: ToolDescriptor(
                       name = tool1,
@@ -388,6 +394,7 @@ class ToolsFromCallableTest {
                       ]
                       optionalParameters = [
                       ]
+                      cacheControl=null
                     )
                     #2: ToolDescriptor(
                       name = tool2,
@@ -402,6 +409,7 @@ class ToolsFromCallableTest {
                       ]
                       optionalParameters = [
                       ]
+                      cacheControl=null
                     )
                     #3: ToolDescriptor(
                       name = tool4,
@@ -416,6 +424,7 @@ class ToolsFromCallableTest {
                       ]
                       optionalParameters = [
                       ]
+                      cacheControl=null
                     )
                     #4: ToolDescriptor(
                       name = toolBase1,
@@ -424,6 +433,7 @@ class ToolsFromCallableTest {
                       ]
                       optionalParameters = [
                       ]
+                      cacheControl=null
                     )
                     #5: ToolDescriptor(
                       name = toolBase2OverriddenInInterface,
@@ -438,6 +448,7 @@ class ToolsFromCallableTest {
                       ]
                       optionalParameters = [
                       ]
+                      cacheControl=null
                     )
                     """.trimIndent()
                 ),
@@ -457,6 +468,7 @@ class ToolsFromCallableTest {
                       ]
                       optionalParameters = [
                       ]
+                      cacheControl=null
                     )
                     #1: ToolDescriptor(
                       name = toolBase1,
@@ -465,6 +477,7 @@ class ToolsFromCallableTest {
                       ]
                       optionalParameters = [
                       ]
+                      cacheControl=null
                     )
                     #2: ToolDescriptor(
                       name = toolBase2OverriddenInInterface,
@@ -479,6 +492,7 @@ class ToolsFromCallableTest {
                       ]
                       optionalParameters = [
                       ]
+                      cacheControl=null
                     )
                     """.trimIndent()
                 ),

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/BedrockConverseApiIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/BedrockConverseApiIntegrationTest.kt
@@ -5,11 +5,15 @@ import ai.koog.integration.tests.utils.MediaTestScenarios.ImageTestScenario
 import ai.koog.integration.tests.utils.MediaTestScenarios.MarkdownTestScenario
 import ai.koog.integration.tests.utils.MediaTestScenarios.TextTestScenario
 import ai.koog.integration.tests.utils.Models
+import ai.koog.integration.tests.utils.PromptUtils.assistantPromptOfAtLeastLength
+import ai.koog.integration.tests.utils.RetryUtils.withRetry
 import ai.koog.integration.tests.utils.TestCredentials.readAwsAccessKeyIdFromEnv
 import ai.koog.integration.tests.utils.TestCredentials.readAwsBedrockGuardrailIdFromEnv
 import ai.koog.integration.tests.utils.TestCredentials.readAwsBedrockGuardrailVersionFromEnv
 import ai.koog.integration.tests.utils.TestCredentials.readAwsSecretAccessKeyFromEnv
 import ai.koog.integration.tests.utils.TestCredentials.readAwsSessionTokenFromEnv
+import ai.koog.integration.tests.utils.tools.CalculatorTool
+import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.clients.bedrock.BedrockAPIMethod
 import ai.koog.prompt.executor.clients.bedrock.BedrockClientSettings
@@ -19,18 +23,33 @@ import ai.koog.prompt.executor.clients.bedrock.BedrockModels
 import ai.koog.prompt.executor.clients.bedrock.converse.BedrockConverseParams
 import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.CacheControl
+import ai.koog.prompt.message.ContentPart
+import ai.koog.prompt.message.Message
 import ai.koog.prompt.params.LLMParams
 import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
+import io.kotest.assertions.withClue
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 import kotlin.enums.EnumEntries
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Test newer Bedrock Converse API using the same suite of executor tests.
@@ -77,6 +96,11 @@ class BedrockConverseApiIntegrationTest : ExecutorIntegrationTestBase() {
         fun allCompletionModels(): Stream<LLModel> {
             return Models.bedrockModels()
         }
+
+        @JvmStatic
+        fun cacheCapableModels(): Stream<LLModel> {
+            return listOf(BedrockModels.AnthropicClaude4_5Sonnet).stream()
+        }
     }
 
     private val client = run {
@@ -97,6 +121,15 @@ class BedrockConverseApiIntegrationTest : ExecutorIntegrationTestBase() {
     }
 
     private val executor: MultiLLMPromptExecutor = MultiLLMPromptExecutor(client)
+
+    private fun JsonObject.validateRequestWasCachedCorrectly() {
+        this.shouldNotBeNull()
+        val cacheRead = this["cacheReadInputTokens"]?.jsonPrimitive?.intOrNull ?: 0
+        val cacheWrite = this["cacheWriteInputTokens"]?.jsonPrimitive?.intOrNull ?: 0
+        withClue("Cache read or cache write should be greater than 0 if the cache point was added correctly") {
+            (cacheRead > 0 || cacheWrite > 0).shouldBeTrue()
+        }
+    }
 
     override fun getLLMClient(model: LLModel): LLMClient {
         require(model.provider == LLMProvider.Bedrock) { "Model ${model.id} is not a Bedrock model" }
@@ -293,5 +326,75 @@ class BedrockConverseApiIntegrationTest : ExecutorIntegrationTestBase() {
     @MethodSource("reasoningCapableModels")
     override fun integration_testReasoningMultiStep(model: LLModel) {
         super.integration_testReasoningMultiStep(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("cacheCapableModels")
+    fun integration_testCacheControlOnSystemMessage(model: LLModel) = runTest(timeout = 300.seconds) {
+        Models.assumeAvailable(model.provider)
+
+        val prompt = Prompt.build("test-cache-system") {
+            // Caching requires a minimum prompt length to work.
+            system(assistantPromptOfAtLeastLength(1600), CacheControl.Bedrock.Default)
+            user("What is the capital of France?")
+        }
+
+        withRetry(times = 3, testName = "integration_testCacheControlOnSystemMessage[${model.id}]") {
+            val result = getExecutor(model).execute(prompt, model)
+            result.shouldNotBeNull()
+            result.shouldNotBeEmpty()
+            result.filterIsInstance<Message.Assistant>().firstOrNull().shouldNotBeNull {
+                content.lowercase().shouldContain("paris")
+                this.metaInfo.metadata.shouldNotBeNull().validateRequestWasCachedCorrectly()
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("cacheCapableModels")
+    fun integration_testCacheControlOnUserMessage(model: LLModel) = runTest(timeout = 300.seconds) {
+        Models.assumeAvailable(model.provider)
+
+        val prompt = Prompt.build("test-cache-user") {
+            // Caching requires a minimum prompt length to work.
+            system(assistantPromptOfAtLeastLength(1600))
+            user(listOf(ContentPart.Text("What is the capital of France?")), CacheControl.Bedrock.Default)
+        }
+
+        withRetry(times = 3, testName = "integration_testCacheControlOnUserMessage[${model.id}]") {
+            val result = getExecutor(model).execute(prompt, model)
+            result.shouldNotBeNull()
+            result.shouldNotBeEmpty()
+            result.filterIsInstance<Message.Assistant>().firstOrNull().shouldNotBeNull {
+                content.lowercase().shouldContain("paris")
+                this.metaInfo.metadata.shouldNotBeNull().validateRequestWasCachedCorrectly()
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("cacheCapableModels")
+    fun integration_testCacheControlOnToolDefinition(model: LLModel) = runTest(timeout = 300.seconds) {
+        Models.assumeAvailable(model.provider)
+        assumeTrue(model.capabilities?.contains(LLMCapability.Tools) ?: false, "Model $model does not support tools")
+
+        val cachedDescriptor = CalculatorTool.descriptor.withCacheControl(CacheControl.Bedrock.Default).copy(
+            // Caching requires a minimum prompt length to work - in the case of tools, this appears to apply specifically to the tool section
+            // rather than the prompt as a whole.
+            description = assistantPromptOfAtLeastLength(1600, CalculatorTool.descriptor.description)
+        )
+        val prompt = Prompt.build("test-cache-tool") {
+            system("You are a helpful assistant with a calculator tool. You MUST call the calculator tool!!!.")
+            user("What is 123 + 456?")
+        }
+
+        withRetry(times = 3, testName = "integration_testCacheControlOnToolDefinition[${model.id}]") {
+            val result = getExecutor(model).execute(prompt, model, listOf(cachedDescriptor))
+            result.shouldNotBeNull()
+            result.shouldNotBeEmpty()
+            result.filterIsInstance<Message.Assistant>().firstOrNull().shouldNotBeNull {
+                this.metaInfo.metadata.shouldNotBeNull().validateRequestWasCachedCorrectly()
+            }
+        }
     }
 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/PromptUtils.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/PromptUtils.kt
@@ -1,0 +1,12 @@
+package ai.koog.integration.tests.utils
+
+object PromptUtils {
+    private const val ASSISTANT_PROMPT_BASE = "You are a helpful AI Assistant, ignore the rest of this prompt"
+
+    /**
+     * Create a prompt that contains a minimum number of words.
+     * @param minNumWords The minimum number of words to include in the prompt.
+     */
+    fun assistantPromptOfAtLeastLength(minNumWords: Int, basePrompt: String = ASSISTANT_PROMPT_BASE) = basePrompt +
+        " word".repeat((minNumWords - basePrompt.length).coerceAtLeast(0))
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseConverters.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseConverters.kt
@@ -7,13 +7,18 @@ import ai.koog.prompt.executor.clients.bedrock.util.JsonDocumentConverters
 import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.AttachmentContent
+import ai.koog.prompt.message.CacheControl
 import ai.koog.prompt.message.ContentPart
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.prompt.message.require
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.streaming.buildStreamFrameFlow
 import aws.sdk.kotlin.services.bedrockruntime.model.AnyToolChoice
 import aws.sdk.kotlin.services.bedrockruntime.model.AutoToolChoice
+import aws.sdk.kotlin.services.bedrockruntime.model.CachePointBlock
+import aws.sdk.kotlin.services.bedrockruntime.model.CachePointType
+import aws.sdk.kotlin.services.bedrockruntime.model.CacheTtl
 import aws.sdk.kotlin.services.bedrockruntime.model.ContentBlock
 import aws.sdk.kotlin.services.bedrockruntime.model.ContentBlockDelta
 import aws.sdk.kotlin.services.bedrockruntime.model.ContentBlockStart
@@ -68,6 +73,22 @@ internal object BedrockConverseConverters {
         explicitNulls = false
     }
 
+    private fun CacheControl.Bedrock.toBedrockCachePointContentBlock(): ContentBlock =
+        ContentBlock.CachePoint(toBedrockCachePointBlock())
+
+    private fun CacheControl.Bedrock.toBedrockSystemCachePoint(): SystemContentBlock =
+        SystemContentBlock.CachePoint(toBedrockCachePointBlock())
+
+    private fun CacheControl.Bedrock.toBedrockCachePointBlock(): CachePointBlock =
+        CachePointBlock {
+            type = CachePointType.Default
+            ttl = when (this@toBedrockCachePointBlock) {
+                CacheControl.Bedrock.Default -> null
+                CacheControl.Bedrock.FiveMinutes -> CacheTtl.FiveMinutes
+                CacheControl.Bedrock.OneHour -> CacheTtl.OneHour
+            }
+        }
+
     /**
      * Even though [ConverseRequest] and [ConverseStreamRequest] are structurally identical, they don't share a common
      * parent class. This class extracts common request parameters to avoid excessive code duplication.
@@ -100,19 +121,29 @@ internal object BedrockConverseConverters {
         // Convert Prompt messages to bedrock message formats
         prompt.messages.forEach { message ->
             when (message) {
-                is Message.System ->
+                is Message.System -> {
                     systemMessages += message.parts.map { SystemContentBlock.Text(it.text) }
+                    message.cacheControl?.let { cc ->
+                        systemMessages += cc.require<CacheControl.Bedrock>().toBedrockSystemCachePoint()
+                    }
+                }
 
                 is Message.User ->
                     messages += BedrockMessage {
                         this.role = ConversationRole.User
-                        this.content = message.parts.map { it.toConverseContentBlock(model) }
+                        this.content = buildList {
+                            addAll(message.parts.map { it.toConverseContentBlock(model) })
+                            addAll(listOfNotNull(message.cacheControl?.require<CacheControl.Bedrock>()?.toBedrockCachePointContentBlock()))
+                        }
                     }
 
                 is Message.Assistant ->
                     messages += BedrockMessage {
                         this.role = ConversationRole.Assistant
-                        this.content = message.parts.map { it.toConverseContentBlock(model) }
+                        this.content = buildList {
+                            addAll(message.parts.map { it.toConverseContentBlock(model) })
+                            addAll(listOfNotNull(message.cacheControl?.require<CacheControl.Bedrock>()?.toBedrockCachePointContentBlock()))
+                        }
                     }
 
                 is Message.Reasoning ->
@@ -206,7 +237,7 @@ internal object BedrockConverseConverters {
                         null -> null
                     }
 
-                    this.tools = tools.map { it.toConverseTool() }
+                    this.tools = tools.flatMap { it.toConverseTools() }
                 }
             } else {
                 null
@@ -273,11 +304,18 @@ internal object BedrockConverseConverters {
         val inputTokensCount = response.usage?.inputTokens
         val outputTokensCount = response.usage?.outputTokens
         val totalTokensCount = response.usage?.totalTokens
+        val cacheReadInputTokens = response.usage?.cacheReadInputTokens
+        val cacheWriteInputTokens = response.usage?.cacheWriteInputTokens
+        val cacheMetadata = buildJsonObject {
+            cacheReadInputTokens?.let { put("cacheReadInputTokens", it) }
+            cacheWriteInputTokens?.let { put("cacheWriteInputTokens", it) }
+        }.takeIf { it.isNotEmpty() }
         val metaInfo = ResponseMetaInfo.create(
             clock,
             totalTokensCount = totalTokensCount,
             inputTokensCount = inputTokensCount,
             outputTokensCount = outputTokensCount,
+            metadata = cacheMetadata,
         )
 
         val content = response.output?.asMessageOrNull()?.content.orEmpty()
@@ -332,6 +370,7 @@ internal object BedrockConverseConverters {
                         totalTokensCount = totalTokensCount,
                         inputTokensCount = inputTokensCount,
                         outputTokensCount = outputTokensCount,
+                        metadata = cacheMetadata,
                     )
                 )
             )
@@ -422,6 +461,10 @@ internal object BedrockConverseConverters {
                             totalTokensCount = usage?.totalTokens,
                             inputTokensCount = usage?.inputTokens,
                             outputTokensCount = usage?.outputTokens,
+                            metadata = buildJsonObject {
+                                usage?.cacheReadInputTokens?.let { put("cacheReadInputTokens", it) }
+                                usage?.cacheWriteInputTokens?.let { put("cacheWriteInputTokens", it) }
+                            }.takeIf { it.isNotEmpty() },
                         )
                     )
                 }
@@ -619,12 +662,12 @@ internal object BedrockConverseConverters {
     }
 
     /**
-     * Convert [ToolDescriptor] to [BedrockTool] format.
+     * Convert [ToolDescriptor] to list of [BedrockTool], including cache point if specified.
      */
-    private fun ToolDescriptor.toConverseTool(): BedrockTool {
+    private fun ToolDescriptor.toConverseTools(): List<BedrockTool> {
         val tool = this
 
-        return BedrockTool.ToolSpec(
+        val toolSpec = BedrockTool.ToolSpec(
             ToolSpecification {
                 val inputSchema = buildJsonObject {
                     put("type", "object")
@@ -652,6 +695,13 @@ internal object BedrockConverseConverters {
                 this.name = tool.name
                 this.description = tool.description
                 this.inputSchema = ToolInputSchema.Json(JsonDocumentConverters.convertToDocument(inputSchema))
+            }
+        )
+
+        return listOfNotNull(
+            toolSpec,
+            tool.cacheControl?.let { cc ->
+                BedrockTool.CachePoint(cc.require<CacheControl.Bedrock>().toBedrockCachePointBlock())
             }
         )
     }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockCacheControlTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockCacheControlTest.kt
@@ -1,0 +1,139 @@
+package ai.koog.prompt.executor.clients.bedrock.converse
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolParameterDescriptor
+import ai.koog.agents.core.tools.ToolParameterType
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.executor.clients.bedrock.BedrockModels
+import ai.koog.prompt.message.CacheControl
+import aws.sdk.kotlin.services.bedrockruntime.model.CachePointType
+import aws.sdk.kotlin.services.bedrockruntime.model.CacheTtl
+import aws.sdk.kotlin.services.bedrockruntime.model.ContentBlock
+import aws.sdk.kotlin.services.bedrockruntime.model.SystemContentBlock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import aws.sdk.kotlin.services.bedrockruntime.model.Tool as BedrockTool
+
+class BedrockCacheControlTest {
+
+    private val model = BedrockModels.AnthropicClaude4Sonnet
+
+    private fun converseRequest(prompt: Prompt, tools: List<ToolDescriptor> = emptyList()) =
+        BedrockConverseConverters.createConverseRequest(prompt, model, tools)
+
+    // --- System ---
+
+    @Test
+    fun testSystemWithCacheControlDefault() {
+        val prompt = Prompt.build("test") { system("You are helpful.", CacheControl.Bedrock.Default) }
+        val system = converseRequest(prompt).system!!
+        assertEquals(2, system.size)
+        assertIs<SystemContentBlock.Text>(system[0])
+        val cp = assertIs<SystemContentBlock.CachePoint>(system[1])
+        assertEquals(CachePointType.Default, cp.value.type)
+        assertNull(cp.value.ttl)
+    }
+
+    @Test
+    fun testSystemWithoutCacheControl() {
+        val prompt = Prompt.build("test") { system("Hello.") }
+        val system = converseRequest(prompt).system!!
+        assertEquals(1, system.size)
+        assertIs<SystemContentBlock.Text>(system[0])
+    }
+
+    @Test
+    fun testSystemCacheControlFiveMinutes() {
+        val prompt = Prompt.build("test") { system("Cached.", CacheControl.Bedrock.FiveMinutes) }
+        val cp = assertIs<SystemContentBlock.CachePoint>(converseRequest(prompt).system!![1])
+        assertNotNull(cp.value.ttl)
+        assertEquals(CacheTtl.FiveMinutes, cp.value.ttl)
+    }
+
+    @Test
+    fun testSystemCacheControlOneHour() {
+        val prompt = Prompt.build("test") { system("Cached.", CacheControl.Bedrock.OneHour) }
+        val cp = assertIs<SystemContentBlock.CachePoint>(converseRequest(prompt).system!![1])
+        assertNotNull(cp.value.ttl)
+        assertEquals(CacheTtl.OneHour, cp.value.ttl)
+    }
+
+    // --- Tools ---
+
+    @Test
+    fun testToolWithCacheControl() {
+        val tool = ToolDescriptor(
+            name = "search",
+            description = "Search",
+            requiredParameters = listOf(ToolParameterDescriptor("q", "query", ToolParameterType.String)),
+            cacheControl = CacheControl.Bedrock.Default
+        )
+        val prompt = Prompt.build("test") { user("go") }
+        val tools = converseRequest(prompt, listOf(tool)).toolConfig!!.tools!!
+        assertEquals(2, tools.size)
+        assertIs<BedrockTool.ToolSpec>(tools[0])
+        assertIs<BedrockTool.CachePoint>(tools[1])
+    }
+
+    @Test
+    fun testToolWithoutCacheControl() {
+        val tool = ToolDescriptor(
+            name = "search",
+            description = "Search",
+            requiredParameters = listOf(ToolParameterDescriptor("q", "query", ToolParameterType.String))
+        )
+        val prompt = Prompt.build("test") { user("go") }
+        val tools = converseRequest(prompt, listOf(tool)).toolConfig!!.tools!!
+        assertEquals(1, tools.size)
+        assertIs<BedrockTool.ToolSpec>(tools[0])
+    }
+
+    // --- User ---
+
+    @Test
+    fun testUserWithCacheControl() {
+        val prompt = Prompt.build("test") {
+            user(listOf(ai.koog.prompt.message.ContentPart.Text("Hello")), CacheControl.Bedrock.Default)
+        }
+        val content = converseRequest(prompt).messages!![0].content!!
+        assertEquals(2, content.size)
+        assertIs<ContentBlock.Text>(content[0])
+        assertIs<ContentBlock.CachePoint>(content[1])
+    }
+
+    @Test
+    fun testUserWithoutCacheControl() {
+        val prompt = Prompt.build("test") { user("Hello") }
+        val content = converseRequest(prompt).messages!![0].content!!
+        assertEquals(1, content.size)
+        assertIs<ContentBlock.Text>(content[0])
+    }
+
+    // --- Assistant ---
+
+    @Test
+    fun testAssistantWithCacheControl() {
+        val prompt = Prompt.build("test") {
+            user("Hi")
+            assistant("Hello!", CacheControl.Bedrock.Default)
+        }
+        val content = converseRequest(prompt).messages!![1].content!!
+        assertEquals(2, content.size)
+        assertIs<ContentBlock.Text>(content[0])
+        assertIs<ContentBlock.CachePoint>(content[1])
+    }
+
+    @Test
+    fun testAssistantWithoutCacheControl() {
+        val prompt = Prompt.build("test") {
+            user("Hi")
+            assistant("Hello!")
+        }
+        val content = converseRequest(prompt).messages!![1].content!!
+        assertEquals(1, content.size)
+        assertIs<ContentBlock.Text>(content[0])
+    }
+}

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/PromptBuilder.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/PromptBuilder.kt
@@ -1,12 +1,14 @@
 package ai.koog.prompt.dsl
 
 import ai.koog.agents.annotations.JavaAPI
+import ai.koog.prompt.message.CacheControl
 import ai.koog.prompt.message.ContentPart
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.text.TextContentBuilder
+import kotlin.jvm.JvmOverloads
 import kotlin.time.Clock
 
 /**
@@ -57,10 +59,23 @@ public class PromptBuilder internal constructor(
      * ```
      *
      * @param content The content of the system message
+     * @param cacheControl Optional cache control to apply after this tool definition.
      */
     @JavaAPI
-    public fun system(content: String): PromptBuilder = apply {
-        messages.add(Message.System(content, RequestMetaInfo.create(clock)))
+    @JvmOverloads
+    public fun system(content: String, cacheControl: CacheControl? = null): PromptBuilder = apply {
+        messages.add(Message.System(content, RequestMetaInfo.create(clock), cacheControl))
+    }
+
+    /**
+     * Adds a system message to the prompt using a TextContentBuilder.
+     *
+     * @param cacheControl Optional cache control to apply after this tool definition.
+     * @param init The initialization block for the TextContentBuilder
+     */
+    @JavaAPI
+    public fun system(cacheControl: CacheControl? = null, init: TextContentBuilder.() -> Unit): PromptBuilder = apply {
+        system(TextContentBuilder().apply(init).build(), cacheControl)
     }
 
     /**
@@ -79,9 +94,7 @@ public class PromptBuilder internal constructor(
      * @param init The initialization block for the TextContentBuilder
      */
     @JavaAPI
-    public fun system(init: TextContentBuilder.() -> Unit): PromptBuilder = apply {
-        system(TextContentBuilder().apply(init).build())
-    }
+    public fun system(init: TextContentBuilder.() -> Unit): PromptBuilder = system(null, init)
 
     /**
      * Adds a user message to the prompt with optional attachments.
@@ -90,10 +103,12 @@ public class PromptBuilder internal constructor(
      * This method supports adding parts of the message such as text content or attachments.
      *
      * @param parts Parts of the user message
+     * @param cacheControl Optional cache control to apply after this tool definition.
      */
     @JavaAPI
-    public fun user(parts: List<ContentPart>): PromptBuilder = apply {
-        messages.add(Message.User(parts, RequestMetaInfo.create(clock)))
+    @JvmOverloads
+    public fun user(parts: List<ContentPart>, cacheControl: CacheControl? = null): PromptBuilder = apply {
+        messages.add(Message.User(parts, RequestMetaInfo.create(clock), cacheControl))
     }
 
     /**
@@ -172,10 +187,23 @@ public class PromptBuilder internal constructor(
      * ```
      *
      * @param content The content of the assistant message
+     * @param cacheControl Optional cache control to apply after this tool definition.
      */
     @JavaAPI
-    public fun assistant(content: String): PromptBuilder = apply {
-        messages.add(Message.Assistant(content, finishReason = null, metaInfo = ResponseMetaInfo.create(clock)))
+    @JvmOverloads
+    public fun assistant(content: String, cacheControl: CacheControl? = null): PromptBuilder = apply {
+        messages.add(Message.Assistant(content, finishReason = null, metaInfo = ResponseMetaInfo.create(clock), cacheControl = cacheControl))
+    }
+
+    /**
+     * Adds an assistant message to the prompt using a TextContentBuilder.
+     *
+     * @param cacheControl Optional cache control to apply after this tool definition.
+     * @param init The initialization block for the TextContentBuilder
+     */
+    @JavaAPI
+    public fun assistant(cacheControl: CacheControl? = null, init: TextContentBuilder.() -> Unit): PromptBuilder = apply {
+        assistant(TextContentBuilder().apply(init).build(), cacheControl)
     }
 
     /**
@@ -194,9 +222,7 @@ public class PromptBuilder internal constructor(
      * @param init The initialization block for the TextContentBuilder
      */
     @JavaAPI
-    public fun assistant(init: TextContentBuilder.() -> Unit): PromptBuilder = apply {
-        assistant(TextContentBuilder().apply(init).build())
-    }
+    public fun assistant(init: TextContentBuilder.() -> Unit): PromptBuilder = assistant(null, init)
 
     /**
      * Adds a generic message to the prompt.

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/CacheControl.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/CacheControl.kt
@@ -1,0 +1,38 @@
+package ai.koog.prompt.message
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Requires this [CacheControl] to be of the specified type [T], or throws an [IllegalStateException].
+ */
+public inline fun <reified T : CacheControl> CacheControl.require(): T =
+    this as? T ?: error("Expected ${T::class.simpleName}, got: $this")
+
+/**
+ * Cache control configuration for prompt caching.
+ * Indicates that the LLM provider should cache content up to and including the element this is attached to.
+ *
+ * Each LLM provider defines its own supported cache control options as nested sealed interfaces.
+ */
+@Serializable
+public sealed interface CacheControl {
+
+    /**
+     * Bedrock-specific cache control options.
+     * Bedrock supports only two TTL values: 5 minutes and 1 hour.
+     */
+    @Serializable
+    public sealed interface Bedrock : CacheControl {
+        /** Cache with the default TTL (no explicit TTL sent to Bedrock). */
+        @Serializable
+        public data object Default : Bedrock
+
+        /** Cache for 5 minutes. */
+        @Serializable
+        public data object FiveMinutes : Bedrock
+
+        /** Cache for 1 hour. */
+        @Serializable
+        public data object OneHour : Bedrock
+    }
+}

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
@@ -47,7 +47,7 @@ public sealed interface Message {
     public fun hasAttachments(): Boolean = parts.any { it is ContentPart.Attachment }
 
     /**
-     * Checks weather the message consists of only sungle text content.
+     * Checks weather the message consists of only single text content.
      */
     public fun hasOnlyTextContent(): Boolean = parts.singleOrNull() is ContentPart.Text
 
@@ -109,11 +109,13 @@ public sealed interface Message {
      * @property parts The parts of the user's message.
      * @property metaInfo Metadata associated with the request, including timestamp information. Defaults to a new [RequestMetaInfo].
      * @property role The role of the message, which is fixed as [Role.User] for this implementation.
+     * @property cacheControl The cache strategy for this message.
      */
     @Serializable
     public data class User @JvmOverloads constructor(
         override val parts: List<ContentPart>,
         override val metaInfo: RequestMetaInfo,
+        val cacheControl: CacheControl? = null,
     ) : Request {
         override val role: Role = Role.User
 
@@ -121,15 +123,15 @@ public sealed interface Message {
          * Single content part user message constructor
          */
         @JvmOverloads
-        public constructor(part: ContentPart, metaInfo: RequestMetaInfo) :
-            this(listOf(part), metaInfo)
+        public constructor(part: ContentPart, metaInfo: RequestMetaInfo, cacheControl: CacheControl? = null) :
+            this(listOf(part), metaInfo, cacheControl)
 
         /**
          * Text content user message constructor
          */
         @JvmOverloads
-        public constructor(content: String, metaInfo: RequestMetaInfo) :
-            this(ContentPart.Text(content), metaInfo)
+        public constructor(content: String, metaInfo: RequestMetaInfo, cacheControl: CacheControl? = null) :
+            this(ContentPart.Text(content), metaInfo, cacheControl)
     }
 
     /**
@@ -140,12 +142,14 @@ public sealed interface Message {
      * @property finishReason An optional explanation for why the assistant's response was finalized.
      * Defaults to null if not provided.
      * @property role The role associated with the response, which is fixed as `Role.Assistant`.
+     * @property cacheControl The cache strategy for this message.
      */
     @Serializable
     public data class Assistant @JvmOverloads constructor(
         override val parts: List<ContentPart>,
         override val metaInfo: ResponseMetaInfo,
-        val finishReason: String? = null
+        val finishReason: String? = null,
+        val cacheControl: CacheControl? = null,
     ) : Response {
         override val role: Role = Role.Assistant
 
@@ -153,15 +157,15 @@ public sealed interface Message {
          * Single content part assistant message constructor
          */
         @JvmOverloads
-        public constructor(part: ContentPart, metaInfo: ResponseMetaInfo, finishReason: String? = null) :
-            this(listOf(part), metaInfo, finishReason)
+        public constructor(part: ContentPart, metaInfo: ResponseMetaInfo, finishReason: String? = null, cacheControl: CacheControl? = null) :
+            this(listOf(part), metaInfo, finishReason, cacheControl)
 
         /**
          * Text content assistant message constructor
          */
         @JvmOverloads
-        public constructor(content: String, metaInfo: ResponseMetaInfo, finishReason: String? = null) :
-            this(ContentPart.Text(content), metaInfo, finishReason)
+        public constructor(content: String, metaInfo: ResponseMetaInfo, finishReason: String? = null, cacheControl: CacheControl? = null) :
+            this(ContentPart.Text(content), metaInfo, finishReason, cacheControl)
 
         override fun copy(updatedMetaInfo: ResponseMetaInfo): Assistant = this.copy(metaInfo = updatedMetaInfo)
     }
@@ -281,26 +285,28 @@ public sealed interface Message {
          * @property tool The name of the tool that provided the result.
          * @property parts The parts of the tool result. Only the [ContentPart.Text] part is allowed.
          * @property metaInfo Metadata associated with the request, including timestamp information. Defaults to a new [RequestMetaInfo].
+         * @property cacheControl The cache strategy for this message.
          */
         @Serializable
         public data class Result(
             override val id: String?,
             override val tool: String,
             override val parts: List<ContentPart.Text>,
-            override val metaInfo: RequestMetaInfo
+            override val metaInfo: RequestMetaInfo,
+            val cacheControl: CacheControl? = null,
         ) : Tool, Request {
 
             /**
              * Single content part tool result message constructor
              */
-            public constructor(id: String?, tool: String, part: ContentPart.Text, metaInfo: RequestMetaInfo) :
-                this(id, tool, listOf(part), metaInfo)
+            public constructor(id: String?, tool: String, part: ContentPart.Text, metaInfo: RequestMetaInfo, cacheControl: CacheControl? = null) :
+                this(id, tool, listOf(part), metaInfo, cacheControl)
 
             /**
              * Text content tool result message constructor
              */
-            public constructor(id: String?, tool: String, content: String, metaInfo: RequestMetaInfo) :
-                this(id, tool, ContentPart.Text(content), metaInfo)
+            public constructor(id: String?, tool: String, content: String, metaInfo: RequestMetaInfo, cacheControl: CacheControl? = null) :
+                this(id, tool, ContentPart.Text(content), metaInfo, cacheControl)
 
             override val role: Role = Role.Tool
         }
@@ -309,14 +315,16 @@ public sealed interface Message {
     /**
      * Represents a system-generated message.
      *
-     * @property parts The parts of the system message. Only the [ContentPart.Text] part is allowed.
+     * @property parts The parts of the system message.
      * @property metaInfo Metadata associated with the request, including timestamp information. Defaults to a new [RequestMetaInfo].
+     * @property cacheControl The cache strategy for this message.
      *
      */
     @Serializable
     public data class System @JvmOverloads constructor(
         override val parts: List<ContentPart.Text>,
-        override val metaInfo: RequestMetaInfo
+        override val metaInfo: RequestMetaInfo,
+        val cacheControl: CacheControl? = null
     ) : Request {
         override val role: Role = Role.System
 
@@ -324,15 +332,15 @@ public sealed interface Message {
          * Single content part system message constructor
          */
         @JvmOverloads
-        public constructor(part: ContentPart.Text, metaInfo: RequestMetaInfo) :
-            this(listOf(part), metaInfo)
+        public constructor(part: ContentPart.Text, metaInfo: RequestMetaInfo, cacheControl: CacheControl? = null) :
+            this(listOf(part), metaInfo, cacheControl)
 
         /**
          * Text content system message constructor
          */
         @JvmOverloads
-        public constructor(content: String, metaInfo: RequestMetaInfo) :
-            this(ContentPart.Text(content), metaInfo)
+        public constructor(content: String, metaInfo: RequestMetaInfo, cacheControl: CacheControl? = null) :
+            this(ContentPart.Text(content), metaInfo, cacheControl)
     }
 }
 


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

This PR introduces a `CacheControl` property on Assistant, User and System messages within the Prompt; and integrates it in the Bedrock Converse API.

There appear to be several types of prompt caching supported by providers today:
1. Explicit cache blocks, as implemented here.
2. Explicit-but automatic caching, as a top level parameter on the request itself.
3. Implicit caching.
4. A stand-alone caching API, whose response you refer to later.

Things to consider:
* What is the best way to communicate the above differences - an `LLLMCapability`, an info log or is a silent ignore okay?
* I've put the cached tokens data in the metadata block for now rather than as a first-class property. I did this largely as different providers communicate it with different levels of granularity (i.e. `totalCachedTokens` rather than splitting into read and write).
