### PR TITLE
fix(agents): Improve Java API for OpenTelemetry Langfuse and Weave extensions

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryConfig.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetryConfig.kt
@@ -1,5 +1,6 @@
 package ai.koog.agents.features.opentelemetry.feature
 
+import ai.koog.agents.annotations.JavaAPI
 import ai.koog.agents.core.feature.config.FeatureConfig
 import ai.koog.agents.core.feature.handler.AgentLifecycleEventContext
 import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
@@ -25,8 +26,8 @@ import io.opentelemetry.sdk.trace.samplers.Sampler
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 import java.util.Properties
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toKotlinDuration
+import java.time.Duration as JavaDuration
 
 /**
  * Configuration class for OpenTelemetry integration.
@@ -339,18 +340,19 @@ public class OpenTelemetryConfig : FeatureConfig() {
      * @see <a href="https://langfuse.com/faq/all/where-are-langfuse-api-keys">How to set up API keys in Langfuse</a>
      * @see <a href="https://langfuse.com/docs/opentelemetry/get-started#opentelemetry-endpoint">Langfuse OpenTelemetry Docs</a>
      */
+    @JavaAPI
     @JvmOverloads
     public fun addLangfuseExporter(
         langfuseUrl: String? = null,
         langfusePublicKey: String? = null,
         langfuseSecretKey: String? = null,
-        timeout: Duration = 10.seconds,
-        traceAttributes: List<CustomAttribute> = emptyList()
+        timeout: JavaDuration? = null,
+        traceAttributes: List<CustomAttribute>? = null
     ): Unit = this.addLangfuseExporterImpl(
         langfuseUrl,
         langfusePublicKey,
         langfuseSecretKey,
-        timeout,
+        timeout?.toKotlinDuration(),
         traceAttributes
     )
 
@@ -372,12 +374,19 @@ public class OpenTelemetryConfig : FeatureConfig() {
      *
      * @see <a href="https://weave-docs.wandb.ai/guides/tracking/otel/">Weave OpenTelemetry Docs</a>
      */
+    @JavaAPI
     @JvmOverloads
     public fun addWeaveExporter(
         weaveOtelBaseUrl: String? = null,
         weaveEntity: String? = null,
         weaveProjectName: String? = null,
         weaveApiKey: String? = null,
-        timeout: Duration = 10.seconds,
-    ): Unit = addWeaveExporterImpl(weaveOtelBaseUrl, weaveEntity, weaveProjectName, weaveApiKey, timeout)
+        timeout: JavaDuration? = null,
+    ): Unit = addWeaveExporterImpl(
+        weaveOtelBaseUrl,
+        weaveEntity,
+        weaveProjectName,
+        weaveApiKey,
+        timeout?.toKotlinDuration()
+    )
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/Langfuse.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/Langfuse.kt
@@ -1,23 +1,20 @@
 package ai.koog.agents.features.opentelemetry.integration.langfuse
 
-import ai.koog.agents.annotations.JavaAPI
 import ai.koog.agents.features.opentelemetry.attribute.CustomAttribute
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetryConfig
-import ai.koog.utils.time.toKotlinDuration
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
 import java.util.Base64
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
-import java.time.Duration as JavaDuration
 
 internal fun OpenTelemetryConfig.addLangfuseExporterImpl(
     langfuseUrl: String? = null,
     langfusePublicKey: String? = null,
     langfuseSecretKey: String? = null,
-    timeout: Duration = 10.seconds,
-    traceAttributes: List<CustomAttribute> = emptyList()
+    timeout: Duration? = null,
+    traceAttributes: List<CustomAttribute>? = null
 ) {
     val url = langfuseUrl
         ?: System.getenv()["LANGFUSE_HOST"]
@@ -30,6 +27,9 @@ internal fun OpenTelemetryConfig.addLangfuseExporterImpl(
         requireNotNull(langfusePublicKey ?: System.getenv()["LANGFUSE_PUBLIC_KEY"]) { "LANGFUSE_PUBLIC_KEY is not set" }
     val secretKey =
         requireNotNull(langfuseSecretKey ?: System.getenv()["LANGFUSE_SECRET_KEY"]) { "LANGFUSE_SECRET_KEY is not set" }
+
+    val timeout = timeout ?: 10.seconds
+    val traceAttributes = traceAttributes ?: emptyList()
 
     val credentials = "$publicKey:$secretKey"
     val auth = Base64.getEncoder().encodeToString(credentials.toByteArray(Charsets.UTF_8))
@@ -51,25 +51,23 @@ internal fun OpenTelemetryConfig.addLangfuseExporterImpl(
  * @param langfuseUrl the base URL of the Langfuse instance.
  *        If not set, is retrieved from `LANGFUSE_HOST` environment variable.
  *        Defaults to [https://cloud.langfuse.com](https://cloud.langfuse.com).
- * @param langfusePublicKey if not set is retrieved from `LANGFUSE_PUBLIC_KEY` environment variable.
- * @param langfuseSecretKey if not set is retrieved from `LANGFUSE_SECRET_KEY` environment variable.
+ * @param langfusePublicKey if not set, is retrieved from `LANGFUSE_PUBLIC_KEY` environment variable.
+ * @param langfuseSecretKey if not set, is retrieved from `LANGFUSE_SECRET_KEY` environment variable.
  * @param timeout OpenTelemetry SpanExporter timeout as [java.time.Duration].
  * @param traceAttributes list of trace-level Langfuse attributes.
  */
-@JavaAPI
-@JvmOverloads
 public fun OpenTelemetryConfig.addLangfuseExporter(
     langfuseUrl: String?,
     langfusePublicKey: String?,
     langfuseSecretKey: String?,
-    timeout: JavaDuration,
-    traceAttributes: List<CustomAttribute> = emptyList()
+    timeout: Duration?,
+    traceAttributes: List<CustomAttribute>?
 ) {
-    addLangfuseExporter(
+    addLangfuseExporterImpl(
         langfuseUrl = langfuseUrl,
         langfusePublicKey = langfusePublicKey,
         langfuseSecretKey = langfuseSecretKey,
-        timeout = timeout.toKotlinDuration(),
+        timeout = timeout,
         traceAttributes = traceAttributes
     )
 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/weave/Weave.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmMain/kotlin/ai/koog/agents/features/opentelemetry/integration/weave/Weave.kt
@@ -13,7 +13,7 @@ internal fun OpenTelemetryConfig.addWeaveExporterImpl(
     weaveEntity: String? = null,
     weaveProjectName: String? = null,
     weaveApiKey: String? = null,
-    timeout: Duration = 10.seconds,
+    timeout: Duration? = null,
 ) {
     val url = weaveOtelBaseUrl ?: System.getenv()["WEAVE_URL"] ?: "https://trace.wandb.ai"
 
@@ -22,6 +22,7 @@ internal fun OpenTelemetryConfig.addWeaveExporterImpl(
     val entity = requireNotNull(weaveEntity ?: System.getenv()["WEAVE_ENTITY"]) { "WEAVE_ENTITY is not set" }
     val projectName = weaveProjectName ?: System.getenv()["WEAVE_PROJECT_NAME"] ?: "koog-tracing"
     val apiKey = requireNotNull(weaveApiKey ?: System.getenv()["WEAVE_API_KEY"]) { "WEAVE_API_KEY is not set" }
+    val timeout = timeout ?: 10.seconds
 
     val auth = Base64.getEncoder().encodeToString("api:$apiKey".toByteArray(Charsets.UTF_8))
 
@@ -35,6 +36,31 @@ internal fun OpenTelemetryConfig.addWeaveExporterImpl(
     )
 
     addSpanAdapter(WeaveSpanAdapter(this))
+}
+
+/**
+ * Configures and adds a Weave Exporter to the OpenTelemetry configuration.
+ *
+ * @param weaveOtelBaseUrl Optional base URL for the Weave OpenTelemetry endpoint.
+ * @param weaveEntity Optional identifier for the Weave entity.
+ * @param weaveProjectName Optional name of the Weave project to associate telemetry data with.
+ * @param weaveApiKey Optional API key for authenticating with the Weave service.
+ * @param timeout Optional timeout duration for interactions with the Weave endpoint.
+ */
+public fun OpenTelemetryConfig.addWeaveExporter(
+    weaveOtelBaseUrl: String? = null,
+    weaveEntity: String? = null,
+    weaveProjectName: String? = null,
+    weaveApiKey: String? = null,
+    timeout: Duration? = null
+) {
+    addWeaveExporterImpl(
+        weaveOtelBaseUrl,
+        weaveEntity,
+        weaveProjectName,
+        weaveApiKey,
+        timeout
+    )
 }
 
 private val logger = KotlinLogging.logger { }


### PR DESCRIPTION
Fix Java API inside `OpenTelemetryConfig` class which is annotated with `@JavaOverride`. It relies on Kotlin `Duration` class which does not exist in Java. It cause all further attributes are skipped by a compiler.

closes: [KG-754](https://youtrack.jetbrains.com/issue/KG-754/Add-Langfuse-and-Weave-exporters-Java-API-miss-parameters)
