### PR TITLE
docs(agents): update wording in Agent pages, Event handlers, Persistence, Streaming API, and Testing

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,5 @@
 site/
 src/main/
 hooks/__pycache__/
+__pycache__/
+*.pyc

--- a/docs/docs/agents/graph-based-agents.md
+++ b/docs/docs/agents/graph-based-agents.md
@@ -1,8 +1,11 @@
 # Graph-based agents
 
 With graph-based agents, you model the behavior as an explicit state machine:
-nodes of a graph strategy represent actions (LLM calls, tool execution)
-and edges represent data flow between nodes.
+nodes of a graph strategy represent actions (LLM calls, tool execution), and edges represent 
+data flow between nodes.
+
+To implement a graph-based strategy in Kotlin, use the DSL with the `strategy()` function. In 
+Java, use the builder pattern with `AIAgentGraphStrategy.builder()`.
 
 The main advantages of graph-based agents are:
 
@@ -74,8 +77,9 @@ the strategy as a whole also defines some input and output type.
 This example assumes that the input and output types are strings,
 which means the agent implementing this strategy will expect a string and return a string.
 
-To create a strategy, use the [`strategy()`](https://api.koog.ai/agents/agents-core/ai.koog.agents.core.dsl.builder/strategy.html) function with two generics as the input and output types,
-provide a unique identifier for the strategy, and define the nodes and edges.
+To create a strategy, use the [`strategy()`](https://api.koog.ai/agents/agents-core/ai.koog.agents.core.dsl.builder/strategy.html) function (Kotlin) or the 
+`AIAgentGraphStrategy.builder()` method (Java) with the input and output types, provide a unique
+identifier for the strategy, and define the nodes and edges.
 
 === "Kotlin"
 
@@ -158,17 +162,17 @@ Edges can have conditions to determine when to follow a particular edge.
 Edges can also transform the output of the previous node before passing it to the next one.
 This is necessary to connect nodes that have non-matching output and input types.
 
-In the previous example, `onToolCall { true }` means that the edge will follow
-only if the previous node returned a tool call `Message.Tool.Call`.
+In the previous example, `onToolCall { true }` (Kotlin) or `.onCondition(msg -> msg instanceof Message.Tool.Call)`
+(Java) means that the edge will follow only if the previous node returned a tool call.
 
-When using `onAssistantMessage { true }`, the edge will follow
-only if the previous node returned an assistant message `Message.Assistant`.
-This function also extracts the content of the assistant message,
-effectively transforming `Message.Assistant` to `String`, because `nodeFinish` expects a string.
+When using `onAssistantMessage { true }` (Kotlin), or `.onCondition(msg -> msg instanceof Message.Assistant)`
+(Java), the edge will follow only if the previous node returned an assistant message. In Kotlin,
+this function also extracts the content of the assistant message, effectively transforming 
+`Message.Assistant` to `String`, because `nodeFinish` expects a string.
 
 !!! tip
 
-    Instead of `onAssistantMessage {true}`, you can do the following:
+    In Kotlin, instead of `onAssistantMessage {true}`, you can do the following:
 
     <!--- INCLUDE
     /**
@@ -446,7 +450,6 @@ Add the tool registry to the agent configuration:
     import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
     import ai.koog.prompt.executor.ollama.client.OllamaModels
     import kotlinx.coroutines.runBlocking
-    
     @LLMDescription("Tools for performing math operations")
     class MathTools : ToolSet {
         @Tool
@@ -464,16 +467,13 @@ Add the tool registry to the agent configuration:
             return a * b
         }
     }
-    
     val toolRegistry = ToolRegistry {
         tools(MathTools())
     }
-    
     val calculatorAgentStrategy = strategy<String, String>("Simple calculator") {
         val nodeSendInput by nodeLLMRequest()
         val nodeExecuteTool by nodeExecuteTool()
         val nodeSendToolResult by nodeLLMSendToolResult()
-    
         edge(nodeStart forwardTo nodeSendInput)
         edge(nodeSendInput forwardTo nodeFinish onAssistantMessage { true })
         edge(nodeSendInput forwardTo nodeExecuteTool onToolCall { true })
@@ -625,7 +625,6 @@ In our example, it is important to describe how the agent should process complex
     import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
     import ai.koog.prompt.executor.ollama.client.OllamaModels
     import kotlinx.coroutines.runBlocking
-    
     @LLMDescription("Tools for performing math operations")
     class MathTools : ToolSet {
         @Tool
@@ -643,16 +642,13 @@ In our example, it is important to describe how the agent should process complex
             return a * b
         }
     }
-    
     val toolRegistry = ToolRegistry {
         tools(MathTools())
     }
-    
     val calculatorAgentStrategy = strategy<String, String>("Simple calculator") {
         val nodeSendInput by nodeLLMRequest()
         val nodeExecuteTool by nodeExecuteTool()
         val nodeSendToolResult by nodeLLMSendToolResult()
-    
         edge(nodeStart forwardTo nodeSendInput)
         edge(nodeSendInput forwardTo nodeFinish onAssistantMessage { true })
         edge(nodeSendInput forwardTo nodeExecuteTool onToolCall { true })

--- a/docs/docs/agents/planner-agents/goap-agents.md
+++ b/docs/docs/agents/planner-agents/goap-agents.md
@@ -21,15 +21,15 @@ GOAP planners work with three main concepts:
 
     Examples on this page assume that you have set the `OPENAI_API_KEY` environment variable.
 
-In Koog, you define a GOAP agent using a DSL by declaratively specifying the goals and actions.
+In Koog, you define a GOAP agent by declaratively specifying the goals and actions using a DSL (Kotlin) or builder pattern (Java).
 
 To create a GOAP agent, you need to:
 
-1. Define the state as a data class with properties representing various aspects specific to your goal.
-2. Create a [GOAPPlanner](https://api.koog.ai/agents/agents-planner/ai.koog.agents.planner.goap/-g-o-a-p-planner/index.html) instance using the [goap()](https://api.koog.ai/agents/agents-planner/ai.koog.agents.planner.goap/goap.html) function.
-    1. Define actions with preconditions and beliefs using the [action()](https://api.koog.ai/agents/agents-planner/ai.koog.agents.planner.goap/-g-o-a-p-planner-builder/action.html) function.
-    2. Define goals with completion conditions using the [goal()](https://api.koog.ai/agents/agents-planner/ai.koog.agents.planner.goap/-g-o-a-p-planner-builder/goal.html) function.
-3. Wrap the planner with [AIAgentPlannerStrategy](https://api.koog.ai/agents/agents-planner/ai.koog.agents.planner/-a-i-agent-planner-strategy/index.html) and pass it to the [PlannerAIAgent](https://api.koog.ai/agents/agents-planner/ai.koog.agents.planner/-planner-a-i-agent/index.html) constructor.
+1. Define the state class that extends [GoapAgentState](api:agents-core::ai.koog.agents.planner.goap.GoapAgentState) and overrides the [provideOutput()](api:agents-core::ai.koog.agents.planner.goap.GoapAgentState.provideOutput) method. In Kotlin, use a data class for automatic `copy()` method generation. In Java, use a regular class and manually implement a `copy()` method for state updates.
+2. Create an [AIAgentPlannerStrategy](api:agents-core::ai.koog.agents.planner.AIAgentPlannerStrategy) with a GOAP planner. In Kotlin, use the [goap()](api:agents-core::ai.koog.agents.planner.AIAgentPlannerStrategy.Companion.goap) function with a DSL block. In Java, use [AIAgentPlannerStrategy.builder().goap()](api:agents-core::ai.koog.agents.planner.AIAgentPlannerStrategyBuilder.goap) followed by builder methods.
+    1. Define actions with preconditions and beliefs using the [action()](api:agents-core::ai.koog.agents.planner.goap.GOAPPlannerBuilder.action) function in Kotlin or the corresponding `.action()` builder method in Java. In Java, actions also require the `.execute()` method to be implemented.
+    2. Define goals with completion conditions using the [goal()](api:agents-core::ai.koog.agents.planner.goap:GOAPPlannerBuilder:goal) function in Kotlin or the corresponding `.goal()` builder method in Java.
+3. Create the agent and provide the planner strategy. In Kotlin, use the `AIAgent()` constructor with the `strategy` parameter. In Java, use `AIAgent.builder()` with the [.plannerStrategy()](api:agents-core::ai.koog.agents.core.agent=.AIAgentBuilderAPI.plannerStrategy) builder method and a `.build()` call at the end.
 
 !!! note
 

--- a/docs/docs/agents/planner-agents/llm-based-planners.md
+++ b/docs/docs/agents/planner-agents/llm-based-planners.md
@@ -19,13 +19,14 @@ Koog provides two simple planners:
 
 - [SimpleLLMPlanner](https://api.koog.ai/agents/agents-planner/ai.koog.agents.planner.llm/-simple-l-l-m-planner/index.html)
   generates a plan only once at the very beginning and then follows the plan until it is completed.
-  To include replanning, extend `SimpleLLMPlanner` and override the `assessPlan` method,
-  indicating when the agent should replan.
+  To include replanning, extend `SimpleLLMPlanner` (in either Kotlin or Java) and override the `assessPlan` method,
+  indicating when the agent should replan. In Java, use `.llmBasedPlanner()` in the builder to access the default 
+  implementation.
 - [SimpleLLMWithCriticPlanner](https://api.koog.ai/agents/agents-planner/ai.koog.agents.planner.llm/-simple-l-l-m-with-critic-planner/index.html)
-  implements the `assessPlan` method that uses an LLM to check the validity of the plan via an LLM request
+  extends `SimpleLLMPlanner` and overrides the `assessPlan` method to use an LLM to check the validity of the plan via an LLM request
   and assess whether the agent should replan.
 
-The following example shows how to create a simple planner agent using `SimpleLLMPlanner`:
+The following example shows how to create a simple planner agent using `SimpleLLMPlanner`. In Kotlin, you explicitly instantiate `SimpleLLMPlanner` and wrap it in a strategy. In Java, you use the builder pattern with `.llmBasedPlanner()`, which internally creates the planner:
 
 === "Kotlin"
 

--- a/docs/docs/features/agent-event-handlers.md
+++ b/docs/docs/features/agent-event-handlers.md
@@ -1,6 +1,7 @@
 # Event handlers
 
-You can monitor and respond to specific events during the agent workflow by using event handlers for logging, testing, debugging, and extending agent behavior.
+You can monitor and respond to specific events during the agent workflow by using event handlers for logging, testing, 
+debugging, and extending agent behavior.
 
 ## Feature overview
 
@@ -88,7 +89,7 @@ To install the feature and configure event handlers for the agent, do the follow
 
 For more details about event handler configuration, see [API reference](api:agents-features-event-handler::ai.koog.agents.features.eventHandler.feature.EventHandlerConfig).
 
-You can also set up event handlers using the `handleEvents` extension function when creating an agent.
+In Kotlin, you can also set up event handlers using the `handleEvents` extension function when creating an agent.
 This function also installs the event handler feature and configures event handlers for the agent. Here is an example:
 
 === "Kotlin"
@@ -120,28 +121,3 @@ This function also installs the event handler feature and configures event handl
     ```
     <!--- KNIT example-event-handlers-02.kt -->
 
-=== "Java"
-
-    <!--- INCLUDE
-    /**
-    -->
-    <!--- SUFFIX
-    **/
-    -->
-    ```java
-    AIAgent<String, String> agent = AIAgent.builder()
-        .promptExecutor(simpleOllamaAIExecutor("http://localhost:11434"))
-        .llmModel(OllamaModels.Meta.LLAMA_3_2)
-        .install(EventHandler.Feature, cfg -> {
-            // Handle tool calls
-            cfg.onToolCallStarting(ctx -> {
-                System.out.println("Tool called: " + ctx.getToolName() + " with args " + ctx.getToolArgs());
-            });
-            // Handle event triggered when the agent completes its execution
-            cfg.onAgentCompleted(ctx -> {
-                System.out.println("Agent finished with result: " + ctx.getResult());
-            });
-        })
-        .build();
-    ```
-    <!--- KNIT example-event-handlers-java-02.java -->

--- a/docs/docs/features/agent-persistence.md
+++ b/docs/docs/features/agent-persistence.md
@@ -370,9 +370,9 @@ With Koog Persistence you can achieve that by providing a `RollbackToolRegistry`
     ```
     <!--- KNIT example-agent-persistence-java-06.java -->
 
-### Using extension functions
+### Using extension functions (Kotlin)
 
-The Agent Persistence feature provides convenient extension functions for working with checkpoints:
+The Agent Persistence feature provides convenient extension functions in Kotlin for working with checkpoints:
 
 === "Kotlin"
 

--- a/docs/docs/streaming-api.md
+++ b/docs/docs/streaming-api.md
@@ -69,7 +69,6 @@ The streaming API distinguishes between two types of frames:
 
 Typically, you'll work with delta frames for UI updates and complete frames for extracting final structured data.
 
----
 ## Usage
 
 ### Working with frames directly
@@ -176,7 +175,7 @@ This is the most general approach: react to each frame kind.
         return null;
     });
     ```
-    <!--- KNIT exampleStreamingApiJava01.java -->
+    <!--- KNIT example-streaming-api-java-01.java -->
 
 
 It is important to note that you can parse the output by working directly with a raw string stream.
@@ -273,7 +272,7 @@ Here is a raw string stream with the Markdown definition of the output structure
         return null;
     });
     ```
-    <!--- KNIT exampleStreamingApiJava02.java -->
+    <!--- KNIT example-streaming-api-java-02.java -->
 
 ### Working with reasoning frames
 
@@ -406,8 +405,8 @@ Models that support reasoning (such as Claude Sonnet 4.5 or GPT-o1) emit reasoni
 
 ### Working with a raw text stream (derived)
 
-If you have existing streaming parsers that expect `Flow<String>`,
-derive text chunks via `filterTextOnly()` or collect them with `collectText()`.
+If you have existing streaming parsers that expect a stream of text chunks (Kotlin `Flow<String>` or Java reactive streams),
+you can derive text chunks via `filterTextOnly()` or collect them with `collectText()`.
 
 === "Kotlin"
 
@@ -490,7 +489,7 @@ derive text chunks via `filterTextOnly()` or collect them with `collectText()`.
         return null;
     });
     ```
-    <!--- KNIT exampleStreamingApiJava03.java -->
+    <!--- KNIT example-streaming-api-java-03.java -->
 
 ### Listening to stream events in event handlers
 
@@ -579,7 +578,7 @@ You can listen to stream events in [agent event handlers](features/agent-event-h
         });
     })
     ```
-    <!--- KNIT exampleStreamingApiJava04.java -->
+    <!--- KNIT example-streaming-api-java-04.java -->
 
 ### Converting frames to `Message.Response`
 
@@ -638,7 +637,7 @@ First, define a data class to represent your structured data:
     ```java
     // TODO not yet supported in Java
     ```
-    <!--- KNIT exampleStreamingApiJava05.java -->
+    <!--- KNIT exampleStreamingApiJava01.java -->
 
 #### 2. Define the Markdown structure
 
@@ -687,7 +686,7 @@ Create a definition that specifies how your data should be structured in Markdow
     ```java
     // TODO not yet supported in Java
     ```
-    <!--- KNIT exampleStreamingApiJava06.java -->
+    <!--- KNIT example-streaming-api-java-05.java -->
 
 #### 3. Create a parser for your data structure
 
@@ -736,7 +735,7 @@ The `markdownStreamingParser` provides several handlers for different Markdown e
     ```java
     // TODO not yet supported in Java
     ```
-    <!--- KNIT exampleStreamingApiJava07.java -->
+    <!--- KNIT example-streaming-api-java-06.java -->
 
 Using the defined handlers, you can implement a function that parses the Markdown stream and emits your data objects 
 with the `markdownStreamingParser` function.
@@ -804,7 +803,7 @@ with the `markdownStreamingParser` function.
     ```java
     // TODO not yet supported in Java
     ```
-    <!--- KNIT exampleStreamingApiJava08.java -->
+    <!--- KNIT example-streaming-api-java-07.java -->
 
 #### 4. Use the parser in your agent strategy
 
@@ -858,7 +857,7 @@ with the `markdownStreamingParser` function.
     ```java
     // TODO not yet supported in Java
     ```
-    <!--- KNIT exampleStreamingApiJava09.java -->
+    <!--- KNIT example-streaming-api-java-08.java -->
 
 ### Advanced usage: Streaming with tools
 
@@ -921,7 +920,7 @@ The following sections provide a brief step-by-step guide on how to define a too
         }
     }
     ```
-    <!--- KNIT exampleStreamingApiJava10.java -->
+    <!--- KNIT example-streaming-api-java-09.java -->
 
 ### 2. Use the tool with streaming data
 
@@ -1034,7 +1033,7 @@ The following sections provide a brief step-by-step guide on how to define a too
     strategy.edge(strategy.nodeStart, getMdOutput);
     strategy.edge(getMdOutput, strategy.nodeFinish);
     ```
-    <!--- KNIT exampleStreamingApiJava11.java -->
+    <!--- KNIT example-streaming-api-java-10.java -->
 
 ### 3. Register the tool in your agent configuration
 
@@ -1094,7 +1093,7 @@ The following sections provide a brief step-by-step guide on how to define a too
         .toolRegistry(toolRegistry)
         .build();
     ```
-    <!--- KNIT exampleStreamingApiJava12.java -->
+    <!--- KNIT example-streaming-api-java-11.java -->
 
 ## Best practices
 

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -208,7 +208,7 @@ The examples above demonstrate different ways to mock tools, from simple to more
 
 ### Enabling testing mode
 
-To enable the testing mode on an agent, use the `withTesting()` function within the AIAgent constructor block:
+To enable the testing mode on an agent, use the `withTesting()` function (Kotlin) or the testing feature installation (Java) within the AIAgent configuration:
 
 === "Kotlin"
 


### PR DESCRIPTION
Updated wording to account for Java on the following pages:

* Event handlers
* Agent Persistence
* Streaming API
* Testing
* Graph-based agents
* Planner agents (including subpages)
