### PR TITLE
refactor(agents)!: Added Java-Kotlin time conversion API

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/Langfuse.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/Langfuse.kt
@@ -74,6 +74,7 @@ public fun OpenTelemetryConfig.addLangfuseExporter(
  * @param traceAttributes list of trace-level Langfuse attributes.
  */
 @JavaAPI
+@JvmOverloads
 public fun OpenTelemetryConfig.addLangfuseExporter(
     langfuseUrl: String?,
     langfusePublicKey: String?,

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/Langfuse.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/Langfuse.kt
@@ -3,12 +3,12 @@ package ai.koog.agents.features.opentelemetry.integration.langfuse
 import ai.koog.agents.annotations.JavaAPI
 import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryConfig
+import ai.koog.utils.time.toKotlinDuration
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
 import java.util.Base64
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
-import ai.koog.utils.time.toKotlinDuration
 import kotlin.time.Duration.Companion.seconds
 import java.time.Duration as JavaDuration
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/Langfuse.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/Langfuse.kt
@@ -1,5 +1,6 @@
 package ai.koog.agents.features.opentelemetry.integration.langfuse
 
+import ai.koog.agents.annotations.JavaAPI
 import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryConfig
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -7,7 +8,9 @@ import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
 import java.util.Base64
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
+import ai.koog.utils.time.toKotlinDuration
 import kotlin.time.Duration.Companion.seconds
+import java.time.Duration as JavaDuration
 
 /**
  * Configure an OpenTelemetry span exporter that sends data to [Langfuse](https://langfuse.com/).
@@ -57,6 +60,34 @@ public fun OpenTelemetryConfig.addLangfuseExporter(
     )
 
     addSpanAdapter(LangfuseSpanAdapter(traceAttributes, this))
+}
+
+/**
+ * Java-compatible overload of [addLangfuseExporter] that accepts [java.time.Duration] for the timeout parameter.
+ *
+ * @param langfuseUrl the base URL of the Langfuse instance.
+ *        If not set, is retrieved from `LANGFUSE_HOST` environment variable.
+ *        Defaults to [https://cloud.langfuse.com](https://cloud.langfuse.com).
+ * @param langfusePublicKey if not set is retrieved from `LANGFUSE_PUBLIC_KEY` environment variable.
+ * @param langfuseSecretKey if not set is retrieved from `LANGFUSE_SECRET_KEY` environment variable.
+ * @param timeout OpenTelemetry SpanExporter timeout as [java.time.Duration].
+ * @param traceAttributes list of trace-level Langfuse attributes.
+ */
+@JavaAPI
+public fun OpenTelemetryConfig.addLangfuseExporter(
+    langfuseUrl: String?,
+    langfusePublicKey: String?,
+    langfuseSecretKey: String?,
+    timeout: JavaDuration,
+    traceAttributes: List<CustomAttribute> = emptyList()
+) {
+    addLangfuseExporter(
+        langfuseUrl = langfuseUrl,
+        langfusePublicKey = langfusePublicKey,
+        langfuseSecretKey = langfuseSecretKey,
+        timeout = timeout.toKotlinDuration(),
+        traceAttributes = traceAttributes
+    )
 }
 
 private val logger = KotlinLogging.logger { }

--- a/koog-spring-boot-starter/src/main/kotlin/ai/koog/spring/prompt/executor/clients/RetryConfigKoogProperties.kt
+++ b/koog-spring-boot-starter/src/main/kotlin/ai/koog/spring/prompt/executor/clients/RetryConfigKoogProperties.kt
@@ -1,5 +1,6 @@
 package ai.koog.spring
 
+import ai.koog.agents.annotations.JavaAPI
 import org.springframework.boot.convert.DurationUnit
 import java.time.Duration
 import java.time.temporal.ChronoUnit
@@ -26,4 +27,93 @@ public class RetryConfigKoogProperties(
     public val maxDelay: Duration? = null,
     public val backoffMultiplier: Double? = null,
     public val jitterFactor: Double? = null
-)
+) {
+    /**
+     * Companion object for [RetryConfigKoogProperties], providing a builder for constructing instances.
+     */
+    public companion object {
+        /**
+         * Creates a new [RetryConfigKoogPropertiesBuilder] for constructing [RetryConfigKoogProperties] instances.
+         *
+         * @return a new builder instance.
+         */
+        @JavaAPI
+        @JvmStatic
+        public fun builder(): RetryConfigKoogPropertiesBuilder = RetryConfigKoogPropertiesBuilder()
+    }
+
+    /**
+     * A builder class for constructing [RetryConfigKoogProperties] instances from Java code.
+     */
+    @JavaAPI
+    public class RetryConfigKoogPropertiesBuilder {
+        private var enabled: Boolean = false
+        private var maxAttempts: Int? = null
+        private var initialDelay: Duration? = null
+        private var maxDelay: Duration? = null
+        private var backoffMultiplier: Double? = null
+        private var jitterFactor: Double? = null
+
+        /**
+         * Sets whether retries are enabled.
+         *
+         * @param enabled true to enable retries, false to disable.
+         * @return the updated builder instance.
+         */
+        public fun enabled(enabled: Boolean): RetryConfigKoogPropertiesBuilder = apply { this.enabled = enabled }
+
+        /**
+         * Sets the maximum number of retry attempts.
+         *
+         * @param maxAttempts the maximum number of retry attempts.
+         * @return the updated builder instance.
+         */
+        public fun maxAttempts(maxAttempts: Int): RetryConfigKoogPropertiesBuilder = apply { this.maxAttempts = maxAttempts }
+
+        /**
+         * Sets the initial delay before the first retry attempt.
+         *
+         * @param initialDelay the initial delay duration.
+         * @return the updated builder instance.
+         */
+        public fun initialDelay(initialDelay: Duration): RetryConfigKoogPropertiesBuilder = apply { this.initialDelay = initialDelay }
+
+        /**
+         * Sets the maximum delay allowed between retry attempts.
+         *
+         * @param maxDelay the maximum delay duration.
+         * @return the updated builder instance.
+         */
+        public fun maxDelay(maxDelay: Duration): RetryConfigKoogPropertiesBuilder = apply { this.maxDelay = maxDelay }
+
+        /**
+         * Sets the backoff multiplier for subsequent retry attempts.
+         *
+         * @param backoffMultiplier the multiplier to apply to the delay for each subsequent retry.
+         * @return the updated builder instance.
+         */
+        public fun backoffMultiplier(backoffMultiplier: Double): RetryConfigKoogPropertiesBuilder = apply { this.backoffMultiplier = backoffMultiplier }
+
+        /**
+         * Sets the jitter factor to introduce randomness in delay calculations.
+         *
+         * @param jitterFactor the factor for randomness in delays.
+         * @return the updated builder instance.
+         */
+        public fun jitterFactor(jitterFactor: Double): RetryConfigKoogPropertiesBuilder = apply { this.jitterFactor = jitterFactor }
+
+        /**
+         * Builds a new [RetryConfigKoogProperties] instance with the configured values.
+         *
+         * @return a new [RetryConfigKoogProperties] instance.
+         */
+        public fun build(): RetryConfigKoogProperties = RetryConfigKoogProperties(
+            enabled = enabled,
+            maxAttempts = maxAttempts,
+            initialDelay = initialDelay,
+            maxDelay = maxDelay,
+            backoffMultiplier = backoffMultiplier,
+            jitterFactor = jitterFactor
+        )
+    }
+}

--- a/koog-spring-boot-starter/src/main/kotlin/ai/koog/spring/prompt/executor/clients/utils.kt
+++ b/koog-spring-boot-starter/src/main/kotlin/ai/koog/spring/prompt/executor/clients/utils.kt
@@ -4,7 +4,7 @@ import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.clients.retry.RetryConfig
 import ai.koog.prompt.executor.clients.retry.toRetryingClient
 import ai.koog.spring.RetryConfigKoogProperties
-import kotlin.time.toKotlinDuration
+import ai.koog.utils.time.toKotlinDuration
 
 internal fun LLMClient.toRetryingClient(properties: RetryConfigKoogProperties?): LLMClient {
     val self = this

--- a/koog-spring-boot-starter/src/test/kotlin/ai/koog/spring/RetryConfigKoogPropertiesBuilderTest.kt
+++ b/koog-spring-boot-starter/src/test/kotlin/ai/koog/spring/RetryConfigKoogPropertiesBuilderTest.kt
@@ -1,10 +1,10 @@
 package ai.koog.spring
 
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 import java.time.Duration
 
 class RetryConfigKoogPropertiesBuilderTest {

--- a/koog-spring-boot-starter/src/test/kotlin/ai/koog/spring/RetryConfigKoogPropertiesBuilderTest.kt
+++ b/koog-spring-boot-starter/src/test/kotlin/ai/koog/spring/RetryConfigKoogPropertiesBuilderTest.kt
@@ -1,0 +1,65 @@
+package ai.koog.spring
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import java.time.Duration
+
+class RetryConfigKoogPropertiesBuilderTest {
+
+    @Test
+    fun testBuilderDefaults() {
+        val props = RetryConfigKoogProperties.builder().build()
+
+        assertFalse(props.enabled)
+        assertNull(props.maxAttempts)
+        assertNull(props.initialDelay)
+        assertNull(props.maxDelay)
+        assertNull(props.backoffMultiplier)
+        assertNull(props.jitterFactor)
+    }
+
+    @Test
+    fun testBuilderWithAllFields() {
+        val props = RetryConfigKoogProperties.builder()
+            .enabled(true)
+            .maxAttempts(5)
+            .initialDelay(Duration.ofSeconds(2))
+            .maxDelay(Duration.ofSeconds(30))
+            .backoffMultiplier(2.0)
+            .jitterFactor(0.1)
+            .build()
+
+        assertTrue(props.enabled)
+        assertEquals(5, props.maxAttempts)
+        assertEquals(Duration.ofSeconds(2), props.initialDelay)
+        assertEquals(Duration.ofSeconds(30), props.maxDelay)
+        assertEquals(2.0, props.backoffMultiplier)
+        assertEquals(0.1, props.jitterFactor)
+    }
+
+    @Test
+    fun testBuilderWithPartialFields() {
+        val props = RetryConfigKoogProperties.builder()
+            .enabled(true)
+            .maxAttempts(3)
+            .build()
+
+        assertTrue(props.enabled)
+        assertEquals(3, props.maxAttempts)
+        assertNull(props.initialDelay)
+        assertNull(props.maxDelay)
+        assertNull(props.backoffMultiplier)
+        assertNull(props.jitterFactor)
+    }
+
+    @Test
+    fun testBuilderChainingReturnsSameInstance() {
+        val builder = RetryConfigKoogProperties.builder()
+        val returned = builder.enabled(true)
+
+        assertTrue(builder === returned)
+    }
+}

--- a/prompt/prompt-cache/prompt-cache-redis/build.gradle.kts
+++ b/prompt/prompt-cache/prompt-cache-redis/build.gradle.kts
@@ -23,6 +23,8 @@ kotlin {
             dependencies {
                 api(libs.kotlinx.coroutines.jdk9)
                 api(libs.lettuce.core)
+                implementation(project(":agents:agents-utils"))
+                implementation(project(":utils"))
             }
         }
 

--- a/prompt/prompt-cache/prompt-cache-redis/src/jvmMain/kotlin/ai/koog/prompt/cache/redis/RedisPromptCache.kt
+++ b/prompt/prompt-cache/prompt-cache-redis/src/jvmMain/kotlin/ai/koog/prompt/cache/redis/RedisPromptCache.kt
@@ -3,6 +3,7 @@ package ai.koog.prompt.cache.redis
 import ai.koog.agents.annotations.JavaAPI
 import ai.koog.prompt.cache.model.PromptCache
 import ai.koog.prompt.message.Message
+import ai.koog.utils.time.toKotlinDuration
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
 import io.lettuce.core.RedisClient
@@ -13,7 +14,6 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
-import ai.koog.utils.time.toKotlinDuration
 import kotlin.time.Duration.Companion.seconds
 import java.time.Duration as JavaDuration
 
@@ -39,7 +39,9 @@ public class RedisPromptCache(
      */
     @JavaAPI
     public constructor(client: RedisClient, prefix: String, ttl: JavaDuration) : this(
-        client, prefix, ttl.toKotlinDuration()
+        client,
+        prefix,
+        ttl.toKotlinDuration()
     )
 
     /**

--- a/prompt/prompt-cache/prompt-cache-redis/src/jvmMain/kotlin/ai/koog/prompt/cache/redis/RedisPromptCache.kt
+++ b/prompt/prompt-cache/prompt-cache-redis/src/jvmMain/kotlin/ai/koog/prompt/cache/redis/RedisPromptCache.kt
@@ -1,5 +1,6 @@
 package ai.koog.prompt.cache.redis
 
+import ai.koog.agents.annotations.JavaAPI
 import ai.koog.prompt.cache.model.PromptCache
 import ai.koog.prompt.message.Message
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -12,7 +13,9 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
+import ai.koog.utils.time.toKotlinDuration
 import kotlin.time.Duration.Companion.seconds
+import java.time.Duration as JavaDuration
 
 /**
  * Redis-based implementation of [PromptCache].
@@ -26,6 +29,18 @@ public class RedisPromptCache(
     private val prefix: String,
     private val ttl: Duration,
 ) : PromptCache {
+
+    /**
+     * Java-compatible constructor that accepts [java.time.Duration] for the TTL parameter.
+     *
+     * @param client The Redis client to use for connecting to Redis
+     * @param prefix The prefix for cache keys
+     * @param ttl The time-to-live for cache entries as [java.time.Duration]
+     */
+    @JavaAPI
+    public constructor(client: RedisClient, prefix: String, ttl: JavaDuration) : this(
+        client, prefix, ttl.toKotlinDuration()
+    )
 
     /**
      * Companion object for the RedisPromptCache class, functioning as a factory for creating

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfig.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfig.kt
@@ -1,5 +1,6 @@
 package ai.koog.prompt.executor.clients.retry
 
+import kotlin.jvm.JvmOverloads
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -15,7 +16,7 @@ import kotlin.time.Duration.Companion.seconds
  * @property retryablePatterns Patterns to identify retryable errors
  * @property retryAfterExtractor Optional extractor for retry-after hints
  */
-public data class RetryConfig(
+public data class RetryConfig @JvmOverloads constructor(
     val maxAttempts: Int = 3,
     val initialDelay: Duration = 1.seconds,
     val maxDelay: Duration = 30.seconds,

--- a/prompt/prompt-executor/prompt-executor-clients/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfigBuilder.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfigBuilder.kt
@@ -1,0 +1,161 @@
+package ai.koog.prompt.executor.clients.retry
+
+import ai.koog.agents.annotations.JavaAPI
+import ai.koog.utils.time.toKotlinDuration
+import java.time.Duration as JavaDuration
+import kotlin.time.Duration
+
+/**
+ * A builder class for constructing [RetryConfig] instances from Java code.
+ *
+ * Accepts both [java.time.Duration] and [kotlin.time.Duration] for delay parameters.
+ *
+ * Usage from Java:
+ * ```java
+ * RetryConfig config = RetryConfig.builder()
+ *     .maxAttempts(5)
+ *     .initialDelay(Duration.ofSeconds(2))
+ *     .maxDelay(Duration.ofSeconds(60))
+ *     .backoffMultiplier(2.0)
+ *     .jitterFactor(0.15)
+ *     .build();
+ * ```
+ */
+/**
+ * Creates a new [RetryConfigBuilder] for constructing [RetryConfig] instances.
+ */
+@JavaAPI
+public fun RetryConfig.Companion.builder(): RetryConfigBuilder = RetryConfigBuilder()
+
+/**
+ * A builder class for constructing [RetryConfig] instances from Java code.
+ *
+ * Accepts both [java.time.Duration] and [kotlin.time.Duration] for delay parameters.
+ *
+ * Usage from Java:
+ * ```java
+ * RetryConfig config = RetryConfig.builder()
+ *     .maxAttempts(5)
+ *     .initialDelay(Duration.ofSeconds(2))
+ *     .maxDelay(Duration.ofSeconds(60))
+ *     .backoffMultiplier(2.0)
+ *     .jitterFactor(0.15)
+ *     .build();
+ * ```
+ */
+/**
+ * Creates a new [RetryConfigBuilder] for constructing [RetryConfig] instances.
+ */
+@JavaAPI
+public class RetryConfigBuilder {
+    private var maxAttempts: Int? = null
+    private var initialDelay: Duration? = null
+    private var maxDelay: Duration? = null
+    private var backoffMultiplier: Double? = null
+    private var jitterFactor: Double? = null
+    private var retryablePatterns: List<RetryablePattern>? = null
+    private var retryAfterExtractor: RetryAfterExtractor? = null
+    private var retryAfterExtractorSet: Boolean = false
+
+    /**
+     * Sets the maximum number of attempts (including initial).
+     *
+     * @param maxAttempts the maximum number of attempts.
+     * @return the updated builder instance.
+     */
+    public fun maxAttempts(maxAttempts: Int): RetryConfigBuilder = apply { this.maxAttempts = maxAttempts }
+
+    /**
+     * Sets the initial delay before the first retry attempt using [java.time.Duration].
+     *
+     * @param initialDelay the initial delay duration.
+     * @return the updated builder instance.
+     */
+    public fun initialDelay(initialDelay: JavaDuration): RetryConfigBuilder = apply {
+        this.initialDelay = initialDelay.toKotlinDuration()
+    }
+
+    /**
+     * Sets the initial delay before the first retry attempt using [kotlin.time.Duration].
+     *
+     * @param initialDelay the initial delay duration.
+     * @return the updated builder instance.
+     */
+    public fun initialDelay(initialDelay: Duration): RetryConfigBuilder = apply { this.initialDelay = initialDelay }
+
+    /**
+     * Sets the maximum delay allowed between retry attempts using [java.time.Duration].
+     *
+     * @param maxDelay the maximum delay duration.
+     * @return the updated builder instance.
+     */
+    public fun maxDelay(maxDelay: JavaDuration): RetryConfigBuilder = apply {
+        this.maxDelay = maxDelay.toKotlinDuration()
+    }
+
+    /**
+     * Sets the maximum delay allowed between retry attempts using [kotlin.time.Duration].
+     *
+     * @param maxDelay the maximum delay duration.
+     * @return the updated builder instance.
+     */
+    public fun maxDelay(maxDelay: Duration): RetryConfigBuilder = apply { this.maxDelay = maxDelay }
+
+    /**
+     * Sets the backoff multiplier for subsequent retry attempts.
+     *
+     * @param backoffMultiplier the multiplier to apply to the delay for each subsequent retry.
+     * @return the updated builder instance.
+     */
+    public fun backoffMultiplier(backoffMultiplier: Double): RetryConfigBuilder = apply {
+        this.backoffMultiplier = backoffMultiplier
+    }
+
+    /**
+     * Sets the jitter factor to introduce randomness in delay calculations.
+     *
+     * @param jitterFactor the factor for randomness in delays (0.0 to 1.0).
+     * @return the updated builder instance.
+     */
+    public fun jitterFactor(jitterFactor: Double): RetryConfigBuilder = apply { this.jitterFactor = jitterFactor }
+
+    /**
+     * Sets the retryable patterns for identifying retryable errors.
+     *
+     * @param retryablePatterns the list of patterns.
+     * @return the updated builder instance.
+     */
+    public fun retryablePatterns(retryablePatterns: List<RetryablePattern>): RetryConfigBuilder = apply {
+        this.retryablePatterns = retryablePatterns
+    }
+
+    /**
+     * Sets the retry-after extractor for extracting retry-after hints from error messages.
+     *
+     * @param retryAfterExtractor the extractor, or null to disable.
+     * @return the updated builder instance.
+     */
+    public fun retryAfterExtractor(retryAfterExtractor: RetryAfterExtractor?): RetryConfigBuilder = apply {
+        this.retryAfterExtractor = retryAfterExtractor
+        this.retryAfterExtractorSet = true
+    }
+
+    /**
+     * Builds a new [RetryConfig] instance with the configured values.
+     * Any unset values will use [RetryConfig] defaults.
+     *
+     * @return a new [RetryConfig] instance.
+     */
+    public fun build(): RetryConfig {
+        val defaults = RetryConfig()
+        return RetryConfig(
+            maxAttempts = maxAttempts ?: defaults.maxAttempts,
+            initialDelay = initialDelay ?: defaults.initialDelay,
+            maxDelay = maxDelay ?: defaults.maxDelay,
+            backoffMultiplier = backoffMultiplier ?: defaults.backoffMultiplier,
+            jitterFactor = jitterFactor ?: defaults.jitterFactor,
+            retryablePatterns = retryablePatterns ?: defaults.retryablePatterns,
+            retryAfterExtractor = if (retryAfterExtractorSet) retryAfterExtractor else defaults.retryAfterExtractor
+        )
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfigBuilder.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfigBuilder.kt
@@ -2,8 +2,8 @@ package ai.koog.prompt.executor.clients.retry
 
 import ai.koog.agents.annotations.JavaAPI
 import ai.koog.utils.time.toKotlinDuration
-import java.time.Duration as JavaDuration
 import kotlin.time.Duration
+import java.time.Duration as JavaDuration
 
 /**
  * A builder class for constructing [RetryConfig] instances from Java code.

--- a/prompt/prompt-executor/prompt-executor-clients/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfigBuilderTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfigBuilderTest.kt
@@ -1,0 +1,111 @@
+package ai.koog.prompt.executor.clients.retry
+
+import java.time.Duration as JavaDuration
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class RetryConfigBuilderTest {
+
+    @Test
+    fun testBuilderWithDefaults() {
+        val config = RetryConfigBuilder().build()
+        val defaults = RetryConfig()
+
+        assertEquals(defaults.maxAttempts, config.maxAttempts)
+        assertEquals(defaults.initialDelay, config.initialDelay)
+        assertEquals(defaults.maxDelay, config.maxDelay)
+        assertEquals(defaults.backoffMultiplier, config.backoffMultiplier)
+        assertEquals(defaults.jitterFactor, config.jitterFactor)
+        assertEquals(defaults.retryablePatterns, config.retryablePatterns)
+        assertEquals(defaults.retryAfterExtractor, config.retryAfterExtractor)
+    }
+
+    @Test
+    fun testBuilderWithAllKotlinDurations() {
+        val config = RetryConfigBuilder()
+            .maxAttempts(5)
+            .initialDelay(500.milliseconds)
+            .maxDelay(60.seconds)
+            .backoffMultiplier(1.5)
+            .jitterFactor(0.2)
+            .build()
+
+        assertEquals(5, config.maxAttempts)
+        assertEquals(500.milliseconds, config.initialDelay)
+        assertEquals(60.seconds, config.maxDelay)
+        assertEquals(1.5, config.backoffMultiplier)
+        assertEquals(0.2, config.jitterFactor)
+    }
+
+    @Test
+    fun testBuilderWithJavaDurations() {
+        val config = RetryConfigBuilder()
+            .maxAttempts(4)
+            .initialDelay(JavaDuration.ofSeconds(2))
+            .maxDelay(JavaDuration.ofMinutes(1))
+            .build()
+
+        assertEquals(4, config.maxAttempts)
+        assertEquals(2.seconds, config.initialDelay)
+        assertEquals(60.seconds, config.maxDelay)
+    }
+
+    @Test
+    fun testBuilderWithMixedDurations() {
+        val config = RetryConfigBuilder()
+            .initialDelay(JavaDuration.ofMillis(500))
+            .maxDelay(30.seconds)
+            .build()
+
+        assertEquals(500.milliseconds, config.initialDelay)
+        assertEquals(30.seconds, config.maxDelay)
+    }
+
+    @Test
+    fun testBuilderWithRetryablePatterns() {
+        val patterns = listOf(
+            RetryablePattern.Status(429),
+            RetryablePattern.Keyword("rate limit")
+        )
+        val config = RetryConfigBuilder()
+            .retryablePatterns(patterns)
+            .build()
+
+        assertEquals(patterns, config.retryablePatterns)
+    }
+
+    @Test
+    fun testBuilderWithNullRetryAfterExtractor() {
+        val config = RetryConfigBuilder()
+            .retryAfterExtractor(null)
+            .build()
+
+        assertNull(config.retryAfterExtractor)
+    }
+
+    @Test
+    fun testBuilderWithCustomRetryAfterExtractor() {
+        val extractor = RetryAfterExtractor { null }
+        val config = RetryConfigBuilder()
+            .retryAfterExtractor(extractor)
+            .build()
+
+        assertEquals(extractor, config.retryAfterExtractor)
+    }
+
+    @Test
+    fun testCompanionBuilderExtension() {
+        val config = RetryConfig.builder()
+            .maxAttempts(2)
+            .initialDelay(JavaDuration.ofSeconds(1))
+            .maxDelay(JavaDuration.ofSeconds(10))
+            .build()
+
+        assertEquals(2, config.maxAttempts)
+        assertEquals(1.seconds, config.initialDelay)
+        assertEquals(10.seconds, config.maxDelay)
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfigBuilderTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryConfigBuilderTest.kt
@@ -1,11 +1,11 @@
 package ai.koog.prompt.executor.clients.retry
 
-import java.time.Duration as JavaDuration
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import java.time.Duration as JavaDuration
 
 class RetryConfigBuilderTest {
 

--- a/prompt/prompt-model/build.gradle.kts
+++ b/prompt/prompt-model/build.gradle.kts
@@ -20,6 +20,12 @@ kotlin {
             }
         }
 
+        jvmMain {
+            dependencies {
+                implementation(project(":agents:agents-utils"))
+            }
+        }
+
         commonTest {
             dependencies {
                 implementation(project(":test-utils"))

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
@@ -369,7 +369,7 @@ public sealed interface MessageMetaInfo {
  * Defaults to the current system time if not provided.
  */
 @Serializable
-public data class RequestMetaInfo(
+public data class RequestMetaInfo @JvmOverloads constructor(
     override val timestamp: Instant,
     override val metadata: JsonObject? = null
 ) : MessageMetaInfo {
@@ -414,7 +414,7 @@ public data class RequestMetaInfo(
  * Defaults to the current system time if not explicitly set.
  */
 @Serializable
-public data class ResponseMetaInfo(
+public data class ResponseMetaInfo @JvmOverloads constructor(
     public override val timestamp: Instant,
     public val totalTokensCount: Int? = null,
     public val inputTokensCount: Int? = null,

--- a/prompt/prompt-model/src/jvmMain/kotlin/ai/koog/prompt/message/MessageBuilder.kt
+++ b/prompt/prompt-model/src/jvmMain/kotlin/ai/koog/prompt/message/MessageBuilder.kt
@@ -1,0 +1,774 @@
+package ai.koog.prompt.message
+
+import ai.koog.agents.annotations.JavaAPI
+import ai.koog.utils.time.toKotlinInstant
+import kotlinx.serialization.json.JsonObject
+import kotlin.time.Clock
+import kotlin.time.Instant
+import java.time.Instant as JavaInstant
+
+/**
+ * Builder for creating [RequestMetaInfo] instances from Java code.
+ *
+ * Usage from Java:
+ * ```java
+ * RequestMetaInfo metaInfo = RequestMetaInfo.builder()
+ *     .timestamp(Instant.now())
+ *     .metadata(jsonObject)
+ *     .build();
+ * ```
+ */
+@JavaAPI
+public class RequestMetaInfoBuilder {
+    private var timestamp: Instant? = null
+    private var metadata: JsonObject? = null
+
+    /**
+     * Sets the timestamp using [java.time.Instant].
+     */
+    public fun timestamp(timestamp: JavaInstant): RequestMetaInfoBuilder = apply {
+        this.timestamp = timestamp.toKotlinInstant()
+    }
+
+    /**
+     * Sets the timestamp using [kotlin.time.Instant].
+     */
+    public fun timestamp(timestamp: Instant): RequestMetaInfoBuilder = apply {
+        this.timestamp = timestamp
+    }
+
+    /**
+     * Sets the metadata.
+     */
+    public fun metadata(metadata: JsonObject?): RequestMetaInfoBuilder = apply {
+        this.metadata = metadata
+    }
+
+    /**
+     * Builds a new [RequestMetaInfo] instance.
+     * If no timestamp is set, the current system time is used.
+     */
+    public fun build(): RequestMetaInfo = RequestMetaInfo(
+        timestamp = timestamp ?: Clock.System.now(),
+        metadata = metadata
+    )
+}
+
+/**
+ * Creates a new [RequestMetaInfoBuilder].
+ */
+@JavaAPI
+public fun RequestMetaInfo.Companion.builder(): RequestMetaInfoBuilder = RequestMetaInfoBuilder()
+
+/**
+ * Creates a [RequestMetaInfo] with a [java.time.Instant] timestamp.
+ */
+@JavaAPI
+public fun RequestMetaInfo.Companion.fromJavaInstant(
+    timestamp: JavaInstant,
+    metadata: JsonObject? = null
+): RequestMetaInfo = RequestMetaInfo(
+    timestamp = timestamp.toKotlinInstant(),
+    metadata = metadata
+)
+
+/**
+ * Builder for creating [ResponseMetaInfo] instances from Java code.
+ *
+ * Usage from Java:
+ * ```java
+ * ResponseMetaInfo metaInfo = ResponseMetaInfo.builder()
+ *     .timestamp(Instant.now())
+ *     .totalTokensCount(100)
+ *     .inputTokensCount(40)
+ *     .outputTokensCount(60)
+ *     .build();
+ * ```
+ */
+@JavaAPI
+public class ResponseMetaInfoBuilder {
+    private var timestamp: Instant? = null
+    private var totalTokensCount: Int? = null
+    private var inputTokensCount: Int? = null
+    private var outputTokensCount: Int? = null
+    private var metadata: JsonObject? = null
+
+    /**
+     * Sets the timestamp using [java.time.Instant].
+     */
+    public fun timestamp(timestamp: JavaInstant): ResponseMetaInfoBuilder = apply {
+        this.timestamp = timestamp.toKotlinInstant()
+    }
+
+    /**
+     * Sets the timestamp using [kotlin.time.Instant].
+     */
+    public fun timestamp(timestamp: Instant): ResponseMetaInfoBuilder = apply {
+        this.timestamp = timestamp
+    }
+
+    /**
+     * Sets the total token count.
+     */
+    public fun totalTokensCount(count: Int): ResponseMetaInfoBuilder = apply {
+        this.totalTokensCount = count
+    }
+
+    /**
+     * Sets the input token count.
+     */
+    public fun inputTokensCount(count: Int): ResponseMetaInfoBuilder = apply {
+        this.inputTokensCount = count
+    }
+
+    /**
+     * Sets the output token count.
+     */
+    public fun outputTokensCount(count: Int): ResponseMetaInfoBuilder = apply {
+        this.outputTokensCount = count
+    }
+
+    /**
+     * Sets the metadata.
+     */
+    public fun metadata(metadata: JsonObject?): ResponseMetaInfoBuilder = apply {
+        this.metadata = metadata
+    }
+
+    /**
+     * Builds a new [ResponseMetaInfo] instance.
+     * If no timestamp is set, the current system time is used.
+     */
+    public fun build(): ResponseMetaInfo = ResponseMetaInfo(
+        timestamp = timestamp ?: Clock.System.now(),
+        totalTokensCount = totalTokensCount,
+        inputTokensCount = inputTokensCount,
+        outputTokensCount = outputTokensCount,
+        metadata = metadata
+    )
+}
+
+/**
+ * Creates a new [ResponseMetaInfoBuilder].
+ */
+@JavaAPI
+public fun ResponseMetaInfo.Companion.builder(): ResponseMetaInfoBuilder = ResponseMetaInfoBuilder()
+
+/**
+ * Creates a [ResponseMetaInfo] with a [java.time.Instant] timestamp.
+ */
+@JavaAPI
+public fun ResponseMetaInfo.Companion.fromJavaInstant(
+    timestamp: JavaInstant,
+    totalTokensCount: Int? = null,
+    inputTokensCount: Int? = null,
+    outputTokensCount: Int? = null,
+    metadata: JsonObject? = null
+): ResponseMetaInfo = ResponseMetaInfo(
+    timestamp = timestamp.toKotlinInstant(),
+    totalTokensCount = totalTokensCount,
+    inputTokensCount = inputTokensCount,
+    outputTokensCount = outputTokensCount,
+    metadata = metadata
+)
+
+/**
+ * Builder for creating [Message.User] instances from Java code.
+ *
+ * Usage from Java:
+ * ```java
+ * Message.User message = MessageBuilder.user()
+ *     .content("Hello, world!")
+ *     .timestamp(Instant.now())
+ *     .build();
+ * ```
+ */
+@JavaAPI
+public class UserMessageBuilder {
+    private val parts: MutableList<ContentPart> = mutableListOf()
+    private val metaInfoBuilder: RequestMetaInfoBuilder = RequestMetaInfoBuilder()
+
+    /**
+     * Sets a single text content for the message, replacing any previously added parts.
+     */
+    public fun content(content: String): UserMessageBuilder = apply {
+        parts.clear()
+        parts.add(ContentPart.Text(content))
+    }
+
+    /**
+     * Adds a content part to the message.
+     */
+    public fun addPart(part: ContentPart): UserMessageBuilder = apply {
+        parts.add(part)
+    }
+
+    /**
+     * Sets the timestamp using [java.time.Instant].
+     */
+    public fun timestamp(timestamp: JavaInstant): UserMessageBuilder = apply {
+        metaInfoBuilder.timestamp(timestamp)
+    }
+
+    /**
+     * Sets the timestamp using [kotlin.time.Instant].
+     */
+    public fun timestamp(timestamp: Instant): UserMessageBuilder = apply {
+        metaInfoBuilder.timestamp(timestamp)
+    }
+
+    /**
+     * Sets the metadata.
+     */
+    public fun metadata(metadata: JsonObject?): UserMessageBuilder = apply {
+        metaInfoBuilder.metadata(metadata)
+    }
+
+    /**
+     * Builds a new [Message.User] instance.
+     *
+     * @throws IllegalStateException if no content parts have been added.
+     */
+    public fun build(): Message.User {
+        check(parts.isNotEmpty()) { "User message must have at least one content part" }
+        return Message.User(parts = parts.toList(), metaInfo = metaInfoBuilder.build())
+    }
+}
+
+/**
+ * Builder for creating [Message.Assistant] instances from Java code.
+ *
+ * Usage from Java:
+ * ```java
+ * Message.Assistant message = MessageBuilder.assistant()
+ *     .content("Hello!")
+ *     .timestamp(Instant.now())
+ *     .finishReason("stop")
+ *     .build();
+ * ```
+ */
+@JavaAPI
+public class AssistantMessageBuilder {
+    private val parts: MutableList<ContentPart> = mutableListOf()
+    private val metaInfoBuilder: ResponseMetaInfoBuilder = ResponseMetaInfoBuilder()
+    private var finishReason: String? = null
+
+    /**
+     * Sets a single text content for the message, replacing any previously added parts.
+     */
+    public fun content(content: String): AssistantMessageBuilder = apply {
+        parts.clear()
+        parts.add(ContentPart.Text(content))
+    }
+
+    /**
+     * Adds a content part to the message.
+     */
+    public fun addPart(part: ContentPart): AssistantMessageBuilder = apply {
+        parts.add(part)
+    }
+
+    /**
+     * Sets the timestamp using [java.time.Instant].
+     */
+    public fun timestamp(timestamp: JavaInstant): AssistantMessageBuilder = apply {
+        metaInfoBuilder.timestamp(timestamp)
+    }
+
+    /**
+     * Sets the timestamp using [kotlin.time.Instant].
+     */
+    public fun timestamp(timestamp: Instant): AssistantMessageBuilder = apply {
+        metaInfoBuilder.timestamp(timestamp)
+    }
+
+    /**
+     * Sets the total token count.
+     */
+    public fun totalTokensCount(count: Int): AssistantMessageBuilder = apply {
+        metaInfoBuilder.totalTokensCount(count)
+    }
+
+    /**
+     * Sets the input token count.
+     */
+    public fun inputTokensCount(count: Int): AssistantMessageBuilder = apply {
+        metaInfoBuilder.inputTokensCount(count)
+    }
+
+    /**
+     * Sets the output token count.
+     */
+    public fun outputTokensCount(count: Int): AssistantMessageBuilder = apply {
+        metaInfoBuilder.outputTokensCount(count)
+    }
+
+    /**
+     * Sets the metadata.
+     */
+    public fun metadata(metadata: JsonObject?): AssistantMessageBuilder = apply {
+        metaInfoBuilder.metadata(metadata)
+    }
+
+    /**
+     * Sets the finish reason.
+     */
+    public fun finishReason(finishReason: String?): AssistantMessageBuilder = apply {
+        this.finishReason = finishReason
+    }
+
+    /**
+     * Builds a new [Message.Assistant] instance.
+     *
+     * @throws IllegalStateException if no content parts have been added.
+     */
+    public fun build(): Message.Assistant {
+        check(parts.isNotEmpty()) { "Assistant message must have at least one content part" }
+        return Message.Assistant(
+            parts = parts.toList(),
+            metaInfo = metaInfoBuilder.build(),
+            finishReason = finishReason
+        )
+    }
+}
+
+/**
+ * Builder for creating [Message.System] instances from Java code.
+ *
+ * Usage from Java:
+ * ```java
+ * Message.System message = MessageBuilder.system()
+ *     .content("You are a helpful assistant.")
+ *     .build();
+ * ```
+ */
+@JavaAPI
+public class SystemMessageBuilder {
+    private val parts: MutableList<ContentPart.Text> = mutableListOf()
+    private val metaInfoBuilder: RequestMetaInfoBuilder = RequestMetaInfoBuilder()
+
+    /**
+     * Sets a single text content for the message, replacing any previously added parts.
+     */
+    public fun content(content: String): SystemMessageBuilder = apply {
+        parts.clear()
+        parts.add(ContentPart.Text(content))
+    }
+
+    /**
+     * Adds a text content part to the message.
+     */
+    public fun addPart(part: ContentPart.Text): SystemMessageBuilder = apply {
+        parts.add(part)
+    }
+
+    /**
+     * Sets the timestamp using [java.time.Instant].
+     */
+    public fun timestamp(timestamp: JavaInstant): SystemMessageBuilder = apply {
+        metaInfoBuilder.timestamp(timestamp)
+    }
+
+    /**
+     * Sets the timestamp using [kotlin.time.Instant].
+     */
+    public fun timestamp(timestamp: Instant): SystemMessageBuilder = apply {
+        metaInfoBuilder.timestamp(timestamp)
+    }
+
+    /**
+     * Sets the metadata.
+     */
+    public fun metadata(metadata: JsonObject?): SystemMessageBuilder = apply {
+        metaInfoBuilder.metadata(metadata)
+    }
+
+    /**
+     * Builds a new [Message.System] instance.
+     *
+     * @throws IllegalStateException if no content parts have been added.
+     */
+    public fun build(): Message.System {
+        check(parts.isNotEmpty()) { "System message must have at least one content part" }
+        return Message.System(parts = parts.toList(), metaInfo = metaInfoBuilder.build())
+    }
+}
+
+/**
+ * Builder for creating [Message.Tool.Call] instances from Java code.
+ *
+ * Usage from Java:
+ * ```java
+ * Message.Tool.Call message = MessageBuilder.toolCall()
+ *     .id("call_123")
+ *     .tool("search")
+ *     .content("{\"query\": \"hello\"}")
+ *     .build();
+ * ```
+ */
+@JavaAPI
+public class ToolCallMessageBuilder {
+    private var id: String? = null
+    private var tool: String? = null
+    private val parts: MutableList<ContentPart.Text> = mutableListOf()
+    private val metaInfoBuilder: ResponseMetaInfoBuilder = ResponseMetaInfoBuilder()
+
+    /**
+     * Sets the tool call ID.
+     */
+    public fun id(id: String?): ToolCallMessageBuilder = apply { this.id = id }
+
+    /**
+     * Sets the tool name.
+     */
+    public fun tool(tool: String): ToolCallMessageBuilder = apply { this.tool = tool }
+
+    /**
+     * Sets a single text content for the message, replacing any previously added parts.
+     */
+    public fun content(content: String): ToolCallMessageBuilder = apply {
+        parts.clear()
+        parts.add(ContentPart.Text(content))
+    }
+
+    /**
+     * Adds a text content part to the message.
+     */
+    public fun addPart(part: ContentPart.Text): ToolCallMessageBuilder = apply {
+        parts.add(part)
+    }
+
+    /**
+     * Sets the timestamp using [java.time.Instant].
+     */
+    public fun timestamp(timestamp: JavaInstant): ToolCallMessageBuilder = apply {
+        metaInfoBuilder.timestamp(timestamp)
+    }
+
+    /**
+     * Sets the timestamp using [kotlin.time.Instant].
+     */
+    public fun timestamp(timestamp: Instant): ToolCallMessageBuilder = apply {
+        metaInfoBuilder.timestamp(timestamp)
+    }
+
+    /**
+     * Sets the total token count.
+     */
+    public fun totalTokensCount(count: Int): ToolCallMessageBuilder = apply {
+        metaInfoBuilder.totalTokensCount(count)
+    }
+
+    /**
+     * Sets the input token count.
+     */
+    public fun inputTokensCount(count: Int): ToolCallMessageBuilder = apply {
+        metaInfoBuilder.inputTokensCount(count)
+    }
+
+    /**
+     * Sets the output token count.
+     */
+    public fun outputTokensCount(count: Int): ToolCallMessageBuilder = apply {
+        metaInfoBuilder.outputTokensCount(count)
+    }
+
+    /**
+     * Sets the metadata.
+     */
+    public fun metadata(metadata: JsonObject?): ToolCallMessageBuilder = apply {
+        metaInfoBuilder.metadata(metadata)
+    }
+
+    /**
+     * Builds a new [Message.Tool.Call] instance.
+     *
+     * @throws IllegalStateException if tool name or content parts are missing.
+     */
+    public fun build(): Message.Tool.Call {
+        checkNotNull(tool) { "Tool name must be set" }
+        check(parts.isNotEmpty()) { "Tool call message must have at least one content part" }
+        return Message.Tool.Call(
+            id = id,
+            tool = tool!!,
+            parts = parts.toList(),
+            metaInfo = metaInfoBuilder.build()
+        )
+    }
+}
+
+/**
+ * Builder for creating [Message.Tool.Result] instances from Java code.
+ *
+ * Usage from Java:
+ * ```java
+ * Message.Tool.Result message = MessageBuilder.toolResult()
+ *     .id("call_123")
+ *     .tool("search")
+ *     .content("Found 5 results")
+ *     .build();
+ * ```
+ */
+@JavaAPI
+public class ToolResultMessageBuilder {
+    private var id: String? = null
+    private var tool: String? = null
+    private val parts: MutableList<ContentPart.Text> = mutableListOf()
+    private val metaInfoBuilder: RequestMetaInfoBuilder = RequestMetaInfoBuilder()
+
+    /**
+     * Sets the tool result ID.
+     */
+    public fun id(id: String?): ToolResultMessageBuilder = apply { this.id = id }
+
+    /**
+     * Sets the tool name.
+     */
+    public fun tool(tool: String): ToolResultMessageBuilder = apply { this.tool = tool }
+
+    /**
+     * Sets a single text content for the message, replacing any previously added parts.
+     */
+    public fun content(content: String): ToolResultMessageBuilder = apply {
+        parts.clear()
+        parts.add(ContentPart.Text(content))
+    }
+
+    /**
+     * Adds a text content part to the message.
+     */
+    public fun addPart(part: ContentPart.Text): ToolResultMessageBuilder = apply {
+        parts.add(part)
+    }
+
+    /**
+     * Sets the timestamp using [java.time.Instant].
+     */
+    public fun timestamp(timestamp: JavaInstant): ToolResultMessageBuilder = apply {
+        metaInfoBuilder.timestamp(timestamp)
+    }
+
+    /**
+     * Sets the timestamp using [kotlin.time.Instant].
+     */
+    public fun timestamp(timestamp: Instant): ToolResultMessageBuilder = apply {
+        metaInfoBuilder.timestamp(timestamp)
+    }
+
+    /**
+     * Sets the metadata.
+     */
+    public fun metadata(metadata: JsonObject?): ToolResultMessageBuilder = apply {
+        metaInfoBuilder.metadata(metadata)
+    }
+
+    /**
+     * Builds a new [Message.Tool.Result] instance.
+     *
+     * @throws IllegalStateException if tool name or content parts are missing.
+     */
+    public fun build(): Message.Tool.Result {
+        checkNotNull(tool) { "Tool name must be set" }
+        check(parts.isNotEmpty()) { "Tool result message must have at least one content part" }
+        return Message.Tool.Result(
+            id = id,
+            tool = tool!!,
+            parts = parts.toList(),
+            metaInfo = metaInfoBuilder.build()
+        )
+    }
+}
+
+/**
+ * Builder for creating [Message.Reasoning] instances from Java code.
+ *
+ * Usage from Java:
+ * ```java
+ * Message.Reasoning message = MessageBuilder.reasoning()
+ *     .content("Let me think about this...")
+ *     .summary("Thinking about the problem")
+ *     .build();
+ * ```
+ */
+@JavaAPI
+public class ReasoningMessageBuilder {
+    private var id: String? = null
+    private var encrypted: String? = null
+    private val parts: MutableList<ContentPart.Text> = mutableListOf()
+    private var summary: List<ContentPart.Text>? = null
+    private val metaInfoBuilder: ResponseMetaInfoBuilder = ResponseMetaInfoBuilder()
+
+    /**
+     * Sets the reasoning ID.
+     */
+    public fun id(id: String?): ReasoningMessageBuilder = apply { this.id = id }
+
+    /**
+     * Sets the encrypted content.
+     */
+    public fun encrypted(encrypted: String?): ReasoningMessageBuilder = apply { this.encrypted = encrypted }
+
+    /**
+     * Sets a single text content for the message, replacing any previously added parts.
+     */
+    public fun content(content: String): ReasoningMessageBuilder = apply {
+        parts.clear()
+        parts.add(ContentPart.Text(content))
+    }
+
+    /**
+     * Adds a text content part to the message.
+     */
+    public fun addPart(part: ContentPart.Text): ReasoningMessageBuilder = apply {
+        parts.add(part)
+    }
+
+    /**
+     * Sets the summary as a single text string.
+     */
+    public fun summary(summary: String): ReasoningMessageBuilder = apply {
+        this.summary = listOf(ContentPart.Text(summary))
+    }
+
+    /**
+     * Sets the summary as a list of text parts.
+     */
+    public fun summary(summary: List<ContentPart.Text>?): ReasoningMessageBuilder = apply {
+        this.summary = summary
+    }
+
+    /**
+     * Sets the timestamp using [java.time.Instant].
+     */
+    public fun timestamp(timestamp: JavaInstant): ReasoningMessageBuilder = apply {
+        metaInfoBuilder.timestamp(timestamp)
+    }
+
+    /**
+     * Sets the timestamp using [kotlin.time.Instant].
+     */
+    public fun timestamp(timestamp: Instant): ReasoningMessageBuilder = apply {
+        metaInfoBuilder.timestamp(timestamp)
+    }
+
+    /**
+     * Sets the total token count.
+     */
+    public fun totalTokensCount(count: Int): ReasoningMessageBuilder = apply {
+        metaInfoBuilder.totalTokensCount(count)
+    }
+
+    /**
+     * Sets the input token count.
+     */
+    public fun inputTokensCount(count: Int): ReasoningMessageBuilder = apply {
+        metaInfoBuilder.inputTokensCount(count)
+    }
+
+    /**
+     * Sets the output token count.
+     */
+    public fun outputTokensCount(count: Int): ReasoningMessageBuilder = apply {
+        metaInfoBuilder.outputTokensCount(count)
+    }
+
+    /**
+     * Sets the metadata.
+     */
+    public fun metadata(metadata: JsonObject?): ReasoningMessageBuilder = apply {
+        metaInfoBuilder.metadata(metadata)
+    }
+
+    /**
+     * Builds a new [Message.Reasoning] instance.
+     *
+     * @throws IllegalStateException if no content parts have been added.
+     */
+    public fun build(): Message.Reasoning {
+        check(parts.isNotEmpty()) { "Reasoning message must have at least one content part" }
+        return Message.Reasoning(
+            id = id,
+            encrypted = encrypted,
+            parts = parts.toList(),
+            summary = summary,
+            metaInfo = metaInfoBuilder.build()
+        )
+    }
+}
+
+/**
+ * Entry point for creating [Message] instances from Java code using the builder pattern.
+ *
+ * Usage from Java:
+ * ```java
+ * Message.User userMsg = MessageBuilder.user()
+ *     .content("Hello!")
+ *     .timestamp(Instant.now())
+ *     .build();
+ *
+ * Message.Assistant assistantMsg = MessageBuilder.assistant()
+ *     .content("Hi there!")
+ *     .finishReason("stop")
+ *     .build();
+ *
+ * Message.System systemMsg = MessageBuilder.system()
+ *     .content("You are a helpful assistant.")
+ *     .build();
+ *
+ * Message.Tool.Call toolCall = MessageBuilder.toolCall()
+ *     .id("call_123")
+ *     .tool("search")
+ *     .content("{\"query\": \"hello\"}")
+ *     .build();
+ *
+ * Message.Tool.Result toolResult = MessageBuilder.toolResult()
+ *     .id("call_123")
+ *     .tool("search")
+ *     .content("Found 5 results")
+ *     .build();
+ *
+ * Message.Reasoning reasoning = MessageBuilder.reasoning()
+ *     .content("Let me think...")
+ *     .summary("Thinking")
+ *     .build();
+ * ```
+ */
+@JavaAPI
+public object MessageBuilder {
+
+    /**
+     * Creates a new [UserMessageBuilder] for building [Message.User] instances.
+     */
+    @JvmStatic
+    public fun user(): UserMessageBuilder = UserMessageBuilder()
+
+    /**
+     * Creates a new [AssistantMessageBuilder] for building [Message.Assistant] instances.
+     */
+    @JvmStatic
+    public fun assistant(): AssistantMessageBuilder = AssistantMessageBuilder()
+
+    /**
+     * Creates a new [SystemMessageBuilder] for building [Message.System] instances.
+     */
+    @JvmStatic
+    public fun system(): SystemMessageBuilder = SystemMessageBuilder()
+
+    /**
+     * Creates a new [ToolCallMessageBuilder] for building [Message.Tool.Call] instances.
+     */
+    @JvmStatic
+    public fun toolCall(): ToolCallMessageBuilder = ToolCallMessageBuilder()
+
+    /**
+     * Creates a new [ToolResultMessageBuilder] for building [Message.Tool.Result] instances.
+     */
+    @JvmStatic
+    public fun toolResult(): ToolResultMessageBuilder = ToolResultMessageBuilder()
+
+    /**
+     * Creates a new [ReasoningMessageBuilder] for building [Message.Reasoning] instances.
+     */
+    @JvmStatic
+    public fun reasoning(): ReasoningMessageBuilder = ReasoningMessageBuilder()
+}

--- a/prompt/prompt-model/src/jvmTest/kotlin/ai/koog/prompt/message/MessageBuilderTest.kt
+++ b/prompt/prompt-model/src/jvmTest/kotlin/ai/koog/prompt/message/MessageBuilderTest.kt
@@ -1,0 +1,309 @@
+package ai.koog.prompt.message
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import java.time.Instant as JavaInstant
+
+class MessageBuilderTest {
+
+    private val javaInstant: JavaInstant = JavaInstant.parse("2024-01-15T10:30:00Z")
+
+    @Test
+    fun testUserMessageWithContent() {
+        val message = MessageBuilder.user()
+            .content("Hello!")
+            .build()
+
+        assertEquals("Hello!", message.content)
+        assertEquals(Message.Role.User, message.role)
+    }
+
+    @Test
+    fun testUserMessageWithJavaInstant() {
+        val message = MessageBuilder.user()
+            .content("Hello!")
+            .timestamp(javaInstant)
+            .build()
+
+        assertEquals("Hello!", message.content)
+        assertEquals(javaInstant.epochSecond, message.metaInfo.timestamp.epochSeconds)
+    }
+
+    @Test
+    fun testUserMessageWithMultipleParts() {
+        val message = MessageBuilder.user()
+            .addPart(ContentPart.Text("Part 1"))
+            .addPart(ContentPart.Text("Part 2"))
+            .build()
+
+        assertEquals(2, message.parts.size)
+        assertEquals("Part 1\nPart 2", message.content)
+    }
+
+    @Test
+    fun testUserMessageContentReplacesParts() {
+        val message = MessageBuilder.user()
+            .addPart(ContentPart.Text("Old"))
+            .content("New")
+            .build()
+
+        assertEquals(1, message.parts.size)
+        assertEquals("New", message.content)
+    }
+
+    @Test
+    fun testUserMessageEmptyFails() {
+        assertFailsWith<IllegalStateException> {
+            MessageBuilder.user().build()
+        }
+    }
+
+    @Test
+    fun testAssistantMessageWithContent() {
+        val message = MessageBuilder.assistant()
+            .content("Hi there!")
+            .finishReason("stop")
+            .build()
+
+        assertEquals("Hi there!", message.content)
+        assertEquals(Message.Role.Assistant, message.role)
+        assertEquals("stop", message.finishReason)
+    }
+
+    @Test
+    fun testAssistantMessageWithJavaInstant() {
+        val message = MessageBuilder.assistant()
+            .content("Response")
+            .timestamp(javaInstant)
+            .totalTokensCount(100)
+            .inputTokensCount(40)
+            .outputTokensCount(60)
+            .build()
+
+        assertEquals(javaInstant.epochSecond, message.metaInfo.timestamp.epochSeconds)
+        assertEquals(100, message.metaInfo.totalTokensCount)
+        assertEquals(40, message.metaInfo.inputTokensCount)
+        assertEquals(60, message.metaInfo.outputTokensCount)
+    }
+
+    @Test
+    fun testAssistantMessageEmptyFails() {
+        assertFailsWith<IllegalStateException> {
+            MessageBuilder.assistant().build()
+        }
+    }
+
+    @Test
+    fun testSystemMessage() {
+        val message = MessageBuilder.system()
+            .content("You are a helpful assistant.")
+            .build()
+
+        assertEquals("You are a helpful assistant.", message.content)
+        assertEquals(Message.Role.System, message.role)
+    }
+
+    @Test
+    fun testSystemMessageWithJavaInstant() {
+        val message = MessageBuilder.system()
+            .content("System prompt")
+            .timestamp(javaInstant)
+            .build()
+
+        assertEquals(javaInstant.epochSecond, message.metaInfo.timestamp.epochSeconds)
+    }
+
+    @Test
+    fun testSystemMessageEmptyFails() {
+        assertFailsWith<IllegalStateException> {
+            MessageBuilder.system().build()
+        }
+    }
+
+    @Test
+    fun testToolCallMessage() {
+        val message = MessageBuilder.toolCall()
+            .id("call_123")
+            .tool("search")
+            .content("{\"query\": \"hello\"}")
+            .build()
+
+        assertEquals("call_123", message.id)
+        assertEquals("search", message.tool)
+        assertEquals("{\"query\": \"hello\"}", message.content)
+        assertEquals(Message.Role.Tool, message.role)
+    }
+
+    @Test
+    fun testToolCallMessageWithJavaInstant() {
+        val message = MessageBuilder.toolCall()
+            .id("call_456")
+            .tool("calculate")
+            .content("{\"expression\": \"2+2\"}")
+            .timestamp(javaInstant)
+            .build()
+
+        assertEquals(javaInstant.epochSecond, message.metaInfo.timestamp.epochSeconds)
+    }
+
+    @Test
+    fun testToolCallMessageMissingToolFails() {
+        assertFailsWith<IllegalStateException> {
+            MessageBuilder.toolCall()
+                .content("content")
+                .build()
+        }
+    }
+
+    @Test
+    fun testToolCallMessageEmptyContentFails() {
+        assertFailsWith<IllegalStateException> {
+            MessageBuilder.toolCall()
+                .tool("search")
+                .build()
+        }
+    }
+
+    @Test
+    fun testToolResultMessage() {
+        val message = MessageBuilder.toolResult()
+            .id("call_123")
+            .tool("search")
+            .content("Found 5 results")
+            .build()
+
+        assertEquals("call_123", message.id)
+        assertEquals("search", message.tool)
+        assertEquals("Found 5 results", message.content)
+        assertEquals(Message.Role.Tool, message.role)
+    }
+
+    @Test
+    fun testToolResultMessageWithJavaInstant() {
+        val message = MessageBuilder.toolResult()
+            .id("call_789")
+            .tool("fetch")
+            .content("Data retrieved")
+            .timestamp(javaInstant)
+            .build()
+
+        assertEquals(javaInstant.epochSecond, message.metaInfo.timestamp.epochSeconds)
+    }
+
+    @Test
+    fun testToolResultMessageMissingToolFails() {
+        assertFailsWith<IllegalStateException> {
+            MessageBuilder.toolResult()
+                .content("result")
+                .build()
+        }
+    }
+
+    @Test
+    fun testReasoningMessage() {
+        val message = MessageBuilder.reasoning()
+            .content("Let me think about this...")
+            .summary("Thinking about the problem")
+            .build()
+
+        assertEquals("Let me think about this...", message.content)
+        assertEquals(Message.Role.Reasoning, message.role)
+        assertNotNull(message.summary)
+        assertEquals("Thinking about the problem", message.summary?.first()?.text)
+    }
+
+    @Test
+    fun testReasoningMessageWithAllFields() {
+        val message = MessageBuilder.reasoning()
+            .id("reasoning_1")
+            .encrypted("encrypted_content")
+            .content("Reasoning content")
+            .summary("Summary")
+            .timestamp(javaInstant)
+            .totalTokensCount(50)
+            .build()
+
+        assertEquals("reasoning_1", message.id)
+        assertEquals("encrypted_content", message.encrypted)
+        assertEquals("Reasoning content", message.content)
+        assertEquals(javaInstant.epochSecond, message.metaInfo.timestamp.epochSeconds)
+        assertEquals(50, message.metaInfo.totalTokensCount)
+    }
+
+    @Test
+    fun testReasoningMessageEmptyFails() {
+        assertFailsWith<IllegalStateException> {
+            MessageBuilder.reasoning().build()
+        }
+    }
+
+    @Test
+    fun testToolCallWithNullId() {
+        val message = MessageBuilder.toolCall()
+            .tool("search")
+            .content("query")
+            .build()
+
+        assertNull(message.id)
+    }
+
+    @Test
+    fun testRequestMetaInfoBuilder() {
+        val metaInfo = RequestMetaInfo.builder()
+            .timestamp(javaInstant)
+            .build()
+
+        assertEquals(javaInstant.epochSecond, metaInfo.timestamp.epochSeconds)
+    }
+
+    @Test
+    fun testRequestMetaInfoFromJavaInstant() {
+        val metaInfo = RequestMetaInfo.fromJavaInstant(javaInstant)
+
+        assertEquals(javaInstant.epochSecond, metaInfo.timestamp.epochSeconds)
+        assertNull(metaInfo.metadata)
+    }
+
+    @Test
+    fun testResponseMetaInfoBuilder() {
+        val metaInfo = ResponseMetaInfo.builder()
+            .timestamp(javaInstant)
+            .totalTokensCount(100)
+            .inputTokensCount(40)
+            .outputTokensCount(60)
+            .build()
+
+        assertEquals(javaInstant.epochSecond, metaInfo.timestamp.epochSeconds)
+        assertEquals(100, metaInfo.totalTokensCount)
+        assertEquals(40, metaInfo.inputTokensCount)
+        assertEquals(60, metaInfo.outputTokensCount)
+    }
+
+    @Test
+    fun testResponseMetaInfoFromJavaInstant() {
+        val metaInfo = ResponseMetaInfo.fromJavaInstant(
+            timestamp = javaInstant,
+            totalTokensCount = 50,
+            inputTokensCount = 20,
+            outputTokensCount = 30
+        )
+
+        assertEquals(javaInstant.epochSecond, metaInfo.timestamp.epochSeconds)
+        assertEquals(50, metaInfo.totalTokensCount)
+    }
+
+    @Test
+    fun testRequestMetaInfoBuilderDefaultTimestamp() {
+        val metaInfo = RequestMetaInfo.builder().build()
+        assertNotNull(metaInfo.timestamp)
+    }
+
+    @Test
+    fun testResponseMetaInfoBuilderDefaultTimestamp() {
+        val metaInfo = ResponseMetaInfo.builder().build()
+        assertNotNull(metaInfo.timestamp)
+    }
+}

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
                 api(libs.junit.jupiter.params)
                 api(libs.testcontainers)
                 api(libs.awaitility)
+                implementation(project(":utils"))
                 runtimeOnly(libs.slf4j.simple)
             }
         }

--- a/test-utils/src/jvmMain/kotlin/ai/koog/test/utils/AwaitilityExtensions.kt
+++ b/test-utils/src/jvmMain/kotlin/ai/koog/test/utils/AwaitilityExtensions.kt
@@ -1,12 +1,12 @@
 package ai.koog.test.utils
 
+import ai.koog.utils.time.toJavaDuration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
 import org.awaitility.core.ConditionFactory
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.coroutines.ContinuationInterceptor
-import ai.koog.utils.time.toJavaDuration
 import kotlin.time.Duration
 
 /**

--- a/test-utils/src/jvmMain/kotlin/ai/koog/test/utils/AwaitilityExtensions.kt
+++ b/test-utils/src/jvmMain/kotlin/ai/koog/test/utils/AwaitilityExtensions.kt
@@ -6,8 +6,8 @@ import org.awaitility.core.ConditionFactory
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.coroutines.ContinuationInterceptor
+import ai.koog.utils.time.toJavaDuration
 import kotlin.time.Duration
-import kotlin.time.toJavaDuration
 
 /**
  * Repeatedly evaluates the given [block] until it does not throw any exceptions.

--- a/utils/src/jvmMain/kotlin/ai/koog/utils/time/TimeUtils.kt
+++ b/utils/src/jvmMain/kotlin/ai/koog/utils/time/TimeUtils.kt
@@ -1,0 +1,67 @@
+package ai.koog.utils.time
+
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.Instant
+import kotlin.time.toDuration
+import java.time.Instant as JavaInstant
+import java.time.Duration as JavaDuration
+
+/**
+ * Utility class providing conversions between Java and Kotlin time types.
+ */
+public object TimeUtils {
+
+    /**
+     * Converts a [java.time.Instant] to a [kotlin.time.Instant].
+     */
+    @JvmStatic
+    public fun fromJavaInstant(instant: JavaInstant): Instant {
+        return Instant.fromEpochSeconds(instant.epochSecond, instant.nano)
+    }
+
+    /**
+     * Converts a [kotlin.time.Instant] to a [java.time.Instant].
+     */
+    @JvmStatic
+    public fun toJavaInstant(instant: Instant): JavaInstant {
+        return JavaInstant.ofEpochSecond(instant.epochSeconds, instant.nanosecondsOfSecond.toLong())
+    }
+
+    /**
+     * Converts a [java.time.Duration] to a [kotlin.time.Duration].
+     */
+    @JvmStatic
+    public fun fromJavaDuration(duration: JavaDuration): Duration {
+        return duration.seconds.toDuration(DurationUnit.SECONDS) +
+            duration.nano.toDuration(DurationUnit.NANOSECONDS)
+    }
+
+    /**
+     * Converts a [kotlin.time.Duration] to a [java.time.Duration].
+     */
+    @JvmStatic
+    public fun toJavaDuration(duration: Duration): JavaDuration {
+        return JavaDuration.ofNanos(duration.inWholeNanoseconds)
+    }
+}
+
+/**
+ * Converts this [java.time.Instant] to a [kotlin.time.Instant].
+ */
+public fun JavaInstant.toKotlinInstant(): Instant = TimeUtils.fromJavaInstant(this)
+
+/**
+ * Converts this [kotlin.time.Instant] to a [java.time.Instant].
+ */
+public fun Instant.toJavaInstant(): JavaInstant = TimeUtils.toJavaInstant(this)
+
+/**
+ * Converts this [java.time.Duration] to a [kotlin.time.Duration].
+ */
+public fun JavaDuration.toKotlinDuration(): Duration = TimeUtils.fromJavaDuration(this)
+
+/**
+ * Converts this [kotlin.time.Duration] to a [java.time.Duration].
+ */
+public fun Duration.toJavaDuration(): JavaDuration = TimeUtils.toJavaDuration(this)

--- a/utils/src/jvmMain/kotlin/ai/koog/utils/time/TimeUtils.kt
+++ b/utils/src/jvmMain/kotlin/ai/koog/utils/time/TimeUtils.kt
@@ -4,8 +4,8 @@ import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.Instant
 import kotlin.time.toDuration
-import java.time.Instant as JavaInstant
 import java.time.Duration as JavaDuration
+import java.time.Instant as JavaInstant
 
 /**
  * Utility class providing conversions between Java and Kotlin time types.


### PR DESCRIPTION
- Add Java-compatible builders for Message types, RetryConfig, and RetryConfigKoogProperties with both java.time and kotlin.time overloads

- Add Java-compatible constructors/overloads for RedisPromptCache and Langfuse exporter

- Centralize Java/Kotlin time conversion utilities (TimeUtils, toKotlinInstant, toJavaInstant, toKotlinDuration, toJavaDuration) in the utils module, replacing scattered private copies and stdlib imports

