### PR TITLE
fix: Add Kotlin compiler arguments and clean up suppress annotations

### DIFF
--- a/.claude/skills/split-jvm-nonjvm/SKILL.md
+++ b/.claude/skills/split-jvm-nonjvm/SKILL.md
@@ -98,9 +98,6 @@ If `MyClass` original KDoc described certain parameters/properties that it accep
 This constructor KDoc can't have `@property` tag for parameters, use only `@param` for all parameters, even if the original was `@property`.
 
 ```kt
-// Required to put on top of the file containing expect classes to suppress IntelliJ warning about the experimental feature
-@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
-
 package com.example
 
 /**
@@ -160,7 +157,7 @@ It should use `by delegate` to delegate all public symbols from `MyClassAPI` to 
 
 ```kt
 // Suppress IntelliJ warnings
-@file:Suppress("MissingKDocForPublicAPI", "EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+@file:Suppress("MissingKDocForPublicAPI")
 
 package com.example
 
@@ -185,7 +182,7 @@ public symbols not present in the API interface. Such additional public symbols 
 For example, `jvmCommonMain` implementation that uses JVM-specific API
 ```kt
 // Suppress IntelliJ warnings
-@file:Suppress("MissingKDocForPublicAPI", "EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+@file:Suppress("MissingKDocForPublicAPI")
 
 package com.example
 

--- a/convention-plugin-ai/src/main/kotlin/ai.kotlin.configuration.gradle.kts
+++ b/convention-plugin-ai/src/main/kotlin/ai.kotlin.configuration.gradle.kts
@@ -60,6 +60,12 @@ tasks.withType<KotlinJvmCompile>().configureEach {
         jvmTarget.set(JvmTarget.JVM_11)
         jvmDefault = JvmDefaultMode.ENABLE
         javaParameters = true
+        freeCompilerArgs.addAll(
+            listOf(
+                "-Xexpect-actual-classes",
+                "-Xmulti-dollar-interpolation",
+            )
+        )
     }
 }
 


### PR DESCRIPTION

- Add "-Xexpect-actual-classes", "-Xmulti-dollar-interpolation" compiler options
- Removed requirement to add `@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")` in split-jvm-nonjvm skill
