### PR TITLE
fix(prompt): add correct copy overloads in LLMParams subclasses

### DIFF
--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
@@ -1379,11 +1379,6 @@ class AIAgentIntegrationTest : AIAgentTestBase() {
         assumeTrue(model.supports(LLMCapability.Tools), "Model $model does not support tools")
 
         Models.assumeEnumToolCallsAreStable(model, "force-one-tool integration with calculator enum arguments")
-        assumeTrue(
-            model.provider.id != LLMProvider.Google.id,
-            "KG-742 Prompt.withUpdatedParams() drops provider-specific params"
-        )
-
         runWithTracking { eventHandlerConfig, state ->
             val maxAttempts = if (model.provider.id == LLMProvider.MistralAI.id) 2 else 3
             var attempts = 0

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicParams.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicParams.kt
@@ -101,6 +101,33 @@ public class AnthropicParams(
         }
     }
 
+    override fun copy(
+        temperature: Double?,
+        maxTokens: Int?,
+        numberOfChoices: Int?,
+        speculation: String?,
+        schema: Schema?,
+        toolChoice: ToolChoice?,
+        user: String?,
+        additionalProperties: Map<String, JsonElement>?,
+    ): AnthropicParams = copy(
+        temperature = temperature,
+        maxTokens = maxTokens,
+        numberOfChoices = numberOfChoices,
+        speculation = speculation,
+        schema = schema,
+        toolChoice = toolChoice,
+        user = user,
+        additionalProperties = additionalProperties,
+        topP = topP,
+        topK = topK,
+        stopSequences = stopSequences,
+        container = container,
+        mcpServers = mcpServers,
+        serviceTier = serviceTier,
+        thinking = thinking,
+    )
+
     /**
      * Creates a copy of this instance with the ability to modify any of its properties.
      */

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseParams.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseParams.kt
@@ -89,6 +89,31 @@ public class BedrockConverseParams(
         }
     }
 
+    override fun copy(
+        temperature: Double?,
+        maxTokens: Int?,
+        numberOfChoices: Int?,
+        speculation: String?,
+        schema: Schema?,
+        toolChoice: ToolChoice?,
+        user: String?,
+        additionalProperties: Map<String, JsonElement>?,
+    ): BedrockConverseParams = copy(
+        temperature = temperature,
+        maxTokens = maxTokens,
+        numberOfChoices = numberOfChoices,
+        speculation = speculation,
+        schema = schema,
+        toolChoice = toolChoice,
+        user = user,
+        additionalProperties = additionalProperties,
+        topP = topP,
+        stopSequences = stopSequences,
+        performanceConfig = performanceConfig,
+        promptVariables = promptVariables,
+        requestMetadata = requestMetadata,
+    )
+
     /**
      * Creates a copy of this instance with the ability to modify any of its properties.
      */
@@ -103,6 +128,9 @@ public class BedrockConverseParams(
         additionalProperties: Map<String, JsonElement>? = this.additionalProperties,
         topP: Double? = this.topP,
         stopSequences: List<String>? = this.stopSequences,
+        performanceConfig: PerformanceConfiguration? = this.performanceConfig,
+        promptVariables: Map<String, PromptVariableValues>? = this.promptVariables,
+        requestMetadata: Map<String, String>? = this.requestMetadata,
     ): BedrockConverseParams = BedrockConverseParams(
         temperature = temperature,
         maxTokens = maxTokens,
@@ -114,6 +142,9 @@ public class BedrockConverseParams(
         additionalProperties = additionalProperties,
         topP = topP,
         stopSequences = stopSequences,
+        performanceConfig = performanceConfig,
+        promptVariables = promptVariables,
+        requestMetadata = requestMetadata,
     )
 
     override fun equals(other: Any?): Boolean = when {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/dashscope/DashscopeParams.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/dashscope/DashscopeParams.kt
@@ -95,6 +95,35 @@ public class DashscopeParams(
         }
     }
 
+    override fun copy(
+        temperature: Double?,
+        maxTokens: Int?,
+        numberOfChoices: Int?,
+        speculation: String?,
+        schema: Schema?,
+        toolChoice: ToolChoice?,
+        user: String?,
+        additionalProperties: Map<String, JsonElement>?,
+    ): DashscopeParams = copy(
+        temperature = temperature,
+        maxTokens = maxTokens,
+        numberOfChoices = numberOfChoices,
+        speculation = speculation,
+        schema = schema,
+        toolChoice = toolChoice,
+        user = user,
+        additionalProperties = additionalProperties,
+        enableSearch = enableSearch,
+        parallelToolCalls = parallelToolCalls,
+        enableThinking = enableThinking,
+        frequencyPenalty = frequencyPenalty,
+        presencePenalty = presencePenalty,
+        logprobs = logprobs,
+        stop = stop,
+        topLogprobs = topLogprobs,
+        topP = topP,
+    )
+
     /**
      * Creates a copy of this instance with the ability to modify any of its properties.
      */
@@ -138,7 +167,9 @@ public class DashscopeParams(
 
     override fun equals(other: Any?): Boolean = when {
         this === other -> true
+
         other !is DashscopeParams -> false
+
         else ->
             temperature == other.temperature &&
                 maxTokens == other.maxTokens &&

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekParams.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekParams.kt
@@ -89,6 +89,32 @@ public class DeepSeekParams(
         }
     }
 
+    override fun copy(
+        temperature: Double?,
+        maxTokens: Int?,
+        numberOfChoices: Int?,
+        speculation: String?,
+        schema: Schema?,
+        toolChoice: ToolChoice?,
+        user: String?,
+        additionalProperties: Map<String, JsonElement>?,
+    ): DeepSeekParams = copy(
+        temperature = temperature,
+        maxTokens = maxTokens,
+        numberOfChoices = numberOfChoices,
+        speculation = speculation,
+        schema = schema,
+        toolChoice = toolChoice,
+        user = user,
+        additionalProperties = additionalProperties,
+        frequencyPenalty = frequencyPenalty,
+        presencePenalty = presencePenalty,
+        logprobs = logprobs,
+        stop = stop,
+        topLogprobs = topLogprobs,
+        topP = topP,
+    )
+
     /**
      * Creates a copy of this instance with the ability to modify any of its properties.
      */

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleParams.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleParams.kt
@@ -71,6 +71,29 @@ public class GoogleParams(
         }
     }
 
+    override fun copy(
+        temperature: Double?,
+        maxTokens: Int?,
+        numberOfChoices: Int?,
+        speculation: String?,
+        schema: Schema?,
+        toolChoice: ToolChoice?,
+        user: String?,
+        additionalProperties: Map<String, JsonElement>?,
+    ): GoogleParams = copy(
+        temperature = temperature,
+        maxTokens = maxTokens,
+        numberOfChoices = numberOfChoices,
+        speculation = speculation,
+        schema = schema,
+        toolChoice = toolChoice,
+        user = user,
+        additionalProperties = additionalProperties,
+        topP = topP,
+        topK = topK,
+        thinkingConfig = thinkingConfig,
+    )
+
     /**
      * Creates a copy of this instance with the ability to modify any of its properties.
      */

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAIParams.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAIParams.kt
@@ -89,6 +89,34 @@ public class MistralAIParams(
         }
     }
 
+    override fun copy(
+        temperature: Double?,
+        maxTokens: Int?,
+        numberOfChoices: Int?,
+        speculation: String?,
+        schema: Schema?,
+        toolChoice: ToolChoice?,
+        user: String?,
+        additionalProperties: Map<String, JsonElement>?,
+    ): MistralAIParams = copy(
+        temperature = temperature,
+        maxTokens = maxTokens,
+        numberOfChoices = numberOfChoices,
+        speculation = speculation,
+        schema = schema,
+        toolChoice = toolChoice,
+        user = user,
+        additionalProperties = additionalProperties,
+        topP = topP,
+        stop = stop,
+        randomSeed = randomSeed,
+        presencePenalty = presencePenalty,
+        frequencyPenalty = frequencyPenalty,
+        parallelToolCalls = parallelToolCalls,
+        promptMode = promptMode,
+        safePrompt = safePrompt,
+    )
+
     /**
      * Creates a copy of this instance with the ability to modify any of its properties.
      */

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIParams.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIParams.kt
@@ -145,6 +145,40 @@ public class OpenAIChatParams(
         }
     }
 
+    override fun copy(
+        temperature: Double?,
+        maxTokens: Int?,
+        numberOfChoices: Int?,
+        speculation: String?,
+        schema: Schema?,
+        toolChoice: ToolChoice?,
+        user: String?,
+        additionalProperties: Map<String, JsonElement>?,
+    ): OpenAIChatParams = copy(
+        temperature = temperature,
+        maxTokens = maxTokens,
+        numberOfChoices = numberOfChoices,
+        speculation = speculation,
+        schema = schema,
+        toolChoice = toolChoice,
+        user = user,
+        additionalProperties = additionalProperties,
+        frequencyPenalty = frequencyPenalty,
+        presencePenalty = presencePenalty,
+        parallelToolCalls = parallelToolCalls,
+        promptCacheKey = promptCacheKey,
+        safetyIdentifier = safetyIdentifier,
+        serviceTier = serviceTier,
+        store = store,
+        audio = audio,
+        logprobs = logprobs,
+        reasoningEffort = reasoningEffort,
+        stop = stop,
+        topLogprobs = topLogprobs,
+        topP = topP,
+        webSearchOptions = webSearchOptions,
+    )
+
     /**
      * Creates a copy of this instance with the ability to modify any of its properties.
      */
@@ -366,6 +400,39 @@ public class OpenAIResponsesParams(
             require(maxToolCalls >= 0) { "maxToolCalls must be >= 0" }
         }
     }
+
+    override fun copy(
+        temperature: Double?,
+        maxTokens: Int?,
+        numberOfChoices: Int?,
+        speculation: String?,
+        schema: Schema?,
+        toolChoice: ToolChoice?,
+        user: String?,
+        additionalProperties: Map<String, JsonElement>?,
+    ): OpenAIResponsesParams = copy(
+        temperature = temperature,
+        maxTokens = maxTokens,
+        numberOfChoices = numberOfChoices,
+        speculation = speculation,
+        schema = schema,
+        toolChoice = toolChoice,
+        user = user,
+        additionalProperties = additionalProperties,
+        background = background,
+        include = include,
+        maxToolCalls = maxToolCalls,
+        parallelToolCalls = parallelToolCalls,
+        reasoning = reasoning,
+        truncation = truncation,
+        promptCacheKey = promptCacheKey,
+        safetyIdentifier = safetyIdentifier,
+        serviceTier = serviceTier,
+        store = store,
+        logprobs = logprobs,
+        topLogprobs = topLogprobs,
+        topP = topP,
+    )
 
     /**
      * Creates a copy of this instance with the ability to modify any of its properties.

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterParams.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterParams.kt
@@ -121,6 +121,43 @@ public open class OpenRouterParams(
     }
 
     /**
+     * Subclasses that declare additional fields must override this method to preserve those fields.
+     */
+    override fun copy(
+        temperature: Double?,
+        maxTokens: Int?,
+        numberOfChoices: Int?,
+        speculation: String?,
+        schema: Schema?,
+        toolChoice: ToolChoice?,
+        user: String?,
+        additionalProperties: Map<String, JsonElement>?,
+    ): OpenRouterParams = copy(
+        temperature = temperature,
+        maxTokens = maxTokens,
+        numberOfChoices = numberOfChoices,
+        speculation = speculation,
+        schema = schema,
+        toolChoice = toolChoice,
+        user = user,
+        additionalProperties = additionalProperties,
+        frequencyPenalty = frequencyPenalty,
+        presencePenalty = presencePenalty,
+        logprobs = logprobs,
+        stop = stop,
+        topLogprobs = topLogprobs,
+        topP = topP,
+        topK = topK,
+        repetitionPenalty = repetitionPenalty,
+        minP = minP,
+        topA = topA,
+        transforms = transforms,
+        models = models,
+        route = route,
+        provider = provider,
+    )
+
+    /**
      * Creates a copy of this instance with the ability to modify any of its properties.
      */
     public fun copy(

--- a/prompt/prompt-model/src/jvmTest/kotlin/ai/koog/prompt/PromptTest.kt
+++ b/prompt/prompt-model/src/jvmTest/kotlin/ai/koog/prompt/PromptTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
 import kotlin.time.Clock
 import kotlin.time.Instant
@@ -660,5 +661,41 @@ class PromptTest {
         assertEquals("new speculation", multiUpdatedPrompt.params.speculation)
         assertEquals(LLMParams.ToolChoice.Auto, multiUpdatedPrompt.params.toolChoice)
         assertEquals("new_user", multiUpdatedPrompt.params.user)
+    }
+
+    @Test
+    fun testWithUpdatedParamsPreservesLLMParamsSubtype() {
+        class CustomProviderParams(
+            temperature: Double? = null,
+            toolChoice: ToolChoice? = null,
+            val providerField: String? = null,
+        ) : LLMParams(temperature = temperature, toolChoice = toolChoice) {
+            override fun copy(
+                temperature: Double?,
+                maxTokens: Int?,
+                numberOfChoices: Int?,
+                speculation: String?,
+                schema: Schema?,
+                toolChoice: ToolChoice?,
+                user: String?,
+                additionalProperties: Map<String, kotlinx.serialization.json.JsonElement>?,
+            ): CustomProviderParams = CustomProviderParams(
+                temperature = temperature,
+                toolChoice = toolChoice,
+                providerField = providerField,
+            )
+        }
+
+        val originalParams = CustomProviderParams(temperature = 0.7, providerField = "provider-specific")
+        val prompt = Prompt.build("test", originalParams) { system("system") }
+
+        val updated = prompt.withUpdatedParams {
+            toolChoice = LLMParams.ToolChoice.Named("myTool")
+        }
+
+        assertIs<CustomProviderParams>(updated.params)
+        assertEquals(originalParams.providerField, updated.params.providerField)
+        assertEquals(LLMParams.ToolChoice.Named("myTool"), updated.params.toolChoice)
+        assertEquals(originalParams.temperature, updated.params.temperature)
     }
 }


### PR DESCRIPTION
`Prompt.withUpdatedParams` internally calls `params.copy(…)` with the 8-parameter base signature. All `LLMParams` subclasses (`GoogleParams`, `AnthropicParams`, `OpenAIChatParams`, etc.) defined their own `copy()` with additional provider-specific parameters, but did not `override` the base `copy()`. 
Since the signatures differ, JVM virtual dispatch fell through to `LLMParams.copy()`, which always returned a plain `LLMParams` — silently dropping provider-specific fields like `GoogleParams.thinkingConfig`, `AnthropicParams.thinking`, etc.

Fixed by adding `override fun copy(8 base params)` to each subclass. Each override delegates to the subclass's full `copy()`, preserving all provider-specific fields from `this`. The integration test for `requestLLMForceOneTool` that was previously skipping Google models is now unblocked.

Additionally fixed `BedrockConverseParams.copy()` which was missing `performanceConfig`, `promptVariables`, and `requestMetadata` parameters, and `DashscopeParams` which had an override that incorrectly called `super.copy()`.

closes KG-742
