### PR TITLE
fix(prompt): pass tools parameter in JVM PromptExecutor.execute() overload

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,6 +111,19 @@ subprojects {
         outputToConsole = true
         coloredOutput = true
     }
+    val envVars = mapOf(
+        "ANTHROPIC_API_TEST_KEY" to System.getenv("ANTHROPIC_API_TEST_KEY"),
+        "AWS_ACCESS_KEY_ID" to System.getenv("AWS_ACCESS_KEY_ID"),
+        "AWS_BEARER_TOKEN_BEDROCK" to System.getenv("AWS_BEARER_TOKEN_BEDROCK"),
+        "AWS_SECRET_ACCESS_KEY" to System.getenv("AWS_SECRET_ACCESS_KEY"),
+        "AWS_BEDROCK_GUARDRAIL_ID" to System.getenv("AWS_BEDROCK_GUARDRAIL_ID"),
+        "AWS_BEDROCK_GUARDRAIL_VERSION" to System.getenv("AWS_BEDROCK_GUARDRAIL_VERSION"),
+        "DEEPSEEK_API_TEST_KEY" to System.getenv("DEEPSEEK_API_TEST_KEY"),
+        "GEMINI_API_TEST_KEY" to System.getenv("GEMINI_API_TEST_KEY"),
+        "MISTRAL_AI_API_TEST_KEY" to System.getenv("MISTRAL_AI_API_TEST_KEY"),
+        "OPEN_AI_API_TEST_KEY" to System.getenv("OPEN_AI_API_TEST_KEY"),
+        "OPEN_ROUTER_API_TEST_KEY" to System.getenv("OPEN_ROUTER_API_TEST_KEY"),
+    ).filterValues { it != null }
 
     tasks.withType<Test> {
         testLogging {
@@ -118,21 +131,7 @@ subprojects {
             showExceptions = true
             exceptionFormat = FULL
         }
-        environment.putAll(
-            mapOf(
-                "ANTHROPIC_API_TEST_KEY" to System.getenv("ANTHROPIC_API_TEST_KEY"),
-                "AWS_ACCESS_KEY_ID" to System.getenv("AWS_ACCESS_KEY_ID"),
-                "AWS_BEARER_TOKEN_BEDROCK" to System.getenv("AWS_BEARER_TOKEN_BEDROCK"),
-                "AWS_SECRET_ACCESS_KEY" to System.getenv("AWS_SECRET_ACCESS_KEY"),
-                "AWS_BEDROCK_GUARDRAIL_ID" to System.getenv("AWS_BEDROCK_GUARDRAIL_ID"),
-                "AWS_BEDROCK_GUARDRAIL_VERSION" to System.getenv("AWS_BEDROCK_GUARDRAIL_VERSION"),
-                "DEEPSEEK_API_TEST_KEY" to System.getenv("DEEPSEEK_API_TEST_KEY"),
-                "GEMINI_API_TEST_KEY" to System.getenv("GEMINI_API_TEST_KEY"),
-                "MISTRAL_AI_API_TEST_KEY" to System.getenv("MISTRAL_AI_API_TEST_KEY"),
-                "OPEN_AI_API_TEST_KEY" to System.getenv("OPEN_AI_API_TEST_KEY"),
-                "OPEN_ROUTER_API_TEST_KEY" to System.getenv("OPEN_ROUTER_API_TEST_KEY"),
-            )
-        )
+        environment.putAll(envVars)
     }
 }
 

--- a/integration-tests/src/jvmTest/java/ai/koog/integration/tests/executor/JavaPromptExecutorIntegrationTest.java
+++ b/integration-tests/src/jvmTest/java/ai/koog/integration/tests/executor/JavaPromptExecutorIntegrationTest.java
@@ -261,7 +261,6 @@ public class JavaPromptExecutorIntegrationTest extends KoogJavaTestBase {
 
     @ParameterizedTest
     @MethodSource("ai.koog.integration.tests.agent.AIAgentTestBase#getLatestModels")
-    @Disabled("KG-725 Java interop fails to pass tools to execute() method")
     public void integration_ToolChoiceRequiredShouldEmitToolCall(LLModel model) {
         Models.assumeAvailable(model.getProvider());
         MultiLLMPromptExecutor executor = createExecutor(model);
@@ -281,7 +280,8 @@ public class JavaPromptExecutorIntegrationTest extends KoogJavaTestBase {
             .build()
             .withParams(params);
 
-        List<Message.Response> responses = executor.execute(prompt, model, List.of(SimpleCalculatorTool.INSTANCE.getDescriptor()));
+        var tools = List.of(SimpleCalculatorTool.INSTANCE.getDescriptor());
+        List<Message.Response> responses = executor.execute(prompt, model, tools);
         assertThat(responses).isNotEmpty();
         assertThat(responses.stream().anyMatch(Message.Tool.Call.class::isInstance)).isTrue();
     }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/TestCredentials.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/TestCredentials.kt
@@ -1,50 +1,34 @@
 package ai.koog.integration.tests.utils
 
 object TestCredentials {
-    fun readTestAnthropicKeyFromEnv(): String {
-        return System.getenv("ANTHROPIC_API_TEST_KEY")
-            ?: error("ERROR: environment variable `ANTHROPIC_API_TEST_KEY` is not set")
+    private const val GUIDE_URL =
+        "https://github.com/JetBrains/koog/blob/develop/TESTING.md#required-api-tokens-for-integration-tests"
+
+    private fun requireEnv(name: String): String {
+        return System.getenv(name)
+            ?: error(
+                "Environment variable `$name` is not set. " +
+                    "See $GUIDE_URL for setup instructions."
+            )
     }
 
-    fun readTestOpenAIKeyFromEnv(): String {
-        return System.getenv("OPEN_AI_API_TEST_KEY")
-            ?: error("ERROR: environment variable `OPEN_AI_API_TEST_KEY` is not set")
-    }
+    fun readTestAnthropicKeyFromEnv(): String = requireEnv("ANTHROPIC_API_TEST_KEY")
 
-    fun readTestGoogleAIKeyFromEnv(): String {
-        return System.getenv("GEMINI_API_TEST_KEY")
-            ?: error("ERROR: environment variable `GEMINI_API_TEST_KEY` is not set")
-    }
+    fun readTestOpenAIKeyFromEnv(): String = requireEnv("OPEN_AI_API_TEST_KEY")
 
-    fun readTestOpenRouterKeyFromEnv(): String {
-        return System.getenv("OPEN_ROUTER_API_TEST_KEY")
-            ?: error("ERROR: environment variable `OPEN_ROUTER_API_TEST_KEY` is not set")
-    }
+    fun readTestGoogleAIKeyFromEnv(): String = requireEnv("GEMINI_API_TEST_KEY")
 
-    fun readTestMistralAiKeyFromEnv(): String {
-        return System.getenv("MISTRAL_AI_API_TEST_KEY")
-            ?: error("ERROR: environment variable `MISTRAL_AI_API_TEST_KEY` is not set")
-    }
+    fun readTestOpenRouterKeyFromEnv(): String = requireEnv("OPEN_ROUTER_API_TEST_KEY")
 
-    fun readTestDashscopeKeyFromEnv(): String {
-        return System.getenv("DASHSCOPE_API_TEST_KEY")
-            ?: error("ERROR: environment variable `DASHSCOPE_API_TEST_KEY` is not set")
-    }
+    fun readTestMistralAiKeyFromEnv(): String = requireEnv("MISTRAL_AI_API_TEST_KEY")
 
-    fun readAwsAccessKeyIdFromEnv(): String {
-        return System.getenv("AWS_ACCESS_KEY_ID")
-            ?: error("ERROR: environment variable `AWS_ACCESS_KEY_ID` is not set")
-    }
+    fun readTestDashscopeKeyFromEnv(): String = requireEnv("DASHSCOPE_API_TEST_KEY")
 
-    fun readAwsSecretAccessKeyFromEnv(): String {
-        return System.getenv("AWS_SECRET_ACCESS_KEY")
-            ?: error("ERROR: environment variable `AWS_SECRET_ACCESS_KEY` is not set")
-    }
+    fun readAwsAccessKeyIdFromEnv(): String = requireEnv("AWS_ACCESS_KEY_ID")
 
-    fun readAwsBedrockBearerTokenFromEnv(): String {
-        return System.getenv("AWS_BEARER_TOKEN_BEDROCK")
-            ?: error("ERROR: environment variable `AWS_BEARER_TOKEN_BEDROCK` is not set")
-    }
+    fun readAwsSecretAccessKeyFromEnv(): String = requireEnv("AWS_SECRET_ACCESS_KEY")
+
+    fun readAwsBedrockBearerTokenFromEnv(): String = requireEnv("AWS_BEARER_TOKEN_BEDROCK")
 
     fun readAwsSessionTokenFromEnv(): String? {
         return System.getenv("AWS_SESSION_TOKEN")
@@ -53,13 +37,7 @@ object TestCredentials {
             }
     }
 
-    fun readAwsBedrockGuardrailIdFromEnv(): String {
-        return System.getenv("AWS_BEDROCK_GUARDRAIL_ID")
-            ?: error("ERROR: environment variable `AWS_BEDROCK_GUARDRAIL_ID` is not set")
-    }
+    fun readAwsBedrockGuardrailIdFromEnv(): String = requireEnv("AWS_BEDROCK_GUARDRAIL_ID")
 
-    fun readAwsBedrockGuardrailVersionFromEnv(): String {
-        return System.getenv("AWS_BEDROCK_GUARDRAIL_VERSION")
-            ?: error("ERROR: environment variable `AWS_BEDROCK_GUARDRAIL_VERSION` is not set")
-    }
+    fun readAwsBedrockGuardrailVersionFromEnv(): String = requireEnv("AWS_BEDROCK_GUARDRAIL_VERSION")
 }

--- a/prompt/prompt-executor/prompt-executor-model/src/jvmMain/kotlin/ai/koog/prompt/executor/model/PromptExecutor.kt
+++ b/prompt/prompt-executor/prompt-executor-model/src/jvmMain/kotlin/ai/koog/prompt/executor/model/PromptExecutor.kt
@@ -36,7 +36,7 @@ public actual abstract class PromptExecutor actual constructor() : PromptExecuto
         tools: List<ToolDescriptor> = emptyList(),
         executorService: ExecutorService? = null
     ): List<Message.Response> = runOnIOBoundDispatcher(executorService) {
-        execute(prompt, model, emptyList())
+        execute(prompt, model, tools)
     }
 
     /**


### PR DESCRIPTION
The JVM-specific execute() method was ignoring the `tools` argument and always passing emptyList(), breaking Java interop for tool-based calls. Re-enable the integration test that was disabled for [KG-725](https://youtrack.jetbrains.com/issue/KG-725).

closes
KG-725