### PR TITLE
fix(agents): FIx AIAcgentConfig.copy for jvmCommon to copy jvmCommon-spesific fields

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilder.kt
@@ -4,7 +4,6 @@ package ai.koog.agents.core.agent
 
 import ai.koog.agents.core.agent.GraphAIAgent.FeatureContext
 import ai.koog.agents.core.agent.config.AIAgentConfig
-import ai.koog.agents.core.agent.config.copy
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.feature.AIAgentFunctionalFeature
 import ai.koog.agents.core.feature.AIAgentGraphFeature
@@ -479,7 +478,6 @@ public class FunctionalAgentBuilder<Input, Output>(
  * for the agent. This builder allows flexible setup of an agent's functionality and behavior
  * based on the provided configuration and tools.
  *
- * @param State The type representing the state handled by the AI agent.
  * @param strategy The planning strategy used by the agent to process and execute tasks.
  * @param promptExecutor The executor responsible for handling AI prompts.
  * @param toolRegistry The registry of tools available for use by the agent. Defaults to an empty tool registry.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilderImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilderImpl.kt
@@ -2,7 +2,6 @@ package ai.koog.agents.core.agent
 
 import ai.koog.agents.core.agent.AIAgentBuilderImpl.Companion.ModelNotSet
 import ai.koog.agents.core.agent.config.AIAgentConfig
-import ai.koog.agents.core.agent.config.copy
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.feature.AIAgentGraphFeature
 import ai.koog.agents.core.feature.config.FeatureConfig

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilder.kt
@@ -7,7 +7,6 @@ import ai.koog.agents.core.agent.GraphAIAgent.FeatureContext
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.config.MissingToolsConversionStrategy
 import ai.koog.agents.core.agent.config.ToolCallDescriber
-import ai.koog.agents.core.agent.config.copy
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.feature.AIAgentFunctionalFeature

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilderImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentServiceBuilderImpl.kt
@@ -5,7 +5,6 @@ package ai.koog.agents.core.agent
 import ai.koog.agents.annotations.JavaAPI
 import ai.koog.agents.core.agent.AIAgentBuilderImpl.Companion.ModelNotSet
 import ai.koog.agents.core.agent.config.AIAgentConfig
-import ai.koog.agents.core.agent.config.copy
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.tools.ToolRegistry

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/config/AIAgentConfig.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/config/AIAgentConfig.kt
@@ -115,20 +115,24 @@ public expect class AIAgentConfig(
             maxAgentIterations: Int = 3,
         ): AIAgentConfig
     }
-}
 
-internal fun AIAgentConfig.copy(
-    prompt: Prompt = this.prompt,
-    model: LLModel = this.model,
-    maxAgentIterations: Int = this.maxAgentIterations,
-    missingToolsConversionStrategy: MissingToolsConversionStrategy = this.missingToolsConversionStrategy,
-    responseProcessor: ResponseProcessor? = this.responseProcessor,
-    serializer: JSONSerializer = this.serializer
-): AIAgentConfig = AIAgentConfig(
-    prompt = prompt,
-    model = model,
-    maxAgentIterations = maxAgentIterations,
-    missingToolsConversionStrategy = missingToolsConversionStrategy,
-    responseProcessor = responseProcessor,
-    serializer = serializer
-)
+    /**
+     * Creates a copy of this AI agent configuration with the specified modifications.
+     *
+     * @param prompt The prompt to use for the AI agent. Defaults to the existing prompt.
+     * @param model The LLM model to use for the AI agent. Defaults to the existing model.
+     * @param maxAgentIterations The maximum number of iterations allowed for the AI agent. Defaults to the existing value.
+     * @param missingToolsConversionStrategy The strategy for handling missing tools during the AI agent's execution. Defaults to the existing strategy.
+     * @param responseProcessor The processor for handling responses from the LLM. Defaults to the existing processor.
+     * @param serializer The serializer for handling tool arguments and results. Defaults to the existing serializer.
+     * @return A new instance of [AIAgentConfig] with the specified modifications.
+     */
+    internal fun copy(
+        prompt: Prompt = this.prompt,
+        model: LLModel = this.model,
+        maxAgentIterations: Int = this.maxAgentIterations,
+        missingToolsConversionStrategy: MissingToolsConversionStrategy = this.missingToolsConversionStrategy,
+        responseProcessor: ResponseProcessor? = this.responseProcessor,
+        serializer: JSONSerializer = this.serializer
+    ): AIAgentConfig
+}

--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/config/AIAgentConfig.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/config/AIAgentConfig.kt
@@ -57,6 +57,24 @@ public actual class AIAgentConfig actual constructor(
         require(maxAgentIterations > 0) { "maxAgentIterations must be greater than 0" }
     }
 
+    internal actual fun copy(
+        prompt: Prompt,
+        model: LLModel,
+        maxAgentIterations: Int,
+        missingToolsConversionStrategy: MissingToolsConversionStrategy,
+        responseProcessor: ResponseProcessor?,
+        serializer: JSONSerializer
+    ): AIAgentConfig = AIAgentConfig(
+        prompt = prompt,
+        model = model,
+        maxAgentIterations = maxAgentIterations,
+        agentStrategyExecutorService = this.strategyExecutorService,
+        llmRequestExecutorService = this.llmRequestExecutorService,
+        missingToolsConversionStrategy = missingToolsConversionStrategy,
+        responseProcessor = responseProcessor,
+        serializer = serializer
+    )
+
     public actual companion object {
         public actual fun withSystemPrompt(
             prompt: String,
@@ -115,7 +133,7 @@ public actual class AIAgentConfig actual constructor(
             internal var serializer: JSONSerializer = JacksonSerializer()
         ) {
             /**
-             * Sets serializr for underlying tool calls and LLM requests
+             * Sets serializer for underlying tool calls and LLM requests
              *
              * @param serializer The JSON serializer to configure the AI agent with.
              * @return The updated instance of [Companion.AIAgentConfigBuilder]

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/JavaAPIAgentBuilderTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/JavaAPIAgentBuilderTest.kt
@@ -5,6 +5,7 @@ import ai.koog.agents.core.agent.context.AIAgentFunctionalContext
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.testing.tools.getMockExecutor
 import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.dsl.Prompt.Companion.builder
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.params.LLMParams
@@ -113,16 +114,19 @@ class JavaAPIAgentBuilderTest {
             model = OpenAIModels.Chat.GPT4o,
             maxAgentIterations = 100
         )
+        assertEquals(9, config.prompt.messages.size)
 
         val agent = AIAgent.builder()
             .promptExecutor(getMockExecutor(serializer) { })
             .agentConfig(config)
+            .systemPrompt("sys")
             .build()
 
         assertNotNull(agent)
         assertEquals(OpenAIModels.Chat.GPT4o, agent.agentConfig.model)
         // 2 system/user pairs + 2 tool calls + 2 tool results = 6 messages plus initial system => account for actual structure
         assertTrue(agent.agentConfig.prompt.messages.isNotEmpty())
+        assertEquals(10, agent.agentConfig.prompt.messages.size)
     }
 
     @Test
@@ -275,5 +279,57 @@ class JavaAPIAgentBuilderTest {
         assertEquals(maxTokens, prompt.params.maxTokens, "Prompt params should be preserved")
         assertEquals(originalSystemPrompt, prompt.messages.first().content, "original messages should be preserved")
         assertEquals(systemPrompt, prompt.messages.last().content, "system prompt should be added")
+    }
+
+    @Test
+    fun testBuilderOverridesAgentConfig() {
+        val config = AIAgentConfig(
+            builder("copy-test").system("system").build(),
+            OpenAIModels.Chat.GPT4o,
+            3
+        )
+
+        val agent = AIAgent.builder()
+            .promptExecutor(getMockExecutor(serializer) { })
+            .llmModel(OpenAIModels.Chat.GPT4o)
+            .agentConfig(config)
+            .maxIterations(15)
+            .build()
+
+        assertEquals(agent.agentConfig.maxAgentIterations, 15)
+    }
+
+    @Test
+    fun testBuilderOverridesPromptParams() {
+        val params = LLMParams(
+            temperature = 0.5,
+        )
+
+        val agent = AIAgent.builder()
+            .promptExecutor(getMockExecutor(serializer) { })
+            .llmModel(OpenAIModels.Chat.GPT4o)
+            .prompt(prompt("test-prompt", params) { system("system") })
+            .temperature(0.7)
+            .build()
+
+        assertEquals(agent.agentConfig.prompt.params.temperature, 0.7)
+    }
+
+    @Test
+    fun testBuilderOverridesPromptParamsInCustomConfig() {
+        val config = AIAgentConfig(
+            builder("copy-test").system("system").build(),
+            OpenAIModels.Chat.GPT4o,
+            3
+        )
+
+        val agent = AIAgent.builder()
+            .promptExecutor(getMockExecutor(serializer) { })
+            .llmModel(OpenAIModels.Chat.GPT4o)
+            .agentConfig(config)
+            .temperature(0.7)
+            .build()
+
+        assertEquals(agent.agentConfig.prompt.params.temperature, 0.7)
     }
 }

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/JavaAPIAgentBuilderTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/JavaAPIAgentBuilderTest.kt
@@ -4,16 +4,17 @@ import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.context.AIAgentFunctionalContext
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.testing.tools.getMockExecutor
-import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.dsl.Prompt.Companion.builder
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.params.LLMParams
 import ai.koog.serialization.kotlinx.KotlinxSerializer
-import junit.framework.TestCase.assertTrue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
-import java.util.function.BiFunction
-import kotlin.test.assertEquals
+import java.util.concurrent.Executors
 import kotlin.test.assertNotNull
 import kotlin.time.Clock
 import kotlin.time.Instant
@@ -38,7 +39,7 @@ class JavaAPIAgentBuilderTest {
     fun testAIAgentBuilderMethodExists() {
         // Test that AIAgent.builder() static method is accessible
         val builder = AIAgent.builder()
-        assertNotNull(builder)
+        builder.shouldNotBeNull()
     }
 
     @Test
@@ -51,16 +52,16 @@ class JavaAPIAgentBuilderTest {
             .systemPrompt("sys")
             .build()
 
-        assertNotNull(agent)
-        assertEquals(OpenAIModels.Chat.GPT4o, agent.agentConfig.model)
-        assertEquals(50, agent.agentConfig.maxAgentIterations) // default from builder
+        agent.shouldNotBeNull()
+        agent.agentConfig.model.shouldBe(OpenAIModels.Chat.GPT4o)
+        agent.agentConfig.maxAgentIterations.shouldBe(50) // default from builder
     }
 
     @Test
     fun testBuilderWithAgentConfig() {
         // Test the agentConfig() method that's used in Java code
         val config = AIAgentConfig(
-            prompt = Prompt.builder("test-id", testClock)
+            prompt = builder("test-id", testClock)
                 .system("system")
                 .user("user")
                 .assistant("assistant")
@@ -74,10 +75,10 @@ class JavaAPIAgentBuilderTest {
             .agentConfig(config)
             .build()
 
-        assertNotNull(agent)
-        assertEquals(OpenAIModels.Chat.GPT4o, agent.agentConfig.model)
-        assertEquals(100, agent.agentConfig.maxAgentIterations)
-        assertEquals("test-id", agent.agentConfig.prompt.id)
+        agent.shouldNotBeNull()
+        agent.agentConfig.model.shouldBe(OpenAIModels.Chat.GPT4o)
+        agent.agentConfig.maxAgentIterations.shouldBe(100)
+        agent.agentConfig.prompt.id.shouldBe("test-id")
     }
 
     @Test
@@ -91,7 +92,7 @@ class JavaAPIAgentBuilderTest {
             .toolRegistry(toolRegistry)
             .build()
 
-        assertNotNull(agent)
+        agent.shouldNotBeNull()
         // Indirect assertion: agent built successfully with provided registry
     }
 
@@ -100,7 +101,7 @@ class JavaAPIAgentBuilderTest {
         // Test the exact pattern from KoogAgentService.java
         // This matches lines 152-171 of the Java example
         val config = AIAgentConfig(
-            prompt = Prompt.builder("id")
+            prompt = builder("id")
                 .system("system")
                 .user("user")
                 .assistant("assistant")
@@ -114,7 +115,7 @@ class JavaAPIAgentBuilderTest {
             model = OpenAIModels.Chat.GPT4o,
             maxAgentIterations = 100
         )
-        assertEquals(9, config.prompt.messages.size)
+        config.prompt.messages.shouldHaveSize(9)
 
         val agent = AIAgent.builder()
             .promptExecutor(getMockExecutor(serializer) { })
@@ -122,18 +123,18 @@ class JavaAPIAgentBuilderTest {
             .systemPrompt("sys")
             .build()
 
-        assertNotNull(agent)
-        assertEquals(OpenAIModels.Chat.GPT4o, agent.agentConfig.model)
+        agent.shouldNotBeNull()
+        agent.agentConfig.model.shouldBe(OpenAIModels.Chat.GPT4o)
         // 2 system/user pairs + 2 tool calls + 2 tool results = 6 messages plus initial system => account for actual structure
-        assertTrue(agent.agentConfig.prompt.messages.isNotEmpty())
-        assertEquals(10, agent.agentConfig.prompt.messages.size)
+        agent.agentConfig.prompt.messages.shouldNotBeEmpty()
+        agent.agentConfig.prompt.messages.shouldHaveSize(10)
     }
 
     @Test
     fun testFunctionalStrategyWithLambda() {
         // Test that functional strategy BiFunction-based Java API can be set
         val config = AIAgentConfig(
-            prompt = Prompt.builder("test-id", testClock)
+            prompt = builder("test-id", testClock)
                 .system("You are a helpful assistant")
                 .build(),
             model = OpenAIModels.Chat.GPT4o,
@@ -142,15 +143,14 @@ class JavaAPIAgentBuilderTest {
 
         val agent = AIAgent.builder()
             .agentConfig(config)
-            .functionalStrategy<String, String>(
-                "echoStrategy",
-                BiFunction { _: AIAgentFunctionalContext, input: String -> "Echo: $input" }
-            )
+            .functionalStrategy(
+                "echoStrategy"
+            ) { _: AIAgentFunctionalContext, input: String -> "Echo: $input" }
             .promptExecutor(getMockExecutor(serializer) { })
             .build()
 
         val result = agent.javaNonSuspendRun("hello", null, null)
-        assertEquals("Echo: hello", result)
+        result.shouldBe("Echo: hello")
     }
 
     @Test
@@ -164,7 +164,7 @@ class JavaAPIAgentBuilderTest {
         }
 
         val config = AIAgentConfig(
-            prompt = Prompt.builder("test-id", testClock)
+            prompt = builder("test-id", testClock)
                 .system("Test system")
                 .build(),
             model = OpenAIModels.Chat.GPT4o,
@@ -180,14 +180,14 @@ class JavaAPIAgentBuilderTest {
             .build()
 
         val result = agent.javaNonSuspendRun("data")
-        assertEquals("Processed: data", result)
+        result.shouldBe("Processed: data")
     }
 
     @Test
     fun testBuilderChaining() {
         // Test that builder methods can be chained fluently
         val config = AIAgentConfig(
-            prompt = Prompt.builder("chaining-test", testClock)
+            prompt = builder("chaining-test", testClock)
                 .system("System message")
                 .build(),
             model = OpenAIModels.Chat.GPT4o,
@@ -203,16 +203,16 @@ class JavaAPIAgentBuilderTest {
             .temperature(0.7)
             .build()
 
-        assertNotNull(agent)
-        assertEquals(25, agent.agentConfig.maxAgentIterations)
-        assertEquals("chaining-test", agent.agentConfig.prompt.id)
+        agent.shouldNotBeNull()
+        agent.agentConfig.maxAgentIterations.shouldBe(25)
+        agent.agentConfig.prompt.id.shouldBe("chaining-test")
     }
 
     @Test
     fun testBuilderWithMultipleConfigurations() {
         // Test that builder can handle multiple configuration calls
         val config1 = AIAgentConfig(
-            prompt = Prompt.builder("config-1", testClock)
+            prompt = builder("config-1", testClock)
                 .system("First config")
                 .build(),
             model = OpenAIModels.Chat.GPT4o,
@@ -220,7 +220,7 @@ class JavaAPIAgentBuilderTest {
         )
 
         val config2 = AIAgentConfig(
-            prompt = Prompt.builder("config-2", testClock)
+            prompt = builder("config-2", testClock)
                 .system("Second config")
                 .build(),
             model = OpenAIModels.Chat.GPT4o,
@@ -233,9 +233,9 @@ class JavaAPIAgentBuilderTest {
             .agentConfig(config2) // Should override config1
             .build()
 
-        assertNotNull(agent)
-        assertEquals(20, agent.agentConfig.maxAgentIterations)
-        assertEquals("config-2", agent.agentConfig.prompt.id)
+        agent.shouldNotBeNull()
+        agent.agentConfig.maxAgentIterations.shouldBe(20)
+        agent.agentConfig.prompt.id.shouldBe("config-2")
     }
 
     @Test
@@ -274,11 +274,11 @@ class JavaAPIAgentBuilderTest {
 
         val prompt = agent.agentConfig.prompt
 
-        assertEquals(id, prompt.id, "Prompt ID should be preserved")
-        assertEquals(temperature, prompt.params.temperature, "Temperature should be preserved")
-        assertEquals(maxTokens, prompt.params.maxTokens, "Prompt params should be preserved")
-        assertEquals(originalSystemPrompt, prompt.messages.first().content, "original messages should be preserved")
-        assertEquals(systemPrompt, prompt.messages.last().content, "system prompt should be added")
+        prompt.id.shouldBe(id)
+        prompt.params.temperature.shouldBe(temperature)
+        prompt.params.maxTokens.shouldBe(maxTokens)
+        prompt.messages.first().content.shouldBe(originalSystemPrompt)
+        prompt.messages.last().content.shouldBe(systemPrompt)
     }
 
     @Test
@@ -296,7 +296,7 @@ class JavaAPIAgentBuilderTest {
             .maxIterations(15)
             .build()
 
-        assertEquals(agent.agentConfig.maxAgentIterations, 15)
+        agent.agentConfig.maxAgentIterations.shouldBe(15)
     }
 
     @Test
@@ -312,7 +312,7 @@ class JavaAPIAgentBuilderTest {
             .temperature(0.7)
             .build()
 
-        assertEquals(agent.agentConfig.prompt.params.temperature, 0.7)
+        agent.agentConfig.prompt.params.temperature.shouldBe(0.7)
     }
 
     @Test
@@ -330,6 +330,34 @@ class JavaAPIAgentBuilderTest {
             .temperature(0.7)
             .build()
 
-        assertEquals(agent.agentConfig.prompt.params.temperature, 0.7)
+        agent.agentConfig.prompt.params.temperature.shouldBe(0.7)
+    }
+
+    @Test
+    fun testBuilderUpdatePreservesJvmExecutorsFromCustomConfig() {
+        val strategyExecutor = Executors.newSingleThreadExecutor()
+        val llmExecutor = Executors.newSingleThreadExecutor()
+
+        try {
+            val config = AIAgentConfig(
+                prompt = builder("copy-test").system("system").build(),
+                model = OpenAIModels.Chat.GPT4o,
+                maxAgentIterations = 3,
+                agentStrategyExecutorService = strategyExecutor,
+                llmRequestExecutorService = llmExecutor
+            )
+
+            val agent = AIAgent.builder()
+                .promptExecutor(getMockExecutor(serializer) { })
+                .agentConfig(config)
+                .temperature(0.7)
+                .build()
+
+            agent.agentConfig.strategyExecutorService.shouldBe(strategyExecutor)
+            agent.agentConfig.llmRequestExecutorService.shouldBe(llmExecutor)
+        } finally {
+            strategyExecutor.shutdownNow()
+            llmExecutor.shutdownNow()
+        }
     }
 }

--- a/agents/agents-core/src/nonJvmCommonMain/kotlin/ai/koog/agents/core/agent/config/AIAgentConfig.kt
+++ b/agents/agents-core/src/nonJvmCommonMain/kotlin/ai/koog/agents/core/agent/config/AIAgentConfig.kt
@@ -36,4 +36,20 @@ public actual class AIAgentConfig actual constructor(
                 maxAgentIterations = maxAgentIterations
             )
     }
+
+    internal actual fun copy(
+        prompt: Prompt,
+        model: LLModel,
+        maxAgentIterations: Int,
+        missingToolsConversionStrategy: MissingToolsConversionStrategy,
+        responseProcessor: ResponseProcessor?,
+        serializer: JSONSerializer
+    ) = AIAgentConfig(
+        prompt = prompt,
+        model = model,
+        maxAgentIterations = maxAgentIterations,
+        missingToolsConversionStrategy = missingToolsConversionStrategy,
+        responseProcessor = responseProcessor,
+        serializer = serializer
+    )
 }


### PR DESCRIPTION
Replaced AIAcgentConfig.copy extension with an interface to copy jvmCommon-spesific fields fields

closes KG-749
