### PR TITLE
fix(agents): serch for a tool call in responses when forcing a tool call

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMReadSessionImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMReadSessionImpl.kt
@@ -120,7 +120,10 @@ internal class AIAgentLLMReadSessionImpl(
         val promptWithForcingOneTool = prompt.withUpdatedParams {
             toolChoice = LLMParams.ToolChoice.Named(tool.name)
         }
-        return executeSingle(promptWithForcingOneTool, tools)
+        val responses = executeMultiple(promptWithForcingOneTool, tools)
+
+        return responses.firstOrNull { it is Message.Tool.Call }
+            ?: responses.first { it is Message.Assistant }
     }
 
     override suspend fun requestLLMForceOneTool(tool: Tool<*, *>): Message.Response {

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionTest.kt
@@ -495,4 +495,24 @@ class AIAgentLLMWriteSessionTest {
             "Tool call should not be added to the history twice"
         )
     }
+
+    @Test
+    fun testRequestLLMForceOneToolSkipsNonToolMessages() = runTest {
+        val testTool = TestTool()
+
+        val mockExecutor = getMockExecutor(clock = testClock, serializer = serializer) {
+            mockLLMMixedResponse(
+                toolCalls = listOf(
+                    testTool to TestTool.Args("tool"),
+                ),
+                responses = listOf("message")
+            ) onCondition { true }
+        }
+
+        val session = createSession(mockExecutor)
+
+        val response = session.requestLLMForceOneTool(TestTool())
+
+        assertIs<Message.Tool.Call>(response)
+    }
 }


### PR DESCRIPTION
Previously `requestLLMForceOneTool` returned the first of the received messages.
This approach fails to return a tool call message if the model returns a reasoning message followed by a tool call.
To avoid this, this pr updates the method by first searching a tool call in the responses and returning it.