### PR TITLE
feat(prompt): KG-736 Source `think` Ollama parameter from prompt.params

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaChatParams.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaChatParams.kt
@@ -1,0 +1,95 @@
+package ai.koog.prompt.executor.ollama.client
+
+import ai.koog.prompt.params.LLMParams
+import kotlinx.serialization.json.JsonElement
+
+
+/**
+ * Represents the parameters for configuring an Ollama Chat interaction with an LLM.
+ *
+ * @property temperature Controls the randomness of responses. A lower value results in more deterministic outputs,
+ * while a higher value introduces more randomness.
+ * @property maxTokens Specifies the maximum number of tokens the LLM should generate in its response. Limits the
+ * length of the output.
+ * @property numberOfChoices Determines the number of response options the LLM will generate. Useful for exploring
+ * multiple possibilities for a given prompt.
+ * @property speculation Provides contextual guidance or speculative input for the LLM to consider during response
+ * generation.
+ * @property schema Specifies the structured response format using a predefined schema. Enables structured data
+ * generation in compliance with a schema such as JSON.
+ * @property toolChoice Configures the behavior of tool integrations, dictating whether LLM should call specific tools,
+ * avoid tools, or decide adaptively.
+ * @property user Identifies the end user interacting with the chat. Useful for audits or differentiating inputs
+ * in multi-user environments.
+ * @property additionalProperties An optional map for passing extra parameters to the LLM. This can include
+ * implementation-specific configurations or custom options not directly covered by the primary class fields.
+ * @property think Determines whether the LLM interaction enforces thoughtfulness, potentially impacting behavior or
+ * processing strategies.
+ */
+public class OllamaChatParams(
+    temperature: Double? = null,
+    maxTokens: Int? = null,
+    numberOfChoices: Int? = null,
+    speculation: String? = null,
+    schema: Schema? = null,
+    toolChoice: ToolChoice? = null,
+    user: String? = null,
+    additionalProperties: Map<String, JsonElement>? = null,
+    public val think: Boolean? = null,
+) : LLMParams(
+    temperature,
+    maxTokens,
+    numberOfChoices,
+    speculation,
+    schema,
+    toolChoice,
+    user,
+    additionalProperties
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        if (!super.equals(other)) return false
+
+        other as OllamaChatParams
+
+        return think == other.think
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + (think?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String {
+        return "OllamaParams(think=$think, temperature=$temperature, maxTokens=$maxTokens, numberOfChoices=$numberOfChoices, speculation=$speculation, schema=$schema, toolChoice=$toolChoice, user=$user, additionalProperties=$additionalProperties)"
+    }
+
+    /**
+     * Creates a copy of this instance with the ability to modify any of its properties.
+     */
+    public fun copy(
+        temperature: Double? = this.temperature,
+        maxTokens: Int? = this.maxTokens,
+        numberOfChoices: Int? = this.numberOfChoices,
+        speculation: String? = this.speculation,
+        schema: Schema? = this.schema,
+        toolChoice: ToolChoice? = this.toolChoice,
+        user: String? = this.user,
+        additionalProperties: Map<String, JsonElement>? = this.additionalProperties,
+        think: Boolean? = this.think,
+    ): OllamaChatParams {
+        return OllamaChatParams(
+            temperature = temperature,
+            maxTokens = maxTokens,
+            numberOfChoices = numberOfChoices,
+            speculation = speculation,
+            schema = schema,
+            toolChoice = toolChoice,
+            user = user,
+            additionalProperties = additionalProperties,
+            think = think
+        )
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaChatParams.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaChatParams.kt
@@ -3,7 +3,6 @@ package ai.koog.prompt.executor.ollama.client
 import ai.koog.prompt.params.LLMParams
 import kotlinx.serialization.json.JsonElement
 
-
 /**
  * Represents the parameters for configuring an Ollama Chat interaction with an LLM.
  *

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -34,6 +34,7 @@ import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.streaming.buildStreamFrameFlow
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -157,6 +158,20 @@ public class OllamaClient @JvmOverloads constructor(
         }
     }
 
+    internal fun LLMParams.toOllamaChatParams(): OllamaChatParams {
+        if (this is OllamaChatParams) return this
+        return OllamaChatParams(
+            temperature = temperature,
+            maxTokens = maxTokens,
+            numberOfChoices = numberOfChoices,
+            speculation = speculation,
+            schema = schema,
+            toolChoice = toolChoice,
+            user = user,
+            additionalProperties = additionalProperties,
+        )
+    }
+
     /**
      * Provides the type of Language Learning Model (LLM) provider used by the client.
      *
@@ -186,6 +201,8 @@ public class OllamaClient @JvmOverloads constructor(
             null
         }
 
+        val params = prompt.params.toOllamaChatParams()
+
         val request = ollamaJson.encodeToString(
             OllamaChatRequestDTOSerializer,
             OllamaChatRequestDTO(
@@ -195,7 +212,8 @@ public class OllamaClient @JvmOverloads constructor(
                 format = prompt.extractOllamaJsonFormat(),
                 options = extractOllamaOptions(prompt, model),
                 stream = false,
-                additionalProperties = prompt.params.additionalProperties
+                additionalProperties = params.additionalProperties,
+                think = params.think
             )
         )
 
@@ -278,6 +296,8 @@ public class OllamaClient @JvmOverloads constructor(
     ): Flow<StreamFrame> = buildStreamFrameFlow {
         require(model.provider == LLMProvider.Ollama) { "Model not supported by Ollama" }
 
+        val params = prompt.params.toOllamaChatParams()
+
         val request = ollamaJson.encodeToString(
             OllamaChatRequestDTOSerializer,
             OllamaChatRequestDTO(
@@ -285,7 +305,8 @@ public class OllamaClient @JvmOverloads constructor(
                 messages = prompt.toOllamaChatMessages(model),
                 options = extractOllamaOptions(prompt, model),
                 stream = true,
-                additionalProperties = prompt.params.additionalProperties,
+                additionalProperties = params.additionalProperties,
+                think = params.think
             )
         )
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaModels.kt
@@ -64,7 +64,7 @@ internal data class OllamaChatRequestDTO(
     val format: JsonElement? = null,
     val options: Options? = null,
     val stream: Boolean,
-    val think: Boolean = true,
+    val think: Boolean? = null,
     @SerialName("keep_alive") val keepAlive: String? = null,
     val additionalProperties: Map<String, JsonElement>? = null,
 ) {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/OllamaThinkingFeatureTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/OllamaThinkingFeatureTest.kt
@@ -2,6 +2,7 @@ package ai.koog.prompt.executor.ollama.client
 
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.ollama.client.dto.OllamaChatMessageDTO
+import ai.koog.prompt.executor.ollama.client.dto.OllamaChatRequestDTO
 import ai.koog.prompt.executor.ollama.client.dto.OllamaChatResponseDTO
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.streaming.StreamFrame
@@ -11,6 +12,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -350,8 +352,7 @@ class OllamaThinkingFeatureTest {
         assertTrue(allContent.contains(responseContent), "Response content should be in text frames")
     }
 
-    @Test
-    fun `test request includes think parameter`() = runTest {
+    private suspend fun requestFromMockServer(block: suspend OllamaClient.() -> Unit): OllamaChatRequestDTO {
         val mockServer = MockOllamaChatServer { request ->
             OllamaChatResponseDTO(
                 model = request.model,
@@ -367,17 +368,75 @@ class OllamaThinkingFeatureTest {
             baseClient = HttpClient(mockServer.mockEngine)
         )
 
-        ollamaClient.execute(
-            prompt = prompt("test") { },
-            model = OllamaModels.Meta.LLAMA_3_2
-        )
+        ollamaClient.block()
 
-        val requestHistory = mockServer.requestHistory
-        assertEquals(1, requestHistory.size)
+        return mockServer.requestHistory.first()
+    }
 
-        val request = requestHistory.first()
-        // The think parameter should be set to true by default
-        assertTrue(request.think, "Request should have think parameter set to true")
+    @Test
+    fun `execute enables thinking if requested`() = runTest {
+        val request = requestFromMockServer {
+            execute(
+                prompt = prompt("test", OllamaChatParams(think = true)) { },
+                model = OllamaModels.Meta.LLAMA_3_2
+            )
+        }
+        assertEquals(true, request.think, "Request should have think parameter set to true")
+    }
+
+    @Test
+    fun `execute disables thinking if requested`() = runTest {
+        val request = requestFromMockServer {
+            execute(
+                prompt = prompt("test", OllamaChatParams(think = false)) { },
+                model = OllamaModels.Meta.LLAMA_3_2
+            )
+        }
+        assertEquals(false, request.think, "Request should have think parameter set to false")
+    }
+
+    @Test
+    fun `execute does not include think parameter unless requested`() = runTest {
+        val request = requestFromMockServer {
+            execute(
+                prompt = prompt("test") { },
+                model = OllamaModels.Meta.LLAMA_3_2
+            )
+        }
+        assertNull(request.think, "Request should not have think parameter set")
+    }
+
+    @Test
+    fun `executeStreaming enables thinking if requested`() = runTest {
+        val request = requestFromMockServer {
+            executeStreaming(
+                prompt = prompt("test", OllamaChatParams(think = true)) { },
+                model = OllamaModels.Meta.LLAMA_3_2
+            ).toList()
+        }
+        assertEquals(true, request.think, "Request should have think parameter set to true")
+    }
+
+    @Test
+    fun `executeStreaming disables thinking if requested`() = runTest {
+        val request = requestFromMockServer {
+            executeStreaming(
+                prompt = prompt("test", OllamaChatParams(think = false)) { },
+                model = OllamaModels.Meta.LLAMA_3_2
+            ).toList()
+        }
+        assertEquals(false, request.think, "Request should have think parameter set to false")
+    }
+
+    @Test
+    fun `executeStreaming does not include think parameter unless requested`() = runTest {
+        val request = requestFromMockServer {
+            executeStreaming(
+                prompt = prompt("test") { },
+                model = OllamaModels.Meta.LLAMA_3_2
+            ).toList()
+        }
+        assertNull(request.think, "Request should not have think parameter set")
     }
 
     @Test


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

In https://github.com/JetBrains/koog/pull/1532/changes the `think` property was added to `OllamaChatRequestDTO` but it is currently hard-coded to `true`.

This is a request to expose it via prompt.params so that it can be controlled.

<!-- Include BREAKING section below only if this PR introduces breaking changes. Otherwise, delete it. -->

<!-- Include DEPRECATED section below only if this PR deprecates any public APIs. Otherwise, delete it. -->

<!-- Include references to related issues below, e.g., closes #1, closes KG-1. Otherwise, delete it. -->
closes https://youtrack.jetbrains.com/issue/KG-736
