### PR TITLE
docs: update docs about Spring Boot integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ env.properties
 local.properties
 **/kotlin-js-store
 docs/src/main/kotlin/*.kt
+docs/docs-code-snippets/*.java
 **/.env
 .venv
 .DS_Store

--- a/docs/docs/agent-event-handlers.md
+++ b/docs/docs/agent-event-handlers.md
@@ -29,53 +29,22 @@ which provides a way to register callbacks for different agent events, and can b
 
 To install the feature and configure event handlers for the agent, do the following:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.features.eventHandler.feature.handleEvents
-import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
-import ai.koog.prompt.executor.ollama.client.OllamaModels
+=== "Kotlin"
 
-val agent = AIAgent(
-    promptExecutor = simpleOllamaAIExecutor(),
-    llmModel = OllamaModels.Meta.LLAMA_3_2,
-) {
--->
-<!--- SUFFIX 
-} 
--->
-
-```kotlin
-handleEvents {
-    // Handle tool calls
-    onToolCallStarting { eventContext ->
-        println("Tool called: ${eventContext.toolName} with args ${eventContext.toolArgs}")
-    }
-    // Handle event triggered when the agent completes its execution
-    onAgentCompleted { eventContext ->
-        println("Agent finished with result: ${eventContext.result}")
-    }
-
-    // Other event handlers
-}
-```
-<!--- KNIT example-event-handlers-01.kt -->
-
-For more details about event handler configuration, see [API reference](api:agents-features-event-handler::ai.koog.agents.features.eventHandler.feature.EventHandlerConfig).
-
-You can also set up event handlers using the `handleEvents` extension function when creating an agent.
-This function also installs the event handler feature and configures event handlers for the agent. Here is an example:
-
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.features.eventHandler.feature.handleEvents
-import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
-import ai.koog.prompt.executor.ollama.client.OllamaModels
--->
-```kotlin
-val agent = AIAgent(
-    promptExecutor = simpleOllamaAIExecutor(),
-    llmModel = OllamaModels.Meta.LLAMA_3_2,
-){
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.features.eventHandler.feature.handleEvents
+    import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    val agent = AIAgent(
+        promptExecutor = simpleOllamaAIExecutor(),
+        llmModel = OllamaModels.Meta.LLAMA_3_2,
+    ) {
+    -->
+    <!--- SUFFIX 
+    } 
+    -->
+    ```kotlin
     handleEvents {
         // Handle tool calls
         onToolCallStarting { eventContext ->
@@ -88,6 +57,77 @@ val agent = AIAgent(
 
         // Other event handlers
     }
-}
-```
-<!--- KNIT example-event-handlers-02.kt -->
+    ```
+    <!--- KNIT example-event-handlers-01.kt -->
+
+=== "Java"
+
+    ```java
+    AIAgent<String, String> agent = AIAgent.builder()
+        .promptExecutor(simpleOllamaAIExecutor("http://localhost:11434"))
+        .llmModel(OllamaModels.Meta.LLAMA_3_2)
+        .install(EventHandler.Feature, cfg -> {
+            // Handle tool calls
+            cfg.onToolCallStarting(ctx -> {
+                System.out.println("Tool called: " + ctx.getToolName() + " with args " + ctx.getToolArgs());
+            });
+            // Handle event triggered when the agent completes its execution
+            cfg.onAgentCompleted(ctx -> {
+                System.out.println("Agent finished with result: " + ctx.getResult());
+            });
+        })
+        .build();
+    ```
+
+For more details about event handler configuration, see [API reference](api:agents-features-event-handler::ai.koog.agents.features.eventHandler.feature.EventHandlerConfig).
+
+You can also set up event handlers using the `handleEvents` extension function when creating an agent.
+This function also installs the event handler feature and configures event handlers for the agent. Here is an example:
+
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.features.eventHandler.feature.handleEvents
+    import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    -->
+    ```kotlin
+    val agent = AIAgent(
+        promptExecutor = simpleOllamaAIExecutor(),
+        llmModel = OllamaModels.Meta.LLAMA_3_2,
+    ){
+        handleEvents {
+            // Handle tool calls
+            onToolCallStarting { eventContext ->
+                println("Tool called: ${eventContext.toolName} with args ${eventContext.toolArgs}")
+            }
+            // Handle event triggered when the agent completes its execution
+            onAgentCompleted { eventContext ->
+                println("Agent finished with result: ${eventContext.result}")
+            }
+
+            // Other event handlers
+        }
+    }
+    ```
+    <!--- KNIT example-event-handlers-02.kt -->
+
+=== "Java"
+
+    ```java
+    AIAgent<String, String> agent = AIAgent.builder()
+        .promptExecutor(simpleOllamaAIExecutor("http://localhost:11434"))
+        .llmModel(OllamaModels.Meta.LLAMA_3_2)
+        .install(EventHandler.Feature, cfg -> {
+            // Handle tool calls
+            cfg.onToolCallStarting(ctx -> {
+                System.out.println("Tool called: " + ctx.getToolName() + " with args " + ctx.getToolArgs());
+            });
+            // Handle event triggered when the agent completes its execution
+            cfg.onAgentCompleted(ctx -> {
+                System.out.println("Agent finished with result: " + ctx.getResult());
+            });
+        })
+        .build();
+    ```

--- a/docs/docs/agent-events.md
+++ b/docs/docs/agent-events.md
@@ -378,166 +378,182 @@ The following section includes commonly asked questions and answers related to t
 
 Use the `messageFilter` property to filter events. For example, to trace only node execution:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.feature.model.events.LLMCallCompletedEvent
-import ai.koog.agents.core.feature.model.events.LLMCallStartingEvent
-import ai.koog.agents.example.exampleTracing01.outputPath
-import ai.koog.agents.features.tracing.feature.Tracing
-import ai.koog.agents.features.tracing.writer.TraceFeatureMessageFileWriter
-import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
-import ai.koog.prompt.executor.ollama.client.OllamaModels
-import kotlinx.coroutines.runBlocking
-import kotlinx.io.buffered
-import kotlinx.io.files.Path
-import kotlinx.io.files.SystemFileSystem
+=== "Kotlin"
 
-const val input = "What's the weather like in New York?"
-
-fun main() {
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.feature.model.events.LLMCallCompletedEvent
+    import ai.koog.agents.core.feature.model.events.LLMCallStartingEvent
+    import ai.koog.agents.example.exampleTracing01.outputPath
+    import ai.koog.agents.features.tracing.feature.Tracing
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageFileWriter
+    import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    import kotlinx.coroutines.runBlocking
+    import kotlinx.io.buffered
+    import kotlinx.io.files.Path
+    import kotlinx.io.files.SystemFileSystem
+    const val input = "What's the weather like in New York?"
+    fun main() {
     runBlocking {
-        // Creating an agent
-        val agent = AIAgent(
-            promptExecutor = simpleOllamaAIExecutor(),
-            llmModel = OllamaModels.Meta.LLAMA_3_2,
-        ) {
-            val writer = TraceFeatureMessageFileWriter(
-                outputPath,
-                { path: Path -> SystemFileSystem.sink(path).buffered() }
-            )
--->
-<!--- SUFFIX
+    // Creating an agent
+    val agent = AIAgent(
+    promptExecutor = simpleOllamaAIExecutor(),
+    llmModel = OllamaModels.Meta.LLAMA_3_2,
+    ) {
+    val writer = TraceFeatureMessageFileWriter(
+    outputPath,
+    { path: Path -> SystemFileSystem.sink(path).buffered() }
+    )
+    -->
+    <!--- SUFFIX
+            }
         }
     }
-}
--->
-```kotlin
-install(Tracing) {
-    val fileWriter = TraceFeatureMessageFileWriter(
-        outputPath, 
-        { path: Path -> SystemFileSystem.sink(path).buffered() }
-    )
-    addMessageProcessor(fileWriter)
-    
-    // Only trace LLM calls
-    fileWriter.setMessageFilter { message ->
-        message is LLMCallStartingEvent || message is LLMCallCompletedEvent
+    -->
+    ```kotlin
+    install(Tracing) {
+        val fileWriter = TraceFeatureMessageFileWriter(
+            outputPath, 
+            { path: Path -> SystemFileSystem.sink(path).buffered() }
+        )
+        addMessageProcessor(fileWriter)
+        
+        // Only trace LLM calls
+        fileWriter.setMessageFilter { message ->
+            message is LLMCallStartingEvent || message is LLMCallCompletedEvent
+        }
     }
-}
-```
-<!--- KNIT example-events-01.kt -->
+    ```
+    <!--- KNIT example-events-01.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 ### Can I use multiple message processors?
 
 Yes, you can add multiple message processors to trace to different destinations simultaneously:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.feature.remote.server.config.DefaultServerConnectionConfig
-import ai.koog.agents.example.exampleTracing01.outputPath
-import ai.koog.agents.features.tracing.feature.Tracing
-import ai.koog.agents.features.tracing.writer.TraceFeatureMessageFileWriter
-import ai.koog.agents.features.tracing.writer.TraceFeatureMessageLogWriter
-import ai.koog.agents.features.tracing.writer.TraceFeatureMessageRemoteWriter
-import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
-import ai.koog.prompt.executor.ollama.client.OllamaModels
-import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.runBlocking
-import kotlinx.io.buffered
-import kotlinx.io.files.Path
-import kotlinx.io.files.SystemFileSystem
+=== "Kotlin"
 
-const val input = "What's the weather like in New York?"
-val syncOpener = { path: Path -> SystemFileSystem.sink(path).buffered() }
-val logger = KotlinLogging.logger {}
-val connectionConfig = DefaultServerConnectionConfig(host = ai.koog.agents.example.exampleTracing06.host, port = ai.koog.agents.example.exampleTracing06.port)
-
-fun main() {
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.feature.remote.server.config.DefaultServerConnectionConfig
+    import ai.koog.agents.example.exampleTracing01.outputPath
+    import ai.koog.agents.features.tracing.feature.Tracing
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageFileWriter
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageLogWriter
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageRemoteWriter
+    import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    import io.github.oshai.kotlinlogging.KotlinLogging
+    import kotlinx.coroutines.runBlocking
+    import kotlinx.io.buffered
+    import kotlinx.io.files.Path
+    import kotlinx.io.files.SystemFileSystem
+    const val input = "What's the weather like in New York?"
+    val syncOpener = { path: Path -> SystemFileSystem.sink(path).buffered() }
+    val logger = KotlinLogging.logger {}
+    val connectionConfig = DefaultServerConnectionConfig(host = ai.koog.agents.example.exampleTracing06.host, port = ai.koog.agents.example.exampleTracing06.port)
+    fun main() {
     runBlocking {
-        // Creating an agent
-        val agent = AIAgent(
-            promptExecutor = simpleOllamaAIExecutor(),
-            llmModel = OllamaModels.Meta.LLAMA_3_2,
-        ) {
--->
-<!--- SUFFIX
+    // Creating an agent
+    val agent = AIAgent(
+    promptExecutor = simpleOllamaAIExecutor(),
+    llmModel = OllamaModels.Meta.LLAMA_3_2,
+    ) {
+    -->
+    <!--- SUFFIX
+            }
         }
     }
-}
--->
-```kotlin
-install(Tracing) {
-    addMessageProcessor(TraceFeatureMessageLogWriter(logger))
-    addMessageProcessor(TraceFeatureMessageFileWriter(outputPath, syncOpener))
-    addMessageProcessor(TraceFeatureMessageRemoteWriter(connectionConfig))
-}
-```
-<!--- KNIT example-events-02.kt -->
+    -->
+    ```kotlin
+    install(Tracing) {
+        addMessageProcessor(TraceFeatureMessageLogWriter(logger))
+        addMessageProcessor(TraceFeatureMessageFileWriter(outputPath, syncOpener))
+        addMessageProcessor(TraceFeatureMessageRemoteWriter(connectionConfig))
+    }
+    ```
+    <!--- KNIT example-events-02.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 ### How can I create a custom message processor?
 
 Implement the `FeatureMessageProcessor` interface:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.feature.model.events.NodeExecutionStartingEvent
-import ai.koog.agents.core.feature.model.events.LLMCallCompletedEvent
-import ai.koog.agents.core.feature.message.FeatureMessage
-import ai.koog.agents.core.feature.message.FeatureMessageProcessor
-import ai.koog.agents.features.tracing.feature.Tracing
-import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
-import ai.koog.prompt.executor.ollama.client.OllamaModels
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+=== "Kotlin"
 
-fun main() {
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.feature.model.events.NodeExecutionStartingEvent
+    import ai.koog.agents.core.feature.model.events.LLMCallCompletedEvent
+    import ai.koog.agents.core.feature.message.FeatureMessage
+    import ai.koog.agents.core.feature.message.FeatureMessageProcessor
+    import ai.koog.agents.features.tracing.feature.Tracing
+    import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    import kotlinx.coroutines.runBlocking
+    import kotlinx.coroutines.flow.MutableStateFlow
+    import kotlinx.coroutines.flow.StateFlow
+    import kotlinx.coroutines.flow.asStateFlow
+    fun main() {
     runBlocking {
-        // Creating an agent
-        val agent = AIAgent(
-            promptExecutor = simpleOllamaAIExecutor(),
-            llmModel = OllamaModels.Meta.LLAMA_3_2,
-        ) {
--->
-<!--- SUFFIX
+    // Creating an agent
+    val agent = AIAgent(
+    promptExecutor = simpleOllamaAIExecutor(),
+    llmModel = OllamaModels.Meta.LLAMA_3_2,
+    ) {
+    -->
+    <!--- SUFFIX
+            }
         }
     }
-}
--->
-```kotlin
-class CustomTraceProcessor : FeatureMessageProcessor() {
+    -->
+    ```kotlin
+    class CustomTraceProcessor : FeatureMessageProcessor() {
 
-    // Current open state of the processor
-    private var _isOpen = MutableStateFlow(false)
+        // Current open state of the processor
+        private var _isOpen = MutableStateFlow(false)
 
-    override val isOpen: StateFlow<Boolean>
-        get() = _isOpen.asStateFlow()
-    
-    override suspend fun processMessage(message: FeatureMessage) {
-        // Custom processing logic
-        when (message) {
-            is NodeExecutionStartingEvent -> {
-                // Process node start event
+        override val isOpen: StateFlow<Boolean>
+            get() = _isOpen.asStateFlow()
+        
+        override suspend fun processMessage(message: FeatureMessage) {
+            // Custom processing logic
+            when (message) {
+                is NodeExecutionStartingEvent -> {
+                    // Process node start event
+                }
+
+                is LLMCallCompletedEvent -> {
+                    // Process LLM call end event 
+                }
+                // Handle other event types 
             }
+        }
 
-            is LLMCallCompletedEvent -> {
-                // Process LLM call end event 
-            }
-            // Handle other event types 
+        override suspend fun close() {
+            // Close connections of established
         }
     }
 
-    override suspend fun close() {
-        // Close connections of established
+    // Use your custom processor
+    install(Tracing) {
+        addMessageProcessor(CustomTraceProcessor())
     }
-}
+    ```
+    <!--- KNIT example-events-03.kt -->
 
-// Use your custom processor
-install(Tracing) {
-    addMessageProcessor(CustomTraceProcessor())
-}
-```
-<!--- KNIT example-events-03.kt -->
+=== "Java"
+
+    ```java
+    ```
 
 For more information about existing event types that can be handled by message processors, see [Predefined event types](#predefined-event-types).

--- a/docs/docs/agent-persistence.md
+++ b/docs/docs/agent-persistence.md
@@ -24,30 +24,43 @@ Checkpoints are identified by unique IDs and are associated with a specific agen
 
 To use the Agent Persistence feature, add it to your agent's configuration:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.snapshot.feature.Persistence
-import ai.koog.agents.snapshot.providers.InMemoryPersistenceStorageProvider
-import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
-import ai.koog.prompt.executor.ollama.client.OllamaModels
-import ai.koog.agents.core.agent.context.RollbackStrategy
+=== "Kotlin"
 
-val executor = simpleOllamaAIExecutor()
--->
-
-```kotlin
-val agent = AIAgent(
-    promptExecutor = executor,
-    llmModel = OllamaModels.Meta.LLAMA_3_2,
-) {
-    install(Persistence) {
-        // Use in-memory storage for snapshots
-        storage = InMemoryPersistenceStorageProvider()
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.snapshot.feature.Persistence
+    import ai.koog.agents.snapshot.providers.InMemoryPersistenceStorageProvider
+    import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    import ai.koog.agents.core.agent.context.RollbackStrategy
+    val executor = simpleOllamaAIExecutor()
+    -->
+    
+    ```kotlin
+    val agent = AIAgent(
+        promptExecutor = executor,
+        llmModel = OllamaModels.Meta.LLAMA_3_2,
+    ) {
+        install(Persistence) {
+            // Use in-memory storage for snapshots
+            storage = InMemoryPersistenceStorageProvider()
+        }
     }
-}
-```
+    ```
+    <!--- KNIT example-agent-persistence-01.kt -->
 
-<!--- KNIT example-agent-persistence-01.kt -->
+=== "Java"
+
+    ```java
+    AIAgent<String, String> agent = AIAgent.<String, String>builder()
+        .promptExecutor(SimplePromptExecutorsKt.simpleOllamaAIExecutor("http://localhost:11434"))
+        .llmModel(OllamaModels.Meta.LLAMA_3_2)
+        .install(Persistence.Feature, cfg -> {
+            // Use in-memory storage for snapshots
+            cfg.setStorage(new InMemoryPersistenceStorageProvider());
+        })
+    .build();
+    ```
 
 ## Configuration options
 
@@ -55,36 +68,45 @@ The Agent Persistence feature has three main configuration options:
 
 - **Storage provider**: the provider used to save and retrieve checkpoints.
 - **Continuous persistence**: automatic creation of checkpoints after each node is run.
-- **Rollback strategy**: determines which state will be restored when rolling back to a checkpoint.
 
 ### Storage provider
 
 Set the storage provider that will be used to save and retrieve checkpoints:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.snapshot.feature.Persistence
-import ai.koog.agents.snapshot.providers.InMemoryPersistenceStorageProvider
-import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
-import ai.koog.prompt.executor.ollama.client.OllamaModels
+=== "Kotlin"
 
-val agent = AIAgent(
-    promptExecutor = simpleOllamaAIExecutor(),
-    llmModel = OllamaModels.Meta.LLAMA_3_2,
-) {
--->
-<!--- SUFFIX 
-} 
--->
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.snapshot.feature.Persistence
+    import ai.koog.agents.snapshot.providers.InMemoryPersistenceStorageProvider
+    import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    val agent = AIAgent(
+        promptExecutor = simpleOllamaAIExecutor(),
+        llmModel = OllamaModels.Meta.LLAMA_3_2,
+    ) {
+    -->
+    <!--- SUFFIX 
+    } 
+    -->
+    ```kotlin
+    install(Persistence) {
+        storage = InMemoryPersistenceStorageProvider()
+    }
+    ```
+    <!--- KNIT example-agent-persistence-02.kt -->
 
-```kotlin
-install(Persistence) {
-    storage = InMemoryPersistenceStorageProvider()
-}
-```
+=== "Java"
 
-<!--- KNIT example-agent-persistence-02.kt -->
-
+    ```java
+    AIAgent<String, String> agent = AIAgent.<String, String>builder()
+        .promptExecutor(SimplePromptExecutorsKt.simpleOllamaAIExecutor("http://localhost:11434"))
+        .llmModel(OllamaModels.Meta.LLAMA_3_2)
+        .install(Persistence.Feature, cfg -> {
+            cfg.setStorage(new InMemoryPersistenceStorageProvider());
+        })
+        .build();
+    ```
 
 The framework includes the following built-in providers:
 
@@ -100,29 +122,40 @@ For more information, see [Custom storage providers](#custom-storage-providers).
 Continuous persistence means that a checkpoint is automatically created after each node is run.
 To disable continuous persistence, use the code below:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.snapshot.feature.Persistence
-import ai.koog.agents.snapshot.providers.InMemoryPersistenceStorageProvider
-import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
-import ai.koog.prompt.executor.ollama.client.OllamaModels
+=== "Kotlin"
 
-val agent = AIAgent(
-    promptExecutor = simpleOllamaAIExecutor(),
-    llmModel = OllamaModels.Meta.LLAMA_3_2,
-) {
--->
-<!--- SUFFIX 
-} 
--->
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.snapshot.feature.Persistence
+    import ai.koog.agents.snapshot.providers.InMemoryPersistenceStorageProvider
+    import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    val agent = AIAgent(
+        promptExecutor = simpleOllamaAIExecutor(),
+        llmModel = OllamaModels.Meta.LLAMA_3_2,
+    ) {
+    -->
+    <!--- SUFFIX 
+    } 
+    -->
+    
+    ```kotlin
+    install(Persistence) {
+        enableAutomaticPersistence = false
+    }
+    ```
+    <!--- KNIT example-agent-persistence-03.kt -->
 
-```kotlin
-install(Persistence) {
-    enableAutomaticPersistence = false
-}
-```
-
-<!--- KNIT example-agent-persistence-03.kt -->
+=== "Java"
+    ```java
+    AIAgent<String, String> agent = AIAgent.<String, String>builder()
+        .promptExecutor(SimplePromptExecutorsKt.simpleOllamaAIExecutor("http://localhost:11434"))
+        .llmModel(OllamaModels.Meta.LLAMA_3_2)
+        .install(Persistence.Feature, cfg -> {
+            cfg.setEnableAutomaticPersistence(true);
+        })
+        .build();
+    ```
 
 If continuous persistence is disabled, you can still create checkpoints manually.
 
@@ -132,61 +165,71 @@ If continuous persistence is disabled, you can still create checkpoints manually
 
 To learn how to create a checkpoint at a specific point in your agent's execution, see the code sample below:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.context.AIAgentContext
-import ai.koog.agents.snapshot.feature.persistence
-import kotlin.reflect.typeOf
+=== "Kotlin"
 
-const val outputData = "some-output-data"
-val outputType = typeOf<String>()
--->
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.context.AIAgentContext
+    import ai.koog.agents.snapshot.feature.persistence
+    import kotlin.reflect.typeOf
+    const val outputData = "some-output-data"
+    val outputType = typeOf<String>()
+    -->
+    ```kotlin
+    suspend fun example(context: AIAgentContext) {
+        // Create a checkpoint with the current state
+        val checkpoint = context.persistence().createCheckpointAfterNode(
+            agentContext = context,
+            nodePath = context.executionInfo.path(),
+            lastOutput = outputData,
+            lastOutputType = outputType,
+            checkpointId = context.runId,
+            version = 0L
+        )
 
-```kotlin
-suspend fun example(context: AIAgentContext) {
-    // Create a checkpoint with the current state
-    val checkpoint = context.persistence().createCheckpointAfterNode(
-        agentContext = context,
-        nodePath = context.executionInfo.path(),
-        lastOutput = outputData,
-        lastOutputType = outputType,
-        checkpointId = context.runId,
-        version = 0L
-    )
+        // The checkpoint ID can be stored for later use
+        val checkpointId = checkpoint?.checkpointId
+    }
+    ```
+    <!--- KNIT example-agent-persistence-04.kt -->
 
-    // The checkpoint ID can be stored for later use
-    val checkpointId = checkpoint?.checkpointId
-}
-```
+=== "Java"
 
-<!--- KNIT example-agent-persistence-04.kt -->
+    ```java
+    ```
 
 ### Restoring from a checkpoint
 
 To restore the state of an agent from a specific checkpoint, follow the code sample below:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.context.AIAgentContext
-import ai.koog.agents.snapshot.feature.persistence
--->
+=== "Kotlin"
 
-```kotlin
-suspend fun example(context: AIAgentContext, checkpointId: String) {
-    // Roll back to a specific checkpoint
-    context.persistence().rollbackToCheckpoint(checkpointId, context)
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.context.AIAgentContext
+    import ai.koog.agents.snapshot.feature.persistence
+    -->
+    ```kotlin
+    suspend fun example(context: AIAgentContext, checkpointId: String) {
+        // Roll back to a specific checkpoint
+        context.persistence().rollbackToCheckpoint(checkpointId, context)
 
-    // Or roll back to the latest checkpoint
-    context.persistence().rollbackToLatestCheckpoint(context)
-}
-```
+        // Or roll back to the latest checkpoint
+        context.persistence().rollbackToLatestCheckpoint(context)
+    }
+    ```
+    <!--- KNIT example-agent-persistence-05.kt -->
 
-<!--- KNIT example-agent-persistence-05.kt -->
+=== "Java"
+
+    ```java
+    ```
 
 #### Rolling back all side-effects produced by tools
 
 It's quite common for some tools to produce side-effects. Specifically, when you are running your agents on the backend, 
 some of the tools would likely perform some database transactions. This makes it much harder for your agent to travel back in time.
 
-Imagine, that you have a tool `createUser` that creates a new user in your database. And your agent has populated multiple tool calls overtime:
+Imagine you have a tool `createUser` that creates a new user in your database. And your agent has populated multiple tool calls overtime:
+
 ```
 tool call: createUser "Alex"
 
@@ -202,74 +245,82 @@ this would mean removing `Maria` and `Daniel` from the database.
 
 With Koog Persistence you can achieve that by providing a `RollbackToolRegistry` to `Persistence` feature config:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.snapshot.feature.Persistence
-import ai.koog.agents.snapshot.providers.InMemoryPersistenceStorageProvider
-import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
-import ai.koog.prompt.executor.ollama.client.OllamaModels
-import ai.koog.agents.snapshot.feature.RollbackToolRegistry
+=== "Kotlin"
 
-fun createUser(name: String) {}
-
-fun removeUser(name: String) {}
-
-val agent = AIAgent(
-    promptExecutor = simpleOllamaAIExecutor(),
-    llmModel = OllamaModels.Meta.LLAMA_3_2,
-) {
--->
-<!--- SUFFIX 
-} 
--->
-
-```kotlin
-install(Persistence) {
-    enableAutomaticPersistence = true
-    rollbackToolRegistry = RollbackToolRegistry {
-        // For every `createUser` tool call there will be a `removeUser` invocation in the reverse order 
-        // when rolling back to the desired execution point.
-        // Note: `removeUser` tool should take the same exact arguments as `createUser`. 
-        // It's the developer's responsibility to make sure that `removeUser` invocation rolls back all side-effects of `createUser`:
-        registerRollback(::createUser, ::removeUser)
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.snapshot.feature.Persistence
+    import ai.koog.agents.snapshot.providers.InMemoryPersistenceStorageProvider
+    import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    import ai.koog.agents.snapshot.feature.RollbackToolRegistry
+    fun createUser(name: String) {}
+    fun removeUser(name: String) {}
+    val agent = AIAgent(
+        promptExecutor = simpleOllamaAIExecutor(),
+        llmModel = OllamaModels.Meta.LLAMA_3_2,
+    ) {
+    -->
+    <!--- SUFFIX 
+    } 
+    -->
+    ```kotlin
+    install(Persistence) {
+        enableAutomaticPersistence = true
+        rollbackToolRegistry = RollbackToolRegistry {
+            // For every `createUser` tool call there will be a `removeUser` invocation in the reverse order 
+            // when rolling back to the desired execution point.
+            // Note: `removeUser` tool should take the same exact arguments as `createUser`. 
+            // It's the developer's responsibility to make sure that `removeUser` invocation rolls back all side-effects of `createUser`:
+            registerRollback(::createUser, ::removeUser)
+        }
     }
-}
-```
+    ```
+    <!--- KNIT example-agent-persistence-06.kt -->
 
-<!--- KNIT example-agent-persistence-06.kt -->
+=== "Java"
+
+    ```java
+    ```
 
 ### Using extension functions
 
 The Agent Persistence feature provides convenient extension functions for working with checkpoints:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.context.AIAgentContext
-import ai.koog.agents.example.exampleAgentPersistence04.outputData
-import ai.koog.agents.example.exampleAgentPersistence04.outputType
-import ai.koog.agents.snapshot.feature.persistence
-import ai.koog.agents.snapshot.feature.withPersistence
--->
+=== "Kotlin"
 
-```kotlin
-suspend fun example(context: AIAgentContext) {
-    // Access the checkpoint feature
-    val checkpointFeature = context.persistence()
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.context.AIAgentContext
+    import ai.koog.agents.example.exampleAgentPersistence04.outputData
+    import ai.koog.agents.example.exampleAgentPersistence04.outputType
+    import ai.koog.agents.snapshot.feature.persistence
+    import ai.koog.agents.snapshot.feature.withPersistence
+    -->
+    ```kotlin
+    suspend fun example(context: AIAgentContext) {
+        // Access the checkpoint feature
+        val checkpointFeature = context.persistence()
 
-    // Or perform an action with the checkpoint feature
-    context.withPersistence { ctx ->
-        // 'this' is the checkpoint feature
-        createCheckpointAfterNode(
-            agentContext = ctx,
-            nodePath = ctx.executionInfo.path(),
-            lastOutput = outputData,
-            lastOutputType = outputType,
-            checkpointId = ctx.runId,
-            version = 0L
-        )
+        // Or perform an action with the checkpoint feature
+        context.withPersistence { ctx ->
+            // 'this' is the checkpoint feature
+            createCheckpointAfterNode(
+                agentContext = ctx,
+                nodePath = ctx.executionInfo.path(),
+                lastOutput = outputData,
+                lastOutputType = outputType,
+                checkpointId = ctx.runId,
+                version = 0L
+            )
+        }
     }
-}
-```
-<!--- KNIT example-agent-persistence-07.kt -->
+    ```
+    <!--- KNIT example-agent-persistence-07.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 ## Advanced usage
 
@@ -277,113 +328,123 @@ suspend fun example(context: AIAgentContext) {
 
 You can implement custom storage providers by implementing the `PersistenceStorageProvider` interface:
 
-<!--- INCLUDE
-import ai.koog.agents.snapshot.feature.AgentCheckpointData
-import ai.koog.agents.snapshot.providers.PersistenceStorageProvider
+=== "Kotlin"
 
-/*
-// KNIT: Ignore example
--->
-<!--- SUFFIX
-*/
--->
-```kotlin
-class MyCustomStorageProvider<MyFilterType> : PersistenceStorageProvider<MyFilterType> {
-    override suspend fun getCheckpoints(sessionId: String, filter: MyFilterType?): List<AgentCheckpointData> {
-        TODO("Not yet implemented")
+    <!--- INCLUDE
+    import ai.koog.agents.snapshot.feature.AgentCheckpointData
+    import ai.koog.agents.snapshot.providers.PersistenceStorageProvider
+    /*
+    // KNIT: Ignore example
+    -->
+    <!--- SUFFIX
+    */
+    -->
+    ```kotlin
+    class MyCustomStorageProvider<MyFilterType> : PersistenceStorageProvider<MyFilterType> {
+        override suspend fun getCheckpoints(sessionId: String, filter: MyFilterType?): List<AgentCheckpointData> {
+            TODO("Not yet implemented")
+        }
+
+        override suspend fun saveCheckpoint(sessionId: String, agentCheckpointData: AgentCheckpointData) {
+            TODO("Not yet implemented")
+        }
+
+        override suspend fun getLatestCheckpoint(sessionId: String, filter: MyFilterType?): AgentCheckpointData? {
+            TODO("Not yet implemented")
+        }
     }
+    ```
+    <!--- KNIT example-agent-persistence-08.kt -->
 
-    override suspend fun saveCheckpoint(sessionId: String, agentCheckpointData: AgentCheckpointData) {
-        TODO("Not yet implemented")
-    }
+=== "Java"
 
-    override suspend fun getLatestCheckpoint(sessionId: String, filter: MyFilterType?): AgentCheckpointData? {
-        TODO("Not yet implemented")
-    }
-}
-
-```
-
-<!--- KNIT example-agent-persistence-08.kt -->
+    ```java
+    ```
 
 To use your custom provider in the feature configuration, set it as the storage when configuring the Agent Persistence
 feature in your agent.
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.snapshot.feature.AgentCheckpointData
-import ai.koog.agents.snapshot.feature.Persistence
-import ai.koog.agents.snapshot.providers.PersistenceStorageProvider
-import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
-import ai.koog.prompt.executor.ollama.client.OllamaModels
+=== "Kotlin"
 
-class MyCustomStorageProvider<MyFilterType> : PersistenceStorageProvider<MyFilterType> {
-    override suspend fun getCheckpoints(sessionId: String, filter: MyFilterType?): List<AgentCheckpointData> {
-        TODO("Not yet implemented")
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.snapshot.feature.AgentCheckpointData
+    import ai.koog.agents.snapshot.feature.Persistence
+    import ai.koog.agents.snapshot.providers.PersistenceStorageProvider
+    import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    class MyCustomStorageProvider<MyFilterType> : PersistenceStorageProvider<MyFilterType> {
+        override suspend fun getCheckpoints(sessionId: String, filter: MyFilterType?): List<AgentCheckpointData> {
+            TODO("Not yet implemented")
+        }
+        override suspend fun saveCheckpoint(sessionId: String, agentCheckpointData: AgentCheckpointData) {
+            TODO("Not yet implemented")
+        }
+        override suspend fun getLatestCheckpoint(sessionId: String, filter: MyFilterType?): AgentCheckpointData? {
+            TODO("Not yet implemented")
+        }
     }
-
-    override suspend fun saveCheckpoint(sessionId: String, agentCheckpointData: AgentCheckpointData) {
-        TODO("Not yet implemented")
+    val agent = AIAgent(
+        promptExecutor = simpleOllamaAIExecutor(),
+        llmModel = OllamaModels.Meta.LLAMA_3_2,
+    ) {
+    -->
+    <!--- SUFFIX 
+    } 
+    -->
+    ```kotlin
+    install(Persistence) {
+        storage = MyCustomStorageProvider<Any>()
     }
+    ```
+    <!--- KNIT example-agent-persistence-09.kt -->
 
-    override suspend fun getLatestCheckpoint(sessionId: String, filter: MyFilterType?): AgentCheckpointData? {
-        TODO("Not yet implemented")
-    }
-}
+=== "Java"
 
-val agent = AIAgent(
-    promptExecutor = simpleOllamaAIExecutor(),
-    llmModel = OllamaModels.Meta.LLAMA_3_2,
-) {
--->
-<!--- SUFFIX 
-} 
--->
-
-```kotlin
-install(Persistence) {
-    storage = MyCustomStorageProvider<Any>()
-}
-```
-
-<!--- KNIT example-agent-persistence-09.kt -->
+    ```java
+    ```
 
 ### Setting execution points
 
 For advanced control, you can directly set the execution point of an agent:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.context.AIAgentContext
-import ai.koog.agents.snapshot.feature.persistence
-import ai.koog.prompt.message.Message.User
-import kotlinx.serialization.json.JsonPrimitive
+=== "Kotlin"
 
-val customInput = JsonPrimitive("custom-input")
-val customOutput = JsonPrimitive("custom-output")
-val customMessageHistory = emptyList<User>()
--->
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.context.AIAgentContext
+    import ai.koog.agents.snapshot.feature.persistence
+    import ai.koog.prompt.message.Message.User
+    import kotlinx.serialization.json.JsonPrimitive
+    
+    val customInput = JsonPrimitive("custom-input")
+    val customOutput = JsonPrimitive("custom-output")
+    val customMessageHistory = emptyList<User>()
+    -->
+    ```kotlin
+    fun example(context: AIAgentContext) {
+        // You can set the execution point before some node and provide an input for it:
+        context.persistence().setExecutionPoint(
+            agentContext = context,
+            nodePath = context.executionInfo.path(),
+            messageHistory = customMessageHistory,
+            input = customInput
+        )
 
-```kotlin
-fun example(context: AIAgentContext) {
-    // You can set the execution point before some node and provide an input for it:
-    context.persistence().setExecutionPoint(
-        agentContext = context,
-        nodePath = context.executionInfo.path(),
-        messageHistory = customMessageHistory,
-        input = customInput
-    )
+        // Or after some node and provide an output from the node:
+        context.persistence().setExecutionPointAfterNode(
+            agentContext = context,
+            nodePath = context.executionInfo.path(),
+            messageHistory = customMessageHistory,
+            output = customOutput
+        )
+    }
 
-    // Or after some node and provide an output from the node:
-    context.persistence().setExecutionPointAfterNode(
-        agentContext = context,
-        nodePath = context.executionInfo.path(),
-        messageHistory = customMessageHistory,
-        output = customOutput
-    )
-}
+    ```
+    <!--- KNIT example-agent-persistence-10.kt -->
 
-```
+=== "Java"
 
-<!--- KNIT example-agent-persistence-10.kt -->
+    ```java
+    ```
 
 This allows for more fine-grained control over the agent's state beyond just restoring from checkpoints.

--- a/docs/docs/agents/basic-agents.md
+++ b/docs/docs/agents/basic-agents.md
@@ -25,29 +25,48 @@ you can see how to re-create the predefined strategy graph used by basic agents.
 To create the most basic agent, instantiate [`AIAgent`](https://api.koog.ai/agents/agents-core/ai.koog.agents.core.agent/-a-i-agent/index.html)
 and provide a [prompt executor](../prompts/prompt-executors.md) with a [language model](../model-capabilities.md#creating-a-model-llmodel-configuration):
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
-import kotlinx.coroutines.runBlocking
--->
-```kotlin
-val agent = AIAgent(
-    promptExecutor = simpleOpenAIExecutor(System.getenv("OPENAI_API_KEY")),
-    llmModel = OpenAIModels.Chat.GPT4o
-)
-```
+=== "Kotlin"
 
-This agent will expect a string as input and return a string as output.
-To run the agent, use the `run()` function with some user input:
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+    import kotlinx.coroutines.runBlocking
+    -->
+    ```kotlin
+    val agent = AIAgent(
+        promptExecutor = simpleOpenAIExecutor(System.getenv("OPENAI_API_KEY")),
+        llmModel = OpenAIModels.Chat.GPT4o
+    )
+    ```
 
-```kotlin
-fun main() = runBlocking {
-    val result = agent.run("Hello! How can you help me?")
-    println(result)
-}
-```
-<!--- KNIT example-basic-01.kt -->
+    This agent will expect a string as input and return a string as output.
+    To run the agent, use the `run()` function with some user input:
+
+    ```kotlin
+    fun main() = runBlocking {
+        val result = agent.run("Hello! How can you help me?")
+        println(result)
+    }
+    ```
+    <!--- KNIT example-basic-01.kt -->
+
+=== "Java"
+
+    ```java
+    AIAgent<String, String> agent = AIAgent.builder()
+        .promptExecutor(simpleOpenAIExecutor(System.getenv("OPENAI_API_KEY")))
+        .llmModel(OpenAIModels.Chat.GPT4o)
+        .build();
+    ```
+
+    This agent will expect a string as input and return a string as output.
+    To run the agent, use the `run()` function with some user input:
+
+    ```java
+    String result = agent.run("Hello! How can you help me?");
+    System.out.println(result);
+    ```
 
 The agent will return a generic answer, such as:
 
@@ -70,19 +89,31 @@ What's on your mind? Do you have a specific question, topic, or task you'd like 
 Provide a [system message](../prompts/prompt-creation/index.md#system-message) to define the agent's role
 as well as the purpose, context, and instructions related to the task.
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
--->
-```kotlin
-val agent = AIAgent(
-    promptExecutor = simpleOpenAIExecutor(System.getenv("YOUR_API_KEY")),
-    systemPrompt = "You are an expert in internet memes. Be helpful, friendly, and answer user questions concisely, showing your knowledge of memes.",
-    llmModel = OpenAIModels.Chat.GPT4o
-)
-```
-<!--- KNIT example-basic-02.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+    -->
+    ```kotlin
+    val agent = AIAgent(
+        promptExecutor = simpleOpenAIExecutor(System.getenv("YOUR_API_KEY")),
+        systemPrompt = "You are an expert in internet memes. Be helpful, friendly, and answer user questions concisely, showing your knowledge of memes.",
+        llmModel = OpenAIModels.Chat.GPT4o
+    )
+    ```
+    <!--- KNIT example-basic-02.kt -->
+
+=== "Java"
+
+    ```java
+    AIAgent<String, String> agent = AIAgent.builder()
+        .promptExecutor(simpleOpenAIExecutor(System.getenv("OPENAI_API_KEY")))
+        .systemPrompt("You are an expert in internet memes. Be helpful, friendly, and answer user questions concisely, showing your knowledge of memes.")
+        .llmModel(OpenAIModels.Chat.GPT4o)
+        .build();
+    ```
 
 The instructions in the system prompt will guide the agent's response:
 
@@ -98,20 +129,33 @@ You can provide some [LLM parameters](../llm-parameters.md#llm-parameter-referen
 to customize the behavior of the LLM.
 For example, use the `temperature` parameter to adjust the randomness of the generated responses:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
--->
-```kotlin
-val agent = AIAgent(
-    promptExecutor = simpleOpenAIExecutor(System.getenv("YOUR_API_KEY")),
-    systemPrompt = "You are an expert in internet memes. Be helpful, friendly, and answer user questions concisely, showing your knowledge of memes.",
-    llmModel = OpenAIModels.Chat.GPT4o,
-    temperature = 0.7
-)
-```
-<!--- KNIT example-basic-03.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+    -->
+    ```kotlin
+    val agent = AIAgent(
+        promptExecutor = simpleOpenAIExecutor(System.getenv("YOUR_API_KEY")),
+        systemPrompt = "You are an expert in internet memes. Be helpful, friendly, and answer user questions concisely, showing your knowledge of memes.",
+        llmModel = OpenAIModels.Chat.GPT4o,
+        temperature = 0.7
+    )
+    ```
+    <!--- KNIT example-basic-03.kt -->
+
+=== "Java"
+
+    ```java
+    AIAgent<String, String> agent = AIAgent.builder()
+        .promptExecutor(simpleOpenAIExecutor(System.getenv("OPENAI_API_KEY")))
+        .systemPrompt("You are an expert in internet memes. Be helpful, friendly, and answer user questions concisely, showing your knowledge of memes.")
+        .llmModel(OpenAIModels.Chat.GPT4o)
+        .temperature(0.7)
+        .build();
+    ```
 
 Here are some response examples with different temperature values:
 
@@ -145,46 +189,85 @@ Agents can use [tools](../tools-overview.md) to perform specific tasks.
 
 First, create a tool by annotating a function with the [`@Tool`](https://api.koog.ai/agents/agents-tools/ai.koog.agents.core.tools.annotations/-tool/index.html) annotation:
 
+=== "Kotlin"
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.tools.ToolRegistry
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
-import ai.koog.agents.core.tools.annotations.LLMDescription
-import ai.koog.agents.core.tools.annotations.Tool
-import ai.koog.agents.core.tools.reflect.tool
--->
-```kotlin
-@Tool
-@LLMDescription("Ask the user a question by sending it to stdout and return the answer from stdin")
-fun askUser(
-    @LLMDescription("Question from the agent")
-    question: String
-): String {
-    println(question)
-    return readln()
-}
-```
-
-Then, use the [`ToolRegistry`](https://api.koog.ai/agents/agents-tools/ai.koog.agents.core.tools/-tool-registry/index.html) to make this tool available to the agent:
-
-```kotlin
-val agent = AIAgent(
-    promptExecutor = simpleOpenAIExecutor(System.getenv("YOUR_API_KEY")),
-    systemPrompt = "You are an expert in internet memes. Be helpful, friendly, and answer user questions concisely, showing your knowledge of memes.",
-    llmModel = OpenAIModels.Chat.GPT4o,
-    temperature = 0.7,
-    toolRegistry = ToolRegistry {
-        tool(::askUser)
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.tools.ToolRegistry
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+    import ai.koog.agents.core.tools.annotations.LLMDescription
+    import ai.koog.agents.core.tools.annotations.Tool
+    import ai.koog.agents.core.tools.reflect.tool
+    -->
+    ```kotlin
+    @Tool
+    @LLMDescription("Ask the user a question by sending it to stdout and return the answer from stdin")
+    fun askUser(
+        @LLMDescription("Question from the agent")
+        question: String
+    ): String {
+        println(question)
+        return readln()
     }
-)
-```
-<!--- KNIT example-basic-04.kt -->
+    ```
 
-In the example, `askUser` is a tool that helps the agent maintain a conversation with the user via printing and reading from the console.
-If the agent decides to ask the user a question,
-it can call this tool that writes to `stdout` via `println()` and reads from `stdin` via `readln()`.
+    Then, use the [`ToolRegistry`](https://api.koog.ai/agents/agents-tools/ai.koog.agents.core.tools/-tool-registry/index.html) to make this tool available to the agent:
+
+    ```kotlin
+    val agent = AIAgent(
+        promptExecutor = simpleOpenAIExecutor(System.getenv("YOUR_API_KEY")),
+        systemPrompt = "You are an expert in internet memes. Be helpful, friendly, and answer user questions concisely, showing your knowledge of memes.",
+        llmModel = OpenAIModels.Chat.GPT4o,
+        temperature = 0.7,
+        toolRegistry = ToolRegistry {
+            tool(::askUser)
+        }
+    )
+    ```
+    <!--- KNIT example-basic-04.kt -->
+
+    In the example, `askUser` is a tool that helps the agent maintain a conversation with the user via printing and reading from the console.
+    If the agent decides to ask the user a question,
+    it can call this tool that writes to `stdout` via `println()` and reads from `stdin` via `readln()`.
+
+=== "Java"
+
+    ```java
+    // Create a ToolSet class
+    static class UserConversationTools implements ToolSet {
+        @Tool
+        @LLMDescription(description = "Ask the user a question by sending it to stdout and return the answer from stdin")
+        public String askUser(
+            @LLMDescription(description = "Question from the agent")
+            String question
+        ) {
+            System.out.println(question);
+            Scanner scanner = new Scanner(System.in);
+            return scanner.nextLine();
+        }
+    }
+    ```
+    
+    Then, use the [`ToolRegistry`](https://api.koog.ai/agents/agents-tools/ai.koog.agents.core.tools/-tool-registry/index.html) to make this tool available to the agent:
+
+    ```java
+    UserConversationTools askUser = new UserConversationTools();
+
+    ToolRegistry toolRegistry = ToolRegistry.builder()
+            .tools(askUser)
+            .build();
+
+    AIAgent<String, String> agent = AIAgent.builder()
+        .promptExecutor(simpleOpenAIExecutor(System.getenv("OPENAI_API_KEY")))
+        .systemPrompt("You are an expert in internet memes. Be helpful, friendly, and answer user questions concisely, showing your knowledge of memes.")
+        .llmModel(OpenAIModels.Chat.GPT4o)
+        .temperature(0.7)
+        .toolRegistry(toolRegistry)
+        .build();
+    ```
+
+    In the example, `askUser` is a tool that helps the agent maintain a conversation with the user via printing and reading from the console.
 
 Here is an example interaction with the agent:
 
@@ -221,92 +304,169 @@ Use the `maxIterations` parameter to either increase this limit if you expect th
 (such as tool calls and LLM requests) or decrease it for agents that require only a few steps.
 For example, a simple agent described here is not likely to require more than 10 steps:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.tools.ToolRegistry
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
-import ai.koog.agents.core.tools.annotations.LLMDescription
-import ai.koog.agents.core.tools.annotations.Tool
-import ai.koog.agents.core.tools.reflect.tool
+=== "Kotlin"
 
-@Tool
-@LLMDescription("Asks the user a question by sending it to stdout and returns the answer from stdin")
-fun askUser(
-    @LLMDescription("Question from the agent")
-    question: String
-): String {
-    println(question)
-    return readln()
-}
--->
-```kotlin
-val agent = AIAgent(
-    promptExecutor = simpleOpenAIExecutor(System.getenv("YOUR_API_KEY")),
-    systemPrompt = "You are an expert in internet memes. Be helpful, friendly, and answer user questions concisely, showing your knowledge of memes.",
-    llmModel = OpenAIModels.Chat.GPT4o,
-    temperature = 0.7,
-    toolRegistry = ToolRegistry {
-        tool(::askUser)
-    },
-    maxIterations = 10
-)
-```
-<!--- KNIT example-basic-05.kt -->
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.tools.ToolRegistry
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+    import ai.koog.agents.core.tools.annotations.LLMDescription
+    import ai.koog.agents.core.tools.annotations.Tool
+    import ai.koog.agents.core.tools.reflect.tool
+    @Tool
+    @LLMDescription("Asks the user a question by sending it to stdout and returns the answer from stdin")
+    fun askUser(
+        @LLMDescription("Question from the agent")
+        question: String
+    ): String {
+        println(question)
+        return readln()
+    }
+    -->
+    ```kotlin
+    val agent = AIAgent(
+        promptExecutor = simpleOpenAIExecutor(System.getenv("YOUR_API_KEY")),
+        systemPrompt = "You are an expert in internet memes. Be helpful, friendly, and answer user questions concisely, showing your knowledge of memes.",
+        llmModel = OpenAIModels.Chat.GPT4o,
+        temperature = 0.7,
+        toolRegistry = ToolRegistry {
+            tool(::askUser)
+        },
+        maxIterations = 10
+    )
+    ```
+    <!--- KNIT example-basic-05.kt -->
 
-!!! tip
+    !!! tip
 
-    Instead of passing the model, temperature, max iterations,
-    and other parameters directly to the agent constructor,
-    you can also define and pass them as a separate configuration object.
-    For more information, see [Agent configuration](index.md#agent-configuration).
+        Instead of passing the model, temperature, max iterations,
+        and other parameters directly to the agent constructor,
+        you can also define and pass them as a separate configuration object.
+        For more information, see [Agent configuration](index.md#agent-configuration).
+
+=== "Java"
+
+    ```java
+    // Create a ToolSet class
+    static class UserConversationTools implements ToolSet {
+        @Tool
+        @LLMDescription(description = "Ask the user a question by sending it to stdout and return the answer from stdin")
+        public String askUser(
+            @LLMDescription(description = "Question from the agent")
+            String question
+        ) {
+            System.out.println(question);
+            Scanner scanner = new Scanner(System.in);
+            return scanner.nextLine();
+        }
+    }
+
+    // In main method:
+    UserConversationTools askUser = new UserConversationTools();
+
+    ToolRegistry toolRegistry = ToolRegistry.builder()
+            .tools(askUser)
+            .build();
+
+    AIAgent<String, String> agent = AIAgent.builder()
+        .promptExecutor(simpleOpenAIExecutor(System.getenv("OPENAI_API_KEY")))
+        .systemPrompt("You are an expert in internet memes. Be helpful, friendly, and answer user questions concisely, showing your knowledge of memes.")
+        .llmModel(OpenAIModels.Chat.GPT4o)
+        .temperature(0.7)
+        .toolRegistry(toolRegistry)
+        .maxIterations(10)
+        .build();
+    ```
 
 ## Handle events during agent runtime
 
 To assist with testing and debugging, as well as making hooks for chained agent interactions,
 Koog provides the [EventHandler](https://api.koog.ai/agents/agents-features/agents-features-event-handler/ai.koog.agents.features.eventHandler.feature/-event-handler/index.html) feature.
-Call the `handleEvents()` function inside the agent constructor lambda to install the feature and register event handlers:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.tools.ToolRegistry
-import ai.koog.agents.features.eventHandler.feature.handleEvents
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
-import ai.koog.agents.core.tools.annotations.LLMDescription
-import ai.koog.agents.core.tools.annotations.Tool
-import ai.koog.agents.core.tools.reflect.tool
+=== "Kotlin"
 
-@Tool
-@LLMDescription("Asks the user a question by sending it to stdout and returns the answer from stdin")
-fun askUser(
-    @LLMDescription("Question from the agent")
-    question: String
-): String {
-    println(question)
-    return readln()
-}
--->
-```kotlin
-val agent = AIAgent(
-    promptExecutor = simpleOpenAIExecutor(System.getenv("YOUR_API_KEY")),
-    systemPrompt = "You are an expert in internet memes. Be helpful, friendly, and answer user questions concisely, showing your knowledge of memes.",
-    llmModel = OpenAIModels.Chat.GPT4o,
-    temperature = 0.7,
-    toolRegistry = ToolRegistry {
-        tool(::askUser)
-    },
-    maxIterations = 10
-){
-    handleEvents {
-        // Handle tool calls
-        onToolCallStarting { eventContext ->
-            println("Tool called: ${eventContext.toolName} with args ${eventContext.toolArgs}")
+    Call the `handleEvents()` function inside the agent constructor lambda to install the feature and register event handlers:
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.tools.ToolRegistry
+    import ai.koog.agents.features.eventHandler.feature.handleEvents
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+    import ai.koog.agents.core.tools.annotations.LLMDescription
+    import ai.koog.agents.core.tools.annotations.Tool
+    import ai.koog.agents.core.tools.reflect.tool
+    @Tool
+    @LLMDescription("Asks the user a question by sending it to stdout and returns the answer from stdin")
+    fun askUser(
+        @LLMDescription("Question from the agent")
+        question: String
+    ): String {
+        println(question)
+        return readln()
+    }
+    -->
+    ```kotlin
+    val agent = AIAgent(
+        promptExecutor = simpleOpenAIExecutor(System.getenv("YOUR_API_KEY")),
+        systemPrompt = "You are an expert in internet memes. Be helpful, friendly, and answer user questions concisely, showing your knowledge of memes.",
+        llmModel = OpenAIModels.Chat.GPT4o,
+        temperature = 0.7,
+        toolRegistry = ToolRegistry {
+            tool(::askUser)
+        },
+        maxIterations = 10
+    ){
+        handleEvents {
+            // Handle tool calls
+            onToolCallStarting { eventContext ->
+                println("Tool called: ${eventContext.toolName} with args ${eventContext.toolArgs}")
+            }
         }
     }
-}
-```
-<!--- KNIT example-basic-06.kt -->
+    ```
+    <!--- KNIT example-basic-06.kt -->
+
+=== "Java"
+
+    ```java
+    // Create a ToolSet class
+    static class UserConversationTools implements ToolSet {
+        @Tool
+        @LLMDescription(description = "Ask the user a question by sending it to stdout and return the answer from stdin")
+        public String askUser(
+            @LLMDescription(description = "Question from the agent")
+            String question
+        ) {
+            System.out.println(question);
+            Scanner scanner = new Scanner(System.in);
+            return scanner.nextLine();
+        }
+    }
+
+    // In main method:
+    UserConversationTools askUser = new UserConversationTools();
+
+    ToolRegistry toolRegistry = ToolRegistry.builder()
+            .tools(askUser)
+            .build();
+
+    AIAgent<String, String> agent = AIAgent.builder()
+        .promptExecutor(simpleOpenAIExecutor(System.getenv("OPENAI_API_KEY")))
+        .systemPrompt("You are an expert in internet memes. Be helpful, friendly, and answer user questions concisely, showing your knowledge of memes.")
+        .llmModel(OpenAIModels.Chat.GPT4o)
+        .temperature(0.7)
+        .toolRegistry(toolRegistry)
+        .maxIterations(10)
+        .install(EventHandler.Feature, config -> {
+            config.onToolCallStarting(eventContext -> {
+                System.out.println("Tool called: " + eventContext.getToolName() +
+                    " with args " + eventContext.getToolArgs());
+            });
+        })
+        .build();
+    ```
 
 The agent will now output something similar to the following when it calls the `askUser` tool:
 

--- a/docs/docs/agents/functional-agents.md
+++ b/docs/docs/agents/functional-agents.md
@@ -31,31 +31,52 @@ The most convenient way is to use the `functionalStrategy {...}` DSL method.
 For example, here is how to define a functional strategy that expects a string input and returns a string output,
 makes one LLM call, then returns the content of the assistant message from the response.
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.agent.functionalStrategy
-import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
-import ai.koog.prompt.executor.ollama.client.OllamaModels
-import kotlinx.coroutines.runBlocking
--->
-```kotlin
-val strategy = functionalStrategy<String, String> { input ->
-    val response = requestLLM(input)
-    response.asAssistantMessage().content
-}
+=== "Kotlin"
 
-val mathAgent = AIAgent(
-    promptExecutor = simpleOllamaAIExecutor(),
-    llmModel = OllamaModels.Meta.LLAMA_3_2,
-    strategy = strategy
-)
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.agent.functionalStrategy
+    import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    import kotlinx.coroutines.runBlocking
+    -->
+    ```kotlin
+    val strategy = functionalStrategy<String, String> { input ->
+        val response = requestLLM(input)
+        response.asAssistantMessage().content
+    }
 
-fun main() = runBlocking {
-    val result = mathAgent.run("What is 12 × 9?")
-    println(result)
-}
-```
-<!--- KNIT example-functional-agent-01.kt -->
+    val mathAgent = AIAgent(
+        promptExecutor = simpleOllamaAIExecutor(),
+        llmModel = OllamaModels.Meta.LLAMA_3_2,
+        strategy = strategy
+    )
+
+    fun main() = runBlocking {
+        val result = mathAgent.run("What is 12 × 9?")
+        println(result)
+    }
+    ```
+    <!--- KNIT example-functional-agent-01.kt -->
+
+=== "Java"
+
+    ```java
+    AIAgent<String, String> mathAgent = AIAgent.builder()
+        .promptExecutor(SimpleLLMExecutorsKt.simpleOllamaAIExecutor("http://localhost:11434"))
+        .llmModel(OllamaModels.Meta.LLAMA_3_2)
+        .functionalStrategy("mathStrategy", (AIAgentFunctionalContext context, String input) -> {
+            Message.Response response = context.requestLLM(input);
+            if (response instanceof Message.Assistant) {
+                return ((Message.Assistant) response).getContent();
+            }
+            return "";
+        })
+        .build();
+
+    String result = mathAgent.run("What is 12 × 9?");
+    System.out.println(result);
+    ```
 
 The agent can produce the following output:
 
@@ -67,20 +88,54 @@ The answer to 12 × 9 is 108.
 
 You can extend the previous strategy to make multiple sequential LLM calls:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.functionalStrategy
--->
-```kotlin
-val strategy = functionalStrategy<String, String> { input ->
-    // The first LLM call produces an initial draft based on the user input
-    val draft = requestLLM("Draft: $input").asAssistantMessage().content
-    // The second LLM call improves the initial draft
-    val improved = requestLLM("Improve and clarify.").asAssistantMessage().content
-    // The final LLM call formats the improved text and returns the result
-    requestLLM("Format the result as bold.").asAssistantMessage().content
-}
-```
-<!--- KNIT example-functional-agent-02.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.functionalStrategy
+    -->
+    ```kotlin
+    val strategy = functionalStrategy<String, String> { input ->
+        // The first LLM call produces an initial draft based on the user input
+        val draft = requestLLM("Draft: $input").asAssistantMessage().content
+        // The second LLM call improves the initial draft
+        val improved = requestLLM("Improve and clarify.").asAssistantMessage().content
+        // The final LLM call formats the improved text and returns the result
+        requestLLM("Format the result as bold.").asAssistantMessage().content
+    }
+    ```
+    <!--- KNIT example-functional-agent-02.kt -->
+
+=== "Java"
+
+    ```java
+    AIAgent<String, String> mathAgent = AIAgent.builder()
+        .promptExecutor(simpleOllamaAIExecutor("http://localhost:11434"))
+        .systemPrompt("You are a precise math assistant.")
+        .llmModel(OllamaModels.Meta.LLAMA_3_2)
+        .functionalStrategy((AIAgentFunctionalContext context, String input) -> {
+            // The first LLM call produces an initial draft based on the user input
+            Message.Response draftResponse = context.requestLLM("Draft: " + input);
+            String draft = "";
+            if (draftResponse instanceof Message.Assistant) {
+                draft = ((Message.Assistant) draftResponse).getContent();
+            }
+
+            // The second LLM call improves the initial draft
+            Message.Response improvedResponse = context.requestLLM("Improve and clarify.");
+            String improved = "";
+            if (improvedResponse instanceof Message.Assistant) {
+                improved = ((Message.Assistant) improvedResponse).getContent();
+            }
+
+            // The final LLM call formats the improved text and returns the result
+            Message.Response finalResponse = context.requestLLM("Format the result as bold.");
+            if (finalResponse instanceof Message.Assistant) {
+                return ((Message.Assistant) finalResponse).getContent();
+            }
+            return "";
+        })
+        .build();
+    ```
 
 The agent can produce the following output:
 
@@ -103,65 +158,119 @@ Here is what you need to do:
 3. Make sure the agent strategy can identify tool calls in LLM responses, execute the requested tools,
    send their results back to the LLM, and repeat the process until there are no tool calls remaining.
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.agent.functionalStrategy
-import ai.koog.agents.core.tools.ToolRegistry
-import ai.koog.agents.core.tools.annotations.LLMDescription
-import ai.koog.agents.core.tools.annotations.Tool
-import ai.koog.agents.core.tools.reflect.ToolSet
-import ai.koog.agents.core.tools.reflect.tool
-import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
-import ai.koog.prompt.executor.ollama.client.OllamaModels
-import kotlinx.coroutines.runBlocking
--->
-```kotlin
-@LLMDescription("Tools for performing math operations")
-class MathTools : ToolSet {
-    @Tool
-    @LLMDescription("Multiplies two numbers and returns the result")
-    fun multiply(a: Int, b: Int): Int {
-        // This is not necessary, but it helps to see the tool call in the console output
-        println("Multiplying $a and $b...")
-        return a * b
-    }
-}
+=== "Kotlin"
 
-val toolRegistry = ToolRegistry {
-    tool(MathTools()::multiply)
-}
-
-val strategy = functionalStrategy<String, String> { input ->
-    // Send the user input to the LLM
-    var responses = requestLLMMultiple(input)
-
-    // Only loop while the LLM requests tools
-    while (responses.containsToolCalls()) {
-        // Extract tool calls from the response
-        val pendingCalls = extractToolCalls(responses)
-        // Execute the tools and return the results
-        val results = executeMultipleTools(pendingCalls)
-        // Send the tool results back to the LLM. The LLM may call more tools or return a final output
-        responses = sendMultipleToolResults(results)
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.agent.functionalStrategy
+    import ai.koog.agents.core.tools.ToolRegistry
+    import ai.koog.agents.core.tools.annotations.LLMDescription
+    import ai.koog.agents.core.tools.annotations.Tool
+    import ai.koog.agents.core.tools.reflect.ToolSet
+    import ai.koog.agents.core.tools.reflect.tool
+    import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    import kotlinx.coroutines.runBlocking
+    -->
+    ```kotlin
+    @LLMDescription("Tools for performing math operations")
+    class MathTools : ToolSet {
+        @Tool
+        @LLMDescription("Multiplies two numbers and returns the result")
+        fun multiply(a: Int, b: Int): Int {
+            // This is not necessary, but it helps to see the tool call in the console output
+            println("Multiplying $a and $b...")
+            return a * b
+        }
     }
 
-    // When no tool calls remain, extract and return the assistant message content from the response
-    responses.single().asAssistantMessage().content
-}
+    val toolRegistry = ToolRegistry {
+        tool(MathTools()::multiply)
+    }
 
-val mathAgentWithTools = AIAgent(
-    promptExecutor = simpleOllamaAIExecutor(),
-    llmModel = OllamaModels.Meta.LLAMA_3_2,
-    toolRegistry = toolRegistry,
-    strategy = strategy
-)
+    val strategy = functionalStrategy<String, String> { input ->
+        // Send the user input to the LLM
+        var responses = requestLLMMultiple(input)
 
-fun main() = runBlocking {
-    val result = mathAgentWithTools.run("Multiply 3 by 4, then multiply the result by 5.")
-    println(result)
-}
-```
-<!--- KNIT example-functional-agent-03.kt -->
+        // Only loop while the LLM requests tools
+        while (responses.containsToolCalls()) {
+            // Extract tool calls from the response
+            val pendingCalls = extractToolCalls(responses)
+            // Execute the tools and return the results
+            val results = executeMultipleTools(pendingCalls)
+            // Send the tool results back to the LLM. The LLM may call more tools or return a final output
+            responses = sendMultipleToolResults(results)
+        }
+
+        // When no tool calls remain, extract and return the assistant message content from the response
+        responses.single().asAssistantMessage().content
+    }
+
+    val mathAgentWithTools = AIAgent(
+        promptExecutor = simpleOllamaAIExecutor(),
+        llmModel = OllamaModels.Meta.LLAMA_3_2,
+        toolRegistry = toolRegistry,
+        strategy = strategy
+    )
+
+    fun main() = runBlocking {
+        val result = mathAgentWithTools.run("Multiply 3 by 4, then multiply the result by 5.")
+        println(result)
+    }
+    ```
+    <!--- KNIT example-functional-agent-03.kt -->
+
+=== "Java"
+
+    ```java
+    @LLMDescription(description = "Tools for performing math operations")
+    public static class MathTools implements ToolSet {
+        @Tool
+        @LLMDescription(description = "Multiplies two numbers and returns the result")
+        public int multiply(int a, int b) {
+            // This is not necessary, but it helps to see the tool call in the console output
+            System.out.println("Multiplying " + a + " and " + b + "...");
+            return a * b;
+        }
+    }
+
+    public static void main(String[] args) {
+        MathTools mathTools = new MathTools();
+        ToolRegistry toolRegistry = ToolRegistry.builder()
+            .tools(mathTools)
+            .build();
+
+        AIAgent<String, String> mathAgentWithTools = AIAgent.builder()
+            .promptExecutor(SimpleLLMExecutorsKt.simpleOllamaAIExecutor("http://localhost:11434"))
+            .llmModel(OllamaModels.Meta.LLAMA_3_2)
+            .toolRegistry(toolRegistry)
+            .functionalStrategy("mathWithTools", (AIAgentFunctionalContext context, String input) -> {
+                // Send the user input to the LLM
+                List<Message.Response> responses = context.requestLLMMultiple(input);
+
+                // Only loop while the LLM requests tools
+                while (context.containsToolCalls(responses)) {
+                    // Extract tool calls from the response
+                    List<Message.Tool.Call> pendingCalls = context.extractToolCalls(responses);
+                    // Execute the tools and return the results
+                    List<ReceivedToolResult> results = context.executeMultipleTools(pendingCalls, false);
+                    // Send the tool results back to the LLM
+                    responses = context.sendMultipleToolResults(results);
+                }
+
+                // Extract and return the assistant message content from the response
+                Message.Response finalResponse = responses.get(0);
+                if (finalResponse instanceof Message.Assistant) {
+                    return ((Message.Assistant) finalResponse).getContent();
+                }
+                return "";
+            })
+            .build();
+
+        String result = mathAgentWithTools.run("Multiply 3 by 4, then multiply the result by 5.");
+        System.out.println(result);
+    }
+    ```
 
 The agent can produce the following output:
 

--- a/docs/docs/agents/index.md
+++ b/docs/docs/agents/index.md
@@ -41,55 +41,99 @@ including the initial prompt, language model, and iteration limits.
 For simple agents, besides the mandatory prompt executor and language model,
 you can specify the initial system prompt and some other parameters directly in the agent constructor:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
--->
-```kotlin
-val agent = AIAgent(
-    promptExecutor = simpleOpenAIExecutor(System.getenv("YOUR_API_KEY")),
-    llmModel = OpenAIModels.Chat.GPT4o,
-    systemPrompt = "You are a helpful assistant.",
-    temperature = 0.7,
-    maxIterations = 10
-)
-```
-<!--- KNIT example-agent-config-01.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+    -->
+    ```kotlin
+    val agent = AIAgent(
+        promptExecutor = simpleOpenAIExecutor(System.getenv("YOUR_API_KEY")),
+        llmModel = OpenAIModels.Chat.GPT4o,
+        systemPrompt = "You are a helpful assistant.",
+        temperature = 0.7,
+        maxIterations = 10
+    )
+    ```
+    <!--- KNIT example-agent-config-01.kt -->
+
+=== "Java"
+
+    ```java
+    AIAgent<String, String> agent = AIAgent.builder()
+        .promptExecutor(simpleOpenAIExecutor(System.getenv("YOUR_API_KEY")))
+        .llmModel(OpenAIModels.Chat.GPT4o)
+        .systemPrompt("You are a helpful assistant.")
+        .temperature(0.7)
+        .maxIterations(10)
+        .build();
+    ```
 
 Alternatively, you can create an instance of [`AIAgentConfig`](https://api.koog.ai/agents/agents-core/ai.koog.agents.core.agent.config/-a-i-agent-config/index.html)
 to define the agent's behavior and parameters more granularly, then pass it to the agent constructor.
 This enables you to define complex prompts with multiple messages,
 conversation history, LLM parameters, and additional execution parameters.
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.agent.config.AIAgentConfig
-import ai.koog.prompt.dsl.prompt
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
-import ai.koog.prompt.params.LLMParams
--->
-```kotlin
-val agentConfig = AIAgentConfig(
-    prompt = prompt(
-        id = "assistant",
-        params = LLMParams(
-            temperature = 0.7
-        )
-    ) {
-        system("You are a helpful assistant.")
-    },
-    model = OpenAIModels.Chat.GPT4o,
-    maxAgentIterations = 10
-)
+=== "Kotlin"
 
-val agent = AIAgent(
-    promptExecutor = simpleOpenAIExecutor(System.getenv("OPENAI_API_KEY")),
-    agentConfig = agentConfig
-)
-```
-<!--- KNIT example-agent-config-02.kt -->
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.agent.config.AIAgentConfig
+    import ai.koog.prompt.dsl.prompt
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+    import ai.koog.prompt.params.LLMParams
+    -->
+    ```kotlin
+    val agentConfig = AIAgentConfig(
+        prompt = prompt(
+            id = "assistant",
+            params = LLMParams(
+                temperature = 0.7
+            )
+        ) {
+            system("You are a helpful assistant.")
+        },
+        model = OpenAIModels.Chat.GPT4o,
+        maxAgentIterations = 10
+    )
+
+    val agent = AIAgent(
+        promptExecutor = simpleOpenAIExecutor(System.getenv("OPENAI_API_KEY")),
+        agentConfig = agentConfig
+    )
+    ```
+    <!--- KNIT example-agent-config-02.kt -->
+
+=== "Java"
+
+    ```java
+    Prompt prompt = Prompt.builder("assistant")
+        .system("You are a helpful assistant.")
+        .build()
+        .withParams(new LLMParams(
+            0.7,         // temperature
+            null,        // maxTokens
+            1,           // numberOfChoices
+            null,        // speculation
+            null,        // schema
+            LLMParams.ToolChoice.Auto.INSTANCE, // toolChoice
+            null,        // user
+            null         // additionalProperties
+        ));
+
+    AIAgentConfig agentConfig = AIAgentConfig.builder(OpenAIModels.Chat.GPT4o)
+        .prompt(prompt)
+        .maxAgentIterations(10)
+        .build();
+
+    AIAgent<String, String> agent = AIAgent.builder()
+        .promptExecutor(simpleOpenAIExecutor(System.getenv("OPENAI_API_KEY")))
+        .agentConfig(agentConfig)
+        .build();
+    ```
 
 Here are the parameters of `AIAgentConfig`:
 

--- a/docs/docs/annotation-based-tools.md
+++ b/docs/docs/annotation-based-tools.md
@@ -25,13 +25,10 @@ The functions annotated with `@Tool` are collected by reflection from objects th
 
 ### Definition
 
-<!--- INCLUDE
--->
-```kotlin
+```text
 @Target(AnnotationTarget.FUNCTION)
 public annotation class Tool(val customName: String = "")
 ```
-<!--- KNIT example-annotation-based-tools-01.kt -->
 
 ### Parameters
 
@@ -42,26 +39,47 @@ public annotation class Tool(val customName: String = "")
 ### Usage
 
 To mark a function as a tool, apply the `@Tool` annotation to this function in a class that implements the `ToolSet` interface:
-<!--- INCLUDE
-import ai.koog.agents.core.tools.annotations.Tool
-import ai.koog.agents.core.tools.reflect.ToolSet
--->
-```kotlin
-class MyToolSet : ToolSet {
-    @Tool
-    fun myTool(): String {
-        // Tool implementation
-        return "Result"
-    }
 
-    @Tool(customName = "customToolName")
-    fun anotherTool(): String {
-        // Tool implementation
-        return "Result"
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.tools.annotations.Tool
+    import ai.koog.agents.core.tools.reflect.ToolSet
+    -->
+    ```kotlin
+    class MyToolSet : ToolSet {
+        @Tool
+        fun myTool(): String {
+            // Tool implementation
+            return "Result"
+        }
+    
+        @Tool(customName = "customToolName")
+        fun anotherTool(): String {
+            // Tool implementation
+            return "Result"
+        }
     }
-}
-```
-<!--- KNIT example-annotation-based-tools-02.kt -->
+    ```
+    <!--- KNIT example-annotation-based-tools-01.kt -->
+
+=== "Java"
+
+    ```java
+    public class MyToolSet implements ToolSet {
+        @Tool
+        public String myTool() {
+            // Tool implementation
+            return "Result";
+        }
+    
+        @Tool(customName = "customToolName")
+        public String anotherTool() {
+            // Tool implementation
+            return "Result";
+        }
+    }
+    ```
 
 ## @LLMDescription annotation
 
@@ -70,20 +88,16 @@ This helps LLMs understand the purpose and usage of these elements.
 
 ### Definition
 
-<!--- INCLUDE
--->
-```kotlin
+```text
 @Target(
     AnnotationTarget.PROPERTY,
     AnnotationTarget.CLASS,
-    AnnotationTarget.PROPERTY,
     AnnotationTarget.TYPE,
     AnnotationTarget.VALUE_PARAMETER,
     AnnotationTarget.FUNCTION
 )
 public annotation class LLMDescription(val description: String)
 ```
-<!--- KNIT example-annotation-based-tools-03.kt -->
 
 ### Parameters
 
@@ -91,47 +105,76 @@ public annotation class LLMDescription(val description: String)
 |---------------|----------|------------------------------------------------|
 | `description` | Yes      | A string that describes the annotated element. |
 
-
 ### Usage
 
 The `@LLMDescription` annotation can be applied at various levels. For example:
 
 * Function level:
-<!--- INCLUDE
-import ai.koog.agents.core.tools.annotations.LLMDescription
-import ai.koog.agents.core.tools.annotations.Tool
--->
-```kotlin
-@Tool
-@LLMDescription("Performs a specific operation and returns the result")
-fun myTool(): String {
-    // Function implementation
-    return "Result"
-}
-```
-<!--- KNIT example-annotation-based-tools-04.kt -->
 
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.tools.annotations.LLMDescription
+    import ai.koog.agents.core.tools.annotations.Tool
+    -->
+    ```kotlin
+    @Tool
+    @LLMDescription("Performs a specific operation and returns the result")
+    fun myTool(): String {
+        // Function implementation
+        return "Result"
+    }
+    ```
+    <!--- KNIT example-annotation-based-tools-02.kt -->
+
+=== "Java"
+
+    ```java
+    @Tool
+    @LLMDescription(description = "Performs a specific operation and returns the result")
+    public String myTool() {
+        // Function implementation
+        return "Result";
+    }
+    ```
+    
 * Parameter level:
 
-<!--- INCLUDE
-import ai.koog.agents.core.tools.annotations.LLMDescription
-import ai.koog.agents.core.tools.annotations.Tool
--->
-```kotlin
-@Tool
-@LLMDescription("Processes input data")
-fun processTool(
-    @LLMDescription("The input data to process")
-    input: String,
+=== "Kotlin"
 
-    @LLMDescription("Optional configuration parameters")
-    config: String = ""
-): String {
-    // Function implementation
-    return "Processed: $input with config: $config"
-}
-```
-<!--- KNIT example-annotation-based-tools-05.kt -->
+    <!--- INCLUDE
+    import ai.koog.agents.core.tools.annotations.LLMDescription
+    import ai.koog.agents.core.tools.annotations.Tool
+    -->
+    ```kotlin
+    @Tool
+    @LLMDescription("Processes input data")
+    fun processTool(
+        @LLMDescription("The input data to process")
+        input: String,
+    
+        @LLMDescription("Optional configuration parameters")
+        config: String = ""
+    ): String {
+        // Function implementation
+        return "Processed: $input with config: $config"
+    }
+    ```
+    <!--- KNIT example-annotation-based-tools-03.kt -->
+
+=== "Java"
+
+    ```java
+    @Tool
+    @LLMDescription(description = "Processes input data")
+    public String processTool(
+            @LLMDescription(description = "The input data to process") String input,
+            @LLMDescription(description = "Optional configuration parameters") String config
+    ) {
+        // Function implementation
+        return "Processed: " + input + " with config: " + config;
+    }
+    ```
 
 ## Creating a tool
 
@@ -140,96 +183,166 @@ fun processTool(
 Create a class that implements the [`ToolSet`](api:agents-tools::ai.koog.agents.core.tools.reflect.ToolSet) interface.
 This interface marks your class as a container for tools.
 
-<!--- INCLUDE
-import ai.koog.agents.core.tools.reflect.ToolSet
--->
-```kotlin
-class MyFirstToolSet : ToolSet {
-    // Tools will go here
-}
-```
-<!--- KNIT example-annotation-based-tools-06.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.tools.reflect.ToolSet
+    -->
+    ```kotlin
+    class MyFirstToolSet : ToolSet {
+        // Tools will go here
+    }
+    ```
+    <!--- KNIT example-annotation-based-tools-04.kt -->
+
+=== "Java"
+
+    ```java
+    public class MyFirstToolSet implements ToolSet {
+        // Tools will go here
+    }
+    ```
 
 ### 2. Add tool functions
 
 Add functions to your class and annotate them with `@Tool` to expose them as tools:
 
-<!--- INCLUDE
-import ai.koog.agents.core.tools.annotations.Tool
-import ai.koog.agents.core.tools.reflect.ToolSet
--->
-```kotlin
-class MyFirstToolSet : ToolSet {
-    @Tool
-    fun getWeather(location: String): String {
-        // In a real implementation, you would call a weather API
-        return "The weather in $location is sunny and 72°F"
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.tools.annotations.Tool
+    import ai.koog.agents.core.tools.reflect.ToolSet
+    -->
+    ```kotlin
+    class MyFirstToolSet : ToolSet {
+        @Tool
+        fun getWeather(location: String): String {
+            // In a real implementation, you would call a weather API
+            return "The weather in $location is sunny and 72°F"
+        }
     }
-}
-```
-<!--- KNIT example-annotation-based-tools-07.kt -->
+    ```
+    <!--- KNIT example-annotation-based-tools-05.kt -->
+
+=== "Java"
+
+    ```java
+    public class MyFirstToolSet implements ToolSet {
+        @Tool
+        public String getWeather(String location) {
+            // In a real implementation, you would call a weather API
+            return "The weather in " + location + " is sunny and 72°F";
+        }
+    }
+    ```
 
 ### 3. Add descriptions
 
 Add `@LLMDescription` annotations to provide context for the LLM:
-<!--- INCLUDE
-import ai.koog.agents.core.tools.reflect.ToolSet
-import ai.koog.agents.core.tools.annotations.LLMDescription
-import ai.koog.agents.core.tools.annotations.Tool
--->
-```kotlin
-@LLMDescription("Tools for getting weather information")
-class MyFirstToolSet : ToolSet {
-    @Tool
-    @LLMDescription("Get the current weather for a location")
-    fun getWeather(
-        @LLMDescription("The city and state/country")
-        location: String
-    ): String {
-        // In a real implementation, you would call a weather API
-        return "The weather in $location is sunny and 72°F"
+
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.tools.reflect.ToolSet
+    import ai.koog.agents.core.tools.annotations.LLMDescription
+    import ai.koog.agents.core.tools.annotations.Tool
+    -->
+    ```kotlin
+    @LLMDescription("Tools for getting weather information")
+    class MyFirstToolSet : ToolSet {
+        @Tool
+        @LLMDescription("Get the current weather for a location")
+        fun getWeather(
+            @LLMDescription("The city and state/country")
+            location: String
+        ): String {
+            // In a real implementation, you would call a weather API
+            return "The weather in $location is sunny and 72°F"
+        }
     }
-}
-```
-<!--- KNIT example-annotation-based-tools-08.kt -->
+    ```
+    <!--- KNIT example-annotation-based-tools-06.kt -->
+
+=== "Java"
+
+    ```java
+    @LLMDescription(description = "Tools for getting weather information")
+    public class MyFirstToolSet implements ToolSet {
+        @Tool
+        @LLMDescription(description = "Get the current weather for a location")
+        public String getWeather(
+                @LLMDescription(description = "The city and state/country") String location
+        ) {
+            // In a real implementation, you would call a weather API
+            return "The weather in " + location + " is sunny and 72°F";
+        }
+    }
+    ```
 
 ### 4. Use your tools with an agent
 
 Now you can use your tools with an agent:
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.tools.ToolRegistry
-import ai.koog.agents.core.tools.reflect.tools
-import ai.koog.agents.example.exampleAnnotationBasedTools06.MyFirstToolSet
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
-import kotlinx.coroutines.runBlocking
 
-const val apiToken = ""
--->
-```kotlin
-fun main() {
-    runBlocking {
-        // Create your tool set
-        val weatherTools = MyFirstToolSet()
-
-        // Create an agent with your tools
-
-        val agent = AIAgent(
-            promptExecutor = simpleOpenAIExecutor(apiToken),
-            systemPrompt = "Provide weather information for a given location.",
-            llmModel = OpenAIModels.Chat.GPT4o,
-            toolRegistry = ToolRegistry {
-                tools(weatherTools)
-            }
-        )
-
-        // The agent can now use your weather tools
-        agent.run("What's the weather like in New York?")
+=== "Kotlin"
+    
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.tools.ToolRegistry
+    import ai.koog.agents.core.tools.reflect.tools
+    import ai.koog.agents.example.exampleAnnotationBasedTools06.MyFirstToolSet
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+    import kotlinx.coroutines.runBlocking
+    const val apiToken = ""
+    -->
+    ```kotlin
+    fun main() {
+        runBlocking {
+            // Create your tool set
+            val weatherTools = MyFirstToolSet()
+    
+            // Create an agent with your tools
+    
+            val agent = AIAgent(
+                promptExecutor = simpleOpenAIExecutor(apiToken),
+                systemPrompt = "Provide weather information for a given location.",
+                llmModel = OpenAIModels.Chat.GPT4o,
+                toolRegistry = ToolRegistry {
+                    tools(weatherTools)
+                }
+            )
+    
+            // The agent can now use your weather tools
+            agent.run("What's the weather like in New York?")
+        }
     }
-}
-```
-<!--- KNIT example-annotation-based-tools-09.kt -->
+    ```
+    <!--- KNIT example-annotation-based-tools-07.kt -->
+
+=== "Java"
+
+    ```java
+    String apiToken = System.getenv("OPENAI_API_KEY");
+
+    // Create your tool set
+     MyFirstToolSet weatherTools = new MyFirstToolSet();
+
+    ToolRegistry toolRegistry = ToolRegistry.builder()
+        .tools(weatherTools)
+        .build();
+
+    // Create an agent with your tools
+    AIAgent<String, String> agent = AIAgent.builder()
+        .promptExecutor(simpleOpenAIExecutor(System.getenv("OPENAI_API_KEY")))
+        .systemPrompt("Provide weather information for a given location.")
+        .llmModel(OpenAIModels.Chat.GPT4o)
+        .toolRegistry(toolRegistry)
+        .build();
+
+    // The agent can now use your weather tools
+    String result = agent.run("What's the weather like in New York?");
+    System.out.println(result);
+    ```
 
 ## Usage examples
 
@@ -238,42 +351,88 @@ Here are some real-world examples of tool annotations.
 ### Basic example: Switch controller
 
 This example shows a simple tool set for controlling a switch:
-<!--- INCLUDE
-import ai.koog.agents.core.tools.reflect.ToolSet
-import ai.koog.agents.core.tools.annotations.LLMDescription
-import ai.koog.agents.core.tools.annotations.Tool
 
-class Switch(private var state: Boolean) {
-    fun switch(state: Boolean) {
-        this.state = state
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.tools.reflect.ToolSet
+    import ai.koog.agents.core.tools.annotations.LLMDescription
+    import ai.koog.agents.core.tools.annotations.Tool
+    class Switch(private var state: Boolean) {
+        fun switch(state: Boolean) {
+            this.state = state
+        }
+        fun isOn(): Boolean {
+            return state
+        }
+    }
+    -->
+    ```kotlin
+    @LLMDescription("Tools for controlling a switch")
+    class SwitchTools(val switch: Switch) : ToolSet {
+        @Tool
+        @LLMDescription("Switches the state of the switch")
+        fun switch(
+            @LLMDescription("The state to set (true for on, false for off)")
+            state: Boolean
+        ): String {
+            switch.switch(state)
+            return "Switched to ${if (state) "on" else "off"}"
+        }
+    
+        @Tool
+        @LLMDescription("Returns the current state of the switch")
+        fun switchState(): String {
+            return "Switch is ${if (switch.isOn()) "on" else "off"}"
+        }
+    }
+    ```
+    <!--- KNIT example-annotation-based-tools-08.kt -->
+
+=== "Java"
+
+    ```java
+    public class Switch {
+        private boolean state;
+
+        public Switch(boolean state) {
+            this.state = state;
+        }
+
+        // "switch" is a reserved keyword in Java, so we use a different method name
+        public void setState(boolean state) {
+            this.state = state;
+        }
+
+        public boolean isOn() {
+            return state;
+        }
     }
     
-    fun isOn(): Boolean {
-        return state
-    }
-}
--->
-```kotlin
-@LLMDescription("Tools for controlling a switch")
-class SwitchTools(val switch: Switch) : ToolSet {
-    @Tool
-    @LLMDescription("Switches the state of the switch")
-    fun switch(
-        @LLMDescription("The state to set (true for on, false for off)")
-        state: Boolean
-    ): String {
-        switch.switch(state)
-        return "Switched to ${if (state) "on" else "off"}"
-    }
+    @LLMDescription(description = "Tools for controlling a switch")
+    public class SwitchTools implements ToolSet {
+        private final Switch sw;
 
-    @Tool
-    @LLMDescription("Returns the current state of the switch")
-    fun switchState(): String {
-        return "Switch is ${if (switch.isOn()) "on" else "off"}"
+        public SwitchTools(Switch sw) {
+            this.sw = sw;
+        }
+
+        @Tool
+        @LLMDescription(description = "Switches the state of the switch")
+        public String switchStateTo(
+                @LLMDescription(description = "The state to set (true for on, false for off)") boolean state
+        ) {
+            sw.setState(state);
+            return "Switched to " + (state ? "on" : "off");
+        }
+
+        @Tool
+        @LLMDescription(description = "Returns the current state of the switch")
+        public String switchState() {
+            return "Switch is " + (sw.isOn() ? "on" : "off");
+        }
     }
-}
-```
-<!--- KNIT example-annotation-based-tools-10.kt -->
+    ```
 
 When an LLM needs to control a switch, it can understand the following information from the provided description:
 
@@ -285,39 +444,73 @@ When an LLM needs to control a switch, it can understand the following informati
 ### Advanced example: Diagnostic tools
 
 This example shows a more complex tool set for device diagnostics:
-<!--- INCLUDE
-import ai.koog.agents.core.tools.reflect.ToolSet
-import ai.koog.agents.core.tools.annotations.LLMDescription
-import ai.koog.agents.core.tools.annotations.Tool
--->
-```kotlin
-@LLMDescription("Tools for performing diagnostics and troubleshooting on devices")
-class DiagnosticToolSet : ToolSet {
-    @Tool
-    @LLMDescription("Run diagnostic on a device to check its status and identify any issues")
-    fun runDiagnostic(
-        @LLMDescription("The ID of the device to diagnose")
-        deviceId: String,
 
-        @LLMDescription("Additional information for the diagnostic (optional)")
-        additionalInfo: String = ""
-    ): String {
-        // Implementation
-        return "Diagnostic results for device $deviceId"
-    }
+=== "Kotlin"
 
-    @Tool
-    @LLMDescription("Analyze an error code to determine its meaning and possible solutions")
-    fun analyzeError(
-        @LLMDescription("The error code to analyze (e.g., 'E1001')")
-        errorCode: String
-    ): String {
-        // Implementation
-        return "Analysis of error code $errorCode"
+    <!--- INCLUDE
+    import ai.koog.agents.core.tools.reflect.ToolSet
+    import ai.koog.agents.core.tools.annotations.LLMDescription
+    import ai.koog.agents.core.tools.annotations.Tool
+    -->
+    ```kotlin
+    @LLMDescription("Tools for performing diagnostics and troubleshooting on devices")
+    class DiagnosticToolSet : ToolSet {
+        @Tool
+        @LLMDescription("Run diagnostic on a device to check its status and identify any issues")
+        fun runDiagnostic(
+            @LLMDescription("The ID of the device to diagnose")
+            deviceId: String,
+    
+            @LLMDescription("Additional information for the diagnostic (optional)")
+            additionalInfo: String = ""
+        ): String {
+            // Implementation
+            return "Diagnostic results for device $deviceId"
+        }
+    
+        @Tool
+        @LLMDescription("Analyze an error code to determine its meaning and possible solutions")
+        fun analyzeError(
+            @LLMDescription("The error code to analyze (e.g., 'E1001')")
+            errorCode: String
+        ): String {
+            // Implementation
+            return "Analysis of error code $errorCode"
+        }
     }
-}
-```
-<!--- KNIT example-annotation-based-tools-11.kt -->
+    ```
+    <!--- KNIT example-annotation-based-tools-09.kt -->
+
+=== "Java"
+
+    ```java
+    @LLMDescription(description = "Tools for performing diagnostics and troubleshooting on devices")
+    public class DiagnosticToolSet implements ToolSet {
+        // Convenience overload (not exposed as a tool)
+        public String runDiagnostic(String deviceId) {
+            return runDiagnostic(deviceId, "");
+        }
+    
+        @Tool
+        @LLMDescription(description = "Run diagnostic on a device to check its status and identify any issues")
+        public String runDiagnostic(
+                @LLMDescription(description = "The ID of the device to diagnose") String deviceId,
+                @LLMDescription(description = "Additional information for the diagnostic (optional)") String additionalInfo
+        ) {
+            // Implementation
+            return "Diagnostic results for device " + deviceId;
+        }
+    
+        @Tool
+        @LLMDescription(description = "Analyze an error code to determine its meaning and possible solutions")
+        public String analyzeError(
+                @LLMDescription(description = "The error code to analyze (e.g., 'E1001')") String errorCode
+        ) {
+            // Implementation
+            return "Analysis of error code " + errorCode;
+        }
+    }
+    ```
 
 ## Best practices
 

--- a/docs/docs/class-based-tools.md
+++ b/docs/docs/class-based-tools.md
@@ -43,43 +43,74 @@ Each tool consists of the following components:
 
 Here is an example of a custom tool implementation using the `Tool` class that returns a numeric result:
 
-<!--- INCLUDE
-import ai.koog.agents.core.tools.Tool
-import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.agents.core.tools.ToolParameterDescriptor
-import ai.koog.agents.core.tools.ToolParameterType
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.builtins.serializer
-import ai.koog.agents.core.tools.annotations.LLMDescription
--->
-```kotlin
-// Implement a simple calculator tool that adds two digits
-object CalculatorTool : Tool<CalculatorTool.Args, Int>(
-    argsSerializer = Args.serializer(),
-    resultSerializer = Int.serializer(),
-    name = "calculator",
-    description = "A simple calculator that can add two digits (0-9)."
-) {
+=== "Kotlin"
 
-    // Arguments for the calculator tool
-    @Serializable
-    data class Args(
-        @property:LLMDescription("The first digit to add (0-9)")
-        val digit1: Int,
-        @property:LLMDescription("The second digit to add (0-9)")
-        val digit2: Int
+    <!--- INCLUDE
+    import ai.koog.agents.core.tools.Tool
+    import ai.koog.agents.core.tools.ToolDescriptor
+    import ai.koog.agents.core.tools.ToolParameterDescriptor
+    import ai.koog.agents.core.tools.ToolParameterType
+    import kotlinx.serialization.Serializable
+    import kotlinx.serialization.builtins.serializer
+    import ai.koog.agents.core.tools.annotations.LLMDescription
+    -->
+    ```kotlin
+    // Implement a simple calculator tool that adds two digits
+    object CalculatorTool : Tool<CalculatorTool.Args, Int>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = Int.serializer(),
+        name = "calculator",
+        description = "A simple calculator that can add two digits (0-9)."
     ) {
-        init {
-            require(digit1 in 0..9) { "digit1 must be a single digit (0-9)" }
-            require(digit2 in 0..9) { "digit2 must be a single digit (0-9)" }
+
+        // Arguments for the calculator tool
+        @Serializable
+        data class Args(
+            @property:LLMDescription("The first digit to add (0-9)")
+            val digit1: Int,
+            @property:LLMDescription("The second digit to add (0-9)")
+            val digit2: Int
+        ) {
+            init {
+                require(digit1 in 0..9) { "digit1 must be a single digit (0-9)" }
+                require(digit2 in 0..9) { "digit2 must be a single digit (0-9)" }
+            }
+        }
+
+        // Function to add two digits
+        override suspend fun execute(args: Args): Int = args.digit1 + args.digit2
+    }
+    ```
+    <!--- KNIT example-class-based-tools-01.kt --> 
+
+=== "Java"
+
+    ```java
+    // Java equivalent: implement the tool as a Java method and register it via ToolRegistry.builder().
+    // This is the recommended Java interop path instead of subclassing the Kotlin Tool base class.
+    public final class CalculatorTool {
+        private CalculatorTool() {}
+
+        @Tool(customName = "calculator")
+        @LLMDescription(description = "A simple calculator that can add two digits (0-9).")
+        public static int calculator(
+                @LLMDescription(description = "The first digit to add (0-9)") int digit1,
+                @LLMDescription(description = "The second digit to add (0-9)") int digit2
+        ) {
+            if (digit1 < 0 || digit1 > 9) throw new IllegalArgumentException("digit1 must be a single digit (0-9)");
+            if (digit2 < 0 || digit2 > 9) throw new IllegalArgumentException("digit2 must be a single digit (0-9)");
+            return digit1 + digit2;
+        }
+
+        public static ToolRegistry registry() throws NoSuchMethodException {
+            return ToolRegistry.builder()
+                .tool(CalculatorTool.class.getMethod("calculator", int.class, int.class))
+                .build();
         }
     }
-
-    // Function to add two digits
-    override suspend fun execute(args: Args): Int = args.digit1 + args.digit2
-}
-```
-<!--- KNIT example-class-based-tools-01.kt --> 
+    // Note: Subclassing the Kotlin Tool<TArgs, TResult> and overriding a suspend execute(...) from Java is not supported.
+    // The Java interop uses reflection-based registration of Java methods as tools.
+    ```
 
 After implementing your tool, you need to add it to a tool registry and then use it with an agent. For details, see [Tool registry](tools-overview.md#tool-registry).
 
@@ -106,41 +137,74 @@ Each simple tool consists of the following components:
 
 Here is an example of a custom tool implementation using `SimpleTool`:
 
-<!--- INCLUDE
-import ai.koog.agents.core.tools.SimpleTool
-import ai.koog.agents.core.tools.annotations.LLMDescription
-import kotlinx.serialization.Serializable
--->
-```kotlin
-// Create a tool that casts a string expression to a double value
-object CastToDoubleTool : SimpleTool<CastToDoubleTool.Args>(
-    argsSerializer = Args.serializer(),
-    name = "cast_to_double",
-    description = "casts the passed expression to double or returns 0.0 if the expression is not castable"
-) {
-    // Define tool arguments
-    @Serializable
-    data class Args(
-        @property:LLMDescription("An expression to case to double")
-        val expression: String,
-        @property:LLMDescription("A comment on how to process the expression")
-        val comment: String
-    )
+=== "Kotlin"
 
-    // Function that executes the tool with the provided arguments
-    override suspend fun execute(args: Args): String {
-        return "Result: ${castToDouble(args.expression)}, " + "the comment was: ${args.comment}"
+    <!--- INCLUDE
+    import ai.koog.agents.core.tools.SimpleTool
+    import ai.koog.agents.core.tools.annotations.LLMDescription
+    import kotlinx.serialization.Serializable
+    -->
+    ```kotlin
+    // Create a tool that casts a string expression to a double value
+    object CastToDoubleTool : SimpleTool<CastToDoubleTool.Args>(
+        argsSerializer = Args.serializer(),
+        name = "cast_to_double",
+        description = "casts the passed expression to double or returns 0.0 if the expression is not castable"
+    ) {
+        // Define tool arguments
+        @Serializable
+        data class Args(
+            @property:LLMDescription("An expression to case to double")
+            val expression: String,
+            @property:LLMDescription("A comment on how to process the expression")
+            val comment: String
+        )
+
+        // Function that executes the tool with the provided arguments
+        override suspend fun execute(args: Args): String {
+            return "Result: ${castToDouble(args.expression)}, " + "the comment was: ${args.comment}"
+        }
+
+        // Function to cast a string expression to a double value
+        private fun castToDouble(expression: String): Double {
+            return expression.toDoubleOrNull() ?: 0.0
+        }
     }
+    ```
+    <!--- KNIT example-class-based-tools-02.kt --> 
 
-    // Function to cast a string expression to a double value
-    private fun castToDouble(expression: String): Double {
-        return expression.toDoubleOrNull() ?: 0.0
+=== "Java"
+
+    ```java
+    // Java equivalent of SimpleTool: provide a Java method and register it as a tool.
+    public final class CastToDoubleTool {
+        private CastToDoubleTool() {}
+
+        @Tool(customName = "cast_to_double")
+        @LLMDescription(description = "casts the passed expression to double or returns 0.0 if the expression is not castable")
+        public static String castToDouble(
+                @LLMDescription(description = "An expression to case to double") String expression,
+                @LLMDescription(description = "A comment on how to process the expression") String comment
+        ) {
+            double value;
+            try {
+                value = Double.parseDouble(expression);
+            } catch (Exception e) {
+                value = 0.0;
+            }
+            return "Result: " + value + ", the comment was: " + comment;
+        }
+
+        public static ToolRegistry registry() throws NoSuchMethodException {
+            return ToolRegistry.builder()
+                .tool(CastToDoubleTool.class.getMethod("castToDouble", String.class, String.class))
+                .build();
+        }
     }
-}
-```
-<!--- KNIT example-class-based-tools-02.kt --> 
+    // Note: Extending Kotlin SimpleTool<TArgs> from Java is not required; registering a Java method is the idiomatic approach.
+    ```
 
-### Sending Tool Result to LLM in Custom Format
+### Sending tool result to LLM in custom format
 
 If you are not happy with JSON results sent to LLM (in some cases, LLMs can work better if tool output is structured as Markdown, for instance), you have to follow the following steps:
 1. Implement `ToolResult.TextSerializable` interface, and override `textForLLM()` method
@@ -148,72 +212,110 @@ If you are not happy with JSON results sent to LLM (in some cases, LLMs can work
 
 #### Example
 
-<!--- INCLUDE
-import ai.koog.agents.core.tools.Tool
-import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.agents.core.tools.ToolParameterDescriptor
-import ai.koog.agents.core.tools.ToolParameterType
-import kotlinx.serialization.Serializable
-import ai.koog.agents.core.tools.annotations.LLMDescription
-import ai.koog.prompt.markdown.markdown
--->
-```kotlin
-// A tool that edits file
-object EditFile : Tool<EditFile.Args, EditFile.Result>(
-    argsSerializer = Args.serializer(),
-    resultSerializer = Result.serializer(),
-    name = "edit_file",
-    description = "Edits the given file"
-) {
-    // Define tool arguments
-    @Serializable
-    public data class Args(
-        val path: String,
-        val original: String,
-        val replacement: String
-    )
+=== "Kotlin"
 
-    @Serializable
-    public data class Result(
-        private val patchApplyResult: PatchApplyResult
+    <!--- INCLUDE
+    import ai.koog.agents.core.tools.Tool
+    import ai.koog.agents.core.tools.ToolDescriptor
+    import ai.koog.agents.core.tools.ToolParameterDescriptor
+    import ai.koog.agents.core.tools.ToolParameterType
+    import kotlinx.serialization.Serializable
+    import ai.koog.agents.core.tools.annotations.LLMDescription
+    import ai.koog.prompt.markdown.markdown
+    -->
+    ```kotlin
+    // A tool that edits file
+    object EditFile : Tool<EditFile.Args, EditFile.Result>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = Result.serializer(),
+        name = "edit_file",
+        description = "Edits the given file"
     ) {
+        // Define tool arguments
+        @Serializable
+        public data class Args(
+            val path: String,
+            val original: String,
+            val replacement: String
+        )
 
         @Serializable
-        public sealed interface PatchApplyResult {
-            @Serializable
-            public data class Success(val updatedContent: String) : PatchApplyResult
+        public data class Result(
+            private val patchApplyResult: PatchApplyResult
+        ) {
 
             @Serializable
-            public sealed class Failure(public val reason: String) : PatchApplyResult
+            public sealed interface PatchApplyResult {
+                @Serializable
+                public data class Success(val updatedContent: String) : PatchApplyResult
+
+                @Serializable
+                public sealed class Failure(public val reason: String) : PatchApplyResult
+            }
+
+            // Textual output (in Markdown format) that will be visible to the LLM after the tool finishes.
+            fun textForLLM(): String = markdown {
+                if (patchApplyResult is PatchApplyResult.Success) {
+                    line {
+                        bold("Successfully").text(" edited file (patch applied)")
+                    }
+                } else {
+                    line {
+                        text("File was ")
+                            .bold("not")
+                            .text(" modified (patch application failed: ${(patchApplyResult as PatchApplyResult.Failure).reason})")
+                    }
+                }
+            }
+
+            override fun toString(): String = textForLLM()
         }
 
-        // Textual output (in Markdown format) that will be visible to the LLM after the tool finishes.
-        fun textForLLM(): String = markdown {
-            if (patchApplyResult is PatchApplyResult.Success) {
-                line {
-                    bold("Successfully").text(" edited file (patch applied)")
-                }
+        // Function that executes the tool with the provided arguments
+        override suspend fun execute(args: Args): Result {
+            return TODO("Implement file edit")
+        }
+    }
+    ```
+    <!--- KNIT example-class-based-tools-03.kt -->
+
+=== "Java"
+
+    ```java
+    import ai.koog.agents.core.tools.ToolRegistry;
+    import ai.koog.agents.core.tools.annotations.LLMDescription;
+    import ai.koog.agents.core.tools.annotations.Tool;
+
+    // Java equivalent: return Markdown text directly to the LLM from a Java method and register it as a tool.
+    // This avoids needing a custom serializable Result type (which would require Kotlin serialization support).
+    public final class EditFile {
+        private EditFile() {}
+
+        @Tool(customName = "edit_file")
+        @LLMDescription(description = "Edits the given file")
+        public static String editFile(
+                String path,
+                String original,
+                String replacement
+        ) {
+            // TODO: Implement file edit logic; below is a placeholder illustrating Markdown output
+            boolean success = false;
+            if (success) {
+                return "**Successfully** edited file (patch applied)";
             } else {
-                line {
-                    text("File was ")
-                        .bold("not")
-                        .text(" modified (patch application failed: ${(patchApplyResult as PatchApplyResult.Failure).reason})")
-                }
+                return "File was **not** modified (patch application failed: reason)";
             }
         }
 
-        override fun toString(): String = textForLLM()
+        public static ToolRegistry registry() throws NoSuchMethodException {
+            return ToolRegistry.builder()
+                .tool(EditFile.class.getMethod("editFile", String.class, String.class, String.class))
+                .build();
+        }
     }
-
-    // Function that executes the tool with the provided arguments
-    override suspend fun execute(args: Args): Result {
-        return TODO("Implement file edit")
-    }
-}
-```
-<!--- KNIT example-class-based-tools-03.kt -->
-
-
+    // Note: If you need a structured custom Result object from Java, you must expose a Kotlin @Serializable type
+    // or another serializer-aware type. Returning String works out-of-the-box with Koog's Java interop.
+    ```
 
 After implementing your tool, you need to add it to a tool registry and then use it with an agent.
 For details, see [Tool registry](tools-overview.md#tool-registry).

--- a/docs/docs/history-compression.md
+++ b/docs/docs/history-compression.md
@@ -34,69 +34,83 @@ Depending on which step you decide to perform compression, the following scenari
 
 * To compress the history when it becomes too long, you can define a helper function and add the `nodeLLMCompressHistory` node to your strategy graph with the following logic:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.context.AIAgentContext
-import ai.koog.agents.core.dsl.builder.forwardTo
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.nodeExecuteTool
-import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
-import ai.koog.agents.core.dsl.extension.nodeLLMRequest
-import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResult
-import ai.koog.agents.core.dsl.extension.onAssistantMessage
-import ai.koog.agents.core.dsl.extension.onToolCall
-import ai.koog.agents.core.environment.ReceivedToolResult
--->
-```kotlin
-// Define that the history is too long if there are more than 100 messages
-private suspend fun AIAgentContext.historyIsTooLong(): Boolean = llm.readSession { prompt.messages.size > 100 }
+=== "Kotlin"
 
-val strategy = strategy<String, String>("execute-with-history-compression") {
-    val callLLM by nodeLLMRequest()
-    val executeTool by nodeExecuteTool()
-    val sendToolResult by nodeLLMSendToolResult()
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.context.AIAgentContext
+    import ai.koog.agents.core.dsl.builder.forwardTo
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.agents.core.dsl.extension.nodeExecuteTool
+    import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
+    import ai.koog.agents.core.dsl.extension.nodeLLMRequest
+    import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResult
+    import ai.koog.agents.core.dsl.extension.onAssistantMessage
+    import ai.koog.agents.core.dsl.extension.onToolCall
+    import ai.koog.agents.core.environment.ReceivedToolResult
+    -->
+    ```kotlin
+    // Define that the history is too long if there are more than 100 messages
+    private suspend fun AIAgentContext.historyIsTooLong(): Boolean = llm.readSession { prompt.messages.size > 100 }
+    
+    val strategy = strategy<String, String>("execute-with-history-compression") {
+        val callLLM by nodeLLMRequest()
+        val executeTool by nodeExecuteTool()
+        val sendToolResult by nodeLLMSendToolResult()
+    
+        // Compress the LLM history and keep the current ReceivedToolResult for the next node
+        val compressHistory by nodeLLMCompressHistory<ReceivedToolResult>()
+    
+        edge(nodeStart forwardTo callLLM)
+        edge(callLLM forwardTo nodeFinish onAssistantMessage { true })
+        edge(callLLM forwardTo executeTool onToolCall { true })
+    
+        // Compress history after executing any tool if the history is too long 
+        edge(executeTool forwardTo compressHistory onCondition { historyIsTooLong() })
+        edge(compressHistory forwardTo sendToolResult)
+        // Otherwise, proceed to the next LLM request
+        edge(executeTool forwardTo sendToolResult onCondition { !historyIsTooLong() })
+    
+        edge(sendToolResult forwardTo executeTool onToolCall { true })
+        edge(sendToolResult forwardTo nodeFinish onAssistantMessage { true })
+    }
+    ```
+    <!--- KNIT example-history-compression-01.kt -->
 
-    // Compress the LLM history and keep the current ReceivedToolResult for the next node
-    val compressHistory by nodeLLMCompressHistory<ReceivedToolResult>()
+=== "Java"
 
-    edge(nodeStart forwardTo callLLM)
-    edge(callLLM forwardTo nodeFinish onAssistantMessage { true })
-    edge(callLLM forwardTo executeTool onToolCall { true })
-
-    // Compress history after executing any tool if the history is too long 
-    edge(executeTool forwardTo compressHistory onCondition { historyIsTooLong() })
-    edge(compressHistory forwardTo sendToolResult)
-    // Otherwise, proceed to the next LLM request
-    edge(executeTool forwardTo sendToolResult onCondition { !historyIsTooLong() })
-
-    edge(sendToolResult forwardTo executeTool onToolCall { true })
-    edge(sendToolResult forwardTo nodeFinish onAssistantMessage { true })
-}
-```
-<!--- KNIT example-history-compression-01.kt -->
+    ```java
+    ```
 
 In this example, the strategy checks if the history is too long after each tool call.
 The history is compressed before sending the tool result back to the LLM. This prevents the context from growing during long conversations.
 
 * To compress the history between the logical steps (subgraphs) of your strategy, you can implement your strateg as follows:
 
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
--->
-```kotlin
-val strategy = strategy<String, String>("execute-with-history-compression") {
-    val collectInformation by subgraph<String, String> {
-        // Some steps to collect the information
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
+    -->
+    ```kotlin
+    val strategy = strategy<String, String>("execute-with-history-compression") {
+        val collectInformation by subgraph<String, String> {
+            // Some steps to collect the information
+        }
+        val compressHistory by nodeLLMCompressHistory<String>()
+        val makeTheDecision by subgraph<String, String> {
+            // Some steps to make the decision based on the current compressed history and collected information
+        }
+        
+        nodeStart then collectInformation then compressHistory then makeTheDecision
     }
-    val compressHistory by nodeLLMCompressHistory<String>()
-    val makeTheDecision by subgraph<String, String> {
-        // Some steps to make the decision based on the current compressed history and collected information
-    }
-    
-    nodeStart then collectInformation then compressHistory then makeTheDecision
-}
-```
-<!--- KNIT example-history-compression-02.kt -->
+    ```
+    <!--- KNIT example-history-compression-02.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 In this example, the history is compressed after completing the information collection phase, but before proceeding to the decision-making phase.
 
@@ -104,23 +118,33 @@ In this example, the history is compressed after completing the information coll
 
 If you are implementing a custom node, you can compress history using the `replaceHistoryWithTLDR()` function as follows:
 
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.replaceHistoryWithTLDR
+=== "Kotlin"
 
-val strategy = strategy<String, String>("strategy_name") {
-    val node by node<Unit, Unit> {
--->
-<!--- SUFFIX
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.agents.core.dsl.extension.replaceHistoryWithTLDR
+    val strategy = strategy<String, String>("strategy_name") {
+        val node by node<Unit, Unit> {
+    -->
+    <!--- SUFFIX
+        }
     }
-}
--->
-```kotlin
-llm.writeSession {
-    replaceHistoryWithTLDR()
-}
-```
-<!--- KNIT example-history-compression-03.kt -->
+    -->
+    ```kotlin
+    llm.writeSession {
+        replaceHistoryWithTLDR()
+    }
+    ```
+    <!--- KNIT example-history-compression-03.kt -->
+
+=== "Java"
+
+    ```java
+    // FAILED: `replaceHistoryWithTLDR()` is a suspend Kotlin extension on AIAgentLLMWriteSession
+    // and requires a coroutine context. From Java, calling suspend functions directly
+    // would require passing a Continuation and coroutine machinery, which is not part of the
+    // public Java API. No non-suspending Java wrapper is available for this action.
+    ```
 
 This approach gives you more flexibility to implement compression at any point in your custom node logic, based on your specific requirements.
 
@@ -139,47 +163,66 @@ This strategy works well for most general use cases where you want to maintain a
 You can use it as follows: 
 
 * In a strategy graph:
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
-import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
 
-typealias ProcessedInput = String
+=== "Kotlin"
 
-val strategy = strategy<String, String>("strategy_name") {
-    val node by node<Unit, Unit> {
--->
-<!--- SUFFIX
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
+    import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
+    typealias ProcessedInput = String
+    val strategy = strategy<String, String>("strategy_name") {
+        val node by node<Unit, Unit> {
+    -->
+    <!--- SUFFIX
+        }
     }
-}
--->
-```kotlin
-val compressHistory by nodeLLMCompressHistory<ProcessedInput>(
-    strategy = HistoryCompressionStrategy.WholeHistory
-)
-```
-<!--- KNIT example-history-compression-04.kt -->
+    -->
+    ```kotlin
+    val compressHistory by nodeLLMCompressHistory<ProcessedInput>(
+        strategy = HistoryCompressionStrategy.WholeHistory
+    )
+    ```
+    <!--- KNIT example-history-compression-04.kt -->
+
+=== "Java"
+
+    ```java
+    // FAILED: `nodeLLMCompressHistory<ProcessedInput>(strategy = HistoryCompressionStrategy.WholeHistory)`
+    // is a Kotlin DSL node with a reified generic. There is no Java builder to add this node
+    // into a graph strategy. The HistoryCompressionStrategy type exists, but invoking the DSL
+    // from Java is not supported.
+    ```
 
 * In a custom node:
 
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
-import ai.koog.agents.core.dsl.extension.replaceHistoryWithTLDR
+=== "Kotlin"
 
-val strategy = strategy<String, String>("strategy_name") {
-    val node by node<Unit, Unit> {
--->
-<!--- SUFFIX
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
+    import ai.koog.agents.core.dsl.extension.replaceHistoryWithTLDR
+    val strategy = strategy<String, String>("strategy_name") {
+        val node by node<Unit, Unit> {
+    -->
+    <!--- SUFFIX
+        }
     }
-}
--->
-```kotlin
-llm.writeSession {
-    replaceHistoryWithTLDR(strategy = HistoryCompressionStrategy.WholeHistory)
-}
-```
-<!--- KNIT example-history-compression-05.kt -->
+    -->
+    ```kotlin
+    llm.writeSession {
+        replaceHistoryWithTLDR(strategy = HistoryCompressionStrategy.WholeHistory)
+    }
+    ```
+    <!--- KNIT example-history-compression-05.kt -->
+
+=== "Java"
+
+    ```java
+    // FAILED: `replaceHistoryWithTLDR(strategy = HistoryCompressionStrategy.WholeHistory)` is a suspend
+    // Kotlin extension on AIAgentLLMWriteSession and requires coroutines. No non-suspending Java
+    // wrapper exists in the current Koog API to perform this operation.
+    ```
 
 ### FromLastNMessages
 
@@ -190,49 +233,64 @@ You can use it as follows:
 
 * In a strategy graph:
 
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
-import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
+=== "Kotlin"
 
-typealias ProcessedInput = String
-
-val strategy = strategy<String, String>("strategy_name") {
-val node by node<Unit, Unit> {
--->
-<!--- SUFFIX
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
+    import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
+    typealias ProcessedInput = String
+    val strategy = strategy<String, String>("strategy_name") {
+    val node by node<Unit, Unit> {
+    -->
+    <!--- SUFFIX
+        }
     }
-}
--->
-```kotlin
-val compressHistory by nodeLLMCompressHistory<ProcessedInput>(
-    strategy = HistoryCompressionStrategy.FromLastNMessages(5)
-)
-```
-<!--- KNIT example-history-compression-06.kt -->
+    -->
+    ```kotlin
+    val compressHistory by nodeLLMCompressHistory<ProcessedInput>(
+        strategy = HistoryCompressionStrategy.FromLastNMessages(5)
+    )
+    ```
+    <!--- KNIT example-history-compression-06.kt -->
+
+=== "Java"
+
+    ```java
+    // FAILED: The Kotlin DSL node `nodeLLMCompressHistory<ProcessedInput>(
+    //   strategy = HistoryCompressionStrategy.FromLastNMessages(5)
+    // )` relies on reified generics and DSL builders not callable from Java.
+    ```
 
 * In a custom node:
 
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
-import ai.koog.agents.core.dsl.extension.replaceHistoryWithTLDR
+=== "Kotlin"
 
-typealias ProcessedInput = String
-
-val strategy = strategy<String, String>("strategy_name") {
-val node by node<Unit, Unit> {
--->
-<!--- SUFFIX
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
+    import ai.koog.agents.core.dsl.extension.replaceHistoryWithTLDR
+    typealias ProcessedInput = String
+    val strategy = strategy<String, String>("strategy_name") {
+    val node by node<Unit, Unit> {
+    -->
+    <!--- SUFFIX
+        }
     }
-}
--->
-```kotlin
-llm.writeSession {
-    replaceHistoryWithTLDR(strategy = HistoryCompressionStrategy.FromLastNMessages(5))
-}
-```
-<!--- KNIT example-history-compression-07.kt -->
+    -->
+    ```kotlin
+    llm.writeSession {
+        replaceHistoryWithTLDR(strategy = HistoryCompressionStrategy.FromLastNMessages(5))
+    }
+    ```
+    <!--- KNIT example-history-compression-07.kt -->
+
+=== "Java"
+
+    ```java
+    // FAILED: Calling `replaceHistoryWithTLDR(strategy = HistoryCompressionStrategy.FromLastNMessages(5))`
+    // requires a suspend Kotlin context. There is no Java-accessible non-suspending API for this.
+    ```
 
 ### Chunked
 
@@ -243,49 +301,64 @@ You can use it as follows:
 
 * In a strategy graph:
 
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
-import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
+=== "Kotlin"
 
-typealias ProcessedInput = String
-
-val strategy = strategy<String, String>("strategy_name") {
-val node by node<Unit, Unit> {
--->
-<!--- SUFFIX
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
+    import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
+    typealias ProcessedInput = String
+    val strategy = strategy<String, String>("strategy_name") {
+    val node by node<Unit, Unit> {
+    -->
+    <!--- SUFFIX
+        }
     }
-}
--->
-```kotlin
-val compressHistory by nodeLLMCompressHistory<ProcessedInput>(
-    strategy = HistoryCompressionStrategy.Chunked(10)
-)
-```
-<!--- KNIT example-history-compression-08.kt -->
+    -->
+    ```kotlin
+    val compressHistory by nodeLLMCompressHistory<ProcessedInput>(
+        strategy = HistoryCompressionStrategy.Chunked(10)
+    )
+    ```
+    <!--- KNIT example-history-compression-08.kt -->
+
+=== "Java"
+
+    ```java
+    // FAILED: The Kotlin graph DSL and `nodeLLMCompressHistory<ProcessedInput>(
+    //   strategy = HistoryCompressionStrategy.Chunked(10)
+    // )` are not available from Java due to reified generics and lack of a Java graph builder API.
+    ```
 
 * In a custom node:
 
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
-import ai.koog.agents.core.dsl.extension.replaceHistoryWithTLDR
+=== "Kotlin"
 
-typealias ProcessedInput = String
-
-val strategy = strategy<String, String>("strategy_name") {
-val node by node<Unit, Unit> {
--->
-<!--- SUFFIX
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
+    import ai.koog.agents.core.dsl.extension.replaceHistoryWithTLDR
+    typealias ProcessedInput = String
+    val strategy = strategy<String, String>("strategy_name") {
+    val node by node<Unit, Unit> {
+    -->
+    <!--- SUFFIX
+        }
     }
-}
--->
-```kotlin
-llm.writeSession {
-    replaceHistoryWithTLDR(strategy = HistoryCompressionStrategy.Chunked(10))
-}
-```
-<!--- KNIT example-history-compression-09.kt -->
+    -->
+    ```kotlin
+    llm.writeSession {
+        replaceHistoryWithTLDR(strategy = HistoryCompressionStrategy.Chunked(10))
+    }
+    ```
+    <!--- KNIT example-history-compression-09.kt -->
+
+=== "Java"
+
+    ```java
+    // FAILED: `replaceHistoryWithTLDR(strategy = HistoryCompressionStrategy.Chunked(10))` is a suspend
+    // Kotlin API; there is no current non-suspending Java entry point to perform this action inside a node.
+    ```
 
 ### RetrieveFactsFromHistory
 
@@ -297,75 +370,27 @@ You can use it as follows:
 
 * In a strategy graph:
 
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
-import ai.koog.agents.memory.feature.history.RetrieveFactsFromHistory
-import ai.koog.agents.memory.model.Concept
-import ai.koog.agents.memory.model.FactType
+=== "Kotlin"
 
-typealias ProcessedInput = String
-
-val strategy = strategy<String, String>("strategy_name") {
-val node by node<Unit, Unit> {
--->
-<!--- SUFFIX
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
+    import ai.koog.agents.memory.feature.history.RetrieveFactsFromHistory
+    import ai.koog.agents.memory.model.Concept
+    import ai.koog.agents.memory.model.FactType
+    typealias ProcessedInput = String
+    val strategy = strategy<String, String>("strategy_name") {
+    val node by node<Unit, Unit> {
+    -->
+    <!--- SUFFIX
+        }
     }
-}
--->
-```kotlin
-val compressHistory by nodeLLMCompressHistory<ProcessedInput>(
-    strategy = RetrieveFactsFromHistory(
-        Concept(
-            keyword = "user_preferences",
-            // Description to the LLM -- what specifically to search for
-            description = "User's preferences for the recommendation system, including the preferred conversation style, theme in the application, etc.",
-            // LLM would search for multiple relevant facts related to this concept:
-            factType = FactType.MULTIPLE
-        ),
-        Concept(
-            keyword = "product_details",
-            // Description to the LLM -- what specifically to search for
-            description = "Brief details about products in the catalog the user has been checking",
-            // LLM would search for multiple relevant facts related to this concept:
-            factType = FactType.MULTIPLE
-        ),
-        Concept(
-            keyword = "issue_solved",
-            // Description to the LLM -- what specifically to search for
-            description = "Was the initial user's issue resolved?",
-            // LLM would search for a single answer to the question:
-            factType = FactType.SINGLE
-        )
-    )
-)
-```
-<!--- KNIT example-history-compression-10.kt -->
-
-* In a custom node:
-
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.replaceHistoryWithTLDR
-import ai.koog.agents.memory.feature.history.RetrieveFactsFromHistory
-import ai.koog.agents.memory.model.Concept
-import ai.koog.agents.memory.model.FactType
-
-typealias ProcessedInput = String
-
-val strategy = strategy<String, String>("strategy_name") {
-val node by node<Unit, Unit> {
--->
-<!--- SUFFIX
-    }
-}
--->
-```kotlin
-llm.writeSession {
-    replaceHistoryWithTLDR(
+    -->
+    ```kotlin
+    val compressHistory by nodeLLMCompressHistory<ProcessedInput>(
         strategy = RetrieveFactsFromHistory(
             Concept(
-                keyword = "user_preferences", 
+                keyword = "user_preferences",
                 // Description to the LLM -- what specifically to search for
                 description = "User's preferences for the recommendation system, including the preferred conversation style, theme in the application, etc.",
                 // LLM would search for multiple relevant facts related to this concept:
@@ -387,9 +412,72 @@ llm.writeSession {
             )
         )
     )
-}
-```
-<!--- KNIT example-history-compression-11.kt -->
+    ```
+    <!--- KNIT example-history-compression-10.kt -->
+
+=== "Java"
+
+    ```java
+    // FAILED: `nodeLLMCompressHistory<ProcessedInput>(strategy = new RetrieveFactsFromHistory(...))`
+    // is part of the Kotlin graph DSL with reified generics; Java cannot call it and there is no
+    // equivalent Java graph builder API to inject this node.
+    ```
+
+* In a custom node:
+
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.agents.core.dsl.extension.replaceHistoryWithTLDR
+    import ai.koog.agents.memory.feature.history.RetrieveFactsFromHistory
+    import ai.koog.agents.memory.model.Concept
+    import ai.koog.agents.memory.model.FactType
+    typealias ProcessedInput = String
+    val strategy = strategy<String, String>("strategy_name") {
+    val node by node<Unit, Unit> {
+    -->
+    <!--- SUFFIX
+        }
+    }
+    -->
+    ```kotlin
+    llm.writeSession {
+        replaceHistoryWithTLDR(
+            strategy = RetrieveFactsFromHistory(
+                Concept(
+                    keyword = "user_preferences", 
+                    // Description to the LLM -- what specifically to search for
+                    description = "User's preferences for the recommendation system, including the preferred conversation style, theme in the application, etc.",
+                    // LLM would search for multiple relevant facts related to this concept:
+                    factType = FactType.MULTIPLE
+                ),
+                Concept(
+                    keyword = "product_details",
+                    // Description to the LLM -- what specifically to search for
+                    description = "Brief details about products in the catalog the user has been checking",
+                    // LLM would search for multiple relevant facts related to this concept:
+                    factType = FactType.MULTIPLE
+                ),
+                Concept(
+                    keyword = "issue_solved",
+                    // Description to the LLM -- what specifically to search for
+                    description = "Was the initial user's issue resolved?",
+                    // LLM would search for a single answer to the question:
+                    factType = FactType.SINGLE
+                )
+            )
+        )
+    }
+    ```
+    <!--- KNIT example-history-compression-11.kt -->
+
+=== "Java"
+
+    ```java
+    // FAILED: `replaceHistoryWithTLDR(strategy = new RetrieveFactsFromHistory(...))` is a suspend
+    // Kotlin extension requiring coroutines; no Java wrapper is available.
+    ```
 
 ## Custom history compression strategy implementation
 
@@ -397,43 +485,53 @@ You can create your own history compression strategy by extending the `HistoryCo
 
 Here is an example:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.session.AIAgentLLMWriteSession
-import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
-import ai.koog.prompt.message.Message
--->
-```kotlin
-class MyCustomCompressionStrategy : HistoryCompressionStrategy() {
-    override suspend fun compress(
-        llmSession: AIAgentLLMWriteSession,
-        memoryMessages: List<Message>
-    ) {
-        // 1. Process the current history in llmSession.prompt.messages
-        // 2. Create new compressed messages
-        // 3. Update the prompt with the compressed messages
+=== "Kotlin"
 
-        // Save original messages to preserve them
-        val originalMessages = llmSession.prompt.messages
-        
-        // Example implementation:
-        val importantMessages = llmSession.prompt.messages.filter {
-            // Your custom filtering logic
-            it.content.contains("important")
-        }.filterIsInstance<Message.Response>()
-        
-        // Note: you can also make LLM requests using the `llmSession` and ask the LLM to do some job for you using, for example, `llmSession.requestLLMWithoutTools()`
-        // Or you can change the current model: `llmSession.model = AnthropicModels.Opus_4_6` and ask some other LLM model -- but don't forget to change it back after
-
-        // Compose the prompt with the filtered messages
-        val compressedMessages = composeMessageHistory(
-            originalMessages,
-            importantMessages,
-            memoryMessages
-        )
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.session.AIAgentLLMWriteSession
+    import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
+    import ai.koog.prompt.message.Message
+    -->
+    ```kotlin
+    class MyCustomCompressionStrategy : HistoryCompressionStrategy() {
+        override suspend fun compress(
+            llmSession: AIAgentLLMWriteSession,
+            memoryMessages: List<Message>
+        ) {
+            // 1. Process the current history in llmSession.prompt.messages
+            // 2. Create new compressed messages
+            // 3. Update the prompt with the compressed messages
+    
+            // Save original messages to preserve them
+            val originalMessages = llmSession.prompt.messages
+            
+            // Example implementation:
+            val importantMessages = llmSession.prompt.messages.filter {
+                // Your custom filtering logic
+                it.content.contains("important")
+            }.filterIsInstance<Message.Response>()
+            
+            // Note: you can also make LLM requests using the `llmSession` and ask the LLM to do some job for you using, for example, `llmSession.requestLLMWithoutTools()`
+            // Or you can change the current model: `llmSession.model = AnthropicModels.Opus_4_6` and ask some other LLM model -- but don't forget to change it back after
+    
+            // Compose the prompt with the filtered messages
+            val compressedMessages = composeMessageHistory(
+                originalMessages,
+                importantMessages,
+                memoryMessages
+            )
+        }
     }
-}
-```
-<!--- KNIT example-history-compression-12.kt -->
+    ```
+    <!--- KNIT example-history-compression-12.kt -->
+
+=== "Java"
+
+    ```java
+    // FAILED: Custom strategies must extend Kotlin `HistoryCompressionStrategy` and override the
+    // suspend method `compress(AIAgentLLMWriteSession, List<Message>)`. Java cannot implement
+    // suspend functions directly. A Kotlin shim would be required; no direct Java implementation is possible.
+    ```
 
 In this example, the custom strategy filters messages that contain the word "important" and keeps only those in the compressed history.
 
@@ -441,47 +539,62 @@ Then you can use it as follows:
 
 * In a strategy graph:
 
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
-import ai.koog.agents.example.exampleHistoryCompression12.MyCustomCompressionStrategy
+=== "Kotlin"
 
-typealias ProcessedInput = String
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
+    import ai.koog.agents.example.exampleHistoryCompression12.MyCustomCompressionStrategy
+    typealias ProcessedInput = String
+    val strategy = strategy<String, String>("strategy_name") {
+    -->
+    <!--- SUFFIX
+    }
+    -->
+    ```kotlin
+    val compressHistory by nodeLLMCompressHistory<ProcessedInput>(
+        strategy = MyCustomCompressionStrategy()
+    )
+    ```
+    <!--- KNIT example-history-compression-13.kt -->
 
-val strategy = strategy<String, String>("strategy_name") {
--->
-<!--- SUFFIX
-}
--->
-```kotlin
-val compressHistory by nodeLLMCompressHistory<ProcessedInput>(
-    strategy = MyCustomCompressionStrategy()
-)
-```
-<!--- KNIT example-history-compression-13.kt -->
+=== "Java"
+
+    ```java
+    // FAILED: Even with a custom strategy, adding it via `nodeLLMCompressHistory<ProcessedInput>(
+    //   strategy = new MyCustomCompressionStrategy()
+    // )` is Kotlin DSL-only with reified generics; no Java graph builder is provided.
+    ```
 
 * In a custom node:
 
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.replaceHistoryWithTLDR
-import ai.koog.agents.example.exampleHistoryCompression12.MyCustomCompressionStrategy
+=== "Kotlin"
 
-typealias ProcessedInput = String
-
-val strategy = strategy<String, String>("strategy_name") {
-val node by node<Unit, Unit> {
--->
-<!--- SUFFIX
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.agents.core.dsl.extension.replaceHistoryWithTLDR
+    import ai.koog.agents.example.exampleHistoryCompression12.MyCustomCompressionStrategy
+    typealias ProcessedInput = String
+    val strategy = strategy<String, String>("strategy_name") {
+    val node by node<Unit, Unit> {
+    -->
+    <!--- SUFFIX
+        }
     }
-}
--->
-```kotlin
-llm.writeSession {
-    replaceHistoryWithTLDR(strategy = MyCustomCompressionStrategy())
-}
-```
-<!--- KNIT example-history-compression-14.kt -->
+    -->
+    ```kotlin
+    llm.writeSession {
+        replaceHistoryWithTLDR(strategy = MyCustomCompressionStrategy())
+    }
+    ```
+    <!--- KNIT example-history-compression-14.kt -->
+
+=== "Java"
+
+    ```java
+    // FAILED: `replaceHistoryWithTLDR(strategy = new MyCustomCompressionStrategy())` is a suspend
+    // Kotlin API; not callable from Java without coroutine interop glue, which the public API lacks.
+    ```
 
 ##  Memory preservation during compression
 
@@ -492,48 +605,62 @@ You can use the `preserveMemory` parameter as follows:
 
 * In a strategy graph:
 
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
-import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
+=== "Kotlin"
 
-typealias ProcessedInput = String
-
-val strategy = strategy<String, String>("strategy_name") {
--->
-<!--- SUFFIX
-}
--->
-```kotlin
-val compressHistory by nodeLLMCompressHistory<ProcessedInput>(
-    strategy = HistoryCompressionStrategy.WholeHistory,
-    preserveMemory = true
-)
-```
-<!--- KNIT example-history-compression-15.kt -->
-
-* In a custom node:
-
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
-import ai.koog.agents.core.dsl.extension.replaceHistoryWithTLDR
-
-typealias ProcessedInput = String
-
-val strategy = strategy<String, String>("strategy_name") {
-val node by node<Unit, Unit> {
--->
-<!--- SUFFIX
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
+    import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
+    typealias ProcessedInput = String
+    val strategy = strategy<String, String>("strategy_name") {
+    -->
+    <!--- SUFFIX
     }
-}
--->
-```kotlin
-llm.writeSession {
-    replaceHistoryWithTLDR(
+    -->
+    ```kotlin
+    val compressHistory by nodeLLMCompressHistory<ProcessedInput>(
         strategy = HistoryCompressionStrategy.WholeHistory,
         preserveMemory = true
     )
-}
-```
-<!--- KNIT example-history-compression-16.kt -->
+    ```
+    <!--- KNIT example-history-compression-15.kt -->
+
+=== "Java"
+
+    ```java
+    // FAILED: Passing `preserveMemory = true` to `nodeLLMCompressHistory<ProcessedInput>(...)`
+    // still relies on the Kotlin graph DSL with reified generics; Java cannot use this API directly.
+    ```
+
+* In a custom node:
+
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
+    import ai.koog.agents.core.dsl.extension.replaceHistoryWithTLDR
+    typealias ProcessedInput = String
+    val strategy = strategy<String, String>("strategy_name") {
+    val node by node<Unit, Unit> {
+    -->
+    <!--- SUFFIX
+        }
+    }
+    -->
+    ```kotlin
+    llm.writeSession {
+        replaceHistoryWithTLDR(
+            strategy = HistoryCompressionStrategy.WholeHistory,
+            preserveMemory = true
+        )
+    }
+    ```
+    <!--- KNIT example-history-compression-16.kt -->
+
+=== "Java"
+
+    ```java
+    // FAILED: `replaceHistoryWithTLDR(strategy = HistoryCompressionStrategy.WholeHistory, preserveMemory = true)`
+    // is a suspend Kotlin extension; there is no Java-accessible non-suspending wrapper in Koog.
+    ```

--- a/docs/docs/llm-parameters.md
+++ b/docs/docs/llm-parameters.md
@@ -10,93 +10,126 @@ In Koog, the `LLMParams` class incorporates LLM parameters and provides a consis
 
 - When creating a prompt:
 
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
-import ai.koog.prompt.params.LLMParams
--->
-```kotlin
-val prompt = prompt(
-    id = "dev-assistant",
-    params = LLMParams(
-        temperature = 0.7,
-        maxTokens = 500
-    )
-) {
-    // Add a system message to set the context
-    system("You are a helpful assistant.")
+=== "Kotlin"
 
-    // Add a user message
-    user("Tell me about Kotlin")
-}
-```
-<!--- KNIT example-llm-parameters-01.kt -->
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    import ai.koog.prompt.params.LLMParams
+    -->
+    ```kotlin
+    val prompt = prompt(
+        id = "dev-assistant",
+        params = LLMParams(
+            temperature = 0.7,
+            maxTokens = 500
+        )
+    ) {
+        // Add a system message to set the context
+        system("You are a helpful assistant.")
+
+        // Add a user message
+        user("Tell me about Kotlin")
+    }
+    ```
+    <!--- KNIT example-llm-parameters-01.kt -->
+
+=== "Java"
+
+    ```java
+    Prompt prompt = Prompt.builder("dev-assistant")
+        .withParams(new LLMParams(
+            0.7,         // temperature
+            500,         // maxTokens
+            1,           // numberOfChoices
+            null,        // speculation
+            null,        // schema
+            LLMParams.ToolChoice.Auto.INSTANCE, // toolChoice
+            null,        // user
+            null         // additionalProperties
+        ))
+        .system("You are a helpful assistant.")
+        .user("Tell me about Kotlin")
+        .build();
+    ```
 
 For more information about prompt creation, see [Prompts](prompts/prompt-creation/index.md).
 
 - When creating a subgraph:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.ToolCalls
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.ext.tool.SayToUser
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.agents.ext.agent.subgraphWithTask
-import ai.koog.prompt.params.LLMParams
+=== "Kotlin"
 
-val searchTool = SayToUser
-val calculatorTool = SayToUser
-val weatherTool = SayToUser
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.ToolCalls
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.agents.ext.tool.SayToUser
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.agents.ext.agent.subgraphWithTask
+    import ai.koog.prompt.params.LLMParams
+    val searchTool = SayToUser
+    val calculatorTool = SayToUser
+    val weatherTool = SayToUser
+    val strategy = strategy<String, String>("strategy_name") {
+    -->
+    <!--- SUFFIX
+    }
+    -->
+    ```kotlin
+    val processQuery by subgraphWithTask<String, String>(
+        tools = listOf(searchTool, calculatorTool, weatherTool),
+        llmModel = OpenAIModels.Chat.GPT4o,
+        llmParams = LLMParams(
+            temperature = 0.7,
+            maxTokens = 500
+        ),
+        runMode = ToolCalls.SEQUENTIAL,
+        assistantResponseRepeatMax = 3,
+    ) { userQuery ->
+        """
+        You are a helpful assistant that can answer questions about various topics.
+        Please help with the following query:
+        $userQuery
+        """
+    }
+    ```
+    <!--- KNIT example-llm-parameters-02.kt -->
 
-val strategy = strategy<String, String>("strategy_name") {
--->
-<!--- SUFFIX
-}
--->
-```kotlin
-val processQuery by subgraphWithTask<String, String>(
-    tools = listOf(searchTool, calculatorTool, weatherTool),
-    llmModel = OpenAIModels.Chat.GPT4o,
-    llmParams = LLMParams(
-        temperature = 0.7,
-        maxTokens = 500
-    ),
-    runMode = ToolCalls.SEQUENTIAL,
-    assistantResponseRepeatMax = 3,
-) { userQuery ->
-    """
-    You are a helpful assistant that can answer questions about various topics.
-    Please help with the following query:
-    $userQuery
-    """
-}
-```
-<!--- KNIT example-llm-parameters-02.kt -->
+=== "Java"
+
+    ```java
+    ```
 
 For more information about existing subgraph types in Koog, see [Predefined subgraphs](nodes-and-components.md#predefined-subgraphs). To learn how to create and implement your own subgraphs, see [Custom subgraphs](custom-subgraphs.md).
 
 - When updating a prompt in an LLM write session:
 
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.prompt.params.LLMParams
-val strategy = strategy<Unit, Unit>("strategy-name") {
-val node by node<Unit, Unit> {
--->
-<!--- SUFFIX
-   }
-}
--->
-```kotlin
-llm.writeSession {
-    changeLLMParams(
-        LLMParams(
-            temperature = 0.7,
-            maxTokens = 500
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.prompt.params.LLMParams
+    val strategy = strategy<Unit, Unit>("strategy-name") {
+    val node by node<Unit, Unit> {
+    -->
+    <!--- SUFFIX
+       }
+    }
+    -->
+    ```kotlin
+    llm.writeSession {
+        changeLLMParams(
+            LLMParams(
+                temperature = 0.7,
+                maxTokens = 500
+            )
         )
-    )
-}
-```
-<!--- KNIT example-llm-parameters-03.kt -->
+    }
+    ```
+    <!--- KNIT example-llm-parameters-03.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 For more information about sessions, see [LLM sessions and manual history management](sessions.md).
 
@@ -138,79 +171,162 @@ JSON schemas let you request structured JSON data from language models. Koog sup
 
 1) **Basic JSON Schema** (`LLMParams.Schema.JSON.Basic`): Used for basic JSON processing capabilities. This format primarily focuses on nested data definitions without advanced JSON Schema functionalities.
 
-<!--- INCLUDE
-import ai.koog.prompt.params.LLMParams
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonPrimitive
--->
-```kotlin
-// Create parameters with a basic JSON schema
-val jsonParams = LLMParams(
-    temperature = 0.2,
-    schema = LLMParams.Schema.JSON.Basic(
-        name = "PersonInfo",
-        schema = JsonObject(mapOf(
-            "type" to JsonPrimitive("object"),
-            "properties" to JsonObject(
-                mapOf(
-                    "name" to JsonObject(mapOf("type" to JsonPrimitive("string"))),
-                    "age" to JsonObject(mapOf("type" to JsonPrimitive("number"))),
-                    "skills" to JsonObject(
-                        mapOf(
-                            "type" to JsonPrimitive("array"),
-                            "items" to JsonObject(mapOf("type" to JsonPrimitive("string")))
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.prompt.params.LLMParams
+    import kotlinx.serialization.json.JsonObject
+    import kotlinx.serialization.json.JsonArray
+    import kotlinx.serialization.json.JsonPrimitive
+    -->
+    ```kotlin
+    // Create parameters with a basic JSON schema
+    val jsonParams = LLMParams(
+        temperature = 0.2,
+        schema = LLMParams.Schema.JSON.Basic(
+            name = "PersonInfo",
+            schema = JsonObject(mapOf(
+                "type" to JsonPrimitive("object"),
+                "properties" to JsonObject(
+                    mapOf(
+                        "name" to JsonObject(mapOf("type" to JsonPrimitive("string"))),
+                        "age" to JsonObject(mapOf("type" to JsonPrimitive("number"))),
+                        "skills" to JsonObject(
+                            mapOf(
+                                "type" to JsonPrimitive("array"),
+                                "items" to JsonObject(mapOf("type" to JsonPrimitive("string")))
+                            )
                         )
                     )
-                )
-            ),
-            "additionalProperties" to JsonPrimitive(false),
-            "required" to JsonArray(listOf(JsonPrimitive("name"), JsonPrimitive("age"), JsonPrimitive("skills")))
-        ))
+                ),
+                "additionalProperties" to JsonPrimitive(false),
+                "required" to JsonArray(listOf(JsonPrimitive("name"), JsonPrimitive("age"), JsonPrimitive("skills")))
+            ))
+        )
     )
-)
-```
-<!--- KNIT example-llm-parameters-04.kt -->
+    ```
+    <!--- KNIT example-llm-parameters-04.kt -->
+
+=== "Java"
+
+    ```java
+    // Create parameters with a basic JSON schema
+    LLMParams jsonParams = new LLMParams(
+        0.2,         // temperature
+        null,        // maxTokens
+        1,           // numberOfChoices
+        null,        // speculation
+        new LLMParams.Schema.JSON.Basic(
+            "PersonInfo",
+            new JsonObject(Map.of(
+                "type", new JsonPrimitive("object"),
+                "properties", new JsonObject(Map.of(
+                    "name", new JsonObject(Map.of("type", new JsonPrimitive("string"))),
+                    "age", new JsonObject(Map.of("type", new JsonPrimitive("number"))),
+                    "skills", new JsonObject(Map.of(
+                        "type", new JsonPrimitive("array"),
+                        "items", new JsonObject(Map.of("type", new JsonPrimitive("string")))
+                    ))
+                )),
+                "additionalProperties", new JsonPrimitive(false),
+                "required", new JsonArray(List.of(
+                    new JsonPrimitive("name"),
+                    new JsonPrimitive("age"),
+                    new JsonPrimitive("skills")
+                ))
+            ))
+        ),
+        LLMParams.ToolChoice.Auto.INSTANCE, // toolChoice
+        null,        // user
+        null         // additionalProperties
+    );
+    ```
 
 2) **Standard JSON Schema** (`LLMParams.Schema.JSON.Standard`): Represents a standard JSON schema according to [json-schema.org](https://json-schema.org/). This format is a proper subset of the official JSON Schema specification. Note that the flavor across different LLM providers might vary, since not all of them support full JSON schemas.
 
-<!--- INCLUDE
-import ai.koog.prompt.params.LLMParams
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.JsonArray
--->
-```kotlin
-// Create parameters with a standard JSON schema
-val standardJsonParams = LLMParams(
-    temperature = 0.2,
-    schema = LLMParams.Schema.JSON.Standard(
-        name = "ProductCatalog",
-        schema = JsonObject(mapOf(
-            "type" to JsonPrimitive("object"),
-            "properties" to JsonObject(mapOf(
-                "products" to JsonObject(mapOf(
-                    "type" to JsonPrimitive("array"),
-                    "items" to JsonObject(mapOf(
-                        "type" to JsonPrimitive("object"),
-                        "properties" to JsonObject(mapOf(
-                            "id" to JsonObject(mapOf("type" to JsonPrimitive("string"))),
-                            "name" to JsonObject(mapOf("type" to JsonPrimitive("string"))),
-                            "price" to JsonObject(mapOf("type" to JsonPrimitive("number"))),
-                            "description" to JsonObject(mapOf("type" to JsonPrimitive("string")))
-                        )),
-                        "additionalProperties" to JsonPrimitive(false),
-                        "required" to JsonArray(listOf(JsonPrimitive("id"), JsonPrimitive("name"), JsonPrimitive("price"), JsonPrimitive("description")))
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.prompt.params.LLMParams
+    import kotlinx.serialization.json.JsonObject
+    import kotlinx.serialization.json.JsonPrimitive
+    import kotlinx.serialization.json.JsonArray
+    -->
+    ```kotlin
+    // Create parameters with a standard JSON schema
+    val standardJsonParams = LLMParams(
+        temperature = 0.2,
+        schema = LLMParams.Schema.JSON.Standard(
+            name = "ProductCatalog",
+            schema = JsonObject(mapOf(
+                "type" to JsonPrimitive("object"),
+                "properties" to JsonObject(mapOf(
+                    "products" to JsonObject(mapOf(
+                        "type" to JsonPrimitive("array"),
+                        "items" to JsonObject(mapOf(
+                            "type" to JsonPrimitive("object"),
+                            "properties" to JsonObject(mapOf(
+                                "id" to JsonObject(mapOf("type" to JsonPrimitive("string"))),
+                                "name" to JsonObject(mapOf("type" to JsonPrimitive("string"))),
+                                "price" to JsonObject(mapOf("type" to JsonPrimitive("number"))),
+                                "description" to JsonObject(mapOf("type" to JsonPrimitive("string")))
+                            )),
+                            "additionalProperties" to JsonPrimitive(false),
+                            "required" to JsonArray(listOf(JsonPrimitive("id"), JsonPrimitive("name"), JsonPrimitive("price"), JsonPrimitive("description")))
+                        ))
                     ))
-                ))
-            )),
-            "additionalProperties" to JsonPrimitive(false),
-            "required" to JsonArray(listOf(JsonPrimitive("products")))
-        ))
+                )),
+                "additionalProperties" to JsonPrimitive(false),
+                "required" to JsonArray(listOf(JsonPrimitive("products")))
+            ))
+        )
     )
-)
-```
-<!--- KNIT example-llm-parameters-05.kt -->
+    ```
+    <!--- KNIT example-llm-parameters-05.kt -->
+
+=== "Java"
+
+    ```java
+    // Create parameters with a standard JSON schema
+    LLMParams standardJsonParams = new LLMParams(
+        0.2,         // temperature
+        null,        // maxTokens
+        1,           // numberOfChoices
+        null,        // speculation
+        new LLMParams.Schema.JSON.Standard(
+            "ProductCatalog",
+            new JsonObject(Map.of(
+                "type", new JsonPrimitive("object"),
+                "properties", new JsonObject(Map.of(
+                    "products", new JsonObject(Map.of(
+                        "type", new JsonPrimitive("array"),
+                        "items", new JsonObject(Map.of(
+                            "type", new JsonPrimitive("object"),
+                            "properties", new JsonObject(Map.of(
+                                "id", new JsonObject(Map.of("type", new JsonPrimitive("string"))),
+                                "name", new JsonObject(Map.of("type", new JsonPrimitive("string"))),
+                                "price", new JsonObject(Map.of("type", new JsonPrimitive("number"))),
+                                "description", new JsonObject(Map.of("type", new JsonPrimitive("string")))
+                            )),
+                            "additionalProperties", new JsonPrimitive(false),
+                            "required", new JsonArray(List.of(
+                                new JsonPrimitive("id"),
+                                new JsonPrimitive("name"),
+                                new JsonPrimitive("price"),
+                                new JsonPrimitive("description")
+                            ))
+                        ))
+                    ))
+                )),
+                "additionalProperties", new JsonPrimitive(false),
+                "required", new JsonArray(List.of(new JsonPrimitive("products")))
+            ))
+        ),
+        LLMParams.ToolChoice.Auto.INSTANCE, // toolChoice
+        null,        // user
+        null         // additionalProperties
+    );
+    ```
 
 ## Tool choice
 
@@ -225,17 +341,32 @@ The `ToolChoice` class controls how the language model uses tools. It provides t
 
 Here is an example of using the `LLMParams.ToolChoice.Named` class to call a specific tool:
 
+=== "Kotlin"
 
+    <!--- INCLUDE
+    import ai.koog.prompt.params.LLMParams
+    -->
+    ```kotlin
+    val specificToolParams = LLMParams(
+        toolChoice = LLMParams.ToolChoice.Named(name = "calculator")
+    )
+    ```
+    <!--- KNIT example-llm-parameters-06.kt -->
 
-<!--- INCLUDE
-import ai.koog.prompt.params.LLMParams
--->
-```kotlin
-val specificToolParams = LLMParams(
-    toolChoice = LLMParams.ToolChoice.Named(name = "calculator")
-)
-```
-<!--- KNIT example-llm-parameters-06.kt -->
+=== "Java"
+
+    ```java
+    LLMParams specificToolParams = new LLMParams(
+        null,        // temperature
+        null,        // maxTokens
+        1,           // numberOfChoices
+        null,        // speculation
+        null,        // schema
+        new LLMParams.ToolChoice.Named("calculator"), // toolChoice
+        null,        // user
+        null         // additionalProperties
+    );
+    ```
 
 ## Provider-specific parameters
 
@@ -377,40 +508,89 @@ Here is the complete reference of provider-specific parameters in Koog:
 
 The following example shows defined OpenRouter LLM parameters using the provider-specific `OpenRouterParams` class:
 
-<!--- INCLUDE
-import ai.koog.prompt.executor.clients.openrouter.OpenRouterParams
--->
-```kotlin
-val openRouterParams = OpenRouterParams(
-    temperature = 0.7,
-    maxTokens = 500,
-    frequencyPenalty = 0.5,
-    presencePenalty = 0.5,
-    topP = 0.9,
-    topK = 40,
-    repetitionPenalty = 1.1,
-    models = listOf("anthropic/claude-3-opus", "anthropic/claude-3-sonnet"),
-    transforms = listOf("middle-out")
-)
-```
-<!--- KNIT example-llm-parameters-07.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.prompt.executor.clients.openrouter.OpenRouterParams
+    -->
+    ```kotlin
+    val openRouterParams = OpenRouterParams(
+        temperature = 0.7,
+        maxTokens = 500,
+        frequencyPenalty = 0.5,
+        presencePenalty = 0.5,
+        topP = 0.9,
+        topK = 40,
+        repetitionPenalty = 1.1,
+        models = listOf("anthropic/claude-3-opus", "anthropic/claude-3-sonnet"),
+        transforms = listOf("middle-out")
+    )
+    ```
+    <!--- KNIT example-llm-parameters-07.kt -->
+
+=== "Java"
+
+    ```java
+    OpenRouterParams openRouterParams = new OpenRouterParams(
+        0.7,         // temperature
+        500,         // maxTokens
+        1,           // numberOfChoices
+        null,        // speculation
+        null,        // schema
+        null,        // toolChoice
+        null,        // user
+        null,        // additionalProperties
+        0.5,         // frequencyPenalty
+        null,        // logprobs
+        null,        // minP
+        Arrays.asList("anthropic/claude-3-opus", "anthropic/claude-3-sonnet"), // models
+        0.5,         // presencePenalty
+        null,        // provider
+        1.1,         // repetitionPenalty
+        null,        // route
+        null,        // stop
+        null,        // topA
+        40,          // topK
+        null,        // topLogprobs
+        0.9,         // topP
+        Arrays.asList("middle-out") // transforms
+    );
+    ```
 
 ## Usage examples
 
 ### Basic usage
 
-<!--- INCLUDE
-import ai.koog.prompt.params.LLMParams
--->
-```kotlin
-// A basic set of parameters with limited length 
-val basicParams = LLMParams(
-    temperature = 0.7,
-    maxTokens = 150,
-    toolChoice = LLMParams.ToolChoice.Auto
-)
-```
-<!--- KNIT example-llm-parameters-08.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.prompt.params.LLMParams
+    -->
+    ```kotlin
+    // A basic set of parameters with limited length
+    val basicParams = LLMParams(
+        temperature = 0.7,
+        maxTokens = 150,
+        toolChoice = LLMParams.ToolChoice.Auto
+    )
+    ```
+    <!--- KNIT example-llm-parameters-08.kt -->
+
+=== "Java"
+
+    ```java
+    // A basic set of parameters with limited length
+    LLMParams basicParams = new LLMParams(
+        0.7,         // temperature
+        150,         // maxTokens
+        1,           // numberOfChoices
+        null,        // speculation
+        null,        // schema
+        LLMParams.ToolChoice.Auto.INSTANCE, // toolChoice
+        null,        // user
+        null         // additionalProperties
+    );
+    ```
 
 ### Reasoning control
 
@@ -418,50 +598,133 @@ You implement reasoning control through provider-specific parameters that contro
 When using the OpenAI Chat API and models that support reasoning, use the `reasoningEffort` parameter
 to control how many reasoning tokens the model generates before providing a response:
 
-<!--- INCLUDE
-import ai.koog.prompt.executor.clients.openai.OpenAIChatParams
-import ai.koog.prompt.executor.clients.openai.base.models.ReasoningEffort
--->
-```kotlin
-val openAIReasoningEffortParams = OpenAIChatParams(
-    reasoningEffort = ReasoningEffort.MEDIUM
-)
-```
-<!--- KNIT example-llm-parameters-09.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.prompt.executor.clients.openai.OpenAIChatParams
+    import ai.koog.prompt.executor.clients.openai.base.models.ReasoningEffort
+    -->
+    ```kotlin
+    val openAIReasoningEffortParams = OpenAIChatParams(
+        reasoningEffort = ReasoningEffort.MEDIUM
+    )
+    ```
+    <!--- KNIT example-llm-parameters-09.kt -->
+
+=== "Java"
+
+    ```java
+    OpenAIChatParams openAIReasoningEffortParams = new OpenAIChatParams(
+        null,        // temperature
+        null,        // maxTokens
+        1,           // numberOfChoices
+        null,        // speculation
+        null,        // schema
+        null,        // toolChoice
+        null,        // user
+        null,        // additionalProperties
+        null,        // audio
+        null,        // frequencyPenalty
+        null,        // logprobs
+        null,        // parallelToolCalls
+        null,        // presencePenalty
+        null,        // promptCacheKey
+        ReasoningEffort.MEDIUM, // reasoningEffort
+        null,        // safetyIdentifier
+        null,        // serviceTier
+        null,        // stop
+        null,        // store
+        null,        // topLogprobs
+        null,        // topP
+        null         // webSearchOptions
+    );
+    ```
 
 In addition, when using the OpenAI Responses API in a stateless mode, you keep an encrypted history of reasoning items and send it to the model in every conversation turn. The encryption is done on the OpenAI side, and you need to request encrypted reasoning tokens by setting the `include` parameter in your requests to `reasoning.encrypted_content`.
 You can then pass the encrypted reasoning tokens back to the model in the next conversation turns.
 
-<!--- INCLUDE
-import ai.koog.prompt.executor.clients.openai.OpenAIResponsesParams
-import ai.koog.prompt.executor.clients.openai.models.OpenAIInclude
--->
-```kotlin
-val openAIStatelessReasoningParams = OpenAIResponsesParams(
-    include = listOf(OpenAIInclude.REASONING_ENCRYPTED_CONTENT)
-)
-```
-<!--- KNIT example-llm-parameters-10.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.prompt.executor.clients.openai.OpenAIResponsesParams
+    import ai.koog.prompt.executor.clients.openai.models.OpenAIInclude
+    -->
+    ```kotlin
+    val openAIStatelessReasoningParams = OpenAIResponsesParams(
+        include = listOf(OpenAIInclude.REASONING_ENCRYPTED_CONTENT)
+    )
+    ```
+    <!--- KNIT example-llm-parameters-10.kt -->
+
+=== "Java"
+
+    ```java
+    OpenAIResponsesParams openAIStatelessReasoningParams = new OpenAIResponsesParams(
+        null,        // temperature
+        null,        // maxTokens
+        1,           // numberOfChoices
+        null,        // speculation
+        null,        // schema
+        null,        // toolChoice
+        null,        // user
+        null,        // additionalProperties
+        null,        // background
+        Arrays.asList(OpenAIInclude.REASONING_ENCRYPTED_CONTENT), // include
+        null,        // logprobs
+        null,        // maxToolCalls
+        null,        // parallelToolCalls
+        null,        // promptCacheKey
+        null,        // reasoning
+        null,        // safetyIdentifier
+        null,        // serviceTier
+        null,        // store
+        null,        // topLogprobs
+        null,        // topP
+        null         // truncation
+    );
+    ```
 
 ### Custom parameters
 
 To add custom parameters that may be provider specific and not supported in Koog out of the box, use the `additionalProperties` property as shown in the example below.
 
-<!--- INCLUDE
-import ai.koog.prompt.params.LLMParams
-import ai.koog.prompt.params.additionalPropertiesOf
--->
-```kotlin
-// Add custom parameters for specific model providers
-val customParams = LLMParams(
-    additionalProperties = additionalPropertiesOf(
-        "top_p" to 0.95,
-        "frequency_penalty" to 0.5,
-        "presence_penalty" to 0.5
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.prompt.params.LLMParams
+    import ai.koog.prompt.params.additionalPropertiesOf
+    -->
+    ```kotlin
+    // Add custom parameters for specific model providers
+    val customParams = LLMParams(
+        additionalProperties = additionalPropertiesOf(
+            "top_p" to 0.95,
+            "frequency_penalty" to 0.5,
+            "presence_penalty" to 0.5
+        )
     )
-)
-```
-<!--- KNIT example-llm-parameters-11.kt -->
+    ```
+    <!--- KNIT example-llm-parameters-11.kt -->
+
+=== "Java"
+
+    ```java
+    // Add custom parameters for specific model providers
+    LLMParams customParams = new LLMParams(
+        null,        // temperature
+        null,        // maxTokens
+        1,           // numberOfChoices
+        null,        // speculation
+        null,        // schema
+        null,        // toolChoice
+        null,        // user
+        AdditionalPropertiesKt.additionalPropertiesOf(
+            "top_p", 0.95,
+            "frequency_penalty", 0.5,
+            "presence_penalty", 0.5
+        )
+    );
+    ```
 
 ### Setting and overriding parameters
 
@@ -469,36 +732,83 @@ The code sample below shows how you can define a set of LLM parameters that you 
 then create another set by partially overriding values from the original set and adding new values to it.
 This lets you define parameters that are common to most requests but also add more specific parameter combinations without having to repeat the common parameters.
 
-<!--- INCLUDE
-import ai.koog.prompt.params.LLMParams
--->
-```kotlin
-// Define default parameters
-val defaultParams = LLMParams(
-    temperature = 0.7,
-    maxTokens = 150,
-    toolChoice = LLMParams.ToolChoice.Auto
-)
+=== "Kotlin"
 
-// Create parameters with some overrides, using defaults for the rest
-val overrideParams = LLMParams(
-    temperature = 0.2,
-    numberOfChoices = 3
-).default(defaultParams)
-```
-<!--- KNIT example-llm-parameters-12.kt -->
+    <!--- INCLUDE
+    import ai.koog.prompt.params.LLMParams
+    -->
+    ```kotlin
+    // Define default parameters
+    val defaultParams = LLMParams(
+        temperature = 0.7,
+        maxTokens = 150,
+        toolChoice = LLMParams.ToolChoice.Auto
+    )
+
+    // Create parameters with some overrides, using defaults for the rest
+    val overrideParams = LLMParams(
+        temperature = 0.2,
+        numberOfChoices = 3
+    ).default(defaultParams)
+    ```
+    <!--- KNIT example-llm-parameters-12.kt -->
+
+=== "Java"
+
+    ```java
+    // Define default parameters
+    LLMParams defaultParams = new LLMParams(
+        0.7,         // temperature
+        150,         // maxTokens
+        1,           // numberOfChoices
+        null,        // speculation
+        null,        // schema
+        LLMParams.ToolChoice.Auto.INSTANCE, // toolChoice
+        null,        // user
+        null         // additionalProperties
+    );
+
+    // Create parameters with some overrides, using defaults for the rest
+    LLMParams overrideParams = new LLMParams(
+        0.2,         // temperature
+        null,        // maxTokens
+        3,           // numberOfChoices
+        null,        // speculation
+        null,        // schema
+        null,        // toolChoice
+        null,        // user
+        null         // additionalProperties
+    ).applyDefaults(defaultParams);
+    ```
 
 The values in the resulting `overrideParams` set are equivalent to the following:
 
-<!--- INCLUDE
-import ai.koog.prompt.params.LLMParams
--->
-```kotlin
-val overrideParams = LLMParams(
-    temperature = 0.2,
-    maxTokens = 150,
-    toolChoice = LLMParams.ToolChoice.Auto,
-    numberOfChoices = 3
-)
-```
-<!--- KNIT example-llm-parameters-13.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.prompt.params.LLMParams
+    -->
+    ```kotlin
+    val overrideParams = LLMParams(
+        temperature = 0.2,
+        maxTokens = 150,
+        toolChoice = LLMParams.ToolChoice.Auto,
+        numberOfChoices = 3
+    )
+    ```
+    <!--- KNIT example-llm-parameters-13.kt -->
+
+=== "Java"
+
+    ```java
+    LLMParams overrideParams = new LLMParams(
+        0.2,         // temperature
+        150,         // maxTokens
+        3,           // numberOfChoices
+        null,        // speculation
+        null,        // schema
+        LLMParams.ToolChoice.Auto.INSTANCE, // toolChoice
+        null,        // user
+        null         // additionalProperties
+    );
+    ```

--- a/docs/docs/prompts/handling-failures.md
+++ b/docs/docs/prompts/handling-failures.md
@@ -11,33 +11,44 @@ The `RetryingLLMClient` decorator adds automatic retry logic to any LLM client.
 
 Wrap any existing client with the retry capability:
 
-<!--- INCLUDE
-import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.clients.retry.RetryingLLMClient
-import ai.koog.prompt.dsl.prompt
-import kotlinx.coroutines.runBlocking
+=== "Kotlin"
 
-fun main() {
-    runBlocking {
-        val apiKey = System.getenv("OPENAI_API_KEY")
-        val prompt = prompt("test") {
-            user("Hello")
+    <!--- INCLUDE
+    import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.executor.clients.retry.RetryingLLMClient
+    import ai.koog.prompt.dsl.prompt
+    import kotlinx.coroutines.runBlocking
+    fun main() {
+        runBlocking {
+            val apiKey = System.getenv("OPENAI_API_KEY")
+            val prompt = prompt("test") {
+                user("Hello")
+            }
+    -->
+    <!--- SUFFIX
         }
--->
-<!--- SUFFIX
     }
-}
--->
-```kotlin
-// Wrap any client with the retry capability
-val client = OpenAILLMClient(apiKey)
-val resilientClient = RetryingLLMClient(client)
+    -->
+    ```kotlin
+    // Wrap any client with the retry capability
+    val client = OpenAILLMClient(apiKey)
+    val resilientClient = RetryingLLMClient(client)
 
-// Now all operations will automatically retry on transient errors
-val response = resilientClient.execute(prompt, OpenAIModels.Chat.GPT4o)
-```
-<!--- KNIT example-handling-failures-01.kt -->
+    // Now all operations will automatically retry on transient errors
+    val response = resilientClient.execute(prompt, OpenAIModels.Chat.GPT4o)
+    ```
+    <!--- KNIT example-handling-failures-01.kt -->
+
+=== "Java"
+
+    ```java
+    OpenAILLMClient client = new OpenAILLMClient(apiKey);
+    RetryingLLMClient resilientClient = new RetryingLLMClient(client);
+
+    // Now all operations will automatically retry on transient errors
+    List<Message.Response> response = resilientClient.execute(prompt, OpenAIModels.Chat.GPT4o);
+    ```
 
 ### Configuring retry behavior
 
@@ -46,22 +57,33 @@ and a 30-second maximum delay.
 You can specify a different retry configuration using a `RetryConfig` passed to `RetryingLLMClient`.
 For example:
 
-<!--- INCLUDE
-import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
-import ai.koog.prompt.executor.clients.retry.RetryConfig
-import ai.koog.prompt.executor.clients.retry.RetryingLLMClient
+=== "Kotlin"
 
-val apiKey = System.getenv("OPENAI_API_KEY")
-val client = OpenAILLMClient(apiKey)
--->
-```kotlin
-// Use the predefined configuration
-val conservativeClient = RetryingLLMClient(
-    delegate = client,
-    config = RetryConfig.CONSERVATIVE
-)
-```
-<!--- KNIT example-handling-failures-02.kt -->
+    <!--- INCLUDE
+    import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+    import ai.koog.prompt.executor.clients.retry.RetryConfig
+    import ai.koog.prompt.executor.clients.retry.RetryingLLMClient
+    val apiKey = System.getenv("OPENAI_API_KEY")
+    val client = OpenAILLMClient(apiKey)
+    -->
+    ```kotlin
+    // Use the predefined configuration
+    val conservativeClient = RetryingLLMClient(
+        delegate = client,
+        config = RetryConfig.CONSERVATIVE
+    )
+    ```
+    <!--- KNIT example-handling-failures-02.kt -->
+
+=== "Java"
+
+    ```java
+    OpenAILLMClient client = new OpenAILLMClient(apiKey);
+    RetryingLLMClient conservativeClient = new RetryingLLMClient(
+        client,
+        RetryConfig.Companion.getCONSERVATIVE()
+    );
+    ```
 
 Koog provides several predefined retry configurations:
 
@@ -183,7 +205,6 @@ val config = RetryConfig(
 ```
 <!--- KNIT example-handling-failures-05.kt -->
 
-
 ### Streaming with retry
 
 Streaming operations can optionally be retried. This feature is disabled by default.
@@ -195,7 +216,6 @@ import ai.koog.prompt.executor.clients.retry.RetryConfig
 import ai.koog.prompt.executor.clients.retry.RetryingLLMClient
 import ai.koog.prompt.dsl.prompt
 import kotlinx.coroutines.runBlocking
-
 fun main() {
     runBlocking {
         val baseClient = OpenAILLMClient(System.getenv("OPENAI_API_KEY"))
@@ -227,46 +247,77 @@ val stream = client.executeStreaming(prompt, OpenAIModels.Chat.GPT4o)
 When working with prompt executors, you can wrap the underlying LLM client with a retry mechanism before creating the executor.
 To learn more about prompt executors, see [Prompt executors](prompt-executors.md).
 
-<!--- INCLUDE
-import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
-import ai.koog.prompt.executor.clients.bedrock.BedrockLLMClient
-import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
-import ai.koog.prompt.executor.clients.retry.RetryConfig
-import ai.koog.prompt.executor.clients.retry.RetryingLLMClient
-import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
-import ai.koog.prompt.llm.LLMProvider
-import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
+=== "Kotlin"
 
--->
-```kotlin
-// Single provider executor with retry
-val resilientClient = RetryingLLMClient(
-    OpenAILLMClient(System.getenv("OPENAI_API_KEY")),
-    RetryConfig.PRODUCTION
-)
-val executor = MultiLLMPromptExecutor(resilientClient)
-
-// Multi-provider executor with flexible client configuration
-val multiExecutor = MultiLLMPromptExecutor(
-    LLMProvider.OpenAI to RetryingLLMClient(
+    <!--- INCLUDE
+    import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
+    import ai.koog.prompt.executor.clients.bedrock.BedrockLLMClient
+    import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+    import ai.koog.prompt.executor.clients.retry.RetryConfig
+    import ai.koog.prompt.executor.clients.retry.RetryingLLMClient
+    import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
+    import ai.koog.prompt.llm.LLMProvider
+    import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
+    -->
+    ```kotlin
+    // Single provider executor with retry
+    val resilientClient = RetryingLLMClient(
         OpenAILLMClient(System.getenv("OPENAI_API_KEY")),
-        RetryConfig.CONSERVATIVE
-    ),
-    LLMProvider.Anthropic to RetryingLLMClient(
-        AnthropicLLMClient(System.getenv("ANTHROPIC_API_KEY")),
-        RetryConfig.AGGRESSIVE  
-    ),
-    // The Bedrock client already has a built-in AWS SDK retry 
-    LLMProvider.Bedrock to BedrockLLMClient(
-        identityProvider = StaticCredentialsProvider {
-            accessKeyId = System.getenv("AWS_ACCESS_KEY_ID")
-            secretAccessKey = System.getenv("AWS_SECRET_ACCESS_KEY")
-            sessionToken = System.getenv("AWS_SESSION_TOKEN")
-        },
-    ),
-)
-```
-<!--- KNIT example-handling-failures-07.kt -->
+        RetryConfig.PRODUCTION
+    )
+    val executor = MultiLLMPromptExecutor(resilientClient)
+
+    // Multi-provider executor with flexible client configuration
+    val multiExecutor = MultiLLMPromptExecutor(
+        LLMProvider.OpenAI to RetryingLLMClient(
+            OpenAILLMClient(System.getenv("OPENAI_API_KEY")),
+            RetryConfig.CONSERVATIVE
+        ),
+        LLMProvider.Anthropic to RetryingLLMClient(
+            AnthropicLLMClient(System.getenv("ANTHROPIC_API_KEY")),
+            RetryConfig.AGGRESSIVE  
+        ),
+        // The Bedrock client already has a built-in AWS SDK retry 
+        LLMProvider.Bedrock to BedrockLLMClient(
+            identityProvider = StaticCredentialsProvider {
+                accessKeyId = System.getenv("AWS_ACCESS_KEY_ID")
+                secretAccessKey = System.getenv("AWS_SECRET_ACCESS_KEY")
+                sessionToken = System.getenv("AWS_SESSION_TOKEN")
+            },
+        ),
+    )
+    ```
+    <!--- KNIT example-handling-failures-07.kt -->
+
+=== "Java"
+
+    ```java
+    // Single provider executor with retry (Java)
+    RetryingLLMClient resilientClient = new RetryingLLMClient(
+        new OpenAILLMClient(System.getenv("OPENAI_API_KEY")),
+        RetryConfig.Companion.getPRODUCTION()
+    );
+
+    MultiLLMPromptExecutor executor = new MultiLLMPromptExecutor(resilientClient);
+
+    // Multi-provider executor with flexible client configuration (Java)
+    LLMClient openai = new RetryingLLMClient(
+        new OpenAILLMClient(System.getenv("OPENAI_API_KEY")),
+        RetryConfig.Companion.getCONSERVATIVE()
+    );
+
+    LLMClient anthropic = new RetryingLLMClient(
+        new AnthropicLLMClient(System.getenv("ANTHROPIC_API_KEY")),
+        RetryConfig.Companion.getAGGRESSIVE()
+    );
+
+    Map<LLMProvider, LLMClient> clients = Map.of(
+        LLMProvider.OpenAI, openai,
+        LLMProvider.Anthropic, anthropic
+    );
+
+    MultiLLMPromptExecutor multiExecutor = new MultiLLMPromptExecutor(clients);
+    ```
 
 ## Timeout configuration
 
@@ -284,26 +335,48 @@ the [`ConnectionTimeoutConfig`](api:prompt-executor-clients::ai.koog.prompt.exec
 
 You can customize these values for your specific needs. For example:
 
-<!--- INCLUDE
-import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
-import ai.koog.prompt.executor.clients.openai.OpenAIClientSettings
-import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+=== "Kotlin"
 
-val apiKey = System.getenv("OPENAI_API_KEY")    
--->
-```kotlin
-val client = OpenAILLMClient(
-    apiKey = apiKey,
-    settings = OpenAIClientSettings(
-        timeoutConfig = ConnectionTimeoutConfig(
-            connectTimeoutMillis = 5000,    // 5 seconds to establish connection
-            requestTimeoutMillis = 60000,    // 60 seconds for the entire request
-            socketTimeoutMillis = 120000   // 120 seconds for data on the socket
+    <!--- INCLUDE
+    import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
+    import ai.koog.prompt.executor.clients.openai.OpenAIClientSettings
+    import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+    val apiKey = System.getenv("OPENAI_API_KEY")    
+    -->
+    ```kotlin
+    val client = OpenAILLMClient(
+        apiKey = apiKey,
+        settings = OpenAIClientSettings(
+            timeoutConfig = ConnectionTimeoutConfig(
+                connectTimeoutMillis = 5000,    // 5 seconds to establish connection
+                requestTimeoutMillis = 60000,    // 60 seconds for the entire request
+                socketTimeoutMillis = 120000   // 120 seconds for data on the socket
+            )
         )
     )
-)
-```
-<!--- KNIT example-handling-failures-08.kt -->
+    ```
+    <!--- KNIT example-handling-failures-08.kt -->
+
+=== "Java"
+
+    ```java
+    String apiKey = System.getenv("OPENAI_API_KEY");
+    ConnectionTimeoutConfig timeouts = new ConnectionTimeoutConfig(
+        5000L,   // connectTimeoutMillis
+        60000L,  // requestTimeoutMillis
+        120000L  // socketTimeoutMillis
+    );
+    OpenAIClientSettings settings = new OpenAIClientSettings(
+        "https://api.openai.com", // baseUrl
+        timeouts,
+        "v1/chat/completions",    // chatCompletionsPath
+        "v1/responses",           // responsesAPIPath
+        "v1/embeddings",          // embeddingsPath
+        "v1/moderations",         // moderationsPath
+        "v1/models"               // modelsPath
+    );
+    OpenAILLMClient client = new OpenAILLMClient(apiKey, settings);
+    ```
 
 !!! tip
     For long-running or streaming calls, set higher values for `requestTimeoutMillis` and `socketTimeoutMillis`.
@@ -319,53 +392,91 @@ When working with LLMs in production, you need to implement error handling, incl
 
 Here is an example of error handling:
 
-<!--- INCLUDE
-import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.clients.retry.RetryingLLMClient
-import ai.koog.prompt.executor.clients.retry.RetryConfig
-import ai.koog.prompt.dsl.prompt
-import kotlinx.coroutines.runBlocking
-import org.slf4j.LoggerFactory
--->
-```kotlin
-fun main() {
-    runBlocking {
-        val logger = LoggerFactory.getLogger("Example")
-        val resilientClient = RetryingLLMClient(
-            OpenAILLMClient(System.getenv("OPENAI_API_KEY")),
-            RetryConfig.PRODUCTION
-        )
-        val prompt = prompt("test") { user("Hello") }
-        val model = OpenAIModels.Chat.GPT4o
+=== "Kotlin"
 
-        fun processResponse(response: Any) { /* implmenentation */ }
-        fun scheduleRetryLater() { /* implmenentation */ }
-        fun notifyAdministrator() { /* implmenentation */ }
-        fun useDefaultResponse() { /* implmenentation */ }
+    <!--- INCLUDE
+    import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.executor.clients.retry.RetryingLLMClient
+    import ai.koog.prompt.executor.clients.retry.RetryConfig
+    import ai.koog.prompt.dsl.prompt
+    import kotlinx.coroutines.runBlocking
+    import org.slf4j.LoggerFactory
+    fun main() {
+        runBlocking {
+    -->
+    <!--- SUFFIX
+        }
+    }
+    -->
+    ```kotlin
+    val logger = LoggerFactory.getLogger("Example")
+    val resilientClient = RetryingLLMClient(
+        OpenAILLMClient(System.getenv("OPENAI_API_KEY")),
+        RetryConfig.PRODUCTION
+    )
+    val prompt = prompt("test") { user("Hello") }
+    val model = OpenAIModels.Chat.GPT4o
 
-        try {
-            val response = resilientClient.execute(prompt, model)
-            processResponse(response)
-        } catch (e: Exception) {
-            logger.error("LLM operation failed", e)
+    fun processResponse(response: Any) { /* implmenentation */ }
+    fun scheduleRetryLater() { /* implmenentation */ }
+    fun notifyAdministrator() { /* implmenentation */ }
+    fun useDefaultResponse() { /* implmenentation */ }
 
-            when {
-                e.message?.contains("rate limit") == true -> {
-                    // Handle rate limiting specifically
-                    scheduleRetryLater()
-                }
-                e.message?.contains("invalid api key") == true -> {
-                    // Handle authentication errors
-                    notifyAdministrator()
-                }
-                else -> {
-                    // Fall back to an alternative solution
-                    useDefaultResponse()
-                }
+    try {
+        val response = resilientClient.execute(prompt, model)
+        processResponse(response)
+    } catch (e: Exception) {
+        logger.error("LLM operation failed", e)
+
+        when {
+            e.message?.contains("rate limit") == true -> {
+                // Handle rate limiting specifically
+                scheduleRetryLater()
+            }
+            e.message?.contains("invalid api key") == true -> {
+                // Handle authentication errors
+                notifyAdministrator()
+            }
+            else -> {
+                // Fall back to an alternative solution
+                useDefaultResponse()
             }
         }
     }
-}
-```
-<!--- KNIT example-handling-failures-09.kt -->
+    ```
+    <!--- KNIT example-handling-failures-09.kt -->
+
+=== "Java"
+
+    ```java
+    Logger logger = LoggerFactory.getLogger("Example");
+    RetryingLLMClient resilientClient = new RetryingLLMClient(
+        new OpenAILLMClient(System.getenv("OPENAI_API_KEY")),
+        RetryConfig.Companion.getPRODUCTION()
+    );
+    Prompt prompt = Prompt.builder("test")
+        .user("Hello")
+        .build();
+    MultiLLMPromptExecutor promptExecutor = new MultiLLMPromptExecutor(resilientClient);
+
+    java.util.function.Consumer<List<Message.Response>> processResponse = (resp) -> { /* implementation */ };
+    Runnable scheduleRetryLater = () -> { /* implementation */ };
+    Runnable notifyAdministrator = () -> { /* implementation */ };
+    Runnable useDefaultResponse = () -> { /* implementation */ };
+
+    try {
+        List<Message.Response> response = promptExecutor.execute(prompt, OpenAIModels.Chat.GPT4o);
+        processResponse.accept(response);
+    } catch (Exception e) {
+        logger.error("LLM operation failed", e);
+        String msg = e.getMessage() == null ? "" : e.getMessage().toLowerCase();
+        if (msg.contains("rate limit")) {
+            scheduleRetryLater.run();
+        } else if (msg.contains("invalid api key")) {
+            notifyAdministrator.run();
+        } else {
+            useDefaultResponse.run();
+        }
+    }
+    ```

--- a/docs/docs/prompts/index.md
+++ b/docs/docs/prompts/index.md
@@ -6,7 +6,7 @@ This section describes how to create and run prompts with Koog.
 
 ## Creating prompts
 
-In Koog, prompts are instances of the [**Prompt**](api:prompt-model::ai.koog.prompt.dsl.Prompt) 
+In Koog, prompts are instances of the [**Prompt**](api:prompt-model::ai.koog.prompt.dsl.Prompt)
 data class with the following properties:
 
 - `id`: A unique identifier for the prompt.
@@ -14,19 +14,33 @@ data class with the following properties:
 - `params`: Optional [LLM configuration parameters](prompt-creation/index.md#prompt-parameters) (such as temperature, tool choice, and others).
 
 Although you can instantiate the `Prompt` class directly,
-the recommended way to create prompts is by using the [Kotlin DSL](prompt-creation/index.md), 
+the recommended way to create prompts is by using the [Kotlin DSL](prompt-creation/index.md),
 which provides a structured way to define the conversation.
 
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
--->
-```kotlin
-val myPrompt = prompt("hello-koog") {
-    system("You are a helpful assistant.")
-    user("What is Koog?")
-}
-```
-<!--- KNIT example-prompts-01.kt -->
+!!! note
+    Kotlin examples on this page use the Kotlin DSL. Java examples use the `Prompt.builder("id")` builder with explicit methods like `system(...)`, `user(...)`, `assistant(...)`, `toolCall(...)`, `toolResult(...)`, and `withOutput(Foo.class)` where applicable.
+
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    -->
+    ```kotlin
+    val myPrompt = prompt("hello-koog") {
+        system("You are a helpful assistant.")
+        user("What is Koog?")
+    }
+    ```
+    <!--- KNIT example-prompts-01.kt -->
+
+=== "Java"
+
+    ```java
+    var myPrompt = Prompt.builder("hello-koog")
+        .system("You are a helpful assistant.")
+        .user("What is Koog?")
+        .build();
+    ```
 
 !!! note
     AI agents can take a simple text prompt as input.
@@ -95,7 +109,7 @@ Koog allows you to optimize performance and handle failures when running prompts
 ## Prompts in AI agents
 
 In Koog, AI agents maintain and manage prompts during their lifecycle.
-While LLM clients or executors are used to run prompts, agents handle the flow of prompt updates, ensuring the 
+While LLM clients or executors are used to run prompts, agents handle the flow of prompt updates, ensuring the
 conversation history remains relevant and consistent.
 
 The prompt lifecycle in an agent usually includes several stages:
@@ -113,31 +127,43 @@ Then, when you call the agent's `run()` method,
 you typically provide an initial [user message](prompt-creation/index.md#user-messages) as input.
 Together, these messages form the agent's initial prompt. For example: 
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
-import kotlinx.coroutines.runBlocking
+=== "Kotlin"
 
-val apiKey = System.getenv("OPENAI_API_KEY")
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+    import kotlinx.coroutines.runBlocking
+    val apiKey = System.getenv("OPENAI_API_KEY")
+    fun main() = runBlocking {
+    -->
+    <!--- SUFFIX
+    }
+    -->
+    ```kotlin
+    // Create an agent
+    val agent = AIAgent(
+        promptExecutor = simpleOpenAIExecutor(apiKey),
+        systemPrompt = "You are a helpful assistant.",
+        llmModel = OpenAIModels.Chat.GPT4o
+    )
+    
+    // Run the agent
+    val result = agent.run("What is Koog?")
+    ```
+    <!--- KNIT example-prompts-02.kt -->
 
-fun main() = runBlocking {
--->
-<!--- SUFFIX
-}
--->
-```kotlin
-// Create an agent
-val agent = AIAgent(
-    promptExecutor = simpleOpenAIExecutor(apiKey),
-    systemPrompt = "You are a helpful assistant.",
-    llmModel = OpenAIModels.Chat.GPT4o
-)
+=== "Java"
 
-// Run the agent
-val result = agent.run("What is Koog?")
-```
-<!--- KNIT example-prompts-02.kt -->
+    ```java
+    AIAgent<String, String> agent = AIAgent.builder()
+        .promptExecutor(simpleOpenAIExecutor(System.getenv("OPENAI_API_KEY")))
+        .systemPrompt("You are a helpful assistant. Answer user questions concisely.")
+        .llmModel(OpenAIModels.Chat.GPT4o)
+        .build();
+
+    var result = agent.run("What is Koog?");
+    ```
 
 In the example, the agent automatically converts the text prompt to the Prompt object and sends it to the prompt executor:
 

--- a/docs/docs/prompts/llm-clients.md
+++ b/docs/docs/prompts/llm-clients.md
@@ -29,41 +29,67 @@ To run a prompt using an LLM client, perform the following:
 
 Here is an example that uses `OpenAILLMClient` to run prompts:
 
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
-import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.params.LLMParams
-import kotlinx.coroutines.runBlocking
--->
-```kotlin
-fun main() = runBlocking {
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.params.LLMParams
+    import kotlinx.coroutines.runBlocking
+    -->
+
+    ```kotlin
+    fun main() = runBlocking {
+        // Create an OpenAI client
+        val apiKey = System.getenv("OPENAI_API_KEY")
+        val client = OpenAILLMClient(apiKey)
+
+        // Create a prompt
+        val prompt = prompt("prompt_name", LLMParams()) {
+            // Add a system message to set the context
+            system("You are a helpful assistant.")
+
+            // Add a user message
+            user("Tell me about Kotlin")
+
+            // You can also add assistant messages for few-shot examples
+            assistant("Kotlin is a modern programming language...")
+
+            // Add another user message
+            user("What are its key features?")
+        }
+
+        // Run the prompt
+        val response = client.execute(prompt, OpenAIModels.Chat.GPT4o)
+        // Print the response
+        println(response)
+    }
+    ```
+    <!--- KNIT example-llm-clients-01.kt -->
+
+=== "Java"
+
+    ```java
     // Create an OpenAI client
-    val token = System.getenv("OPENAI_API_KEY")
-    val client = OpenAILLMClient(token)
+    String apiKey = System.getenv("OPENAI_API_KEY");
+    OpenAILLMClient client = new OpenAILLMClient(apiKey);
 
     // Create a prompt
-    val prompt = prompt("prompt_name", LLMParams()) {
-        // Add a system message to set the context
-        system("You are a helpful assistant.")
-
-        // Add a user message
-        user("Tell me about Kotlin")
-
-        // You can also add assistant messages for few-shot examples
-        assistant("Kotlin is a modern programming language...")
-
-        // Add another user message
-        user("What are its key features?")
-    }
+    Prompt prompt = Prompt.builder("prompt_name")
+        .system("You are a helpful assistant.")
+        .user("Tell me about Kotlin")
+        .assistant("Kotlin is a modern programming language...")
+        .user("What are its key features?")
+        .build();
 
     // Run the prompt
-    val response = client.execute(prompt, OpenAIModels.Chat.GPT4o)
+    List<Message.Response> response = client.execute(prompt, OpenAIModels.Chat.GPT4o, Collections.emptyList());
     // Print the response
-    println(response)
-}
-```
-<!--- KNIT example-llm-clients-01.kt -->
+    System.out.println(response);
+
+    client.close();
+    ```
 
 ## Streaming responses
 
@@ -81,39 +107,88 @@ The streaming API provides different frame types:
 For models that support reasoning (such as Claude Sonnet 4.5 or GPT-o1), reasoning frames will be emitted during streaming.
 See the [Streaming API documentation](../streaming-api.md) for more details on working with frames.
 
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
-import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.streaming.StreamFrame
-import kotlinx.coroutines.runBlocking
+=== "Kotlin"
 
-fun main() = runBlocking {
--->
-<!--- SUFFIX
-}
--->
-```kotlin
-// Set up the OpenAI client with your API key
-val token = System.getenv("OPENAI_API_KEY")
-val client = OpenAILLMClient(token)
-
-val response = client.executeStreaming(
-    prompt = prompt("stream_demo") { user("Stream this response in short chunks.") },
-    model = OpenAIModels.Chat.GPT4_1
-)
-
-response.collect { frame ->
-    when (frame) {
-        is StreamFrame.TextDelta -> print(frame.text)
-        is StreamFrame.ReasoningDelta -> print("[Reasoning] ${frame.text}")
-        is StreamFrame.ToolCallComplete -> println("\nTool call: ${frame.name}")
-        is StreamFrame.End -> println("\n[done] Reason: ${frame.finishReason}")
-        else -> {} // Handle other frame types if needed
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.streaming.StreamFrame
+    import kotlinx.coroutines.runBlocking
+    fun main() = runBlocking {
+    -->
+    <!--- SUFFIX
     }
-}
-```
-<!--- KNIT example-llm-clients-02.kt -->
+    -->
+    ```kotlin
+    // Set up the OpenAI client with your API key
+    val token = System.getenv("OPENAI_API_KEY")
+    val client = OpenAILLMClient(token)
+
+    val response = client.executeStreaming(
+        prompt = prompt("stream_demo") { user("Stream this response in short chunks.") },
+        model = OpenAIModels.Chat.GPT4_1
+    )
+
+    response.collect { frame ->
+        when (frame) {
+            is StreamFrame.TextDelta -> print(frame.text)
+            is StreamFrame.ReasoningDelta -> print("[Reasoning] ${frame.text}")
+            is StreamFrame.ToolCallComplete -> println("\nTool call: ${frame.name}")
+            is StreamFrame.End -> println("\n[done] Reason: ${frame.finishReason}")
+            else -> {} // Handle other frame types if needed
+        }
+    }
+    ```
+    <!--- KNIT example-llm-clients-02.kt -->
+
+=== "Java"
+
+    ```java
+    // Set up the OpenAI client with your API key
+    String token = System.getenv("OPENAI_API_KEY");
+    OpenAILLMClient client = new OpenAILLMClient(token);
+
+    Prompt prompt = Prompt.builder("stream_demo")
+                .user("Stream this response in short chunks.")
+                .build();
+    
+    Publisher<StreamFrame> response = client.executeStreamingWithPublisher(prompt, OpenAIModels.Chat.GPT4_1);
+
+    // Subscribe to the Publisher to consume frames
+    response.subscribe(new Subscriber<StreamFrame>() {
+        private Subscription subscription;
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            this.subscription = s;
+            s.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(StreamFrame frame) {
+            switch (frame) {
+                case StreamFrame.TextDelta delta ->
+                        System.out.print(delta.getText());
+                case StreamFrame.ReasoningDelta reasoning ->
+                        System.out.print("[Reasoning] " + reasoning.getText());
+                case StreamFrame.ToolCallComplete toolCall ->
+                        System.out.println("\nTool call: " + toolCall.getName());
+                case StreamFrame.End end ->
+                        System.out.println("\n[done] Reason: " + end.getFinishReason());
+                default -> {} // Handle other frame types
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            t.printStackTrace();
+        }
+
+        @Override
+        public void onComplete() { }
+    });
+    ```
 
 ## Multiple choices
 
@@ -124,33 +199,75 @@ You can request multiple alternative responses from the model in a single call b
 It requires additionally specifying the [`numberOfChoices`](prompt-creation/index.md#prompt-parameters) LLM parameter in the prompt
 being executed.
 
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
-import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.params.LLMParams
-import kotlinx.coroutines.runBlocking
--->
-```kotlin
-fun main() = runBlocking {
-    val apiKey = System.getenv("OPENAI_API_KEY")
-    val client = OpenAILLMClient(apiKey)
+=== "Kotlin"
 
-    val choices = client.executeMultipleChoices(
-        prompt = prompt("n_best", params = LLMParams(numberOfChoices = 3)) {
-            system("You are a creative assistant.")
-            user("Give me three different opening lines for a story.")
-        },
-        model = OpenAIModels.Chat.GPT4o
-    )
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.params.LLMParams
+    import kotlinx.coroutines.runBlocking
+    -->
+    ```kotlin
+    fun main() = runBlocking {
+        val apiKey = System.getenv("OPENAI_API_KEY")
+        val client = OpenAILLMClient(apiKey)
 
-    choices.forEachIndexed { i, choice ->
-        val text = choice.joinToString(" ") { it.content }
-        println("Line #${i + 1}: $text")
+        val choices = client.executeMultipleChoices(
+            prompt = prompt("n_best", params = LLMParams(numberOfChoices = 3)) {
+                system("You are a creative assistant.")
+                user("Give me three different opening lines for a story.")
+            },
+            model = OpenAIModels.Chat.GPT4o
+        )
+
+        choices.forEachIndexed { i, choice ->
+            val text = choice.joinToString(" ") { it.content }
+            println("Line #${i + 1}: $text")
+        }
     }
-}
-```
-<!--- KNIT example-llm-clients-03.kt -->
+    ```
+    <!--- KNIT example-llm-clients-03.kt -->
+
+=== "Java"
+
+    ```java
+    String apiKey = System.getenv("OPENAI_API_KEY");
+    OpenAILLMClient client = new OpenAILLMClient(apiKey);
+
+    // Configure parameters (LLMParams constructor requires all 8 arguments in Java)
+    LLMParams params = new LLMParams(
+        null, // temperature
+        null, // maxTokens
+        3,    // numberOfChoices
+        null, // speculation
+        null, // schema
+        null, // toolChoice
+        null, // user
+        null  // additionalProperties
+    );
+
+    Prompt prompt = Prompt.builder("n_best")
+        .system("You are a creative assistant.")
+        .user("Give me three different opening lines for a story.")
+        .build()
+        .withParams(params);
+
+    // LLMChoice is a type alias for List<Message.Response>
+    List<List<Message.Response>> choices = client.executeMultipleChoices(
+        prompt, 
+        OpenAIModels.Chat.GPT4o
+    );
+
+    for (int i = 0; i < choices.size(); i++) {
+        List<Message.Response> choice = choices.get(i);
+        StringBuilder text = new StringBuilder();
+        for (Message.Response msg : choice) {
+            text.append(msg.getContent()).append(" ");
+        }
+        System.out.println("Line #" + (i + 1) + ": " + text.toString().trim());
+    }
+    ```
 
 ## Listing available models
 
@@ -159,23 +276,37 @@ fun main() = runBlocking {
 
 To get a list of available model IDs supported by the LLM client, use the `models()` method:    
 
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
-import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.llm.LLModel
-import kotlinx.coroutines.runBlocking
--->
-```kotlin
-fun main() = runBlocking {
-    val apiKey = System.getenv("OPENAI_API_KEY")
-    val client = OpenAILLMClient(apiKey)
+=== "Kotlin"
 
-    val models: List<LLModel> = client.models()
-    models.forEach { println(it.id) }
-}
-```
-<!--- KNIT example-llm-clients-04.kt -->
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.llm.LLModel
+    import kotlinx.coroutines.runBlocking
+    -->
+    ```kotlin
+    fun main() = runBlocking {
+        val apiKey = System.getenv("OPENAI_API_KEY")
+        val client = OpenAILLMClient(apiKey)
+
+        val models: List<LLModel> = client.models()
+        models.forEach { println(it.id) }
+    }
+    ```
+    <!--- KNIT example-llm-clients-04.kt -->
+
+=== "Java"
+
+    ```java
+    String apiKey = System.getenv("OPENAI_API_KEY");
+    OpenAILLMClient client = new OpenAILLMClient(apiKey);
+
+    List<LLModel> models = client.models();
+    for (LLModel model : models) {
+        System.out.println(model.getId());
+    }
+    ```
 
 ## Embeddings
 
@@ -213,28 +344,44 @@ fun main() = runBlocking {
 
 You can use the `moderate()` method with a moderation model to check whether a prompt contains inappropriate content:
 
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
-import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import kotlinx.coroutines.runBlocking
--->
-```kotlin
-fun main() = runBlocking {
-    val apiKey = System.getenv("OPENAI_API_KEY")
-    val client = OpenAILLMClient(apiKey)
+=== "Kotlin"
 
-    val result = client.moderate(
-        prompt = prompt("moderation") {
-            user("This is a test message that may contain offensive content.")
-        },
-        model = OpenAIModels.Moderation.Omni
-    )
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import kotlinx.coroutines.runBlocking
+    -->
+    ```kotlin
+    fun main() = runBlocking {
+        val apiKey = System.getenv("OPENAI_API_KEY")
+        val client = OpenAILLMClient(apiKey)
 
-    println(result)
-}
-```
-<!--- KNIT example-llm-clients-06.kt -->
+        val result = client.moderate(
+            prompt = prompt("moderation") {
+                user("This is a test message that may contain offensive content.")
+            },
+            model = OpenAIModels.Moderation.Omni
+        )
+
+        println(result)
+    }
+    ```
+    <!--- KNIT example-llm-clients-06.kt -->
+
+=== "Java"
+
+    ```java
+    String apiKey = System.getenv("OPENAI_API_KEY");
+    OpenAILLMClient client = new OpenAILLMClient(apiKey);
+
+    Prompt prompt = Prompt.builder("moderation")
+        .user("This is a test message that may contain offensive content.")
+        .build();
+
+    ModerationResult result = client.moderate(prompt, OpenAIModels.Moderation.Omni);
+    System.out.println(result);
+    ```
 
 ## Integration with prompt executors
 

--- a/docs/docs/prompts/llm-response-caching.md
+++ b/docs/docs/prompts/llm-response-caching.md
@@ -14,57 +14,89 @@ To create a cached prompt executor, perform the following:
 
 Here is an example:
 
-<!--- INCLUDE
-import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
-import ai.koog.prompt.executor.cached.CachedPromptExecutor
-import ai.koog.prompt.cache.files.FilePromptCache
-import kotlin.system.measureTimeMillis
-import ai.koog.prompt.dsl.prompt
-import kotlin.io.path.Path
+=== "Kotlin"
 
-import kotlinx.coroutines.runBlocking
-
-fun main() {
-    runBlocking {
-        val prompt = prompt("test") {
-            user("Hello")
+    <!--- INCLUDE
+    import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
+    import ai.koog.prompt.executor.cached.CachedPromptExecutor
+    import ai.koog.prompt.cache.files.FilePromptCache
+    import kotlin.system.measureTimeMillis
+    import ai.koog.prompt.dsl.prompt
+    import kotlin.io.path.Path
+    import kotlinx.coroutines.runBlocking
+    fun main() {
+        runBlocking {
+            val prompt = prompt("test") {
+                user("Hello")
+            }
+    -->
+    <!--- SUFFIX
         }
-
--->
-<!--- SUFFIX
     }
-}
---> 
-```kotlin
-// Create a prompt executor
-val client = OpenAILLMClient(System.getenv("OPENAI_API_KEY"))
-val promptExecutor = MultiLLMPromptExecutor(client)
+    -->
+    ```kotlin
+    // Create a prompt executor
+    val client = OpenAILLMClient(System.getenv("OPENAI_API_KEY"))
+    val promptExecutor = MultiLLMPromptExecutor(client)
 
-// Create a cached prompt executor
-val cachedExecutor = CachedPromptExecutor(
-    cache = FilePromptCache(Path("path/to/your/cache/directory")),
-    nested = promptExecutor
-)
+    // Create a cached prompt executor
+    val cachedExecutor = CachedPromptExecutor(
+        cache = FilePromptCache(Path("path/to/your/cache/directory")),
+        nested = promptExecutor
+    )
 
-// Run cached prompt executor for the first time
-// This will perform an actual LLM request
-val firstTime = measureTimeMillis {
-    val firstResponse = cachedExecutor.execute(prompt, OpenAIModels.Chat.GPT4o)
-    println("First response: ${firstResponse.first().content}")
-}
-println("First execution took: ${firstTime}ms")
+    // Run cached prompt executor for the first time
+    // This will perform an actual LLM request
+    val firstTime = measureTimeMillis {
+        val firstResponse = cachedExecutor.execute(prompt, OpenAIModels.Chat.GPT4o)
+        println("First response: ${firstResponse.first().content}")
+    }
+    println("First execution took: ${firstTime}ms")
 
-// Run cached prompt executor for the second time
-// This will return the result immediately from the cache
-val secondTime = measureTimeMillis {
-    val secondResponse = cachedExecutor.execute(prompt, OpenAIModels.Chat.GPT4o)
-    println("Second response: ${secondResponse.first().content}")
-}
-println("Second execution took: ${secondTime}ms")
-```
-<!--- KNIT example-llm-response-caching-01.kt -->
+    // Run cached prompt executor for the second time
+    // This will return the result immediately from the cache
+    val secondTime = measureTimeMillis {
+        val secondResponse = cachedExecutor.execute(prompt, OpenAIModels.Chat.GPT4o)
+        println("Second response: ${secondResponse.first().content}")
+    }
+    println("Second execution took: ${secondTime}ms")
+    ```
+    <!--- KNIT example-llm-response-caching-01.kt -->
+
+=== "Java"
+
+    ```java
+    // Create a prompt
+    Prompt prompt = Prompt.builder("test")
+            .user("Hello")
+            .build();
+
+    // Create a prompt executor
+    OpenAILLMClient client = new OpenAILLMClient(System.getenv("OPENAI_API_KEY"));
+    MultiLLMPromptExecutor promptExecutor = new MultiLLMPromptExecutor(client);
+
+    // Create a cached prompt executor
+    FilePromptCache cache = new FilePromptCache(Path.of("path/to/your/cache/directory"), null);
+    CachedPromptExecutor cachedExecutor = new CachedPromptExecutor(cache, promptExecutor, Clock.System.INSTANCE);
+
+    // Run cached prompt executor for the first time
+    // This will perform an actual LLM request
+    long start1 = System.nanoTime();
+    List<Message.Response> firstResponse = cachedExecutor.execute(prompt, OllamaModels.Meta.LLAMA_3_2);
+    long firstTimeMs = (System.nanoTime() - start1) / 1_000_000L;
+    System.out.println("First response: " + firstResponse.getFirst().getContent());
+    System.out.println("First execution took: " + firstTimeMs + "ms");
+
+    // Run cached prompt executor for the second time
+    // This will return the result immediately from the cache
+    long start2 = System.nanoTime();
+    List<Message.Response> secondResponse = cachedExecutor.execute(prompt, OllamaModels.Meta.LLAMA_3_2);
+    long secondTimeMs = (System.nanoTime() - start2) / 1_000_000L;
+    System.out.println("Second response: " + secondResponse.getFirst().getContent());
+    System.out.println("Second execution took: " + secondTimeMs + "ms");
+    ```
 
 The example produces the following output:
 
@@ -79,4 +111,4 @@ The second response is retrieved from the cache, which took only 1ms.
 !!!note
     * If you call `executeStreaming()` with the cached prompt executor, it produces a response as a single chunk.
     * If you call `moderate()` with the cached prompt executor, it forwards the request to the nested prompt executor and does not use the cache.
-    * Caching of multiple choice responses (`executeMultipleChoice()`) is not supported.
+    * Caching of multiple choice responses (`executeMultipleChoices()`) is not supported.

--- a/docs/docs/prompts/prompt-creation/index.md
+++ b/docs/docs/prompts/prompt-creation/index.md
@@ -1,24 +1,34 @@
 # Creating prompts
 
-Koog uses the type-safe Kotlin DSL to create prompts with control over message types,
-their order, and content.
+Koog provides a structured way to create prompts with control over message types, their order, and content:
 
-These prompts let you pre-configure conversation history with multiple messages, provide multimodal content,
-examples, tool calls, and their results.
+* For **Kotlin** users, through a type-safe Kotlin DSL.
+* For **Java** users, through a fluent builder API.
 
 ## Basic structure
 
-The `prompt()` function creates a Prompt object with a unique ID and a list of messages:
+The `prompt()` function in Kotlin or the `Prompt.builder()` in Java creates a Prompt object with a unique ID and a list of messages:
 
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
--->
-```kotlin
-val prompt = prompt("unique_prompt_id") {
-    // List of messages
-}
-```
-<!--- KNIT example-creating-prompts-01.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    -->
+
+    ```kotlin
+    val prompt = prompt("unique_prompt_id") {
+        // List of messages
+    }
+    ```
+    <!--- KNIT example-creating-prompts-01.kt -->
+
+=== "Java"
+
+    ```java
+    Prompt prompt = Prompt.builder("unique_prompt_id")
+        // List of messages
+        .build();
+    ```
 
 ## Message types
 
@@ -29,20 +39,33 @@ The Kotlin DSL supports the following types of messages, each of which correspon
 - **Assistant message**: Represents LLM responses that are used for few-shot learning or to continue the conversation.
 - **Tool message**: Represents tool calls and their results.
 
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
--->
-```kotlin
-val prompt = prompt("unique_prompt_id") {
-    // Add a system message to set the context
-    system("You are a helpful assistant with access to tools.")
-    // Add a user message
-    user("What is 5 + 3 ?")
-    // Add an assistant message
-    assistant("The result is 8.")
-}
-```
-<!--- KNIT example-creating-prompts-02.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    -->
+
+    ```kotlin
+    val prompt = prompt("unique_prompt_id") {
+        // Add a system message to set the context
+        system("You are a helpful assistant with access to tools.")
+        // Add a user message
+        user("What is 5 + 3 ?")
+        // Add an assistant message
+        assistant("The result is 8.")
+    }
+    ```
+    <!--- KNIT example-creating-prompts-02.kt -->
+
+=== "Java"
+
+    ```java
+    Prompt prompt = Prompt.builder("unique_prompt_id")
+        .system("You are a helpful assistant with access to tools.")
+        .user("What is 5 + 3 ?")
+        .assistant("The result is 8.")
+        .build();
+    ```
 
 ### System message
 
@@ -51,31 +74,54 @@ It can specify the model's role, tone, provide guidelines and constraints on res
 
 To create the system message, provide a string to the `system()` function as an argument:
 
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
--->
-```kotlin
-val prompt = prompt("assistant") {
-    system("You are a helpful assistant that explains technical concepts.")
-}
-```
-<!--- KNIT example-creating-prompts-03.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    -->
+
+    ```kotlin
+    val prompt = prompt("system_message") {
+        system("You are a helpful assistant that explains technical concepts.")
+    }
+    ```
+    <!--- KNIT example-creating-prompts-03.kt -->
+
+=== "Java"
+
+    ```java
+    Prompt prompt = Prompt.builder("system_message")
+        .system("You are a helpful assistant that explains technical concepts.")
+        .build();
+    ```
 
 ### User messages
 
 A user message represents input from the user.
 To create the user message, provide a string to the `user()` function as an argument:
 
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
--->
-```kotlin
-val prompt = prompt("question") {
-    system("You are a helpful assistant.")
-    user("What is Koog?")
-}
-```
-<!--- KNIT example-creating-prompts-04.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    -->
+
+    ```kotlin
+    val prompt = prompt("user_message") {
+        system("You are a helpful assistant.")
+        user("What is Koog?")
+    }
+    ```
+    <!--- KNIT example-creating-prompts-04.kt -->
+
+=== "Java"
+
+    ```java
+    Prompt prompt = Prompt.builder("user_message")
+        .system("You are a helpful assistant.")
+        .user("What is Koog?")
+        .build();
+    ```
 
 Most user messages contain plain text, but they can also include multimodal content, such as images, audio, video, and documents.
 For details and examples, see [Multimodal content](multimodal-content.md).
@@ -87,30 +133,48 @@ to continue a conversation, or to demonstrate the expected output structure.
 
 To create the assistant message, provide a string to the `assistant()` function as an argument:
 
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
--->
-```kotlin
-val prompt = prompt("article_review") {
-    system("Evaluate the article.")
+=== "Kotlin"
 
-    // Example 1
-    user("The article is clear and easy to understand.")
-    assistant("positive")
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    -->
 
-    // Example 2
-    user("The article is hard to read but it's clear and useful.")
-    assistant("neutral")
+    ```kotlin
+    val prompt = prompt("article_review") {
+        system("Evaluate the article.")
 
-    // Example 3
-    user("The article is confusing and misleading.")
-    assistant("negative")
+        // Example 1
+        user("The article is clear and easy to understand.")
+        assistant("positive")
 
-    // New input to classify
-    user("The article is interesting and helpful.")
-}
-```
-<!--- KNIT example-creating-prompts-05.kt -->
+        // Example 2
+        user("The article is hard to read but it's clear and useful.")
+        assistant("neutral")
+
+        // Example 3
+        user("The article is confusing and misleading.")
+        assistant("negative")
+
+        // New input to classify
+        user("The article is interesting and helpful.")
+    }
+    ```
+    <!--- KNIT example-creating-prompts-05.kt -->
+
+=== "Java"
+
+    ```java
+    Prompt prompt = Prompt.builder("article_review")
+        .system("Evaluate the article.")
+        .user("The article is clear and easy to understand.")
+        .assistant("positive")
+        .user("The article is hard to read but it's clear and useful.")
+        .assistant("neutral")
+        .user("The article is confusing and misleading.")
+        .assistant("negative")
+        .user("The article is interesting and helpful.")
+        .build();
+    ```
 
 ### Tool messages
 
@@ -122,101 +186,123 @@ A tool message represents a tool call and its result, which can be used to pre-f
 
 To create the tool message, call the `tool()` function:
 
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
--->
-```kotlin
-val prompt = prompt("calculator_example") {
-    system("You are a helpful assistant with access to tools.")
-    user("What is 5 + 3?")
-    tool {
-        // Tool call
-        call(
-            id = "calculator_tool_id",
-            tool = "calculator",
-            content = """{"operation": "add", "a": 5, "b": 3}"""
-        )
+=== "Kotlin"
 
-        // Tool result
-        result(
-            id = "calculator_tool_id",
-            tool = "calculator",
-            content = "8"
-        )
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    -->
+
+    ```kotlin
+    val prompt = prompt("calculator_example") {
+        system("You are a helpful assistant with access to tools.")
+        user("What is 5 + 3?")
+        tool {
+            // Tool call
+            call(
+                id = "calculator_tool_id",
+                tool = "calculator",
+                content = """{"operation": "add", "a": 5, "b": 3}"""
+            )
+
+            // Tool result
+            result(
+                id = "calculator_tool_id",
+                tool = "calculator",
+                content = "8"
+            )
+        }
+
+        // LLM response based on tool result
+        assistant("The result of 5 + 3 is 8.")
+        user("What is 4 + 5?")
     }
+    ```
+    <!--- KNIT example-creating-prompts-06.kt -->
 
-    // LLM response based on tool result
-    assistant("The result of 5 + 3 is 8.")
-    user("What is 4 + 5?")
-}
-```
-<!--- KNIT example-creating-prompts-06.kt -->
+=== "Java"
+
+    ```java
+    Prompt prompt = Prompt.builder("calculator_example")
+        .system("You are a helpful assistant with access to tools.")
+        .user("What is 5 + 3?")
+        .toolCall("calculator_tool_id", "calculator", "{\"operation\": \"add\", \"a\": 5, \"b\": 3}")
+        .toolResult("calculator_tool_id", "calculator", "8")
+        .assistant("The result of 5 + 3 is 8.")
+        .user("What is 4 + 5?")
+        .build();
+    ```
 
 ## Text message builders
 
-When building a `system()`, `user()`, or `assistant()` message, you can use 
-helper [text-building functions](api:prompt-model::ai.koog.prompt.text.TextContentBuilder)
+!!! warning
+    Text message builders are available only in Kotlin.
+
+When building a `system()`, `user()`, or `assistant()` message, you can use helper [text-building functions](api:prompt-model::ai.koog.prompt.text.TextContentBuilder)
 for rich text formatting.
 
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
--->
-```kotlin
-val prompt = prompt("text_example") {
-    user {
-        +"Review the following code snippet:"
-        +"fun greet(name: String) = println(\"Hello, \$name!\")"
+=== "Kotlin"
 
-        // Paragraph break
-        br()
-        text("Please include in your explanation:")
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    -->
 
-        // Indent content
-        padding("  ") {
-            +"1. What the function does."
-            +"2. How string interpolation works."
-        }
-    }
-}
-```
-<!--- KNIT example-creating-prompts-07.kt -->
+    ```kotlin
+    val prompt = prompt("text_example") {
+        user {
+            +"Review the following code snippet:"
+            +"fun greet(name: String) = println(\"Hello, \$name!\")"
 
-You can also use the [Markdown](api:prompt-markdown::ai.koog.prompt.markdown.markdown) 
-and [XML](api:prompt-xml::ai.koog.prompt.xml.xml) builders to add the content in 
-the corresponding format.
+            // Paragraph break
+            br()
+            text("Please include in your explanation:")
 
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
-import ai.koog.prompt.markdown.markdown
-import ai.koog.prompt.xml.xml
--->
-```kotlin
-val prompt = prompt("markdown_xml_example") {
-    // A user message in Markdown format
-    user {
-        markdown {
-            h2("Evaluate the article using the following criteria:")
-            bulleted {
-                item { +"Clarity and readability" }
-                item { +"Accuracy of information" }
-                item { +"Usefulness to the reader" }
+            // Indent content
+            padding("  ") {
+                +"1. What the function does."
+                +"2. How string interpolation works."
             }
         }
     }
-    // An assistant message in XML format
-    assistant {
-        xml {
-            xmlDeclaration()
-            tag("review") {
-                tag("clarity") { text("positive") }
-                tag("accuracy") { text("neutral") }
-                tag("usefulness") { text("positive") }
+    ```
+    <!--- KNIT example-creating-prompts-07.kt -->
+
+You can also use the [Markdown](api:prompt-markdown::ai.koog.prompt.markdown.markdown) and [XML](api:prompt-xml::ai.koog.prompt.xml.xml) builders to add the content in the corresponding format.
+
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    import ai.koog.prompt.markdown.markdown
+    import ai.koog.prompt.xml.xml
+    -->
+
+    ```kotlin
+    val prompt = prompt("markdown_xml_example") {
+        // A user message in Markdown format
+        user {
+            markdown {
+                h2("Evaluate the article using the following criteria:")
+                bulleted {
+                    item { +"Clarity and readability" }
+                    item { +"Accuracy of information" }
+                    item { +"Usefulness to the reader" }
+                }
+            }
+        }
+        // An assistant message in XML format
+        assistant {
+            xml {
+                xmlDeclaration()
+                tag("review") {
+                    tag("clarity") { text("positive") }
+                    tag("accuracy") { text("neutral") }
+                    tag("usefulness") { text("positive") }
+                }
             }
         }
     }
-}
-```
-<!--- KNIT example-creating-prompts-08.kt -->
+    ```
+    <!--- KNIT example-creating-prompts-08.kt -->
 
 !!! tip
     You can mix the text building functions with the XML and Markdown builders.
@@ -225,25 +311,52 @@ val prompt = prompt("markdown_xml_example") {
 
 Prompts can be customized by configuring parameters that control the LLM's behavior.
 
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
-import ai.koog.prompt.params.LLMParams
-import ai.koog.prompt.params.LLMParams.ToolChoice
--->
-```kotlin
-val prompt = prompt(
-    id = "custom_params",
-    params = LLMParams(
-        temperature = 0.7,
-        numberOfChoices = 1,
-        toolChoice = LLMParams.ToolChoice.Auto
-    )
-) {
-    system("You are a creative writing assistant.")
-    user("Write a song about winter.")
-}
-```
-<!--- KNIT example-creating-prompts-09.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    import ai.koog.prompt.params.LLMParams
+    import ai.koog.prompt.params.LLMParams.ToolChoice
+    -->
+
+    ```kotlin
+    val prompt = prompt(
+        id = "custom_params",
+        params = LLMParams(
+            temperature = 0.7,
+            numberOfChoices = 1,
+            toolChoice = LLMParams.ToolChoice.Auto
+        )
+    ) {
+        system("You are a creative writing assistant.")
+        user("Write a song about winter.")
+    }
+    ```
+    <!--- KNIT example-creating-prompts-09.kt -->
+
+=== "Java"
+
+    ```java
+    // Create params first
+    LLMParams params = new LLMParams(
+        0.7,                    // temperature
+        null,                   // maxTokens
+        1,                      // numberOfChoices
+        null,                   // speculation
+        null,                   // schema
+        LLMParams.ToolChoice.Auto.INSTANCE, // toolChoice
+        null,                   // user
+        null                    // additionalProperties
+    );
+
+    Prompt prompt = Prompt.builder("custom_params")
+        .system("You are a creative writing assistant.")
+        .user("Write a song about winter.")
+        .build();
+        
+    // Apply params to the built prompt
+    prompt = prompt.withParams(params);
+    ```
 
 The following parameters are supported:
 
@@ -260,21 +373,38 @@ For more information, see [LLM parameters](../../llm-parameters.md).
 
 You can extend an existing prompt by calling the `prompt()` function with the existing prompt as an argument:
 
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
--->
-```kotlin
-val basePrompt = prompt("base") {
-    system("You are a helpful assistant.")
-    user("Hello!")
-    assistant("Hi! How can I help you?")
-}
+=== "Kotlin"
 
-val extendedPrompt = prompt(basePrompt) {
-    user("What's the weather like?")
-}
-```
-<!--- KNIT example-creating-prompts-10.kt -->
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    -->
+
+    ```kotlin
+    val basePrompt = prompt("base") {
+        system("You are a helpful assistant.")
+        user("Hello!")
+        assistant("Hi! How can I help you?")
+    }
+
+    val extendedPrompt = prompt(basePrompt) {
+        user("What's the weather like?")
+    }
+    ```
+    <!--- KNIT example-creating-prompts-10.kt -->
+
+=== "Java"
+
+    ```java
+    Prompt basePrompt = Prompt.builder("base")
+        .system("You are a helpful assistant.")
+        .user("Hello!")
+        .assistant("Hi! How can I help you?")
+        .build();
+
+    Prompt extendedPrompt = Prompt.builder(String.valueOf(basePrompt))
+        .user("What's the weather like?")
+        .build();
+    ```
 
 This creates a new prompt that includes all messages from `basePrompt` and the new user message.
 

--- a/docs/docs/prompts/prompt-creation/multimodal-content.md
+++ b/docs/docs/prompts/prompt-creation/multimodal-content.md
@@ -25,26 +25,41 @@ the corresponding attachment parameters based on the file extension.
 
 The general format of the `user` message that includes a text message and a list of auto-configured attachments is as follows:
 
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
-import kotlinx.io.files.Path
+=== "Kotlin"
 
-val prompt = prompt("image_analysis") {
--->
-<!--- SUFFIX
-}
--->
-```kotlin
-user {
-    +"Describe these images:"
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    import kotlinx.io.files.Path
+    val prompt = prompt("image_analysis") {
+    -->
+    <!--- SUFFIX
+    }
+    -->
 
-    image("https://example.com/test.png")
-    image(Path("/path/to/image.png"))
+    ```kotlin
+    user {
+        +"Describe these images:"
 
-    +"Focus on the main subjects."
-}
-```
-<!--- KNIT example-multimodal-content-01.kt -->
+        image("https://example.com/test.png")
+        image(Path("/path/to/image.png"))
+
+        +"Focus on the main subjects."
+    }
+    ```
+    <!--- KNIT example-multimodal-content-01.kt -->
+
+=== "Java"
+
+    ```java
+    ContentPartsBuilder partsBuilder = new ContentPartsBuilder();
+    partsBuilder.text("Describe these images:");
+    partsBuilder.image("https://example.com/test.png");
+    partsBuilder.text("Focus on the main subjects.");
+
+    Prompt prompt = Prompt.builder("image_analysis")
+        .user(partsBuilder.build())
+        .build();
+    ```
 
 The `+` operator adds text content to the user message along with the attachments.
 
@@ -59,30 +74,48 @@ configure its parameters, and pass it to the corresponding `image()`, `audio()`,
 
 The general format of the `user` message that includes a text message and a list of custom-configured attachments is as follows:
 
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
-import ai.koog.prompt.message.AttachmentContent
-import ai.koog.prompt.message.ContentPart
+=== "Kotlin"
 
-val prompt = prompt("custom_image") {
--->
-<!--- SUFFIX
-}
--->
-```kotlin
-user {
-    +"Describe this image"
-    image(
-        ContentPart.Image(
-            content = AttachmentContent.URL("https://example.com/capture.png"),
-            format = "png",
-            mimeType = "image/png",
-            fileName = "capture.png"
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    import ai.koog.prompt.message.AttachmentContent
+    import ai.koog.prompt.message.ContentPart
+    val prompt = prompt("custom_image") {
+    -->
+    <!--- SUFFIX
+    }
+    -->
+
+    ```kotlin
+    user {
+        +"Describe this image"
+        image(
+            ContentPart.Image(
+                content = AttachmentContent.URL("https://example.com/capture.png"),
+                format = "png",
+                mimeType = "image/png",
+                fileName = "capture.png"
+            )
         )
-    )
-}
-```
-<!--- KNIT example-multimodal-content-02.kt -->
+    }
+    ```
+    <!--- KNIT example-multimodal-content-02.kt -->
+
+=== "Java"
+
+    ```java
+    Prompt prompt = Prompt.builder("custom_image")
+        .user(List.of(
+            new ContentPart.Text("Describe this image"),
+            new ContentPart.Image(
+                new AttachmentContent.URL("https://example.com/capture.png"),
+                "png",
+                "image/png",
+                "capture.png"
+            )
+        ))
+        .build();
+    ```
 
 Koog provides the following specialized classes for each media type that implement the `ContentPart.Attachment` interface:
 
@@ -105,21 +138,21 @@ All `ContentPart.Attachment` types accept the following parameters:
 Implementations of the AttachmentContent interface define the type and source of content that is provided as input to the LLM:
 
 - [`AttachmentContent.URL`](api:prompt-model::ai.koog.prompt.message.AttachmentContent.URL) defines the URL of the provided content:
-    ```kotlin
+    ```text
     AttachmentContent.URL("https://example.com/image.png")
     ```
 - [`AttachmentContent.Binary.Bytes`](api:prompt-model::ai.koog.prompt.message.AttachmentContent.Binary) defines the file content as a byte array:
-    ```kotlin
+    ```text
     AttachmentContent.Binary.Bytes(byteArrayOf(/* ... */))
     ```
 
 - [`AttachmentContent.Binary.Base64`](api:prompt-model::ai.koog.prompt.message.AttachmentContent.Binary) defines the file content as a Base64-encoded string containing file data:
-    ```kotlin
+    ```text
     AttachmentContent.Binary.Base64("iVBORw0KGgoAAAANS...")
     ```
 
 - [`AttachmentContent.PlainText`](api:prompt-model::ai.koog.prompt.message.AttachmentContent.PlainText) defines the file content as plain text (for [`ContentPart.File`](api:prompt-model::ai.koog.prompt.message.ContentPart.File) only):
-    ```kotlin
+    ```text
     AttachmentContent.PlainText("This is the file content.")
     ```
 
@@ -127,24 +160,50 @@ Implementations of the AttachmentContent interface define the type and source of
 
 In addition to providing different types of attachments in separate prompts or messages, you can also provide multiple and mixed types of attachments in a single `user()` message:
 
-<!--- CLEAR -->
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
-import kotlinx.io.files.Path
--->
-```kotlin
-val prompt = prompt("mixed_content") {
-    system("You are a helpful assistant.")
+=== "Kotlin"
 
-    user {
-        +"Compare the image with the document content."
-        image(Path("/path/to/image.png"))
-        binaryFile(Path("/path/to/page.pdf"), "application/pdf")
-        +"Structure the result as a table"
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    import kotlinx.io.files.Path
+    -->
+
+    ```kotlin
+    val prompt = prompt("mixed_content") {
+        system("You are a helpful assistant.")
+
+        user {
+            +"Compare the image with the document content."
+            image(Path("/path/to/image.png"))
+            binaryFile(Path("/path/to/page.pdf"), "application/pdf")
+            +"Structure the result as a table"
+        }
     }
-}
-```
-<!--- KNIT example-multimodal-content-03.kt -->
+    ```
+    <!--- KNIT example-multimodal-content-03.kt -->
+
+=== "Java"
+
+    ```java
+    Prompt prompt = Prompt.builder("mixed_content_example")
+    .system("You are a helpful assistant.")
+    .user(List.of(
+        new ContentPart.Text("Please analyze this image and the attached document."),
+        new ContentPart.Image(
+            new AttachmentContent.URL("https://example.com/image.png"),
+            "png",
+            "image/png",
+            "image.png"
+        ),
+        new ContentPart.File(
+            new AttachmentContent.URL("https://example.com/document.pdf"),
+            "pdf",
+            "application/pdf",
+            "document.pdf"
+        ),
+        new ContentPart.Text("Summarize the differences.")
+    ))
+    .build();
+    ```
 
 ## Next steps
 

--- a/docs/docs/prompts/prompt-executors.md
+++ b/docs/docs/prompts/prompt-executors.md
@@ -19,19 +19,29 @@ Koog provides three main types of prompt executors that implement the [`PromptEx
 To create a prompt executor for a specific LLM provider, perform the following:
 
 1. Configure an LLM client for a specific provider with the corresponding API key.
-2. Create a prompt executor using [`SingleLLMPromptExecutor`](api:prompt-executor-llms::ai.koog.prompt.executor.llms.SingleLLMPromptExecutor).
+2. Create a prompt executor using [`MultiLLMPromptExecutor`](api:prompt-executor-llms::ai.koog.prompt.executor.llms.MultiLLMPromptExecutor).
 
 Here is an example:
 
-<!--- INCLUDE
-import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
-import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
--->
-```kotlin
-val openAIClient = OpenAILLMClient(System.getenv("OPENAI_KEY"))
-val promptExecutor = MultiLLMPromptExecutor(openAIClient)
-```
-<!--- KNIT example-prompt-executors-01.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+    import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
+    -->
+
+    ```kotlin
+    val openAIClient = OpenAILLMClient(System.getenv("OPENAI_API_KEY"))
+    val promptExecutor = MultiLLMPromptExecutor(openAIClient)
+    ```
+    <!--- KNIT example-prompt-executors-01.kt -->
+
+=== "Java"
+
+    ```java
+    OpenAILLMClient openAIClient = new OpenAILLMClient(System.getenv("OPENAI_API_KEY"));
+    MultiLLMPromptExecutor promptExecutor = new MultiLLMPromptExecutor(openAIClient);
+    ```
 
 ## Creating a multi-provider executor
 
@@ -41,22 +51,34 @@ To create a prompt executor that works with multiple LLM providers, do the follo
 2. Pass the configured clients to the [`MultiLLMPromptExecutor`](api:prompt-executor-llms::ai.koog.prompt.executor.llms.MultiLLMPromptExecutor) class constructor to create a prompt executor
    with multiple LLM providers.
 
-<!--- INCLUDE
-import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
-import ai.koog.prompt.executor.ollama.client.OllamaClient
-import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
-import ai.koog.prompt.llm.LLMProvider
--->
-```kotlin
-val openAIClient = OpenAILLMClient(System.getenv("OPENAI_KEY"))
-val ollamaClient = OllamaClient()
+=== "Kotlin"
 
-val multiExecutor = MultiLLMPromptExecutor(
-    LLMProvider.OpenAI to openAIClient,
-    LLMProvider.Ollama to ollamaClient
-)
-```
-<!--- KNIT example-prompt-executors-02.kt -->
+    <!--- INCLUDE
+    import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+    import ai.koog.prompt.executor.ollama.client.OllamaClient
+    import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
+    import ai.koog.prompt.llm.LLMProvider
+    -->
+
+    ```kotlin
+    val openAIClient = OpenAILLMClient(System.getenv("OPENAI_API_KEY"))
+    val ollamaClient = OllamaClient()
+
+    val multiExecutor = MultiLLMPromptExecutor(
+        LLMProvider.OpenAI to openAIClient,
+        LLMProvider.Ollama to ollamaClient
+    )
+    ```
+    <!--- KNIT example-prompt-executors-02.kt -->
+
+=== "Java"
+
+    ```java
+    OpenAILLMClient openAIClient = new OpenAILLMClient(System.getenv("OPENAI_API_KEY"));
+    OllamaClient ollamaClient = new OllamaClient();
+
+    MultiLLMPromptExecutor promptExecutor = new MultiLLMPromptExecutor(openAIClient, ollamaClient);
+    ```
 
 ## Creating a routing executor
 
@@ -72,25 +94,42 @@ To create a prompt executor that distributes requests across multiple LLM client
 
 This is useful for avoiding rate limits, improving throughput, and implementing failover strategies.
 
-<!--- INCLUDE
-import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
-import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
-import ai.koog.prompt.executor.llms.RoundRobinRouter
-import ai.koog.prompt.executor.llms.RoutingLLMPromptExecutor
--->
-```kotlin
-// Create multiple client instances
-val openAI1 = OpenAILLMClient(apiKey = "openai-key-1")
-val openAI2 = OpenAILLMClient(apiKey = "openai-key-2")
-val anthropic = AnthropicLLMClient(apiKey = "anthropic-key")
+=== "Kotlin"
 
-// Create router with round-robin strategy
-val router = RoundRobinRouter(openAI1, openAI2, anthropic)
+    <!--- INCLUDE
+    import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+    import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
+    import ai.koog.prompt.executor.llms.RoundRobinRouter
+    import ai.koog.prompt.executor.llms.RoutingLLMPromptExecutor
+    -->
+    ```kotlin
+    // Create multiple client instances
+    val openAI1 = OpenAILLMClient(apiKey = "openai-key-1")
+    val openAI2 = OpenAILLMClient(apiKey = "openai-key-2")
+    val anthropic = AnthropicLLMClient(apiKey = "anthropic-key")
 
-// Create routing executor
-val routingExecutor = RoutingLLMPromptExecutor(router)
-```
-<!--- KNIT example-prompt-executors-03.kt -->
+    // Create router with round-robin strategy
+    val router = RoundRobinRouter(openAI1, openAI2, anthropic)
+
+    // Create routing executor
+    val routingExecutor = RoutingLLMPromptExecutor(router)
+    ```
+    <!--- KNIT example-prompt-executors-03.kt -->
+
+=== "Java"
+
+    ```java
+    // Create multiple client instances
+    OpenAILLMClient openAI1 = new OpenAILLMClient("openai-key-1");
+    OpenAILLMClient openAI2 = new OpenAILLMClient("openai-key-2");
+    AnthropicLLMClient anthropic = new AnthropicLLMClient("anthropic-key");
+
+    // Create router with round-robin strategy
+    RoundRobinRouter router = new RoundRobinRouter(openAI1, openAI2, anthropic);
+
+    // Create routing executor
+    RoutingLLMPromptExecutor routingExecutor = new RoutingLLMPromptExecutor(router);
+    ```
 
 When you execute prompts with this executor, requests to OpenAI models will alternate between `openAI1` and `openAI2` using the round-robin strategy.
 Requests to Anthropic models always go to the single `anthropic` client, as round-robin maintains an independent counter per provider.
@@ -104,6 +143,9 @@ For faster setup, Koog provides the ready-to-use executor implementations for co
 The following table includes the **pre-defined single-provider executors**
 that return `SingleLLMPromptExecutor` configured with a specific LLM client.
 
+<!--TODO: SingleLLMPromptExecutor is deprecated and is being replaced by PromptExecutor. Once it is implemented,
+the predefined executors will return a PromptExecutor instance configured with a specific client.-->
+
 | LLM provider   | Prompt executor                                                                                                                                                                             | Description                                                                      |
 |----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
 | OpenAI         | [simpleOpenAIExecutor](api:prompt-executor-llms-all::ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor)                                  | Wraps `OpenAILLMClient` that runs prompts with OpenAI models.                    |
@@ -116,27 +158,31 @@ that return `SingleLLMPromptExecutor` configured with a specific LLM client.
 | Mistral        | [simpleMistralAIExecutor](api:prompt-executor-llms-all::ai.koog.prompt.executor.llms.all.simpleMistralAIExecutor)                            | Wraps `MistralAILLMClient` that runs prompts with Mistral models.                |
 | Ollama         | [simpleOllamaAIExecutor](api:prompt-executor-llms-all::ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor)                              | Wraps `OllamaClient` that runs prompts with Ollama.                              |
 
-Here is an example of creating pre-defined single and multi-provider executors:
+Here is an example of creating a pre-defined executor:
 
-<!--- INCLUDE
-import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
-import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
-import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
-import ai.koog.prompt.executor.clients.google.GoogleLLMClient
-import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
-import kotlinx.coroutines.runBlocking
--->
-```kotlin
-// Create an OpenAI executor
-val promptExecutor = simpleOpenAIExecutor("OPENAI_KEY")
+=== "Kotlin"
 
-// Create a MultiLLMPromptExecutor with OpenAI, Anthropic, and Google LLM clients
-val openAIClient = OpenAILLMClient("OPENAI_KEY")
-val anthropicClient = AnthropicLLMClient("ANTHROPIC_KEY")
-val googleClient = GoogleLLMClient("GOOGLE_KEY")
-val multiExecutor = MultiLLMPromptExecutor(openAIClient, anthropicClient, googleClient)
-```
-<!--- KNIT example-prompt-executors-04.kt -->
+    <!--- INCLUDE
+    import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+    import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
+    import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
+    import ai.koog.prompt.executor.clients.google.GoogleLLMClient
+    import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+    import kotlinx.coroutines.runBlocking
+    -->
+
+    ```kotlin
+    // Create an OpenAI executor
+    val promptExecutor = simpleOpenAIExecutor("OPENAI_API_KEY")
+    ```
+    <!--- KNIT example-prompt-executors-04.kt -->
+
+=== "Java"
+
+    ```java
+    // Create an OpenAI executor
+    PromptExecutor openAIExecutor = simpleOpenAIExecutor("OPENAI_API_KEY");
+    ```
 
 ## Running a prompt
 
@@ -147,30 +193,47 @@ To run a prompt using a prompt executor, do the following:
 
 Here is an example:
 
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
-import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import kotlinx.coroutines.runBlocking
+=== "Kotlin"
 
-fun main() {
-    runBlocking {
--->
-<!--- SUFFIX
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import kotlinx.coroutines.runBlocking
+    fun main() {
+        runBlocking {
+    -->
+    <!--- SUFFIX
+        }
     }
-}
--->
-```kotlin
-// Create an OpenAI executor
-val promptExecutor = simpleOpenAIExecutor("OPENAI_KEY")
+    -->
 
-// Execute a prompt
-val response = promptExecutor.execute(
-    prompt = prompt("demo") { user("Summarize this.") },
-    model = OpenAIModels.Chat.GPT4o
-)
-```
-<!--- KNIT example-prompt-executors-05.kt -->
+    ```kotlin
+    // Create an OpenAI executor
+    val promptExecutor = simpleOpenAIExecutor("OPENAI_API_KEY")
+
+    // Execute a prompt
+    val response = promptExecutor.execute(
+        prompt = prompt("demo") { user("Summarize this.") },
+        model = OpenAIModels.Chat.GPT4o
+    )
+    ```
+    <!--- KNIT example-prompt-executors-05.kt -->
+
+=== "Java"
+
+    ```java
+    // Create an OpenAI executor
+    PromptExecutor promptExecutor = simpleOpenAIExecutor("OPENAI_API_KEY");
+
+    // Create a prompt
+    Prompt prompt = Prompt.builder("demo")
+        .user("Summarize this.")
+        .build();
+
+    // Run the prompt
+    List<Message.Response> response = promptExecutor.execute(prompt, OpenAIModels.Chat.GPT4o);
+    ```
 
 This will run the prompt with the `GPT4o` model and return the response.
 
@@ -192,112 +255,177 @@ The process is as follows:
 
 Here is an example of switching between providers:
 
-<!--- INCLUDE
-import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
-import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
-import ai.koog.prompt.executor.clients.google.GoogleLLMClient
-import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
-import ai.koog.prompt.llm.LLMProvider
-import ai.koog.prompt.dsl.prompt
-import kotlinx.coroutines.runBlocking
+=== "Kotlin"
 
-fun main() = runBlocking {
--->
-<!--- SUFFIX
-}
--->
-```kotlin
-// Create LLM clients for OpenAI, Anthropic, and Google providers
-val openAIClient = OpenAILLMClient("OPENAI_API_KEY")
-val anthropicClient = AnthropicLLMClient("ANTHROPIC_API_KEY")
-val googleClient = GoogleLLMClient("GOOGLE_API_KEY")
+    <!--- INCLUDE
+    import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
+    import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
+    import ai.koog.prompt.executor.clients.google.GoogleLLMClient
+    import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
+    import ai.koog.prompt.llm.LLMProvider
+    import ai.koog.prompt.dsl.prompt
+    import kotlinx.coroutines.runBlocking
+    fun main() = runBlocking {
+    -->
+    <!--- SUFFIX
+    }
+    -->
 
-// Create a MultiLLMPromptExecutor that maps LLM providers to LLM clients
-val executor = MultiLLMPromptExecutor(
-    LLMProvider.OpenAI to openAIClient,
-    LLMProvider.Anthropic to anthropicClient,
-    LLMProvider.Google to googleClient
-)
+    ```kotlin
+    // Create LLM clients for OpenAI, Anthropic, and Google providers
+    val openAIClient = OpenAILLMClient("OPENAI_API_KEY")
+    val anthropicClient = AnthropicLLMClient("ANTHROPIC_API_KEY")
+    val googleClient = GoogleLLMClient("GOOGLE_API_KEY")
 
-// Create a prompt
-val p = prompt("demo") { user("Summarize this.") }
+    // Create a MultiLLMPromptExecutor that maps LLM providers to LLM clients
+    val executor = MultiLLMPromptExecutor(
+        LLMProvider.OpenAI to openAIClient,
+        LLMProvider.Anthropic to anthropicClient,
+        LLMProvider.Google to googleClient
+    )
 
-// Run the prompt with an OpenAI model; the prompt executor automatically switches to the OpenAI client
-val openAIResult = executor.execute(p, OpenAIModels.Chat.GPT4o)
+    // Create a prompt
+    val p = prompt("demo") { user("Summarize this.") }
 
-// Run the prompt with an Anthropic model; the prompt executor automatically switches to the Anthropic client
-val anthropicResult = executor.execute(p, AnthropicModels.Opus_4_6)
-```
-<!--- KNIT example-prompt-executors-06.kt -->
+    // Run the prompt with an OpenAI model; the prompt executor automatically switches to the OpenAI client
+    val openAIResult = executor.execute(p, OpenAIModels.Chat.GPT4o)
+
+    // Run the prompt with an Anthropic model; the prompt executor automatically switches to the Anthropic client
+    val anthropicResult = executor.execute(p, AnthropicModels.Sonnet_4_5)
+    ```
+    <!--- KNIT example-prompt-executors-06.kt -->
+
+=== "Java"
+
+    ```java
+    // Create LLM clients for OpenAI, Anthropic, and Google providers
+    OpenAILLMClient openAIClient = new OpenAILLMClient("OPENAI_API_KEY");
+    AnthropicLLMClient anthropicClient = new AnthropicLLMClient("ANTHROPIC_API_KEY");
+    GoogleLLMClient googleClient = new GoogleLLMClient("GOOGLE_API_KEY");
+
+    // Create a MultiLLMPromptExecutor that maps LLM providers to LLM clients
+    MultiLLMPromptExecutor promptExecutor = new MultiLLMPromptExecutor(
+        Map.of(
+            LLMProvider.OpenAI, openAIClient,
+            LLMProvider.Anthropic, anthropicClient,
+            LLMProvider.Google, googleClient
+        )
+    );
+
+    // Create a prompt
+    Prompt prompt = Prompt.builder("demo")
+        .user("Summarize this.")
+        .build();
+
+    // Run the prompt with an OpenAI model; the prompt executor automatically switches to the OpenAI client
+    List<Message.Response> openAIResult = promptExecutor.execute(prompt, OpenAIModels.Chat.GPT4o);
+
+    // Run the prompt with an Anthropic model; the prompt executor automatically switches to the Anthropic client
+    List<Message.Response> anthropicResult = promptExecutor.execute(prompt, AnthropicModels.Sonnet_4_5);
+    ```
 
 You can optionally configure a fallback LLM provider and model to use when the requested client is unavailable.
+For details, refer to [Configuring fallbacks](#configuring-fallbacks).
 
 ## Configuring fallbacks
 
 Multi-provider and routing prompt executors can be configured to use a fallback LLM provider and model when the requested LLM client is unavailable.
 To configure the fallback mechanism, provide the `fallback` parameter to the `MultiLLMPromptExecutor` or `RoutingLLMPromptExecutor` constructor:
 
-<!--- INCLUDE
-import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
-import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
-import ai.koog.prompt.executor.ollama.client.OllamaClient
-import ai.koog.prompt.executor.ollama.client.OllamaModels
-import ai.koog.prompt.llm.LLMProvider
--->
-```kotlin
-val openAIClient = OpenAILLMClient(System.getenv("OPENAI_KEY"))
-val ollamaClient = OllamaClient()
+=== "Kotlin"
 
-val multiExecutor = MultiLLMPromptExecutor(
-    LLMProvider.OpenAI to openAIClient,
-    LLMProvider.Ollama to ollamaClient,
-    fallback = MultiLLMPromptExecutor.FallbackPromptExecutorSettings(
-        fallbackProvider = LLMProvider.Ollama,
-        fallbackModel = OllamaModels.Meta.LLAMA_3_2
+    <!--- INCLUDE
+    import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
+    import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+    import ai.koog.prompt.executor.ollama.client.OllamaClient
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    import ai.koog.prompt.llm.LLMProvider
+    -->
+
+    ```kotlin
+    val openAIClient = OpenAILLMClient(System.getenv("OPENAI_API_KEY"))
+    val ollamaClient = OllamaClient()
+
+    val multiExecutor = MultiLLMPromptExecutor(
+        LLMProvider.OpenAI to openAIClient,
+        LLMProvider.Ollama to ollamaClient,
+        fallback = MultiLLMPromptExecutor.FallbackPromptExecutorSettings(
+            fallbackProvider = LLMProvider.Ollama,
+            fallbackModel = OllamaModels.Meta.LLAMA_3_2
+        )
     )
-)
-```
-<!--- KNIT example-prompt-executors-07.kt -->
+    ```
+    <!--- KNIT example-prompt-executors-07.kt -->
+
+=== "Java"
+
+    ```java
+    OpenAILLMClient openAIClient = new OpenAILLMClient(System.getenv("OPENAI_API_KEY"));
+    OllamaClient ollamaClient = new OllamaClient();
+
+    MultiLLMPromptExecutor multiExecutor = new MultiLLMPromptExecutor(
+        Map.of(
+            LLMProvider.OpenAI, openAIClient,
+            LLMProvider.Ollama, ollamaClient
+        ),
+        new MultiLLMPromptExecutor.FallbackPromptExecutorSettings(
+            LLMProvider.Ollama,
+            OllamaModels.Meta.LLAMA_3_2
+        )
+    );
+    ```
 
 If you pass a model from an LLM provider that is not included in the `MultiLLMPromptExecutor`,
 the prompt executor will use the fallback model:
 
-<!--- INCLUDE
-import ai.koog.prompt.dsl.prompt
-import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
-import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
-import ai.koog.prompt.executor.ollama.client.OllamaClient
-import ai.koog.prompt.executor.clients.google.GoogleModels
-import ai.koog.prompt.executor.ollama.client.OllamaModels
-import ai.koog.prompt.llm.LLMProvider
-import kotlinx.coroutines.runBlocking
+=== "Kotlin"
 
-val openAIClient = OpenAILLMClient(System.getenv("OPENAI_KEY"))
-val ollamaClient = OllamaClient()
-
-val multiExecutor = MultiLLMPromptExecutor(
-    LLMProvider.OpenAI to openAIClient,
-    LLMProvider.Ollama to ollamaClient,
-    fallback = MultiLLMPromptExecutor.FallbackPromptExecutorSettings(
-        fallbackProvider = LLMProvider.Ollama,
-        fallbackModel = OllamaModels.Meta.LLAMA_3_2
+    <!--- INCLUDE
+    import ai.koog.prompt.dsl.prompt
+    import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
+    import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+    import ai.koog.prompt.executor.ollama.client.OllamaClient
+    import ai.koog.prompt.executor.clients.google.GoogleModels
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    import ai.koog.prompt.llm.LLMProvider
+    import kotlinx.coroutines.runBlocking
+    val openAIClient = OpenAILLMClient(System.getenv("OPENAI_API_KEY"))
+    val ollamaClient = OllamaClient()
+    val multiExecutor = MultiLLMPromptExecutor(
+        LLMProvider.OpenAI to openAIClient,
+        LLMProvider.Ollama to ollamaClient,
+        fallback = MultiLLMPromptExecutor.FallbackPromptExecutorSettings(
+            fallbackProvider = LLMProvider.Ollama,
+            fallbackModel = OllamaModels.Meta.LLAMA_3_2
+        )
     )
-)
+    fun main() = runBlocking {
+    -->
+    <!--- SUFFIX
+    }
+    -->
 
-fun main() = runBlocking {
--->
-<!--- SUFFIX
-}
--->
-```kotlin
-// Create a prompt
-val p = prompt("demo") { user("Summarize this") }
-// If you pass a Google model, the prompt executor will use the fallback model, as the Google client is not included
-val response = multiExecutor.execute(p, GoogleModels.Gemini2_5Pro)
-```
-<!--- KNIT example-prompt-executors-08.kt -->
+    ```kotlin
+    // Create a prompt
+    val p = prompt("demo") { user("Summarize this") }
+    // If you pass a Google model, the prompt executor will use the fallback model, as the Google client is not included
+    val response = multiExecutor.execute(p, GoogleModels.Gemini2_5Pro)
+    ```
+    <!--- KNIT example-prompt-executors-08.kt -->
+
+=== "Java"
+
+    ```java
+    // Create a prompt
+    Prompt p = Prompt.builder("demo")
+        .user("Summarize this")
+        .build();
+
+    // If you pass a Google model, the prompt executor will use the fallback model, as the Google client is not included
+    List<Message.Response> response = multiExecutor.execute(p, GoogleModels.Gemini2_5Pro);
+    ```
 
 !!! note
     Fallbacks are available for the `execute()` and `executeMultipleChoices()` methods only.

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -152,30 +152,52 @@ Koog requires either an API key from a [supported LLM provider](llm-providers.md
 
     The following example creates and runs a simple Koog agent using the [`GPT-4o`](https://platform.openai.com/docs/models/gpt-4o) model via the OpenAI API.
 
-    <!--- INCLUDE
-    import ai.koog.agents.core.agent.AIAgent
-    import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
-    import ai.koog.prompt.executor.clients.openai.OpenAIModels
-    import kotlinx.coroutines.runBlocking
-    -->
-    ```kotlin
-    fun main() = runBlocking {
-        // Get the OpenAI API key from the OPENAI_API_KEY environment variable
-        val apiKey = System.getenv("OPENAI_API_KEY")
-            ?: error("The API key is not set.")
+    === "Kotlin"
+
+        <!--- INCLUDE
+        import ai.koog.agents.core.agent.AIAgent
+        import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+        import ai.koog.prompt.executor.clients.openai.OpenAIModels
+        import kotlinx.coroutines.runBlocking
+        -->
+        ```kotlin
+        fun main() = runBlocking {
+            // Get the OpenAI API key from the OPENAI_API_KEY environment variable
+            val apiKey = System.getenv("OPENAI_API_KEY")
+                ?: error("The API key is not set.")
+            
+            // Create an agent
+            val agent = AIAgent(
+                promptExecutor = simpleOpenAIExecutor(apiKey),
+                llmModel = OpenAIModels.Chat.GPT4o
+            )
         
+            // Run the agent
+            val result = agent.run("Hello! How can you help me?")
+            println(result)
+        }
+        ```
+        <!--- KNIT example-getting-started-01.kt -->
+
+    === "Java"
+
+        ```java
+        // Get the OpenAI API key from the OPENAI_API_KEY environment variable
+        String apiKey = System.getenv("OPENAI_API_KEY");
+        if (apiKey == null) {
+            throw new RuntimeException("The API key is not set.");
+        }
+
         // Create an agent
-        val agent = AIAgent(
-            promptExecutor = simpleOpenAIExecutor(apiKey),
-            llmModel = OpenAIModels.Chat.GPT4o
-        )
-    
+        AIAgent<String, String> agent = AIAgent.builder()
+            .promptExecutor(simpleOpenAIExecutor(apiKey))
+            .llmModel(OpenAIModels.Chat.GPT4o)
+            .build();
+
         // Run the agent
-        val result = agent.run("Hello! How can you help me?")
-        println(result)
-    }
-    ```
-    <!--- KNIT example-getting-started-01.kt -->
+        String result = agent.run("Hello! How can you help me?");
+        System.out.println(result);
+        ```
 
     The example can produce the following output:
     
@@ -198,30 +220,52 @@ Koog requires either an API key from a [supported LLM provider](llm-providers.md
 
     The following example creates and runs a simple Koog agent using the [`Claude Opus 4.1`](https://www.anthropic.com/news/claude-opus-4-1) model via the Anthropic API.
 
-    <!--- INCLUDE
-    import ai.koog.agents.core.agent.AIAgent
-    import ai.koog.prompt.executor.llms.all.simpleAnthropicExecutor
-    import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
-    import kotlinx.coroutines.runBlocking
-    -->
-    ```kotlin
-    fun main() = runBlocking {
-        // Get the Anthropic API key from the ANTHROPIC_API_KEY environment variable
-        val apiKey = System.getenv("ANTHROPIC_API_KEY")
-            ?: error("The API key is not set.")
+    === "Kotlin"
+
+        <!--- INCLUDE
+        import ai.koog.agents.core.agent.AIAgent
+        import ai.koog.prompt.executor.llms.all.simpleAnthropicExecutor
+        import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
+        import kotlinx.coroutines.runBlocking
+        -->
+        ```kotlin
+        fun main() = runBlocking {
+            // Get the Anthropic API key from the ANTHROPIC_API_KEY environment variable
+            val apiKey = System.getenv("ANTHROPIC_API_KEY")
+                ?: error("The API key is not set.")
+            
+            // Create an agent
+            val agent = AIAgent(
+                promptExecutor = simpleAnthropicExecutor(apiKey),
+                llmModel = AnthropicModels.Opus_4_1
+            )
         
+            // Run the agent
+            val result = agent.run("Hello! How can you help me?")
+            println(result)
+        }
+        ```
+        <!--- KNIT example-getting-started-02.kt -->
+
+    === "Java"
+
+        ```java
+       // Get the Anthropic API key from the ANTHROPIC_API_KEY environment variable
+        String apiKey = System.getenv("ANTHROPIC_API_KEY");
+        if (apiKey == null) {
+            throw new RuntimeException("The API key is not set.");
+        }
+
         // Create an agent
-        val agent = AIAgent(
-            promptExecutor = simpleAnthropicExecutor(apiKey),
-            llmModel = AnthropicModels.Opus_4_1
-        )
-    
+        AIAgent<String, String> agent = AIAgent.builder()
+            .promptExecutor(simpleAnthropicExecutor(apiKey))
+            .llmModel(AnthropicModels.Opus_4_1)
+            .build();
+
         // Run the agent
-        val result = agent.run("Hello! How can you help me?")
-        println(result)
-    }
-    ```
-    <!--- KNIT example-getting-started-02.kt -->
+        String result = agent.run("Hello! How can you help me?");
+        System.out.println(result);
+        ```
 
     The example can produce the following output:
 
@@ -242,30 +286,52 @@ Koog requires either an API key from a [supported LLM provider](llm-providers.md
 
     The following example creates and runs a simple Koog agent using the [`Gemini 2.5 Pro`](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-pro) model via the Gemini API.
 
-    <!--- INCLUDE
-    import ai.koog.agents.core.agent.AIAgent
-    import ai.koog.prompt.executor.llms.all.simpleGoogleAIExecutor
-    import ai.koog.prompt.executor.clients.google.GoogleModels
-    import kotlinx.coroutines.runBlocking
-    -->
-    ```kotlin
-    fun main() = runBlocking {
-        // Get the Gemini API key from the GOOGLE_API_KEY environment variable
-        val apiKey = System.getenv("GOOGLE_API_KEY")
-            ?: error("The API key is not set.")
+    === "Kotlin"
+
+        <!--- INCLUDE
+        import ai.koog.agents.core.agent.AIAgent
+        import ai.koog.prompt.executor.llms.all.simpleGoogleAIExecutor
+        import ai.koog.prompt.executor.clients.google.GoogleModels
+        import kotlinx.coroutines.runBlocking
+        -->
+        ```kotlin
+        fun main() = runBlocking {
+            // Get the Gemini API key from the GOOGLE_API_KEY environment variable
+            val apiKey = System.getenv("GOOGLE_API_KEY")
+                ?: error("The API key is not set.")
+            
+            // Create an agent
+            val agent = AIAgent(
+                promptExecutor = simpleGoogleAIExecutor(apiKey),
+                llmModel = GoogleModels.Gemini2_5Pro
+            )
         
+            // Run the agent
+            val result = agent.run("Hello! How can you help me?")
+            println(result)
+        }
+        ```
+        <!--- KNIT example-getting-started-03.kt -->
+
+    === "Java"
+
+        ```java
+        // Get the Gemini API key from the GOOGLE_API_KEY environment variable
+        String apiKey = System.getenv("GOOGLE_API_KEY");
+        if (apiKey == null) {
+            throw new RuntimeException("The API key is not set.");
+        }
+
         // Create an agent
-        val agent = AIAgent(
-            promptExecutor = simpleGoogleAIExecutor(apiKey),
-            llmModel = GoogleModels.Gemini2_5Pro
-        )
-    
+        AIAgent<String, String> agent = AIAgent.builder()
+            .promptExecutor(simpleGoogleAIExecutor(apiKey))
+            .llmModel(GoogleModels.Gemini2_5Pro)
+            .build();
+
         // Run the agent
-        val result = agent.run("Hello! How can you help me?")
-        println(result)
-    }
-    ```
-    <!--- KNIT example-getting-started-03.kt -->
+        String result = agent.run("Hello! How can you help me?");
+        System.out.println(result);
+        ```
 
     The example can produce the following output:
 
@@ -286,36 +352,63 @@ Koog requires either an API key from a [supported LLM provider](llm-providers.md
 
     The following example creates and runs a simple Koog agent using the `deepseek-chat` model via the DeepSeek API.
 
-    <!--- INCLUDE
-    import ai.koog.agents.core.agent.AIAgent
-    import ai.koog.prompt.executor.clients.deepseek.DeepSeekLLMClient
-    import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
-    import ai.koog.prompt.executor.clients.deepseek.DeepSeekModels
-    import kotlinx.coroutines.runBlocking
-    -->
-    ```kotlin
-    fun main() = runBlocking {
-        // Get the DeepSeek API key from the DEEPSEEK_API_KEY environment variable
-        val apiKey = System.getenv("DEEPSEEK_API_KEY")
-            ?: error("The API key is not set.")
+    === "Kotlin"
+
+        <!--- INCLUDE
+        import ai.koog.agents.core.agent.AIAgent
+        import ai.koog.prompt.executor.clients.deepseek.DeepSeekLLMClient
+        import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
+        import ai.koog.prompt.executor.clients.deepseek.DeepSeekModels
+        import kotlinx.coroutines.runBlocking
+        -->
+        ```kotlin
+        fun main() = runBlocking {
+            // Get the DeepSeek API key from the DEEPSEEK_API_KEY environment variable
+            val apiKey = System.getenv("DEEPSEEK_API_KEY")
+                ?: error("The API key is not set.")
+            
+            // Create an LLM client
+            val deepSeekClient = DeepSeekLLMClient(apiKey)
         
+            // Create an agent
+            val agent = AIAgent(
+                // Create a prompt executor using the LLM client
+                promptExecutor = MultiLLMPromptExecutor(deepSeekClient),
+                // Provide a model
+                llmModel = DeepSeekModels.DeepSeekChat
+            )
+        
+            // Run the agent
+            val result = agent.run("Hello! How can you help me?")
+            println(result)
+        }
+        ```
+        <!--- KNIT example-getting-started-04.kt -->
+
+    === "Java"
+
+        ```java
+        // Get the DeepSeek API key from the DEEPSEEK_API_KEY environment variable
+        String apiKey = System.getenv("DEEPSEEK_API_KEY");
+        if (apiKey == null) {
+            throw new RuntimeException("The API key is not set.");
+        }
+
         // Create an LLM client
-        val deepSeekClient = DeepSeekLLMClient(apiKey)
-    
+        DeepSeekLLMClient deepSeekClient = new DeepSeekLLMClient(apiKey);
+
         // Create an agent
-        val agent = AIAgent(
+        AIAgent<String, String> agent = AIAgent.builder()
             // Create a prompt executor using the LLM client
-            promptExecutor = MultiLLMPromptExecutor(deepSeekClient),
+            .promptExecutor(new MultiLLMPromptExecutor(deepSeekClient))
             // Provide a model
-            llmModel = DeepSeekModels.DeepSeekChat
-        )
-    
+            .llmModel(DeepSeekModels.DeepSeekChat)
+            .build();
+
         // Run the agent
-        val result = agent.run("Hello! How can you help me?")
-        println(result)
-    }
-    ```
-    <!--- KNIT example-getting-started-04.kt -->
+        String result = agent.run("Hello! How can you help me?");
+        System.out.println(result);
+        ```
 
     The example can produce the following output:
 
@@ -327,30 +420,52 @@ Koog requires either an API key from a [supported LLM provider](llm-providers.md
 
     The following example creates and runs a simple Koog agent using the [`GPT-4o`](https://openrouter.ai/openai/gpt-4o) model via the OpenRouter API.
 
-    <!--- INCLUDE
-    import ai.koog.agents.core.agent.AIAgent
-    import ai.koog.prompt.executor.llms.all.simpleOpenRouterExecutor
-    import ai.koog.prompt.executor.clients.openrouter.OpenRouterModels
-    import kotlinx.coroutines.runBlocking
-    -->
-    ```kotlin
-    fun main() = runBlocking {
-        // Get the OpenRouter API key from the OPENROUTER_API_KEY environment variable
-        val apiKey = System.getenv("OPENROUTER_API_KEY")
-            ?: error("The API key is not set.")
+    === "Kotlin"
+
+        <!--- INCLUDE
+        import ai.koog.agents.core.agent.AIAgent
+        import ai.koog.prompt.executor.llms.all.simpleOpenRouterExecutor
+        import ai.koog.prompt.executor.clients.openrouter.OpenRouterModels
+        import kotlinx.coroutines.runBlocking
+        -->
+        ```kotlin
+        fun main() = runBlocking {
+            // Get the OpenRouter API key from the OPENROUTER_API_KEY environment variable
+            val apiKey = System.getenv("OPENROUTER_API_KEY")
+                ?: error("The API key is not set.")
+            
+            // Create an agent
+            val agent = AIAgent(
+                promptExecutor = simpleOpenRouterExecutor(apiKey),
+                llmModel = OpenRouterModels.GPT4o
+            )
         
+            // Run the agent
+            val result = agent.run("Hello! How can you help me?")
+            println(result)
+        }
+        ```
+        <!--- KNIT example-getting-started-05.kt -->
+
+    === "Java"
+
+        ```java
+        // Get the OpenRouter API key from the OPENROUTER_API_KEY environment variable
+        String apiKey = System.getenv("OPENROUTER_API_KEY");
+        if (apiKey == null) {
+            throw new RuntimeException("The API key is not set.");
+        }
+
         // Create an agent
-        val agent = AIAgent(
-            promptExecutor = simpleOpenRouterExecutor(apiKey),
-            llmModel = OpenRouterModels.GPT4o
-        )
-    
+        AIAgent<String, String> agent = AIAgent.builder()
+            .promptExecutor(simpleOpenRouterExecutor(apiKey))
+            .llmModel(OpenRouterModels.GPT4o)
+            .build();
+
         // Run the agent
-        val result = agent.run("Hello! How can you help me?")
-        println(result)
-    }
-    ```
-    <!--- KNIT example-getting-started-05.kt -->
+        String result = agent.run("Hello! How can you help me?");
+        System.out.println(result);
+        ```
 
     The example can produce the following output:
 
@@ -361,31 +476,53 @@ Koog requires either an API key from a [supported LLM provider](llm-providers.md
 === "Bedrock"
 
     The following example creates and runs a simple Koog agent using the [`Claude Sonnet 4.5`](https://www.anthropic.com/news/claude-sonnet-4-5) model via the Bedrock API.
-
-    <!--- INCLUDE
-    import ai.koog.agents.core.agent.AIAgent
-    import ai.koog.prompt.executor.llms.all.simpleBedrockExecutorWithBearerToken
-    import ai.koog.prompt.executor.clients.bedrock.BedrockModels
-    import kotlinx.coroutines.runBlocking
-    -->
-    ```kotlin
-    fun main() = runBlocking {
-        // Get the Bedrock API key from the BEDROCK_API_KEY environment variable
-        val apiKey = System.getenv("BEDROCK_API_KEY")
-            ?: error("The API key is not set.")
-        
-        // Create an agent
-        val agent = AIAgent(
-            promptExecutor = simpleBedrockExecutorWithBearerToken(apiKey),
-            llmModel = BedrockModels.AnthropicClaude4_5Sonnet
-        )
     
+    === "Kotlin"
+
+        <!--- INCLUDE
+        import ai.koog.agents.core.agent.AIAgent
+        import ai.koog.prompt.executor.llms.all.simpleBedrockExecutorWithBearerToken
+        import ai.koog.prompt.executor.clients.bedrock.BedrockModels
+        import kotlinx.coroutines.runBlocking
+        -->
+        ```kotlin
+        fun main() = runBlocking {
+            // Get the Bedrock API key from the BEDROCK_API_KEY environment variable
+            val apiKey = System.getenv("BEDROCK_API_KEY")
+                ?: error("The API key is not set.")
+            
+            // Create an agent
+            val agent = AIAgent(
+                .promptExecutor(simpleBedrockExecutorWithBearerToken(apiKey, new BedrockClientSettings()))
+                .llmModel(BedrockModels.INSTANCE.getAnthropicClaude4_5Sonnet())
+            )
+        
+            // Run the agent
+            val result = agent.run("Hello! How can you help me?")
+            println(result)
+        }
+        ```
+        <!--- KNIT example-getting-started-06.kt -->
+
+    === "Java"
+
+        ```java
+        // Get the Bedrock API key from the BEDROCK_API_KEY environment variable
+        String apiKey = System.getenv("BEDROCK_API_KEY");
+        if (apiKey == null) {
+            throw new RuntimeException("The API key is not set.");
+        }
+
+        // Create an agent
+        AIAgent<String, String> agent = AIAgent.builder()
+            .promptExecutor(simpleBedrockExecutorWithBearerToken(apiKey))
+            .llmModel(BedrockModels.AnthropicClaude4_5Sonnet)
+            .build();
+
         // Run the agent
-        val result = agent.run("Hello! How can you help me?")
-        println(result)
-    }
-    ```
-    <!--- KNIT example-getting-started-06.kt -->
+        String result = agent.run("Hello! How can you help me?");
+        System.out.println(result);
+        ```
 
     The example can produce the following output:
 
@@ -408,30 +545,52 @@ Koog requires either an API key from a [supported LLM provider](llm-providers.md
 
     The following example creates and runs a simple Koog agent using the [`Mistral Medium 3.1`](https://docs.mistral.ai/models/mistral-medium-3-1-25-08) model via the Mistral AI API.
 
-    <!--- INCLUDE
-    import ai.koog.agents.core.agent.AIAgent
-    import ai.koog.prompt.executor.llms.all.simpleMistralAIExecutor
-    import ai.koog.prompt.executor.clients.mistralai.MistralAIModels
-    import kotlinx.coroutines.runBlocking
-    -->
-    ```kotlin
-    fun main() = runBlocking {
-        // Get the Mistral AI API key from the MISTRAL_API_KEY environment variable
-        val apiKey = System.getenv("MISTRAL_API_KEY")
-            ?: error("The API key is not set.")
+    === "Kotlin"
+
+        <!--- INCLUDE
+        import ai.koog.agents.core.agent.AIAgent
+        import ai.koog.prompt.executor.llms.all.simpleMistralAIExecutor
+        import ai.koog.prompt.executor.clients.mistralai.MistralAIModels
+        import kotlinx.coroutines.runBlocking
+        -->
+        ```kotlin
+        fun main() = runBlocking {
+            // Get the Mistral AI API key from the MISTRAL_API_KEY environment variable
+            val apiKey = System.getenv("MISTRAL_API_KEY")
+                ?: error("The API key is not set.")
+            
+            // Create an agent
+            val agent = AIAgent(
+                promptExecutor = simpleMistralAIExecutor(apiKey),
+                llmModel = MistralAIModels.Chat.MistralMedium31
+            )
         
-        // Create an agent
-        val agent = AIAgent(
-            promptExecutor = simpleMistralAIExecutor(apiKey),
-            llmModel = MistralAIModels.Chat.MistralMedium31
-        )
+            // Run the agent
+            val result = agent.run("Hello! How can you help me?")
+            println(result)
+        }
+        ```
+        <!--- KNIT example-getting-started-07.kt -->
     
+    === "Java"
+
+        ```java
+        // Get the Mistral AI API key from the MISTRAL_API_KEY environment variable
+        String apiKey = System.getenv("MISTRAL_API_KEY");
+        if (apiKey == null) {
+            throw new RuntimeException("The API key is not set.");
+        }
+
+        // Create an agent
+        AIAgent<String, String> agent = AIAgent.builder()
+            .promptExecutor(simpleMistralAIExecutor(apiKey))
+            .llmModel(MistralAIModels.Chat.MistralMedium31)
+            .build();
+
         // Run the agent
-        val result = agent.run("Hello! How can you help me?")
-        println(result)
-    }
-    ```
-    <!--- KNIT example-getting-started-07.kt -->
+        String result = agent.run("Hello! How can you help me?");
+        System.out.println(result);
+        ```
 
     The example can produce the following output:
 
@@ -454,26 +613,42 @@ Koog requires either an API key from a [supported LLM provider](llm-providers.md
 
     The following example creates and runs a simple Koog agent using the [`llama3.2`](https://ollama.com/library/llama3.2) model running locally via Ollama.
 
-    <!--- INCLUDE
-    import ai.koog.agents.core.agent.AIAgent
-    import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
-    import ai.koog.prompt.executor.ollama.client.OllamaModels
-    import kotlinx.coroutines.runBlocking
-    -->
-    ```kotlin
-    fun main() = runBlocking {
+    === "Kotlin"
+
+        <!--- INCLUDE
+        import ai.koog.agents.core.agent.AIAgent
+        import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
+        import ai.koog.prompt.executor.ollama.client.OllamaModels
+        import kotlinx.coroutines.runBlocking
+        -->
+        ```kotlin
+        fun main() = runBlocking {
+            // Create an agent
+            val agent = AIAgent(
+                promptExecutor = simpleOllamaAIExecutor(),
+                llmModel = OllamaModels.Meta.LLAMA_3_2
+            )
+
+            // Run the agent
+            val result = agent.run("Hello! How can you help me?")
+            println(result)
+        }
+        ```
+        <!--- KNIT example-getting-started-08.kt -->
+
+    === "Java"
+
+        ```java
         // Create an agent
-        val agent = AIAgent(
-            promptExecutor = simpleOllamaAIExecutor(),
-            llmModel = OllamaModels.Meta.LLAMA_3_2
-        )
+        AIAgent<String, String> agent = AIAgent.builder()
+            .promptExecutor(simpleOllamaAIExecutor("http://localhost:11434"))
+            .llmModel(OllamaModels.Meta.LLAMA_3_2)
+            .build();
 
         // Run the agent
-        val result = agent.run("Hello! How can you help me?")
-        println(result)
-    }
-    ```
-    <!--- KNIT example-getting-started-08.kt -->
+        String result = agent.run("Hello! How can you help me?");
+        System.out.println(result);
+        ```
 
     The example can produce the following output:
 

--- a/docs/docs/quickstart/chat-agent.md
+++ b/docs/docs/quickstart/chat-agent.md
@@ -63,175 +63,339 @@ messages before each run and storing the updated history afterward.
 
 === "OpenAI"
 
-    <!--- INCLUDE
-    import ai.koog.agents.chatMemory.feature.ChatMemory
-    import ai.koog.agents.chatMemory.feature.InMemoryChatHistoryProvider
-    import ai.koog.agents.core.agent.AIAgent
-    import ai.koog.agents.core.tools.ToolRegistry
-    import ai.koog.prompt.executor.clients.openai.OpenAIModels
-    import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
-    -->
-    ```kotlin
-    suspend fun main() {
-        val sessionId = "my-conversation"
+    === "Kotlin"
 
-        val toolRegistry = ToolRegistry {
-            // register your tools here
-        }
+        <!--- INCLUDE
+        import ai.koog.agents.chatMemory.feature.ChatMemory
+        import ai.koog.agents.chatMemory.feature.InMemoryChatHistoryProvider
+        import ai.koog.agents.core.agent.AIAgent
+        import ai.koog.agents.core.tools.ToolRegistry
+        import ai.koog.prompt.executor.clients.openai.OpenAIModels
+        import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+        -->
+        ```kotlin
+        suspend fun main() {
+            val sessionId = "my-conversation"
 
-        simpleOpenAIExecutor(System.getenv("OPENAI_API_KEY")).use { executor ->
-            val agent = AIAgent(
-                promptExecutor = executor,
-                llmModel = OpenAIModels.Chat.GPT5_2,
-                systemPrompt = "You are a helpful assistant.",
-                toolRegistry = toolRegistry,
-            ) {
-                install(ChatMemory) {
-                    windowSize(20) // keep only the last 20 messages
+            val toolRegistry = ToolRegistry {
+                // register your tools here
+            }
+
+            simpleOpenAIExecutor(System.getenv("OPENAI_API_KEY")).use { executor ->
+                val agent = AIAgent(
+                    promptExecutor = executor,
+                    llmModel = OpenAIModels.Chat.GPT5_2,
+                    systemPrompt = "You are a helpful assistant.",
+                    toolRegistry = toolRegistry,
+                ) {
+                    install(ChatMemory) {
+                        windowSize(20) // keep only the last 20 messages
+                    }
+                }
+
+                while (true) {
+                    print("You: ")
+                    val input = readln().trim()
+                    if (input == "/bye") break
+                    if (input.isEmpty()) continue
+
+                    val reply = agent.run(input, sessionId)
+                    println("Assistant: $reply\n")
                 }
             }
+        }
+        ```
 
-            while (true) {
-                print("You: ")
-                val input = readln().trim()
-                if (input == "/bye") break
-                if (input.isEmpty()) continue
+    === "Java"
 
-                val reply = agent.run(input, sessionId)
-                println("Assistant: $reply\n")
+        ```java
+        public class ExampleChatAgentOpenAI {
+            public static void main(String[] args) {
+                String sessionId = "my-conversation";
+        
+                ToolRegistry toolRegistry = ToolRegistry.builder()
+                        // register your tools here
+                        .build();
+        
+                try (var executor = simpleOpenAIExecutor(System.getenv("OPENAI_API_KEY"))) {
+                    AIAgent<String, String> agent = AIAgent.builder()
+                            .promptExecutor(executor)
+                            .llmModel(OpenAIModels.Chat.GPT5_2)
+                            .systemPrompt("You are a helpful assistant.")
+                            .toolRegistry(toolRegistry)
+                            .install(ChatMemory.Feature, config -> {
+                                config.windowSize(20); // keep only the last 20 messages
+                            })
+                            .build();
+        
+                    Scanner scanner = new Scanner(System.in);
+                    while (true) {
+                        System.out.print("You: ");
+                        String input = scanner.nextLine().trim();
+                        if (input.equals("/bye")) break;
+                        if (input.isEmpty()) continue;
+        
+                        String reply = agent.run(input, sessionId);
+                        System.out.println("Assistant: " + reply + "\n");
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
             }
         }
-    }
-    ```
+        ```
 
 === "Anthropic"
 
-    <!--- INCLUDE
-    import ai.koog.agents.chatMemory.feature.ChatMemory
-    import ai.koog.agents.chatMemory.feature.InMemoryChatHistoryProvider
-    import ai.koog.agents.core.agent.AIAgent
-    import ai.koog.agents.core.tools.ToolRegistry
-    import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
-    import ai.koog.prompt.executor.llms.all.simpleAnthropicExecutor
-    -->
-    ```kotlin
-    suspend fun main() {
-        val sessionId = "my-conversation"
+    === "Kotlin"
 
-        val toolRegistry = ToolRegistry {
-            // register your tools here
-        }
+        <!--- INCLUDE
+        import ai.koog.agents.chatMemory.feature.ChatMemory
+        import ai.koog.agents.chatMemory.feature.InMemoryChatHistoryProvider
+        import ai.koog.agents.core.agent.AIAgent
+        import ai.koog.agents.core.tools.ToolRegistry
+        import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
+        import ai.koog.prompt.executor.llms.all.simpleAnthropicExecutor
+        -->
+        ```kotlin
+        suspend fun main() {
+            val sessionId = "my-conversation"
 
-        simpleAnthropicExecutor(System.getenv("ANTHROPIC_API_KEY")).use { executor ->
-            val agent = AIAgent(
-                promptExecutor = executor,
-                llmModel = AnthropicModels.Sonnet4_1,
-                systemPrompt = "You are a helpful assistant.",
-                toolRegistry = toolRegistry,
-            ) {
-                install(ChatMemory) {
-                    windowSize(20)
+            val toolRegistry = ToolRegistry {
+                // register your tools here
+            }
+
+            simpleAnthropicExecutor(System.getenv("ANTHROPIC_API_KEY")).use { executor ->
+                val agent = AIAgent(
+                    promptExecutor = executor,
+                    llmModel = AnthropicModels.Sonnet_4_5,
+                    systemPrompt = "You are a helpful assistant.",
+                    toolRegistry = toolRegistry,
+                ) {
+                    install(ChatMemory) {
+                        windowSize(20)
+                    }
+                }
+
+                while (true) {
+                    print("You: ")
+                    val input = readln().trim()
+                    if (input == "/bye") break
+                    if (input.isEmpty()) continue
+
+                    val reply = agent.run(input, sessionId)
+                    println("Assistant: $reply\n")
                 }
             }
+        }
+        ```
 
-            while (true) {
-                print("You: ")
-                val input = readln().trim()
-                if (input == "/bye") break
-                if (input.isEmpty()) continue
+    === "Java"
 
-                val reply = agent.run(input, sessionId)
-                println("Assistant: $reply\n")
+        ```java
+        public class ExampleChatAgentAnthropic {
+            public static void main(String[] args) {
+                String sessionId = "my-conversation";
+        
+                ToolRegistry toolRegistry = ToolRegistry.builder()
+                        // register your tools here
+                        .build();
+        
+                try (var executor = simpleAnthropicExecutor(System.getenv("ANTHROPIC_API_KEY"))) {
+                    AIAgent<String, String> agent = AIAgent.builder()
+                            .promptExecutor(executor)
+                            .llmModel(AnthropicModels.Sonnet_4_5)
+                            .systemPrompt("You are a helpful assistant.")
+                            .toolRegistry(toolRegistry)
+                            .install(ChatMemory.Feature, config -> {
+                                config.windowSize(20);
+                            })
+                            .build();
+        
+                    Scanner scanner = new Scanner(System.in);
+                    while (true) {
+                        System.out.print("You: ");
+                        String input = scanner.nextLine().trim();
+                        if (input.equals("/bye")) break;
+                        if (input.isEmpty()) continue;
+        
+                        String reply = agent.run(input, sessionId);
+                        System.out.println("Assistant: " + reply + "\n");
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
             }
         }
-    }
-    ```
+        ```
 
 === "Google"
 
-    <!--- INCLUDE
-    import ai.koog.agents.chatMemory.feature.ChatMemory
-    import ai.koog.agents.chatMemory.feature.InMemoryChatHistoryProvider
-    import ai.koog.agents.core.agent.AIAgent
-    import ai.koog.agents.core.tools.ToolRegistry
-    import ai.koog.prompt.executor.clients.google.GoogleModels
-    import ai.koog.prompt.executor.llms.all.simpleGoogleAIExecutor
-    -->
-    ```kotlin
-    suspend fun main() {
-        val sessionId = "my-conversation"
+    === "Kotlin"
 
-        val toolRegistry = ToolRegistry {
-            // register your tools here
-        }
+        <!--- INCLUDE
+        import ai.koog.agents.chatMemory.feature.ChatMemory
+        import ai.koog.agents.chatMemory.feature.InMemoryChatHistoryProvider
+        import ai.koog.agents.core.agent.AIAgent
+        import ai.koog.agents.core.tools.ToolRegistry
+        import ai.koog.prompt.executor.clients.google.GoogleModels
+        import ai.koog.prompt.executor.llms.all.simpleGoogleAIExecutor
+        -->
+        ```kotlin
+        suspend fun main() {
+            val sessionId = "my-conversation"
 
-        simpleGoogleAIExecutor(System.getenv("GOOGLE_API_KEY")).use { executor ->
-            val agent = AIAgent(
-                promptExecutor = executor,
-                llmModel = GoogleModels.Gemini2_5Pro,
-                systemPrompt = "You are a helpful assistant.",
-                toolRegistry = toolRegistry,
-            ) {
-                install(ChatMemory) {
-                    windowSize(20)
+            val toolRegistry = ToolRegistry {
+                // register your tools here
+            }
+
+            simpleGoogleAIExecutor(System.getenv("GOOGLE_API_KEY")).use { executor ->
+                val agent = AIAgent(
+                    promptExecutor = executor,
+                    llmModel = GoogleModels.Gemini2_5Pro,
+                    systemPrompt = "You are a helpful assistant.",
+                    toolRegistry = toolRegistry,
+                ) {
+                    install(ChatMemory) {
+                        windowSize(20)
+                    }
+                }
+
+                while (true) {
+                    print("You: ")
+                    val input = readln().trim()
+                    if (input == "/bye") break
+                    if (input.isEmpty()) continue
+
+                    val reply = agent.run(input, sessionId)
+                    println("Assistant: $reply\n")
                 }
             }
+        }
+        ```
 
-            while (true) {
-                print("You: ")
-                val input = readln().trim()
-                if (input == "/bye") break
-                if (input.isEmpty()) continue
+    === "Java"
 
-                val reply = agent.run(input, sessionId)
-                println("Assistant: $reply\n")
+        ```java
+        public class ExampleChatAgentGoogle {
+            public static void main(String[] args) {
+                String sessionId = "my-conversation";
+        
+                ToolRegistry toolRegistry = ToolRegistry.builder()
+                        // register your tools here
+                        .build();
+        
+                try (var executor = simpleGoogleAIExecutor(System.getenv("GOOGLE_API_KEY"))) {
+                    AIAgent<String, String> agent = AIAgent.builder()
+                            .promptExecutor(executor)
+                            .llmModel(GoogleModels.Gemini2_5Pro)
+                            .systemPrompt("You are a helpful assistant.")
+                            .toolRegistry(toolRegistry)
+                            .install(ChatMemory.Feature, config -> {
+                                config.windowSize(20);
+                            })
+                            .build();
+        
+                    Scanner scanner = new Scanner(System.in);
+                    while (true) {
+                        System.out.print("You: ");
+                        String input = scanner.nextLine().trim();
+                        if (input.equals("/bye")) break;
+                        if (input.isEmpty()) continue;
+        
+                        String reply = agent.run(input, sessionId);
+                        System.out.println("Assistant: " + reply + "\n");
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
             }
         }
-    }
-    ```
+        ```
 
 === "Ollama"
 
-    <!--- INCLUDE
-    import ai.koog.agents.chatMemory.feature.ChatMemory
-    import ai.koog.agents.chatMemory.feature.InMemoryChatHistoryProvider
-    import ai.koog.agents.core.agent.AIAgent
-    import ai.koog.agents.core.tools.ToolRegistry
-    import ai.koog.prompt.executor.ollama.client.OllamaModels
-    import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
-    -->
-    ```kotlin
-    suspend fun main() {
-        val sessionId = "my-conversation"
+    === "Kotlin"
 
-        val toolRegistry = ToolRegistry {
-            // register your tools here
-        }
+        <!--- INCLUDE
+        import ai.koog.agents.chatMemory.feature.ChatMemory
+        import ai.koog.agents.chatMemory.feature.InMemoryChatHistoryProvider
+        import ai.koog.agents.core.agent.AIAgent
+        import ai.koog.agents.core.tools.ToolRegistry
+        import ai.koog.prompt.executor.ollama.client.OllamaModels
+        import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
+        -->
+        ```kotlin
+        suspend fun main() {
+            val sessionId = "my-conversation"
 
-        simpleOllamaAIExecutor().use { executor ->
-            val agent = AIAgent(
-                promptExecutor = executor,
-                llmModel = OllamaModels.Meta.LLAMA_3_2,
-                systemPrompt = "You are a helpful assistant.",
-                toolRegistry = toolRegistry,
-            ) {
-                install(ChatMemory) {
-                    windowSize(20)
+            val toolRegistry = ToolRegistry {
+                // register your tools here
+            }
+
+            simpleOllamaAIExecutor().use { executor ->
+                val agent = AIAgent(
+                    promptExecutor = executor,
+                    llmModel = OllamaModels.Meta.LLAMA_3_2,
+                    systemPrompt = "You are a helpful assistant.",
+                    toolRegistry = toolRegistry,
+                ) {
+                    install(ChatMemory) {
+                        windowSize(20)
+                    }
+                }
+
+                while (true) {
+                    print("You: ")
+                    val input = readln().trim()
+                    if (input == "/bye") break
+                    if (input.isEmpty()) continue
+
+                    val reply = agent.run(input, sessionId)
+                    println("Assistant: $reply\n")
                 }
             }
+        }
+        ```
 
-            while (true) {
-                print("You: ")
-                val input = readln().trim()
-                if (input == "/bye") break
-                if (input.isEmpty()) continue
+    === "Java"
 
-                val reply = agent.run(input, sessionId)
-                println("Assistant: $reply\n")
+        ```java
+        public class ExampleChatAgentOllama {
+            public static void main(String[] args) {
+                String sessionId = "my-conversation";
+
+                ToolRegistry toolRegistry = ToolRegistry.builder()
+                        // register your tools here
+                        .build();
+
+                try (var executor = simpleOllamaAIExecutor("http://localhost:11434")) {
+                    AIAgent<String, String> agent = AIAgent.builder()
+                            .promptExecutor(executor)
+                            .llmModel(OllamaModels.Meta.LLAMA_3_2)
+                            .systemPrompt("You are a helpful assistant.")
+                            .toolRegistry(toolRegistry)
+                            .install(ChatMemory.Feature, config -> {
+                                config.windowSize(20);
+                            })
+                            .build();
+
+                    Scanner scanner = new Scanner(System.in);
+                    while (true) {
+                        System.out.print("You: ");
+                        String input = scanner.nextLine().trim();
+                        if (input.equals("/bye")) break;
+                        if (input.isEmpty()) continue;
+
+                        String reply = agent.run(input, sessionId);
+                        System.out.println("Assistant: " + reply + "\n");
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
             }
         }
-    }
-    ```
+        ```
 
 ## How it works
 
@@ -241,18 +405,34 @@ The example above has three key parts:
 
 ChatMemory is installed as a [feature](../features-overview.md) inside the agent builder block:
 
-```kotlin
-AIAgent(
-    promptExecutor = executor,
-    llmModel = OpenAIModels.Chat.GPT5_2,
-    systemPrompt = "You are a helpful assistant.",
-    toolRegistry = toolRegistry,
-) {
-    install(ChatMemory) {
-        windowSize(20) // keep only the last 20 messages
+=== "Kotlin"
+
+    ```kotlin
+    AIAgent(
+        promptExecutor = executor,
+        llmModel = OpenAIModels.Chat.GPT5_2,
+        systemPrompt = "You are a helpful assistant.",
+        toolRegistry = toolRegistry,
+    ) {
+        install(ChatMemory) {
+            windowSize(20) // keep only the last 20 messages
+        }
     }
-}
-```
+    ```
+
+=== "Java"
+
+    ```java
+    AIAgent<String, String> agent = AIAgent.builder()
+            .promptExecutor(executor)
+            .llmModel(OpenAIModels.Chat.GPT5_2)
+            .systemPrompt("You are a helpful assistant.")
+            .toolRegistry(toolRegistry)
+            .install(ChatMemory.Feature, config -> {
+                config.windowSize(20); // keep only the last 20 messages
+            })
+            .build();
+    ```
 
 The `windowSize(20)` [preprocessor](../chat-memory.md#preprocessors) ensures that the conversation context
 stays bounded — only the 20 most recent messages are kept. Without this, prompt size
@@ -262,9 +442,17 @@ grows unboundedly as the conversation gets longer.
 
 The second argument to `agent.run()` is the session ID:
 
-```kotlin
-val reply = agent.run(input, sessionId)
-```
+=== "Kotlin"
+
+    ```kotlin
+    val reply = agent.run(input, sessionId)
+    ```
+
+=== "Java"
+
+    ```java
+    String reply = agent.run(input, sessionId);
+    ```
 
 ChatMemory uses this ID to load and store the conversation. All calls with the same session ID
 share the same history. Different session IDs produce fully isolated conversations.

--- a/docs/docs/quickstart/index.md
+++ b/docs/docs/quickstart/index.md
@@ -152,30 +152,52 @@ Koog requires either an API key from a [supported LLM provider](../llm-providers
 
     The following example creates and runs a simple Koog agent using the [`GPT-4o`](https://platform.openai.com/docs/models/gpt-4o) model via the OpenAI API.
 
-    <!--- INCLUDE
-    import ai.koog.agents.core.agent.AIAgent
-    import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
-    import ai.koog.prompt.executor.clients.openai.OpenAIModels
-    import kotlinx.coroutines.runBlocking
-    -->
-    ```kotlin
-    fun main() = runBlocking {
-        // Get the OpenAI API key from the OPENAI_API_KEY environment variable
-        val apiKey = System.getenv("OPENAI_API_KEY")
-            ?: error("The API key is not set.")
+    === "Kotlin"
+
+        <!--- INCLUDE
+        import ai.koog.agents.core.agent.AIAgent
+        import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+        import ai.koog.prompt.executor.clients.openai.OpenAIModels
+        import kotlinx.coroutines.runBlocking
+        -->
+        ```kotlin
+        fun main() = runBlocking {
+            // Get the OpenAI API key from the OPENAI_API_KEY environment variable
+            val apiKey = System.getenv("OPENAI_API_KEY")
+                ?: error("The API key is not set.")
+            
+            // Create an agent
+            val agent = AIAgent(
+                promptExecutor = simpleOpenAIExecutor(apiKey),
+                llmModel = OpenAIModels.Chat.GPT4o
+            )
         
+            // Run the agent
+            val result = agent.run("Hello! How can you help me?")
+            println(result)
+        }
+        ```
+        <!--- KNIT example-getting-started-01.kt -->
+
+    === "Java"
+
+        ```java
+        // Get the OpenAI API key from the OPENAI_API_KEY environment variable
+        String apiKey = System.getenv("OPENAI_API_KEY");
+        if (apiKey == null) {
+            throw new RuntimeException("The API key is not set.");
+        }
+
         // Create an agent
-        val agent = AIAgent(
-            promptExecutor = simpleOpenAIExecutor(apiKey),
-            llmModel = OpenAIModels.Chat.GPT4o
-        )
-    
+        AIAgent<String, String> agent = AIAgent.builder()
+            .promptExecutor(simpleOpenAIExecutor(apiKey))
+            .llmModel(OpenAIModels.Chat.GPT4o)
+            .build();
+
         // Run the agent
-        val result = agent.run("Hello! How can you help me?")
-        println(result)
-    }
-    ```
-    <!--- KNIT example-getting-started-01.kt -->
+        String result = agent.run("Hello! How can you help me?");
+        System.out.println(result);
+        ```
 
     The example can produce the following output:
     
@@ -198,30 +220,52 @@ Koog requires either an API key from a [supported LLM provider](../llm-providers
 
     The following example creates and runs a simple Koog agent using the [`Claude Opus 4.1`](https://www.anthropic.com/news/claude-opus-4-1) model via the Anthropic API.
 
-    <!--- INCLUDE
-    import ai.koog.agents.core.agent.AIAgent
-    import ai.koog.prompt.executor.llms.all.simpleAnthropicExecutor
-    import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
-    import kotlinx.coroutines.runBlocking
-    -->
-    ```kotlin
-    fun main() = runBlocking {
-        // Get the Anthropic API key from the ANTHROPIC_API_KEY environment variable
-        val apiKey = System.getenv("ANTHROPIC_API_KEY")
-            ?: error("The API key is not set.")
+    === "Kotlin"
+
+        <!--- INCLUDE
+        import ai.koog.agents.core.agent.AIAgent
+        import ai.koog.prompt.executor.llms.all.simpleAnthropicExecutor
+        import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
+        import kotlinx.coroutines.runBlocking
+        -->
+        ```kotlin
+        fun main() = runBlocking {
+            // Get the Anthropic API key from the ANTHROPIC_API_KEY environment variable
+            val apiKey = System.getenv("ANTHROPIC_API_KEY")
+                ?: error("The API key is not set.")
+            
+            // Create an agent
+            val agent = AIAgent(
+                promptExecutor = simpleAnthropicExecutor(apiKey),
+                llmModel = AnthropicModels.Opus_4_1
+            )
         
+            // Run the agent
+            val result = agent.run("Hello! How can you help me?")
+            println(result)
+        }
+        ```
+        <!--- KNIT example-getting-started-02.kt -->
+
+    === "Java"
+
+        ```java
+       // Get the Anthropic API key from the ANTHROPIC_API_KEY environment variable
+        String apiKey = System.getenv("ANTHROPIC_API_KEY");
+        if (apiKey == null) {
+            throw new RuntimeException("The API key is not set.");
+        }
+
         // Create an agent
-        val agent = AIAgent(
-            promptExecutor = simpleAnthropicExecutor(apiKey),
-            llmModel = AnthropicModels.Opus_4_1
-        )
-    
+        AIAgent<String, String> agent = AIAgent.builder()
+            .promptExecutor(simpleAnthropicExecutor(apiKey))
+            .llmModel(AnthropicModels.Opus_4_1)
+            .build();
+
         // Run the agent
-        val result = agent.run("Hello! How can you help me?")
-        println(result)
-    }
-    ```
-    <!--- KNIT example-getting-started-02.kt -->
+        String result = agent.run("Hello! How can you help me?");
+        System.out.println(result);
+        ```
 
     The example can produce the following output:
 
@@ -242,30 +286,52 @@ Koog requires either an API key from a [supported LLM provider](../llm-providers
 
     The following example creates and runs a simple Koog agent using the [`Gemini 2.5 Pro`](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-pro) model via the Gemini API.
 
-    <!--- INCLUDE
-    import ai.koog.agents.core.agent.AIAgent
-    import ai.koog.prompt.executor.llms.all.simpleGoogleAIExecutor
-    import ai.koog.prompt.executor.clients.google.GoogleModels
-    import kotlinx.coroutines.runBlocking
-    -->
-    ```kotlin
-    fun main() = runBlocking {
-        // Get the Gemini API key from the GOOGLE_API_KEY environment variable
-        val apiKey = System.getenv("GOOGLE_API_KEY")
-            ?: error("The API key is not set.")
+    === "Kotlin"
+
+        <!--- INCLUDE
+        import ai.koog.agents.core.agent.AIAgent
+        import ai.koog.prompt.executor.llms.all.simpleGoogleAIExecutor
+        import ai.koog.prompt.executor.clients.google.GoogleModels
+        import kotlinx.coroutines.runBlocking
+        -->
+        ```kotlin
+        fun main() = runBlocking {
+            // Get the Gemini API key from the GOOGLE_API_KEY environment variable
+            val apiKey = System.getenv("GOOGLE_API_KEY")
+                ?: error("The API key is not set.")
+            
+            // Create an agent
+            val agent = AIAgent(
+                promptExecutor = simpleGoogleAIExecutor(apiKey),
+                llmModel = GoogleModels.Gemini2_5Pro
+            )
         
+            // Run the agent
+            val result = agent.run("Hello! How can you help me?")
+            println(result)
+        }
+        ```
+        <!--- KNIT example-getting-started-03.kt -->
+
+    === "Java"
+
+        ```java
+        // Get the Gemini API key from the GOOGLE_API_KEY environment variable
+        String apiKey = System.getenv("GOOGLE_API_KEY");
+        if (apiKey == null) {
+            throw new RuntimeException("The API key is not set.");
+        }
+
         // Create an agent
-        val agent = AIAgent(
-            promptExecutor = simpleGoogleAIExecutor(apiKey),
-            llmModel = GoogleModels.Gemini2_5Pro
-        )
-    
+        AIAgent<String, String> agent = AIAgent.builder()
+            .promptExecutor(simpleGoogleAIExecutor(apiKey))
+            .llmModel(GoogleModels.Gemini2_5Pro)
+            .build();
+
         // Run the agent
-        val result = agent.run("Hello! How can you help me?")
-        println(result)
-    }
-    ```
-    <!--- KNIT example-getting-started-03.kt -->
+        String result = agent.run("Hello! How can you help me?");
+        System.out.println(result);
+        ```
 
     The example can produce the following output:
 
@@ -286,36 +352,63 @@ Koog requires either an API key from a [supported LLM provider](../llm-providers
 
     The following example creates and runs a simple Koog agent using the `deepseek-chat` model via the DeepSeek API.
 
-    <!--- INCLUDE
-    import ai.koog.agents.core.agent.AIAgent
-    import ai.koog.prompt.executor.clients.deepseek.DeepSeekLLMClient
-    import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
-    import ai.koog.prompt.executor.clients.deepseek.DeepSeekModels
-    import kotlinx.coroutines.runBlocking
-    -->
-    ```kotlin
-    fun main() = runBlocking {
-        // Get the DeepSeek API key from the DEEPSEEK_API_KEY environment variable
-        val apiKey = System.getenv("DEEPSEEK_API_KEY")
-            ?: error("The API key is not set.")
+    === "Kotlin"
+
+        <!--- INCLUDE
+        import ai.koog.agents.core.agent.AIAgent
+        import ai.koog.prompt.executor.clients.deepseek.DeepSeekLLMClient
+        import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
+        import ai.koog.prompt.executor.clients.deepseek.DeepSeekModels
+        import kotlinx.coroutines.runBlocking
+        -->
+        ```kotlin
+        fun main() = runBlocking {
+            // Get the DeepSeek API key from the DEEPSEEK_API_KEY environment variable
+            val apiKey = System.getenv("DEEPSEEK_API_KEY")
+                ?: error("The API key is not set.")
+            
+            // Create an LLM client
+            val deepSeekClient = DeepSeekLLMClient(apiKey)
         
+            // Create an agent
+            val agent = AIAgent(
+                // Create a prompt executor using the LLM client
+                promptExecutor = MultiLLMPromptExecutor(deepSeekClient),
+                // Provide a model
+                llmModel = DeepSeekModels.DeepSeekChat
+            )
+        
+            // Run the agent
+            val result = agent.run("Hello! How can you help me?")
+            println(result)
+        }
+        ```
+        <!--- KNIT example-getting-started-04.kt -->
+
+    === "Java"
+
+        ```java
+        // Get the DeepSeek API key from the DEEPSEEK_API_KEY environment variable
+        String apiKey = System.getenv("DEEPSEEK_API_KEY");
+        if (apiKey == null) {
+            throw new RuntimeException("The API key is not set.");
+        }
+
         // Create an LLM client
-        val deepSeekClient = DeepSeekLLMClient(apiKey)
-    
+        DeepSeekLLMClient deepSeekClient = new DeepSeekLLMClient(apiKey);
+
         // Create an agent
-        val agent = AIAgent(
+        AIAgent<String, String> agent = AIAgent.builder()
             // Create a prompt executor using the LLM client
-            promptExecutor = MultiLLMPromptExecutor(deepSeekClient),
+            .promptExecutor(new MultiLLMPromptExecutor(deepSeekClient))
             // Provide a model
-            llmModel = DeepSeekModels.DeepSeekChat
-        )
-    
+            .llmModel(DeepSeekModels.DeepSeekChat)
+            .build();
+
         // Run the agent
-        val result = agent.run("Hello! How can you help me?")
-        println(result)
-    }
-    ```
-    <!--- KNIT example-getting-started-04.kt -->
+        String result = agent.run("Hello! How can you help me?");
+        System.out.println(result);
+        ```
 
     The example can produce the following output:
 
@@ -327,30 +420,52 @@ Koog requires either an API key from a [supported LLM provider](../llm-providers
 
     The following example creates and runs a simple Koog agent using the [`GPT-4o`](https://openrouter.ai/openai/gpt-4o) model via the OpenRouter API.
 
-    <!--- INCLUDE
-    import ai.koog.agents.core.agent.AIAgent
-    import ai.koog.prompt.executor.llms.all.simpleOpenRouterExecutor
-    import ai.koog.prompt.executor.clients.openrouter.OpenRouterModels
-    import kotlinx.coroutines.runBlocking
-    -->
-    ```kotlin
-    fun main() = runBlocking {
-        // Get the OpenRouter API key from the OPENROUTER_API_KEY environment variable
-        val apiKey = System.getenv("OPENROUTER_API_KEY")
-            ?: error("The API key is not set.")
+    === "Kotlin"
+
+        <!--- INCLUDE
+        import ai.koog.agents.core.agent.AIAgent
+        import ai.koog.prompt.executor.llms.all.simpleOpenRouterExecutor
+        import ai.koog.prompt.executor.clients.openrouter.OpenRouterModels
+        import kotlinx.coroutines.runBlocking
+        -->
+        ```kotlin
+        fun main() = runBlocking {
+            // Get the OpenRouter API key from the OPENROUTER_API_KEY environment variable
+            val apiKey = System.getenv("OPENROUTER_API_KEY")
+                ?: error("The API key is not set.")
+            
+            // Create an agent
+            val agent = AIAgent(
+                promptExecutor = simpleOpenRouterExecutor(apiKey),
+                llmModel = OpenRouterModels.GPT4o
+            )
         
+            // Run the agent
+            val result = agent.run("Hello! How can you help me?")
+            println(result)
+        }
+        ```
+        <!--- KNIT example-getting-started-05.kt -->
+
+    === "Java"
+
+        ```java
+        // Get the OpenRouter API key from the OPENROUTER_API_KEY environment variable
+        String apiKey = System.getenv("OPENROUTER_API_KEY");
+        if (apiKey == null) {
+            throw new RuntimeException("The API key is not set.");
+        }
+
         // Create an agent
-        val agent = AIAgent(
-            promptExecutor = simpleOpenRouterExecutor(apiKey),
-            llmModel = OpenRouterModels.GPT4o
-        )
-    
+        AIAgent<String, String> agent = AIAgent.builder()
+            .promptExecutor(simpleOpenRouterExecutor(apiKey))
+            .llmModel(OpenRouterModels.GPT4o)
+            .build();
+
         // Run the agent
-        val result = agent.run("Hello! How can you help me?")
-        println(result)
-    }
-    ```
-    <!--- KNIT example-getting-started-05.kt -->
+        String result = agent.run("Hello! How can you help me?");
+        System.out.println(result);
+        ```
 
     The example can produce the following output:
 
@@ -361,31 +476,53 @@ Koog requires either an API key from a [supported LLM provider](../llm-providers
 === "Bedrock"
 
     The following example creates and runs a simple Koog agent using the [`Claude Sonnet 4.5`](https://www.anthropic.com/news/claude-sonnet-4-5) model via the Bedrock API.
-
-    <!--- INCLUDE
-    import ai.koog.agents.core.agent.AIAgent
-    import ai.koog.prompt.executor.llms.all.simpleBedrockExecutorWithBearerToken
-    import ai.koog.prompt.executor.clients.bedrock.BedrockModels
-    import kotlinx.coroutines.runBlocking
-    -->
-    ```kotlin
-    fun main() = runBlocking {
-        // Get the Bedrock API key from the BEDROCK_API_KEY environment variable
-        val apiKey = System.getenv("BEDROCK_API_KEY")
-            ?: error("The API key is not set.")
-        
-        // Create an agent
-        val agent = AIAgent(
-            promptExecutor = simpleBedrockExecutorWithBearerToken(apiKey),
-            llmModel = BedrockModels.AnthropicClaude4_5Sonnet
-        )
     
+    === "Kotlin"
+
+        <!--- INCLUDE
+        import ai.koog.agents.core.agent.AIAgent
+        import ai.koog.prompt.executor.llms.all.simpleBedrockExecutorWithBearerToken
+        import ai.koog.prompt.executor.clients.bedrock.BedrockModels
+        import kotlinx.coroutines.runBlocking
+        -->
+        ```kotlin
+        fun main() = runBlocking {
+            // Get the Bedrock API key from the BEDROCK_API_KEY environment variable
+            val apiKey = System.getenv("BEDROCK_API_KEY")
+                ?: error("The API key is not set.")
+            
+            // Create an agent
+            val agent = AIAgent(
+                promptExecutor = simpleBedrockExecutorWithBearerToken(apiKey),
+                llmModel = BedrockModels.AnthropicClaude4_5Sonnet
+            )
+        
+            // Run the agent
+            val result = agent.run("Hello! How can you help me?")
+            println(result)
+        }
+        ```
+        <!--- KNIT example-getting-started-06.kt -->
+
+    === "Java"
+
+        ```java
+        // Get the Bedrock API key from the BEDROCK_API_KEY environment variable
+        String apiKey = System.getenv("BEDROCK_API_KEY");
+        if (apiKey == null) {
+            throw new RuntimeException("The API key is not set.");
+        }
+
+        // Create an agent
+        AIAgent<String, String> agent = AIAgent.builder()
+            .promptExecutor(simpleBedrockExecutorWithBearerToken(apiKey, new BedrockClientSettings()))
+            .llmModel(BedrockModels.INSTANCE.getAnthropicClaude4_5Sonnet())
+            .build();
+
         // Run the agent
-        val result = agent.run("Hello! How can you help me?")
-        println(result)
-    }
-    ```
-    <!--- KNIT example-getting-started-06.kt -->
+        String result = agent.run("Hello! How can you help me?");
+        System.out.println(result);
+        ```
 
     The example can produce the following output:
 
@@ -408,30 +545,52 @@ Koog requires either an API key from a [supported LLM provider](../llm-providers
 
     The following example creates and runs a simple Koog agent using the [`Mistral Medium 3.1`](https://docs.mistral.ai/models/mistral-medium-3-1-25-08) model via the Mistral AI API.
 
-    <!--- INCLUDE
-    import ai.koog.agents.core.agent.AIAgent
-    import ai.koog.prompt.executor.llms.all.simpleMistralAIExecutor
-    import ai.koog.prompt.executor.clients.mistralai.MistralAIModels
-    import kotlinx.coroutines.runBlocking
-    -->
-    ```kotlin
-    fun main() = runBlocking {
-        // Get the Mistral AI API key from the MISTRAL_API_KEY environment variable
-        val apiKey = System.getenv("MISTRAL_API_KEY")
-            ?: error("The API key is not set.")
+    === "Kotlin"
+
+        <!--- INCLUDE
+        import ai.koog.agents.core.agent.AIAgent
+        import ai.koog.prompt.executor.llms.all.simpleMistralAIExecutor
+        import ai.koog.prompt.executor.clients.mistralai.MistralAIModels
+        import kotlinx.coroutines.runBlocking
+        -->
+        ```kotlin
+        fun main() = runBlocking {
+            // Get the Mistral AI API key from the MISTRAL_API_KEY environment variable
+            val apiKey = System.getenv("MISTRAL_API_KEY")
+                ?: error("The API key is not set.")
+            
+            // Create an agent
+            val agent = AIAgent(
+                promptExecutor = simpleMistralAIExecutor(apiKey),
+                llmModel = MistralAIModels.Chat.MistralMedium31
+            )
         
-        // Create an agent
-        val agent = AIAgent(
-            promptExecutor = simpleMistralAIExecutor(apiKey),
-            llmModel = MistralAIModels.Chat.MistralMedium31
-        )
+            // Run the agent
+            val result = agent.run("Hello! How can you help me?")
+            println(result)
+        }
+        ```
+        <!--- KNIT example-getting-started-07.kt -->
     
+    === "Java"
+
+        ```java
+        // Get the Mistral AI API key from the MISTRAL_API_KEY environment variable
+        String apiKey = System.getenv("MISTRAL_API_KEY");
+        if (apiKey == null) {
+            throw new RuntimeException("The API key is not set.");
+        }
+
+        // Create an agent
+        AIAgent<String, String> agent = AIAgent.builder()
+            .promptExecutor(simpleMistralAIExecutor(apiKey))
+            .llmModel(MistralAIModels.Chat.MistralMedium31)
+            .build();
+
         // Run the agent
-        val result = agent.run("Hello! How can you help me?")
-        println(result)
-    }
-    ```
-    <!--- KNIT example-getting-started-07.kt -->
+        String result = agent.run("Hello! How can you help me?");
+        System.out.println(result);
+        ```
 
     The example can produce the following output:
 
@@ -454,26 +613,42 @@ Koog requires either an API key from a [supported LLM provider](../llm-providers
 
     The following example creates and runs a simple Koog agent using the [`llama3.2`](https://ollama.com/library/llama3.2) model running locally via Ollama.
 
-    <!--- INCLUDE
-    import ai.koog.agents.core.agent.AIAgent
-    import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
-    import ai.koog.prompt.executor.ollama.client.OllamaModels
-    import kotlinx.coroutines.runBlocking
-    -->
-    ```kotlin
-    fun main() = runBlocking {
+    === "Kotlin"
+
+        <!--- INCLUDE
+        import ai.koog.agents.core.agent.AIAgent
+        import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
+        import ai.koog.prompt.executor.ollama.client.OllamaModels
+        import kotlinx.coroutines.runBlocking
+        -->
+        ```kotlin
+        fun main() = runBlocking {
+            // Create an agent
+            val agent = AIAgent(
+                promptExecutor = simpleOllamaAIExecutor(),
+                llmModel = OllamaModels.Meta.LLAMA_3_2
+            )
+
+            // Run the agent
+            val result = agent.run("Hello! How can you help me?")
+            println(result)
+        }
+        ```
+        <!--- KNIT example-getting-started-08.kt -->
+
+    === "Java"
+
+        ```java
         // Create an agent
-        val agent = AIAgent(
-            promptExecutor = simpleOllamaAIExecutor(),
-            llmModel = OllamaModels.Meta.LLAMA_3_2
-        )
+        AIAgent<String, String> agent = AIAgent.builder()
+            .promptExecutor(simpleOllamaAIExecutor("http://localhost:11434"))
+            .llmModel(OllamaModels.Meta.LLAMA_3_2)
+            .build();
 
         // Run the agent
-        val result = agent.run("Hello! How can you help me?")
-        println(result)
-    }
-    ```
-    <!--- KNIT example-getting-started-08.kt -->
+        String result = agent.run("Hello! How can you help me?");
+        System.out.println(result);
+        ```
 
     The example can produce the following output:
 

--- a/docs/docs/ranked-document-storage.md
+++ b/docs/docs/ranked-document-storage.md
@@ -42,125 +42,133 @@ To implement a RAG system in Koog, follow the steps below:
 
 This sequence of steps represents a *relevance search* flow that returns the most relevant documents for a given user query. Here is a code sample showing how to implement the entire sequence of steps described above:
 
-<!--- INCLUDE
-import ai.koog.embeddings.local.LLMEmbedder
-import ai.koog.prompt.executor.ollama.client.OllamaModels
-import ai.koog.prompt.executor.ollama.client.OllamaClient
-import ai.koog.rag.base.mostRelevantDocuments
-import ai.koog.rag.vector.EmbeddingBasedDocumentStorage
-import ai.koog.rag.vector.InMemoryVectorStorage
-import ai.koog.rag.vector.JVMTextDocumentEmbedder
-import kotlinx.coroutines.runBlocking
-import java.nio.file.Path
+=== "Kotlin"
 
-fun main() {
-    runBlocking {
--->
-<!--- SUFFIX
+    <!--- INCLUDE
+    import ai.koog.embeddings.local.LLMEmbedder
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    import ai.koog.prompt.executor.ollama.client.OllamaClient
+    import ai.koog.rag.base.mostRelevantDocuments
+    import ai.koog.rag.vector.EmbeddingBasedDocumentStorage
+    import ai.koog.rag.vector.InMemoryVectorStorage
+    import ai.koog.rag.vector.JVMTextDocumentEmbedder
+    import kotlinx.coroutines.runBlocking
+    import java.nio.file.Path
+    fun main() {
+        runBlocking {
+    -->
+    <!--- SUFFIX
+        }
     }
-}
--->
-```kotlin
-// Create an embedder using Ollama
-val embedder = LLMEmbedder(OllamaClient(), OllamaModels.Embeddings.NOMIC_EMBED_TEXT)
-// You may also use OpenAI embeddings with:
-// val embedder = LLMEmbedder(OpenAILLMClient("API_KEY"), OpenAIModels.Embeddings.TextEmbeddingAda3Large)
+    -->
+    ```kotlin
+    // Create an embedder using Ollama
+    val embedder = LLMEmbedder(OllamaClient(), OllamaModels.Embeddings.NOMIC_EMBED_TEXT)
+    // You may also use OpenAI embeddings with:
+    // val embedder = LLMEmbedder(OpenAILLMClient("API_KEY"), OpenAIModels.Embeddings.TextEmbeddingAda3Large)
 
-// Create a JVM-specific document embedder
-val documentEmbedder = JVMTextDocumentEmbedder(embedder)
+    // Create a JVM-specific document embedder
+    val documentEmbedder = JVMTextDocumentEmbedder(embedder)
 
-// Create a ranked document storage using in-memory vector storage
-val rankedDocumentStorage = EmbeddingBasedDocumentStorage(documentEmbedder, InMemoryVectorStorage())
+    // Create a ranked document storage using in-memory vector storage
+    val rankedDocumentStorage = EmbeddingBasedDocumentStorage(documentEmbedder, InMemoryVectorStorage())
 
-// Store documents in the storage
-rankedDocumentStorage.store(Path.of("./my/documents/doc1.txt"))
-rankedDocumentStorage.store(Path.of("./my/documents/doc2.txt"))
-rankedDocumentStorage.store(Path.of("./my/documents/doc3.txt"))
-// ... store more documents as needed
-rankedDocumentStorage.store(Path.of("./my/documents/doc100.txt"))
+    // Store documents in the storage
+    rankedDocumentStorage.store(Path.of("./my/documents/doc1.txt"))
+    rankedDocumentStorage.store(Path.of("./my/documents/doc2.txt"))
+    rankedDocumentStorage.store(Path.of("./my/documents/doc3.txt"))
+    // ... store more documents as needed
+    rankedDocumentStorage.store(Path.of("./my/documents/doc100.txt"))
 
-// Find the most relevant documents for a user query
-val query = "I want to open a bank account but I'm getting a 404 when I open your website. I used to be your client with a different account 5 years ago before you changed your firm name"
-val relevantFiles = rankedDocumentStorage.mostRelevantDocuments(query, count = 3)
+    // Find the most relevant documents for a user query
+    val query = "I want to open a bank account but I'm getting a 404 when I open your website. I used to be your client with a different account 5 years ago before you changed your firm name"
+    val relevantFiles = rankedDocumentStorage.mostRelevantDocuments(query, count = 3)
 
-// Process the relevant files
-relevantFiles.forEach { file ->
-    println("Relevant file: ${file.toAbsolutePath()}")
-    // Process the file content as needed
-}
-```
-<!--- KNIT example-ranked-document-storage-01.kt -->
+    // Process the relevant files
+    relevantFiles.forEach { file ->
+        println("Relevant file: ${file.toAbsolutePath()}")
+        // Process the file content as needed
+    }
+    ```
+    <!--- KNIT example-ranked-document-storage-01.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 
 ### Providing relevance search for use by AI agents
 
 Once you have a ranked document storage system, you can use it to provide relevant context to an AI agent for answering user queries. This enhances the agent's ability to provide accurate and contextually appropriate responses.
 
-Here is an example of how to implement the defined RAG system for an AI agent to be able to answer queries by getting information from the document storage: 
+Here is an example of how to implement the defined RAG system for an AI agent to be able to answer queries by getting information from the document storage:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.agent.config.AIAgentConfig
-import ai.koog.embeddings.local.LLMEmbedder
-import ai.koog.prompt.executor.ollama.client.OllamaModels
-import ai.koog.prompt.dsl.prompt
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
-import ai.koog.prompt.executor.ollama.client.OllamaClient
-import ai.koog.rag.base.mostRelevantDocuments
-import ai.koog.rag.vector.EmbeddingBasedDocumentStorage
-import ai.koog.rag.vector.InMemoryVectorStorage
-import ai.koog.rag.vector.JVMTextDocumentEmbedder
-import kotlin.io.path.pathString
+=== "Kotlin"
 
-// Create an embedder using Ollama
-val embedder = LLMEmbedder(OllamaClient(), OllamaModels.Embeddings.NOMIC_EMBED_TEXT)
-// You may also use OpenAI embeddings with:
-// val embedder = LLMEmbedder(OpenAILLMClient("API_KEY"), OpenAIModels.Embeddings.TextEmbeddingAda3Large)
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.agent.config.AIAgentConfig
+    import ai.koog.embeddings.local.LLMEmbedder
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    import ai.koog.prompt.dsl.prompt
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+    import ai.koog.prompt.executor.ollama.client.OllamaClient
+    import ai.koog.rag.base.mostRelevantDocuments
+    import ai.koog.rag.vector.EmbeddingBasedDocumentStorage
+    import ai.koog.rag.vector.InMemoryVectorStorage
+    import ai.koog.rag.vector.JVMTextDocumentEmbedder
+    import kotlin.io.path.pathString
+    // Create an embedder using Ollama
+    val embedder = LLMEmbedder(OllamaClient(), OllamaModels.Embeddings.NOMIC_EMBED_TEXT)
+    // You may also use OpenAI embeddings with:
+    // val embedder = LLMEmbedder(OpenAILLMClient("API_KEY"), OpenAIModels.Embeddings.TextEmbeddingAda3Large)
+    // Create a JVM-specific document embedder
+    val documentEmbedder = JVMTextDocumentEmbedder(embedder)
+    // Create a ranked document storage using in-memory vector storage
+    val rankedDocumentStorage = EmbeddingBasedDocumentStorage(documentEmbedder, InMemoryVectorStorage())
+    const val apiKey = "apikey"
+    -->
+    ```kotlin
+    suspend fun solveUserRequest(query: String) {
+        // Retrieve top-5 documents from the document provider
+        val relevantDocuments = rankedDocumentStorage.mostRelevantDocuments(query, count = 5)
 
-// Create a JVM-specific document embedder
-val documentEmbedder = JVMTextDocumentEmbedder(embedder)
-
-// Create a ranked document storage using in-memory vector storage
-val rankedDocumentStorage = EmbeddingBasedDocumentStorage(documentEmbedder, InMemoryVectorStorage())
-
-const val apiKey = "apikey"
-
--->
-```kotlin
-suspend fun solveUserRequest(query: String) {
-    // Retrieve top-5 documents from the document provider
-    val relevantDocuments = rankedDocumentStorage.mostRelevantDocuments(query, count = 5)
-
-    // Create an AI Agent with the relevant context
-    val agentConfig = AIAgentConfig(
-        prompt = prompt("context") {
-            system("You are a helpful assistant. Use the provided context to answer the user's question accurately.")
-            user {
-                +"Relevant context:"
-                relevantDocuments.forEach {
-                    file(it.pathString, "text/plain")
+        // Create an AI Agent with the relevant context
+        val agentConfig = AIAgentConfig(
+            prompt = prompt("context") {
+                system("You are a helpful assistant. Use the provided context to answer the user's question accurately.")
+                user {
+                    +"Relevant context:"
+                    relevantDocuments.forEach {
+                        file(it.pathString, "text/plain")
+                    }
                 }
-            }
-        },
-        model = OpenAIModels.Chat.GPT4o, // Or a different model of your choice
-        maxAgentIterations = 100,
-    )
+            },
+            model = OpenAIModels.Chat.GPT4o, // Or a different model of your choice
+            maxAgentIterations = 100,
+        )
 
-    val agent = AIAgent(
-        promptExecutor = simpleOpenAIExecutor(apiKey),
-        llmModel = OpenAIModels.Chat.GPT4o
-    )
+        val agent = AIAgent(
+            promptExecutor = simpleOpenAIExecutor(apiKey),
+            llmModel = OpenAIModels.Chat.GPT4o
+        )
 
 
-    // Run the agent to get a response
-    val response = agent.run(query)
+        // Run the agent to get a response
+        val response = agent.run(query)
 
-    // Return or process the response
-    println("Agent response: $response")
-}
-```
-<!--- KNIT example-ranked-document-storage-02.kt -->
+        // Return or process the response
+        println("Agent response: $response")
+    }
+    ```
+    <!--- KNIT example-ranked-document-storage-02.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 
 ### Providing relevance search as a tool
@@ -169,84 +177,86 @@ Instead of directly providing document content as context, you can also implemen
 
 Here is an example of how to implement a relevance search tool:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.tools.ToolRegistry
-import ai.koog.agents.core.tools.annotations.LLMDescription
-import ai.koog.agents.core.tools.annotations.Tool
-import ai.koog.agents.core.tools.reflect.asTool
-import ai.koog.embeddings.local.LLMEmbedder
-import ai.koog.prompt.executor.ollama.client.OllamaModels
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
-import ai.koog.prompt.executor.ollama.client.OllamaClient
-import ai.koog.rag.base.mostRelevantDocuments
-import ai.koog.rag.vector.EmbeddingBasedDocumentStorage
-import ai.koog.rag.vector.InMemoryVectorStorage
-import ai.koog.rag.vector.JVMTextDocumentEmbedder
-import kotlinx.coroutines.runBlocking
-import java.nio.file.Files
+=== "Kotlin"
 
-// Create an embedder using Ollama
-val embedder = LLMEmbedder(OllamaClient(), OllamaModels.Embeddings.NOMIC_EMBED_TEXT)
-// You may also use OpenAI embeddings with:
-// val embedder = LLMEmbedder(OpenAILLMClient("API_KEY"), OpenAIModels.Embeddings.TextEmbeddingAda3Large)
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.tools.ToolRegistry
+    import ai.koog.agents.core.tools.annotations.LLMDescription
+    import ai.koog.agents.core.tools.annotations.Tool
+    import ai.koog.agents.core.tools.reflect.asTool
+    import ai.koog.embeddings.local.LLMEmbedder
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+    import ai.koog.prompt.executor.ollama.client.OllamaClient
+    import ai.koog.rag.base.mostRelevantDocuments
+    import ai.koog.rag.vector.EmbeddingBasedDocumentStorage
+    import ai.koog.rag.vector.InMemoryVectorStorage
+    import ai.koog.rag.vector.JVMTextDocumentEmbedder
+    import kotlinx.coroutines.runBlocking
+    import java.nio.file.Files
+    // Create an embedder using Ollama
+    val embedder = LLMEmbedder(OllamaClient(), OllamaModels.Embeddings.NOMIC_EMBED_TEXT)
+    // You may also use OpenAI embeddings with:
+    // val embedder = LLMEmbedder(OpenAILLMClient("API_KEY"), OpenAIModels.Embeddings.TextEmbeddingAda3Large)
+    // Create a JVM-specific document embedder
+    val documentEmbedder = JVMTextDocumentEmbedder(embedder)
+    // Create a ranked document storage using in-memory vector storage
+    val rankedDocumentStorage = EmbeddingBasedDocumentStorage(documentEmbedder, InMemoryVectorStorage())
+    const val apiKey = "apikey"
+    -->
+    ```kotlin
+    @Tool
+    @LLMDescription("Search for relevant documents about any topic (if exists). Returns the content of the most relevant documents.")
+    suspend fun searchDocuments(
+        @LLMDescription("Query to search relevant documents about")
+        query: String,
+        @LLMDescription("Maximum number of documents")
+        count: Int
+    ): String {
+        val relevantDocuments =
+            rankedDocumentStorage.mostRelevantDocuments(query, count = count, similarityThreshold = 0.9).toList()
 
-// Create a JVM-specific document embedder
-val documentEmbedder = JVMTextDocumentEmbedder(embedder)
-
-// Create a ranked document storage using in-memory vector storage
-val rankedDocumentStorage = EmbeddingBasedDocumentStorage(documentEmbedder, InMemoryVectorStorage())
-
-const val apiKey = "apikey"
-
--->
-```kotlin
-@Tool
-@LLMDescription("Search for relevant documents about any topic (if exists). Returns the content of the most relevant documents.")
-suspend fun searchDocuments(
-    @LLMDescription("Query to search relevant documents about")
-    query: String,
-    @LLMDescription("Maximum number of documents")
-    count: Int
-): String {
-    val relevantDocuments =
-        rankedDocumentStorage.mostRelevantDocuments(query, count = count, similarityThreshold = 0.9).toList()
-
-    if (!relevantDocuments.isEmpty()) {
-        return "No relevant documents found for the query: $query"
-    }
-
-    val result = StringBuilder("Found ${relevantDocuments.size} relevant documents:\n\n")
-
-    relevantDocuments.forEachIndexed { index, document ->
-        val content = Files.readString(document)
-        result.append("Document ${index + 1}: ${document.fileName}\n")
-        result.append("Content: $content\n\n")
-    }
-
-    return result.toString()
-}
-
-fun main() {
-    runBlocking {
-        val tools = ToolRegistry {
-            tool(::searchDocuments.asTool())
+        if (!relevantDocuments.isEmpty()) {
+            return "No relevant documents found for the query: $query"
         }
 
-        val agent = AIAgent(
-            toolRegistry = tools,
-            promptExecutor = simpleOpenAIExecutor(apiKey),
-            llmModel = OpenAIModels.Chat.GPT4o
-        )
+        val result = StringBuilder("Found ${relevantDocuments.size} relevant documents:\n\n")
 
-        val response = agent.run("How to make a cake?")
-        println("Agent response: $response")
+        relevantDocuments.forEachIndexed { index, document ->
+            val content = Files.readString(document)
+            result.append("Document ${index + 1}: ${document.fileName}\n")
+            result.append("Content: $content\n\n")
+        }
 
+        return result.toString()
     }
-}
-```
-<!--- KNIT example-ranked-document-storage-03.kt -->
+
+    fun main() {
+        runBlocking {
+            val tools = ToolRegistry {
+                tool(::searchDocuments.asTool())
+            }
+
+            val agent = AIAgent(
+                toolRegistry = tools,
+                promptExecutor = simpleOpenAIExecutor(apiKey),
+                llmModel = OpenAIModels.Chat.GPT4o
+            )
+
+            val response = agent.run("How to make a cake?")
+            println("Agent response: $response")
+
+        }
+    }
+    ```
+    <!--- KNIT example-ranked-document-storage-03.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 With this approach, the agent can decide when to use the search tool based on your query. This is particularly useful for complex queries that may require information from multiple documents or when the agent needs to search for specific details.
 
@@ -260,14 +270,22 @@ For convenience and easier implementation of a RAG system, Koog provides several
 
 A simple in-memory implementation that stores documents and their vector embeddings in memory. Suitable for testing or small-scale applications.
 
-<!--- INCLUDE
-import ai.koog.rag.vector.InMemoryVectorStorage
-import java.nio.file.Path
--->
-```kotlin
-val inMemoryStorage = InMemoryVectorStorage<Path>()
-```
-<!--- KNIT example-ranked-document-storage-04.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.rag.vector.InMemoryVectorStorage
+    import java.nio.file.Path
+    -->
+    ```kotlin
+    val inMemoryStorage = InMemoryVectorStorage<Path>()
+    ```
+    <!--- KNIT example-ranked-document-storage-04.kt -->
+
+=== "Java"
+
+    ```java
+    InMemoryVectorStorage<Path> inMemoryStorage = new InMemoryVectorStorage<>();
+    ```
 
 For more information, see the [InMemoryVectorStorage](api:vector-storage::ai.koog.rag.vector.InMemoryVectorStorage) reference.
 
@@ -275,20 +293,27 @@ For more information, see the [InMemoryVectorStorage](api:vector-storage::ai.koo
 
 A file-based implementation that stores documents and their vector embeddings on disk. Suitable for persistent storage across application restarts.
 
-<!--- INCLUDE
-/*
--->
-<!--- SUFFIX
-*/
--->
-```kotlin
-val fileStorage = FileVectorStorage<Document, Path>(
-   documentReader = documentProvider,
-   fs = fileSystemProvider,
-   root = rootPath
-)
-```
-<!--- KNIT example-ranked-document-storage-05.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    /*
+    -->
+    <!--- SUFFIX
+    */
+    -->
+    ```kotlin
+    val fileStorage = FileVectorStorage<Document, Path>(
+       documentReader = documentProvider,
+       fs = fileSystemProvider,
+       root = rootPath
+    )
+    ```
+    <!--- KNIT example-ranked-document-storage-05.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 For more information, see the [FileVectorStorage](api:vector-storage::ai.koog.rag.vector.FileVectorStorage) reference.
 
@@ -296,14 +321,21 @@ For more information, see the [FileVectorStorage](api:vector-storage::ai.koog.ra
 
 A JVM-specific implementation of `FileVectorStorage` that works with `java.nio.file.Path`.
 
-<!--- INCLUDE
-import ai.koog.rag.vector.JVMFileVectorStorage
-import java.nio.file.Path
--->
-```kotlin
-val jvmFileStorage = JVMFileVectorStorage(root = Path.of("/path/to/storage"))
-```
-<!--- KNIT example-ranked-document-storage-06.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.rag.vector.JVMFileVectorStorage
+    import java.nio.file.Path
+    -->
+    ```kotlin
+    val jvmFileStorage = JVMFileVectorStorage(root = Path.of("/path/to/storage"))
+    ```
+    <!--- KNIT example-ranked-document-storage-06.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 For more information, see the [JVMFileVectorStorage](api:vector-storage::ai.koog.rag.vector.JVMFileVectorStorage) reference.
 
@@ -313,19 +345,26 @@ For more information, see the [JVMFileVectorStorage](api:vector-storage::ai.koog
 
 A generic implementation that works with any document type that can be converted to text.
 
-<!--- INCLUDE
-/*
--->
-<!--- SUFFIX
-*/
--->
-```kotlin
-val textEmbedder = TextDocumentEmbedder<Document, Path>(
-   documentReader = documentProvider,
-   embedder = embedder
-)
-```
-<!--- KNIT example-ranked-document-storage-07.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    /*
+    -->
+    <!--- SUFFIX
+    */
+    -->
+    ```kotlin
+    val textEmbedder = TextDocumentEmbedder<Document, Path>(
+       documentReader = documentProvider,
+       embedder = embedder
+    )
+    ```
+    <!--- KNIT example-ranked-document-storage-07.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 For more information, see the [TextDocumentEmbedder](api:vector-storage::ai.koog.rag.vector.TextDocumentEmbedder) reference.
 
@@ -333,18 +372,26 @@ For more information, see the [TextDocumentEmbedder](api:vector-storage::ai.koog
 
 A JVM-specific implementation that works with `java.nio.file.Path`.
 
-<!--- INCLUDE
-import ai.koog.embeddings.local.LLMEmbedder
-import ai.koog.prompt.executor.ollama.client.OllamaModels
-import ai.koog.prompt.executor.ollama.client.OllamaClient
-import ai.koog.rag.vector.JVMTextDocumentEmbedder
+=== "Kotlin"
 
--->
-```kotlin
-val embedder = LLMEmbedder(OllamaClient(), OllamaModels.Embeddings.NOMIC_EMBED_TEXT)
-val jvmTextEmbedder = JVMTextDocumentEmbedder(embedder = embedder)
-```
-<!--- KNIT example-ranked-document-storage-08.kt -->
+    <!--- INCLUDE
+    import ai.koog.embeddings.local.LLMEmbedder
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    import ai.koog.prompt.executor.ollama.client.OllamaClient
+    import ai.koog.rag.vector.JVMTextDocumentEmbedder
+    -->
+    ```kotlin
+    val embedder = LLMEmbedder(OllamaClient(), OllamaModels.Embeddings.NOMIC_EMBED_TEXT)
+    val jvmTextEmbedder = JVMTextDocumentEmbedder(embedder = embedder)
+    ```
+    <!--- KNIT example-ranked-document-storage-08.kt -->
+
+=== "Java"
+
+    ```java
+    LLMEmbedder embedder = new LLMEmbedder(new OllamaClient("http://localhost:11434"), OllamaModels.Embeddings.NOMIC_EMBED_TEXT);
+    JVMTextDocumentEmbedder jvmTextEmbedder = new JVMTextDocumentEmbedder(embedder);
+    ```
 
 For more information, see the [JVMTextDocumentEmbedder](api:vector-storage::ai.koog.rag.vector.JVMTextDocumentEmbedder) reference.
 
@@ -354,22 +401,35 @@ For more information, see the [JVMTextDocumentEmbedder](api:vector-storage::ai.k
 
 Combines a document embedder and a vector storage to provide a complete solution for storing and ranking documents.
 
-<!--- INCLUDE
-import ai.koog.agents.example.exampleRankedDocumentStorage02.documentEmbedder
-import ai.koog.rag.vector.EmbeddingBasedDocumentStorage
-import ai.koog.rag.vector.InMemoryVectorStorage
-import java.nio.file.Path
+=== "Kotlin"
 
-val vectorStorage = InMemoryVectorStorage<Path>()
+    <!--- INCLUDE
+    import ai.koog.agents.example.exampleRankedDocumentStorage02.documentEmbedder
+    import ai.koog.rag.vector.EmbeddingBasedDocumentStorage
+    import ai.koog.rag.vector.InMemoryVectorStorage
+    import java.nio.file.Path
+    val vectorStorage = InMemoryVectorStorage<Path>()
+    -->
+    ```kotlin
+    val embeddingStorage = EmbeddingBasedDocumentStorage(
+        embedder = documentEmbedder,
+        storage = vectorStorage
+    )
+    ```
+    <!--- KNIT example-ranked-document-storage-09.kt -->
 
--->
-```kotlin
-val embeddingStorage = EmbeddingBasedDocumentStorage(
-    embedder = documentEmbedder,
-    storage = vectorStorage
-)
-```
-<!--- KNIT example-ranked-document-storage-09.kt -->
+=== "Java"
+
+    ```java
+    LLMEmbedder embedder = new LLMEmbedder(new OllamaClient("http://localhost:11434"), OllamaModels.Embeddings.NOMIC_EMBED_TEXT);
+    JVMTextDocumentEmbedder documentEmbedder = new JVMTextDocumentEmbedder(embedder);
+    InMemoryVectorStorage<Path> vectorStorage = new InMemoryVectorStorage<>();
+
+    EmbeddingBasedDocumentStorage<Path> embeddingStorage = new EmbeddingBasedDocumentStorage<>(
+        documentEmbedder,
+        vectorStorage
+    );
+    ```
 
 For more information, see the [EmbeddingBasedDocumentStorage](api:vector-storage::ai.koog.rag.vector.EmbeddingBasedDocumentStorage) reference.
 
@@ -377,20 +437,30 @@ For more information, see the [EmbeddingBasedDocumentStorage](api:vector-storage
 
 An in-memory implementation of `EmbeddingBasedDocumentStorage`.
 
-<!--- INCLUDE
-import ai.koog.agents.example.exampleRankedDocumentStorage03.documentEmbedder
-import ai.koog.rag.vector.InMemoryDocumentEmbeddingStorage
-import java.nio.file.Path
+=== "Kotlin"
 
-typealias Document = Path
--->
-```kotlin
-val inMemoryEmbeddingStorage = InMemoryDocumentEmbeddingStorage<Document>(
-    embedder = documentEmbedder
-)
+    <!--- INCLUDE
+    import ai.koog.agents.example.exampleRankedDocumentStorage03.documentEmbedder
+    import ai.koog.rag.vector.InMemoryDocumentEmbeddingStorage
+    import java.nio.file.Path
+    typealias Document = Path
+    -->
+    ```kotlin
+    val inMemoryEmbeddingStorage = InMemoryDocumentEmbeddingStorage<Document>(
+        embedder = documentEmbedder
+    )
+    ```
+    <!--- KNIT example-ranked-document-storage-10.kt -->
 
-```
-<!--- KNIT example-ranked-document-storage-10.kt -->
+=== "Java"
+
+    ```java
+    LLMEmbedder embedder = new LLMEmbedder(new OllamaClient("http://localhost:11434"), OllamaModels.Embeddings.NOMIC_EMBED_TEXT);
+    JVMTextDocumentEmbedder documentEmbedder = new JVMTextDocumentEmbedder(embedder);
+
+    InMemoryDocumentEmbeddingStorage<Path> inMemoryEmbeddingStorage =
+        new InMemoryDocumentEmbeddingStorage<>(documentEmbedder);
+    ```
 
 For more information, see the [InMemoryDocumentEmbeddingStorage](api:vector-storage::ai.koog.rag.vector.InMemoryDocumentEmbeddingStorage) reference.
 
@@ -398,21 +468,28 @@ For more information, see the [InMemoryDocumentEmbeddingStorage](api:vector-stor
 
 A file-based implementation of `EmbeddingBasedDocumentStorage`.
 
-<!--- INCLUDE
-/*
--->
-<!--- SUFFIX
-*/
--->
-```kotlin
-val fileEmbeddingStorage = FileDocumentEmbeddingStorage<Document, Path>(
-   embedder = documentEmbedder,
-   documentProvider = documentProvider,
-   fs = fileSystemProvider,
-   root = rootPath
-)
-```
-<!--- KNIT example-ranked-document-storage-11.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    /*
+    -->
+    <!--- SUFFIX
+    */
+    -->
+    ```kotlin
+    val fileEmbeddingStorage = FileDocumentEmbeddingStorage<Document, Path>(
+       embedder = documentEmbedder,
+       documentProvider = documentProvider,
+       fs = fileSystemProvider,
+       root = rootPath
+    )
+    ```
+    <!--- KNIT example-ranked-document-storage-11.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 For more information, see the [FileDocumentEmbeddingStorage](api:vector-storage::ai.koog.rag.vector.FileDocumentEmbeddingStorage) reference.
 
@@ -420,18 +497,32 @@ For more information, see the [FileDocumentEmbeddingStorage](api:vector-storage:
 
 A JVM-specific implementation of `FileDocumentEmbeddingStorage`.
 
-<!--- INCLUDE
-import ai.koog.agents.example.exampleRankedDocumentStorage03.documentEmbedder
-import ai.koog.rag.vector.JVMFileDocumentEmbeddingStorage
-import java.nio.file.Path
--->
-```kotlin
-val jvmFileEmbeddingStorage = JVMFileDocumentEmbeddingStorage(
-   embedder = documentEmbedder,
-   root = Path.of("/path/to/storage")
-)
-```
-<!--- KNIT example-ranked-document-storage-12.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.example.exampleRankedDocumentStorage03.documentEmbedder
+    import ai.koog.rag.vector.JVMFileDocumentEmbeddingStorage
+    import java.nio.file.Path
+    -->
+    ```kotlin
+    val jvmFileEmbeddingStorage = JVMFileDocumentEmbeddingStorage(
+       embedder = documentEmbedder,
+       root = Path.of("/path/to/storage")
+    )
+    ```
+    <!--- KNIT example-ranked-document-storage-12.kt -->
+
+=== "Java"
+
+    ```java
+    LLMEmbedder embedder = new LLMEmbedder(new OllamaClient("http://localhost:11434"), OllamaModels.Embeddings.NOMIC_EMBED_TEXT);
+    JVMTextDocumentEmbedder documentEmbedder = new JVMTextDocumentEmbedder(embedder);
+
+    JVMFileDocumentEmbeddingStorage jvmFileEmbeddingStorage = new JVMFileDocumentEmbeddingStorage(
+       documentEmbedder,
+       Path.of("/path/to/storage")
+    );
+    ```
 
 For more information, see the [JVMFileDocumentEmbeddingStorage](api:vector-storage::ai.koog.rag.vector.JVMFileDocumentEmbeddingStorage) reference.
 
@@ -439,18 +530,31 @@ For more information, see the [JVMFileDocumentEmbeddingStorage](api:vector-stora
 
 A JVM-specific implementation that combines `JVMTextDocumentEmbedder` and `JVMFileVectorStorage`.
 
-<!--- INCLUDE
-import ai.koog.agents.example.exampleRankedDocumentStorage08.embedder
-import ai.koog.rag.vector.JVMTextFileDocumentEmbeddingStorage
-import java.nio.file.Path
--->
-```kotlin
-val jvmTextFileEmbeddingStorage = JVMTextFileDocumentEmbeddingStorage(
-   embedder = embedder,
-   root = Path.of("/path/to/storage")
-)
-```
-<!--- KNIT example-ranked-document-storage-13.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.example.exampleRankedDocumentStorage08.embedder
+    import ai.koog.rag.vector.JVMTextFileDocumentEmbeddingStorage
+    import java.nio.file.Path
+    -->
+    ```kotlin
+    val jvmTextFileEmbeddingStorage = JVMTextFileDocumentEmbeddingStorage(
+       embedder = embedder,
+       root = Path.of("/path/to/storage")
+    )
+    ```
+    <!--- KNIT example-ranked-document-storage-13.kt -->
+
+=== "Java"
+
+    ```java
+    LLMEmbedder embedder = new LLMEmbedder(new OllamaClient("http://localhost:11434"), OllamaModels.Embeddings.NOMIC_EMBED_TEXT);
+
+    JVMTextFileDocumentEmbeddingStorage jvmTextFileEmbeddingStorage = new JVMTextFileDocumentEmbeddingStorage(
+       embedder,
+       Path.of("/path/to/storage")
+    );
+    ```
 
 For more information, see the [JVMTextFileDocumentEmbeddingStorage](api:vector-storage::ai.koog.rag.vector.JVMTextFileDocumentEmbeddingStorage) reference.
 
@@ -462,119 +566,126 @@ You can extend Koog's vector storage framework by implementing your own custom d
 
 Here's an example of implementing a custom document embedder for PDF documents:
 
-<!--- INCLUDE
-import ai.koog.embeddings.base.Embedder
-import ai.koog.embeddings.base.Vector
-import ai.koog.embeddings.local.LLMEmbedder
-import ai.koog.prompt.executor.ollama.client.OllamaModels
-import ai.koog.prompt.executor.ollama.client.OllamaClient
-import ai.koog.rag.base.RankedDocument
-import ai.koog.rag.base.RankedDocumentStorage
-import ai.koog.rag.base.files.DocumentProvider
-import ai.koog.rag.base.mostRelevantDocuments
-import ai.koog.rag.vector.DocumentEmbedder
-import ai.koog.rag.vector.InMemoryVectorStorage
-import ai.koog.rag.vector.VectorStorage
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import java.nio.file.Path
--->
-```kotlin
-// Define a PDFDocument class
-class PDFDocument(private val path: Path) {
-    fun readText(): String {
-        // Use a PDF library to extract text from the PDF
-        return "Text extracted from PDF at $path"
-    }
-}
+=== "Kotlin"
 
-// Implement a DocumentProvider for PDFDocument
-class PDFDocumentProvider : DocumentProvider<Path, PDFDocument> {
-    override suspend fun document(path: Path): PDFDocument? {
-        return if (path.toString().endsWith(".pdf")) {
-            PDFDocument(path)
-        } else {
-            null
+    <!--- INCLUDE
+    import ai.koog.embeddings.base.Embedder
+    import ai.koog.embeddings.base.Vector
+    import ai.koog.embeddings.local.LLMEmbedder
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    import ai.koog.prompt.executor.ollama.client.OllamaClient
+    import ai.koog.rag.base.RankedDocument
+    import ai.koog.rag.base.RankedDocumentStorage
+    import ai.koog.rag.base.files.DocumentProvider
+    import ai.koog.rag.base.mostRelevantDocuments
+    import ai.koog.rag.vector.DocumentEmbedder
+    import ai.koog.rag.vector.InMemoryVectorStorage
+    import ai.koog.rag.vector.VectorStorage
+    import kotlinx.coroutines.flow.Flow
+    import kotlinx.coroutines.flow.flow
+    import java.nio.file.Path
+    -->
+    ```kotlin
+    // Define a PDFDocument class
+    class PDFDocument(private val path: Path) {
+        fun readText(): String {
+            // Use a PDF library to extract text from the PDF
+            return "Text extracted from PDF at $path"
         }
     }
 
-    override suspend fun text(document: PDFDocument): CharSequence {
-        return document.readText()
-    }
-}
+    // Implement a DocumentProvider for PDFDocument
+    class PDFDocumentProvider : DocumentProvider<Path, PDFDocument> {
+        override suspend fun document(path: Path): PDFDocument? {
+            return if (path.toString().endsWith(".pdf")) {
+                PDFDocument(path)
+            } else {
+                null
+            }
+        }
 
-// Implement a DocumentEmbedder for PDFDocument
-class PDFDocumentEmbedder(private val embedder: Embedder) : DocumentEmbedder<PDFDocument> {
-    override suspend fun embed(document: PDFDocument): Vector {
-        val text = document.readText()
-        return embed(text)
+        override suspend fun text(document: PDFDocument): CharSequence {
+            return document.readText()
+        }
     }
 
-    override suspend fun embed(text: String): Vector {
-        return embedder.embed(text)
+    // Implement a DocumentEmbedder for PDFDocument
+    class PDFDocumentEmbedder(private val embedder: Embedder) : DocumentEmbedder<PDFDocument> {
+        override suspend fun embed(document: PDFDocument): Vector {
+            val text = document.readText()
+            return embed(text)
+        }
+
+        override suspend fun embed(text: String): Vector {
+            return embedder.embed(text)
+        }
+
+        override fun diff(embedding1: Vector, embedding2: Vector): Double {
+            return embedder.diff(embedding1, embedding2)
+        }
     }
 
-    override fun diff(embedding1: Vector, embedding2: Vector): Double {
-        return embedder.diff(embedding1, embedding2)
-    }
-}
-
-// Create a custom vector storage for PDF documents
-class PDFVectorStorage(
-    private val pdfProvider: PDFDocumentProvider,
-    private val embedder: PDFDocumentEmbedder,
-    private val storage: VectorStorage<PDFDocument>
-) : RankedDocumentStorage<PDFDocument> {
-    override fun rankDocuments(query: String): Flow<RankedDocument<PDFDocument>> = flow {
-        val queryVector = embedder.embed(query)
-        storage.allDocumentsWithPayload().collect { (document, documentVector) ->
-            emit(
-                RankedDocument(
-                    document = document,
-                    similarity = 1.0 - embedder.diff(queryVector, documentVector)
+    // Create a custom vector storage for PDF documents
+    class PDFVectorStorage(
+        private val pdfProvider: PDFDocumentProvider,
+        private val embedder: PDFDocumentEmbedder,
+        private val storage: VectorStorage<PDFDocument>
+    ) : RankedDocumentStorage<PDFDocument> {
+        override fun rankDocuments(query: String): Flow<RankedDocument<PDFDocument>> = flow {
+            val queryVector = embedder.embed(query)
+            storage.allDocumentsWithPayload().collect { (document, documentVector) ->
+                emit(
+                    RankedDocument(
+                        document = document,
+                        similarity = 1.0 - embedder.diff(queryVector, documentVector)
+                    )
                 )
-            )
+            }
+        }
+
+        override suspend fun store(document: PDFDocument, data: Unit): String {
+            val vector = embedder.embed(document)
+            return storage.store(document, vector)
+        }
+
+        override suspend fun delete(documentId: String): Boolean {
+            return storage.delete(documentId)
+        }
+
+        override suspend fun read(documentId: String): PDFDocument? {
+            return storage.read(documentId)
+        }
+
+        override fun allDocuments(): Flow<PDFDocument> = flow {
+            storage.allDocumentsWithPayload().collect {
+                emit(it.document)
+            }
         }
     }
 
-    override suspend fun store(document: PDFDocument, data: Unit): String {
-        val vector = embedder.embed(document)
-        return storage.store(document, vector)
+    // Usage example
+    suspend fun main() {
+        val pdfProvider = PDFDocumentProvider()
+        val embedder = LLMEmbedder(OllamaClient(), OllamaModels.Embeddings.NOMIC_EMBED_TEXT)
+        val pdfEmbedder = PDFDocumentEmbedder(embedder)
+        val storage = InMemoryVectorStorage<PDFDocument>()
+        val pdfStorage = PDFVectorStorage(pdfProvider, pdfEmbedder, storage)
+
+        // Store PDF documents
+        val pdfDocument = PDFDocument(Path.of("./documents/sample.pdf"))
+        pdfStorage.store(pdfDocument)
+
+        // Query for relevant PDF documents
+        val relevantPDFs = pdfStorage.mostRelevantDocuments("information about climate change", count = 3)
+
     }
+    ```
+    <!--- KNIT example-ranked-document-storage-14.kt -->
 
-    override suspend fun delete(documentId: String): Boolean {
-        return storage.delete(documentId)
-    }
+=== "Java"
 
-    override suspend fun read(documentId: String): PDFDocument? {
-        return storage.read(documentId)
-    }
-
-    override fun allDocuments(): Flow<PDFDocument> = flow {
-        storage.allDocumentsWithPayload().collect {
-            emit(it.document)
-        }
-    }
-}
-
-// Usage example
-suspend fun main() {
-    val pdfProvider = PDFDocumentProvider()
-    val embedder = LLMEmbedder(OllamaClient(), OllamaModels.Embeddings.NOMIC_EMBED_TEXT)
-    val pdfEmbedder = PDFDocumentEmbedder(embedder)
-    val storage = InMemoryVectorStorage<PDFDocument>()
-    val pdfStorage = PDFVectorStorage(pdfProvider, pdfEmbedder, storage)
-
-    // Store PDF documents
-    val pdfDocument = PDFDocument(Path.of("./documents/sample.pdf"))
-    pdfStorage.store(pdfDocument)
-
-    // Query for relevant PDF documents
-    val relevantPDFs = pdfStorage.mostRelevantDocuments("information about climate change", count = 3)
-
-}
-```
-<!--- KNIT example-ranked-document-storage-14.kt -->
+    ```java
+    ```
 
 ## Implementing custom non-embedding-based RankedDocumentStorage
 
@@ -588,127 +699,141 @@ While embedding-based document ranking is powerful, there are scenarios where yo
 
 Here's an example of implementing a custom `RankedDocumentStorage` that uses a simple keyword-based ranking approach:
 
-<!--- INCLUDE
-import ai.koog.rag.base.DocumentStorage
-import ai.koog.rag.base.RankedDocument
-import ai.koog.rag.base.RankedDocumentStorage
-import ai.koog.rag.base.files.DocumentProvider
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import java.nio.file.Path
--->
-```kotlin
-class KeywordBasedDocumentStorage<Document>(
-    private val documentProvider: DocumentProvider<Path, Document>,
-    private val storage: DocumentStorage<Document>
-) : RankedDocumentStorage<Document> {
+=== "Kotlin"
 
-    override fun rankDocuments(query: String): Flow<RankedDocument<Document>> = flow {
-        // Split the query into keywords
-        val keywords = query.lowercase().split(Regex("\\W+")).filter { it.length > 2 }
+    <!--- INCLUDE
+    import ai.koog.rag.base.DocumentStorage
+    import ai.koog.rag.base.RankedDocument
+    import ai.koog.rag.base.RankedDocumentStorage
+    import ai.koog.rag.base.files.DocumentProvider
+    import kotlinx.coroutines.flow.Flow
+    import kotlinx.coroutines.flow.flow
+    import java.nio.file.Path
+    -->
+    ```kotlin
+    class KeywordBasedDocumentStorage<Document>(
+        private val documentProvider: DocumentProvider<Path, Document>,
+        private val storage: DocumentStorage<Document>
+    ) : RankedDocumentStorage<Document> {
 
-        // Process each document
-        storage.allDocuments().collect { document ->
-            // Get the document text
-            val documentText = documentProvider.text(document).toString().lowercase()
+        override fun rankDocuments(query: String): Flow<RankedDocument<Document>> = flow {
+            // Split the query into keywords
+            val keywords = query.lowercase().split(Regex("\\W+")).filter { it.length > 2 }
 
-            // Calculate a simple similarity score based on keyword frequency
-            var similarity = 0.0
-            for (keyword in keywords) {
-                val count = countOccurrences(documentText, keyword)
-                if (count > 0) {
-                    similarity += count.toDouble() / documentText.length * 1000
+            // Process each document
+            storage.allDocuments().collect { document ->
+                // Get the document text
+                val documentText = documentProvider.text(document).toString().lowercase()
+
+                // Calculate a simple similarity score based on keyword frequency
+                var similarity = 0.0
+                for (keyword in keywords) {
+                    val count = countOccurrences(documentText, keyword)
+                    if (count > 0) {
+                        similarity += count.toDouble() / documentText.length * 1000
+                    }
+                }
+
+                // Emit the document with its similarity score
+                emit(RankedDocument(document, similarity))
+            }
+        }
+
+        private fun countOccurrences(text: String, keyword: String): Int {
+            var count = 0
+            var index = 0
+            while (index != -1) {
+                index = text.indexOf(keyword, index)
+                if (index != -1) {
+                    count++
+                    index += keyword.length
                 }
             }
+            return count
+        }
 
-            // Emit the document with its similarity score
-            emit(RankedDocument(document, similarity))
+        override suspend fun store(document: Document, data: Unit): String {
+            return storage.store(document)
+        }
+
+        override suspend fun delete(documentId: String): Boolean {
+            return storage.delete(documentId)
+        }
+
+        override suspend fun read(documentId: String): Document? {
+            return storage.read(documentId)
+        }
+
+        override fun allDocuments(): Flow<Document> {
+            return storage.allDocuments()
         }
     }
+    ```
+    <!--- KNIT example-ranked-document-storage-15.kt -->
 
-    private fun countOccurrences(text: String, keyword: String): Int {
-        var count = 0
-        var index = 0
-        while (index != -1) {
-            index = text.indexOf(keyword, index)
-            if (index != -1) {
-                count++
-                index += keyword.length
-            }
-        }
-        return count
-    }
+=== "Java"
 
-    override suspend fun store(document: Document, data: Unit): String {
-        return storage.store(document)
-    }
-
-    override suspend fun delete(documentId: String): Boolean {
-        return storage.delete(documentId)
-    }
-
-    override suspend fun read(documentId: String): Document? {
-        return storage.read(documentId)
-    }
-
-    override fun allDocuments(): Flow<Document> {
-        return storage.allDocuments()
-    }
-}
-```
-<!--- KNIT example-ranked-document-storage-15.kt -->
+    ```java
+    ```
 
 This implementation ranks documents based on the frequency of keywords from the query appearing in the document text. You could extend this approach with more sophisticated algorithms like TF-IDF (Term Frequency-Inverse Document Frequency) or BM25.
 
 Another example is a time-based ranking system that prioritizes recent documents:
 
-<!--- INCLUDE
-import ai.koog.rag.base.DocumentStorage
-import ai.koog.rag.base.RankedDocument
-import ai.koog.rag.base.RankedDocumentStorage
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import java.lang.System.currentTimeMillis
--->
-```kotlin
-class TimeBasedDocumentStorage<Document>(
-    private val storage: DocumentStorage<Document>,
-    private val getDocumentTimestamp: (Document) -> Long
-) : RankedDocumentStorage<Document> {
+=== "Kotlin"
 
-    override fun rankDocuments(query: String): Flow<RankedDocument<Document>> = flow {
-        val currentTime = System.currentTimeMillis()
+    <!--- INCLUDE
+    import ai.koog.rag.base.DocumentStorage
+    import ai.koog.rag.base.RankedDocument
+    import ai.koog.rag.base.RankedDocumentStorage
+    import kotlinx.coroutines.flow.Flow
+    import kotlinx.coroutines.flow.flow
+    import java.lang.System.currentTimeMillis
+    -->
+    ```kotlin
+    class TimeBasedDocumentStorage<Document>(
+        private val storage: DocumentStorage<Document>,
+        private val getDocumentTimestamp: (Document) -> Long
+    ) : RankedDocumentStorage<Document> {
 
-        storage.allDocuments().collect { document ->
-            val timestamp = getDocumentTimestamp(document)
-            val ageInHours = (currentTime - timestamp) / (1000.0 * 60 * 60)
+        override fun rankDocuments(query: String): Flow<RankedDocument<Document>> = flow {
+            val currentTime = System.currentTimeMillis()
 
-            // Calculate a decay factor based on age (newer documents get higher scores)
-            val decayFactor = Math.exp(-0.01 * ageInHours)
+            storage.allDocuments().collect { document ->
+                val timestamp = getDocumentTimestamp(document)
+                val ageInHours = (currentTime - timestamp) / (1000.0 * 60 * 60)
 
-            emit(RankedDocument(document, decayFactor))
+                // Calculate a decay factor based on age (newer documents get higher scores)
+                val decayFactor = Math.exp(-0.01 * ageInHours)
+
+                emit(RankedDocument(document, decayFactor))
+            }
+        }
+
+        // Implement other required methods from RankedDocumentStorage
+        override suspend fun store(document: Document, data: Unit): String {
+            return storage.store(document)
+        }
+
+        override suspend fun delete(documentId: String): Boolean {
+            return storage.delete(documentId)
+        }
+
+        override suspend fun read(documentId: String): Document? {
+            return storage.read(documentId)
+        }
+
+        override fun allDocuments(): Flow<Document> {
+            return storage.allDocuments()
         }
     }
+    ```
+    <!--- KNIT example-ranked-document-storage-16.kt -->
 
-    // Implement other required methods from RankedDocumentStorage
-    override suspend fun store(document: Document, data: Unit): String {
-        return storage.store(document)
-    }
+=== "Java"
 
-    override suspend fun delete(documentId: String): Boolean {
-        return storage.delete(documentId)
-    }
-
-    override suspend fun read(documentId: String): Document? {
-        return storage.read(documentId)
-    }
-
-    override fun allDocuments(): Flow<Document> {
-        return storage.allDocuments()
-    }
-}
-```
-<!--- KNIT example-ranked-document-storage-16.kt -->
+    ```java
+    ```
 
 By implementing the `RankedDocumentStorage` interface, you can create custom ranking mechanisms tailored to your specific use case while still leveraging the rest of the RAG infrastructure.
 

--- a/docs/docs/spring-boot.md
+++ b/docs/docs/spring-boot.md
@@ -19,8 +19,7 @@ ready-to-use beans for dependency injection. It supports all major LLM providers
 
 ### 1. Add Dependency
 
-Add the Koog Spring Boot starter and [Ktor Client Engine](https://ktor.io/docs/client-engines.html#jvm) 
-to your `build.gradle.kts` or `pom.xml`:
+Add the Koog Spring Boot starter and [Ktor Client Engine](https://ktor.io/docs/client-engines.html#jvm) to your build configuration:
 
 ```kotlin
 dependencies {
@@ -117,33 +116,67 @@ For example, setting the environment variable `OPENAI_API_KEY` is enough for Ope
 
 Inject the auto-configured executors into your services:
 
-```kotlin
-@Service
-class AIService(
-    private val openAIExecutor: MultiLLMPromptExecutor?,
-    private val anthropicExecutor: MultiLLMPromptExecutor?
-) {
+=== "Kotlin"
 
-    suspend fun generateResponse(input: String): String {
-        val prompt = prompt {
-            system("You are a helpful AI assistant")
-            user(input)
-        }
+    ```kotlin
+    @Service
+    class AIService(
+        private val openAIExecutor: MultiLLMPromptExecutor?,
+        private val anthropicExecutor: MultiLLMPromptExecutor?
+    ) {
 
-        return when {
-            openAIExecutor != null -> {
-                val result = openAIExecutor.execute(prompt)
-                result.text
+        suspend fun generateResponse(input: String): String {
+            val prompt = prompt {
+                system("You are a helpful AI assistant")
+                user(input)
             }
-            anthropicExecutor != null -> {
-                val result = anthropicExecutor.execute(prompt)
-                result.text
+
+            return when {
+                openAIExecutor != null -> {
+                    val result = openAIExecutor.execute(prompt)
+                    result.text
+                }
+                anthropicExecutor != null -> {
+                    val result = anthropicExecutor.execute(prompt)
+                    result.text
+                }
+                else -> throw IllegalStateException("No LLM provider configured")
             }
-            else -> throw IllegalStateException("No LLM provider configured")
         }
     }
-}
-```
+    ```
+
+=== "Java"
+
+    ```java
+    @Service
+    public class AIService {
+        private final MultiLLMPromptExecutor openAIExecutor;
+        private final MultiLLMPromptExecutor anthropicExecutor;
+
+        public AIService(MultiLLMPromptExecutor openAIExecutor, MultiLLMPromptExecutor anthropicExecutor) {
+            this.openAIExecutor = openAIExecutor;
+            this.anthropicExecutor = anthropicExecutor;
+        }
+
+        public String generateResponse(String input) {
+            Prompt prompt = Prompt.builder("ai-service")
+                .system("You are a helpful AI assistant")
+                .user(input)
+                .build();
+
+            if (openAIExecutor != null) {
+                List<Message.Response> result = openAIExecutor.execute(prompt, OpenAIModels.Chat.GPT4o);
+                return result.get(0).getContent();
+            } else if (anthropicExecutor != null) {
+                List<Message.Response> result = anthropicExecutor.execute(prompt, AnthropicModels.Haiku_4_5);
+                return result.get(0).getContent();
+            } else {
+                throw new IllegalStateException("No LLM provider configured");
+            }
+        }
+    }
+    ```
 
 ## Advanced Usage
 
@@ -151,101 +184,235 @@ class AIService(
 
 Create a chat endpoint using auto-configured executors:
 
-```kotlin
-@RestController
-@RequestMapping("/api/chat")
-class ChatController(
-    private val anthropicExecutor: MultiLLMPromptExecutor?
-) {
+=== "Kotlin"
 
-    @PostMapping
-    suspend fun chat(@RequestBody request: ChatRequest): ResponseEntity<ChatResponse> {
-        return if (anthropicExecutor != null) {
-            try {
-                val prompt = prompt {
-                    system("You are a helpful assistant")
-                    user(request.message)
+    ```kotlin
+    @RestController
+    @RequestMapping("/api/chat")
+    class ChatController(
+        private val anthropicExecutor: MultiLLMPromptExecutor?
+    ) {
+
+        @PostMapping
+        suspend fun chat(@RequestBody request: ChatRequest): ResponseEntity<ChatResponse> {
+            return if (anthropicExecutor != null) {
+                try {
+                    val prompt = prompt {
+                        system("You are a helpful assistant")
+                        user(request.message)
+                    }
+
+                    val result = anthropicExecutor.execute(prompt)
+                    ResponseEntity.ok(ChatResponse(result.text))
+                } catch (e: Exception) {
+                    ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .body(ChatResponse("Error processing request"))
                 }
-
-                val result = anthropicExecutor.execute(prompt)
-                ResponseEntity.ok(ChatResponse(result.text))
-            } catch (e: Exception) {
-                ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(ChatResponse("Error processing request"))
+            } else {
+                ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                    .body(ChatResponse("AI service not configured"))
             }
-        } else {
-            ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
-                .body(ChatResponse("AI service not configured"))
         }
     }
-}
 
-data class ChatRequest(val message: String)
-data class ChatResponse(val response: String)
-```
+    data class ChatRequest(val message: String)
+    data class ChatResponse(val response: String)
+    ```
+
+=== "Java"
+
+    ```java
+    @RestController
+    @RequestMapping("/api/chat")
+    public class ChatController {
+        private final MultiLLMPromptExecutor anthropicExecutor;
+
+        public ChatController(MultiLLMPromptExecutor anthropicExecutor) {
+            this.anthropicExecutor = anthropicExecutor;
+        }
+
+        @PostMapping
+        public ResponseEntity<ChatResponse> chat(@RequestBody ChatRequest request) {
+            if (anthropicExecutor != null) {
+                try {
+                    Prompt prompt = Prompt.builder("chat")
+                        .system("You are a helpful assistant")
+                        .user(request.message)
+                        .build();
+
+                    List<Message.Response> result = anthropicExecutor.execute(prompt, AnthropicModels.Haiku_4_5);
+                    return ResponseEntity.ok(new ChatResponse(result.get(0).getContent()));
+                } catch (Exception e) {
+                    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .body(new ChatResponse("Error processing request"));
+                }
+            } else {
+                return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                    .body(new ChatResponse("AI service not configured"));
+            }
+        }
+    }
+
+    class ChatRequest {
+        public String message;
+    }
+    class ChatResponse {
+        public final String response;
+        public ChatResponse(String response) { this.response = response; }
+    }
+    ```
 
 ### Multiple Provider Support
 
 Handle multiple providers with fallback logic:
 
-```kotlin
-@Service
-class RobustAIService(
-    private val openAIExecutor: MultiLLMPromptExecutor?,
-    private val anthropicExecutor: MultiLLMPromptExecutor?,
-    private val openRouterExecutor: MultiLLMPromptExecutor?
-) {
+=== "Kotlin"
 
-    suspend fun generateWithFallback(input: String): String {
-        val prompt = prompt {
-            system("You are a helpful AI assistant")
-            user(input)
+    ```kotlin
+    @Service
+    class RobustAIService(
+        private val openAIExecutor: MultiLLMPromptExecutor?,
+        private val anthropicExecutor: MultiLLMPromptExecutor?,
+        private val openRouterExecutor: MultiLLMPromptExecutor?
+    ) {
+
+        suspend fun generateWithFallback(input: String): String {
+            val prompt = prompt {
+                system("You are a helpful AI assistant")
+                user(input)
+            }
+
+            val executors = listOfNotNull(openAIExecutor, anthropicExecutor, openRouterExecutor)
+
+            for (executor in executors) {
+                try {
+                    val result = executor.execute(prompt)
+                    return result.text
+                } catch (e: Exception) {
+                    logger.warn("Executor failed, trying next: ${e.message}")
+                    continue
+                }
+            }
+
+            throw IllegalStateException("All AI providers failed")
         }
 
-        val executors = listOfNotNull(openAIExecutor, anthropicExecutor, openRouterExecutor)
+        companion object {
+            private val logger = LoggerFactory.getLogger(RobustAIService::class.java)
+        }
+    }
+    ```
 
-        for (executor in executors) {
-            try {
-                val result = executor.execute(prompt)
-                return result.text
-            } catch (e: Exception) {
-                logger.warn("Executor failed, trying next: ${e.message}")
-                continue
+=== "Java"
+
+    ```java
+    @Service
+    public class RobustAIService {
+        private static final Logger logger = LoggerFactory.getLogger(RobustAIService.class);
+
+        private static class ProviderConfig {
+            final String name;
+            final MultiLLMPromptExecutor executor;
+            final LLModel model;
+
+            ProviderConfig(String name, MultiLLMPromptExecutor executor, LLModel model) {
+                this.name = name;
+                this.executor = executor;
+                this.model = model;
             }
         }
 
-        throw IllegalStateException("All AI providers failed")
-    }
+        private final List<ProviderConfig> providers;
 
-    companion object {
-        private val logger = LoggerFactory.getLogger(RobustAIService::class.java)
+        public RobustAIService(MultiLLMPromptExecutor openAIExecutor,
+                               MultiLLMPromptExecutor anthropicExecutor,
+                               MultiLLMPromptExecutor openRouterExecutor) {
+            providers = new ArrayList<>();
+            if (openAIExecutor != null) {
+                providers.add(new ProviderConfig("OpenAI", openAIExecutor, OpenAIModels.Chat.GPT4oMini));
+            }
+            if (anthropicExecutor != null) {
+                providers.add(new ProviderConfig("Anthropic", anthropicExecutor, AnthropicModels.Haiku_4_5));
+            }
+            if (openRouterExecutor != null) {
+                providers.add(new ProviderConfig("OpenRouter", openRouterExecutor, OpenRouterModels.Claude3Haiku));
+            }
+        }
+
+        public String generateWithFallback(String input) {
+            Prompt prompt = Prompt.builder("robust")
+                .system("You are a helpful AI assistant")
+                .user(input)
+                .build();
+
+            for (ProviderConfig provider : providers) {
+                try {
+                    List<Message.Response> result = provider.executor.execute(prompt, provider.model);
+                    return result.get(0).getContent();
+                } catch (Exception e) {
+                    logger.warn("{} executor failed, trying next: {}", provider.name, e.getMessage());
+                }
+            }
+
+            throw new IllegalStateException("All AI providers failed");
+        }
     }
-}
-```
+    ```
 
 ### Configuration Properties
 
 You can also inject configuration properties for custom logic:
 
-```kotlin
-@Service
-class ConfigurableAIService(
-    private val openAIExecutor: MultiLLMPromptExecutor?,
-    @Value("\${ai.koog.openai.api-key:}") private val openAIKey: String
-) {
+=== "Kotlin"
 
-    fun isOpenAIConfigured(): Boolean = openAIKey.isNotBlank() && openAIExecutor != null
+    ```kotlin
+    @Service
+    class ConfigurableAIService(
+        private val openAIExecutor: MultiLLMPromptExecutor?,
+        @Value("\${ai.koog.openai.api-key:}") private val openAIKey: String
+    ) {
 
-    suspend fun processIfConfigured(input: String): String? {
-        return if (isOpenAIConfigured()) {
-            val result = openAIExecutor!!.execute(prompt { user(input) })
-            result.text
-        } else {
-            null
+        fun isOpenAIConfigured(): Boolean = openAIKey.isNotBlank() && openAIExecutor != null
+
+        suspend fun processIfConfigured(input: String): String? {
+            return if (isOpenAIConfigured()) {
+                val result = openAIExecutor!!.execute(prompt { user(input) })
+                result.text
+            } else {
+                null
+            }
         }
     }
-}
-```
+    ```
+
+=== "Java"
+
+    ```java
+    @Service
+    public class ConfigurableAIService {
+        private final MultiLLMPromptExecutor openAIExecutor;
+        private final String openAIKey;
+
+        public ConfigurableAIService(MultiLLMPromptExecutor openAIExecutor,
+                                     @Value("${ai.koog.openai.api-key:}") String openAIKey) {
+            this.openAIExecutor = openAIExecutor;
+            this.openAIKey = openAIKey;
+        }
+
+        public boolean isOpenAIConfigured() {
+            return openAIKey != null && !openAIKey.isBlank() && openAIExecutor != null;
+        }
+
+        public String processIfConfigured(String input) {
+            if (!isOpenAIConfigured()) return null;
+
+            Prompt prompt = Prompt.builder("configurable").user(input).build();
+
+            List<Message.Response> result = openAIExecutor.execute(prompt, OpenAIModels.Chat.GPT4o);
+            return result.get(0).getContent();
+        }
+    }
+    ```
 
 ## Configuration Reference
 
@@ -296,15 +463,34 @@ Multiple qualifying beans of type 'MultiLLMPromptExecutor' available
 
 **Solution:** Use `@Qualifier` to specify which bean you want:
 
-```kotlin
-@Service
-class MyService(
-    @Qualifier("openAIExecutor") private val openAIExecutor: MultiLLMPromptExecutor,
-    @Qualifier("anthropicExecutor") private val anthropicExecutor: MultiLLMPromptExecutor
-) {
-    // ...
-}
-```
+=== "Kotlin"
+
+    ```kotlin
+    @Service
+    class MyService(
+        @Qualifier("openAIExecutor") private val openAIExecutor: MultiLLMPromptExecutor,
+        @Qualifier("anthropicExecutor") private val anthropicExecutor: MultiLLMPromptExecutor
+    ) {
+        // ...
+    }
+    ```
+
+=== "Java"
+
+    ```java
+    @Service
+    public class MyService {
+        private final MultiLLMPromptExecutor openAIExecutor;
+        private final MultiLLMPromptExecutor anthropicExecutor;
+
+        public MyService(@Qualifier("openAIExecutor") MultiLLMPromptExecutor openAIExecutor,
+                         @Qualifier("anthropicExecutor") MultiLLMPromptExecutor anthropicExecutor) {
+            this.openAIExecutor = openAIExecutor;
+            this.anthropicExecutor = anthropicExecutor;
+        }
+        // ...
+    }
+    ```
 
 **API key not loaded:**
 

--- a/docs/docs/spring-boot.md
+++ b/docs/docs/spring-boot.md
@@ -120,7 +120,7 @@ Provider's base urls are set to their default values in the Spring Boot starter,
 application.
 
 !!! tip "Environment Variables"
-It's recommended to use environment variables for API keys to keep them secure and out of version control.
+    It's recommended to use environment variables for API keys to keep them secure and out of version control.
 Spring configuration uses LLM provider's well-known environment variables.
 For example, setting the environment variable `OPENAI_API_KEY` is enough for OpenAI spring configuration to activate.
 

--- a/docs/docs/spring-boot.md
+++ b/docs/docs/spring-boot.md
@@ -13,20 +13,32 @@ ready-to-use beans for dependency injection. It supports all major LLM providers
 - Google
 - OpenRouter
 - DeepSeek
+- Mistral
 - Ollama
 
 ## Getting Started
 
 ### 1. Add Dependency
 
-Add the Koog Spring Boot starter and [Ktor Client Engine](https://ktor.io/docs/client-engines.html#jvm) to your build configuration:
-
+Add the Koog Spring Boot starter to your Gradle build configuration:
 ```kotlin
 dependencies {
     implementation("ai.koog:koog-spring-boot-starter:$koogVersion")
-    implementation("io.ktor:ktor-client-okhttp-jvm:$ktorVersion")
 }
 ```
+or for Maven
+```xml
+<dependency>
+    <groupId>ai.koog</groupId>
+    <artifactId>koog-spring-boot-starter</artifactId>
+    <version>$koogVersion</version>
+</dependency>
+```
+
+Make sure that your Kotlin or Java project has:
+- Spring Boot 3 (it requires Java 17 or higher)
+- Kotlin version 2.3.10
+- kotlinx-serialization version 1.10.0 (namely, kotlinx-serialization-core-jvm and kotlinx-serialization-json-jvm)
 
 ### 2. Configure Providers
 
@@ -53,9 +65,13 @@ ai.koog.openrouter.base-url=https://openrouter.ai
 ai.koog.deepseek.enabled=true
 ai.koog.deepseek.api-key=${DEEPSEEK_API_KEY}
 ai.koog.deepseek.base-url=https://api.deepseek.com
+# Mistral Configuration
+ai.koog.mistral.enabled=true
+ai.koog.mistral.api-key=${MISTRALAI_API_KEY}
+ai.koog.mistral.base-url=https://api.mistral.ai
 # Ollama Configuration (local - no API key required)
 ai.koog.ollama.enabled=true
-ai.koog.ollama.base-url=http://localhost:11434
+ai.koog.ollama.base-url=http://127.0.0.1:11434
 ```
 
 Or using YAML format (`application.yml`):
@@ -83,9 +99,13 @@ ai:
             enabled: true
             api-key: ${DEEPSEEK_API_KEY}
             base-url: https://api.deepseek.com
+        mistral:
+            enabled: true
+            api-key: ${MISTRALAI_API_KEY}
+            base-url: https://api.mistral.ai
         ollama:
             enabled: true # Set it to `true` explicitly to activate !!!
-            base-url: http://localhost:11434
+            base-url: http://127.0.0.1:11434
 ```
 
 Both `ai.koog.PROVIDER.api-key` and `ai.koog.PROVIDER.enabled` properties are used to activate the provider.
@@ -111,99 +131,45 @@ For example, setting the environment variable `OPENAI_API_KEY` is enough for Ope
 | Google       | `GOOGLE_API_KEY`      |
 | OpenRouter   | `OPENROUTER_API_KEY`  |
 | DeepSeek     | `DEEPSEEK_API_KEY`    |
+| Mistral      | `MISTRALAI_API_KEY`   |
 
-### 3. Inject and Use
+### 3. Use in your project
 
-Inject the auto-configured executors into your services:
-
-=== "Kotlin"
-
-    ```kotlin
-    @Service
-    class AIService(
-        private val openAIExecutor: MultiLLMPromptExecutor?,
-        private val anthropicExecutor: MultiLLMPromptExecutor?
-    ) {
-
-        suspend fun generateResponse(input: String): String {
-            val prompt = prompt {
-                system("You are a helpful AI assistant")
-                user(input)
-            }
-
-            return when {
-                openAIExecutor != null -> {
-                    val result = openAIExecutor.execute(prompt)
-                    result.text
-                }
-                anthropicExecutor != null -> {
-                    val result = anthropicExecutor.execute(prompt)
-                    result.text
-                }
-                else -> throw IllegalStateException("No LLM provider configured")
-            }
-        }
-    }
-    ```
-
-=== "Java"
-
-    ```java
-    @Service
-    public class AIService {
-        private final MultiLLMPromptExecutor openAIExecutor;
-        private final MultiLLMPromptExecutor anthropicExecutor;
-
-        public AIService(MultiLLMPromptExecutor openAIExecutor, MultiLLMPromptExecutor anthropicExecutor) {
-            this.openAIExecutor = openAIExecutor;
-            this.anthropicExecutor = anthropicExecutor;
-        }
-
-        public String generateResponse(String input) {
-            Prompt prompt = Prompt.builder("ai-service")
-                .system("You are a helpful AI assistant")
-                .user(input)
-                .build();
-
-            if (openAIExecutor != null) {
-                List<Message.Response> result = openAIExecutor.execute(prompt, OpenAIModels.Chat.GPT4o);
-                return result.get(0).getContent();
-            } else if (anthropicExecutor != null) {
-                List<Message.Response> result = anthropicExecutor.execute(prompt, AnthropicModels.Haiku_4_5);
-                return result.get(0).getContent();
-            } else {
-                throw new IllegalStateException("No LLM provider configured");
-            }
-        }
-    }
-    ```
-
-## Advanced Usage
-
-### REST Controller Example
-
-Create a chat endpoint using auto-configured executors:
+Below is a usage example of an auto-configured executor in Spring MVC RestController. It requires the following:
+- spring-boot-starter-web dependency
+- for Kotlin kotlinx-coroutines-core and kotlinx-coroutines-reactor dependencies should be added (Java version calls blocking `execute` method)
+- Anthropic is enabled via property (ai.koog.anthropic.enabled=true)
 
 === "Kotlin"
 
     ```kotlin
+    import ai.koog.prompt.dsl.prompt
+    import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
+    import ai.koog.prompt.executor.model.PromptExecutor
+    import org.springframework.http.HttpStatus
+    import org.springframework.http.ResponseEntity
+    import org.springframework.web.bind.annotation.PostMapping
+    import org.springframework.web.bind.annotation.RequestBody
+    import org.springframework.web.bind.annotation.RequestMapping
+    import org.springframework.web.bind.annotation.RestController
+
     @RestController
     @RequestMapping("/api/chat")
     class ChatController(
-        private val anthropicExecutor: MultiLLMPromptExecutor?
+        private val anthropicExecutor: PromptExecutor?
     ) {
 
         @PostMapping
         suspend fun chat(@RequestBody request: ChatRequest): ResponseEntity<ChatResponse> {
             return if (anthropicExecutor != null) {
                 try {
-                    val prompt = prompt {
+                    val prompt = prompt("example-prompt") {
                         system("You are a helpful assistant")
                         user(request.message)
                     }
 
-                    val result = anthropicExecutor.execute(prompt)
-                    ResponseEntity.ok(ChatResponse(result.text))
+                    val result = anthropicExecutor.execute(prompt, AnthropicModels.Haiku_4_5)
+                    ResponseEntity.ok(ChatResponse(result.first().content))
                 } catch (e: Exception) {
                     ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                         .body(ChatResponse("Error processing request"))
@@ -222,12 +188,27 @@ Create a chat endpoint using auto-configured executors:
 === "Java"
 
     ```java
+    import ai.koog.prompt.dsl.Prompt;
+    import ai.koog.prompt.executor.clients.anthropic.AnthropicModels;
+    import ai.koog.prompt.executor.model.PromptExecutor;
+    import ai.koog.prompt.message.Message;
+    import org.springframework.http.HttpStatus;
+    import org.springframework.http.ResponseEntity;
+    import org.springframework.web.bind.annotation.PostMapping;
+    import org.springframework.web.bind.annotation.RequestBody;
+    import org.springframework.web.bind.annotation.RequestMapping;
+    import org.springframework.web.bind.annotation.RestController;
+
+    import jakarta.annotation.Nullable;
+    import java.util.List;
+
     @RestController
     @RequestMapping("/api/chat")
     public class ChatController {
-        private final MultiLLMPromptExecutor anthropicExecutor;
+        @Nullable
+        private final PromptExecutor anthropicExecutor;
 
-        public ChatController(MultiLLMPromptExecutor anthropicExecutor) {
+        public ChatController(@Nullable PromptExecutor anthropicExecutor) {
             this.anthropicExecutor = anthropicExecutor;
         }
 
@@ -237,7 +218,7 @@ Create a chat endpoint using auto-configured executors:
                 try {
                     Prompt prompt = Prompt.builder("chat")
                         .system("You are a helpful assistant")
-                        .user(request.message)
+                        .user(request.message())
                         .build();
 
                     List<Message.Response> result = anthropicExecutor.execute(prompt, AnthropicModels.Haiku_4_5);
@@ -253,44 +234,46 @@ Create a chat endpoint using auto-configured executors:
         }
     }
 
-    class ChatRequest {
-        public String message;
-    }
-    class ChatResponse {
-        public final String response;
-        public ChatResponse(String response) { this.response = response; }
-    }
+    record ChatRequest(String message) {}
+    record ChatResponse(String response) {}
     ```
+Spring Framework injected the executor for Anthropic by bean name (`anthropicExecutor`),
+but you can also inject multiple `PromptExecutor` beans using `@Qualifier` annotation (see "Multiple beans error" below).
 
-### Multiple Provider Support
+## Advanced usage
+### LLM Provider Fallback
 
-Handle multiple providers with fallback logic:
+After configuring multiple LLM providers you can send request to multiple LLMs via `MultiLLMPromptExecutor`:
 
 === "Kotlin"
 
     ```kotlin
+    import ai.koog.prompt.dsl.prompt
+    import ai.koog.prompt.executor.clients.anthropic.AnthropicModels.Haiku_4_5
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels.Chat.GPT4oMini
+    import ai.koog.prompt.executor.clients.openrouter.OpenRouterModels.Claude3Haiku
+    import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
+    import org.slf4j.Logger
+    import org.slf4j.LoggerFactory
+    import org.springframework.stereotype.Service
+
     @Service
-    class RobustAIService(
-        private val openAIExecutor: MultiLLMPromptExecutor?,
-        private val anthropicExecutor: MultiLLMPromptExecutor?,
-        private val openRouterExecutor: MultiLLMPromptExecutor?
-    ) {
+    class RobustAIService(private val multiLLMPromptExecutor: MultiLLMPromptExecutor) {
+
+        private val llms = listOf(GPT4oMini, Haiku_4_5, Claude3Haiku)
 
         suspend fun generateWithFallback(input: String): String {
-            val prompt = prompt {
+            val prompt = prompt("robust") {
                 system("You are a helpful AI assistant")
                 user(input)
             }
 
-            val executors = listOfNotNull(openAIExecutor, anthropicExecutor, openRouterExecutor)
-
-            for (executor in executors) {
+            for (llm in llms) {
                 try {
-                    val result = executor.execute(prompt)
-                    return result.text
+                    val result = multiLLMPromptExecutor.execute(prompt, llm)
+                    return result.first().content
                 } catch (e: Exception) {
-                    logger.warn("Executor failed, trying next: ${e.message}")
-                    continue
+                    logger.warn("{} executor failed, trying next: {}", llm.id, e.message)
                 }
             }
 
@@ -306,37 +289,29 @@ Handle multiple providers with fallback logic:
 === "Java"
 
     ```java
+    import ai.koog.prompt.dsl.Prompt;
+    import ai.koog.prompt.executor.clients.anthropic.AnthropicModels;
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels;
+    import ai.koog.prompt.executor.clients.openrouter.OpenRouterModels;
+    import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor;
+    import ai.koog.prompt.llm.LLModel;
+    import ai.koog.prompt.message.Message;
+    import org.slf4j.Logger;
+    import org.slf4j.LoggerFactory;
+    import org.springframework.stereotype.Service;
+
+    import java.util.List;
+
     @Service
     public class RobustAIService {
         private static final Logger logger = LoggerFactory.getLogger(RobustAIService.class);
 
-        private static class ProviderConfig {
-            final String name;
-            final MultiLLMPromptExecutor executor;
-            final LLModel model;
+        private final List<LLModel> llms = List.of(OpenAIModels.Chat.GPT4oMini, AnthropicModels.Haiku_4_5, OpenRouterModels.Claude3Haiku);
 
-            ProviderConfig(String name, MultiLLMPromptExecutor executor, LLModel model) {
-                this.name = name;
-                this.executor = executor;
-                this.model = model;
-            }
-        }
+        private final MultiLLMPromptExecutor multiLLMPromptExecutor;
 
-        private final List<ProviderConfig> providers;
-
-        public RobustAIService(MultiLLMPromptExecutor openAIExecutor,
-                               MultiLLMPromptExecutor anthropicExecutor,
-                               MultiLLMPromptExecutor openRouterExecutor) {
-            providers = new ArrayList<>();
-            if (openAIExecutor != null) {
-                providers.add(new ProviderConfig("OpenAI", openAIExecutor, OpenAIModels.Chat.GPT4oMini));
-            }
-            if (anthropicExecutor != null) {
-                providers.add(new ProviderConfig("Anthropic", anthropicExecutor, AnthropicModels.Haiku_4_5));
-            }
-            if (openRouterExecutor != null) {
-                providers.add(new ProviderConfig("OpenRouter", openRouterExecutor, OpenRouterModels.Claude3Haiku));
-            }
+        public RobustAIService(MultiLLMPromptExecutor multiLLMPromptExecutor) {
+            this.multiLLMPromptExecutor = multiLLMPromptExecutor;
         }
 
         public String generateWithFallback(String input) {
@@ -345,12 +320,12 @@ Handle multiple providers with fallback logic:
                 .user(input)
                 .build();
 
-            for (ProviderConfig provider : providers) {
+            for (LLModel llm : llms) {
                 try {
-                    List<Message.Response> result = provider.executor.execute(prompt, provider.model);
+                    List<Message.Response> result = multiLLMPromptExecutor.execute(prompt, llm);
                     return result.get(0).getContent();
                 } catch (Exception e) {
-                    logger.warn("{} executor failed, trying next: {}", provider.name, e.getMessage());
+                    logger.warn("{} executor failed, trying next: {}", llm.getId(), e.getMessage());
                 }
             }
 
@@ -358,79 +333,28 @@ Handle multiple providers with fallback logic:
         }
     }
     ```
-
-### Configuration Properties
-
-You can also inject configuration properties for custom logic:
-
-=== "Kotlin"
-
-    ```kotlin
-    @Service
-    class ConfigurableAIService(
-        private val openAIExecutor: MultiLLMPromptExecutor?,
-        @Value("\${ai.koog.openai.api-key:}") private val openAIKey: String
-    ) {
-
-        fun isOpenAIConfigured(): Boolean = openAIKey.isNotBlank() && openAIExecutor != null
-
-        suspend fun processIfConfigured(input: String): String? {
-            return if (isOpenAIConfigured()) {
-                val result = openAIExecutor!!.execute(prompt { user(input) })
-                result.text
-            } else {
-                null
-            }
-        }
-    }
-    ```
-
-=== "Java"
-
-    ```java
-    @Service
-    public class ConfigurableAIService {
-        private final MultiLLMPromptExecutor openAIExecutor;
-        private final String openAIKey;
-
-        public ConfigurableAIService(MultiLLMPromptExecutor openAIExecutor,
-                                     @Value("${ai.koog.openai.api-key:}") String openAIKey) {
-            this.openAIExecutor = openAIExecutor;
-            this.openAIKey = openAIKey;
-        }
-
-        public boolean isOpenAIConfigured() {
-            return openAIKey != null && !openAIKey.isBlank() && openAIExecutor != null;
-        }
-
-        public String processIfConfigured(String input) {
-            if (!isOpenAIConfigured()) return null;
-
-            Prompt prompt = Prompt.builder("configurable").user(input).build();
-
-            List<Message.Response> result = openAIExecutor.execute(prompt, OpenAIModels.Chat.GPT4o);
-            return result.get(0).getContent();
-        }
-    }
-    ```
+You can also register your own `MultiLLMPromptExecutor` bean and pass a `FallbackPromptExecutorSettings` to it.
+To override the auto-configuration for your beans you can use `@Primary` annotation.
 
 ## Configuration Reference
 
 ### Available Properties
 
-| Property                      | Description         | Bean Condition                                                  | Default                                     |
-|-------------------------------|---------------------|-----------------------------------------------------------------|---------------------------------------------|
-| `ai.koog.openai.api-key`      | OpenAI API key      | Required for `openAIExecutor` bean                              | -                                           |
-| `ai.koog.openai.base-url`     | OpenAI base URL     | Optional                                                        | `https://api.openai.com`                    |
-| `ai.koog.anthropic.api-key`   | Anthropic API key   | Required for `anthropicExecutor` bean                           | -                                           |
-| `ai.koog.anthropic.base-url`  | Anthropic base URL  | Optional                                                        | `https://api.anthropic.com`                 |
-| `ai.koog.google.api-key`      | Google API key      | Required for `googleExecutor` bean                              | -                                           |
-| `ai.koog.google.base-url`     | Google base URL     | Optional                                                        | `https://generativelanguage.googleapis.com` |
-| `ai.koog.openrouter.api-key`  | OpenRouter API key  | Required for `openRouterExecutor` bean                          | -                                           |
-| `ai.koog.openrouter.base-url` | OpenRouter base URL | Optional                                                        | `https://openrouter.ai`                     |
-| `ai.koog.deepseek.api-key`    | DeepSeek API key    | Required for `deepSeekExecutor` bean                            | -                                           |
-| `ai.koog.deepseek.base-url`   | DeepSeek base URL   | Optional                                                        | `https://api.deepseek.com`                  |
-| `ai.koog.ollama.base-url`     | Ollama base URL     | Any `ai.koog.ollama.*` property activates `ollamaExecutor` bean | `http://localhost:11434`                    |
+| Property                      | Description         | Bean Condition                         | Default                                     |
+|-------------------------------|---------------------|----------------------------------------|---------------------------------------------|
+| `ai.koog.openai.api-key`      | OpenAI API key      | Required for `openAIExecutor` bean     | -                                           |
+| `ai.koog.openai.base-url`     | OpenAI base URL     | Optional                               | `https://api.openai.com`                    |
+| `ai.koog.anthropic.api-key`   | Anthropic API key   | Required for `anthropicExecutor` bean  | -                                           |
+| `ai.koog.anthropic.base-url`  | Anthropic base URL  | Optional                               | `https://api.anthropic.com`                 |
+| `ai.koog.google.api-key`      | Google API key      | Required for `googleExecutor` bean     | -                                           |
+| `ai.koog.google.base-url`     | Google base URL     | Optional                               | `https://generativelanguage.googleapis.com` |
+| `ai.koog.openrouter.api-key`  | OpenRouter API key  | Required for `openRouterExecutor` bean | -                                           |
+| `ai.koog.openrouter.base-url` | OpenRouter base URL | Optional                               | `https://openrouter.ai`                     |
+| `ai.koog.deepseek.api-key`    | DeepSeek API key    | Required for `deepSeekExecutor` bean   | -                                           |
+| `ai.koog.deepseek.base-url`   | DeepSeek base URL   | Optional                               | `https://api.deepseek.com`                  |
+| `ai.koog.mistral.api-key`     | Mistral API key     | Required for `mistralAIExecutor` bean  | -                                           |
+| `ai.koog.mistral.base-url`    | Mistral base URL    | Optional                               | `https://api.mistral.ai`                    |
+| `ai.koog.ollama.base-url`     | Ollama base URL     | Optional                               | `http://127.0.0.1:11434`                    |
 
 ### Bean Names
 
@@ -441,7 +365,9 @@ The auto-configuration creates the following beans (when configured):
 - `googleExecutor` - Google executor (requires `ai.koog.google.api-key`)
 - `openRouterExecutor` - OpenRouter executor (requires `ai.koog.openrouter.api-key`)
 - `deepSeekExecutor` - DeepSeek executor (requires `ai.koog.deepseek.api-key`)
-- `ollamaExecutor` - Ollama executor (requires any `ai.koog.ollama.*` property)
+- `mistralAIExecutor` - Mistral AI executor (requires `ai.koog.mistral.api-key`)
+- `ollamaExecutor` - Ollama executor (requires `ai.koog.ollama.enabled=true`)
+- `multiLLMPromptExecutor` - MultiLLMPromptExecutor
 
 ## Troubleshooting
 
@@ -450,7 +376,7 @@ The auto-configuration creates the following beans (when configured):
 **Bean not found error:**
 
 ```
-No qualifying bean of type 'MultiLLMPromptExecutor' available
+No qualifying bean of type 'PromptExecutor' available
 ```
 
 **Solution:** Ensure you have configured at least one provider in your properties file.
@@ -458,7 +384,7 @@ No qualifying bean of type 'MultiLLMPromptExecutor' available
 **Multiple beans error:**
 
 ```
-Multiple qualifying beans of type 'MultiLLMPromptExecutor' available
+Multiple qualifying beans of type 'PromptExecutor' available
 ```
 
 **Solution:** Use `@Qualifier` to specify which bean you want:
@@ -468,8 +394,8 @@ Multiple qualifying beans of type 'MultiLLMPromptExecutor' available
     ```kotlin
     @Service
     class MyService(
-        @Qualifier("openAIExecutor") private val openAIExecutor: MultiLLMPromptExecutor,
-        @Qualifier("anthropicExecutor") private val anthropicExecutor: MultiLLMPromptExecutor
+        @Qualifier("openAIExecutor") private val openAIExecutor: PromptExecutor,
+        @Qualifier("anthropicExecutor") private val anthropicExecutor: PromptExecutor
     ) {
         // ...
     }
@@ -480,11 +406,11 @@ Multiple qualifying beans of type 'MultiLLMPromptExecutor' available
     ```java
     @Service
     public class MyService {
-        private final MultiLLMPromptExecutor openAIExecutor;
-        private final MultiLLMPromptExecutor anthropicExecutor;
+        private final PromptExecutor openAIExecutor;
+        private final PromptExecutor anthropicExecutor;
 
-        public MyService(@Qualifier("openAIExecutor") MultiLLMPromptExecutor openAIExecutor,
-                         @Qualifier("anthropicExecutor") MultiLLMPromptExecutor anthropicExecutor) {
+        public MyService(@Qualifier("openAIExecutor") PromptExecutor openAIExecutor,
+                         @Qualifier("anthropicExecutor") PromptExecutor anthropicExecutor) {
             this.openAIExecutor = openAIExecutor;
             this.anthropicExecutor = anthropicExecutor;
         }
@@ -503,8 +429,7 @@ API key is required but not provided
 ## Best Practices
 
 1. **Environment Variables**: Always use environment variables for API keys
-2. **Nullable Injection**: Use nullable types (`MultiLLMPromptExecutor?`) to handle cases where providers aren't
-   configured
+2. **Nullable Injection**: Use nullable types to handle cases where providers aren't configured
 3. **Fallback Logic**: Implement fallback mechanisms when using multiple providers
 4. **Error Handling**: Always wrap executor calls in try-catch blocks for production code
 5. **Testing**: Use mocks in tests to avoid making actual API calls

--- a/docs/docs/streaming-api.md
+++ b/docs/docs/streaming-api.md
@@ -1,8 +1,5 @@
 # Streaming API
 
-
-## Introduction
-
 Koog’s **Streaming API** lets you consume **LLM output incrementally** as a `Flow<StreamFrame>`. Instead of waiting for a full response, your code can:
 
 - render assistant text as it arrives,
@@ -26,9 +23,7 @@ The stream carries **typed frames** organized into two categories:
 
 Helpers are provided to extract plain text, convert frames to `Message.Response` objects, and safely **combine chunked tool calls**.
 
----
-
-## Streaming API overview
+## API overview
 
 With streaming you can:
 
@@ -57,73 +52,86 @@ Typically, you'll work with delta frames for UI updates and complete frames for 
 
 This is the most general approach: react to each frame kind.
 
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.prompt.streaming.StreamFrame
+=== "Kotlin"
 
-val strategy = strategy<String, String>("strategy_name") {
-    val node by node<Unit, Unit> {
--->
-<!--- SUFFIX
-   }
-}
--->
-```kotlin
-llm.writeSession {
-    appendPrompt { user("Tell me a joke, then call a tool with JSON args.") }
-
-    val stream = requestLLMStreaming() // Flow<StreamFrame>
-
-    stream.collect { frame ->
-        when (frame) {
-            is StreamFrame.TextDelta -> print(frame.text)
-            is StreamFrame.ReasoningDelta -> print("[Reasoning] text=${frame.text} summary=${frame.summary}")
-            is StreamFrame.ToolCallComplete -> {
-                println("\n🔧 Tool call: ${frame.name} args=${frame.content}")
-                // Optionally parse lazily:
-                // val json = frame.contentJson
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.prompt.streaming.StreamFrame
+    
+    val strategy = strategy<String, String>("strategy_name") {
+        val node by node<Unit, Unit> {
+    -->
+    <!--- SUFFIX
+       }
+    }
+    -->
+    ```kotlin
+    llm.writeSession {
+        appendPrompt { user("Tell me a joke, then call a tool with JSON args.") }
+    
+        val stream = requestLLMStreaming() // Flow<StreamFrame>
+    
+        stream.collect { frame ->
+            when (frame) {
+                is StreamFrame.TextDelta -> print(frame.text)
+                is StreamFrame.ReasoningDelta -> print("[Reasoning] text=${frame.text} summary=${frame.summary}")
+                is StreamFrame.ToolCallComplete -> {
+                    println("\n🔧 Tool call: ${frame.name} args=${frame.content}")
+                    // Optionally parse lazily:
+                    // val json = frame.contentJson
+                }
+                is StreamFrame.End -> println("\n[END] reason=${frame.finishReason}")
+                else -> {} // Handle other frame types (TextComplete, ToolCallDelta, etc.)
             }
-            is StreamFrame.End -> println("\n[END] reason=${frame.finishReason}")
-            else -> {} // Handle other frame types (TextComplete, ToolCallDelta, etc.)
         }
     }
-}
-```
-<!--- KNIT example-streaming-api-01.kt -->
+    ```
+    <!--- KNIT example-streaming-api-01.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 It is important to note that you can parse the output by working directly with a raw string stream.
 This approach gives you more flexibility and control over the parsing process.
 
 Here is a raw string stream with the Markdown definition of the output structure:
 
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.prompt.structure.markdown.MarkdownStructureDefinition
+=== "Kotlin"
 
-val strategy = strategy<String, String>("strategy_name") {
-    val node by node<Unit, Unit> {
--->
-<!--- SUFFIX
-   }
-}
--->
-```kotlin
-fun markdownBookDefinition(): MarkdownStructureDefinition {
-    return MarkdownStructureDefinition("name", schema = { /*...*/ })
-}
-
-val mdDefinition = markdownBookDefinition()
-
-llm.writeSession {
-    val stream = requestLLMStreaming(mdDefinition)
-    // Access the raw string chunks directly
-    stream.collect { chunk ->
-        // Process each chunk of text as it arrives
-        println("Received chunk: $chunk") // The chunks together will be structured as a text following the mdDefinition schema
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.prompt.structure.markdown.MarkdownStructureDefinition
+    val strategy = strategy<String, String>("strategy_name") {
+        val node by node<Unit, Unit> {
+    -->
+    <!--- SUFFIX
+       }
     }
-}
-```
-<!--- KNIT example-streaming-api-02.kt -->
+    -->
+    ```kotlin
+    fun markdownBookDefinition(): MarkdownStructureDefinition {
+        return MarkdownStructureDefinition("name", schema = { /*...*/ })
+    }
+
+    val mdDefinition = markdownBookDefinition()
+
+    llm.writeSession {
+        val stream = requestLLMStreaming(mdDefinition)
+        // Access the raw string chunks directly
+        stream.collect { chunk ->
+            // Process each chunk of text as it arrives
+            println("Received chunk: $chunk") // The chunks together will be structured as a text following the mdDefinition schema
+        }
+    }
+    ```
+    <!--- KNIT example-streaming-api-02.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 ### Working with reasoning frames
 
@@ -179,69 +187,82 @@ llm.writeSession {
 If you have existing streaming parsers that expect `Flow<String>`,
 derive text chunks via `filterTextOnly()` or collect them with `collectText()`.
 
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.prompt.streaming.filterTextOnly
-import ai.koog.prompt.streaming.collectText
+=== "Kotlin"
 
-val strategy = strategy<String, String>("strategy_name") {
-    val node by node<Unit, Unit> {
--->
-<!--- SUFFIX
-   }
-}
--->
-```kotlin
-llm.writeSession {
-    val frames = requestLLMStreaming()
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.prompt.streaming.filterTextOnly
+    import ai.koog.prompt.streaming.collectText
+    val strategy = strategy<String, String>("strategy_name") {
+        val node by node<Unit, Unit> {
+    -->
+    <!--- SUFFIX
+       }
+    }
+    -->
+    ```kotlin
+    llm.writeSession {
+        val frames = requestLLMStreaming()
 
-    // Stream text chunks as they come:
-    frames.filterTextOnly().collect { chunk -> print(chunk) }
+        // Stream text chunks as they come:
+        frames.filterTextOnly().collect { chunk -> print(chunk) }
 
-    // Or, gather all text into one String after End:
-    val fullText = frames.collectText()
-    println("\n---\n$fullText")
-}
-```
-<!--- KNIT example-streaming-api-02-01.kt -->
+        // Or, gather all text into one String after End:
+        val fullText = frames.collectText()
+        println("\n---\n$fullText")
+    }
+    ```
+    <!--- KNIT example-streaming-api-02-01.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 ### Listening to stream events in event handlers
 
 You can listen to stream events in [agent event handlers](agent-event-handlers.md).
 
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.agent.GraphAIAgent
-import ai.koog.agents.features.eventHandler.feature.handleEvents
-import ai.koog.prompt.streaming.StreamFrame
-import ai.koog.prompt.structure.markdown.MarkdownStructureDefinition
+=== "Kotlin"
 
-fun GraphAIAgent.FeatureContext.installStreamingApi() {
--->
-<!--- SUFFIX
-}
--->
-```kotlin
-handleEvents {
-    onToolCallStarting { context ->
-        println("\n🔧 Using ${context.toolName} with ${context.toolArgs}... ")
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.agents.core.agent.GraphAIAgent
+    import ai.koog.agents.features.eventHandler.feature.handleEvents
+    import ai.koog.prompt.streaming.StreamFrame
+    import ai.koog.prompt.structure.markdown.MarkdownStructureDefinition
+    
+    fun GraphAIAgent.FeatureContext.installStreamingApi() {
+    -->
+    <!--- SUFFIX
     }
-    onLLMStreamingFrameReceived { context ->
-        when (val frame = context.streamFrame) {
-            is StreamFrame.TextDelta -> print(frame.text)
-            is StreamFrame.ReasoningDelta -> print("[Reasoning] text=${frame.text} summary=${frame.summary}")
-            else -> {} // Handle other frame types if needed
+    -->
+    ```kotlin
+    handleEvents {
+        onToolCallStarting { context ->
+            println("\n🔧 Using ${context.toolName} with ${context.toolArgs}... ")
+        }
+        onLLMStreamingFrameReceived { context ->
+            when (val frame = context.streamFrame) {
+                is StreamFrame.TextDelta -> print(frame.text)
+                is StreamFrame.ReasoningDelta -> print("[Reasoning] text=${frame.text} summary=${frame.summary}")
+                else -> {} // Handle other frame types if needed
+            }
+        }
+        onLLMStreamingFailed { context ->
+            println("❌ Error: ${context.error}")
+        }
+        onLLMStreamingCompleted {
+            println("🏁 Done")
         }
     }
-    onLLMStreamingFailed { context ->
-        println("❌ Error: ${context.error}")
-    }
-    onLLMStreamingCompleted {
-        println("🏁 Done")
-    }
-}
-```
-<!--- KNIT example-streaming-api-02-02.kt -->
+    ```
+    <!--- KNIT example-streaming-api-02-02.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 ### Converting frames to `Message.Response`
 
@@ -250,8 +271,6 @@ You can transform a collected list of frames to standard message objects:
 - `toReasoningMessageOrNull()` — extracts `Message.Reasoning` from reasoning frames
 - `toToolCallMessages()` — extracts `Message.Tool.Call` from tool call frames
 - `toMessageResponses()` — converts all complete frames to their corresponding `Message.Response` objects
-
----
 
 ## Examples
 
@@ -273,171 +292,216 @@ The sections below provide step-by-step instructions and code samples related to
 
 First, define a data class to represent your structured data:
 
-<!--- INCLUDE
-import kotlinx.serialization.Serializable
--->
-```kotlin
-@Serializable
-data class Book(
-    val title: String,
-    val author: String,
-    val description: String
-)
-```
-<!--- KNIT example-streaming-api-03.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import kotlinx.serialization.Serializable
+    -->
+    ```kotlin
+    @Serializable
+    data class Book(
+        val title: String,
+        val author: String,
+        val description: String
+    )
+    ```
+    <!--- KNIT example-streaming-api-03.kt -->
+
+=== "Java"
+
+    ```java
+    // A simple Java POJO equivalent to the Kotlin @Serializable data class.
+    public class Book {
+        public final String title;
+        public final String author;
+        public final String description;
+
+        public Book(String title, String author, String description) {
+            this.title = title;
+            this.author = author;
+            this.description = description;
+        }
+    }
+    ```
 
 #### 2. Define the Markdown structure
 
 Create a definition that specifies how your data should be structured in Markdown with the
 `MarkdownStructureDefinition` class:
 
-<!--- INCLUDE
-import ai.koog.prompt.markdown.markdown
-import ai.koog.prompt.structure.markdown.MarkdownStructureDefinition
--->
-```kotlin
-fun markdownBookDefinition(): MarkdownStructureDefinition {
-    return MarkdownStructureDefinition("bookList", schema = {
-        markdown {
-            header(1, "title")
-            bulleted {
-                item("author")
-                item("description")
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.prompt.markdown.markdown
+    import ai.koog.prompt.structure.markdown.MarkdownStructureDefinition
+    -->
+    ```kotlin
+    fun markdownBookDefinition(): MarkdownStructureDefinition {
+        return MarkdownStructureDefinition("bookList", schema = {
+            markdown {
+                header(1, "title")
+                bulleted {
+                    item("author")
+                    item("description")
+                }
             }
-        }
-    }, examples = {
-        markdown {
-            header(1, "The Great Gatsby")
-            bulleted {
-                item("F. Scott Fitzgerald")
-                item("A novel set in the Jazz Age that tells the story of Jay Gatsby's unrequited love for Daisy Buchanan.")
+        }, examples = {
+            markdown {
+                header(1, "The Great Gatsby")
+                bulleted {
+                    item("F. Scott Fitzgerald")
+                    item("A novel set in the Jazz Age that tells the story of Jay Gatsby's unrequited love for Daisy Buchanan.")
+                }
             }
-        }
-    })
-}
-```
-<!--- KNIT example-streaming-api-04.kt -->
+        })
+    }
+    ```
+    <!--- KNIT example-streaming-api-04.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 #### 3. Create a parser for your data structure
 
 The `markdownStreamingParser` provides several handlers for different Markdown elements:
 
-<!--- INCLUDE
-import ai.koog.agents.example.exampleStreamingApi03.Book
-import ai.koog.prompt.structure.markdown.markdownStreamingParser
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+=== "Kotlin"
 
-fun parseMarkdownStreamToBooks(markdownStream: Flow<String>): Flow<Book> {
-    return flow {
--->
-<!--- SUFFIX
-   }
-}
--->
-```kotlin
-markdownStreamingParser {
-    // Handle level 1 headings (level ranges from 1 to 6)
-    onHeader(1) { headerText -> }
-    // Handle bullet points
-    onBullet { bulletText -> }
-    // Handle code blocks
-    onCodeBlock { codeBlockContent -> }
-    // Handle lines matching a regex pattern
-    onLineMatching(Regex("pattern")) { line -> }
-    // Handle the end of the stream
-    onFinishStream { remainingText -> }
-}
-```
-<!--- KNIT example-streaming-api-05.kt -->
+    <!--- INCLUDE
+    import ai.koog.agents.example.exampleStreamingApi03.Book
+    import ai.koog.prompt.structure.markdown.markdownStreamingParser
+    import kotlinx.coroutines.flow.Flow
+    import kotlinx.coroutines.flow.flow
+    fun parseMarkdownStreamToBooks(markdownStream: Flow<String>): Flow<Book> {
+        return flow {
+    -->
+    <!--- SUFFIX
+       }
+    }
+    -->
+    ```kotlin
+    markdownStreamingParser {
+        // Handle level 1 headings (level ranges from 1 to 6)
+        onHeader(1) { headerText -> }
+        // Handle bullet points
+        onBullet { bulletText -> }
+        // Handle code blocks
+        onCodeBlock { codeBlockContent -> }
+        // Handle lines matching a regex pattern
+        onLineMatching(Regex("pattern")) { line -> }
+        // Handle the end of the stream
+        onFinishStream { remainingText -> }
+    }
+    ```
+    <!--- KNIT example-streaming-api-05.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 Using the defined handlers, you can implement a function that parses the Markdown stream and emits your data objects 
 with the `markdownStreamingParser` function.
 
-<!--- INCLUDE
-import ai.koog.agents.example.exampleStreamingApi03.Book
-import ai.koog.prompt.structure.markdown.markdownStreamingParser
-import ai.koog.prompt.streaming.StreamFrame
-import ai.koog.prompt.streaming.filterTextOnly
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+=== "Kotlin"
 
--->
-```kotlin
-fun parseMarkdownStreamToBooks(markdownStream: Flow<StreamFrame>): Flow<Book> {
-   return flow {
-      markdownStreamingParser {
-         var currentBookTitle = ""
-         val bulletPoints = mutableListOf<String>()
+    <!--- INCLUDE
+    import ai.koog.agents.example.exampleStreamingApi03.Book
+    import ai.koog.prompt.structure.markdown.markdownStreamingParser
+    import ai.koog.prompt.streaming.StreamFrame
+    import ai.koog.prompt.streaming.filterTextOnly
+    import kotlinx.coroutines.flow.Flow
+    import kotlinx.coroutines.flow.flow
+    -->
+    ```kotlin
+    fun parseMarkdownStreamToBooks(markdownStream: Flow<StreamFrame>): Flow<Book> {
+       return flow {
+          markdownStreamingParser {
+             var currentBookTitle = ""
+             val bulletPoints = mutableListOf<String>()
 
-         // Handle the event of receiving the Markdown header in the response stream
-         onHeader(1) { headerText ->
-            // If there was a previous book, emit it
-            if (currentBookTitle.isNotEmpty() && bulletPoints.isNotEmpty()) {
-               val author = bulletPoints.getOrNull(0) ?: ""
-               val description = bulletPoints.getOrNull(1) ?: ""
-               emit(Book(currentBookTitle, author, description))
-            }
+             // Handle the event of receiving the Markdown header in the response stream
+             onHeader(1) { headerText ->
+                // If there was a previous book, emit it
+                if (currentBookTitle.isNotEmpty() && bulletPoints.isNotEmpty()) {
+                   val author = bulletPoints.getOrNull(0) ?: ""
+                   val description = bulletPoints.getOrNull(1) ?: ""
+                   emit(Book(currentBookTitle, author, description))
+                }
 
-            currentBookTitle = headerText
-            bulletPoints.clear()
-         }
+                currentBookTitle = headerText
+                bulletPoints.clear()
+             }
 
-         // Handle the event of receiving the Markdown bullets list in the response stream
-         onBullet { bulletText ->
-            bulletPoints.add(bulletText)
-         }
+             // Handle the event of receiving the Markdown bullets list in the response stream
+             onBullet { bulletText ->
+                bulletPoints.add(bulletText)
+             }
 
-         // Handle the end of the response stream
-         onFinishStream {
-            // Emit the last book, if present
-            if (currentBookTitle.isNotEmpty() && bulletPoints.isNotEmpty()) {
-               val author = bulletPoints.getOrNull(0) ?: ""
-               val description = bulletPoints.getOrNull(1) ?: ""
-               emit(Book(currentBookTitle, author, description))
-            }
-         }
-      }.parseStream(markdownStream.filterTextOnly())
-   }
-}
-```
-<!--- KNIT example-streaming-api-06.kt -->
+             // Handle the end of the response stream
+             onFinishStream {
+                // Emit the last book, if present
+                if (currentBookTitle.isNotEmpty() && bulletPoints.isNotEmpty()) {
+                   val author = bulletPoints.getOrNull(0) ?: ""
+                   val description = bulletPoints.getOrNull(1) ?: ""
+                   emit(Book(currentBookTitle, author, description))
+                }
+             }
+          }.parseStream(markdownStream.filterTextOnly())
+       }
+    }
+    ```
+    <!--- KNIT example-streaming-api-06.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 #### 4. Use the parser in your agent strategy
 
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.forwardTo
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.example.exampleStreamingApi03.Book
-import ai.koog.agents.example.exampleStreamingApi04.markdownBookDefinition
-import ai.koog.agents.example.exampleStreamingApi06.parseMarkdownStreamToBooks
--->
-```kotlin
-val agentStrategy = strategy<String, List<Book>>("library-assistant") {
-   // Describe the node containing the output stream parsing
-   val getMdOutput by node<String, List<Book>> { booksDescription ->
-      val books = mutableListOf<Book>()
-      val mdDefinition = markdownBookDefinition()
+=== "Kotlin"
 
-      llm.writeSession {
-         appendPrompt { user(booksDescription) }
-         // Initiate the response stream in the form of the definition `mdDefinition`
-         val markdownStream = requestLLMStreaming(mdDefinition)
-         // Call the parser with the result of the response stream and perform actions with the result
-         parseMarkdownStreamToBooks(markdownStream).collect { book ->
-            books.add(book)
-            println("Parsed Book: ${book.title} by ${book.author}")
-         }
-      }
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.forwardTo
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.agents.example.exampleStreamingApi03.Book
+    import ai.koog.agents.example.exampleStreamingApi04.markdownBookDefinition
+    import ai.koog.agents.example.exampleStreamingApi06.parseMarkdownStreamToBooks
+    -->
+    ```kotlin
+    val agentStrategy = strategy<String, List<Book>>("library-assistant") {
+       // Describe the node containing the output stream parsing
+       val getMdOutput by node<String, List<Book>> { booksDescription ->
+          val books = mutableListOf<Book>()
+          val mdDefinition = markdownBookDefinition()
 
-      books
-   }
-   // Describe the agent's graph making sure the node is accessible
-   edge(nodeStart forwardTo getMdOutput)
-   edge(getMdOutput forwardTo nodeFinish)
-}
-```
-<!--- KNIT example-streaming-api-07.kt -->
+          llm.writeSession {
+             appendPrompt { user(booksDescription) }
+             // Initiate the response stream in the form of the definition `mdDefinition`
+             val markdownStream = requestLLMStreaming(mdDefinition)
+             // Call the parser with the result of the response stream and perform actions with the result
+             parseMarkdownStreamToBooks(markdownStream).collect { book ->
+                books.add(book)
+                println("Parsed Book: ${book.title} by ${book.author}")
+             }
+          }
+
+          books
+       }
+       // Describe the agent's graph making sure the node is accessible
+       edge(nodeStart forwardTo getMdOutput)
+       edge(getMdOutput forwardTo nodeFinish)
+    }
+    ```
+    <!--- KNIT example-streaming-api-07.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 ### Advanced usage: Streaming with tools
 
@@ -446,79 +510,91 @@ The following sections provide a brief step-by-step guide on how to define a too
 
 ### 1. Define a tool for your data structure
 
-<!--- INCLUDE
-import ai.koog.agents.core.tools.SimpleTool
-import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.agents.example.exampleStreamingApi03.Book
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
+=== "Kotlin"
 
--->
-```kotlin
-@Serializable
-data class Book(
-   val title: String,
-   val author: String,
-   val description: String
-)
-
-class BookTool(): SimpleTool<Book>(
-    argsSerializer = Book.serializer(),
-    name = NAME,
-    description = "A tool to parse book information from Markdown"
-) {
-
-    companion object { const val NAME = "book" }
-
-    override suspend fun execute(args: Book): String {
-        println("${args.title} by ${args.author}:\n ${args.description}")
-        return "Done"
+    <!--- INCLUDE
+    import ai.koog.agents.core.tools.SimpleTool
+    import ai.koog.agents.core.tools.ToolDescriptor
+    import ai.koog.agents.example.exampleStreamingApi03.Book
+    import kotlinx.serialization.KSerializer
+    import kotlinx.serialization.Serializable
+    -->
+    ```kotlin
+    @Serializable
+    data class Book(
+       val title: String,
+       val author: String,
+       val description: String
+    )
+    
+    class BookTool(): SimpleTool<Book>(
+        argsSerializer = Book.serializer(),
+        name = NAME,
+        description = "A tool to parse book information from Markdown"
+    ) {
+    
+        companion object { const val NAME = "book" }
+    
+        override suspend fun execute(args: Book): String {
+            println("${args.title} by ${args.author}:\n ${args.description}")
+            return "Done"
+        }
     }
-}
-```
-<!--- KNIT example-streaming-api-08.kt -->
+    ```
+    <!--- KNIT example-streaming-api-08.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 ### 2. Use the tool with streaming data
 
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.forwardTo
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.example.exampleStreamingApi04.markdownBookDefinition
-import ai.koog.agents.example.exampleStreamingApi06.parseMarkdownStreamToBooks
-import ai.koog.agents.example.exampleStreamingApi08.BookTool
-import ai.koog.agents.core.agent.session.callToolRaw
+=== "Kotlin"
 
--->
-```kotlin
-val agentStrategy = strategy<String, Unit>("library-assistant") {
-   val getMdOutput by node<String, Unit> { input ->
-      val mdDefinition = markdownBookDefinition()
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.forwardTo
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.agents.example.exampleStreamingApi04.markdownBookDefinition
+    import ai.koog.agents.example.exampleStreamingApi06.parseMarkdownStreamToBooks
+    import ai.koog.agents.example.exampleStreamingApi08.BookTool
+    import ai.koog.agents.core.agent.session.callToolRaw
+    -->
+    ```kotlin
+    val agentStrategy = strategy<String, Unit>("library-assistant") {
+       val getMdOutput by node<String, Unit> { input ->
+          val mdDefinition = markdownBookDefinition()
 
-      llm.writeSession {
-         appendPrompt { user(input) }
-         val markdownStream = requestLLMStreaming(mdDefinition)
+          llm.writeSession {
+             appendPrompt { user(input) }
+             val markdownStream = requestLLMStreaming(mdDefinition)
 
-         parseMarkdownStreamToBooks(markdownStream).collect { book ->
-            callToolRaw(BookTool.NAME, book)
-            /* Other possible options:
-                callTool(BookTool::class, book)
-                callTool<BookTool>(book)
-                findTool(BookTool::class).execute(book)
-            */
-         }
+             parseMarkdownStreamToBooks(markdownStream).collect { book ->
+                callToolRaw(BookTool.NAME, book)
+                /* Other possible options:
+                    callTool(BookTool::class, book)
+                    callTool<BookTool>(book)
+                    findTool(BookTool::class).execute(book)
+                */
+             }
 
-         // We can make parallel tool calls
-         parseMarkdownStreamToBooks(markdownStream).toParallelToolCallsRaw(toolClass=BookTool::class).collect {
-            println("Tool call result: $it")
-         }
-      }
-   }
+             // We can make parallel tool calls
+             parseMarkdownStreamToBooks(markdownStream).toParallelToolCallsRaw(toolClass=BookTool::class).collect {
+                println("Tool call result: $it")
+             }
+          }
+       }
 
-   edge(nodeStart forwardTo getMdOutput)
-   edge(getMdOutput forwardTo nodeFinish)
- }
-```
-<!--- KNIT example-streaming-api-09.kt -->
+       edge(nodeStart forwardTo getMdOutput)
+       edge(getMdOutput forwardTo nodeFinish)
+     }
+    ```
+    <!--- KNIT example-streaming-api-09.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 ### 3. Register the tool in your agent configuration
 

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -21,6 +21,7 @@ The primary purpose of this feature is to facilitate testing of agent-based AI f
 ### Setting up test dependencies
 
 Before setting up a test environment, make sure that you have added the following dependencies:
+
 <!--- INCLUDE
 /*
 -->
@@ -35,137 +36,166 @@ dependencies {
 }
 ```
 <!--- KNIT example-testing-01.kt -->
+
 ### Mocking LLM responses
 
 The basic form of testing involves mocking LLM responses to ensure deterministic behavior. You can do this using  `MockLLMBuilder` and related utilities.
 
-<!--- INCLUDE
-import ai.koog.agents.core.tools.ToolRegistry
-import ai.koog.agents.testing.tools.getMockExecutor
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.tools.ToolRegistry
+    import ai.koog.agents.testing.tools.getMockExecutor
 
 
-val toolRegistry = ToolRegistry {}
+    val toolRegistry = ToolRegistry {}
 
--->
-```kotlin
-// Create a mock LLM executor
-val mockLLMApi = getMockExecutor(toolRegistry) {
-  // Mock a simple text response
-  mockLLMAnswer("Hello!") onRequestContains "Hello"
+    -->
+    ```kotlin
+    // Create a mock LLM executor
+    val mockLLMApi = getMockExecutor(toolRegistry) {
+      // Mock a simple text response
+      mockLLMAnswer("Hello!") onRequestContains "Hello"
 
-  // Mock a default response
-  mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
-}
-```
-<!--- KNIT example-testing-02.kt -->
+      // Mock a default response
+      mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+    }
+    ```
+    <!--- KNIT example-testing-02.kt -->
+
+=== "Java"
+
+    ```java
+    import ai.koog.agents.core.tools.ToolRegistry;
+    import ai.koog.agents.testing.tools.MockExecutor;
+    import ai.koog.prompt.executor.model.PromptExecutor;
+
+    // Create a tool registry (empty)
+    ToolRegistry toolRegistry = ToolRegistry.builder().build();
+
+    // Create a mock LLM executor
+    PromptExecutor mockLLMApi = MockExecutor.builder()
+        .toolRegistry(toolRegistry)
+        .mockLLMAnswer("Hello!").onRequestContains("Hello")
+        .mockLLMAnswer("I don't know how to answer that.").asDefaultResponse()
+        .build();
+    ```
 
 ### Mocking tool calls
 
 You can mock the LLM to call specific tools based on input patterns:
-<!--- INCLUDE
-import ai.koog.agents.core.tools.*
-import ai.koog.agents.ext.tool.AskUser
-import ai.koog.agents.ext.tool.SayToUser
-import ai.koog.agents.testing.tools.getMockExecutor
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.builtins.serializer
-import ai.koog.agents.core.tools.annotations.LLMDescription
 
-public object CreateTool : Tool<CreateTool.Args, String>(
-    argsSerializer = Args.serializer(),
-    resultSerializer = String.serializer(),
-    name = "message",
-    description = "Service tool, used by the agent to talk with user"
-) {
-    /**
-    * Represents the arguments for the [AskUser] tool
-    *
-    * @property message The message to be used as an argument for the tool's execution.
-    */
-    @Serializable
-    public data class Args(
-        @property:LLMDescription("Message from the agent")
-        val message: String
-    )
+=== "Kotlin"
 
-    override suspend fun execute(args: Args): String = args.message
-}
+    <!--- INCLUDE
+    import ai.koog.agents.core.tools.*
+    import ai.koog.agents.ext.tool.AskUser
+    import ai.koog.agents.ext.tool.SayToUser
+    import ai.koog.agents.testing.tools.getMockExecutor
+    import kotlinx.serialization.KSerializer
+    import kotlinx.serialization.Serializable
+    import kotlinx.serialization.builtins.serializer
+    import ai.koog.agents.core.tools.annotations.LLMDescription
 
-public object SearchTool : Tool<SearchTool.Args, String>(
-    argsSerializer = Args.serializer(),
-    resultSerializer = String.serializer(),
-    name = "message",
-    description = "Service tool, used by the agent to talk with user"
-) {
-    /**
-    * Represents the arguments for the [AskUser] tool
-    *
-    * @property message The message to be used as an argument for the tool's execution.
-    */
-    @Serializable
-    public data class Args(
-        @property:LLMDescription("Message from the agent")
-        val query: String
-    )
+    public object CreateTool : Tool<CreateTool.Args, String>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = String.serializer(),
+        name = "message",
+        description = "Service tool, used by the agent to talk with user"
+    ) {
+        /**
+        * Represents the arguments for the [AskUser] tool
+        *
+        * @property message The message to be used as an argument for the tool's execution.
+        */
+        @Serializable
+        public data class Args(
+            @property:LLMDescription("Message from the agent")
+            val message: String
+        )
 
-    override suspend fun execute(args: Args): String = args.query
-}
+        override suspend fun execute(args: Args): String = args.message
+    }
+
+    public object SearchTool : Tool<SearchTool.Args, String>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = String.serializer(),
+        name = "message",
+        description = "Service tool, used by the agent to talk with user"
+    ) {
+        /**
+        * Represents the arguments for the [AskUser] tool
+        *
+        * @property message The message to be used as an argument for the tool's execution.
+        */
+        @Serializable
+        public data class Args(
+            @property:LLMDescription("Message from the agent")
+            val query: String
+        )
+
+        override suspend fun execute(args: Args): String = args.query
+    }
 
 
-public object AnalyzeTool : Tool<AnalyzeTool.Args, String>(
-    argsSerializer = Args.serializer(),
-    resultSerializer = String.serializer(),
-    name = "message",
-    description = "Service tool, used by the agent to talk with user"
-) {
-    /**
-    * Represents the arguments for the [AskUser] tool
-    *
-    * @property message The message to be used as an argument for the tool's execution.
-    */
-    @Serializable
-    public data class Args(
-        @property:LLMDescription("Message from the agent")
-        val query: String
-    )
+    public object AnalyzeTool : Tool<AnalyzeTool.Args, String>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = String.serializer(),
+        name = "message",
+        description = "Service tool, used by the agent to talk with user"
+    ) {
+        /**
+        * Represents the arguments for the [AskUser] tool
+        *
+        * @property message The message to be used as an argument for the tool's execution.
+        */
+        @Serializable
+        public data class Args(
+            @property:LLMDescription("Message from the agent")
+            val query: String
+        )
 
-    override suspend fun execute(args: Args): String = args.query
-}
+        override suspend fun execute(args: Args): String = args.query
+    }
 
-typealias PositiveToneTool = SayToUser
-typealias NegativeToneTool = SayToUser
+    typealias PositiveToneTool = SayToUser
+    typealias NegativeToneTool = SayToUser
 
-val mockLLMApi = getMockExecutor {
--->
-<!--- SUFFIX
-}
--->
-```kotlin
-// Mock a tool call response
-mockLLMToolCall(CreateTool, CreateTool.Args("solve")) onRequestEquals "Solve task"
+    val mockLLMApi = getMockExecutor {
+    -->
+    <!--- SUFFIX
+    }
+    -->
+    ```kotlin
+    // Mock a tool call response
+    mockLLMToolCall(CreateTool, CreateTool.Args("solve")) onRequestEquals "Solve task"
 
-// Mock tool behavior - simplest form without lambda
-mockTool(PositiveToneTool) alwaysReturns "The text has a positive tone."
+    // Mock tool behavior - simplest form without lambda
+    mockTool(PositiveToneTool) alwaysReturns "The text has a positive tone."
 
-// Using lambda when you need to perform extra actions
-mockTool(NegativeToneTool) alwaysTells {
-  // Perform some extra action
-  println("Negative tone tool called")
+    // Using lambda when you need to perform extra actions
+    mockTool(NegativeToneTool) alwaysTells {
+      // Perform some extra action
+      println("Negative tone tool called")
 
-  // Return the result
-  "The text has a negative tone."
-}
+      // Return the result
+      "The text has a negative tone."
+    }
 
-// Mock tool behavior based on specific arguments
-mockTool(AnalyzeTool) returns "Detailed analysis" onArguments AnalyzeTool.Args("analyze deeply")
+    // Mock tool behavior based on specific arguments
+    mockTool(AnalyzeTool) returns "Detailed analysis" onArguments AnalyzeTool.Args("analyze deeply")
 
-// Mock tool behavior with conditional argument matching
-mockTool(SearchTool) returns "Found results" onArgumentsMatching { args ->
-  args.query.contains("important")
-}
-```
-<!--- KNIT example-testing-03.kt -->
+    // Mock tool behavior with conditional argument matching
+    mockTool(SearchTool) returns "Found results" onArgumentsMatching { args ->
+      args.query.contains("important")
+    }
+    ```
+    <!--- KNIT example-testing-03.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 The examples above demonstrate different ways to mock tools, from simple to more complex ones:
 
@@ -178,33 +208,40 @@ The examples above demonstrate different ways to mock tools, from simple to more
 
 To enable the testing mode on an agent, use the `withTesting()` function within the AIAgent constructor block:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.example.exampleTesting02.mockLLMApi
-import ai.koog.agents.example.exampleTesting02.toolRegistry
-import ai.koog.agents.testing.feature.withTesting
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
+=== "Kotlin"
 
-val llmModel = OpenAIModels.Chat.GPT4o
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.example.exampleTesting02.mockLLMApi
+    import ai.koog.agents.example.exampleTesting02.toolRegistry
+    import ai.koog.agents.testing.feature.withTesting
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
 
-// Create the agent with testing enabled
-fun main() {
--->
-<!--- SUFFIX
-}
--->
-```kotlin
-// Create the agent with testing enabled
-AIAgent(
-    promptExecutor = mockLLMApi,
-    toolRegistry = toolRegistry,
-    llmModel = llmModel
-) {
-    // Enable testing mode
-    withTesting()
-}
-```
-<!--- KNIT example-testing-04.kt -->
+    val llmModel = OpenAIModels.Chat.GPT4o
+
+    // Create the agent with testing enabled
+    fun main() {
+    -->
+    <!--- SUFFIX
+    }
+    -->
+    ```kotlin
+    // Create the agent with testing enabled
+    AIAgent(
+        promptExecutor = mockLLMApi,
+        toolRegistry = toolRegistry,
+        llmModel = llmModel
+    ) {
+        // Enable testing mode
+        withTesting()
+    }
+    ```
+    <!--- KNIT example-testing-04.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 ## Advanced testing
 
@@ -218,60 +255,67 @@ The Testing feature provides a comprehensive way to test your agent's graph stru
 
 Start by validating the fundamental structure of your agent's graph:
 
-<!--- INCLUDE
+=== "Kotlin"
 
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.environment.ReceivedToolResult
-import ai.koog.agents.example.exampleTesting02.mockLLMApi
-import ai.koog.agents.example.exampleTesting02.toolRegistry
-import ai.koog.agents.testing.feature.testGraph
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.message.Message
+    <!--- INCLUDE
+
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.environment.ReceivedToolResult
+    import ai.koog.agents.example.exampleTesting02.mockLLMApi
+    import ai.koog.agents.example.exampleTesting02.toolRegistry
+    import ai.koog.agents.testing.feature.testGraph
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.message.Message
 
 
-val llmModel = OpenAIModels.Chat.GPT4o
+    val llmModel = OpenAIModels.Chat.GPT4o
 
-fun main() {
+    fun main() {
 
--->
-<!--- SUFFIX
-}
--->
-```kotlin
-AIAgent(
-    // Constructor arguments
-    promptExecutor = mockLLMApi,
-    toolRegistry = toolRegistry,
-    llmModel = llmModel
-) {
-    testGraph<String, String>("test") {
-        val firstSubgraph = assertSubgraphByName<String, String>("first")
-        val secondSubgraph = assertSubgraphByName<String, String>("second")
+    -->
+    <!--- SUFFIX
+    }
+    -->
+    ```kotlin
+    AIAgent(
+        // Constructor arguments
+        promptExecutor = mockLLMApi,
+        toolRegistry = toolRegistry,
+        llmModel = llmModel
+    ) {
+        testGraph<String, String>("test") {
+            val firstSubgraph = assertSubgraphByName<String, String>("first")
+            val secondSubgraph = assertSubgraphByName<String, String>("second")
 
-        // Assert subgraph connections
-        assertEdges {
-            startNode() alwaysGoesTo firstSubgraph
-            firstSubgraph alwaysGoesTo secondSubgraph
-            secondSubgraph alwaysGoesTo finishNode()
-        }
+            // Assert subgraph connections
+            assertEdges {
+                startNode() alwaysGoesTo firstSubgraph
+                firstSubgraph alwaysGoesTo secondSubgraph
+                secondSubgraph alwaysGoesTo finishNode()
+            }
 
-        // Verify the first subgraph
-        verifySubgraph(firstSubgraph) {
-            val start = startNode()
-            val finish = finishNode()
+            // Verify the first subgraph
+            verifySubgraph(firstSubgraph) {
+                val start = startNode()
+                val finish = finishNode()
 
-            // Assert nodes by name
-            val askLLM = assertNodeByName<String, Message.Response>("callLLM")
-            val callTool = assertNodeByName<Message.Tool.Call, ReceivedToolResult>("executeTool")
+                // Assert nodes by name
+                val askLLM = assertNodeByName<String, Message.Response>("callLLM")
+                val callTool = assertNodeByName<Message.Tool.Call, ReceivedToolResult>("executeTool")
 
-            // Assert node reachability
-            assertReachable(start, askLLM)
-            assertReachable(askLLM, callTool)
+                // Assert node reachability
+                assertReachable(start, askLLM)
+                assertReachable(askLLM, callTool)
+            }
         }
     }
-}
-```
-<!--- KNIT example-testing-05.kt -->
+    ```
+    <!--- KNIT example-testing-05.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 ### Testing node behavior
 
@@ -282,50 +326,57 @@ This is crucial for ensuring that your agent's logic works correctly under diffe
 
 Start with simple input and output validations for individual nodes:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.example.exampleTesting02.mockLLMApi
-import ai.koog.agents.example.exampleTesting02.toolRegistry
-import ai.koog.agents.example.exampleTesting03.CreateTool
-import ai.koog.agents.testing.feature.assistantMessage
-import ai.koog.agents.testing.feature.testGraph
-import ai.koog.agents.testing.feature.toolCallMessage
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.message.Message
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.example.exampleTesting02.mockLLMApi
+    import ai.koog.agents.example.exampleTesting02.toolRegistry
+    import ai.koog.agents.example.exampleTesting03.CreateTool
+    import ai.koog.agents.testing.feature.assistantMessage
+    import ai.koog.agents.testing.feature.testGraph
+    import ai.koog.agents.testing.feature.toolCallMessage
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.message.Message
 
 
-val llmModel = OpenAIModels.Chat.GPT4o
+    val llmModel = OpenAIModels.Chat.GPT4o
 
-fun main() {
+    fun main() {
 
-    AIAgent(
-        // Constructor arguments
-        promptExecutor = mockLLMApi,
-        toolRegistry = toolRegistry,
-        llmModel = llmModel
-    ) {
-        testGraph<String, String>("test") {
-            assertNodes {
-                val askLLM = assertNodeByName<String, Message.Response>("callLLM")
-    
--->
-<!--- SUFFIX
+        AIAgent(
+            // Constructor arguments
+            promptExecutor = mockLLMApi,
+            toolRegistry = toolRegistry,
+            llmModel = llmModel
+        ) {
+            testGraph<String, String>("test") {
+                assertNodes {
+                    val askLLM = assertNodeByName<String, Message.Response>("callLLM")
+        
+    -->
+    <!--- SUFFIX
+                }
             }
         }
     }
-}
--->
-```kotlin
-assertNodes {
+    -->
+    ```kotlin
+    assertNodes {
 
-    // Test basic text responses
-    askLLM withInput "Hello" outputs assistantMessage("Hello!")
+        // Test basic text responses
+        askLLM withInput "Hello" outputs assistantMessage("Hello!")
 
-    // Test tool call responses
-    askLLM withInput "Solve task" outputs toolCallMessage(CreateTool, CreateTool.Args("solve"))
-}
-```
-<!--- KNIT example-testing-06.kt -->
+        // Test tool call responses
+        askLLM withInput "Solve task" outputs toolCallMessage(CreateTool, CreateTool.Args("solve"))
+    }
+    ```
+    <!--- KNIT example-testing-06.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 The example above shows how to test the following behavior:
 1. When the LLM node receives `Hello` as the input, it responds with a simple text message.
@@ -335,220 +386,242 @@ The example above shows how to test the following behavior:
 
 You can also test nodes that run tools:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.environment.ReceivedToolResult
-import ai.koog.agents.core.tools.*
-import ai.koog.agents.example.exampleTesting02.mockLLMApi
-import ai.koog.agents.example.exampleTesting02.toolRegistry
-import ai.koog.agents.ext.tool.AskUser
-import ai.koog.agents.testing.feature.testGraph
-import ai.koog.agents.testing.feature.toolCallMessage
-import ai.koog.agents.testing.feature.toolResult
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.message.Message
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
-import ai.koog.agents.core.tools.annotations.LLMDescription
+=== "Kotlin"
 
-object SolveTool : SimpleTool<SolveTool.Args>(
-    argsSerializer = Args.serializer(),
-    name = "message",
-    description = "Service tool, used by the agent to talk with user"
-) {
-    @Serializable
-    data class Args(
-        @property:LLMDescription("Message from the agent")
-        val message: String
-    )
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.environment.ReceivedToolResult
+    import ai.koog.agents.core.tools.*
+    import ai.koog.agents.example.exampleTesting02.mockLLMApi
+    import ai.koog.agents.example.exampleTesting02.toolRegistry
+    import ai.koog.agents.ext.tool.AskUser
+    import ai.koog.agents.testing.feature.testGraph
+    import ai.koog.agents.testing.feature.toolCallMessage
+    import ai.koog.agents.testing.feature.toolResult
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.message.Message
+    import kotlinx.serialization.KSerializer
+    import kotlinx.serialization.Serializable
+    import ai.koog.agents.core.tools.annotations.LLMDescription
 
-    override suspend fun execute(args: Args): String {
-        return args.message
-    }
-}
-
-val llmModel = OpenAIModels.Chat.GPT4o
-
-fun main() {
-
-    AIAgent(
-        // Constructor arguments
-        promptExecutor = mockLLMApi,
-        toolRegistry = toolRegistry,
-        llmModel = llmModel
+    object SolveTool : SimpleTool<SolveTool.Args>(
+        argsSerializer = Args.serializer(),
+        name = "message",
+        description = "Service tool, used by the agent to talk with user"
     ) {
-        testGraph<String, String>("test") {
-            assertNodes {
-                val callTool = assertNodeByName<Message.Tool.Call, ReceivedToolResult>("executeTool")
-    
--->
-<!--- SUFFIX
+        @Serializable
+        data class Args(
+            @property:LLMDescription("Message from the agent")
+            val message: String
+        )
+
+        override suspend fun execute(args: Args): String {
+            return args.message
+        }
+    }
+
+    val llmModel = OpenAIModels.Chat.GPT4o
+
+    fun main() {
+
+        AIAgent(
+            // Constructor arguments
+            promptExecutor = mockLLMApi,
+            toolRegistry = toolRegistry,
+            llmModel = llmModel
+        ) {
+            testGraph<String, String>("test") {
+                assertNodes {
+                    val callTool = assertNodeByName<Message.Tool.Call, ReceivedToolResult>("executeTool")
+        
+    -->
+    <!--- SUFFIX
+                }
             }
         }
     }
-}
--->
-```kotlin
-assertNodes {
-    // Test tool runs with specific arguments
-    callTool withInput toolCallMessage(
-        SolveTool,
-        SolveTool.Args("solve")
-    ) outputs toolResult(SolveTool, SolveTool.Args("solve"), "solved")
-}
-```
-<!--- KNIT example-testing-07.kt -->
+    -->
+    ```kotlin
+    assertNodes {
+        // Test tool runs with specific arguments
+        callTool withInput toolCallMessage(
+            SolveTool,
+            SolveTool.Args("solve")
+        ) outputs toolResult(SolveTool, SolveTool.Args("solve"), "solved")
+    }
+    ```
+    <!--- KNIT example-testing-07.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 This verifies that when the tool execution node receives a specific tool call signature, it produces the expected tool result.
 
 #### Advanced node testing
 
 For more complex scenarios, you can test nodes with structured inputs and outputs:
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.tools.*
-import ai.koog.agents.example.exampleTesting02.mockLLMApi
-import ai.koog.agents.example.exampleTesting02.toolRegistry
-import ai.koog.agents.ext.tool.AskUser
-import ai.koog.agents.testing.feature.assistantMessage
-import ai.koog.agents.testing.feature.testGraph
-import ai.koog.agents.testing.feature.toolCallMessage
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.message.Message
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.builtins.serializer
-import ai.koog.agents.core.tools.annotations.LLMDescription
 
-object AnalyzeTool : Tool<AnalyzeTool.Args, String>(
-    argsSerializer = Args.serializer(),
-    resultSerializer = String.serializer(),
-    name = "message",
-    description = "Service tool, used by the agent to talk with user"
-) {
+=== "Kotlin"
 
-    @Serializable
-    data class Args(
-        @property:LLMDescription("Message from the agent")
-        val query: String,
-        val depth: Int
-    )
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.tools.*
+    import ai.koog.agents.example.exampleTesting02.mockLLMApi
+    import ai.koog.agents.example.exampleTesting02.toolRegistry
+    import ai.koog.agents.ext.tool.AskUser
+    import ai.koog.agents.testing.feature.assistantMessage
+    import ai.koog.agents.testing.feature.testGraph
+    import ai.koog.agents.testing.feature.toolCallMessage
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.message.Message
+    import kotlinx.serialization.KSerializer
+    import kotlinx.serialization.Serializable
+    import kotlinx.serialization.builtins.serializer
+    import ai.koog.agents.core.tools.annotations.LLMDescription
 
-    override suspend fun execute(args: Args): String = args.query
-}
-
-
-val llmModel = OpenAIModels.Chat.GPT4o
-
-fun main() {
-
-    AIAgent(
-        // Constructor arguments
-        promptExecutor = mockLLMApi,
-        toolRegistry = toolRegistry,
-        llmModel = llmModel
+    object AnalyzeTool : Tool<AnalyzeTool.Args, String>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = String.serializer(),
+        name = "message",
+        description = "Service tool, used by the agent to talk with user"
     ) {
-        testGraph<String, String>("test") {
-            assertNodes {
-                val askLLM = assertNodeByName<String, Message.Response>("callLLM")
--->
-<!--- SUFFIX
+
+        @Serializable
+        data class Args(
+            @property:LLMDescription("Message from the agent")
+            val query: String,
+            val depth: Int
+        )
+
+        override suspend fun execute(args: Args): String = args.query
+    }
+
+
+    val llmModel = OpenAIModels.Chat.GPT4o
+
+    fun main() {
+
+        AIAgent(
+            // Constructor arguments
+            promptExecutor = mockLLMApi,
+            toolRegistry = toolRegistry,
+            llmModel = llmModel
+        ) {
+            testGraph<String, String>("test") {
+                assertNodes {
+                    val askLLM = assertNodeByName<String, Message.Response>("callLLM")
+    -->
+    <!--- SUFFIX
+                }
             }
         }
     }
-}
--->
-```kotlin
-assertNodes {
-    // Test with different inputs to the same node
-    askLLM withInput "Simple query" outputs assistantMessage("Simple response")
+    -->
+    ```kotlin
+    assertNodes {
+        // Test with different inputs to the same node
+        askLLM withInput "Simple query" outputs assistantMessage("Simple response")
 
-    // Test with complex parameters
-    askLLM withInput "Complex query with parameters" outputs toolCallMessage(
-        AnalyzeTool,
-        AnalyzeTool.Args(query = "parameters", depth = 3)
-    )
-}
-```
-<!--- KNIT example-testing-08.kt -->
+        // Test with complex parameters
+        askLLM withInput "Complex query with parameters" outputs toolCallMessage(
+            AnalyzeTool,
+            AnalyzeTool.Args(query = "parameters", depth = 3)
+        )
+    }
+    ```
+    <!--- KNIT example-testing-08.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 You can also test complex tool call scenarios with detailed result structures:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.environment.ReceivedToolResult
-import ai.koog.agents.core.tools.*
-import ai.koog.agents.example.exampleTesting02.mockLLMApi
-import ai.koog.agents.example.exampleTesting02.toolRegistry
-import ai.koog.agents.testing.feature.testGraph
-import ai.koog.agents.testing.feature.toolCallMessage
-import ai.koog.agents.testing.feature.toolResult
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.message.Message
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
+=== "Kotlin"
 
-object AnalyzeTool : Tool<AnalyzeTool.Args, AnalyzeTool.Result>(
-    argsSerializer = Args.serializer(),
-    resultSerializer = Result.serializer(),
-    name = "message",
-    description = "Service tool, used by the agent to talk with user"
-) {
-    @Serializable
-    data class Args(
-        val query: String,
-        val depth: Int
-    )
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.environment.ReceivedToolResult
+    import ai.koog.agents.core.tools.*
+    import ai.koog.agents.example.exampleTesting02.mockLLMApi
+    import ai.koog.agents.example.exampleTesting02.toolRegistry
+    import ai.koog.agents.testing.feature.testGraph
+    import ai.koog.agents.testing.feature.toolCallMessage
+    import ai.koog.agents.testing.feature.toolResult
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.message.Message
+    import kotlinx.serialization.KSerializer
+    import kotlinx.serialization.Serializable
 
-    @Serializable
-    data class Result(
-        val analysis: String,
-        val confidence: Double,
-        val metadata: Map<String, String> = mapOf()
-    )
-
-    override suspend fun execute(args: Args): Result {
-        return Result(
-            args.query, 0.95,
-            mapOf("source" to "mock", "timestamp" to "2023-06-15")
-        )
-    }
-}
-
-val llmModel = OpenAIModels.Chat.GPT4o
-
-fun main() {
-
-    AIAgent(
-        // Constructor arguments
-        promptExecutor = mockLLMApi,
-        toolRegistry = toolRegistry,
-        llmModel = llmModel
+    object AnalyzeTool : Tool<AnalyzeTool.Args, AnalyzeTool.Result>(
+        argsSerializer = Args.serializer(),
+        resultSerializer = Result.serializer(),
+        name = "message",
+        description = "Service tool, used by the agent to talk with user"
     ) {
-        testGraph<String, String>("test") {
-            assertNodes {
-                val callTool = assertNodeByName<Message.Tool.Call, ReceivedToolResult>("executeTool")
--->
-<!--- SUFFIX
+        @Serializable
+        data class Args(
+            val query: String,
+            val depth: Int
+        )
+
+        @Serializable
+        data class Result(
+            val analysis: String,
+            val confidence: Double,
+            val metadata: Map<String, String> = mapOf()
+        )
+
+        override suspend fun execute(args: Args): Result {
+            return Result(
+                args.query, 0.95,
+                mapOf("source" to "mock", "timestamp" to "2023-06-15")
+            )
+        }
+    }
+
+    val llmModel = OpenAIModels.Chat.GPT4o
+
+    fun main() {
+
+        AIAgent(
+            // Constructor arguments
+            promptExecutor = mockLLMApi,
+            toolRegistry = toolRegistry,
+            llmModel = llmModel
+        ) {
+            testGraph<String, String>("test") {
+                assertNodes {
+                    val callTool = assertNodeByName<Message.Tool.Call, ReceivedToolResult>("executeTool")
+    -->
+    <!--- SUFFIX
+                }
             }
         }
     }
-}
--->
-```kotlin
-assertNodes {
-    // Test a complex tool call with a structured result
-    callTool withInput toolCallMessage(
-        AnalyzeTool,
-        AnalyzeTool.Args(query = "complex", depth = 5)
-    ) outputs toolResult(AnalyzeTool, AnalyzeTool.Args(query = "complex", depth = 5), AnalyzeTool.Result(
-        analysis = "Detailed analysis",
-        confidence = 0.95,
-        metadata = mapOf("source" to "database", "timestamp" to "2023-06-15")
-    ))
-}
-```
-<!--- KNIT example-testing-09.kt -->
+    -->
+    ```kotlin
+    assertNodes {
+        // Test a complex tool call with a structured result
+        callTool withInput toolCallMessage(
+            AnalyzeTool,
+            AnalyzeTool.Args(query = "complex", depth = 5)
+        ) outputs toolResult(AnalyzeTool, AnalyzeTool.Args(query = "complex", depth = 5), AnalyzeTool.Result(
+            analysis = "Detailed analysis",
+            confidence = 0.95,
+            metadata = mapOf("source" to "database", "timestamp" to "2023-06-15")
+        ))
+    }
+    ```
+    <!--- KNIT example-testing-09.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 These advanced tests help ensure that your nodes handle complex data structures correctly, which is essential for sophisticated agent behaviors.
 
@@ -560,53 +633,60 @@ Edge connections testing allows you to verify that your agent's graph correctly 
 
 Start with simple edge connection tests:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.environment.ReceivedToolResult
-import ai.koog.agents.core.tools.*
-import ai.koog.agents.example.exampleTesting02.mockLLMApi
-import ai.koog.agents.example.exampleTesting02.toolRegistry
-import ai.koog.agents.example.exampleTesting03.CreateTool
-import ai.koog.agents.testing.feature.assistantMessage
-import ai.koog.agents.testing.feature.testGraph
-import ai.koog.agents.testing.feature.toolCallMessage
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.message.Message
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
+=== "Kotlin"
 
-val llmModel = OpenAIModels.Chat.GPT4o
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.environment.ReceivedToolResult
+    import ai.koog.agents.core.tools.*
+    import ai.koog.agents.example.exampleTesting02.mockLLMApi
+    import ai.koog.agents.example.exampleTesting02.toolRegistry
+    import ai.koog.agents.example.exampleTesting03.CreateTool
+    import ai.koog.agents.testing.feature.assistantMessage
+    import ai.koog.agents.testing.feature.testGraph
+    import ai.koog.agents.testing.feature.toolCallMessage
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.message.Message
+    import kotlinx.serialization.KSerializer
+    import kotlinx.serialization.Serializable
 
-fun main() {
+    val llmModel = OpenAIModels.Chat.GPT4o
 
-    AIAgent(
-        // Constructor arguments
-        promptExecutor = mockLLMApi,
-        toolRegistry = toolRegistry,
-        llmModel = llmModel
-    ) {
-        testGraph<String, String>("test") {
-            assertNodes {
-                val callTool = assertNodeByName<Message.Tool.Call, ReceivedToolResult>("executeTool")
-                val askLLM = assertNodeByName<String, Message.Response>("callLLM")
-                val giveFeedback = assertNodeByName<String, Message.Response>("giveFeedback")
--->
-<!--- SUFFIX
+    fun main() {
+
+        AIAgent(
+            // Constructor arguments
+            promptExecutor = mockLLMApi,
+            toolRegistry = toolRegistry,
+            llmModel = llmModel
+        ) {
+            testGraph<String, String>("test") {
+                assertNodes {
+                    val callTool = assertNodeByName<Message.Tool.Call, ReceivedToolResult>("executeTool")
+                    val askLLM = assertNodeByName<String, Message.Response>("callLLM")
+                    val giveFeedback = assertNodeByName<String, Message.Response>("giveFeedback")
+    -->
+    <!--- SUFFIX
+                }
             }
         }
     }
-}
--->
-```kotlin
-assertEdges {
-    // Test text message routing
-    askLLM withOutput assistantMessage("Hello!") goesTo giveFeedback
+    -->
+    ```kotlin
+    assertEdges {
+        // Test text message routing
+        askLLM withOutput assistantMessage("Hello!") goesTo giveFeedback
 
-    // Test tool call routing
-    askLLM withOutput toolCallMessage(CreateTool, CreateTool.Args("solve")) goesTo callTool
-}
-```
-<!--- KNIT example-testing-10.kt -->
+        // Test tool call routing
+        askLLM withOutput toolCallMessage(CreateTool, CreateTool.Args("solve")) goesTo callTool
+    }
+    ```
+    <!--- KNIT example-testing-10.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 This example verifies the following behavior:
 1. When the LLM node outputs a simple text message, the flow is directed to the `giveFeedback` node.
@@ -616,149 +696,170 @@ This example verifies the following behavior:
 
 You can test a more complex routing logic based on the content of outputs:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.environment.ReceivedToolResult
-import ai.koog.agents.example.exampleTesting02.mockLLMApi
-import ai.koog.agents.example.exampleTesting02.toolRegistry
-import ai.koog.agents.testing.feature.assistantMessage
-import ai.koog.agents.testing.feature.testGraph
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.message.Message
+=== "Kotlin"
 
-val llmModel = OpenAIModels.Chat.GPT4o
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.environment.ReceivedToolResult
+    import ai.koog.agents.example.exampleTesting02.mockLLMApi
+    import ai.koog.agents.example.exampleTesting02.toolRegistry
+    import ai.koog.agents.testing.feature.assistantMessage
+    import ai.koog.agents.testing.feature.testGraph
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.message.Message
 
-fun main() {
+    val llmModel = OpenAIModels.Chat.GPT4o
 
-    AIAgent(
-        // Constructor arguments
-        promptExecutor = mockLLMApi,
-        toolRegistry = toolRegistry,
-        llmModel = llmModel
-    ) {
-        testGraph<String, String>("test") {
-            assertNodes {
-                val askLLM = assertNodeByName<String, Message.Response>("callLLM")
-                val askForInfo = assertNodeByName<String, ReceivedToolResult>("askForInfo")
-                val processRequest = assertNodeByName<String, Message.Response>("processRequest")
--->
-<!--- SUFFIX
+    fun main() {
+
+        AIAgent(
+            // Constructor arguments
+            promptExecutor = mockLLMApi,
+            toolRegistry = toolRegistry,
+            llmModel = llmModel
+        ) {
+            testGraph<String, String>("test") {
+                assertNodes {
+                    val askLLM = assertNodeByName<String, Message.Response>("callLLM")
+                    val askForInfo = assertNodeByName<String, ReceivedToolResult>("askForInfo")
+                    val processRequest = assertNodeByName<String, Message.Response>("processRequest")
+    -->
+    <!--- SUFFIX
+                }
             }
         }
     }
-}
--->
-```kotlin
-assertEdges {
-    // Different text responses can route to different nodes
-    askLLM withOutput assistantMessage("Need more information") goesTo askForInfo
-    askLLM withOutput assistantMessage("Ready to proceed") goesTo processRequest
-}
-```
-<!--- KNIT example-testing-11.kt -->
+    -->
+    ```kotlin
+    assertEdges {
+        // Different text responses can route to different nodes
+        askLLM withOutput assistantMessage("Need more information") goesTo askForInfo
+        askLLM withOutput assistantMessage("Ready to proceed") goesTo processRequest
+    }
+    ```
+    <!--- KNIT example-testing-11.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 #### Advanced edge testing
 
 For sophisticated agents, you can test conditional routing based on structured data in tool results:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.environment.ReceivedToolResult
-import ai.koog.agents.example.exampleTesting02.mockLLMApi
-import ai.koog.agents.example.exampleTesting02.toolRegistry
-import ai.koog.agents.example.exampleTesting09.AnalyzeTool
-import ai.koog.agents.testing.feature.testGraph
-import ai.koog.agents.testing.feature.toolResult
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.message.Message
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.environment.ReceivedToolResult
+    import ai.koog.agents.example.exampleTesting02.mockLLMApi
+    import ai.koog.agents.example.exampleTesting02.toolRegistry
+    import ai.koog.agents.example.exampleTesting09.AnalyzeTool
+    import ai.koog.agents.testing.feature.testGraph
+    import ai.koog.agents.testing.feature.toolResult
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.message.Message
 
 
-val llmModel = OpenAIModels.Chat.GPT4o
+    val llmModel = OpenAIModels.Chat.GPT4o
 
-fun main() {
+    fun main() {
 
-    AIAgent(
-        // Constructor arguments
-        promptExecutor = mockLLMApi,
-        toolRegistry = toolRegistry,
-        llmModel = llmModel
-    ) {
-        testGraph<String, String>("test") {
-            assertNodes {
-                val callTool = assertNodeByName<Message.Tool.Call, ReceivedToolResult>("executeTool")
-                val processResult = assertNodeByName<String, Message.Response>("processResult")
--->
-<!--- SUFFIX
+        AIAgent(
+            // Constructor arguments
+            promptExecutor = mockLLMApi,
+            toolRegistry = toolRegistry,
+            llmModel = llmModel
+        ) {
+            testGraph<String, String>("test") {
+                assertNodes {
+                    val callTool = assertNodeByName<Message.Tool.Call, ReceivedToolResult>("executeTool")
+                    val processResult = assertNodeByName<String, Message.Response>("processResult")
+    -->
+    <!--- SUFFIX
+                }
             }
         }
     }
-}
--->
-```kotlin
-assertEdges {
-    // Test routing based on tool result content
-    callTool withOutput toolResult(
-        AnalyzeTool,
-        AnalyzeTool.Args(query = "parameters", depth = 3),
-        AnalyzeTool.Result(analysis = "Needs more processing", confidence = 0.5)
-    ) goesTo processResult
-}
-```
-<!--- KNIT example-testing-12.kt -->
+    -->
+    ```kotlin
+    assertEdges {
+        // Test routing based on tool result content
+        callTool withOutput toolResult(
+            AnalyzeTool,
+            AnalyzeTool.Args(query = "parameters", depth = 3),
+            AnalyzeTool.Result(analysis = "Needs more processing", confidence = 0.5)
+        ) goesTo processResult
+    }
+    ```
+    <!--- KNIT example-testing-12.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 You can also test complex decision paths based on different result properties:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.environment.ReceivedToolResult
-import ai.koog.agents.example.exampleTesting02.mockLLMApi
-import ai.koog.agents.example.exampleTesting02.toolRegistry
-import ai.koog.agents.example.exampleTesting09.AnalyzeTool
-import ai.koog.agents.testing.feature.testGraph
-import ai.koog.agents.testing.feature.toolResult
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.message.Message
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.environment.ReceivedToolResult
+    import ai.koog.agents.example.exampleTesting02.mockLLMApi
+    import ai.koog.agents.example.exampleTesting02.toolRegistry
+    import ai.koog.agents.example.exampleTesting09.AnalyzeTool
+    import ai.koog.agents.testing.feature.testGraph
+    import ai.koog.agents.testing.feature.toolResult
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.message.Message
 
 
-val llmModel = OpenAIModels.Chat.GPT4o
+    val llmModel = OpenAIModels.Chat.GPT4o
 
-fun main() {
+    fun main() {
 
-    AIAgent(
-        // Constructor arguments
-        promptExecutor = mockLLMApi,
-        toolRegistry = toolRegistry,
-        llmModel = llmModel
-    ) {
-        testGraph<String, String>("test") {
-            assertNodes {
-                val callTool = assertNodeByName<Message.Tool.Call, ReceivedToolResult>("executeTool")
-                val finish = assertNodeByName<String, Message.Response>("finish")
-                val verifyResult = assertNodeByName<String, Message.Response>("verifyResult")
--->
-<!--- SUFFIX
+        AIAgent(
+            // Constructor arguments
+            promptExecutor = mockLLMApi,
+            toolRegistry = toolRegistry,
+            llmModel = llmModel
+        ) {
+            testGraph<String, String>("test") {
+                assertNodes {
+                    val callTool = assertNodeByName<Message.Tool.Call, ReceivedToolResult>("executeTool")
+                    val finish = assertNodeByName<String, Message.Response>("finish")
+                    val verifyResult = assertNodeByName<String, Message.Response>("verifyResult")
+    -->
+    <!--- SUFFIX
+                }
             }
         }
     }
-}
--->
-```kotlin
-assertEdges {
-    // Route to different nodes based on confidence level
-    callTool withOutput toolResult(
-        AnalyzeTool,
-        AnalyzeTool.Args(query = "parameters", depth = 3),
-        AnalyzeTool.Result(analysis = "Complete", confidence = 0.9)
-    ) goesTo finish
+    -->
+    ```kotlin
+    assertEdges {
+        // Route to different nodes based on confidence level
+        callTool withOutput toolResult(
+            AnalyzeTool,
+            AnalyzeTool.Args(query = "parameters", depth = 3),
+            AnalyzeTool.Result(analysis = "Complete", confidence = 0.9)
+        ) goesTo finish
 
-    callTool withOutput toolResult(
-        AnalyzeTool,
-        AnalyzeTool.Args(query = "parameters", depth = 3),
-        AnalyzeTool.Result(analysis = "Uncertain", confidence = 0.3)
-    ) goesTo verifyResult
-}
-```
-<!--- KNIT example-testing-13.kt -->
+        callTool withOutput toolResult(
+            AnalyzeTool,
+            AnalyzeTool.Args(query = "parameters", depth = 3),
+            AnalyzeTool.Result(analysis = "Uncertain", confidence = 0.3)
+        ) goesTo verifyResult
+    }
+    ```
+    <!--- KNIT example-testing-13.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 These advanced edge tests help ensure that your agent makes the correct decisions based on the content and structure of node outputs, which is essential for creating intelligent, context-aware workflows.
 
@@ -770,243 +871,257 @@ You are developing a tone analysis agent that analyzes the tone of the text and 
 
 Here is how you can test this agent:
 
-<!--- INCLUDE
-/*
--->
-<!--- SUFFIX
-*/
--->
-```kotlin
-@Test
-fun testToneAgent() = runTest {
-    // Create a list to track tool calls
-    var toolCalls = mutableListOf<String>()
-    var result: String? = null
+=== "Kotlin"
 
-    // Create a tool registry
-    val toolRegistry = ToolRegistry {
-        // A special tool, required with this type of agent
-        tool(SayToUser)
+    <!--- INCLUDE
+    /*
+    -->
+    <!--- SUFFIX
+    */
+    -->
+    ```kotlin
+    @Test
+    fun testToneAgent() = runTest {
+        // Create a list to track tool calls
+        var toolCalls = mutableListOf<String>()
+        var result: String? = null
 
-        with(ToneTools) {
-            tools()
+        // Create a tool registry
+        val toolRegistry = ToolRegistry {
+            // A special tool, required with this type of agent
+            tool(SayToUser)
+
+            with(ToneTools) {
+                tools()
+            }
         }
+
+        // Create an event handler
+        val eventHandler = EventHandler {
+            onToolCallStarting { tool, args ->
+                println("[DEBUG_LOG] Tool called: tool ${tool.name}, args $args")
+                toolCalls.add(tool.name)
+            }
+
+            handleError {
+                println("[DEBUG_LOG] An error occurred: ${it.message}\n${it.stackTraceToString()}")
+                true
+            }
+
+            handleResult {
+                println("[DEBUG_LOG] Result: $it")
+                result = it
+            }
+        }
+
+        val positiveText = "I love this product!"
+        val negativeText = "Awful service, hate the app."
+        val defaultText = "I don't know how to answer this question."
+
+        val positiveResponse = "The text has a positive tone."
+        val negativeResponse = "The text has a negative tone."
+        val neutralResponse = "The text has a neutral tone."
+
+        val mockLLMApi = getMockExecutor(toolRegistry, eventHandler) {
+            // Set up LLM responses for different input texts
+            mockLLMToolCall(NeutralToneTool, ToneTool.Args(defaultText)) onRequestEquals defaultText
+            mockLLMToolCall(PositiveToneTool, ToneTool.Args(positiveText)) onRequestEquals positiveText
+            mockLLMToolCall(NegativeToneTool, ToneTool.Args(negativeText)) onRequestEquals negativeText
+
+            // Mock the behavior where the LLM responds with just tool responses when the tools return results
+            mockLLMAnswer(positiveResponse) onRequestContains positiveResponse
+            mockLLMAnswer(negativeResponse) onRequestContains negativeResponse
+            mockLLMAnswer(neutralResponse) onRequestContains neutralResponse
+
+            mockLLMAnswer(defaultText).asDefaultResponse
+
+            // Tool mocks
+            mockTool(PositiveToneTool) alwaysTells {
+                toolCalls += "Positive tone tool called"
+                positiveResponse
+            }
+            mockTool(NegativeToneTool) alwaysTells {
+                toolCalls += "Negative tone tool called"
+                negativeResponse
+            }
+            mockTool(NeutralToneTool) alwaysTells {
+                toolCalls += "Neutral tone tool called"
+                neutralResponse
+            }
+        }
+
+        // Create a strategy
+        val strategy = toneStrategy("tone_analysis")
+
+        // Create an agent configuration
+        val agentConfig = AIAgentConfig(
+            prompt = prompt("test-agent") {
+                system(
+                    """
+                    You are an question answering agent with access to the tone analysis tools.
+                    You need to answer 1 question with the best of your ability.
+                    Be as concise as possible in your answers.
+                    DO NOT ANSWER ANY QUESTIONS THAT ARE BESIDES PERFORMING TONE ANALYSIS!
+                    DO NOT HALLUCINATE!
+                """.trimIndent()
+                )
+            },
+            model = mockk<LLModel>(relaxed = true),
+            maxAgentIterations = 10
+        )
+
+        // Create an agent with testing enabled
+        val agent = AIAgent(
+            promptExecutor = mockLLMApi,
+            toolRegistry = toolRegistry,
+            strategy = strategy,
+            eventHandler = eventHandler,
+            agentConfig = agentConfig,
+        ) {
+            withTesting()
+        }
+
+        // Test the positive text
+        agent.run(positiveText)
+        assertEquals("The text has a positive tone.", result, "Positive tone result should match")
+        assertEquals(1, toolCalls.size, "One tool is expected to be called")
+
+        // Test the negative text
+        agent.run(negativeText)
+        assertEquals("The text has a negative tone.", result, "Negative tone result should match")
+        assertEquals(2, toolCalls.size, "Two tools are expected to be called")
+
+        //Test the neutral text
+        agent.run(defaultText)
+        assertEquals("The text has a neutral tone.", result, "Neutral tone result should match")
+        assertEquals(3, toolCalls.size, "Three tools are expected to be called")
     }
+    ```
+    <!--- KNIT example-testing-14.kt -->
 
-    // Create an event handler
-    val eventHandler = EventHandler {
-        onToolCallStarting { tool, args ->
-            println("[DEBUG_LOG] Tool called: tool ${tool.name}, args $args")
-            toolCalls.add(tool.name)
-        }
+=== "Java"
 
-        handleError {
-            println("[DEBUG_LOG] An error occurred: ${it.message}\n${it.stackTraceToString()}")
-            true
-        }
-
-        handleResult {
-            println("[DEBUG_LOG] Result: $it")
-            result = it
-        }
-    }
-
-    val positiveText = "I love this product!"
-    val negativeText = "Awful service, hate the app."
-    val defaultText = "I don't know how to answer this question."
-
-    val positiveResponse = "The text has a positive tone."
-    val negativeResponse = "The text has a negative tone."
-    val neutralResponse = "The text has a neutral tone."
-
-    val mockLLMApi = getMockExecutor(toolRegistry, eventHandler) {
-        // Set up LLM responses for different input texts
-        mockLLMToolCall(NeutralToneTool, ToneTool.Args(defaultText)) onRequestEquals defaultText
-        mockLLMToolCall(PositiveToneTool, ToneTool.Args(positiveText)) onRequestEquals positiveText
-        mockLLMToolCall(NegativeToneTool, ToneTool.Args(negativeText)) onRequestEquals negativeText
-
-        // Mock the behavior where the LLM responds with just tool responses when the tools return results
-        mockLLMAnswer(positiveResponse) onRequestContains positiveResponse
-        mockLLMAnswer(negativeResponse) onRequestContains negativeResponse
-        mockLLMAnswer(neutralResponse) onRequestContains neutralResponse
-
-        mockLLMAnswer(defaultText).asDefaultResponse
-
-        // Tool mocks
-        mockTool(PositiveToneTool) alwaysTells {
-            toolCalls += "Positive tone tool called"
-            positiveResponse
-        }
-        mockTool(NegativeToneTool) alwaysTells {
-            toolCalls += "Negative tone tool called"
-            negativeResponse
-        }
-        mockTool(NeutralToneTool) alwaysTells {
-            toolCalls += "Neutral tone tool called"
-            neutralResponse
-        }
-    }
-
-    // Create a strategy
-    val strategy = toneStrategy("tone_analysis")
-
-    // Create an agent configuration
-    val agentConfig = AIAgentConfig(
-        prompt = prompt("test-agent") {
-            system(
-                """
-                You are an question answering agent with access to the tone analysis tools.
-                You need to answer 1 question with the best of your ability.
-                Be as concise as possible in your answers.
-                DO NOT ANSWER ANY QUESTIONS THAT ARE BESIDES PERFORMING TONE ANALYSIS!
-                DO NOT HALLUCINATE!
-            """.trimIndent()
-            )
-        },
-        model = mockk<LLModel>(relaxed = true),
-        maxAgentIterations = 10
-    )
-
-    // Create an agent with testing enabled
-    val agent = AIAgent(
-        promptExecutor = mockLLMApi,
-        toolRegistry = toolRegistry,
-        strategy = strategy,
-        eventHandler = eventHandler,
-        agentConfig = agentConfig,
-    ) {
-        withTesting()
-    }
-
-    // Test the positive text
-    agent.run(positiveText)
-    assertEquals("The text has a positive tone.", result, "Positive tone result should match")
-    assertEquals(1, toolCalls.size, "One tool is expected to be called")
-
-    // Test the negative text
-    agent.run(negativeText)
-    assertEquals("The text has a negative tone.", result, "Negative tone result should match")
-    assertEquals(2, toolCalls.size, "Two tools are expected to be called")
-
-    //Test the neutral text
-    agent.run(defaultText)
-    assertEquals("The text has a neutral tone.", result, "Neutral tone result should match")
-    assertEquals(3, toolCalls.size, "Three tools are expected to be called")
-}
-```
-<!--- KNIT example-testing-14.kt -->
+    ```java
+    ```
 
 For more complex agents with multiple subgraphs, you can also test the graph structure:
 
-<!--- INCLUDE
-/*
--->
-<!--- SUFFIX
-*/
--->
-```kotlin
-@Test
-fun testMultiSubgraphAgentStructure() = runTest {
-    val strategy = strategy("test") {
-        val firstSubgraph by subgraph(
-            "first",
-            tools = listOf(DummyTool, CreateTool, SolveTool)
-        ) {
-            val callLLM by nodeLLMRequest(allowToolCalls = false)
-            val executeTool by nodeExecuteTool()
-            val sendToolResult by nodeLLMSendToolResult()
-            val giveFeedback by node<String, String> { input ->
-                llm.writeSession {
-                    appendPrompt {
-                        user("Call tools! Don't chat!")
+=== "Kotlin"
+
+    <!--- INCLUDE
+    /*
+    -->
+    <!--- SUFFIX
+    */
+    -->
+    ```kotlin
+    @Test
+    fun testMultiSubgraphAgentStructure() = runTest {
+        val strategy = strategy("test") {
+            val firstSubgraph by subgraph(
+                "first",
+                tools = listOf(DummyTool, CreateTool, SolveTool)
+            ) {
+                val callLLM by nodeLLMRequest(allowToolCalls = false)
+                val executeTool by nodeExecuteTool()
+                val sendToolResult by nodeLLMSendToolResult()
+                val giveFeedback by node<String, String> { input ->
+                    llm.writeSession {
+                        appendPrompt {
+                            user("Call tools! Don't chat!")
+                        }
                     }
+                    input
                 }
-                input
+
+                edge(nodeStart forwardTo callLLM)
+                edge(callLLM forwardTo executeTool onToolCall { true })
+                edge(callLLM forwardTo giveFeedback onAssistantMessage { true })
+                edge(giveFeedback forwardTo giveFeedback onAssistantMessage { true })
+                edge(giveFeedback forwardTo executeTool onToolCall { true })
+                edge(executeTool forwardTo nodeFinish transformed { it.content })
             }
 
-            edge(nodeStart forwardTo callLLM)
-            edge(callLLM forwardTo executeTool onToolCall { true })
-            edge(callLLM forwardTo giveFeedback onAssistantMessage { true })
-            edge(giveFeedback forwardTo giveFeedback onAssistantMessage { true })
-            edge(giveFeedback forwardTo executeTool onToolCall { true })
-            edge(executeTool forwardTo nodeFinish transformed { it.content })
-        }
-
-        val secondSubgraph by subgraph<String, String>("second") {
-            edge(nodeStart forwardTo nodeFinish)
-        }
-
-        edge(nodeStart forwardTo firstSubgraph)
-        edge(firstSubgraph forwardTo secondSubgraph)
-        edge(secondSubgraph forwardTo nodeFinish)
-    }
-
-    val toolRegistry = ToolRegistry {
-        tool(DummyTool)
-        tool(CreateTool)
-        tool(SolveTool)
-    }
-
-    val mockLLMApi = getMockExecutor(toolRegistry) {
-        mockLLMAnswer("Hello!") onRequestContains "Hello"
-        mockLLMToolCall(CreateTool, CreateTool.Args("solve")) onRequestEquals "Solve task"
-    }
-
-    val basePrompt = prompt("test") {}
-
-    AIAgent(
-        toolRegistry = toolRegistry,
-        strategy = strategy,
-        eventHandler = EventHandler {},
-        agentConfig = AIAgentConfig(prompt = basePrompt, model = OpenAIModels.Chat.GPT4o, maxAgentIterations = 100),
-        promptExecutor = mockLLMApi,
-    ) {
-        testGraph("test") {
-            val firstSubgraph = assertSubgraphByName<String, String>("first")
-            val secondSubgraph = assertSubgraphByName<String, String>("second")
-
-            assertEdges {
-                startNode() alwaysGoesTo firstSubgraph
-                firstSubgraph alwaysGoesTo secondSubgraph
-                secondSubgraph alwaysGoesTo finishNode()
+            val secondSubgraph by subgraph<String, String>("second") {
+                edge(nodeStart forwardTo nodeFinish)
             }
 
-            verifySubgraph(firstSubgraph) {
-                val start = startNode()
-                val finish = finishNode()
+            edge(nodeStart forwardTo firstSubgraph)
+            edge(firstSubgraph forwardTo secondSubgraph)
+            edge(secondSubgraph forwardTo nodeFinish)
+        }
 
-                val askLLM = assertNodeByName<String, Message.Response>("callLLM")
-                val callTool = assertNodeByName<Message.Tool.Call, ReceivedToolResult>("executeTool")
-                val giveFeedback = assertNodeByName<Any?, Any?>("giveFeedback")
+        val toolRegistry = ToolRegistry {
+            tool(DummyTool)
+            tool(CreateTool)
+            tool(SolveTool)
+        }
 
-                assertReachable(start, askLLM)
-                assertReachable(askLLM, callTool)
+        val mockLLMApi = getMockExecutor(toolRegistry) {
+            mockLLMAnswer("Hello!") onRequestContains "Hello"
+            mockLLMToolCall(CreateTool, CreateTool.Args("solve")) onRequestEquals "Solve task"
+        }
 
-                assertNodes {
-                    askLLM withInput "Hello" outputs Message.Assistant("Hello!")
-                    askLLM withInput "Solve task" outputs toolCallMessage(CreateTool, CreateTool.Args("solve"))
+        val basePrompt = prompt("test") {}
 
-                    callTool withInput toolCallSignature(
-                        SolveTool,
-                        SolveTool.Args("solve")
-                    ) outputs toolResult(SolveTool, "solved")
-
-                    callTool withInput toolCallSignature(
-                        CreateTool,
-                        CreateTool.Args("solve")
-                    ) outputs toolResult(CreateTool, "created")
-                }
+        AIAgent(
+            toolRegistry = toolRegistry,
+            strategy = strategy,
+            eventHandler = EventHandler {},
+            agentConfig = AIAgentConfig(prompt = basePrompt, model = OpenAIModels.Chat.GPT4o, maxAgentIterations = 100),
+            promptExecutor = mockLLMApi,
+        ) {
+            testGraph("test") {
+                val firstSubgraph = assertSubgraphByName<String, String>("first")
+                val secondSubgraph = assertSubgraphByName<String, String>("second")
 
                 assertEdges {
-                    askLLM withOutput Message.Assistant("Hello!") goesTo giveFeedback
-                    askLLM withOutput toolCallMessage(CreateTool, CreateTool.Args("solve")) goesTo callTool
+                    startNode() alwaysGoesTo firstSubgraph
+                    firstSubgraph alwaysGoesTo secondSubgraph
+                    secondSubgraph alwaysGoesTo finishNode()
+                }
+
+                verifySubgraph(firstSubgraph) {
+                    val start = startNode()
+                    val finish = finishNode()
+
+                    val askLLM = assertNodeByName<String, Message.Response>("callLLM")
+                    val callTool = assertNodeByName<Message.Tool.Call, ReceivedToolResult>("executeTool")
+                    val giveFeedback = assertNodeByName<Any?, Any?>("giveFeedback")
+
+                    assertReachable(start, askLLM)
+                    assertReachable(askLLM, callTool)
+
+                    assertNodes {
+                        askLLM withInput "Hello" outputs Message.Assistant("Hello!")
+                        askLLM withInput "Solve task" outputs toolCallMessage(CreateTool, CreateTool.Args("solve"))
+
+                        callTool withInput toolCallSignature(
+                            SolveTool,
+                            SolveTool.Args("solve")
+                        ) outputs toolResult(SolveTool, "solved")
+
+                        callTool withInput toolCallSignature(
+                            CreateTool,
+                            CreateTool.Args("solve")
+                        ) outputs toolResult(CreateTool, "created")
+                    }
+
+                    assertEdges {
+                        askLLM withOutput Message.Assistant("Hello!") goesTo giveFeedback
+                        askLLM withOutput toolCallMessage(CreateTool, CreateTool.Args("solve")) goesTo callTool
+                    }
                 }
             }
         }
     }
-}
-```
-<!--- KNIT example-testing-15.kt -->
+    ```
+    <!--- KNIT example-testing-15.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 ## API reference
 
@@ -1017,88 +1132,119 @@ For a complete API reference related to the Testing feature, see the reference d
 #### How do I mock a specific tool response?
 
 Use the `mockTool` method in `MockLLMBuilder`:
-<!--- INCLUDE
-/*
--->
-<!--- SUFFIX
-*/
--->
-```kotlin
-val mockExecutor = getMockExecutor {
-    mockTool(myTool) alwaysReturns myResult
 
-    // Or with conditions
-    mockTool(myTool) returns myResult onArguments myArgs
-}
-```
-<!--- KNIT example-testing-16.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    /*
+    -->
+    <!--- SUFFIX
+    */
+    -->
+    ```kotlin
+    val mockExecutor = getMockExecutor {
+        mockTool(myTool) alwaysReturns myResult
+
+        // Or with conditions
+        mockTool(myTool) returns myResult onArguments myArgs
+    }
+    ```
+    <!--- KNIT example-testing-16.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 #### How can I test complex graph structures?
 
 Use the subgraph assertions, `verifySubgraph`, and node references:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.example.exampleTesting02.mockLLMApi
-import ai.koog.agents.example.exampleTesting02.toolRegistry
-import ai.koog.agents.testing.feature.testGraph
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.example.exampleTesting02.mockLLMApi
+    import ai.koog.agents.example.exampleTesting02.toolRegistry
+    import ai.koog.agents.testing.feature.testGraph
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
 
 
-val llmModel = OpenAIModels.Chat.GPT4o
+    val llmModel = OpenAIModels.Chat.GPT4o
 
-fun main() {
-    AIAgent(
-        // Constructor arguments
-        promptExecutor = mockLLMApi,
-        toolRegistry = toolRegistry,
-        llmModel = llmModel
-    ) {
--->
-<!--- SUFFIX
-    }
-}
--->
-```kotlin
-testGraph<Unit, String>("test") {
-    val mySubgraph = assertSubgraphByName<Unit, String>("mySubgraph")
-
-    verifySubgraph(mySubgraph) {
-        // Get references to nodes
-        val nodeA = assertNodeByName<Unit, String>("nodeA")
-        val nodeB = assertNodeByName<String, String>("nodeB")
-
-        // Assert reachability
-        assertReachable(nodeA, nodeB)
-
-        // Assert edge connections
-        assertEdges {
-            nodeA.withOutput("result") goesTo nodeB
+    fun main() {
+        AIAgent(
+            // Constructor arguments
+            promptExecutor = mockLLMApi,
+            toolRegistry = toolRegistry,
+            llmModel = llmModel
+        ) {
+    -->
+    <!--- SUFFIX
         }
     }
-}
-```
-<!--- KNIT example-testing-17.kt -->
+    -->
+    ```kotlin
+    testGraph<Unit, String>("test") {
+        val mySubgraph = assertSubgraphByName<Unit, String>("mySubgraph")
+
+        verifySubgraph(mySubgraph) {
+            // Get references to nodes
+            val nodeA = assertNodeByName<Unit, String>("nodeA")
+            val nodeB = assertNodeByName<String, String>("nodeB")
+
+            // Assert reachability
+            assertReachable(nodeA, nodeB)
+
+            // Assert edge connections
+            assertEdges {
+                nodeA.withOutput("result") goesTo nodeB
+            }
+        }
+    }
+    ```
+    <!--- KNIT example-testing-17.kt -->
+
+=== "Java"
+
+    ```java
+    ```
 
 #### How do I simulate different LLM responses based on input?
 
 Use pattern matching methods:
 
-<!--- INCLUDE
-import ai.koog.agents.testing.tools.getMockExecutor
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.testing.tools.getMockExecutor
 
 
-val promptExecutor = 
--->
-```kotlin
-getMockExecutor {
-    mockLLMAnswer("Response A") onRequestContains "topic A"
-    mockLLMAnswer("Response B") onRequestContains "topic B"
-    mockLLMAnswer("Exact response") onRequestEquals "exact question"
-    mockLLMAnswer("Conditional response") onCondition { it.contains("keyword") && it.length > 10 }
-}
-```
-<!--- KNIT example-testing-18.kt -->
+    val promptExecutor = 
+    -->
+    ```kotlin
+    getMockExecutor {
+        mockLLMAnswer("Response A") onRequestContains "topic A"
+        mockLLMAnswer("Response B") onRequestContains "topic B"
+        mockLLMAnswer("Exact response") onRequestEquals "exact question"
+        mockLLMAnswer("Conditional response") onCondition { it.contains("keyword") && it.length > 10 }
+    }
+    ```
+    <!--- KNIT example-testing-18.kt -->
+
+=== "Java"
+
+    ```java
+    import ai.koog.agents.testing.tools.MockExecutor;
+    import ai.koog.prompt.executor.model.PromptExecutor;
+
+    PromptExecutor promptExecutor = MockExecutor.builder()
+        .mockLLMAnswer("Response A").onRequestContains("topic A")
+        .mockLLMAnswer("Response B").onRequestContains("topic B")
+        .mockLLMAnswer("Exact response").onRequestEquals("exact question")
+        .mockLLMAnswer("Conditional response").onCondition(s -> s.contains("keyword") && s.length() > 10)
+        .build();
+    ```
 
 ### Troubleshooting
 

--- a/docs/docs/tools-overview.md
+++ b/docs/docs/tools-overview.md
@@ -35,61 +35,136 @@ To learn more, see [ToolRegistry](api:agents-tools::ai.koog.agents.core.tools.To
 
 Here is an example of how to create the tool registry and add the tool to it:
 
-<!--- INCLUDE
-import ai.koog.agents.core.tools.ToolRegistry
-import ai.koog.agents.ext.tool.SayToUser
--->
-```kotlin
-val toolRegistry = ToolRegistry {
-    tool(SayToUser)
-}
-```
-<!--- KNIT example-tools-overview-01.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.tools.ToolRegistry
+    import ai.koog.agents.core.tools.annotations.Tool
+    import ai.koog.agents.core.tools.reflect.ToolSet
+    import ai.koog.agents.core.tools.reflect.tools
+    class MyToolSet : ToolSet {
+        @Tool
+        fun myTool(): String {
+            // Tool implementation
+            return "Result"
+        }
+    }
+    val myTool = MyToolSet()
+    -->
+    ```kotlin
+    val toolRegistry = ToolRegistry {
+        tools(myTool)
+    }
+    ```
+    <!--- KNIT example-tools-overview-01.kt -->
+
+=== "Java"
+
+    ```java
+    // Create an instance of your ToolSet
+    MyToolSet myTool = new MyToolSet();
+
+    // Build the ToolRegistry and register tools from the ToolSet
+    ToolRegistry toolRegistry = ToolRegistry.builder()
+        .tools(myTool)
+        .build();
+    ```
 
 To merge multiple tool registries, do the following:
 
-<!--- INCLUDE
-import ai.koog.agents.core.tools.ToolRegistry
-import ai.koog.agents.ext.tool.AskUser
-import ai.koog.agents.ext.tool.SayToUser
+=== "Kotlin"
 
-typealias FirstSampleTool = AskUser
-typealias SecondSampleTool = SayToUser
--->
-```kotlin
-val firstToolRegistry = ToolRegistry {
-    tool(FirstSampleTool)
-}
+    <!--- INCLUDE
+    import ai.koog.agents.core.tools.ToolRegistry
+    import ai.koog.agents.core.tools.annotations.Tool
+    import ai.koog.agents.core.tools.reflect.ToolSet
+    import ai.koog.agents.core.tools.reflect.tools
+    class FirstToolSet : ToolSet {
+        @Tool
+        fun firstSampleTool(): String {
+            // Tool implementation
+            return "First result"
+        }
+    }
+    class SecondToolSet : ToolSet {
+        @Tool
+        fun secondSampleTool(): String {
+            // Tool implementation
+            return "Second result"
+        }
+    }
+    val firstSampleTool = FirstToolSet()
+    val secondSampleTool = SecondToolSet()
+    -->
+    ```kotlin
+    val firstToolRegistry = ToolRegistry {
+        tools(firstSampleTool)
+    }
+    
+    val secondToolRegistry = ToolRegistry {
+        tools(secondSampleTool)
+    }
+    
+    val newRegistry = firstToolRegistry + secondToolRegistry
+    ```
+    <!--- KNIT example-tools-overview-02.kt -->
 
-val secondToolRegistry = ToolRegistry {
-    tool(SecondSampleTool)
-}
+=== "Java"
+    
+    ```java
+    // Create instances of your ToolSets
+    FirstToolSet firstSampleTool = new FirstToolSet();
+    SecondToolSet secondSampleTool = new SecondToolSet();
 
-val newRegistry = firstToolRegistry + secondToolRegistry
-```
-<!--- KNIT example-tools-overview-02.kt -->
+    // Build separate tool registries
+    ToolRegistry firstToolRegistry = ToolRegistry.builder()
+        .tools(firstSampleTool)
+        .build();
+
+    ToolRegistry secondToolRegistry = ToolRegistry.builder()
+        .tools(secondSampleTool)
+        .build();
+
+    ToolRegistry newRegistry = firstToolRegistry.plus(secondToolRegistry);
+    ```
 
 ### Passing tools to an agent
 
 To enable an agent to use a tool, you need to provide a tool registry that contains this tool as an argument when creating the agent:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.example.exampleToolsOverview01.toolRegistry
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
--->
-```kotlin
-// Agent initialization
-val agent = AIAgent(
-    promptExecutor = simpleOpenAIExecutor(System.getenv("OPENAI_API_KEY")),
-    systemPrompt = "You are a helpful assistant with strong mathematical skills.",
-    llmModel = OpenAIModels.Chat.GPT4o,
-    // Pass your tool registry to the agent
-    toolRegistry = toolRegistry
-)
-```
-<!--- KNIT example-tools-overview-03.kt -->
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.example.exampleToolsOverview01.toolRegistry
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+    -->
+    ```kotlin
+    // Agent initialization
+    val agent = AIAgent(
+        promptExecutor = simpleOpenAIExecutor(System.getenv("OPENAI_API_KEY")),
+        systemPrompt = "You are a helpful assistant with strong mathematical skills.",
+        llmModel = OpenAIModels.Chat.GPT4o,
+        // Pass your tool registry to the agent
+        toolRegistry = toolRegistry
+    )
+    ```
+    <!--- KNIT example-tools-overview-03.kt -->
+
+=== "Java"
+
+    ```java
+    AIAgent<String, String> agent = AIAgent.builder()
+        .promptExecutor(simpleOpenAIExecutor(System.getenv("OPENAI_API_KEY")))
+        .systemPrompt("You are a helpful assistant with strong mathematical skills.")
+        .llmModel(OpenAIModels.Chat.GPT4o)
+        .toolRegistry(ToolRegistry.builder()
+            .tools(secondSampleTool)
+            .build()
+        )
+        .build();
+    ```
 
 ### Calling tools
 
@@ -115,52 +190,59 @@ For more details, see [API reference](api:agents-core::ai.koog.agents.core.agent
 
 You can also call tools in parallel using the `toParallelToolCallsRaw` extension. For example:
 
-<!--- INCLUDE
-import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.tools.SimpleTool
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.flow
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
--->
-```kotlin
-@Serializable
-data class Book(
-    val title: String,
-    val author: String,
-    val description: String
-)
+=== "Kotlin"
 
-class BookTool() : SimpleTool<Book>(
-    argsSerializer = Book.serializer(),
-    name = NAME,
-    description = "A tool to parse book information from Markdown"
-) {
-    companion object {
-        const val NAME = "book"
-    }
-
-    override suspend fun execute(args: Book): String {
-        println("${args.title} by ${args.author}:\n ${args.description}")
-        return "Done"
-    }
-}
-
-val strategy = strategy<Unit, Unit>("strategy-name") {
-
-    /*...*/
-
-    val myNode by node<Unit, Unit> { _ ->
-        llm.writeSession {
-            flow {
-                emit(Book("Book 1", "Author 1", "Description 1"))
-            }.toParallelToolCallsRaw(BookTool::class).collect()
+    <!--- INCLUDE
+    import ai.koog.agents.core.dsl.builder.strategy
+    import ai.koog.agents.core.tools.SimpleTool
+    import kotlinx.coroutines.flow.collect
+    import kotlinx.coroutines.flow.flow
+    import kotlinx.serialization.KSerializer
+    import kotlinx.serialization.Serializable
+    -->
+    ```kotlin
+    @Serializable
+    data class Book(
+        val title: String,
+        val author: String,
+        val description: String
+    )
+    
+    class BookTool() : SimpleTool<Book>(
+        argsSerializer = Book.serializer(),
+        name = NAME,
+        description = "A tool to parse book information from Markdown"
+    ) {
+        companion object {
+            const val NAME = "book"
+        }
+    
+        override suspend fun execute(args: Book): String {
+            println("${args.title} by ${args.author}:\n ${args.description}")
+            return "Done"
         }
     }
-}
+    
+    val strategy = strategy<Unit, Unit>("strategy-name") {
+    
+        /*...*/
+    
+        val myNode by node<Unit, Unit> { _ ->
+            llm.writeSession {
+                flow {
+                    emit(Book("Book 1", "Author 1", "Description 1"))
+                }.toParallelToolCallsRaw(BookTool::class).collect()
+            }
+        }
+    }
+    
+    ```
+    <!--- KNIT example-tools-overview-04.kt -->
 
-```
-<!--- KNIT example-tools-overview-04.kt -->
+=== "Java"
+
+    ```java
+    ```
 
 #### Calling tools from nodes
 
@@ -185,65 +267,75 @@ This powerful feature enables you to create hierarchical agent architectures whe
 
 To convert an agent into a tool, use the `AIAgentService` and the `createAgentTool()` extension function:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.agent.AIAgentService
-import ai.koog.agents.core.agent.createAgentTool
-import ai.koog.agents.core.tools.ToolParameterDescriptor
-import ai.koog.agents.core.tools.ToolParameterType
-import ai.koog.agents.core.tools.ToolRegistry
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+=== "Kotlin"
 
-const val apiKey = ""
-val analysisToolRegistry = ToolRegistry {}
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.agent.AIAgentService
+    import ai.koog.agents.core.agent.createAgentTool
+    import ai.koog.agents.core.tools.ToolParameterDescriptor
+    import ai.koog.agents.core.tools.ToolParameterType
+    import ai.koog.agents.core.tools.ToolRegistry
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+    const val apiKey = ""
+    val analysisToolRegistry = ToolRegistry {}
+    -->
+    ```kotlin
+    // Create a specialized agent service, responsible for creating financial analysis agents.
+    val analysisAgentService = AIAgentService(
+        promptExecutor = simpleOpenAIExecutor(apiKey),
+        llmModel = OpenAIModels.Chat.GPT4o,
+        systemPrompt = "You are a financial analysis specialist.",
+        toolRegistry = analysisToolRegistry
+    )
+    
+    // Create a tool that would run financial analysis agent once called.
+    val analysisAgentTool = analysisAgentService.createAgentTool(
+        agentName = "analyzeTransactions",
+        agentDescription = "Performs financial transaction analysis",
+        inputDescription = "Transaction analysis request",
+    )
+    ```
+    <!--- KNIT example-tools-overview-05.kt -->
 
--->
-```kotlin
-// Create a specialized agent service, responsible for creating financial analysis agents.
-val analysisAgentService = AIAgentService(
-    promptExecutor = simpleOpenAIExecutor(apiKey),
-    llmModel = OpenAIModels.Chat.GPT4o,
-    systemPrompt = "You are a financial analysis specialist.",
-    toolRegistry = analysisToolRegistry
-)
+=== "Java"
 
-// Create a tool that would run financial analysis agent once called.
-val analysisAgentTool = analysisAgentService.createAgentTool(
-    agentName = "analyzeTransactions",
-    agentDescription = "Performs financial transaction analysis",
-    inputDescription = "Transaction analysis request",
-)
-```
-<!--- KNIT example-tools-overview-05.kt -->
+    ```java
+    ```
 
 ### Using agent tools in other agents
 
 Once converted to a tool, you can add the agent tool to another agent's tool registry:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.tools.ToolRegistry
-import ai.koog.agents.example.exampleToolsOverview05.analysisAgentTool
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+=== "Kotlin"
 
-const val apiKey = ""
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.tools.ToolRegistry
+    import ai.koog.agents.example.exampleToolsOverview05.analysisAgentTool
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
+    const val apiKey = ""
+    -->
+    ```kotlin
+    // Create a coordinator agent that can use specialized agents as tools
+    val coordinatorAgent = AIAgent(
+        promptExecutor = simpleOpenAIExecutor(apiKey),
+        llmModel = OpenAIModels.Chat.GPT4o,
+        systemPrompt = "You coordinate different specialized services.",
+        toolRegistry = ToolRegistry {
+            tool(analysisAgentTool)
+            // Add other tools as needed
+        }
+    )
+    ```
+    <!--- KNIT example-tools-overview-06.kt -->
 
--->
-```kotlin
-// Create a coordinator agent that can use specialized agents as tools
-val coordinatorAgent = AIAgent(
-    promptExecutor = simpleOpenAIExecutor(apiKey),
-    llmModel = OpenAIModels.Chat.GPT4o,
-    systemPrompt = "You coordinate different specialized services.",
-    toolRegistry = ToolRegistry {
-        tool(analysisAgentTool)
-        // Add other tools as needed
-    }
-)
-```
-<!--- KNIT example-tools-overview-06.kt -->
+=== "Java"
+
+    ```java
+    ```
 
 ### Agent tool execution
 

--- a/docs/docs/tools/tool-descriptor-schemer.md
+++ b/docs/docs/tools/tool-descriptor-schemer.md
@@ -1,8 +1,6 @@
 # ToolDescriptorSchemer
 
-## What is it
-
-`ToolDescriptorSchemer` is a extension point that converts a `ToolDescriptor` into a JSON Schema object compatible with specific LLM providers.
+`ToolDescriptorSchemer` is an extension point that converts a `ToolDescriptor` into a JSON Schema object compatible with specific LLM providers.
 
 Key points:
 
@@ -10,8 +8,7 @@ Key points:
 - Contract: a single function `scheme(toolDescriptor: ToolDescriptor): JsonObject`
 - Implementations provided:
   - `OpenAICompatibleToolDescriptorSchemer` — generates schemas compatible with OpenAI‑style function/tool definitions.
-  - `OllamaToolDescriptorSchemer` — generates schemas compatible with Ollama tool JSON.
-
+- `OllamaToolDescriptorSchemer` — generates schemas compatible with Ollama tool JSON.
 
 <!--- INCLUDE
 import ai.koog.agents.core.tools.ToolDescriptor
@@ -22,140 +19,164 @@ import kotlinx.serialization.json.JsonObject
 ```kotlin
 // Interface
 interface ToolDescriptorSchemaGenerator {
-  fun generate(toolDescriptor: ToolDescriptor): JsonObject
+fun generate(toolDescriptor: ToolDescriptor): JsonObject
 }
 ```
 <!--- KNIT example-tool-descriptor-schemer-01.kt -->
 
+
 ## Why to use it?
+
 If you want to provide custom scheme for existing or new LLM providers, implement this interface to convert Koog’s `ToolDescriptor` into the expected JSON Schema format.
 
 ## Implementation example
 
 Below is a minimal custom implementation that renders only a subset of parameter types to illustrate how to plug into the SPI. Real implementations should cover all `ToolParameterType`s (String, Integer, Float, Boolean, Null, Enum, List, Object, AnyOf).
 
-<!--- INCLUDE
-import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.agents.core.tools.ToolParameterDescriptor
-import ai.koog.agents.core.tools.ToolParameterType
-import ai.koog.agents.core.tools.serialization.ToolDescriptorSchemaGenerator
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
-import kotlinx.serialization.json.putJsonArray
-import kotlinx.serialization.json.putJsonObject
--->
-```kotlin
+=== "Kotlin"
 
-class MinimalSchemer : ToolDescriptorSchemaGenerator {
-    override fun generate(toolDescriptor: ToolDescriptor): JsonObject = buildJsonObject {
-        put("type", "object")
-        putJsonObject("properties") {
-            (toolDescriptor.requiredParameters + toolDescriptor.optionalParameters).forEach { p ->
-                put(p.name, buildJsonObject {
-                    put("description", p.description)
-                    when (val t = p.type) {
-                        ToolParameterType.String -> put("type", "string")
-                        ToolParameterType.Integer -> put("type", "integer")
-                        is ToolParameterType.Enum -> {
-                            put("type", "string")
-                            putJsonArray("enum") { t.entries.forEach { add(JsonPrimitive(it)) } }
+    <!--- INCLUDE
+    import ai.koog.agents.core.tools.ToolDescriptor
+    import ai.koog.agents.core.tools.ToolParameterDescriptor
+    import ai.koog.agents.core.tools.ToolParameterType
+    import ai.koog.agents.core.tools.serialization.ToolDescriptorSchemaGenerator
+    import kotlinx.serialization.json.JsonPrimitive
+    import kotlinx.serialization.json.JsonObject
+    import kotlinx.serialization.json.buildJsonObject
+    import kotlinx.serialization.json.put
+    import kotlinx.serialization.json.putJsonArray
+    import kotlinx.serialization.json.putJsonObject
+    -->
+    ```kotlin
+    
+    class MinimalSchemer : ToolDescriptorSchemaGenerator {
+        override fun generate(toolDescriptor: ToolDescriptor): JsonObject = buildJsonObject {
+            put("type", "object")
+            putJsonObject("properties") {
+                (toolDescriptor.requiredParameters + toolDescriptor.optionalParameters).forEach { p ->
+                    put(p.name, buildJsonObject {
+                        put("description", p.description)
+                        when (val t = p.type) {
+                            ToolParameterType.String -> put("type", "string")
+                            ToolParameterType.Integer -> put("type", "integer")
+                            is ToolParameterType.Enum -> {
+                                put("type", "string")
+                                putJsonArray("enum") { t.entries.forEach { add(JsonPrimitive(it)) } }
+                            }
+                            else -> put("type", "string") // fallback for brevity
                         }
-                        else -> put("type", "string") // fallback for brevity
-                    }
-                })
+                    })
+                }
             }
+            putJsonArray("required") { toolDescriptor.requiredParameters.forEach { add(JsonPrimitive(it.name)) } }
         }
-        putJsonArray("required") { toolDescriptor.requiredParameters.forEach { add(JsonPrimitive(it.name)) } }
     }
-}
-```
-<!--- KNIT example-tool-descriptor-schemer-02.kt -->
+    ```
+    <!--- KNIT example-tool-descriptor-schemer-02.kt -->
 
-## Example of usage with client
+=== "Java"
+
+    ```java
+    public static class MinimalSchemer extends OpenAICompatibleToolDescriptorSchemaGenerator {
+        @Override
+        public JsonObject generate(ToolDescriptor toolDescriptor) {
+            Map<String, JsonElement> root = new LinkedHashMap<>();
+            root.put("type", JsonPrimitive("object"));
+
+            // properties
+            Map<String, JsonElement> props = new LinkedHashMap<>();
+            for (ToolParameterDescriptor p : concat(toolDescriptor.getRequiredParameters(), toolDescriptor.getOptionalParameters())) {
+                Map<String, JsonElement> prop = new LinkedHashMap<>();
+                prop.put("description", JsonPrimitive(p.getDescription()));
+
+                ToolParameterType t = p.getType();
+                if (t == ToolParameterType.String.INSTANCE) {
+                    prop.put("type", JsonPrimitive("string"));
+                } else if (t == ToolParameterType.Integer.INSTANCE) {
+                    prop.put("type", JsonPrimitive("integer"));
+                } else if (t instanceof ToolParameterType.Enum) {
+                    prop.put("type", JsonPrimitive("string"));
+                    String[] entries = ((ToolParameterType.Enum) t).getEntries();
+                    List<JsonElement> enumVals = new ArrayList<>();
+                    for (String e : entries) enumVals.add(JsonPrimitive(e));
+                    prop.put("enum", new JsonArray(enumVals));
+                } else {
+                    prop.put("type", JsonPrimitive("string")); // fallback for brevity
+                }
+
+                props.put(p.getName(), new JsonObject(prop));
+            }
+            root.put("properties", new JsonObject(props));
+
+            // required array
+            List<JsonElement> required = new ArrayList<>();
+            for (ToolParameterDescriptor p : toolDescriptor.getRequiredParameters()) {
+                required.add(JsonPrimitive(p.getName()));
+            }
+            root.put("required", new JsonArray(required));
+
+            return new JsonObject(root);
+        }
+
+        private static List<ToolParameterDescriptor> concat(List<ToolParameterDescriptor> a, List<ToolParameterDescriptor> b) {
+            List<ToolParameterDescriptor> res = new ArrayList<>(a.size() + b.size());
+            res.addAll(a);
+            res.addAll(b);
+            return res;
+        }
+    }
+    ```
+
+## Using with a client
 
 Typically you do not need to call a schemer directly. Koog clients accept a list of `ToolDescriptor` objects and apply the correct schemer internally when serializing requests for the provider.
 
 The example below defines a simple tool and passes it to the OpenAI client. The client will use `OpenAICompatibleToolDescriptorSchemer` under the hood to build the JSON schema.
 
-<!--- INCLUDE
-import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
-import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.agents.core.tools.ToolParameterDescriptor
-import ai.koog.agents.core.tools.ToolParameterType
-import ai.koog.prompt.dsl.Prompt
-import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.executor.clients.openai.base.OpenAICompatibleToolDescriptorSchemaGenerator
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
-import kotlinx.serialization.json.putJsonArray
-import kotlinx.serialization.json.putJsonObject
-import kotlinx.coroutines.runBlocking
+=== "Kotlin"
 
-class MinimalSchemer : OpenAICompatibleToolDescriptorSchemaGenerator() {
-    override fun generate(toolDescriptor: ToolDescriptor): JsonObject = buildJsonObject {
-        put("type", "object")
-        putJsonObject("properties") {
-            (toolDescriptor.requiredParameters + toolDescriptor.optionalParameters).forEach { p ->
-                put(p.name, buildJsonObject {
-                    put("description", p.description)
-                    when (val t = p.type) {
-                        ToolParameterType.String -> put("type", "string")
-                        ToolParameterType.Integer -> put("type", "integer")
-                        is ToolParameterType.Enum -> {
-                            put("type", "string")
-                            putJsonArray("enum") { t.entries.forEach { add(JsonPrimitive(it)) } }
+    <!--- INCLUDE
+    import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+    import ai.koog.agents.core.tools.ToolDescriptor
+    import ai.koog.agents.core.tools.ToolParameterDescriptor
+    import ai.koog.agents.core.tools.ToolParameterType
+    import ai.koog.prompt.dsl.Prompt
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.executor.clients.openai.base.OpenAICompatibleToolDescriptorSchemaGenerator
+    import kotlinx.serialization.json.JsonPrimitive
+    import kotlinx.serialization.json.JsonObject
+    import kotlinx.serialization.json.buildJsonObject
+    import kotlinx.serialization.json.put
+    import kotlinx.serialization.json.putJsonArray
+    import kotlinx.serialization.json.putJsonObject
+    import kotlinx.coroutines.runBlocking
+    class MinimalSchemer : OpenAICompatibleToolDescriptorSchemaGenerator() {
+        override fun generate(toolDescriptor: ToolDescriptor): JsonObject = buildJsonObject {
+            put("type", "object")
+            putJsonObject("properties") {
+                (toolDescriptor.requiredParameters + toolDescriptor.optionalParameters).forEach { p ->
+                    put(p.name, buildJsonObject {
+                        put("description", p.description)
+                        when (val t = p.type) {
+                            ToolParameterType.String -> put("type", "string")
+                            ToolParameterType.Integer -> put("type", "integer")
+                            is ToolParameterType.Enum -> {
+                                put("type", "string")
+                                putJsonArray("enum") { t.entries.forEach { add(JsonPrimitive(it)) } }
+                            }
+                            else -> put("type", "string") // fallback for brevity
                         }
-                        else -> put("type", "string") // fallback for brevity
-                    }
-                })
+                    })
+                }
             }
+            putJsonArray("required") { toolDescriptor.requiredParameters.forEach { add(JsonPrimitive(it.name)) } }
         }
-        putJsonArray("required") { toolDescriptor.requiredParameters.forEach { add(JsonPrimitive(it.name)) } }
     }
-}
-
--->
-```kotlin
-val client = OpenAILLMClient(apiKey = System.getenv("OPENAI_API_KEY"), toolsConverter = MinimalSchemer())
-
-val getUserTool = ToolDescriptor(
-    name = "get_user",
-    description = "Returns user profile by id",
-    requiredParameters = listOf(
-        ToolParameterDescriptor(
-            name = "id",
-            description = "User id",
-            type = ToolParameterType.String
-        )
-    )
-)
-
-val prompt = Prompt.build(id = "p1") { user("Hello") }
-val responses = runBlocking {
-    client.execute(
-        prompt = prompt,
-        model = OpenAIModels.Chat.GPT4o,
-        tools = listOf(getUserTool)
-    )
-}
-```
-<!--- KNIT example-tool-descriptor-schemer-03.kt -->
-
-If you need direct access to the produced schema (for debugging or for a custom transport), you can instantiate the provider‑specific schemer and serialize the JSON yourself:
-
-<!--- INCLUDE
-import kotlinx.serialization.json.Json
-import ai.koog.prompt.executor.clients.openai.base.OpenAICompatibleToolDescriptorSchemaGenerator
-import ai.koog.agents.core.tools.ToolDescriptor
-import ai.koog.agents.core.tools.ToolParameterDescriptor
-import ai.koog.agents.core.tools.ToolParameterType
-
-fun getUserTool(): ToolDescriptor {
-    return ToolDescriptor(
+    -->
+    ```kotlin
+    val client = OpenAILLMClient(apiKey = System.getenv("OPENAI_API_KEY"), toolsConverter = MinimalSchemer())
+    
+    val getUserTool = ToolDescriptor(
         name = "get_user",
         description = "Returns user profile by id",
         requiredParameters = listOf(
@@ -166,11 +187,74 @@ fun getUserTool(): ToolDescriptor {
             )
         )
     )
-}
--->
+    
+    val prompt = Prompt.build(id = "p1") { user("Hello") }
+    val responses = runBlocking {
+        client.execute(
+            prompt = prompt,
+            model = OpenAIModels.Chat.GPT4o,
+            tools = listOf(getUserTool)
+        )
+    }
+    ```
+    <!--- KNIT example-tool-descriptor-schemer-03.kt -->
 
-```kotlin
-val json = Json { prettyPrint = true }
-val schema = OpenAICompatibleToolDescriptorSchemaGenerator().generate(getUserTool())
-```
-<!--- KNIT example-tool-descriptor-schemer-04.kt -->
+=== "Java"
+
+    ```java
+    // Custom schemer extending the OpenAI-compatible one is Kotlin-only in the docs; for Java example we reuse MinimalSchemer from above.
+    OpenAILLMClient client = new OpenAILLMClient(System.getenv("OPENAI_API_KEY"), new OpenAIClientSettings(), null, null, new OpenAICompatibleToolDescriptorSchemaGenerator());
+    
+    ToolDescriptor getUserTool = new ToolDescriptor(
+        "get_user",
+        "Returns user profile by id",
+        Collections.singletonList(new ToolParameterDescriptor(
+            "id",
+            "User id",
+            ToolParameterType.String.INSTANCE
+        )),
+        Collections.emptyList()
+    );
+
+    Prompt prompt = Prompt.builder("p1")
+        .user("Hello")
+        .build();
+
+    List<Message.Response> responses = client.execute(prompt, OpenAIModels.Chat.GPT4o, java.util.List.of(getUserTool));
+    ```
+
+If you need direct access to the produced schema (for debugging or for a custom transport), you can instantiate the provider‑specific schemer and serialize the JSON yourself:
+
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import kotlinx.serialization.json.Json
+    import ai.koog.prompt.executor.clients.openai.base.OpenAICompatibleToolDescriptorSchemaGenerator
+    import ai.koog.agents.core.tools.ToolDescriptor
+    import ai.koog.agents.core.tools.ToolParameterDescriptor
+    import ai.koog.agents.core.tools.ToolParameterType
+    fun getUserTool(): ToolDescriptor {
+        return ToolDescriptor(
+            name = "get_user",
+            description = "Returns user profile by id",
+            requiredParameters = listOf(
+                ToolParameterDescriptor(
+                    name = "id",
+                    description = "User id",
+                    type = ToolParameterType.String
+                )
+            )
+        )
+    }
+    -->
+    
+    ```kotlin
+    val json = Json { prettyPrint = true }
+    val schema = OpenAICompatibleToolDescriptorSchemaGenerator().generate(getUserTool())
+    ```
+    <!--- KNIT example-tool-descriptor-schemer-04.kt -->
+
+=== "Java"
+
+    ```java
+    ```


### PR DESCRIPTION
The PR has just two pairs (Kotlin&Java) of code examples because of the following:
1. When a user needs just one `PromptExecutor` (e.g. anthropicExecutor) configured in yaml/properties file. The way of injecting the `PromptExecutor` can be either by name (e.g. `PromptExecutor anthropicExecutor`) or via Qualifier annotation, but this is Spring framework functionality.
2. When a users needs multiple `PromptExecutor` implementations (e.g. anthropicExecutor as main and googleExecutor as a fallback) configured in yaml/properties file. Then it makes sense to inject one `MultiLLMPromptExecutor multiLLMPromptExecutor` that can call different providers based on the model.

The example with `@Value` is omitted because it's the basic functionality of the Spring Framework.