### PR TITLE
docs: 0.7.2 release notes, update snapshot version to `0.8.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 0.7.2
+> Published 19 March 2026
+
+## Bug Fixes
+
+- **Java API for OpenTelemetry extensions**: Fixed Java API inside `OpenTelemetryConfig` class annotated with `@JavaOverride`
+  that relied on Kotlin `Duration` class, causing all further attributes to be skipped by the compiler in Langfuse and Weave extensions ([KG-754](https://youtrack.jetbrains.com/issue/KG-754), #1682)
+- **System prompt preservation in agent builder**: Fixed `systemPrompt` method in agent builders to preserve previously configured messages, id, and params in the prompt ([KG-747](https://youtrack.jetbrains.com/issue/KG-747), #1671)
+- **LLMParams copy overloads**: Added correct `override fun copy()` to all `LLMParams` subclasses (`GoogleParams`, `AnthropicParams`, `OpenAIChatParams`, etc.) so that `Prompt.withUpdatedParams` preserves provider-specific fields instead of silently dropping them. Also fixed `BedrockConverseParams.copy()` missing parameters and `DashscopeParams` incorrect `super.copy()` call (KG-742, #1668)
+
+## Breaking Changes
+
+- **Removed `input` parameter from `AIAgentFunctionalContext.subtask`**: The `input` parameter was not actually used; `taskDescription` is the right way to specify the task. Related methods and builders updated accordingly (#1667)
+
+## Documentation
+
+- Started porting rest of the documentation to Java (#1669)
+
 # 0.7.1
 > Published 17 March 2026
 

--- a/README.md
+++ b/README.md
@@ -85,14 +85,15 @@ Currently, the framework supports the JVM, JS, WasmJS and iOS targets.
 ### Requirements
 
 - JDK 17 or higher is required to use the framework on JVM.
-- Kotlin 2.3.10 or higher should be set explicitly in existing projects. Please check the [libs.versions.toml](gradle/libs.versions.toml) to know more about Kotlin dependencies (currently it uses kotlinx-coroutines 1.10.2, kotlinx-serialization 1.10.0 and kotlinx-datetime 0.7.1)
+- Kotlin 2.3.10 or higher should be set explicitly in existing projects. Please check the [libs.versions.toml](gradle/libs.versions.toml) to know more about Kotlin dependencies (currently it uses kotlinx-coroutines 1.10.2, kotlinx-serialization 1.10.0 and kotlinx-datetime 0.7.2)
+
 ### Gradle (Kotlin DSL)
 
 1. Add dependencies to the `build.gradle.kts` file:
 
     ```
     dependencies {
-        implementation("ai.koog:koog-agents:0.7.1")
+        implementation("ai.koog:koog-agents:0.7.2")
     }
     ```
 2. Make sure that you have `mavenCentral()` in the list of repositories.
@@ -102,7 +103,7 @@ Currently, the framework supports the JVM, JS, WasmJS and iOS targets.
 
     ```
     dependencies {
-        implementation 'ai.koog:koog-agents:0.7.1'
+        implementation 'ai.koog:koog-agents:0.7.2'
     }
     ```
 2. Make sure that you have `mavenCentral()` in the list of repositories.
@@ -114,7 +115,7 @@ Currently, the framework supports the JVM, JS, WasmJS and iOS targets.
     <dependency>
         <groupId>ai.koog</groupId>
         <artifactId>koog-agents-jvm</artifactId>
-        <version>0.7.1</version>
+        <version>0.7.2</version>
     </dependency>
     ```
 2. Make sure that you have `mavenCentral` in the list of repositories.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Currently, the framework supports the JVM, JS, WasmJS and iOS targets.
 ### Requirements
 
 - JDK 17 or higher is required to use the framework on JVM.
-- Kotlin 2.3.10 or higher should be set explicitly in existing projects. Please check the [libs.versions.toml](gradle/libs.versions.toml) to know more about Kotlin dependencies (currently it uses kotlinx-coroutines 1.10.2, kotlinx-serialization 1.10.0 and kotlinx-datetime 0.7.2)
+- Kotlin 2.3.10 or higher should be set explicitly in existing projects. Please check the [libs.versions.toml](gradle/libs.versions.toml) to know more about Kotlin dependencies (currently it uses kotlinx-coroutines 1.10.2, kotlinx-serialization 1.10.0 and kotlinx-datetime 0.7.1)
 
 ### Gradle (Kotlin DSL)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ kotlin.native.ignoreDisabledTargets=true
 
 group=ai.koog
 # our version follows the semver specification
-version=0.7.0
+version=0.8.0


### PR DESCRIPTION
Changelog.md and Readme.md updates about 0.7.2 release. Also update Koog version in develop to publish `0.8.0-*` snapshot releases