### PR TITLE
docs: update wording in Overview, Quickstart, and Agents

### DIFF
--- a/docs/docs/agents/basic-agents.md
+++ b/docs/docs/agents/basic-agents.md
@@ -73,8 +73,8 @@ and provide a [prompt executor](../prompts/prompt-executors.md) with a [language
         .build();
     ```
 
-    This agent will expect a string as input and return a string as output.
-    To run the agent, use the `run()` function with some user input:
+    This agent expects a string as input and returns a string as output.
+    To run the agent, use the `run()` method with some user input:
 
     ```java
     String result = agent.run("Hello! How can you help me?");
@@ -155,8 +155,8 @@ What's on your mind? Are you trying to understand a specific meme, need help fin
 
 ## Configure LLM output
 
-You can provide some [LLM parameters](../llm-parameters.md#llm-parameter-reference) directly to the agent constructor
-to customize the behavior of the LLM.
+You can provide some [LLM parameters](../llm-parameters.md#llm-parameter-reference) directly to the agent constructor 
+(Kotlin) or via the builder methods (Java) to customize the behavior of the LLM.
 For example, use the `temperature` parameter to adjust the randomness of the generated responses:
 
 === "Kotlin"
@@ -234,7 +234,7 @@ Here are some response examples with different temperature values:
 
 Agents can use [tools](../tools-overview.md) to perform specific tasks.
 
-First, create a tool by annotating a function with the [`@Tool`](https://api.koog.ai/agents/agents-tools/ai.koog.agents.core.tools.annotations/-tool/index.html) annotation:
+First, create a tool by annotating a function (Kotlin) or method (Java) with the [`@Tool`](https://api.koog.ai/agents/agents-tools/ai.koog.agents.core.tools.annotations/-tool/index.html) annotation:
 
 === "Kotlin"
 
@@ -406,13 +406,6 @@ For example, a simple agent described here is not likely to require more than 10
     ```
     <!--- KNIT example-basic-04.kt -->
 
-    !!! tip
-
-        Instead of passing the model, temperature, max iterations,
-        and other parameters directly to the agent constructor,
-        you can also define and pass them as a separate configuration object.
-        For more information, see [Agent configuration](index.md#agent-configuration).
-
 === "Java"
 
     <!--- INCLUDE
@@ -467,6 +460,12 @@ For example, a simple agent described here is not likely to require more than 10
     ```
     <!--- KNIT exampleBasicJava05.java -->
 
+!!! tip
+
+    Instead of passing the model, temperature, max iterations, and other parameters directly to the Kotlin constructor 
+    or Java builder, you can also define and pass them as a separate configuration object.
+    For more information, see [Agent configuration](index.md#agent-configuration).
+
 ## Handle events during agent runtime
 
 To assist with testing and debugging, as well as making hooks for chained agent interactions,
@@ -517,6 +516,7 @@ Koog provides the [EventHandler](https://api.koog.ai/agents/agents-features/agen
     <!--- KNIT example-basic-05.kt -->
 
 === "Java"
+    Use the `.install()` method on the agent builder to register event handlers with `EventHandler.Feature`:
 
     <!--- INCLUDE
     import ai.koog.agents.core.agent.AIAgent;

--- a/docs/docs/agents/functional-agents.md
+++ b/docs/docs/agents/functional-agents.md
@@ -22,11 +22,10 @@ This page describes how to implement a functional strategy to quickly prototype 
 
 ## Create a minimal functional agent
 
-To create a minimal functional agent,
-use the same [`AIAgent`](https://api.koog.ai/agents/agents-core/ai.koog.agents.core.agent/-a-i-agent/index.html) interface
-as for a [basic agent](basic-agents.md)
-and pass an instance of [`AIAgentFunctionalStrategy`](https://api.koog.ai/agents/agents-core/ai.koog.agents.core.agent/-a-i-agent-functional-strategy/index.html) to it.
-You can define a functional strategy that expects a string input and returns a string output, makes one LLM call, then returns the content of the assistant message from the response.
+To create a minimal functional agent, use the same [`AIAgent`](https://api.koog.ai/agents/agents-core/ai.koog.agents.core.agent/-a-i-agent/index.html) interface as for a [basic agent](basic-agents.md) and pass an 
+instance of [`AIAgentFunctionalStrategy`](https://api.koog.ai/agents/agents-core/ai.koog.agents.core.agent/-a-i-agent-functional-strategy/index.html) to it.
+You can define a functional strategy that expects an input and returns an output, makes one LLM call, then returns the 
+content of the assistant message from the response.
 
 In Kotlin, the most convenient way is to use the `functionalStrategy {...}` DSL method. In Java, you can use the `functionalStrategy` method on the `AIAgent` builder.
 

--- a/docs/docs/agents/functional-agents.md
+++ b/docs/docs/agents/functional-agents.md
@@ -26,10 +26,9 @@ To create a minimal functional agent,
 use the same [`AIAgent`](https://api.koog.ai/agents/agents-core/ai.koog.agents.core.agent/-a-i-agent/index.html) interface
 as for a [basic agent](basic-agents.md)
 and pass an instance of [`AIAgentFunctionalStrategy`](https://api.koog.ai/agents/agents-core/ai.koog.agents.core.agent/-a-i-agent-functional-strategy/index.html) to it.
-The most convenient way is to use the `functionalStrategy {...}` DSL method.
+You can define a functional strategy that expects a string input and returns a string output, makes one LLM call, then returns the content of the assistant message from the response.
 
-For example, here is how to define a functional strategy that expects a string input and returns a string output,
-makes one LLM call, then returns the content of the assistant message from the response.
+In Kotlin, the most convenient way is to use the `functionalStrategy {...}` DSL method. In Java, you can use the `functionalStrategy` method on the `AIAgent` builder.
 
 === "Kotlin"
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,9 +1,9 @@
 # Overview
 
-Koog is an open-source JetBrains framework for building AI agents with an idiomatic, type-safe Kotlin DSL designed specifically for JVM and Kotlin developers.
-It lets you create agents that interact with tools, handle complex workflows, and communicate with users.
+Koog is an open-source JetBrains framework for building AI agents designed specifically for the JVM ecosystem.
+It provides a first-class development experience for both Kotlin and Java developers, featuring an idiomatic, type-safe Kotlin DSL and fluent builder-style Java APIs.
 
-You can customize agent capabilities with a modular feature system and deploy your agents across JVM, JS, WasmJS, Android, and iOS targets using Kotlin Multiplatform.
+While Java developers can leverage the full power of Koog on the JVM using idiomatic APIs, Kotlin developers can also deploy agents across JS, WasmJS, Android, and iOS targets using Kotlin Multiplatform.
 
 <div class="grid cards" markdown>
 
@@ -37,7 +37,7 @@ Learn about [agents in general](agents/index.md) and how to create different typ
 
     ---
 
-    Define custom logic as a lambda function in plain Kotlin 
+    Define custom logic as a lambda function in plain Kotlin or Java
 
 -   :material-state-machine:{ .lg .middle } [**Graph-based agents**](agents/graph-based-agents.md)
 

--- a/docs/docs/key-features.md
+++ b/docs/docs/key-features.md
@@ -2,13 +2,13 @@
 
 Key features of Koog include:
 
-- **Multiplatform development**: Deploy agents across JVM, JS, WasmJS, Android, and iOS targets using Kotlin Multiplatform.
+- **Idiomatic Kotlin and Java support**: Choose between a type-safe Kotlin DSL or a dedicated, fluent Java builder API. The Java API is designed to feel natural to Java teams, using standard thread pool executors instead of exposing coroutines.
 - **Reliability and fault-tolerance**: Handle failures with built-in retries and restore the agent state at specific points during execution with the agent persistence feature.
 - **Intelligent history compression**: Optimize token usage while maintaining context in long-running conversations using advanced built-in history compression techniques.
 - **Enterprise-ready integrations**: Utilize integration with popular JVM frameworks such as Spring Boot and Ktor to embed Koog into your applications.
 - **Observability with OpenTelemetry exporters**: Monitor and debug applications with built-in support for popular observability providers (W&B Weave, Langfuse).
-- **LLM switching and seamless history adaptation**: Switch to a different LLM at any point without losing the existing conversation history, or reroute between multiple LLM providers.
-- **Integration with JVM and Kotlin applications**: Build AI agents with an idiomatic, type-safe Kotlin DSL designed specifically for JVM and Kotlin developers.
+- **LLM switching and seamless history adaptation**: Switch to a different LLM at any point without losing the existing conversation history or reroute between multiple LLM providers.
+- **Multiplatform development**: For agents written in Kotlin, deploy agents across JVM, JS, WasmJS, Android, and iOS targets using Kotlin Multiplatform.
 - **Model Context Protocol integration**: Use Model Context Protocol (MCP) tools in AI agents.
 - **Knowledge retrieval and memory**: Retain and retrieve knowledge across conversations using vector embeddings, ranked document storage, and shared agent memory.
 - **Powerful Streaming API**: Process responses in real-time with streaming support and parallel tool calls.


### PR DESCRIPTION
Update wording to account for Java code snippets and the general availability of the Java API. 

First PR in the scope of KG-666 😈
