### PR TITLE
feat(agents): add DataDog LLM Observability exporter and forward response metadata to inference spans

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/README.md
+++ b/agents/agents-features/agents-features-opentelemetry/README.md
@@ -227,6 +227,7 @@ The OpenTelemetry feature creates different types of spans for various operation
         - `gen_ai.usage.output_tokens` (when available)
         - `gen_ai.usage.total_tokens` (when available)
         - `gen_ai.response.finish_reasons` (Stop, ToolCalls, etc.)
+        - `gen_ai.response.metadata` (when `ResponseMetaInfo.metadata` is present — serialized JSON containing free-form provider or application metadata)
 
 6. **Execute Tool Span**
     - Purpose: Execution of a tool or function call triggered by the agent or LLM.
@@ -369,6 +370,41 @@ suspend fun main() {
     
     // Wait for telemetry data to be exported
     TimeUnit.SECONDS.sleep(10)
+}
+```
+
+### Datadog
+
+[Datadog](https://www.datadoghq.com/) supports direct OTLP intake for LLM Observability. To send traces to Datadog:
+
+```kotlin
+install(OpenTelemetry) {
+    addDatadogExporter()
+}
+```
+
+The exporter reads the `DD_API_KEY` environment variable by default. You can also pass it explicitly:
+
+```kotlin
+install(OpenTelemetry) {
+    addDatadogExporter(
+        datadogApiKey = "your-api-key",
+        datadogSite = "datadoghq.eu",             // defaults to datadoghq.com
+        traceAttributes = mapOf(
+            "env" to "production",
+            "service.name" to "my-agent",
+        ),
+    )
+}
+```
+
+The `buildDatadogExporter()` function is also available if you need to wrap the exporter with custom decorators before registering it:
+
+```kotlin
+install(OpenTelemetry) {
+    val exporter = buildDatadogExporter()
+    val wrapped = MyCustomSpanExporter(exporter) // e.g. attribute post-processing
+    addSpanExporter(wrapped)
 }
 ```
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/SpanAttributes.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/attribute/SpanAttributes.kt
@@ -304,6 +304,12 @@ internal object SpanAttributes {
             override val key: String = super.key.concatKey("model")
             override val value: String = model.id
         }
+
+        // gen_ai.response.metadata
+        data class Metadata(private val metadata: String) : Response {
+            override val key: String = super.key.concatKey("metadata")
+            override val value: String = metadata
+        }
     }
 
     // gen_ai.usage

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryConfig.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryConfig.kt
@@ -6,9 +6,9 @@ import ai.koog.agents.core.feature.handler.AgentLifecycleEventContext
 import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
 import ai.koog.agents.features.opentelemetry.attribute.addAttributes
 import ai.koog.agents.features.opentelemetry.integration.SpanAdapter
+import ai.koog.agents.features.opentelemetry.integration.datadog.addDatadogExporterImpl
 import ai.koog.agents.features.opentelemetry.integration.langfuse.addLangfuseExporterImpl
 import ai.koog.agents.features.opentelemetry.integration.weave.addWeaveExporterImpl
-import ai.koog.agents.features.opentelemetry.integration.datadog.buildDatadogExporter
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
@@ -238,40 +238,6 @@ public class OpenTelemetryConfig : FeatureConfig() {
         _spanAdapter = adapter
     }
 
-    /**
-     * Java-friendly version of the [addDatadogExporter][ai.koog.agents.features.opentelemetry.integration.datadog.addDatadogExporter]
-     * extension function that accepts [java.time.Duration] instead of [kotlin.time.Duration].
-     *
-     * @param datadogApiKey Datadog API key.
-     *        If not set, is retrieved from `DD_API_KEY` environment variable.
-     * @param datadogSite Datadog site (e.g. `datadoghq.com`, `datadoghq.eu`).
-     *        If not set, is retrieved from `DD_SITE` environment variable.
-     *        Defaults to `datadoghq.com`.
-     * @param timeout OpenTelemetry SpanExporter timeout as [java.time.Duration].
-     * @param traceAttributes resource-level attributes to add to all exported spans.
-     *
-     * @see <a href="https://docs.datadoghq.com/opentelemetry/guide/otlp_api/">Datadog OTLP API Intake</a>
-     * @see <a href="https://docs.datadoghq.com/llm_observability/">Datadog LLM Observability</a>
-     */
-    @JavaAPI
-    @JvmOverloads
-    public fun addDatadogExporter(
-        datadogApiKey: String? = null,
-        datadogSite: String? = null,
-        timeout: java.time.Duration = java.time.Duration.ofSeconds(10),
-        traceAttributes: Map<String, String> = emptyMap(),
-    ) {
-        addSpanExporter(buildDatadogExporter(datadogApiKey, datadogSite, timeout.toKotlinDuration()))
-
-        if (traceAttributes.isNotEmpty()) {
-            addResourceAttributes(
-                traceAttributes.map { (key, value) ->
-                    AttributeKey.stringKey(key) to value
-                }.toMap()
-            )
-        }
-    }
-
     //region Private Methods
 
     private fun initializeOpenTelemetry(): OpenTelemetrySdk {
@@ -423,5 +389,37 @@ public class OpenTelemetryConfig : FeatureConfig() {
         weaveProjectName,
         weaveApiKey,
         timeout?.toKotlinDuration()
+    )
+
+    /**
+     * Configure an OpenTelemetry span exporter that sends data to [Datadog](https://www.datadoghq.com/)
+     * via direct OTLP intake.
+     *
+     * @param datadogApiKey Datadog API key.
+     *        If not set, is retrieved from `DD_API_KEY` environment variable.
+     * @param datadogSite Datadog site (e.g. `datadoghq.com`, `datadoghq.eu`).
+     *        If not set, is retrieved from `DD_SITE` environment variable.
+     *        Defaults to `datadoghq.com`.
+     * @param timeout OpenTelemetry SpanExporter timeout.
+     *        See [io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder.setTimeout].
+     * @param traceAttributes resource-level attributes to add to all exported spans.
+     *        Useful for tagging traces with application-specific metadata
+     *        (e.g. `"env"`, `"tenant_id"`, `"prompt_name"`).
+     *
+     * @see <a href="https://docs.datadoghq.com/opentelemetry/guide/otlp_api/">Datadog OTLP API Intake</a>
+     * @see <a href="https://docs.datadoghq.com/llm_observability/">Datadog LLM Observability</a>
+     */
+    @JavaAPI
+    @JvmOverloads
+    public fun addDatadogExporter(
+        datadogApiKey: String? = null,
+        datadogSite: String? = null,
+        timeout: JavaDuration? = null,
+        traceAttributes: Map<String, String>? = null,
+    ): Unit = addDatadogExporterImpl(
+        datadogApiKey,
+        datadogSite,
+        timeout?.toKotlinDuration(),
+        traceAttributes
     )
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryConfig.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryConfig.kt
@@ -8,6 +8,7 @@ import ai.koog.agents.features.opentelemetry.attribute.addAttributes
 import ai.koog.agents.features.opentelemetry.integration.SpanAdapter
 import ai.koog.agents.features.opentelemetry.integration.langfuse.addLangfuseExporterImpl
 import ai.koog.agents.features.opentelemetry.integration.weave.addWeaveExporterImpl
+import ai.koog.agents.features.opentelemetry.integration.datadog.buildDatadogExporter
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
@@ -235,6 +236,40 @@ public class OpenTelemetryConfig : FeatureConfig() {
      */
     internal fun addSpanAdapter(adapter: SpanAdapter) {
         _spanAdapter = adapter
+    }
+
+    /**
+     * Java-friendly version of the [addDatadogExporter][ai.koog.agents.features.opentelemetry.integration.datadog.addDatadogExporter]
+     * extension function that accepts [java.time.Duration] instead of [kotlin.time.Duration].
+     *
+     * @param datadogApiKey Datadog API key.
+     *        If not set, is retrieved from `DD_API_KEY` environment variable.
+     * @param datadogSite Datadog site (e.g. `datadoghq.com`, `datadoghq.eu`).
+     *        If not set, is retrieved from `DD_SITE` environment variable.
+     *        Defaults to `datadoghq.com`.
+     * @param timeout OpenTelemetry SpanExporter timeout as [java.time.Duration].
+     * @param traceAttributes resource-level attributes to add to all exported spans.
+     *
+     * @see <a href="https://docs.datadoghq.com/opentelemetry/guide/otlp_api/">Datadog OTLP API Intake</a>
+     * @see <a href="https://docs.datadoghq.com/llm_observability/">Datadog LLM Observability</a>
+     */
+    @JavaAPI
+    @JvmOverloads
+    public fun addDatadogExporter(
+        datadogApiKey: String? = null,
+        datadogSite: String? = null,
+        timeout: java.time.Duration = java.time.Duration.ofSeconds(10),
+        traceAttributes: Map<String, String> = emptyMap(),
+    ) {
+        addSpanExporter(buildDatadogExporter(datadogApiKey, datadogSite, timeout.toKotlinDuration()))
+
+        if (traceAttributes.isNotEmpty()) {
+            addResourceAttributes(
+                traceAttributes.map { (key, value) ->
+                    AttributeKey.stringKey(key) to value
+                }.toMap()
+            )
+        }
     }
 
     //region Private Methods

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/datadog/Datadog.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/datadog/Datadog.kt
@@ -1,0 +1,86 @@
+package ai.koog.agents.features.opentelemetry.integration.datadog
+
+import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryConfig
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
+import io.opentelemetry.sdk.trace.export.SpanExporter
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Builds a Datadog-ready [SpanExporter] that sends OTLP traces directly to Datadog's intake endpoint.
+ *
+ * Returns the exporter without registering it, so callers can wrap it with
+ * additional decorators before calling [OpenTelemetryConfig.addSpanExporter].
+ *
+ * Requires a `DD_API_KEY` environment variable (or explicit [datadogApiKey] parameter).
+ * The `dd-otlp-source: llmobs` header routes spans to the LLM Observability product.
+ *
+ * @param datadogApiKey Datadog API key. Falls back to `DD_API_KEY` environment variable.
+ * @param datadogSite Datadog site (e.g. `datadoghq.com`, `datadoghq.eu`).
+ *        Falls back to `DD_SITE` environment variable, defaults to `datadoghq.com`.
+ * @param timeout OpenTelemetry SpanExporter timeout.
+ * @return a [SpanExporter] configured for Datadog direct OTLP intake.
+ *
+ * @see <a href="https://docs.datadoghq.com/opentelemetry/guide/otlp_api/">Datadog OTLP API Intake</a>
+ */
+public fun buildDatadogExporter(
+    datadogApiKey: String? = null,
+    datadogSite: String? = null,
+    timeout: Duration = 10.seconds,
+): SpanExporter {
+    val apiKey = datadogApiKey
+        ?: System.getenv("DD_API_KEY")
+        ?: error("DD_API_KEY environment variable is required for Datadog direct intake")
+
+    val site = datadogSite ?: System.getenv("DD_SITE") ?: "datadoghq.com"
+    val endpoint = "https://otlp.$site/v1/traces"
+
+    logger.debug { "Configuring Datadog direct intake exporter: endpoint=$endpoint" }
+
+    return OtlpHttpSpanExporter.builder()
+        .setTimeout(timeout.inWholeSeconds, TimeUnit.SECONDS)
+        .setEndpoint(endpoint)
+        .addHeader("dd-api-key", apiKey)
+        .addHeader("dd-otlp-source", "llmobs")
+        .build()
+}
+
+/**
+ * Configure an OpenTelemetry span exporter that sends data to [Datadog](https://www.datadoghq.com/)
+ * via direct OTLP intake.
+ *
+ * @param datadogApiKey Datadog API key.
+ *        If not set, is retrieved from `DD_API_KEY` environment variable.
+ * @param datadogSite Datadog site (e.g. `datadoghq.com`, `datadoghq.eu`).
+ *        If not set, is retrieved from `DD_SITE` environment variable.
+ *        Defaults to `datadoghq.com`.
+ * @param timeout OpenTelemetry SpanExporter timeout.
+ *        See [io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder.setTimeout].
+ * @param traceAttributes resource-level attributes to add to all exported spans.
+ *        Useful for tagging traces with application-specific metadata
+ *        (e.g. `"env"`, `"tenant_id"`, `"prompt_name"`).
+ *
+ * @see <a href="https://docs.datadoghq.com/opentelemetry/guide/otlp_api/">Datadog OTLP API Intake</a>
+ * @see <a href="https://docs.datadoghq.com/llm_observability/">Datadog LLM Observability</a>
+ */
+public fun OpenTelemetryConfig.addDatadogExporter(
+    datadogApiKey: String? = null,
+    datadogSite: String? = null,
+    timeout: Duration = 10.seconds,
+    traceAttributes: Map<String, String> = emptyMap(),
+) {
+    addSpanExporter(buildDatadogExporter(datadogApiKey, datadogSite, timeout))
+
+    if (traceAttributes.isNotEmpty()) {
+        addResourceAttributes(
+            traceAttributes.map { (key, value) ->
+                AttributeKey.stringKey(key) to value
+            }.toMap()
+        )
+    }
+}
+
+private val logger = KotlinLogging.logger { }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/datadog/Datadog.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/datadog/Datadog.kt
@@ -48,6 +48,23 @@ public fun buildDatadogExporter(
         .build()
 }
 
+internal fun OpenTelemetryConfig.addDatadogExporterImpl(
+    datadogApiKey: String? = null,
+    datadogSite: String? = null,
+    timeout: Duration? = null,
+    traceAttributes: Map<String, String>? = null,
+) {
+    addSpanExporter(buildDatadogExporter(datadogApiKey, datadogSite, timeout ?: 10.seconds))
+
+    if (traceAttributes != null && traceAttributes.isNotEmpty()) {
+        addResourceAttributes(
+            traceAttributes.map { (key, value) ->
+                AttributeKey.stringKey(key) to value
+            }.toMap()
+        )
+    }
+}
+
 /**
  * Configure an OpenTelemetry span exporter that sends data to [Datadog](https://www.datadoghq.com/)
  * via direct OTLP intake.
@@ -69,18 +86,10 @@ public fun buildDatadogExporter(
 public fun OpenTelemetryConfig.addDatadogExporter(
     datadogApiKey: String? = null,
     datadogSite: String? = null,
-    timeout: Duration = 10.seconds,
-    traceAttributes: Map<String, String> = emptyMap(),
+    timeout: Duration? = null,
+    traceAttributes: Map<String, String>? = null,
 ) {
-    addSpanExporter(buildDatadogExporter(datadogApiKey, datadogSite, timeout))
-
-    if (traceAttributes.isNotEmpty()) {
-        addResourceAttributes(
-            traceAttributes.map { (key, value) ->
-                AttributeKey.stringKey(key) to value
-            }.toMap()
-        )
-    }
+    addDatadogExporterImpl(datadogApiKey, datadogSite, timeout, traceAttributes)
 }
 
 private val logger = KotlinLogging.logger { }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/inferenceSpan.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/span/inferenceSpan.kt
@@ -11,6 +11,8 @@ import ai.koog.prompt.message.Message
 import ai.koog.prompt.params.LLMParams
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.Tracer
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 
 /**
  * Build and start a new Inference Span with necessary attributes.
@@ -133,6 +135,7 @@ internal fun startInferenceSpan(
  * - gen_ai.response.finish_reasons (recommended)
  * - gen_ai.response.id (recommended)
  * - gen_ai.response.model (recommended)
+ * - gen_ai.response.metadata (recommended)
  * - gen_ai.usage.input_tokens (recommended)
  * - gen_ai.usage.output_tokens (recommended)
  * - gen_ai.output.messages (recommended)
@@ -157,6 +160,17 @@ internal fun endInferenceSpan(
     // gen_ai.response.id - Ignore. Not supported in Koog
     // gen_ai.response.model
     span.addAttribute(SpanAttributes.Response.Model(model))
+
+    // gen_ai.response.metadata
+    val responseMetadata = messages.filterIsInstance<Message.Response>()
+        .mapNotNull { message -> message.metaInfo.metadata }
+        .fold(mutableMapOf<String, JsonElement>()) { acc, jsonObject ->
+            acc.putAll(jsonObject)
+            acc
+        }
+    if (responseMetadata.isNotEmpty()) {
+        span.addAttribute(SpanAttributes.Response.Metadata(JsonObject(responseMetadata).toString()))
+    }
 
     // gen_ai.usage.input_tokens
     span.addAttribute(

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryResponseMetadataTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryResponseMetadataTest.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.features.opentelemetry.feature.span
 
-import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
 import ai.koog.agents.features.opentelemetry.mock.MockLLMProvider
 import ai.koog.agents.features.opentelemetry.mock.MockTracer
 import ai.koog.agents.features.opentelemetry.span.endInferenceSpan

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryResponseMetadataTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryResponseMetadataTest.kt
@@ -1,0 +1,121 @@
+package ai.koog.agents.features.opentelemetry.feature.span
+
+import ai.koog.agents.features.opentelemetry.attribute.SpanAttributes
+import ai.koog.agents.features.opentelemetry.mock.MockLLMProvider
+import ai.koog.agents.features.opentelemetry.mock.MockTracer
+import ai.koog.agents.features.opentelemetry.span.endInferenceSpan
+import ai.koog.agents.features.opentelemetry.span.startInferenceSpan
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.prompt.params.LLMParams
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.time.Clock
+
+class OpenTelemetryResponseMetadataTest {
+
+    private val tracer = MockTracer()
+    private val provider = MockLLMProvider()
+    private val model = LLModel(provider, "test-model")
+    private val clock = Clock.System
+
+    private fun createInferenceSpan(id: String) = startInferenceSpan(
+        tracer = tracer,
+        parentSpan = null,
+        id = id,
+        provider = provider,
+        runId = "run-$id",
+        model = model,
+        messages = emptyList(),
+        llmParams = LLMParams(),
+        tools = emptyList()
+    )
+
+    @Test
+    fun `test response metadata from ResponseMetaInfo is forwarded to inference span`() {
+        val metadata = JsonObject(
+            mapOf(
+                "cache_status" to JsonPrimitive("hit"),
+                "region" to JsonPrimitive("us-east-1"),
+            )
+        )
+
+        val span = createInferenceSpan("metadata-forwarded")
+
+        val responseMessages = listOf(
+            Message.Assistant(
+                "test response",
+                ResponseMetaInfo(
+                    timestamp = clock.now(),
+                    inputTokensCount = 10,
+                    outputTokensCount = 20,
+                    metadata = metadata,
+                )
+            )
+        )
+
+        endInferenceSpan(span = span, messages = responseMessages, model = model, verbose = true)
+
+        val metadataAttribute = span.attributes.find { it.key == "gen_ai.response.metadata" }
+        assertNotNull(metadataAttribute, "gen_ai.response.metadata attribute should be present")
+        assertEquals(metadata.toString(), metadataAttribute.value)
+    }
+
+    @Test
+    fun `test response metadata attribute is omitted when ResponseMetaInfo has no metadata`() {
+        val span = createInferenceSpan("no-metadata")
+
+        val responseMessages = listOf(
+            Message.Assistant(
+                "test response",
+                ResponseMetaInfo(
+                    timestamp = clock.now(),
+                    inputTokensCount = 10,
+                    outputTokensCount = 20,
+                )
+            )
+        )
+
+        endInferenceSpan(span = span, messages = responseMessages, model = model, verbose = true)
+
+        val metadataAttribute = span.attributes.find { it.key == "gen_ai.response.metadata" }
+        assertNull(metadataAttribute, "gen_ai.response.metadata attribute should not be present when metadata is null")
+    }
+
+    @Test
+    fun `test response metadata from multiple response messages is merged into single attribute`() {
+        val metadata1 = JsonObject(mapOf("request_id" to JsonPrimitive("req-123")))
+        val metadata2 = JsonObject(mapOf("served_by" to JsonPrimitive("node-7")))
+
+        val span = createInferenceSpan("merged-metadata")
+
+        val responseMessages = listOf(
+            Message.Assistant(
+                "response 1",
+                ResponseMetaInfo(timestamp = clock.now(), metadata = metadata1)
+            ),
+            Message.Assistant(
+                "response 2",
+                ResponseMetaInfo(timestamp = clock.now(), metadata = metadata2)
+            ),
+        )
+
+        endInferenceSpan(span = span, messages = responseMessages, model = model, verbose = true)
+
+        val metadataAttribute = span.attributes.find { it.key == "gen_ai.response.metadata" }
+        assertNotNull(metadataAttribute, "gen_ai.response.metadata attribute should be present")
+
+        val expectedMerged = JsonObject(
+            mapOf(
+                "request_id" to JsonPrimitive("req-123"),
+                "served_by" to JsonPrimitive("node-7"),
+            )
+        )
+        assertEquals(expectedMerged.toString(), metadataAttribute.value)
+    }
+}

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/datadog/DatadogExporterTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/datadog/DatadogExporterTest.kt
@@ -1,0 +1,23 @@
+package ai.koog.agents.features.opentelemetry.integration.datadog
+
+import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryConfig
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.Test
+
+class DatadogExporterTest {
+
+    @Test
+    fun `test buildDatadogExporter fails when DD_API_KEY is not set`() {
+        assertThrows<IllegalStateException> {
+            buildDatadogExporter()
+        }
+    }
+
+    @Test
+    fun `test addDatadogExporter fails when DD_API_KEY is not set`() {
+        val config = OpenTelemetryConfig()
+        assertThrows<IllegalStateException> {
+            config.addDatadogExporter()
+        }
+    }
+}


### PR DESCRIPTION
Add Datadog as a first-class OpenTelemetry exporter integration alongside Langfuse and Weave,
and forward `ResponseMetaInfo.metadata` to inference spans as `gen_ai.response.metadata`.

**Datadog exporter**
- `addDatadogExporter()` extension on `OpenTelemetryConfig` — follows the same pattern as `addLangfuseExporter()` and `addWeaveExporter()`
- `buildDatadogExporter()` returns a raw `SpanExporter` so callers can wrap it with custom decorators (e.g. attribute post-processing) before registering
- Sends OTLP traces directly to Datadog's intake endpoint with `dd-otlp-source: llmobs`
- Reads `DD_API_KEY` / `DD_SITE` from environment, with explicit parameter overrides
- Supports `traceAttributes` for adding resource-level tags

**Response metadata forwarding**
`ResponseMetaInfo.metadata` is an existing field (`JsonObject?`) designed for arbitrary provider/application metadata, but the OpenTelemetry feature previously ignored it. This creates a gap for use cases such as:
- Recording which model actually served a request in fallback/retry executor chains
- Propagating provider-specific metadata (cache status, request IDs, region)
- Enabling custom `SpanExporter` decorators that post-process span attributes
    based on response metadata

When present, metadata from all response messages is merged and serialized into a `gen_ai.response.metadata` string attribute on the inference span.
When no metadata is present the attribute is omitted.

closes https://github.com/JetBrains/koog/issues/1403