### PR TITLE
fix(examples): bump koog version for Java examples

### DIFF
--- a/examples/koog-java-api-example/gradle.properties
+++ b/examples/koog-java-api-example/gradle.properties
@@ -1,1 +1,1 @@
-koogVersion=0.7.0-feat-01-01
+koogVersion=0.7.0-feat-1604-1


### PR DESCRIPTION
fixes Java examples, for context see:
- failing build: https://github.com/JetBrains/koog/actions/runs/23049757361/job/66947694613
- corresponding PR: https://github.com/JetBrains/koog/pull/1604
