### PR TITLE
test: no duplicated messages in the history when calling requestLLMForceOneTool

### DIFF
--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionTest.kt
@@ -257,7 +257,7 @@ class AIAgentLLMWriteSessionTest {
         val testTool = TestTool()
         val session = createSession(mockExecutor, listOf(testTool))
 
-        val safeTool = session.findTool<TestTool.Args, String>(TestTool::class)
+        val safeTool = session.findTool(TestTool::class)
         assertNotNull(safeTool)
 
         val result = safeTool.execute(TestTool.Args("test input"))
@@ -319,7 +319,7 @@ class AIAgentLLMWriteSessionTest {
 
         val session = createSession(mockExecutor, prompt = initialPrompt)
 
-        session.rewritePrompt { oldPrompt ->
+        session.rewritePrompt { _ ->
             prompt("rewritten", clock = testClock) {
                 system("Rewritten system message")
                 user("Rewritten user message")

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
@@ -44,6 +44,7 @@ import io.kotest.inspectors.shouldForAny
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.ints.shouldBeGreaterThan
@@ -1342,7 +1343,58 @@ class AIAgentIntegrationTest : AIAgentTestBase() {
         }
     }
 
-    @Disabled("KG-694")
+    @ParameterizedTest
+    @MethodSource("allModels")
+    fun integration_RequestLLMForceOneToolDoesNotDuplicateMessages(model: LLModel) = runTest(timeout = 180.seconds) {
+        Models.assumeAvailable(model.provider)
+        assumeTrue(model.supports(LLMCapability.Tools), "Model $model does not support tools")
+
+        runWithTracking { eventHandlerConfig, state ->
+            withRetry {
+                val testTool = SimpleCalculatorTool
+
+                val agent = AIAgent(
+                    promptExecutor = getExecutor(model),
+                    strategy = functionalStrategy<String, String>("force-one-tool-strategy") { input ->
+                        llm.writeSession {
+                            appendPrompt {
+                                user(input)
+                            }
+                            val response = requestLLMForceOneTool(testTool)
+
+                            assumeTrue(
+                                response is Message.Tool.Call,
+                                "Model returned ${response::class.simpleName} instead of Tool.Call"
+                            )
+
+                            val toolCallMessages = prompt.messages.filterIsInstance<Message.Tool.Call>()
+                                .filter { it.tool == testTool.name }
+                            toolCallMessages.shouldHaveSize(1)
+                        }
+
+                        "Tool call completed successfully without duplication"
+                    },
+                    agentConfig = AIAgentConfig(
+                        prompt = prompt("force-one-tool-test") {
+                            system("You are a helpful assistant that can use tools.")
+                        },
+                        model = model,
+                        maxAgentIterations = 10
+                    ),
+                    toolRegistry = ToolRegistry {
+                        tool(testTool)
+                    },
+                    installFeatures = {
+                        install(EventHandler.Feature, eventHandlerConfig)
+                    }
+                )
+
+                agent.run("Calculate 5 times 3") should contain("successfully")
+                state.errors.shouldBeEmpty()
+            }
+        }
+    }
+
     @Test
     fun integration_ThrowError() = runTest(timeout = 15.seconds) {
         val model = OpenAIModels.Chat.GPT5_1


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

Add integration test for `requestLLMForceOneTool` to avoid duplicated messages.
A follow-up to the fix for [KG-663](https://youtrack.jetbrains.com/issue/KG-663) Extra messages in the history when calling requestLLMForceOneTool.

<!-- Include BREAKING section below only if this PR introduces breaking changes. Otherwise, delete it. -->
BREAKING:
* none

<!-- Include DEPRECATED section below only if this PR deprecates any public APIs. Otherwise, delete it. -->
DEPRECATED:
* none
