### PR TITLE
feat(prompt): KG-656 expose cached token metadata

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonTest/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicMetadataTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonTest/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicMetadataTest.kt
@@ -1,0 +1,82 @@
+package ai.koog.prompt.executor.clients.anthropic
+
+import ai.koog.prompt.executor.clients.anthropic.models.AnthropicUsage
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNamingStrategy
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Tests for [AnthropicUsage] deserialization and cache token metadata extraction.
+ *
+ * Covers deserialization of [AnthropicUsage] and correct mapping of
+ * cache read/creation token counts into metadata JsonObject.
+ */
+class AnthropicMetadataTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        namingStrategy = JsonNamingStrategy.SnakeCase
+    }
+
+    @Test
+    fun testDeserializeFullAnthropicUsageJson() {
+        val jsonResponse = """
+            {
+                "input_tokens": 1500,
+                "output_tokens": 500,
+                "cache_read_input_tokens": 1000,
+                "cache_creation_input_tokens": 250
+            }
+        """.trimIndent()
+
+        val usage = json.decodeFromString<AnthropicUsage>(jsonResponse)
+
+        assertEquals(1500, usage.inputTokens)
+        assertEquals(500, usage.outputTokens)
+        assertEquals(1000, usage.cacheReadInputTokens)
+        assertEquals(250, usage.cacheCreationInputTokens)
+    }
+
+    @Test
+    fun testCacheMetadataPopulatedWhenBothFieldsPresent() {
+        val usage = AnthropicUsage(
+            inputTokens = 1500,
+            outputTokens = 500,
+            cacheReadInputTokens = 1000,
+            cacheCreationInputTokens = 250
+        )
+
+        val cacheMetadata = buildJsonObject {
+            usage.cacheCreationInputTokens?.let { put("cacheCreationInputTokens", it) }
+            usage.cacheReadInputTokens?.let { put("cacheReadInputTokens", it) }
+        }.takeIf { it.isNotEmpty() }
+
+        assertNotNull(cacheMetadata, "metadata should not be null when cache token fields are present")
+        assertEquals(1000, cacheMetadata["cacheReadInputTokens"]?.jsonPrimitive?.int)
+        assertEquals(250, cacheMetadata["cacheCreationInputTokens"]?.jsonPrimitive?.int)
+    }
+
+    @Test
+    fun testCacheMetadataNullWhenCacheTokensAbsent() {
+        val usage = AnthropicUsage(
+            inputTokens = 100,
+            outputTokens = 50,
+            cacheReadInputTokens = null,
+            cacheCreationInputTokens = null
+        )
+
+        val cacheMetadata = buildJsonObject {
+            usage.cacheCreationInputTokens?.let { put("cacheCreationInputTokens", it) }
+            usage.cacheReadInputTokens?.let { put("cacheReadInputTokens", it) }
+        }.takeIf { it.isNotEmpty() }
+
+        assertNull(cacheMetadata, "metadata should be null when cache token fields are both null")
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -27,6 +27,7 @@ import ai.koog.prompt.executor.clients.google.models.GoogleRequest
 import ai.koog.prompt.executor.clients.google.models.GoogleResponse
 import ai.koog.prompt.executor.clients.google.models.GoogleTool
 import ai.koog.prompt.executor.clients.google.models.GoogleToolConfig
+import ai.koog.prompt.executor.clients.google.models.GoogleUsageMetadata
 import ai.koog.prompt.executor.clients.google.structure.GoogleBasicJsonSchemaGenerator
 import ai.koog.prompt.executor.clients.google.structure.GoogleResponseFormat
 import ai.koog.prompt.executor.clients.google.structure.GoogleStandardJsonSchemaGenerator
@@ -775,21 +776,42 @@ public open class GoogleLLMClient @JvmOverloads constructor(
             throw LLMClientException(clientName, "Empty candidates in Google API response")
         }
 
-        // Extract token count from the response
-        val inputTokensCount = response.usageMetadata?.promptTokenCount
-        val outputTokensCount = response.usageMetadata?.candidatesTokenCount
-        val totalTokensCount = response.usageMetadata?.totalTokenCount
-
-        val metaInfo = ResponseMetaInfo.create(
-            clock,
-            totalTokensCount = totalTokensCount,
-            inputTokensCount = inputTokensCount,
-            outputTokensCount = outputTokensCount
-        )
+        val metaInfo = createMetaInfo(response.usageMetadata)
 
         return response.candidates.map { candidate ->
             processGoogleCandidate(candidate, metaInfo)
         }
+    }
+
+    /**
+     * Builds a [ResponseMetaInfo] from a [GoogleUsageMetadata] object returned by the Gemini API.
+     *
+     * When available, the following provider-specific values are included in [ResponseMetaInfo.metadata]:
+     *
+     * - `cachedTokens` — tokens served from a cached content entry ([GoogleUsageMetadata.cachedContentTokenCount]).
+     * - `reasoningTokens` — tokens used for internal chain-of-thought reasoning ([GoogleUsageMetadata.thoughtsTokenCount]).
+     *
+     * [ResponseMetaInfo.metadata] is `null` when neither value is present.
+     *
+     * @param usage the usage metadata from the API response, or `null` if omitted.
+     * @return a fully populated [ResponseMetaInfo] instance.
+     */
+    internal fun createMetaInfo(usage: GoogleUsageMetadata?): ResponseMetaInfo {
+        val tokenDetails = usage?.let {
+            buildJsonObject {
+                it.cachedContentTokenCount?.let { v -> put("cachedTokens", JsonPrimitive(v)) }
+
+                it.thoughtsTokenCount?.let { v -> put("reasoningTokens", JsonPrimitive(v)) }
+            }.takeIf { obj -> obj.isNotEmpty() }
+        }
+
+        return ResponseMetaInfo.create(
+            clock,
+            totalTokensCount = usage?.totalTokenCount,
+            inputTokensCount = usage?.promptTokenCount,
+            outputTokensCount = usage?.candidatesTokenCount,
+            metadata = tokenDetails
+        )
     }
 
     /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/models/GoogleGenerateContent.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/models/GoogleGenerateContent.kt
@@ -465,6 +465,7 @@ internal class GooglePromptFeedback(
  * @property toolUsePromptTokenCount Number of tokens present in tool-use prompt(s).
  * @property thoughtsTokenCount Number of tokens of thoughts for thinking models.
  * @property totalTokenCount Total token count for the generation request (prompt plus response candidates).
+ * @property cachedContentTokenCount tokens served from a cached content entry, billed at a reduced rate.
  */
 @Serializable
 internal class GoogleUsageMetadata(
@@ -473,6 +474,7 @@ internal class GoogleUsageMetadata(
     val toolUsePromptTokenCount: Int? = null,
     val thoughtsTokenCount: Int? = null,
     val totalTokenCount: Int? = null,
+    val cachedContentTokenCount: Int? = null,
 )
 
 /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonTest/kotlin/ai/koog/prompt/executor/clients/google/structure/GoogleMetadataTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonTest/kotlin/ai/koog/prompt/executor/clients/google/structure/GoogleMetadataTest.kt
@@ -1,0 +1,87 @@
+package ai.koog.prompt.executor.clients.google.structure
+
+import ai.koog.prompt.executor.clients.google.GoogleClientSettings
+import ai.koog.prompt.executor.clients.google.GoogleLLMClient
+import ai.koog.prompt.executor.clients.google.models.GoogleUsageMetadata
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Tests for [GoogleLLMClient.createMetaInfo] token metadata extraction.
+ *
+ * Covers deserialization of [GoogleUsageMetadata] and correct mapping of
+ * cached/reasoning token counts into [ResponseMetaInfo.metadata].
+ */
+class GoogleMetadataTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val client = GoogleLLMClient(
+        apiKey = "test-key",
+        settings = GoogleClientSettings()
+    )
+
+    @Test
+    fun testDeserializeFullGoogleUsageJson() {
+        val jsonResponse = """
+            {
+                "promptTokenCount": 120,
+                "candidatesTokenCount": 45,
+                "totalTokenCount": 165,
+                "cachedContentTokenCount": 100,
+                "thoughtsTokenCount": 25
+            }
+        """.trimIndent()
+
+        val usage = json.decodeFromString<GoogleUsageMetadata>(jsonResponse)
+
+        assertEquals(120, usage.promptTokenCount)
+        assertEquals(45, usage.candidatesTokenCount)
+        assertEquals(165, usage.totalTokenCount)
+        assertEquals(100, usage.cachedContentTokenCount)
+        assertEquals(25, usage.thoughtsTokenCount)
+    }
+
+    @Test
+    fun testCreateMetaInfoMapsAllFieldsCorrectly() {
+        val usage = GoogleUsageMetadata(
+            promptTokenCount = 120,
+            candidatesTokenCount = 45,
+            totalTokenCount = 165,
+            cachedContentTokenCount = 100,
+            thoughtsTokenCount = 25
+        )
+
+        val metaInfo = client.createMetaInfo(usage)
+
+        assertEquals(165, metaInfo.totalTokensCount)
+        assertEquals(120, metaInfo.inputTokensCount)
+        assertEquals(45, metaInfo.outputTokensCount)
+
+        val metadata = metaInfo.metadata
+        assertNotNull(metadata, "metadata should not be null when cachedContentTokenCount or thoughtsTokenCount is present")
+        assertEquals(100, metadata["cachedTokens"]?.jsonPrimitive?.int)
+        assertEquals(25, metadata["reasoningTokens"]?.jsonPrimitive?.int)
+    }
+
+    @Test
+    fun testCreateMetaInfoNullCacheAndThoughtsReturnsNullMetadata() {
+        val usage = GoogleUsageMetadata(
+            promptTokenCount = 50,
+            candidatesTokenCount = 10,
+            totalTokenCount = 60,
+            cachedContentTokenCount = null,
+            thoughtsTokenCount = null
+        )
+
+        val metaInfo = client.createMetaInfo(usage)
+
+        assertEquals(60, metaInfo.totalTokensCount)
+        assertNull(metaInfo.metadata, "metadata should be null when cachedContentTokenCount and thoughtsTokenCount are both null")
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
@@ -39,6 +39,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNamingStrategy
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.jvm.JvmOverloads
 import kotlin.time.Clock
@@ -501,15 +503,41 @@ public abstract class AbstractOpenAILLMClient<TResponse : OpenAIBaseLLMResponse,
     }
 
     /**
-     * Creates ResponseMetaInfo from usage data.
-     * Should be used by concrete implementations when processing responses.
+     * Builds a [ResponseMetaInfo] from an [OpenAIUsage] object returned by the OpenAI API.
+     *
+     * In addition to standard token counts, this method populates the [ResponseMetaInfo.metadata]
+     * map with provider-specific token details when available:
+     *
+     * - `cachedTokens` — number of prompt tokens served from the prompt cache
+     *   ([PromptTokensDetails.cachedTokens]). Cached tokens are billed at a reduced rate.
+     * - `reasoningTokens` — number of tokens consumed by internal chain-of-thought reasoning
+     *   ([CompletionTokensDetails.reasoningTokens]). Applicable to o-series models.
+     *
+     * [ResponseMetaInfo.metadata] is `null` when neither value is present in the response.
+     *
+     * @param usage the usage object from the API response, or `null` if the response omits it.
+     * @return a fully populated [ResponseMetaInfo] instance.
      */
-    protected fun createMetaInfo(usage: OpenAIUsage?): ResponseMetaInfo = ResponseMetaInfo.create(
-        clock,
-        totalTokensCount = usage?.totalTokens,
-        inputTokensCount = usage?.promptTokens,
-        outputTokensCount = usage?.completionTokens
-    )
+    protected fun createMetaInfo(usage: OpenAIUsage?): ResponseMetaInfo {
+        val tokenDetails = usage?.let {
+            buildJsonObject {
+                it.promptTokensDetails?.cachedTokens?.let { v ->
+                    put("cachedTokens", JsonPrimitive(v))
+                }
+                it.completionTokensDetails?.reasoningTokens?.let { v ->
+                    put("reasoningTokens", JsonPrimitive(v))
+                }
+            }.takeIf { obj -> obj.isNotEmpty() }
+        }
+
+        return ResponseMetaInfo.create(
+            clock,
+            totalTokensCount = usage?.totalTokens,
+            inputTokensCount = usage?.promptTokens,
+            outputTokensCount = usage?.completionTokens,
+            metadata = tokenDetails
+        )
+    }
 
     protected open fun createResponseFormat(schema: LLMParams.Schema?, model: LLModel): OpenAIResponseFormat? {
         return schema?.let {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/base/OpenAITokenMetadataTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/base/OpenAITokenMetadataTest.kt
@@ -1,0 +1,171 @@
+package ai.koog.prompt.executor.clients.openai.base
+
+import ai.koog.prompt.executor.clients.openai.base.models.CompletionTokensDetails
+import ai.koog.prompt.executor.clients.openai.base.models.OpenAIUsage
+import ai.koog.prompt.executor.clients.openai.base.models.PromptTokensDetails
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Tests for token metadata extraction in [AbstractOpenAILLMClient.createMetaInfo].
+ *
+ * Verifies that cached token counts and reasoning token counts are correctly
+ * propagated from [OpenAIUsage] into [ResponseMetaInfo.metadata].
+ */
+class OpenAITokenMetadataTest {
+
+    private val client = OpenAITokenMetadataTestHelper()
+
+    @Test
+    fun testCreateMetaInfoNullUsageReturnsNullMetadata() {
+        val meta = client.createMetaInfoForTest(null)
+        assertNull(meta.metadata, "metadata should be null when usage is null")
+    }
+
+    @Test
+    fun testCreateMetaInfoNoDetailFieldsReturnsNullMetadata() {
+        val usage = OpenAIUsage(promptTokens = 10, completionTokens = 5, totalTokens = 15)
+        val meta = client.createMetaInfoForTest(usage)
+        assertNull(meta.metadata, "metadata should be null when promptTokensDetails and completionTokensDetails are absent")
+    }
+
+    @Test
+    fun testCreateMetaInfoAllNullDetailValuesReturnsNullMetadata() {
+        val usage = OpenAIUsage(
+            promptTokens = 10,
+            completionTokens = 5,
+            totalTokens = 15,
+            promptTokensDetails = PromptTokensDetails(cachedTokens = null, audioTokens = null),
+            completionTokensDetails = CompletionTokensDetails(reasoningTokens = null)
+        )
+        val meta = client.createMetaInfoForTest(usage)
+        assertNull(meta.metadata, "metadata should be null when all detail fields are null")
+    }
+
+    @Test
+    fun testCreateMetaInfoPopulatesCachedTokens() {
+        val usage = OpenAIUsage(
+            promptTokens = 100,
+            completionTokens = 50,
+            totalTokens = 150,
+            promptTokensDetails = PromptTokensDetails(cachedTokens = 42)
+        )
+        val meta = client.createMetaInfoForTest(usage)
+
+        assertNotNull(meta.metadata)
+        assertEquals(42, meta.metadata!!["cachedTokens"]?.jsonPrimitive?.int)
+        assertNull(meta.metadata!!["reasoningTokens"], "reasoningTokens should be absent when only cachedTokens is provided")
+    }
+
+    @Test
+    fun testCreateMetaInfoCachedTokensZeroIsIncluded() {
+        val usage = OpenAIUsage(
+            promptTokens = 10,
+            completionTokens = 5,
+            totalTokens = 15,
+            promptTokensDetails = PromptTokensDetails(cachedTokens = 0)
+        )
+        val meta = client.createMetaInfoForTest(usage)
+
+        assertNotNull(meta.metadata, "metadata should not be null even when cachedTokens is 0")
+        assertEquals(0, meta.metadata!!["cachedTokens"]?.jsonPrimitive?.int)
+    }
+
+    @Test
+    fun testCreateMetaInfoPopulatesReasoningTokens() {
+        val usage = OpenAIUsage(
+            promptTokens = 100,
+            completionTokens = 200,
+            totalTokens = 300,
+            completionTokensDetails = CompletionTokensDetails(reasoningTokens = 75)
+        )
+        val meta = client.createMetaInfoForTest(usage)
+
+        assertNotNull(meta.metadata)
+        assertEquals(75, meta.metadata!!["reasoningTokens"]?.jsonPrimitive?.int)
+        assertNull(meta.metadata!!["cachedTokens"], "cachedTokens should be absent when only reasoningTokens is provided")
+    }
+
+    @Test
+    fun testCreateMetaInfoReasoningTokensZeroIsIncluded() {
+        val usage = OpenAIUsage(
+            promptTokens = 10,
+            completionTokens = 5,
+            totalTokens = 15,
+            completionTokensDetails = CompletionTokensDetails(reasoningTokens = 0)
+        )
+        val meta = client.createMetaInfoForTest(usage)
+
+        assertNotNull(meta.metadata)
+        assertEquals(0, meta.metadata!!["reasoningTokens"]?.jsonPrimitive?.int)
+    }
+
+    @Test
+    fun testCreateMetaInfoPopulatesBothCachedAndReasoningTokens() {
+        val usage = OpenAIUsage(
+            promptTokens = 100,
+            completionTokens = 200,
+            totalTokens = 300,
+            promptTokensDetails = PromptTokensDetails(cachedTokens = 40),
+            completionTokensDetails = CompletionTokensDetails(reasoningTokens = 80)
+        )
+        val meta = client.createMetaInfoForTest(usage)
+
+        assertNotNull(meta.metadata)
+        assertEquals(40, meta.metadata!!["cachedTokens"]?.jsonPrimitive?.int)
+        assertEquals(80, meta.metadata!!["reasoningTokens"]?.jsonPrimitive?.int)
+    }
+
+    @Test
+    fun testCreateMetaInfoStandardTokenCountsAreCorrect() {
+        val usage = OpenAIUsage(
+            promptTokens = 100,
+            completionTokens = 200,
+            totalTokens = 300,
+            promptTokensDetails = PromptTokensDetails(cachedTokens = 50),
+            completionTokensDetails = CompletionTokensDetails(reasoningTokens = 30)
+        )
+        val meta = client.createMetaInfoForTest(usage)
+
+        assertEquals(100, meta.inputTokensCount)
+        assertEquals(200, meta.outputTokensCount)
+        assertEquals(300, meta.totalTokensCount)
+    }
+
+    @Test
+    fun testCreateMetaInfoDoesNotExposeAudioTokens() {
+        val usage = OpenAIUsage(
+            promptTokens = 100,
+            completionTokens = 50,
+            totalTokens = 150,
+            promptTokensDetails = PromptTokensDetails(cachedTokens = 30, audioTokens = 10)
+        )
+        val meta = client.createMetaInfoForTest(usage)
+
+        assertNotNull(meta.metadata)
+        assertNull(meta.metadata!!["audioTokens"], "audioTokens should not be exposed in metadata")
+        assertNotNull(meta.metadata!!["cachedTokens"])
+    }
+
+    @Test
+    fun testCreateMetaInfoDoesNotExposeAcceptedPredictionTokens() {
+        val usage = OpenAIUsage(
+            promptTokens = 100,
+            completionTokens = 50,
+            totalTokens = 150,
+            completionTokensDetails = CompletionTokensDetails(
+                reasoningTokens = 20,
+                acceptedPredictionTokens = 5
+            )
+        )
+        val meta = client.createMetaInfoForTest(usage)
+
+        assertNotNull(meta.metadata)
+        assertNull(meta.metadata!!["acceptedPredictionTokens"], "acceptedPredictionTokens should not be exposed in metadata")
+        assertNotNull(meta.metadata!!["reasoningTokens"])
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/base/OpenAITokenMetadataTestHelper.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/base/OpenAITokenMetadataTestHelper.kt
@@ -2,14 +2,12 @@ package ai.koog.prompt.executor.clients.openai.base
 
 import ai.koog.prompt.dsl.ModerationResult
 import ai.koog.prompt.dsl.Prompt
-import ai.koog.prompt.executor.clients.openai.base.models.CompletionTokensDetails
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIBaseLLMResponse
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIBaseLLMStreamResponse
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIMessage
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAITool
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIToolChoice
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIUsage
-import ai.koog.prompt.executor.clients.openai.base.models.PromptTokensDetails
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.LLMChoice
@@ -20,8 +18,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonObject
 
 /**
  * Tests for token metadata extraction in [AbstractOpenAILLMClient.createMetaInfo].
@@ -29,9 +25,11 @@ import kotlinx.serialization.json.buildJsonObject
  * Verifies that cached token counts and reasoning token counts are correctly
  * propagated from [OpenAIUsage] into [ResponseMetaInfo.metadata].
  */
-internal class OpenAITokenMetadataTestHelper : AbstractOpenAILLMClient<
-    OpenAITokenMetadataTestHelper.StubResponse,
-    OpenAITokenMetadataTestHelper.StubStreamResponse>(
+internal class OpenAITokenMetadataTestHelper :
+    AbstractOpenAILLMClient<
+        OpenAITokenMetadataTestHelper.StubResponse,
+        OpenAITokenMetadataTestHelper.StubStreamResponse
+    >(
     apiKey = "test-key",
     settings = object : OpenAIBaseSettings(
         baseUrl = "https://test.example.com",

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/base/OpenAITokenMetadataTestHelper.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/base/OpenAITokenMetadataTestHelper.kt
@@ -29,15 +29,15 @@ internal class OpenAITokenMetadataTestHelper :
     AbstractOpenAILLMClient<
         OpenAITokenMetadataTestHelper.StubResponse,
         OpenAITokenMetadataTestHelper.StubStreamResponse
-    >(
-    apiKey = "test-key",
-    settings = object : OpenAIBaseSettings(
-        baseUrl = "https://test.example.com",
-        chatCompletionsPath = "v1/chat/completions"
-    ) {},
-    logger = KotlinLogging.logger("TokenMetadataTestHelper"),
-    toolsConverter = OpenAICompatibleToolDescriptorSchemaGenerator(),
-) {
+        >(
+        apiKey = "test-key",
+        settings = object : OpenAIBaseSettings(
+            baseUrl = "https://test.example.com",
+            chatCompletionsPath = "v1/chat/completions"
+        ) {},
+        logger = KotlinLogging.logger("TokenMetadataTestHelper"),
+        toolsConverter = OpenAICompatibleToolDescriptorSchemaGenerator(),
+    ) {
 
     /**
      * Public wrapper to test [createMetaInfo].

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/base/OpenAITokenMetadataTestHelper.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/base/OpenAITokenMetadataTestHelper.kt
@@ -1,0 +1,81 @@
+package ai.koog.prompt.executor.clients.openai.base
+
+import ai.koog.prompt.dsl.ModerationResult
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.executor.clients.openai.base.models.CompletionTokensDetails
+import ai.koog.prompt.executor.clients.openai.base.models.OpenAIBaseLLMResponse
+import ai.koog.prompt.executor.clients.openai.base.models.OpenAIBaseLLMStreamResponse
+import ai.koog.prompt.executor.clients.openai.base.models.OpenAIMessage
+import ai.koog.prompt.executor.clients.openai.base.models.OpenAITool
+import ai.koog.prompt.executor.clients.openai.base.models.OpenAIToolChoice
+import ai.koog.prompt.executor.clients.openai.base.models.OpenAIUsage
+import ai.koog.prompt.executor.clients.openai.base.models.PromptTokensDetails
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.LLMChoice
+import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.prompt.params.LLMParams
+import ai.koog.prompt.streaming.StreamFrame
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+
+/**
+ * Tests for token metadata extraction in [AbstractOpenAILLMClient.createMetaInfo].
+ *
+ * Verifies that cached token counts and reasoning token counts are correctly
+ * propagated from [OpenAIUsage] into [ResponseMetaInfo.metadata].
+ */
+internal class OpenAITokenMetadataTestHelper : AbstractOpenAILLMClient<
+    OpenAITokenMetadataTestHelper.StubResponse,
+    OpenAITokenMetadataTestHelper.StubStreamResponse>(
+    apiKey = "test-key",
+    settings = object : OpenAIBaseSettings(
+        baseUrl = "https://test.example.com",
+        chatCompletionsPath = "v1/chat/completions"
+    ) {},
+    logger = KotlinLogging.logger("TokenMetadataTestHelper"),
+    toolsConverter = OpenAICompatibleToolDescriptorSchemaGenerator(),
+) {
+
+    /**
+     * Public wrapper to test [createMetaInfo].
+     */
+    fun createMetaInfoForTest(usage: OpenAIUsage?): ResponseMetaInfo = createMetaInfo(usage)
+
+    override fun llmProvider(): LLMProvider = LLMProvider.OpenAI
+
+    override fun serializeProviderChatRequest(
+        messages: List<OpenAIMessage>,
+        model: LLModel,
+        tools: List<OpenAITool>?,
+        toolChoice: OpenAIToolChoice?,
+        params: LLMParams,
+        stream: Boolean
+    ): String = "{}"
+
+    override fun processProviderChatResponse(response: StubResponse): List<LLMChoice> = emptyList()
+    override fun decodeStreamingResponse(data: String): StubStreamResponse = StubStreamResponse()
+    override fun decodeResponse(data: String): StubResponse = StubResponse()
+    override fun processStreamingResponse(response: Flow<StubStreamResponse>): Flow<StreamFrame> = emptyFlow()
+
+    override suspend fun moderate(prompt: Prompt, model: LLModel): ModerationResult =
+        throw UnsupportedOperationException("Not needed in tests")
+
+    @Serializable
+    class StubResponse : OpenAIBaseLLMResponse {
+        override val id: String = "stub"
+        override val model: String = "stub-model"
+        override val created: Long = 0L
+    }
+
+    @Serializable
+    class StubStreamResponse : OpenAIBaseLLMStreamResponse {
+        override val id: String = "stub"
+        override val model: String = "stub-model"
+        override val created: Long = 0L
+    }
+}


### PR DESCRIPTION
Populates the existing ResponseMetaInfo.metadata field with provider-specific
token details that were previously parsed but discarded:

- OpenAI: cachedTokens (prompt_tokens_details.cached_tokens), reasoningTokens (completion_tokens_details.reasoning_tokens)
- Anthropic: cachedTokens (cache_read_input_tokens), cacheCreationTokens (cache_creation_input_tokens)
- Google: cachedTokens (cachedContentTokenCount), reasoningTokens (thoughtsTokenCount)

Adds KDoc and unit tests.

closes KG-656