### PR TITLE
feat(prompt): allow customized field name for AdditionalPropertiesFlatteningSerializer

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/models/OpenRouterChatCompletion.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/models/OpenRouterChatCompletion.kt
@@ -198,4 +198,8 @@ public class OpenRouterError(
 )
 
 internal object OpenRouterChatCompletionRequestSerializer :
-    AdditionalPropertiesFlatteningSerializer<OpenRouterChatCompletionRequest>(OpenRouterChatCompletionRequest.serializer())
+    AdditionalPropertiesFlatteningSerializer<OpenRouterChatCompletionRequest>(
+        OpenRouterChatCompletionRequest.serializer(),
+        // OpenRouter uses snake case
+        additionalPropertiesField = "additional_properties"
+    )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openrouter/models/OpenRouterSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openrouter/models/OpenRouterSerializationTest.kt
@@ -98,11 +98,9 @@ class OpenRouterSerializationTest {
                 ],
                 "model": "anthropic/claude-3-sonnet",
                 "temperature": 0.7,
-                "additional_properties": {
-                    "customProperty": "customValue",
-                    "customNumber": 42,
-                    "customBoolean": true
-                }
+                "customProperty": "customValue",
+                "customNumber": 42,
+                "customBoolean": true
             }
             """.trimIndent()
     }
@@ -158,15 +156,11 @@ class OpenRouterSerializationTest {
         // Verify basic deserialization works
         request.model shouldBe "anthropic/claude-3-sonnet"
         request.temperature shouldBe 0.7
-
-        // Note: Additional properties functionality is currently broken with JsonNamingStrategy.SnakeCase
-        // due to AdditionalPropertiesFlatteningSerializer bug:
-        // KG-531 OpenRouter's AdditionalPropertiesFlatteningSerializer is incompatible with JsonNamingStrategy.SnakeCase
-        // In lenient mode, unknown properties
-        // are ignored instead of collected.
-        //
-        // The test passes because ignoreUnknownKeys = true, but additional properties are not captured
-        request.additionalProperties shouldBe null
+        request.additionalProperties shouldBe mapOf(
+            "extra" to JsonPrimitive("value"),
+            "number" to JsonPrimitive(42),
+            "flag" to JsonPrimitive(true)
+        )
     }
 
     @Test
@@ -645,9 +639,7 @@ class OpenRouterSerializationTest {
                     }
                 },
                 "user": "user-123",
-                "additional_properties": {
-                    "x-extra": "ok"
-                }
+                "x-extra": "ok"
             }
             """.trimIndent()
     }

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/serialization/AdditionalPropertiesFlatteningSerializer.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/serialization/AdditionalPropertiesFlatteningSerializer.kt
@@ -14,11 +14,13 @@ import kotlinx.serialization.json.jsonObject
  * On deserialization: collects unknown properties into `additionalProperties` field.
  *
  * @param knownProperties Set of known property names for the type
+ * @param additionalPropertiesField The name of the field to use for additional properties, defaults to "additionalProperties".
  */
-public abstract class AdditionalPropertiesFlatteningSerializer<T>(tSerializer: KSerializer<T>) :
+public abstract class AdditionalPropertiesFlatteningSerializer<T>(
+    tSerializer: KSerializer<T>,
+    private val additionalPropertiesField: String = "additionalProperties"
+) :
     JsonTransformingSerializer<T>(tSerializer) {
-
-    private val additionalPropertiesField = "additionalProperties"
 
     private val knownProperties = tSerializer.descriptor.elementNames
 


### PR DESCRIPTION
This PR addresses issue #1624 with the following changes:

+ Instead of hardcoding `additionalPropertiesField` to `additionalProperties`, now it's a parameter of the constructor with a default value. This allows the implementations to define their own additional properties field name, which for OpenAI and its compatible APIs, it's the snake case.

The fix only applies to OpenRouter impl since I'm blocking by this issue.

This PR has no breaking change.

closes #1624