### PR TITLE
feat!: Remove `input` parameter from `AIAgentFunctionalContext.subtask` because it was not used, update simple-examples-java to use records

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -24,6 +24,10 @@ simple-examples:
   - *ci-configs
   - 'examples/simple-examples/**'
 
+simple-examples-java:
+  - *ci-configs
+  - 'examples/simple-examples-java/**'
+
 code-agent:
   - *ci-configs
   - 'examples/code-agent/**'

--- a/.github/workflows/simple-examples-java.yml
+++ b/.github/workflows/simple-examples-java.yml
@@ -1,0 +1,110 @@
+name: Simple Examples Java
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Cancel only when the run is not on main or develop
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
+
+env:
+  JAVA_VERSION: 17
+  JAVA_DISTRIBUTION: 'corretto'
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      koog-src: ${{ steps.filter.outputs.koog-src_any_changed }}
+      simple-examples-java: ${{ steps.filter.outputs.simple-examples-java_any_changed  }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a # v47.0.4
+        name: Check changed files
+        id: filter
+        with:
+          write_output_files: 'true'
+          files_yaml_from_source_file: .github/file-filters.yml
+
+      - run: .github/scripts/print_changed_files.sh
+        name: 'Print changed files'
+
+  compilation:
+    needs: changes
+    if: ${{ needs.changes.outputs.koog-src == 'true' || needs.changes.outputs.simple-examples-java == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Configure Git
+        run: |
+          git config --global core.autocrlf input
+      - uses: actions/checkout@v6
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          cache: gradle
+
+      # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
+      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          # Cache downloaded JDKs/konan in addition to the default directories.
+          gradle-home-cache-includes: |
+            caches
+            notifications
+            jdks
+            ~/.konan/**
+
+      - name: Compile
+        working-directory: ./examples/simple-examples-java
+        run: ./gradlew assemble testClasses --stacktrace
+        env:
+          JAVA_OPTS: "-Xmx8g -Dfile.encoding=UTF-8 -Djava.awt.headless=true -Dkotlin.daemon.jvm.options=-Xmx6g"
+
+  tests:
+    needs: compilation
+    if: ${{ needs.changes.outputs.koog-src == 'true' || needs.changes.outputs.simple-examples-java == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Configure Git
+        run: |
+          git config --global core.autocrlf input
+      - uses: actions/checkout@v6
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          cache: gradle
+
+      # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
+      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          # Cache downloaded JDKs/konan in addition to the default directories.
+          gradle-home-cache-includes: |
+            caches
+            notifications
+            jdks
+            ~/.konan/**
+
+      - name: Run tests
+        working-directory: ./examples/simple-examples-java
+        run: ./gradlew test --stacktrace
+        env:
+          JAVA_OPTS: "-Xmx8g -Dfile.encoding=UTF-8 -Djava.awt.headless=true -Dkotlin.daemon.jvm.options=-Xmx6g"

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBase.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBase.kt
@@ -156,9 +156,8 @@ public expect abstract class AIAgentFunctionalContextBase<Pipeline : AIAgentPipe
         preserveMemory: Boolean
     )
 
-    public suspend inline fun <Input, reified Output> subtask(
+    public suspend inline fun <reified Output> subtask(
         taskDescription: String,
-        input: Input,
         tools: List<Tool<*, *>>? = null,
         llmModel: LLModel? = null,
         llmParams: LLMParams? = null,
@@ -166,20 +165,18 @@ public expect abstract class AIAgentFunctionalContextBase<Pipeline : AIAgentPipe
         assistantResponseRepeatMax: Int? = null
     ): Output
 
-    override suspend fun <Input> subtaskWithVerification(
+    override suspend fun subtaskWithVerification(
         taskDescription: String,
-        input: Input,
         tools: List<Tool<*, *>>?,
         llmModel: LLModel?,
         llmParams: LLMParams?,
         runMode: ToolCalls,
         assistantResponseRepeatMax: Int?,
         responseProcessor: ResponseProcessor?
-    ): CriticResult<Input>
+    ): CriticResult<String>
 
-    override suspend fun <Input, Output : Any> subtask(
+    override suspend fun <Output : Any> subtask(
         taskDescription: String,
-        input: Input,
         outputClass: KClass<Output>,
         tools: List<Tool<*, *>>?,
         llmModel: LLModel?,
@@ -189,9 +186,8 @@ public expect abstract class AIAgentFunctionalContextBase<Pipeline : AIAgentPipe
         responseProcessor: ResponseProcessor?
     ): Output
 
-    override suspend fun <Input, OutputTransformed> subtask(
+    override suspend fun <OutputTransformed> subtask(
         taskDescription: String,
-        input: Input,
         tools: List<Tool<*, *>>?,
         finishTool: Tool<*, OutputTransformed>,
         llmModel: LLModel?,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBaseAPI.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBaseAPI.kt
@@ -263,7 +263,6 @@ public interface AIAgentFunctionalContextBaseAPI<Pipeline : AIAgentPipeline> : A
     /**
      * Compresses the current LLM prompt (message history) into a summary, replacing messages with a TLDR.
      *
-     * @param input The input value that will be returned unchanged after compression.
      * @param strategy Determines which messages to include in compression.
      * @param preserveMemory Specifies whether to retain message memory after compression.
      * @return The input value, unchanged.
@@ -280,8 +279,6 @@ public interface AIAgentFunctionalContextBaseAPI<Pipeline : AIAgentPipeline> : A
      * based on its correctness and feedback.
      *
      * @param taskDescription The subtask to be executed by AIAgent.
-     * @param Input The type of the input provided to the subtask.
-     * @param input The input data for the subtask, which will be used to
      * create and execute the task.
      * @param tools An optional list of tools that can be used during
      * the execution of the subtask.
@@ -295,25 +292,22 @@ public interface AIAgentFunctionalContextBaseAPI<Pipeline : AIAgentPipeline> : A
      * and the original input for the subtask.
      */
     @OptIn(InternalAgentToolsApi::class, InternalAgentsApi::class)
-    public suspend fun <Input> subtaskWithVerification(
+    public suspend fun subtaskWithVerification(
         taskDescription: String,
-        input: Input,
         tools: List<Tool<*, *>>? = null,
         llmModel: LLModel? = null,
         llmParams: LLMParams? = null,
         runMode: ToolCalls = ToolCalls.SEQUENTIAL,
         assistantResponseRepeatMax: Int? = null,
         responseProcessor: ResponseProcessor? = null,
-    ): CriticResult<Input>
+    ): CriticResult<String>
 
     /**
      * Executes a subtask within the larger context of an AI agent's functional operation. This method allows you to define a specific
      * task to be performed, using the given input, tools, and optional configuration parameters.
      *
      * @param taskDescription The subtask to be executed by AIAgent.
-     * @param Input The type of input provided to the subtask.
      * @param Output The type of the output expected from the subtask.
-     * @param input The input data required for the subtask execution.
      * @param tools A list of tools available for use within the subtask.
      * @param llmModel The optional large language model to be used during the subtask, if different from the default one.
      * @param llmParams The configuration parameters for the large language model, such as temperature, etc.
@@ -322,9 +316,8 @@ public interface AIAgentFunctionalContextBaseAPI<Pipeline : AIAgentPipeline> : A
      * @return The result of the subtask execution, as an instance of type Output.
      */
     @OptIn(InternalAgentToolsApi::class)
-    public suspend fun <Input, Output : Any> subtask(
+    public suspend fun <Output : Any> subtask(
         taskDescription: String,
-        input: Input,
         outputClass: KClass<Output>,
         tools: List<Tool<*, *>>? = null,
         llmModel: LLModel? = null,
@@ -340,7 +333,6 @@ public interface AIAgentFunctionalContextBaseAPI<Pipeline : AIAgentPipeline> : A
      * employs tools iteratively, and attempts to complete the subtask with a designated finishing tool.
      *
      * @param taskDescription The subtask to be executed by AIAgent.
-     * @param input The input data required to define and execute the subtask.
      * @param tools An optional list of tools that can be used to achieve the task, excluding the finishing tool.
      * @param finishTool A mandatory tool that determines the final result of the subtask by producing and transforming output.
      * @param llmModel An optional specific language learning model (LLM) to use for executing the subtask.
@@ -350,9 +342,8 @@ public interface AIAgentFunctionalContextBaseAPI<Pipeline : AIAgentPipeline> : A
      * @return The transformed final result of executing the finishing tool to complete the subtask.
      */
     @OptIn(InternalAgentToolsApi::class, DetachedPromptExecutorAPI::class, InternalAgentsApi::class)
-    public suspend fun <Input, OutputTransformed> subtask(
+    public suspend fun <OutputTransformed> subtask(
         taskDescription: String,
-        input: Input,
         tools: List<Tool<*, *>>? = null,
         finishTool: Tool<*, OutputTransformed>,
         llmModel: LLModel? = null,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBaseImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBaseImpl.kt
@@ -294,16 +294,15 @@ internal class AIAgentFunctionalContextBaseImpl<Pipeline : AIAgentPipeline>(
         }
     }
 
-    override suspend fun <Input> subtaskWithVerification(
+    override suspend fun subtaskWithVerification(
         taskDescription: String,
-        input: Input,
         tools: List<Tool<*, *>>?,
         llmModel: LLModel?,
         llmParams: LLMParams?,
         runMode: ToolCalls,
         assistantResponseRepeatMax: Int?,
         responseProcessor: ResponseProcessor?
-    ): CriticResult<Input> {
+    ): CriticResult<String> {
         val finishTool = FinishTool<CriticResultFromLLM>(
             outputType = typeToken<CriticResultFromLLM>(),
             customSerializer = KotlinxSerializer()
@@ -311,7 +310,6 @@ internal class AIAgentFunctionalContextBaseImpl<Pipeline : AIAgentPipeline>(
 
         val result = subtask(
             taskDescription = taskDescription,
-            input = input,
             finishTool = finishTool,
             tools = tools,
             llmModel = llmModel,
@@ -324,13 +322,12 @@ internal class AIAgentFunctionalContextBaseImpl<Pipeline : AIAgentPipeline>(
         return CriticResult(
             successful = result.isCorrect,
             feedback = result.feedback,
-            input = input
+            input = taskDescription
         )
     }
 
-    override suspend fun <Input, Output : Any> subtask(
+    override suspend fun <Output : Any> subtask(
         taskDescription: String,
-        input: Input,
         outputClass: KClass<Output>,
         tools: List<Tool<*, *>>?,
         llmModel: LLModel?,
@@ -343,7 +340,6 @@ internal class AIAgentFunctionalContextBaseImpl<Pipeline : AIAgentPipeline>(
 
         return subtask(
             taskDescription,
-            input,
             tools,
             finishTool,
             llmModel,
@@ -355,9 +351,8 @@ internal class AIAgentFunctionalContextBaseImpl<Pipeline : AIAgentPipeline>(
         )
     }
 
-    override suspend fun <Input, OutputTransformed> subtask(
+    override suspend fun <OutputTransformed> subtask(
         taskDescription: String,
-        input: Input,
         tools: List<Tool<*, *>>?,
         finishTool: Tool<*, OutputTransformed>,
         llmModel: LLModel?,
@@ -424,9 +419,8 @@ internal class AIAgentFunctionalContextBaseImpl<Pipeline : AIAgentPipeline>(
 
     @OptIn(InternalAgentToolsApi::class)
     @PublishedApi
-    internal suspend inline fun <Input, reified Output : Any> subtaskImpl(
+    internal suspend inline fun <reified Output : Any> subtaskImpl(
         taskDescription: String,
-        input: Input,
         tools: List<Tool<*, *>>? = null,
         llmModel: LLModel? = null,
         llmParams: LLMParams? = null,
@@ -435,7 +429,6 @@ internal class AIAgentFunctionalContextBaseImpl<Pipeline : AIAgentPipeline>(
     ): Output {
         return subtask(
             taskDescription = taskDescription,
-            input = input,
             outputClass = Output::class,
             tools = tools,
             llmModel = llmModel,

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/FunctionalAIAgentTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/FunctionalAIAgentTest.kt
@@ -8,6 +8,8 @@ import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.agents.ext.agent.CriticResult
+import ai.koog.agents.ext.agent.CriticResultFromLLM
 import ai.koog.agents.ext.agent.SubgraphWithTaskUtils
 import ai.koog.agents.features.eventHandler.feature.EventHandler
 import ai.koog.agents.testing.tools.getMockExecutor
@@ -18,7 +20,6 @@ import ai.koog.prompt.executor.ollama.client.OllamaModels
 import ai.koog.serialization.kotlinx.KotlinxSerializer
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.builtins.serializer
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -498,17 +499,16 @@ class FunctionalAIAgentTest {
                     )
 
                     val assembly = Assembly(engine, body)
-                    product = subtask<Assembly, Spacecraft>(
+
+                    product = subtask<Spacecraft>(
                         taskDescription = "Assemble the product: $assembly",
-                        input = assembly,
                         tools = AssemblyTools.tools,
                         llmModel = OllamaModels.Meta.LLAMA_4,
                         runMode = ToolCalls.SINGLE_RUN_SEQUENTIAL
                     )
 
-                    qaReport = subtask<Spacecraft, FullQAReport>(
-                        taskDescription = "Verify the product is built correctly",
-                        input = product,
+                    qaReport = subtask<FullQAReport>(
+                        taskDescription = "Verify the product is built correctly: $product",
                         tools = QATools.tools,
                         runMode = ToolCalls.SINGLE_RUN_SEQUENTIAL
                     )
@@ -539,10 +539,9 @@ class FunctionalAIAgentTest {
     private suspend fun AIAgentFunctionalContext.buildBody(
         architecture: Architecture,
         additionalInfo: String? = null
-    ): Body = subtask<Architecture, Body>(
+    ): Body = subtask<Body>(
         taskDescription = "Create the body for the given architecture: $architecture" +
             (additionalInfo?.let { "Additional feedback: $additionalInfo" } ?: ""),
-        input = architecture,
         tools = BuildBodyTools.tools,
         llmModel = GoogleModels.Gemini2_0Flash,
         runMode = ToolCalls.SINGLE_RUN_SEQUENTIAL
@@ -551,10 +550,9 @@ class FunctionalAIAgentTest {
     private suspend fun AIAgentFunctionalContext.buildEngine(
         architecture: Architecture,
         additionalInfo: String? = null
-    ): Engine = subtask<Architecture, Engine>(
+    ): Engine = subtask<Engine>(
         taskDescription = "Create the engine for the given architecture: $architecture" +
             (additionalInfo?.let { "Additional feedback: $additionalInfo" } ?: ""),
-        input = architecture,
         tools = BuildEngineTools.tools,
         llmModel = AnthropicModels.Opus_4_6,
         runMode = ToolCalls.SINGLE_RUN_SEQUENTIAL
@@ -563,10 +561,9 @@ class FunctionalAIAgentTest {
     private suspend fun AIAgentFunctionalContext.designArchitecture(
         input: String,
         additionalInfo: String? = null
-    ): Architecture = subtask<String, Architecture>(
+    ): Architecture = subtask<Architecture>(
         taskDescription = "Create the architecture for the following machinery: $input" +
             (additionalInfo?.let { "Additional feedback: $additionalInfo" } ?: ""),
-        input = input,
         tools = ArchitectureTools.tools,
         llmModel = OpenAIModels.Chat.GPT5,
         runMode = ToolCalls.SINGLE_RUN_SEQUENTIAL
@@ -591,9 +588,8 @@ class FunctionalAIAgentTest {
             llmModel = OllamaModels.Meta.LLAMA_3_2,
             toolRegistry = ToolRegistry.EMPTY,
             strategy = functionalStrategy<String, SimpleOut> { input ->
-                subtask<String, SimpleOut>(
+                subtask<SimpleOut>(
                     taskDescription = "Do simple subtask: $input",
-                    input = input,
                     tools = null, // no extra tools
                     runMode = ToolCalls.SEQUENTIAL
                 )
@@ -639,9 +635,8 @@ class FunctionalAIAgentTest {
             promptExecutor = mockLLMApi,
             llmModel = OllamaModels.Meta.LLAMA_3_2,
             strategy = functionalStrategy<String, SimpleOut> { input ->
-                subtask<String, SimpleOut>(
+                subtask<SimpleOut>(
                     taskDescription = "Compose task with tool: $input",
-                    input = input,
                     tools = listOf(DummyTool),
                     runMode = ToolCalls.SEQUENTIAL
                 )
@@ -679,9 +674,8 @@ class FunctionalAIAgentTest {
             promptExecutor = mockLLMApi,
             llmModel = OllamaModels.Meta.LLAMA_3_2,
             strategy = functionalStrategy<String, SimpleOut> { input ->
-                subtask<String, SimpleOut>(
+                subtask<SimpleOut>(
                     taskDescription = "Parallel subtask: $input",
-                    input = input,
                     tools = null,
                     runMode = ToolCalls.PARALLEL
                 )
@@ -715,9 +709,8 @@ class FunctionalAIAgentTest {
             promptExecutor = mockLLMApi,
             llmModel = OllamaModels.Meta.LLAMA_3_2,
             strategy = functionalStrategy<String, SimpleOut> { input ->
-                subtask<String, SimpleOut>(
+                subtask<SimpleOut>(
                     taskDescription = "Single-run subtask: $input",
-                    input = input,
                     tools = null,
                     runMode = ToolCalls.SINGLE_RUN_SEQUENTIAL
                 )
@@ -740,8 +733,8 @@ class FunctionalAIAgentTest {
 
         val mockLLMApi = getMockExecutor(serializer, handleLastAssistantMessage = false) {
             mockLLMToolCall(
-                SubgraphWithTaskUtils.finishTool<ai.koog.agents.ext.agent.CriticResultFromLLM>(),
-                ai.koog.agents.ext.agent.CriticResultFromLLM(isCorrect = true, feedback = "OK")
+                SubgraphWithTaskUtils.finishTool<CriticResultFromLLM>(),
+                CriticResultFromLLM(isCorrect = true, feedback = "OK")
             ) onRequestContains "Judge this:"
 
             mockLLMAnswer("default").asDefaultResponse
@@ -751,10 +744,9 @@ class FunctionalAIAgentTest {
             promptExecutor = mockLLMApi,
             llmModel = OllamaModels.Meta.LLAMA_3_2,
             toolRegistry = ToolRegistry.EMPTY,
-            strategy = functionalStrategy<String, ai.koog.agents.ext.agent.CriticResult<String>> { input ->
+            strategy = functionalStrategy<String, CriticResult<String>> { input ->
                 subtaskWithVerification(
                     taskDescription = "Judge this: $input",
-                    input = input,
                     runMode = ToolCalls.SEQUENTIAL
                 )
             },
@@ -768,7 +760,7 @@ class FunctionalAIAgentTest {
         val result = agent.run("case-A", null)
         assertEquals(true, result.successful)
         assertEquals("OK", result.feedback)
-        assertEquals("case-A", result.input)
+        assertEquals("Judge this: case-A", result.input)
         assertEquals(0, actualToolCalls.size)
     }
 

--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBase.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBase.kt
@@ -50,9 +50,8 @@ public actual abstract class AIAgentFunctionalContextBase<Pipeline : AIAgentPipe
     ): Result<StructuredResponse<T>> = delegate.requestLLMStructured(message, examples, fixingParser)
 
     @JvmOverloads
-    public actual suspend inline fun <Input, reified Output> subtask(
+    public actual suspend inline fun <reified Output> subtask(
         taskDescription: String,
-        input: Input,
         tools: List<Tool<*, *>>?,
         llmModel: LLModel?,
         llmParams: LLMParams?,
@@ -60,7 +59,6 @@ public actual abstract class AIAgentFunctionalContextBase<Pipeline : AIAgentPipe
         assistantResponseRepeatMax: Int?,
     ): Output = delegate.subtaskImpl(
         taskDescription,
-        input,
         tools,
         llmModel,
         llmParams,

--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/context/SubtaskBuilder.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/context/SubtaskBuilder.kt
@@ -24,68 +24,34 @@ public class SubtaskBuilder(
     public val taskDescription: String
 ) {
     /**
-     * Associates an input with the subtask being built.
-     *
-     * @param input The input data to be used for creating or configuring the subtask.
-     * @return A SubtaskBuilderWithInput instance that includes the provided input, enabling further configuration or execution of the subtask.
-     */
-    public fun <Input> withInput(input: Input): SubtaskBuilderWithInput<Input> =
-        SubtaskBuilderWithInput(context, taskDescription, input)
-}
-
-/**
- * A builder class designed for constructing subtasks with input data in the context of an AI agent's functional framework.
- *
- * This class facilitates the creation of subtasks by providing the context, task description, and input data to be used.
- * It enables chaining methods to specify additional configurations, such as output types or finish tools.
- *
- * @param Input The type of the input data to be utilized by the subtask.
- * @property context The functional context associated with the AI agent, used for task execution.
- * @property taskDescription A textual description of the subtask being created.
- * @property input The input data provided to the subtask.
- */
-public class SubtaskBuilderWithInput<Input>(
-    public val context: AIAgentFunctionalContextBase<*>,
-    public val taskDescription: String,
-    public val input: Input
-) {
-
-    /**
      * Specifies the output type for a subtask to be built.
      *
      * @param outputClass The class representing the type of the output for the subtask.
-     * @return A new instance of SubtaskBuilderWithInputAndOutput configured with the specified input and output types.
      */
-    public fun <Output : Any> withOutput(outputClass: Class<Output>): SubtaskBuilderWithInputAndOutput<Input, Output> =
-        SubtaskBuilderWithInputAndOutput(context, taskDescription, input, outputClass)
+    public fun <Output : Any> withOutput(outputClass: Class<Output>): SubtaskBuilderWithInputAndOutput<Output> =
+        SubtaskBuilderWithInputAndOutput(context = context, taskDescription = taskDescription, output = OutputOption.ByClass(outputClass))
 
     /**
      * Associates a finishing tool with the subtask builder, allowing the subtask to produce an output of the specified type.
      *
      * @param finishTool The tool that defines how the subtask's output will be produced and processed.
-     * @return A subtask builder configured with an input and the specified output type.
      */
-    public fun <Output : Any> withFinishTool(finishTool: Tool<*, Output>): SubtaskBuilderWithInputAndOutput<Input, Output> =
-        SubtaskBuilderWithInputAndOutput(context, taskDescription, input, finishTool)
+    public fun <Output : Any> withFinishTool(finishTool: Tool<*, Output>): SubtaskBuilderWithInputAndOutput<Output> =
+        SubtaskBuilderWithInputAndOutput(context = context, taskDescription = taskDescription, output = OutputOption.ByFinishTool(finishTool))
 
     /**
      * Configures the subtask builder to include a verification step in the task pipeline.
-     *
-     * @return A new instance of SubtaskBuilderWithInputAndOutput, which incorporates
-     * the verification step to process the input and produce a CriticResult for the given input type.
      */
-    public fun withVerification(): SubtaskBuilderWithInputAndOutput<Input, CriticResult<Input>> =
-        SubtaskBuilderWithInputAndOutput(context, taskDescription, input, OutputOption.Verification())
+    public fun withVerification(): SubtaskBuilderWithInputAndOutput<CriticResult<String>> =
+        SubtaskBuilderWithInputAndOutput(context, taskDescription, OutputOption.Verification())
 }
 
 /**
  * Builder class to create and configure a subtask with specified input and output types.
  *
- * @param Input The type of the input required for the subtask.
  * @param Output The type of the output produced by the subtask.
  * @param context The functional context associated with the AI agent.
  * @param taskDescription The description of the task that this subtask represents.
- * @param input The input data required for the subtask.
  * @param output Specifies the output of the subtask either by its class or through a finish tool.
  * @param tools Optional list of tools that can be used during the subtask execution.
  * @param llmModel Optional language model to be used for the subtask.
@@ -95,10 +61,9 @@ public class SubtaskBuilderWithInput<Input>(
  * @param assistantResponseRepeatMax Optional maximum number of response repetitions allowed for the assistant.
  * @param executorService Optional executor service for managing asynchronous operations.
  */
-public class SubtaskBuilderWithInputAndOutput<Input, Output : Any>(
+public class SubtaskBuilderWithInputAndOutput<Output : Any>(
     public val context: AIAgentFunctionalContextBase<*>,
     public val taskDescription: String,
-    public val input: Input,
     public val output: OutputOption<Output>,
     public var tools: List<Tool<*, *>>? = null,
     public var llmModel: LLModel? = null,
@@ -116,15 +81,13 @@ public class SubtaskBuilderWithInputAndOutput<Input, Output : Any>(
      *
      * @param context The functional context required to set up the subtask builder.
      * @param taskDescription A textual description of the task being built.
-     * @param input The input data required for the task execution.
      * @param outputClass The class type of the output expected from the task execution.
      */
     public constructor(
         context: AIAgentFunctionalContextBase<*>,
         taskDescription: String,
-        input: Input,
         outputClass: Class<Output>
-    ) : this(context, taskDescription, input, OutputOption.ByClass(outputClass))
+    ) : this(context, taskDescription, OutputOption.ByClass(outputClass))
 
     /**
      * Secondary constructor for initializing an instance of SubtaskBuilderWithInputAndOutput with
@@ -132,24 +95,21 @@ public class SubtaskBuilderWithInputAndOutput<Input, Output : Any>(
      *
      * @param context The functional context in which the subtask is executed.
      * @param taskDescription Description of the task being performed by the subtask.
-     * @param input The input required for the execution of the subtask.
      * @param finishTool A tool used to produce the final output for the subtask.
      */
     public constructor(
         context: AIAgentFunctionalContextBase<*>,
         taskDescription: String,
-        input: Input,
         finishTool: Tool<*, Output>
-    ) : this(context, taskDescription, input, OutputOption.ByFinishTool(finishTool))
+    ) : this(context, taskDescription, OutputOption.ByFinishTool(finishTool))
 
     /**
      * Sets the tools to be used for the subtask configuration.
      *
      * @param tools A list of tools, each represented as an instance of `Tool<*, *>`,
      *              to be utilized for the execution of the subtask.
-     * @return An updated instance of `SubtaskBuilderWithInputAndOutput` reflecting the applied tools.
      */
-    public fun withTools(tools: List<Tool<*, *>>): SubtaskBuilderWithInputAndOutput<Input, Output> =
+    public fun withTools(tools: List<Tool<*, *>>): SubtaskBuilderWithInputAndOutput<Output> =
         apply { this.tools = tools }
 
     /**
@@ -158,36 +118,32 @@ public class SubtaskBuilderWithInputAndOutput<Input, Output : Any>(
      * @param toolSets A variable number of instances of [ToolSet], each representing a group of tools
      *                 that can be used for the execution of the subtask. Each [ToolSet] will be
      *                 converted into a list of tools using its `asTools` method.
-     * @return An updated instance of [SubtaskBuilderWithInputAndOutput] configured with the specified tools.
      */
-    public fun withTools(vararg toolSets: ToolSet): SubtaskBuilderWithInputAndOutput<Input, Output> =
+    public fun withTools(vararg toolSets: ToolSet): SubtaskBuilderWithInputAndOutput<Output> =
         apply { this.tools = toolSets.flatMap { it.asTools() } }
 
     /**
      * Configures the builder to use the specified Large Language Model (LLM) for subsequent tasks.
      *
      * @param llmModel The Large Language Model (LLM) to be used, represented as an instance of [LLModel].
-     * @return The updated instance of [SubtaskBuilderWithInputAndOutput] with the specified LLM configured.
      */
-    public fun useLLM(llmModel: LLModel): SubtaskBuilderWithInputAndOutput<Input, Output> =
+    public fun useLLM(llmModel: LLModel): SubtaskBuilderWithInputAndOutput<Output> =
         apply { this.llmModel = llmModel }
 
     /**
      * Sets the parameters for the language model (LLM) to be used in the subtask.
      *
      * @param llmParams The parameters to configure the behavior of the language model.
-     * @return The current instance of [SubtaskBuilderWithInputAndOutput] with the updated LLM parameters.
      */
-    public fun withParams(llmParams: LLMParams): SubtaskBuilderWithInputAndOutput<Input, Output> =
+    public fun withParams(llmParams: LLMParams): SubtaskBuilderWithInputAndOutput<Output> =
         apply { this.llmParams = llmParams }
 
     /**
      * Sets the response processor to be used for post-processing LLM responses during task execution.
      *
      * @param responseProcessor The instance of [ResponseProcessor] to handle and modify LLM responses during task execution.
-     * @return An updated instance of [SubtaskBuilderWithInputAndOutput] with the specified response processor applied.
      */
-    public fun withResponseProcessor(responseProcessor: ResponseProcessor): SubtaskBuilderWithInputAndOutput<Input, Output> =
+    public fun withResponseProcessor(responseProcessor: ResponseProcessor): SubtaskBuilderWithInputAndOutput<Output> =
         apply { this.responseProcessor = responseProcessor }
 
     /**
@@ -197,9 +153,8 @@ public class SubtaskBuilderWithInputAndOutput<Input, Output : Any>(
      * - `SEQUENTIAL`: Executes multiple tool calls sequentially.
      * - `PARALLEL`: Executes tool calls in parallel.
      * - `SINGLE_RUN_SEQUENTIAL`: Allows only a single tool call to be executed.
-     * @return The current instance of `SubtaskBuilderWithInputAndOutput` to allow for method chaining when configuring the subtask builder.
      */
-    public fun runMode(runMode: ToolCalls): SubtaskBuilderWithInputAndOutput<Input, Output> =
+    public fun runMode(runMode: ToolCalls): SubtaskBuilderWithInputAndOutput<Output> =
         apply { this.runMode = runMode }
 
     /**
@@ -207,26 +162,22 @@ public class SubtaskBuilderWithInputAndOutput<Input, Output : Any>(
      *
      * @param max The maximum number of repetitions allowed for the assistant's response.
      *            Must be a non-negative integer.
-     * @return The current instance of [SubtaskBuilderWithInputAndOutput], allowing for method chaining.
      */
-    public fun assistantResponseRepeatMax(max: Int): SubtaskBuilderWithInputAndOutput<Input, Output> =
+    public fun assistantResponseRepeatMax(max: Int): SubtaskBuilderWithInputAndOutput<Output> =
         apply { this.assistantResponseRepeatMax = max }
 
     /**
      * Configures the subtask builder to use the specified ExecutorService for task execution.
      *
      * @param service the ExecutorService to be used for managing task execution.
-     * @return the current builder instance configured with the given ExecutorService.
      */
-    public fun withExecutorService(service: ExecutorService): SubtaskBuilderWithInputAndOutput<Input, Output> =
+    public fun withExecutorService(service: ExecutorService): SubtaskBuilderWithInputAndOutput<Output> =
         apply { this.executorService = service }
 
     /**
      * Executes the defined task within the configured context and returns the output.
      * The method handles different output options (`OutputOption.ByClass` and `OutputOption.ByFinishTool`)
      * and executes subtasks using the provided input, tools, and configuration parameters.
-     *
-     * @return The result of the subtask execution, which is of type `Output`.
      */
     @OptIn(InternalAgentsApi::class)
     public fun run(): Output = context.config.runOnStrategyDispatcher(executorService) {
@@ -235,7 +186,6 @@ public class SubtaskBuilderWithInputAndOutput<Input, Output : Any>(
             is OutputOption.ByClass<Output> -> {
                 context.subtask(
                     taskDescription,
-                    input = input,
                     outputClass = output.outputClass.kotlin,
                     tools = tools,
                     llmModel = llmModel,
@@ -248,7 +198,6 @@ public class SubtaskBuilderWithInputAndOutput<Input, Output : Any>(
 
             is OutputOption.ByFinishTool<Output> -> context.subtask(
                 taskDescription,
-                input = input,
                 finishTool = output.finishTool,
                 tools = tools,
                 llmModel = llmModel,
@@ -257,16 +206,16 @@ public class SubtaskBuilderWithInputAndOutput<Input, Output : Any>(
                 assistantResponseRepeatMax = assistantResponseRepeatMax,
                 responseProcessor = responseProcessor
             )
+
             is OutputOption.Verification<*> -> context.subtaskWithVerification(
                 taskDescription,
-                input = input,
                 tools = tools,
                 llmModel = llmModel,
                 llmParams = llmParams,
                 runMode = runMode,
                 assistantResponseRepeatMax = assistantResponseRepeatMax,
                 responseProcessor = responseProcessor
-            ) as Output // Output === CriticResult<Input> in this case
+            ) as Output // Output === CriticResult<String> in this case
         }
     }
 }

--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/context/SubtaskBuilder.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/context/SubtaskBuilder.kt
@@ -28,22 +28,22 @@ public class SubtaskBuilder(
      *
      * @param outputClass The class representing the type of the output for the subtask.
      */
-    public fun <Output : Any> withOutput(outputClass: Class<Output>): SubtaskBuilderWithInputAndOutput<Output> =
-        SubtaskBuilderWithInputAndOutput(context = context, taskDescription = taskDescription, output = OutputOption.ByClass(outputClass))
+    public fun <Output : Any> withOutput(outputClass: Class<Output>): SubtaskBuilderWithOutput<Output> =
+        SubtaskBuilderWithOutput(context = context, taskDescription = taskDescription, output = OutputOption.ByClass(outputClass))
 
     /**
      * Associates a finishing tool with the subtask builder, allowing the subtask to produce an output of the specified type.
      *
      * @param finishTool The tool that defines how the subtask's output will be produced and processed.
      */
-    public fun <Output : Any> withFinishTool(finishTool: Tool<*, Output>): SubtaskBuilderWithInputAndOutput<Output> =
-        SubtaskBuilderWithInputAndOutput(context = context, taskDescription = taskDescription, output = OutputOption.ByFinishTool(finishTool))
+    public fun <Output : Any> withFinishTool(finishTool: Tool<*, Output>): SubtaskBuilderWithOutput<Output> =
+        SubtaskBuilderWithOutput(context = context, taskDescription = taskDescription, output = OutputOption.ByFinishTool(finishTool))
 
     /**
      * Configures the subtask builder to include a verification step in the task pipeline.
      */
-    public fun withVerification(): SubtaskBuilderWithInputAndOutput<CriticResult<String>> =
-        SubtaskBuilderWithInputAndOutput(context, taskDescription, OutputOption.Verification())
+    public fun withVerification(): SubtaskBuilderWithOutput<CriticResult<String>> =
+        SubtaskBuilderWithOutput(context, taskDescription, OutputOption.Verification())
 }
 
 /**
@@ -61,7 +61,7 @@ public class SubtaskBuilder(
  * @param assistantResponseRepeatMax Optional maximum number of response repetitions allowed for the assistant.
  * @param executorService Optional executor service for managing asynchronous operations.
  */
-public class SubtaskBuilderWithInputAndOutput<Output : Any>(
+public class SubtaskBuilderWithOutput<Output : Any>(
     public val context: AIAgentFunctionalContextBase<*>,
     public val taskDescription: String,
     public val output: OutputOption<Output>,
@@ -109,7 +109,7 @@ public class SubtaskBuilderWithInputAndOutput<Output : Any>(
      * @param tools A list of tools, each represented as an instance of `Tool<*, *>`,
      *              to be utilized for the execution of the subtask.
      */
-    public fun withTools(tools: List<Tool<*, *>>): SubtaskBuilderWithInputAndOutput<Output> =
+    public fun withTools(tools: List<Tool<*, *>>): SubtaskBuilderWithOutput<Output> =
         apply { this.tools = tools }
 
     /**
@@ -119,7 +119,7 @@ public class SubtaskBuilderWithInputAndOutput<Output : Any>(
      *                 that can be used for the execution of the subtask. Each [ToolSet] will be
      *                 converted into a list of tools using its `asTools` method.
      */
-    public fun withTools(vararg toolSets: ToolSet): SubtaskBuilderWithInputAndOutput<Output> =
+    public fun withTools(vararg toolSets: ToolSet): SubtaskBuilderWithOutput<Output> =
         apply { this.tools = toolSets.flatMap { it.asTools() } }
 
     /**
@@ -127,7 +127,7 @@ public class SubtaskBuilderWithInputAndOutput<Output : Any>(
      *
      * @param llmModel The Large Language Model (LLM) to be used, represented as an instance of [LLModel].
      */
-    public fun useLLM(llmModel: LLModel): SubtaskBuilderWithInputAndOutput<Output> =
+    public fun useLLM(llmModel: LLModel): SubtaskBuilderWithOutput<Output> =
         apply { this.llmModel = llmModel }
 
     /**
@@ -135,7 +135,7 @@ public class SubtaskBuilderWithInputAndOutput<Output : Any>(
      *
      * @param llmParams The parameters to configure the behavior of the language model.
      */
-    public fun withParams(llmParams: LLMParams): SubtaskBuilderWithInputAndOutput<Output> =
+    public fun withParams(llmParams: LLMParams): SubtaskBuilderWithOutput<Output> =
         apply { this.llmParams = llmParams }
 
     /**
@@ -143,7 +143,7 @@ public class SubtaskBuilderWithInputAndOutput<Output : Any>(
      *
      * @param responseProcessor The instance of [ResponseProcessor] to handle and modify LLM responses during task execution.
      */
-    public fun withResponseProcessor(responseProcessor: ResponseProcessor): SubtaskBuilderWithInputAndOutput<Output> =
+    public fun withResponseProcessor(responseProcessor: ResponseProcessor): SubtaskBuilderWithOutput<Output> =
         apply { this.responseProcessor = responseProcessor }
 
     /**
@@ -154,7 +154,7 @@ public class SubtaskBuilderWithInputAndOutput<Output : Any>(
      * - `PARALLEL`: Executes tool calls in parallel.
      * - `SINGLE_RUN_SEQUENTIAL`: Allows only a single tool call to be executed.
      */
-    public fun runMode(runMode: ToolCalls): SubtaskBuilderWithInputAndOutput<Output> =
+    public fun runMode(runMode: ToolCalls): SubtaskBuilderWithOutput<Output> =
         apply { this.runMode = runMode }
 
     /**
@@ -163,7 +163,7 @@ public class SubtaskBuilderWithInputAndOutput<Output : Any>(
      * @param max The maximum number of repetitions allowed for the assistant's response.
      *            Must be a non-negative integer.
      */
-    public fun assistantResponseRepeatMax(max: Int): SubtaskBuilderWithInputAndOutput<Output> =
+    public fun assistantResponseRepeatMax(max: Int): SubtaskBuilderWithOutput<Output> =
         apply { this.assistantResponseRepeatMax = max }
 
     /**
@@ -171,7 +171,7 @@ public class SubtaskBuilderWithInputAndOutput<Output : Any>(
      *
      * @param service the ExecutorService to be used for managing task execution.
      */
-    public fun withExecutorService(service: ExecutorService): SubtaskBuilderWithInputAndOutput<Output> =
+    public fun withExecutorService(service: ExecutorService): SubtaskBuilderWithOutput<Output> =
         apply { this.executorService = service }
 
     /**

--- a/agents/agents-core/src/nonJvmCommonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBase.kt
+++ b/agents/agents-core/src/nonJvmCommonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBase.kt
@@ -22,9 +22,8 @@ public actual abstract class AIAgentFunctionalContextBase<Pipeline : AIAgentPipe
         fixingParser: StructureFixingParser?
     ): Result<StructuredResponse<T>> = delegate.requestLLMStructured(message, examples, fixingParser)
 
-    public actual suspend inline fun <Input, reified Output> subtask(
+    public actual suspend inline fun <reified Output> subtask(
         taskDescription: String,
-        input: Input,
         tools: List<Tool<*, *>>?,
         llmModel: LLModel?,
         llmParams: LLMParams?,
@@ -32,7 +31,6 @@ public actual abstract class AIAgentFunctionalContextBase<Pipeline : AIAgentPipe
         assistantResponseRepeatMax: Int?,
     ): Output = delegate.subtaskImpl(
         taskDescription,
-        input,
         tools,
         llmModel,
         llmParams,

--- a/examples/simple-examples-java/build.gradle.kts
+++ b/examples/simple-examples-java/build.gradle.kts
@@ -47,7 +47,11 @@ fun ExecSpec.doPublishKoogToMavenLocal() {
     workingDir = koogRootDir
     commandLine(
         "${koogRootDir.resolve("gradlew").absolutePath}",
+        // KMP modules: root metadata module and only JVM artifacts
+        "publishKotlinMultiplatformPublicationToMavenLocal",
         "publishJvmPublicationToMavenLocal",
+        // JVM-only modules
+        "publishMavenPublicationToMavenLocal",
         "-Pversion=${koogVersion.removeSuffix("-SNAPSHOT")}",
     )
 }

--- a/examples/simple-examples-java/src/main/java/ai/koog/agents/example/strategies/GraphStrategyExample.java
+++ b/examples/simple-examples-java/src/main/java/ai/koog/agents/example/strategies/GraphStrategyExample.java
@@ -38,7 +38,7 @@ public class GraphStrategyExample {
             .limitedTools(Collections.emptyList())
             .withInput(ProblemDescription.class)
             .withOutput(ProblemSolution.class)
-            .withTask(problem -> "Propose a solution for: " + problem.title + " - " + problem.details)
+            .withTask(problem -> "Propose a solution for: " + problem.title() + " - " + problem.details())
             .build();
 
         // Step 3: Verify the solution using LLM-as-a-judge
@@ -86,6 +86,6 @@ public class GraphStrategyExample {
 
         var result = graphAgent.run("How to make a perfect poached egg?", "sessionId");
 
-        System.out.println("\n\nAgent result:\n%s\n".formatted(result.description));
+        System.out.println("\n\nAgent result:\n%s\n".formatted(result.description()));
     }
 }

--- a/examples/simple-examples-java/src/main/java/ai/koog/agents/example/strategies/entities/ProblemDescription.java
+++ b/examples/simple-examples-java/src/main/java/ai/koog/agents/example/strategies/entities/ProblemDescription.java
@@ -1,34 +1,13 @@
 package ai.koog.agents.example.strategies.entities;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Structured description of an identified problem.
  * Returned by the first subtask so subsequent steps have typed context.
  */
-public class ProblemDescription {
-    @JsonProperty("title") public final String title;
-    @JsonProperty("details") public final String details;
-    @JsonProperty("severity") public final String severity;
-
-    @JsonCreator
-    public ProblemDescription(
-        @JsonProperty("title") String title,
-        @JsonProperty("details") String details,
-        @JsonProperty("severity") String severity
-    ) {
-        this.title = title;
-        this.details = details;
-        this.severity = severity;
-    }
-
-    @Override
-    public String toString() {
-        return "ProblemDescription{\n" +
-            "  title=" + title + ";\n" +
-            "  details=" + details + ";\n" +
-            "  severity=" + severity + ";\n" +
-            '}';
-    }
-}
+public record ProblemDescription(
+    @JsonProperty("title") String title,
+    @JsonProperty("details") String details,
+    @JsonProperty("severity") String severity
+) {}

--- a/examples/simple-examples-java/src/main/java/ai/koog/agents/example/strategies/entities/ProblemSolution.java
+++ b/examples/simple-examples-java/src/main/java/ai/koog/agents/example/strategies/entities/ProblemSolution.java
@@ -1,26 +1,11 @@
 package ai.koog.agents.example.strategies.entities;
 
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Structured solution produced by the solving subtask.
  */
-public class ProblemSolution {
-    @JsonProperty("description") public final String description;
-
-    @JsonCreator
-    public ProblemSolution(
-        @JsonProperty("description") String description
-    ) {
-        this.description = description;
-    }
-
-    @Override
-    public String toString() {
-        return "ProblemSolution{\n" +
-            "  description=" + description + ";\n" +
-            '}';
-    }
-}
+public record ProblemSolution(
+    @JsonProperty("description") String description
+) {}

--- a/examples/simple-examples-java/src/main/java/ai/koog/agents/example/strategies/functional/FunctionalStrategyExample.java
+++ b/examples/simple-examples-java/src/main/java/ai/koog/agents/example/strategies/functional/FunctionalStrategyExample.java
@@ -72,6 +72,6 @@ public class FunctionalStrategyExample {
 
         var result = functionalAgent.run("How to make a perfect poached egg?");
 
-        System.out.println("\n\nAgent result:\n%s\n".formatted(result.description));
+        System.out.println("\n\nAgent result:\n%s\n".formatted(result.description()));
     }
 }

--- a/examples/simple-examples-java/src/main/java/ai/koog/agents/example/strategies/functional/FunctionalStrategyExample.java
+++ b/examples/simple-examples-java/src/main/java/ai/koog/agents/example/strategies/functional/FunctionalStrategyExample.java
@@ -30,7 +30,6 @@ public class FunctionalStrategyExample {
                 // Only give the agent communication and read-only database access here
                 ProblemDescription problem = ctx
                     .subtask("Identify the problem: " + userInput)
-                    .withInput(userInput)
                     .withOutput(ProblemDescription.class)  // Type-safe output
                     .withTools(communicationTools, databaseReadTools)  // Limited tools
                     .run();
@@ -39,16 +38,14 @@ public class FunctionalStrategyExample {
                 // Give the agent database write access only after problem identification
                 ProblemSolution solution = ctx
                     .subtask("Solve the problem: " + problem) // Use output from step 1
-                    .withInput(problem)
                     .withOutput(ProblemSolution.class)
                     .withTools(databaseReadTools, databaseWriteTools)
                     .run();
 
                 // Verify the solution and try to fix it until the solution is satisfying
                 while (true) {
-                    CriticResult<ProblemSolution> verificationResult = ctx
+                    CriticResult<String> verificationResult = ctx
                         .subtask("Now verify that the problem is actually solved: " + solution)
-                        .withInput(solution)
                         .withVerification()
                         .withTools(communicationTools, databaseReadTools)
                         .run();
@@ -58,7 +55,6 @@ public class FunctionalStrategyExample {
                     } else {
                         solution = ctx
                             .subtask("Fix the solution based on the provided feedback: " + verificationResult.getFeedback())
-                            .withInput(verificationResult.getFeedback())
                             .withOutput(ProblemSolution.class)
                             .withTools(databaseReadTools, databaseWriteTools)
                             .run();

--- a/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/ContextApiIntegrationTest.java
+++ b/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/ContextApiIntegrationTest.java
@@ -177,7 +177,6 @@ public class ContextApiIntegrationTest extends KoogJavaTestBase {
             .toolRegistry(ToolRegistry.builder().tools(calculator).build())
             .functionalStrategy((AIAgentFunctionalContext context, String input) -> {
                 String subtaskResult = context.subtask("Calculate the sum of 10 and 20 using the add tool")
-                    .withInput(input)
                     .withOutput(String.class)
                     .withTools(tools)
                     .useLLM(model)
@@ -219,7 +218,6 @@ public class ContextApiIntegrationTest extends KoogJavaTestBase {
             .toolRegistry(ToolRegistry.builder().tools(calculator).build())
             .functionalStrategy((AIAgentFunctionalContext context, String input) -> {
                 String subtaskResult = context.subtask("Calculate 5 + 3 and 4 * 6 using available tools")
-                    .withInput(input)
                     .withOutput(String.class)
                     .withTools(tools)
                     .useLLM(model)
@@ -260,7 +258,6 @@ public class ContextApiIntegrationTest extends KoogJavaTestBase {
             .toolRegistry(ToolRegistry.builder().tools(calculator).build())
             .functionalStrategy((AIAgentFunctionalContext context, String input) -> {
                 String subtaskResult = context.subtask("Add 7 and 8")
-                    .withInput(input)
                     .withOutput(String.class)
                     .withTools(tools)
                     .useLLM(model)

--- a/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/FunctionalStrategyIntegrationTest.java
+++ b/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/FunctionalStrategyIntegrationTest.java
@@ -177,7 +177,6 @@ public class FunctionalStrategyIntegrationTest extends KoogJavaTestBase {
             .toolRegistry(ToolRegistry.builder().tools(calculator).build())
             .functionalStrategy((AIAgentFunctionalContext context, String input) -> {
                 String subtaskResult = context.subtask("Calculate: " + input)
-                    .withInput(input)
                     .withOutput(String.class)
                     .withTools(calculatorTools)
                     .useLLM(model)

--- a/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentIntegrationTest.java
+++ b/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentIntegrationTest.java
@@ -201,7 +201,6 @@ public class JavaAIAgentIntegrationTest extends KoogJavaTestBase {
             .functionalStrategy((AIAgentFunctionalContext context, String input) -> {
                 Message.Response first = context.requestLLM("Reply the user", true);
                 String second = context.subtask("Verify the answer")
-                    .withInput(input)
                     .withOutput(String.class)
                     .useLLM(AnthropicModels.Opus_4_6)
                     .run();

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
@@ -1363,7 +1363,6 @@ class AIAgentIntegrationTest : AIAgentTestBase() {
             strategy = functionalStrategy<String, String> { input ->
                 val result: String = subtask(
                     taskDescription = "Judge this: $input",
-                    input = input,
                     runMode = ToolCalls.SEQUENTIAL
                 )
                 "Subtask completed: $result"


### PR DESCRIPTION
Remove `input` parameter from `AIAgentFunctionalContext.subtask`.
Also update `simple-examples-java` to use record classes and create CI job for these examples

BREAKING:
* Remove `input` parameter from `AIAgentFunctionalContext.subtask` and related methods and builders. It was not actually used, `taskDescription` is the right way to specify the task. 