### PR TITLE
fix: Google LLM client's function call is missing a thought_signature

### DIFF
--- a/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/ContextApiIntegrationTest.java
+++ b/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/ContextApiIntegrationTest.java
@@ -157,10 +157,6 @@ public class ContextApiIntegrationTest extends KoogJavaTestBase {
     @MethodSource("ai.koog.integration.tests.agent.AIAgentTestBase#getLatestModels")
     public void integration_SubtaskSequential(LLModel model) {
         Models.assumeAvailable(model.getProvider());
-        assumeTrue(
-            !LLMProvider.Google.getId().equals(model.getProvider().getId()),
-            "KG-722 Google LLM client: Function call is missing a thought_signature in functionCall parts"
-        );
 
         NumberTools calculator = new NumberTools();
         List<Tool<?, ?>> tools = List.of(calculator.getTool("add"));
@@ -198,10 +194,6 @@ public class ContextApiIntegrationTest extends KoogJavaTestBase {
     @MethodSource("ai.koog.integration.tests.agent.AIAgentTestBase#getLatestModels")
     public void integration_SubtaskParallel(LLModel model) {
         Models.assumeAvailable(model.getProvider());
-        assumeTrue(
-            !LLMProvider.Google.getId().equals(model.getProvider().getId()),
-            "KG-722 Google LLM client: Function call is missing a thought_signature in functionCall parts"
-        );
 
         NumberTools calculator = new NumberTools();
         List<Tool<?, ?>> tools = List.of(calculator.getTool("add"), calculator.getTool("multiply"));
@@ -238,10 +230,6 @@ public class ContextApiIntegrationTest extends KoogJavaTestBase {
     @MethodSource("ai.koog.integration.tests.agent.AIAgentTestBase#getLatestModels")
     public void integration_SubtaskSingleRunSequential(LLModel model) {
         Models.assumeAvailable(model.getProvider());
-        assumeTrue(
-            !LLMProvider.Google.getId().equals(model.getProvider().getId()),
-            "KG-722 Google LLM client: Function call is missing a thought_signature in functionCall parts"
-        );
 
         NumberTools calculator = new NumberTools();
         List<Tool<?, ?>> tools = List.of(calculator.getTool("add"));
@@ -279,10 +267,6 @@ public class ContextApiIntegrationTest extends KoogJavaTestBase {
     @MethodSource("ai.koog.integration.tests.agent.AIAgentTestBase#getLatestModels")
     public void integration_ExecuteMultipleToolsParallel(LLModel model) {
         Models.assumeAvailable(model.getProvider());
-        assumeTrue(
-            !LLMProvider.Google.getId().equals(model.getProvider().getId()),
-            "KG-722 Google LLM client: Function call is missing a thought_signature in functionCall parts"
-        );
 
         NumberTools calculator = new NumberTools();
 
@@ -323,10 +307,6 @@ public class ContextApiIntegrationTest extends KoogJavaTestBase {
     @MethodSource("ai.koog.integration.tests.agent.AIAgentTestBase#getLatestModels")
     public void integration_ExecuteSingleTool(LLModel model) {
         Models.assumeAvailable(model.getProvider());
-        assumeTrue(
-            !LLMProvider.Google.getId().equals(model.getProvider().getId()),
-            "KG-722 Google LLM client: Function call is missing a thought_signature in functionCall parts"
-        );
 
         NumberTools calculator = new NumberTools();
 
@@ -493,10 +473,6 @@ public class ContextApiIntegrationTest extends KoogJavaTestBase {
     @MethodSource("ai.koog.integration.tests.agent.AIAgentTestBase#getLatestModels")
     public void integration_ShouldTriggerToolEventsInOrder(LLModel model) {
         Models.assumeAvailable(model.getProvider());
-        assumeTrue(
-            !LLMProvider.Google.getId().equals(model.getProvider().getId()),
-            "KG-722 Google LLM client: Function call is missing a thought_signature in functionCall parts"
-        );
 
         List<String> eventOrder = new ArrayList<>();
         NumberTools calculator = new NumberTools();

--- a/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/FunctionalStrategyIntegrationTest.java
+++ b/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/FunctionalStrategyIntegrationTest.java
@@ -102,10 +102,6 @@ public class FunctionalStrategyIntegrationTest extends KoogJavaTestBase {
     @MethodSource("ai.koog.integration.tests.agent.AIAgentTestBase#getLatestModels")
     public void integration_FunctionalStrategyWithManualToolHandling(LLModel model) {
         JavaUtils.assumeAvailable(model.getProvider());
-        assumeTrue(
-            !LLMProvider.Google.getId().equals(model.getProvider().getId()),
-            "KG-722 Google LLM client: Function call is missing a thought_signature in functionCall parts"
-        );
 
         NumberTools calculator = new NumberTools();
         ToolRegistry toolRegistry = ToolRegistry.builder().tools(calculator).build();
@@ -145,10 +141,6 @@ public class FunctionalStrategyIntegrationTest extends KoogJavaTestBase {
     @MethodSource("ai.koog.integration.tests.agent.AIAgentTestBase#getLatestModels")
     public void integration_Subtask(LLModel model) {
         JavaUtils.assumeAvailable(model.getProvider());
-        assumeTrue(
-            !LLMProvider.Google.getId().equals(model.getProvider().getId()),
-            "KG-722 Google LLM client: Function call is missing a thought_signature in functionCall parts"
-        );
 
         MultiLLMPromptExecutor executor = createExecutor(model);
 

--- a/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentGraphStrategyTest.java
+++ b/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentGraphStrategyTest.java
@@ -119,7 +119,6 @@ public class JavaAIAgentGraphStrategyTest extends KoogJavaTestBase {
     public void integration_GraphStrategyWithTaskSubgraphAndLimitedTools(LLModel model) {
         Models.assumeAvailable(model.getProvider());
         Assumptions.assumeTrue(model.supports(LLMCapability.Tools.INSTANCE), "Model does not support tools");
-        assumeNoGoogleToolCalling(model);
 
         CalculatorTools calculatorTools = new CalculatorTools();
         ToolRegistry toolRegistry = ToolRegistry.builder().tools(calculatorTools).build();
@@ -174,7 +173,6 @@ public class JavaAIAgentGraphStrategyTest extends KoogJavaTestBase {
     public void integration_GraphStrategyShouldEmitStrategyNodeSubgraphAndToolEvents(LLModel model) {
         Models.assumeAvailable(model.getProvider());
         Assumptions.assumeTrue(model.supports(LLMCapability.Tools.INSTANCE), "Model does not support tools");
-        assumeNoGoogleToolCalling(model);
 
         CalculatorTools calculatorTools = new CalculatorTools();
         ToolRegistry toolRegistry = ToolRegistry.builder().tools(calculatorTools).build();
@@ -240,19 +238,11 @@ public class JavaAIAgentGraphStrategyTest extends KoogJavaTestBase {
         );
     }
 
-    private static void assumeNoGoogleToolCalling(LLModel model) {
-        assumeTrue(
-            !"google".equalsIgnoreCase(model.getProvider().getId()),
-            "Skipping Google models until thought_signature support is fixed (KG-722/KG-596)"
-        );
-    }
-
     @ParameterizedTest
     @MethodSource("ai.koog.integration.tests.agent.AIAgentTestBase#getLatestModels")
     @Retry
     public void integration_GraphStrategyWithVerificationPath(LLModel model) {
         Models.assumeAvailable(model.getProvider());
-        assumeNoGoogleToolCalling(model);
         EventRecorder positiveEvents = new EventRecorder();
         EventRecorder negativeEvents = new EventRecorder();
 

--- a/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentIntegrationTest.java
+++ b/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentIntegrationTest.java
@@ -114,7 +114,6 @@ public class JavaAIAgentIntegrationTest extends KoogJavaTestBase {
     public void integration_ShouldFailOnMaxIterationsExhaustion(LLModel model) {
         Models.assumeAvailable(model.getProvider());
         assumeTrue(model.supports(LLMCapability.Tools.INSTANCE), "Model must support tools");
-        assumeNoGoogleToolCalling(model);
 
         NumberTools numberTools = new NumberTools();
         AtomicInteger errors = new AtomicInteger(0);
@@ -147,7 +146,6 @@ public class JavaAIAgentIntegrationTest extends KoogJavaTestBase {
     public void integration_ShouldCallNoArgToolWithoutParams(LLModel model) {
         Models.assumeAvailable(model.getProvider());
         assumeTrue(model.supports(LLMCapability.Tools.INSTANCE), "Model must support tools");
-        assumeNoGoogleToolCalling(model);
 
         NumberTools tools = new NumberTools();
         ToolRegistry registry = ToolRegistry.builder().tools(tools).build();
@@ -224,7 +222,6 @@ public class JavaAIAgentIntegrationTest extends KoogJavaTestBase {
     public void integration_SubgraphToolShouldReuseAgentTools(LLModel model) {
         Models.assumeAvailable(model.getProvider());
         assumeTrue(model.supports(LLMCapability.Tools.INSTANCE), "Model must support tools");
-        assumeNoGoogleToolCalling(model);
 
         NumberTools numberTools = new NumberTools();
         ToolRegistry toolRegistry = ToolRegistry.builder().tools(numberTools).build();
@@ -336,7 +333,6 @@ public class JavaAIAgentIntegrationTest extends KoogJavaTestBase {
     public void integration_HistoryCompressionSupportsBeforeAndAfterToolResult(LLModel model) {
         Models.assumeAvailable(model.getProvider());
         assumeTrue(model.supports(LLMCapability.Tools.INSTANCE), "Model must support tools");
-        assumeNoGoogleToolCalling(model);
 
         NumberTools numberTools = new NumberTools();
         AtomicInteger errors = new AtomicInteger(0);
@@ -387,13 +383,6 @@ public class JavaAIAgentIntegrationTest extends KoogJavaTestBase {
         assertThat(historyAfterCompression.get().stream().anyMatch(m -> m instanceof Message.System))
             .as("History should preserve system message after compression around tool result")
             .isTrue();
-    }
-
-    private static void assumeNoGoogleToolCalling(LLModel model) {
-        assumeTrue(
-            !"google".equalsIgnoreCase(model.getProvider().getId()),
-            "Skipping Google models until thought_signature support is fixed (KG-722/KG-596)"
-        );
     }
 
     @ParameterizedTest

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
@@ -44,7 +44,6 @@ import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.clients.openai.OpenAIResponsesParams
 import ai.koog.prompt.executor.clients.openai.base.models.ReasoningEffort
 import ai.koog.prompt.executor.clients.openai.models.ReasoningConfig
-import ai.koog.prompt.llm.GoogleLLMProvider
 import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
@@ -499,11 +498,7 @@ class AIAgentIntegrationTest : AIAgentTestBase() {
             "single-run non-parallel integration with calculator enum tool arguments"
         )
         assumeTrue(model.supports(LLMCapability.Tools), "Model $model does not support tools")
-        // TODO: Remove this skip when thought_signature presence is fixed
-        assumeTrue(
-            model.provider !is GoogleLLMProvider,
-            "Skipping Google models until thought_signature support is in this branch (KG-596)"
-        )
+
         assumeTrue(
             model.id != AnthropicModels.Haiku_4_5.id,
             "Anthropic Haiku 4.5 is flaky in single-run sequential tool mode and may exhaust iterations"

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
@@ -182,7 +182,7 @@ class AIAgentIntegrationTest : AIAgentTestBase() {
             prompt = prompt(
                 id = "single-run-agent",
                 params = LLMParams(
-                    temperature = 1.0,
+                    temperature = 0.0,
                     toolChoice = ToolChoice.Auto,
                 )
             ) {
@@ -192,7 +192,7 @@ class AIAgentIntegrationTest : AIAgentTestBase() {
                 }
             },
             model = model,
-            maxAgentIterations = 10,
+            maxAgentIterations = 20,
         ),
         toolRegistry = toolRegistry,
         installFeatures = {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicModels.kt
@@ -30,6 +30,8 @@ import kotlin.jvm.JvmField
  * | [Opus_4_6]   | Moderately fast | $5-$25       | Text, Image, Tools, Document | Text, Tools |
  */
 public object AnthropicModels : LLModelDefinitions {
+    private val thinkingCapabilities: List<LLMCapability> = listOf(LLMCapability.Thinking)
+
     /**
      * Claude 3 Haiku is Anthropic's fastest and most compact model.
      * It's designed for high-throughput, cost-effective applications where speed is a priority.
@@ -76,7 +78,7 @@ public object AnthropicModels : LLModelDefinitions {
             LLMCapability.Vision.Image,
             LLMCapability.Document,
             LLMCapability.Completion,
-        ),
+        ) + thinkingCapabilities,
         contextLength = 200_000,
         maxOutputTokens = 64_000,
     )
@@ -100,7 +102,7 @@ public object AnthropicModels : LLModelDefinitions {
             LLMCapability.Vision.Image,
             LLMCapability.Document,
             LLMCapability.Completion
-        ),
+        ) + thinkingCapabilities,
         contextLength = 200_000,
         maxOutputTokens = 64_000,
     )
@@ -125,7 +127,7 @@ public object AnthropicModels : LLModelDefinitions {
             LLMCapability.Vision.Image,
             LLMCapability.Document,
             LLMCapability.Completion,
-        ),
+        ) + thinkingCapabilities,
         contextLength = 200_000,
         maxOutputTokens = 64_000,
     )
@@ -150,7 +152,7 @@ public object AnthropicModels : LLModelDefinitions {
             LLMCapability.Vision.Image,
             LLMCapability.Document,
             LLMCapability.Completion
-        ),
+        ) + thinkingCapabilities,
         contextLength = 200_000,
         maxOutputTokens = 32_000,
     )
@@ -175,7 +177,7 @@ public object AnthropicModels : LLModelDefinitions {
             LLMCapability.Vision.Image,
             LLMCapability.Document,
             LLMCapability.Completion
-        ),
+        ) + thinkingCapabilities,
         contextLength = 200_000,
         maxOutputTokens = 32_000,
     )
@@ -201,7 +203,7 @@ public object AnthropicModels : LLModelDefinitions {
             LLMCapability.Vision.Image,
             LLMCapability.Document,
             LLMCapability.Completion
-        ),
+        ) + thinkingCapabilities,
         contextLength = 200_000,
         maxOutputTokens = 64_000,
     )
@@ -230,7 +232,7 @@ public object AnthropicModels : LLModelDefinitions {
             LLMCapability.Vision.Image,
             LLMCapability.Document,
             LLMCapability.Completion,
-        ),
+        ) + thinkingCapabilities,
         contextLength = 200_000,
         maxOutputTokens = 1_000_000,
     )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicModelsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicModelsTest.kt
@@ -2,11 +2,13 @@ package ai.koog.prompt.executor.clients.anthropic
 
 import ai.koog.prompt.executor.clients.anthropic.models.AnthropicMessageRequest
 import ai.koog.prompt.executor.clients.list
+import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLMProvider
 import io.kotest.matchers.collections.shouldContain
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 import kotlin.test.assertSame
 
 class AnthropicModelsTest {
@@ -69,5 +71,12 @@ class AnthropicModelsTest {
         reflectionModels.forEach { model ->
             models shouldContain model
         }
+    }
+
+    @Test
+    fun `Anthropic extended thinking models should advertise thinking capability`() {
+        assertNotNull(AnthropicModels.Haiku_4_5.capabilities) shouldContain LLMCapability.Thinking
+        assertNotNull(AnthropicModels.Sonnet_4.capabilities) shouldContain LLMCapability.Thinking
+        assertNotNull(AnthropicModels.Opus_4_6.capabilities) shouldContain LLMCapability.Thinking
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -73,6 +73,7 @@ import kotlin.uuid.Uuid
  *
  * @property baseUrl The base URL for the Google AI API.
  * @property timeoutConfig Timeout configuration for API requests.
+ * @property fallbackThoughtSignature Default `thought_signature` used for thinking models
  */
 public class GoogleClientSettings(
     public val baseUrl: String = "https://generativelanguage.googleapis.com",
@@ -80,7 +81,8 @@ public class GoogleClientSettings(
     public val defaultPath: String = "v1beta/models",
     public val generateContentMethod: String = "generateContent",
     public val streamGenerateContentMethod: String = "streamGenerateContent",
-    public val embedContentMethod: String = "embedContent"
+    public val embedContentMethod: String = "embedContent",
+    public val fallbackThoughtSignature: String = "context_engineering_is_the_way_to_go",
 )
 
 /**
@@ -389,7 +391,7 @@ public open class GoogleLLMClient @JvmOverloads constructor(
                     // If no signature is available from a Reasoning message, use the official workaround dummy signature.
                     // See: https://ai.google.dev/gemini-api/docs/thought-signatures
                     val effectiveSignature = signature ?: if (isThinkingModel) {
-                        "context_engineering_is_the_way_to_go"
+                        settings.fallbackThoughtSignature
                     } else {
                         null
                     }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -295,6 +295,7 @@ public open class GoogleLLMClient @JvmOverloads constructor(
         val pendingCalls = mutableListOf<GooglePart.FunctionCall>()
         val pendingResults = mutableListOf<GooglePart.FunctionResponse>()
         var lastSignature: String? = null
+        val isThinkingModel = model.supports(LLMCapability.Thinking)
 
         fun flushCalls() {
             if (pendingCalls.isNotEmpty()) {
@@ -384,13 +385,22 @@ public open class GoogleLLMClient @JvmOverloads constructor(
                     val signature = lastSignature
                     lastSignature = null // Consume: only first call gets the signature
 
+                    // For thinking models (e.g., Gemini 3), thought_signature is required for all function calls.
+                    // If no signature is available from a Reasoning message, use the official workaround dummy signature.
+                    // See: https://ai.google.dev/gemini-api/docs/thought-signatures
+                    val effectiveSignature = signature ?: if (isThinkingModel) {
+                        "context_engineering_is_the_way_to_go"
+                    } else {
+                        null
+                    }
+
                     pendingCalls += GooglePart.FunctionCall(
                         functionCall = GoogleData.FunctionCall(
                             id = message.id,
                             name = message.tool,
                             args = json.decodeFromString(message.content)
                         ),
-                        thoughtSignature = signature
+                        thoughtSignature = effectiveSignature
                     )
                 }
             }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -470,8 +470,11 @@ public open class GoogleLLMClient @JvmOverloads constructor(
 
         val functionCallingConfig = when (val toolChoice = googleParams.toolChoice) {
             LLMParams.ToolChoice.Auto -> GoogleFunctionCallingConfig(GoogleFunctionCallingMode.AUTO)
+
             LLMParams.ToolChoice.None -> GoogleFunctionCallingConfig(GoogleFunctionCallingMode.NONE)
+
             LLMParams.ToolChoice.Required -> GoogleFunctionCallingConfig(GoogleFunctionCallingMode.ANY)
+
             is LLMParams.ToolChoice.Named -> {
                 GoogleFunctionCallingConfig(
                     GoogleFunctionCallingMode.ANY,
@@ -506,6 +509,7 @@ public open class GoogleLLMClient @JvmOverloads constructor(
 
                         val blob: GoogleData.Blob = when (val content = part.content) {
                             is AttachmentContent.Binary -> GoogleData.Blob(part.mimeType, content.asBytes())
+
                             else -> throw IllegalArgumentException(
                                 "Unsupported image attachment content: ${content::class}"
                             )
@@ -521,6 +525,7 @@ public open class GoogleLLMClient @JvmOverloads constructor(
 
                         val blob: GoogleData.Blob = when (val content = part.content) {
                             is AttachmentContent.Binary -> GoogleData.Blob(part.mimeType, content.asBytes())
+
                             else -> throw IllegalArgumentException(
                                 "Unsupported audio attachment content: ${content::class}"
                             )
@@ -536,6 +541,7 @@ public open class GoogleLLMClient @JvmOverloads constructor(
 
                         val blob: GoogleData.Blob = when (val content = part.content) {
                             is AttachmentContent.Binary -> GoogleData.Blob(part.mimeType, content.asBytes())
+
                             else -> throw IllegalArgumentException(
                                 "Unsupported file attachment content: ${content::class}"
                             )
@@ -551,6 +557,7 @@ public open class GoogleLLMClient @JvmOverloads constructor(
 
                         val blob: GoogleData.Blob = when (val content = part.content) {
                             is AttachmentContent.Binary -> GoogleData.Blob(part.mimeType, content.asBytes())
+
                             else -> throw IllegalArgumentException(
                                 "Unsupported video attachment content: ${content::class}"
                             )
@@ -577,9 +584,13 @@ public open class GoogleLLMClient @JvmOverloads constructor(
         fun JsonObjectBuilder.putType(type: ToolParameterType) {
             when (type) {
                 ToolParameterType.Boolean -> put("type", "boolean")
+
                 ToolParameterType.Float -> put("type", "number")
+
                 ToolParameterType.Integer -> put("type", "integer")
+
                 ToolParameterType.String -> put("type", "string")
+
                 ToolParameterType.Null -> put("type", "null")
 
                 is ToolParameterType.Enum -> {
@@ -716,6 +727,7 @@ public open class GoogleLLMClient @JvmOverloads constructor(
         return when {
             // When the model calls tools, keep Reasoning (for signature) and Tool.Call, filter out Assistant text
             responses.any { it is Message.Tool.Call } -> responses.filter { it is Message.Reasoning || it is Message.Tool.Call }
+
             // If no messages where returned, return an empty message and check finishReason
             responses.isEmpty() -> listOf(
                 Message.Assistant(
@@ -724,6 +736,7 @@ public open class GoogleLLMClient @JvmOverloads constructor(
                     metaInfo = metaInfo
                 )
             )
+
             // Just return responses
             else -> responses
         }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleModels.kt
@@ -196,7 +196,7 @@ public object GoogleModels : LLModelDefinitions {
     public val Gemini3_Pro_Preview: LLModel = LLModel(
         provider = LLMProvider.Google,
         id = "gemini-3-pro-preview",
-        capabilities = fullCapabilities,
+        capabilities = fullCapabilities + LLMCapability.Thinking,
         contextLength = 1_048_576,
         maxOutputTokens = 65_536,
     )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleModels.kt
@@ -178,7 +178,7 @@ public object GoogleModels : LLModelDefinitions {
     public val Gemini3_Flash_Preview: LLModel = LLModel(
         provider = LLMProvider.Google,
         id = "gemini-3-flash-preview",
-        capabilities = fullCapabilities,
+        capabilities = fullCapabilities + LLMCapability.Thinking,
         contextLength = 1_048_576,
         maxOutputTokens = 65_536,
     )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
@@ -420,7 +420,7 @@ class GoogleLLMClientTest {
     }
 
     @Test
-    fun `createGoogleRequest attaches signature from Reasoning to first call only`() {
+    fun `createGoogleRequest attaches signature from Reasoning and fallback to subsequent calls`() {
         val client = GoogleLLMClient(apiKey = "test")
         val request = client.createGoogleRequest(
             Prompt(
@@ -442,8 +442,30 @@ class GoogleLLMClientTest {
         val fc1 = callsParts[0] as GooglePart.FunctionCall
         val fc2 = callsParts[1] as GooglePart.FunctionCall
 
-        fc1.thoughtSignature shouldBe "my-sig" // First gets signature
-        fc2.thoughtSignature shouldBe null // Second doesn't
+        fc1.thoughtSignature shouldBe "my-sig"
+        fc2.thoughtSignature shouldBe "context_engineering_is_the_way_to_go"
+    }
+
+    @Test
+    fun `createGoogleRequest uses configurable fallback thought signature`() {
+        val client = GoogleLLMClient(
+            apiKey = "test",
+            settings = GoogleClientSettings(fallbackThoughtSignature = "custom-fallback")
+        )
+        val request = client.createGoogleRequest(
+            Prompt(
+                messages = listOf(
+                    Message.User("query", RequestMetaInfo.Empty),
+                    Message.Tool.Call(id = "1", tool = "t1", content = "{}", metaInfo = ResponseMetaInfo.Empty),
+                ),
+                id = "id"
+            ),
+            GoogleModels.Gemini3_Pro_Preview,
+            emptyList()
+        )
+
+        val call = request.contents[1].parts!!.single() as GooglePart.FunctionCall
+        call.thoughtSignature shouldBe "custom-fallback"
     }
 
     @Test

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleModelsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleModelsTest.kt
@@ -2,6 +2,7 @@ package ai.koog.prompt.executor.clients.google
 
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.list
+import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.message.Message
 import io.kotest.matchers.collections.shouldContain
@@ -15,6 +16,7 @@ import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertSame
 
 // "Bad" request from Gemini with missing `parts` field
@@ -62,7 +64,7 @@ class GoogleModelsTest {
 
     @Test
     fun `Test when FLASH_2_5 returns no parts GoogleLLMClient does not fail`() = runTest {
-        val mockEngine = MockEngine { request ->
+        val mockEngine = MockEngine { _ ->
             respond(
                 content = ByteReadChannel(badRequest),
                 status = HttpStatusCode.OK,
@@ -100,5 +102,11 @@ class GoogleModelsTest {
         reflectionModels.forEach { model ->
             models shouldContain model
         }
+    }
+
+    @Test
+    fun `Gemini 3 preview models should advertise thinking capability`() {
+        assertNotNull(GoogleModels.Gemini3_Pro_Preview.capabilities) shouldContain LLMCapability.Thinking
+        assertNotNull(GoogleModels.Gemini3_Flash_Preview.capabilities) shouldContain LLMCapability.Thinking
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIModels.kt
@@ -48,6 +48,8 @@ import kotlin.jvm.JvmField
  * | [Moderation.Omni]                | Medium    | $4.40              | Text                         | Moderation Result            |
  */
 public object OpenAIModels : LLModelDefinitions {
+    private val reasoningCapabilities: List<LLMCapability> = listOf(LLMCapability.Thinking)
+
     // TODO: support thinking tokens
     /**
      * Object containing moderation models designed to detect harmful content in text and images.
@@ -273,7 +275,7 @@ public object OpenAIModels : LLModelDefinitions {
                 LLMCapability.MultipleChoices,
                 LLMCapability.OpenAIEndpoint.Completions,
                 LLMCapability.OpenAIEndpoint.Responses,
-            ),
+            ) + reasoningCapabilities,
             contextLength = 200_000,
             maxOutputTokens = 100_000,
         )
@@ -307,7 +309,7 @@ public object OpenAIModels : LLModelDefinitions {
                 LLMCapability.MultipleChoices,
                 LLMCapability.OpenAIEndpoint.Completions,
                 LLMCapability.OpenAIEndpoint.Responses,
-            ),
+            ) + reasoningCapabilities,
             contextLength = 200_000,
             maxOutputTokens = 100_000,
         )
@@ -339,7 +341,7 @@ public object OpenAIModels : LLModelDefinitions {
                 LLMCapability.MultipleChoices,
                 LLMCapability.OpenAIEndpoint.Completions,
                 LLMCapability.OpenAIEndpoint.Responses,
-            ),
+            ) + reasoningCapabilities,
             contextLength = 200_000,
             maxOutputTokens = 100_000,
         )
@@ -373,7 +375,7 @@ public object OpenAIModels : LLModelDefinitions {
                 LLMCapability.MultipleChoices,
                 LLMCapability.OpenAIEndpoint.Completions,
                 LLMCapability.OpenAIEndpoint.Responses,
-            ),
+            ) + reasoningCapabilities,
             contextLength = 200_000,
             maxOutputTokens = 100_000,
         )
@@ -404,7 +406,7 @@ public object OpenAIModels : LLModelDefinitions {
                 LLMCapability.MultipleChoices,
                 LLMCapability.OpenAIEndpoint.Completions,
                 LLMCapability.OpenAIEndpoint.Responses,
-            ),
+            ) + reasoningCapabilities,
             contextLength = 400_000,
             maxOutputTokens = 128_000,
         )
@@ -435,7 +437,7 @@ public object OpenAIModels : LLModelDefinitions {
                 LLMCapability.MultipleChoices,
                 LLMCapability.OpenAIEndpoint.Completions,
                 LLMCapability.OpenAIEndpoint.Responses,
-            ),
+            ) + reasoningCapabilities,
             contextLength = 400_000,
             maxOutputTokens = 128_000,
         )
@@ -467,7 +469,7 @@ public object OpenAIModels : LLModelDefinitions {
                 LLMCapability.MultipleChoices,
                 LLMCapability.OpenAIEndpoint.Completions,
                 LLMCapability.OpenAIEndpoint.Responses,
-            ),
+            ) + reasoningCapabilities,
             contextLength = 400_000,
             maxOutputTokens = 128_000,
         )
@@ -494,7 +496,7 @@ public object OpenAIModels : LLModelDefinitions {
                 LLMCapability.Tools,
                 LLMCapability.ToolChoice,
                 LLMCapability.OpenAIEndpoint.Responses,
-            ),
+            ) + reasoningCapabilities,
             contextLength = 400_000,
             maxOutputTokens = 128_000,
         )
@@ -526,7 +528,7 @@ public object OpenAIModels : LLModelDefinitions {
                 LLMCapability.Vision.Image,
                 LLMCapability.MultipleChoices,
                 LLMCapability.OpenAIEndpoint.Responses,
-            ),
+            ) + reasoningCapabilities,
             contextLength = 400_000,
             maxOutputTokens = 272_000,
         )
@@ -557,7 +559,7 @@ public object OpenAIModels : LLModelDefinitions {
                 LLMCapability.MultipleChoices,
                 LLMCapability.OpenAIEndpoint.Completions,
                 LLMCapability.OpenAIEndpoint.Responses,
-            ),
+            ) + reasoningCapabilities,
             contextLength = 400_000,
             maxOutputTokens = 128_000,
         )
@@ -588,7 +590,7 @@ public object OpenAIModels : LLModelDefinitions {
                 LLMCapability.Document,
                 LLMCapability.MultipleChoices,
                 LLMCapability.OpenAIEndpoint.Responses,
-            ),
+            ) + reasoningCapabilities,
             contextLength = 400_000,
             maxOutputTokens = 128_000,
         )
@@ -619,7 +621,7 @@ public object OpenAIModels : LLModelDefinitions {
                 LLMCapability.Document,
                 LLMCapability.MultipleChoices,
                 LLMCapability.OpenAIEndpoint.Responses,
-            ),
+            ) + reasoningCapabilities,
             contextLength = 400_000,
             maxOutputTokens = 128_000,
         )
@@ -651,7 +653,7 @@ public object OpenAIModels : LLModelDefinitions {
                 LLMCapability.MultipleChoices,
                 LLMCapability.OpenAIEndpoint.Completions,
                 LLMCapability.OpenAIEndpoint.Responses,
-            ),
+            ) + reasoningCapabilities,
             contextLength = 400_000,
             maxOutputTokens = 128_000,
         )
@@ -681,7 +683,7 @@ public object OpenAIModels : LLModelDefinitions {
                 LLMCapability.Document,
                 LLMCapability.MultipleChoices,
                 LLMCapability.OpenAIEndpoint.Responses,
-            ),
+            ) + reasoningCapabilities,
             contextLength = 400_000,
             maxOutputTokens = 128_000,
         )
@@ -710,7 +712,7 @@ public object OpenAIModels : LLModelDefinitions {
                 LLMCapability.Document,
                 LLMCapability.MultipleChoices,
                 LLMCapability.OpenAIEndpoint.Responses,
-            ),
+            ) + reasoningCapabilities,
             contextLength = 400_000,
             maxOutputTokens = 128_000,
         )
@@ -770,7 +772,7 @@ public object OpenAIModels : LLModelDefinitions {
                 LLMCapability.OpenAIEndpoint.Completions,
                 LLMCapability.OpenAIEndpoint.Responses,
                 // ToDo add Batch endpoint as well, see KG-719
-            ),
+            ) + reasoningCapabilities,
             contextLength = 1_050_000,
             maxOutputTokens = 128_000,
         )
@@ -803,7 +805,7 @@ public object OpenAIModels : LLModelDefinitions {
                 LLMCapability.Document,
                 LLMCapability.MultipleChoices,
                 LLMCapability.OpenAIEndpoint.Responses,
-            ),
+            ) + reasoningCapabilities,
             contextLength = 1_050_000,
             maxOutputTokens = 128_000,
         )
@@ -986,59 +988,60 @@ public object OpenAIModels : LLModelDefinitions {
     /**
      * List of the supported models by the OpenAI provider.
      */
-    private val supportedModels: List<LLModel> = listOf(
-        // Chat Models - GPT-4 Series
-        Chat.GPT4o,
-        Chat.GPT4oMini,
+    private val supportedModels: List<LLModel>
+        get() = listOf(
+            // Chat Models - GPT-4 Series
+            Chat.GPT4o,
+            Chat.GPT4oMini,
 
-        // Chat Models - GPT-4.1 Series
-        Chat.GPT4_1,
-        Chat.GPT4_1Nano,
-        Chat.GPT4_1Mini,
+            // Chat Models - GPT-4.1 Series
+            Chat.GPT4_1,
+            Chat.GPT4_1Nano,
+            Chat.GPT4_1Mini,
 
-        // Chat Models - O Series (Reasoning)
-        Chat.O1,
-        Chat.O3,
-        Chat.O3Mini,
-        Chat.O4Mini,
+            // Chat Models - O Series (Reasoning)
+            Chat.O1,
+            Chat.O3,
+            Chat.O3Mini,
+            Chat.O4Mini,
 
-        // Chat Models - GPT-5 Series
-        Chat.GPT5,
-        Chat.GPT5Mini,
-        Chat.GPT5Nano,
-        Chat.GPT5Codex,
-        Chat.GPT5Pro,
+            // Chat Models - GPT-5 Series
+            Chat.GPT5,
+            Chat.GPT5Mini,
+            Chat.GPT5Nano,
+            Chat.GPT5Codex,
+            Chat.GPT5Pro,
 
-        // Chat Models - GPT-5.1 Series
-        Chat.GPT5_1,
-        Chat.GPT5_1Codex,
-        Chat.GPT5_1CodexMax,
+            // Chat Models - GPT-5.1 Series
+            Chat.GPT5_1,
+            Chat.GPT5_1Codex,
+            Chat.GPT5_1CodexMax,
 
-        // Chat Models - GPT-5.2 Series
-        Chat.GPT5_2,
-        Chat.GPT5_2Pro,
-        Chat.GPT5_2Codex,
+            // Chat Models - GPT-5.2 Series
+            Chat.GPT5_2,
+            Chat.GPT5_2Pro,
+            Chat.GPT5_2Codex,
 
-        // Chat Models - GPT-5.3 Series
-        Chat.GPT5_3Codex,
+            // Chat Models - GPT-5.3 Series
+            Chat.GPT5_3Codex,
 
-        // Chat Models - GPT-5.4 Series
-        Chat.GPT5_4,
-        Chat.GPT5_4Pro,
+            // Chat Models - GPT-5.4 Series
+            Chat.GPT5_4,
+            Chat.GPT5_4Pro,
 
-        // Audio Models
-        Audio.GptAudio,
-        Audio.GPT4oMiniAudio,
-        Audio.GPT4oAudio,
+            // Audio Models
+            Audio.GptAudio,
+            Audio.GPT4oMiniAudio,
+            Audio.GPT4oAudio,
 
-        // Embedding Models
-        Embeddings.TextEmbedding3Small,
-        Embeddings.TextEmbedding3Large,
-        Embeddings.TextEmbeddingAda002,
+            // Embedding Models
+            Embeddings.TextEmbedding3Small,
+            Embeddings.TextEmbedding3Large,
+            Embeddings.TextEmbeddingAda002,
 
-        // Moderation Models
-        Moderation.Omni,
-    )
+            // Moderation Models
+            Moderation.Omni,
+        )
 
     /**
      * List of custom models added to the OpenAI provider.

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIModelsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIModelsTest.kt
@@ -1,10 +1,12 @@
 package ai.koog.prompt.executor.clients.openai
 
 import ai.koog.prompt.executor.clients.list
+import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLMProvider
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
+import kotlin.test.assertNotNull
 
 class OpenAIModelsTest {
 
@@ -28,5 +30,15 @@ class OpenAIModelsTest {
         reflectionModels.forEach { model ->
             models shouldContain model
         }
+    }
+
+    @Test
+    fun `reasoning OpenAI models should advertise thinking capability`() {
+        assertNotNull(OpenAIModels.Chat.O1.capabilities) shouldContain LLMCapability.Thinking
+        assertNotNull(OpenAIModels.Chat.O3.capabilities) shouldContain LLMCapability.Thinking
+        assertNotNull(OpenAIModels.Chat.O3Mini.capabilities) shouldContain LLMCapability.Thinking
+        assertNotNull(OpenAIModels.Chat.O4Mini.capabilities) shouldContain LLMCapability.Thinking
+        assertNotNull(OpenAIModels.Chat.GPT5.capabilities) shouldContain LLMCapability.Thinking
+        assertNotNull(OpenAIModels.Chat.GPT5_4.capabilities) shouldContain LLMCapability.Thinking
     }
 }

--- a/prompt/prompt-llm/src/commonMain/kotlin/ai/koog/prompt/llm/LLMCapability.kt
+++ b/prompt/prompt-llm/src/commonMain/kotlin/ai/koog/prompt/llm/LLMCapability.kt
@@ -153,6 +153,18 @@ public sealed class LLMCapability(public val id: String) {
     public data object Moderation : LLMCapability("moderation")
 
     /**
+     * Represents the thinking/reasoning capability of a language model.
+     *
+     * This capability indicates that the model supports exposing its chain-of-thought reasoning
+     * and uses thought signatures to maintain reasoning context across multi-step interactions.
+     * Models with this capability may require thought_signature in function calls.
+     *
+     * Examples: Gemini 3.0 models, o1-series models.
+     */
+    @Serializable
+    public data object Thinking : LLMCapability("thinking")
+
+    /**
      * Represents a structured schema capability for a language model. The schema defines certain characteristics or
      * functionalities related to data interaction and encoding using specific formats.
      *


### PR DESCRIPTION

<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->
- Create and enable thinking capability for Gemini 3 models;
- Integrate thought signature handling in the Google LLM client's logic.

<!-- Include BREAKING section below only if this PR introduces breaking changes. Otherwise, delete it. -->
BREAKING:
* none

<!-- Include DEPRECATED section below only if this PR deprecates any public APIs. Otherwise, delete it. -->
DEPRECATED:
* none

<!-- Include references to related issues below, e.g., closes #1, closes KG-1. Otherwise, delete it. -->
closes [KG-722](https://youtrack.jetbrains.com/issue/KG-722) Google LLM client: Function call is missing a thought_signature in functionCall parts
