### PR TITLE
fix(prompt): ensure `reasoningContent` present with tool calls in Anthropic

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
@@ -594,8 +594,8 @@ public open class AnthropicLLMClient @JvmOverloads constructor(
         }
 
         return when {
-            // Fix the situation when the model decides to both call tools and talk
-            responses.any { it is Message.Tool.Call } -> responses.filterIsInstance<Message.Tool.Call>()
+            // When the model calls tools, keep Reasoning (for thinking) and Tool.Call, filter out Assistant text
+            responses.any { it is Message.Tool.Call } -> responses.filter { it is Message.Reasoning || it is Message.Tool.Call }
 
             // If no messages where returned, return an empty message and check stopReason
             responses.isEmpty() -> listOf(


### PR DESCRIPTION
## Summary

- When the Anthropic model returns both reasoning (thinking) and tool calls, the reasoning content was being filtered out
- Keep `Message.Reasoning` alongside `Message.Tool.Call` instead of discarding everything except tool calls
- Mirrors the fix applied for DeepSeek in #1614

## Test plan

- [x] Verify reasoning content is preserved when Anthropic model returns tool calls with thinking
- [x] Run `./gradlew :prompt:prompt-executor:prompt-executor-clients:prompt-executor-anthropic-client:jvmTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)