### PR TITLE
fix(agents): preserve prompt messages, id, and params when adding systemMessage in agent builder

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilder.kt
@@ -18,6 +18,7 @@ import ai.koog.agents.planner.AIAgentPlannerStrategyBuilder
 import ai.koog.agents.planner.PlannerAIAgent
 import ai.koog.agents.planner.TypedAgentPlannerStrategyBuilder
 import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.serialization.TypeToken
@@ -198,7 +199,7 @@ public class GraphAgentBuilder<Input, Output>(
      * @return The updated instance of GraphAgentBuilder with the system prompt applied.
      */
     public fun systemPrompt(systemPrompt: String): GraphAgentBuilder<Input, Output> =
-        prompt(ai.koog.prompt.dsl.prompt(id = "agent") { system(systemPrompt) })
+        prompt(prompt(config.prompt) { system(systemPrompt) })
 
     /**
      * Sets the prompt for the GraphAgentBuilder and returns the builder instance for further configuration.
@@ -375,7 +376,7 @@ public class FunctionalAgentBuilder<Input, Output>(
      * @return The instance of FunctionalAgentBuilder with the updated system-level prompt.
      */
     public fun systemPrompt(systemPrompt: String): FunctionalAgentBuilder<Input, Output> =
-        prompt(ai.koog.prompt.dsl.prompt(id = "agent") { system(systemPrompt) })
+        prompt(prompt(config.prompt) { system(systemPrompt) })
 
     /**
      * Sets the specified prompt for the functional agent being built.
@@ -546,7 +547,7 @@ public class PlannerAgentBuilder<Input, Output>(
      * @return The current instance of the PlannerAgentBuilder with the specified system prompt applied.
      */
     public fun systemPrompt(systemPrompt: String): PlannerAgentBuilder<Input, Output> =
-        prompt(ai.koog.prompt.dsl.prompt(id = "agent") { system(systemPrompt) })
+        prompt(prompt(config.prompt) { system(systemPrompt) })
 
     /**
      * Sets the prompt to be used by the builder and updates the internal state accordingly.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilderImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilderImpl.kt
@@ -13,6 +13,7 @@ import ai.koog.agents.planner.AIAgentPlannerStrategy
 import ai.koog.agents.planner.AIAgentPlannerStrategyBuilder
 import ai.koog.agents.planner.TypedAgentPlannerStrategyBuilder
 import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
@@ -111,7 +112,7 @@ internal class AIAgentBuilderImpl internal constructor(
     }
 
     override fun systemPrompt(systemPrompt: String): AIAgentBuilderAPI =
-        prompt(Prompt.build(id = "agent") { system(systemPrompt) })
+        prompt(prompt(config.prompt) { system(systemPrompt) })
 
     override fun prompt(prompt: Prompt): AIAgentBuilderAPI = apply {
         this.config = config.copy(prompt = prompt)

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
@@ -16,6 +16,7 @@ import ai.koog.agents.core.feature.config.FeatureConfig
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.utils.ConfigureAction
 import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.serialization.TypeToken
@@ -131,7 +132,7 @@ public class GraphAgentServiceBuilder<Input, Output> internal constructor(
      * @return The updated `GraphServiceBuilder` instance.
      */
     public fun systemPrompt(systemPrompt: String): GraphAgentServiceBuilder<Input, Output> =
-        prompt(ai.koog.prompt.dsl.prompt(id = "agent") { system(systemPrompt) })
+        prompt(prompt(config.prompt) { system(systemPrompt) })
 
     /**
      * Sets the prompt to be used by the GraphServiceBuilder.
@@ -299,7 +300,7 @@ public class FunctionalAgentServiceBuilder<Input, Output> internal constructor(
      * @return The updated instance of FunctionalServiceBuilder with the configured system prompt.
      */
     public fun systemPrompt(systemPrompt: String): FunctionalAgentServiceBuilder<Input, Output> =
-        prompt(ai.koog.prompt.dsl.prompt(id = "agent") { system(systemPrompt) })
+        prompt(prompt(config.prompt) { system(systemPrompt) })
 
     /**
      * Assigns the given prompt to the builder configuration.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilderImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilderImpl.kt
@@ -46,7 +46,7 @@ internal class AIAgentServiceBuilderImpl(
     }
 
     public override fun systemPrompt(systemPrompt: String): AIAgentServiceBuilderAPI =
-        this.prompt(prompt(id = "agent") { system(systemPrompt) })
+        this.prompt(prompt(config.prompt) { system(systemPrompt) })
 
     public override fun prompt(prompt: Prompt): AIAgentServiceBuilderAPI = apply {
         this.config = config.copy(prompt = prompt)

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/JavaAPIAgentBuilderTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/JavaAPIAgentBuilderTest.kt
@@ -261,7 +261,7 @@ class JavaAPIAgentBuilderTest {
         val systemPrompt = "System prompt"
 
         val agent = AIAgent.builder()
-            .promptExecutor(getMockExecutor(serializer) {  })
+            .promptExecutor(getMockExecutor(serializer) { })
             .llmModel(OpenAIModels.Chat.GPT4o)
             .prompt(prompt(id, LLMParams(maxTokens = maxTokens)) { system(originalSystemPrompt) })
             .temperature(temperature)

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/JavaAPIAgentBuilderTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/JavaAPIAgentBuilderTest.kt
@@ -5,7 +5,9 @@ import ai.koog.agents.core.agent.context.AIAgentFunctionalContext
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.testing.tools.getMockExecutor
 import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import ai.koog.prompt.params.LLMParams
 import ai.koog.serialization.kotlinx.KotlinxSerializer
 import junit.framework.TestCase.assertTrue
 import org.junit.jupiter.api.Test
@@ -248,5 +250,30 @@ class JavaAPIAgentBuilderTest {
             .build()
 
         assertNotNull(agent)
+    }
+
+    @Test
+    fun testBuilderSystemMessagePreservesParamsAndId() {
+        val id = "original-prompt-id"
+        val temperature = 0.42
+        val maxTokens = 42
+        val originalSystemPrompt = "Original system prompt"
+        val systemPrompt = "System prompt"
+
+        val agent = AIAgent.builder()
+            .promptExecutor(getMockExecutor(serializer) {  })
+            .llmModel(OpenAIModels.Chat.GPT4o)
+            .prompt(prompt(id, LLMParams(maxTokens = maxTokens)) { system(originalSystemPrompt) })
+            .temperature(temperature)
+            .systemPrompt(systemPrompt)
+            .build()
+
+        val prompt = agent.agentConfig.prompt
+
+        assertEquals(id, prompt.id, "Prompt ID should be preserved")
+        assertEquals(temperature, prompt.params.temperature, "Temperature should be preserved")
+        assertEquals(maxTokens, prompt.params.maxTokens, "Prompt params should be preserved")
+        assertEquals(originalSystemPrompt, prompt.messages.first().content, "original messages should be preserved")
+        assertEquals(systemPrompt, prompt.messages.last().content, "system prompt should be added")
     }
 }

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/Prompt.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/Prompt.kt
@@ -53,7 +53,7 @@ public data class Prompt @JvmOverloads constructor(
          * where no meaningful data or prompt has been provided.
          */
         @JvmField
-        public val Empty: Prompt = Prompt(emptyList(), "")
+        public val Empty: Prompt = Prompt(emptyList(), "default")
 
         /**
          * Builds a `Prompt` object using the specified identifier, parameters, and initialization logic.

--- a/prompt/prompt-model/src/jvmTest/kotlin/ai/koog/prompt/PromptTest.kt
+++ b/prompt/prompt-model/src/jvmTest/kotlin/ai/koog/prompt/PromptTest.kt
@@ -308,7 +308,7 @@ class PromptTest {
         val emptyPrompt = Prompt.Empty
 
         assertTrue(emptyPrompt.messages.isEmpty())
-        assertEquals("", emptyPrompt.id)
+        assertEquals("default", emptyPrompt.id)
         assertEquals(LLMParams(), emptyPrompt.params)
 
         val json = Json.encodeToString(emptyPrompt)
@@ -316,7 +316,7 @@ class PromptTest {
 
         assertEquals(emptyPrompt, decoded)
         assertTrue(decoded.messages.isEmpty())
-        assertEquals("", decoded.id)
+        assertEquals("default", decoded.id)
     }
 
     @Test


### PR DESCRIPTION
Updated `systemPrompt` method in agent builders to preserve previously configured messages, id, and params in the prompt.

closes [KG-747](https://youtrack.jetbrains.com/issue/KG-747)
