### PR TITLE
fix(embeddings): check HTTP status before deserializing Ollama embedding response

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -356,6 +356,14 @@ public class OllamaClient @JvmOverloads constructor(
             setBody(EmbeddingRequestDTO(model = model.id, prompt = text))
         }
 
+        if (!response.status.isSuccess()) {
+            val errorBody = response.bodyAsText()
+            throw LLMClientException(
+                clientName,
+                "Embedding request failed (HTTP ${response.status.value}): $errorBody"
+            )
+        }
+
         val embeddingResponse = response.body<EmbeddingResponseDTO>()
         return embeddingResponse.embedding
     }


### PR DESCRIPTION
When Ollama returns an error response (e.g., model not loaded, server unavailable), `OllamaClient.embed()` attempts to deserialize the error body as `EmbeddingResponseDTO`, causing a `JsonDecodingException`. The user sees a serialization stack trace instead of the actual error message from Ollama.

This adds an HTTP status check before deserialization, matching the pattern already used by `executeImpl()` at line 206 in the same file. On non-success status codes, a `LLMClientException` is thrown with the HTTP status and Ollama's error body, giving users a clear error message like:

```
Embedding request failed (HTTP 404): {"error":"model 'nomic-embed-text' not found"}
```

instead of a `JsonDecodingException` stack trace.

Fixes #1499

This contribution was developed with AI assistance (Claude Code).