### PR TITLE
example: Upgrade dependencies and clock usage in spring-boot-java example

### DIFF
--- a/examples/spring-boot-java/pom.xml
+++ b/examples/spring-boot-java/pom.xml
@@ -28,27 +28,27 @@
     </scm>
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
-        <spring.boot.version>3.5.6</spring.boot.version>
+        <spring.boot.version>3.5.11</spring.boot.version>
 <!--         <koog.version>0.4.3-SNAPSHOT</koog.version>-->
-        <koog.version>0.4.3-develop-20250927-0204</koog.version>
+        <koog.version>0.6.4</koog.version>
+        <kotlin.version>2.3.10</kotlin.version>
         <!-- Kotlinx-serialization version must be aligned -->
-        <kotlinx-serialization.version>1.8.1</kotlinx-serialization.version>
-        <kotlinx-datetime.version>0.7.1</kotlinx-datetime.version>
-        <ktor.version>3.2.3</ktor.version>
+        <kotlinx-serialization.version>1.10.0</kotlinx-serialization.version>
+        <ktor.version>3.3.3</ktor.version>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.jetbrains.kotlinx</groupId>
-                <artifactId>kotlinx-serialization-bom</artifactId>
-                <version>${kotlinx-serialization.version}</version>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-bom</artifactId>
+                <version>${kotlin.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains.kotlinx</groupId>
-                <artifactId>kotlinx-datetime-jvm</artifactId>
-                <version>${kotlinx-datetime.version}</version>
+                <artifactId>kotlinx-serialization-bom</artifactId>
+                <version>${kotlinx-serialization.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/examples/spring-boot-java/src/main/java/com/example/AIService.java
+++ b/examples/spring-boot-java/src/main/java/com/example/AIService.java
@@ -20,12 +20,13 @@ import java.util.stream.Collectors;
 @Service
 record AIService(
     @NonNull JavaPromptExecutor executor,
-    kotlinx.datetime.Clock clock
+    kotlin.time.Clock clock
 ) {
 
     private static final Logger log = LoggerFactory.getLogger(AIService.class);
 
     Mono<String> generateResponse(String input) {
+
 
         RequestMetaInfo metaInfo = RequestMetaInfo.Companion.create(clock);
         final var systemPrompt = new Message.System("You are a helpful pirate", metaInfo);
@@ -38,11 +39,11 @@ record AIService(
         );
 
         return Mono.fromFuture(
-            executor.executeAsync(prompt, OpenAIModels.CostOptimized.INSTANCE.getGPT4_1Nano())
-                .handle((responses, thowable) -> {
-                        if (thowable != null) {
-                            log.error("Error executing prompt", thowable);
-                            return "Error: " + thowable.getMessage();
+            executor.executeAsync(prompt, OpenAIModels.Chat.INSTANCE.getGPT4_1Nano())
+                .handle((responses, throwable) -> {
+                        if (throwable != null) {
+                            log.error("Error executing prompt", throwable);
+                            return "Error: " + throwable.getMessage();
                         } else {
                             return responses.stream()
                                 .map(Response::getContent)

--- a/examples/spring-boot-java/src/main/java/com/example/Application.java
+++ b/examples/spring-boot-java/src/main/java/com/example/Application.java
@@ -1,5 +1,6 @@
 package com.example;
 
+import kotlin.time.Clock;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
@@ -9,8 +10,8 @@ public class Application {
 
     // TODO: Make it work without requiring Kotlin Clock
     @Bean
-    kotlinx.datetime.Clock kotlinClock() {
-        return kotlinx.datetime.Clock.System.INSTANCE;
+    kotlin.time.Clock kotlinClock() {
+        return Clock.System.System.INSTANCE;
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
- Bump Spring Boot to 3.5.11 and Koog to 0.6.4.
- Switch to `kotlin.time.Clock` from `kotlinx.datetime.Clock`.
- Update Kotlin to 2.3.10, adjust BOM dependencies, and align Kotlinx Serialization to 1.10.0 / Ktor to 3.3.3.
- Refactor services and beans to use the updated clock implementation.