### PR TITLE
KG-676 Protect ToolRegistry.EMPTY from mutation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md — Koog
+
+## What this project is
+
+Koog is a Kotlin Multiplatform framework for building AI agents with graph-based workflows.
+See [AGENT.md](AGENT.md) for full architecture, build commands, and code style.
+
+## Key conventions for Claude
+
+- All development goes on the **`develop`** branch. PRs target `develop`, not `main`.
+- Run `./gradlew build` before considering any change done.
+- Test naming: `testXxx` (no backticks).
+- Never suppress compiler warnings without justification.
+- Never commit API keys; use environment variables.
+
+## Navigating the codebase
+
+| Layer | Module path |
+|-------|------------|
+| Core agent abstractions | `agents/agents-core/` |
+| Tool system | `agents/agents-tools/` |
+| Feature plugins | `agents/agents-features-*/` |
+| LLM executors | `prompt/prompt-executor/` |
+| LLM provider clients | `prompt/prompt-executor/clients/` |
+| MCP integration | `agents/agents-mcp/` |
+| A2A communication | `a2a/` |
+| Test utilities | `agents/agents-test/` |
+| Examples | `examples/` |
+
+## Running tests
+
+```bash
+./gradlew jvmTest                          # all unit tests (JVM)
+./gradlew :agents:agents-core:jvmTest      # single module
+./gradlew jvmTest --tests "ClassName.methodName"
+./gradlew jvmIntegrationTest               # requires API keys
+```
+
+Integration tests need env vars: `ANTHROPIC_API_TEST_KEY`, `OPEN_AI_API_TEST_KEY`, `GEMINI_API_TEST_KEY`, etc.
+
+## Key source sets (Kotlin Multiplatform)
+
+- `commonMain` / `commonTest` — shared logic
+- `jvmMain` / `jvmTest` — JVM-specific
+- `jsMain` / `jsTest` — JS target
+- `nativeMain` — native targets
+
+## Further reading
+
+- [AGENT.md](AGENT.md) — architecture deep-dive, patterns, security
+- [TESTING.md](agents/agents-test/TESTING.md) — testing guide with examples
+- [CONTRIBUTING.md](CONTRIBUTING.md) — contribution workflow

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolRegistry.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolRegistry.kt
@@ -26,7 +26,7 @@ package ai.koog.agents.core.tools
  *
  * @property tools The list of tools contained in this registry
  */
-public class ToolRegistry private constructor(tools: List<Tool<*, *>> = emptyList()) {
+public class ToolRegistry private constructor(tools: List<Tool<*, *>> = emptyList(), private val readOnly: Boolean = false) {
 
     private val _tools: MutableList<Tool<*, *>> = tools.toMutableList()
 
@@ -100,8 +100,10 @@ public class ToolRegistry private constructor(tools: List<Tool<*, *>> = emptyLis
      * Adds a tool to the registry if it is not already present.
      *
      * @param tool The tool to be added to the registry.
+     * @throws UnsupportedOperationException if this registry is read-only (e.g. [ToolRegistry.EMPTY]).
      */
     public fun add(tool: Tool<*, *>) {
+        check(!readOnly) { "Cannot add tools to a read-only ToolRegistry. Use ToolRegistry { tool(...) } to create a new registry." }
         if (_tools.contains(tool)) return
         _tools.add(tool)
     }
@@ -112,6 +114,7 @@ public class ToolRegistry private constructor(tools: List<Tool<*, *>> = emptyLis
      * This method accepts a variable number of tools and adds each of them to the registry.
      *
      * @param tools The tools to be added to the registry.
+     * @throws UnsupportedOperationException if this registry is read-only (e.g. [ToolRegistry.EMPTY]).
      */
     public fun addAll(vararg tools: Tool<*, *>) {
         tools.forEach { tool -> add(tool) }
@@ -160,7 +163,10 @@ public class ToolRegistry private constructor(tools: List<Tool<*, *>> = emptyLis
 
         /**
          * A constant representing an empty registry with no tools.
+         *
+         * This instance is read-only; calling [add] or [addAll] on it throws [IllegalStateException].
+         * Use `ToolRegistry { tool(...) }` or the [plus] operator to create a new registry with tools.
          */
-        public val EMPTY: ToolRegistry = ToolRegistry(emptyList())
+        public val EMPTY: ToolRegistry = ToolRegistry(emptyList(), readOnly = true)
     }
 }

--- a/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/serialization/ToolRegistryTest.kt
+++ b/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/serialization/ToolRegistryTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 class ToolRegistryTest {
     private val tool1 = SampleTool("tool_1")
@@ -116,6 +117,36 @@ class ToolRegistryTest {
         assertFailsWith<IllegalArgumentException>("Should fail on unknown tool") {
             sampleRegistry.getTool("unknown_tool")
         }
+    }
+
+    // Regression test for KG-676: ToolRegistry.EMPTY is mutable but stored as a shared constant
+    @Test
+    fun testEmptyRegistryIsReadOnly() = runTest {
+        assertFailsWith<IllegalStateException>("EMPTY registry must not allow add()") {
+            ToolRegistry.EMPTY.add(tool1)
+        }
+        // EMPTY must remain empty after the failed add
+        assertTrue(ToolRegistry.EMPTY.tools.isEmpty())
+    }
+
+    @Test
+    fun testEmptyRegistryAddAllIsReadOnly() = runTest {
+        assertFailsWith<IllegalStateException>("EMPTY registry must not allow addAll()") {
+            ToolRegistry.EMPTY.addAll(tool1, tool2)
+        }
+        assertTrue(ToolRegistry.EMPTY.tools.isEmpty())
+    }
+
+    @Test
+    fun testEmptyRegistryPlusCreatesNewMutableRegistry() = runTest {
+        val registry = ToolRegistry.EMPTY + ToolRegistry { tool(tool1) }
+        assertEquals(1, registry.tools.size)
+        // Original EMPTY is untouched
+        assertTrue(ToolRegistry.EMPTY.tools.isEmpty())
+        // The new registry is mutable
+        registry.add(tool2)
+        assertEquals(2, registry.tools.size)
+        assertFalse(ToolRegistry.EMPTY.tools.isNotEmpty())
     }
 
     @Test


### PR DESCRIPTION
@ Koog Maintainers, ignore this PR, just testing the capabilities of Claude Code

## Summary

Fixes [KG-676](https://youtrack.jetbrains.com/issue/KG-676).

- `ToolRegistry.EMPTY` was a mutable shared singleton — calling `add()` or `addAll()` on it permanently corrupted the constant for every caller in the same process.
- Added a private `readOnly: Boolean` flag to `ToolRegistry`. The `EMPTY` constant is now constructed with `readOnly = true`, making `add()`/`addAll()` throw `IllegalStateException` instead of silently mutating shared state.
- Normal registries created via the builder DSL or the `+` operator are unaffected (`readOnly` defaults to `false`).

## Test plan

- [x] `testEmptyRegistryIsReadOnly` — `add()` on `EMPTY` throws `IllegalStateException`
- [x] `testEmptyRegistryAddAllIsReadOnly` — `addAll()` on `EMPTY` throws `IllegalStateException`
- [x] `testEmptyRegistryPlusCreatesNewMutableRegistry` — `EMPTY + registry` produces a normal mutable registry; `EMPTY` itself stays empty
- [x] All existing `ToolRegistryTest` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)