### PR TITLE
feat(spring-boot): add integration with ChatMemoryRepository from Spring AI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -230,6 +230,7 @@ dependencies {
     dokka(project(":embeddings:embeddings-base"))
     dokka(project(":embeddings:embeddings-llm"))
     dokka(project(":koog-ktor"))
+    dokka(project(":koog-spring-ai:koog-spring-ai-starter-chat-memory"))
     dokka(project(":koog-spring-ai:koog-spring-ai-starter-model-chat"))
     dokka(project(":koog-spring-ai:koog-spring-ai-starter-model-embedding"))
     dokka(project(":koog-spring-boot-starter"))

--- a/koog-agents/build.gradle.kts
+++ b/koog-agents/build.gradle.kts
@@ -46,8 +46,10 @@ val excluded = setOf(
     ":serialization:serialization-jackson",
 
     ":koog-spring-ai",
+    ":koog-spring-ai:koog-spring-ai-common",
     ":koog-spring-ai:koog-spring-ai-starter-model-chat",
     ":koog-spring-ai:koog-spring-ai-starter-model-embedding",
+    ":koog-spring-ai:koog-spring-ai-starter-chat-memory",
 
     project.path, // the current project should not depend on itself
 )

--- a/koog-spring-ai/README.md
+++ b/koog-spring-ai/README.md
@@ -18,5 +18,6 @@ Both starters are independent — pick one based on how you prefer to manage LLM
 |---|---|---|
 | `koog-spring-ai-starter-model-chat` | Adapts a Spring AI `ChatModel` (with optional `ModerationModel`) into a Koog `LLMClient` and `PromptExecutor` | [Module.md](koog-spring-ai-starter-model-chat/Module.md) |
 | `koog-spring-ai-starter-model-embedding` | Adapts a Spring AI `EmbeddingModel` into a Koog `LLMEmbeddingProvider` | [Module.md](koog-spring-ai-starter-model-embedding/Module.md) |
+| `koog-spring-ai-starter-chat-memory` | Adapts a Spring AI `ChatMemoryRepository` into a Koog `ChatHistoryProvider` | [Module.md](koog-spring-ai-starter-chat-memory/Module.md) |
 
 Each submodule is a fully independent Spring Boot starter with its own auto-configuration, configuration properties, and dispatcher management. See the linked `Module.md` for usage details, configuration reference, and examples.

--- a/koog-spring-ai/koog-spring-ai-common/Module.md
+++ b/koog-spring-ai/koog-spring-ai-common/Module.md
@@ -1,0 +1,3 @@
+# Module koog-spring-ai-common
+
+Contains common code shared between Spring Boot starters in koog-spring-ai.

--- a/koog-spring-ai/koog-spring-ai-common/build.gradle.kts
+++ b/koog-spring-ai/koog-spring-ai-common/build.gradle.kts
@@ -6,8 +6,6 @@ version = rootProject.version
 plugins {
     id("ai.kotlin.jvm")
     id("ai.kotlin.jvm.publish")
-    alias(libs.plugins.kotlin.spring)
-    alias(libs.plugins.spring.management)
 }
 kotlin {
     explicitApi()
@@ -23,19 +21,5 @@ tasks.withType<JavaCompile>().configureEach {
     sourceCompatibility = JavaVersion.VERSION_17.toString()
     targetCompatibility = JavaVersion.VERSION_17.toString()
     options.compilerArgs.add("-parameters")
-}
-dependencies {
-    api(project(":koog-spring-ai:koog-spring-ai-common"))
-    api(project(":prompt:prompt-executor:prompt-executor-clients"))
-    implementation(project.dependencies.platform(libs.spring.boot.bom))
-    implementation(project.dependencies.platform(libs.spring.ai.bom))
-    api(libs.bundles.spring.boot.core)
-    api(libs.spring.ai.model)
-    implementation(libs.kotlinx.coroutines.core)
-
-    testImplementation(libs.spring.boot.starter.test)
-    testImplementation(libs.kotlinx.coroutines.test)
-    testImplementation(libs.mockk)
-    testRuntimeOnly(libs.junit.platform.launcher)
 }
 publishToMaven()

--- a/koog-spring-ai/koog-spring-ai-common/src/main/kotlin/ai/koog/spring/ai/common/DispatcherProperties.kt
+++ b/koog-spring-ai/koog-spring-ai-common/src/main/kotlin/ai/koog/spring/ai/common/DispatcherProperties.kt
@@ -1,0 +1,47 @@
+package ai.koog.spring.ai.common
+
+/**
+ * Dispatcher settings for blocking Spring AI calls.
+ *
+ * @property type The dispatcher type to use. Default: [DispatcherType.AUTO].
+ * @property parallelism Maximum parallelism for the dispatcher. When greater than 0 and [DispatcherType.IO]
+ *   is selected, `Dispatchers.IO.limitedParallelism(parallelism)` is used instead of the unbounded `Dispatchers.IO`.
+ */
+public data class DispatcherProperties(
+    val type: DispatcherType = DispatcherType.AUTO,
+    val parallelism: Int = 0,
+)
+
+/**
+ * Dispatcher type for blocking Spring AI calls.
+ */
+public enum class DispatcherType {
+    /**
+     * Automatically detect the best dispatcher.
+     *
+     * When Spring Boot's `spring.threads.virtual.enabled=true` is set, an
+     * [org.springframework.core.task.AsyncTaskExecutor] backed by virtual threads
+     * is available in the application context. In [AUTO] mode the dispatcher is
+     * derived from that executor, so users only need the standard Spring Boot
+     * property to opt into virtual threads.
+     *
+     * Falls back to [kotlinx.coroutines.Dispatchers.IO] when no such executor is present.
+     *
+     * **Warning:** When `spring.threads.virtual.enabled=false` (the default before
+     * Spring Boot 3.2), the application task executor is typically a bounded
+     * `ThreadPoolTaskExecutor` (8 core threads by default). Wrapping it as a
+     * coroutine dispatcher means all blocking calls share the same thread pool
+     * used by `@Async`, scheduled tasks, and web MVC async handlers. Under load this
+     * can cause thread starvation or deadlocks. In such setups, prefer [IO] or enable
+     * virtual threads.
+     */
+    AUTO,
+
+    /**
+     * Use [kotlinx.coroutines.Dispatchers.IO].
+     *
+     * When [DispatcherProperties.parallelism] is greater than 0, uses
+     * `Dispatchers.IO.limitedParallelism(parallelism)` to cap concurrency.
+     */
+    IO,
+}

--- a/koog-spring-ai/koog-spring-ai-common/src/main/kotlin/ai/koog/spring/ai/common/DispatcherProperties.kt
+++ b/koog-spring-ai/koog-spring-ai-common/src/main/kotlin/ai/koog/spring/ai/common/DispatcherProperties.kt
@@ -3,25 +3,18 @@ package ai.koog.spring.ai.common
 /**
  * Dispatcher settings for blocking Spring AI calls.
  *
- * @property type The dispatcher type to use. Default: [DispatcherType.AUTO].
- * @property parallelism Maximum parallelism for the dispatcher. When greater than 0 and [DispatcherType.IO]
- *   is selected, `Dispatchers.IO.limitedParallelism(parallelism)` is used instead of the unbounded `Dispatchers.IO`.
+ * - [Auto]: Automatically detect the best dispatcher. Uses Spring's `AsyncTaskExecutor` when
+ *   available (e.g. virtual-thread executor), otherwise falls back to `Dispatchers.IO`.
+ * - [IO]: Use [kotlinx.coroutines.Dispatchers.IO], optionally limited to [IO.parallelism] threads.
  */
-public data class DispatcherProperties(
-    val type: DispatcherType = DispatcherType.AUTO,
-    val parallelism: Int = 0,
-)
+public sealed interface DispatcherProperties {
 
-/**
- * Dispatcher type for blocking Spring AI calls.
- */
-public enum class DispatcherType {
     /**
      * Automatically detect the best dispatcher.
      *
      * When Spring Boot's `spring.threads.virtual.enabled=true` is set, an
      * [org.springframework.core.task.AsyncTaskExecutor] backed by virtual threads
-     * is available in the application context. In [AUTO] mode the dispatcher is
+     * is available in the application context. In [Auto] mode the dispatcher is
      * derived from that executor, so users only need the standard Spring Boot
      * property to opt into virtual threads.
      *
@@ -35,13 +28,48 @@ public enum class DispatcherType {
      * can cause thread starvation or deadlocks. In such setups, prefer [IO] or enable
      * virtual threads.
      */
-    AUTO,
+    public data object Auto : DispatcherProperties
 
     /**
      * Use [kotlinx.coroutines.Dispatchers.IO].
      *
-     * When [DispatcherProperties.parallelism] is greater than 0, uses
+     * When [parallelism] is greater than 0, uses
      * `Dispatchers.IO.limitedParallelism(parallelism)` to cap concurrency.
+     *
+     * @property parallelism Maximum parallelism for the dispatcher. When `null` or 0,
+     *   the unbounded `Dispatchers.IO` is used.
      */
+    public data class IO(
+        val parallelism: Int? = null
+    ) : DispatcherProperties
+}
+
+/**
+ * Spring Boot–bindable configuration that maps to a [DispatcherProperties] sealed variant.
+ *
+ * Properties:
+ * - `type` – `AUTO` (default) or `IO`.
+ * - `parallelism` – only meaningful when `type = IO`.
+ *
+ * @see DispatcherProperties
+ */
+public data class DispatcherConfig(
+    val type: DispatcherType = DispatcherType.AUTO,
+    val parallelism: Int = 0,
+) {
+    /**
+     * Converts this bindable configuration into the corresponding [DispatcherProperties] variant.
+     */
+    public fun toDispatcherProperties(): DispatcherProperties = when (type) {
+        DispatcherType.AUTO -> DispatcherProperties.Auto
+        DispatcherType.IO -> DispatcherProperties.IO(parallelism.takeIf { it > 0 })
+    }
+}
+
+/**
+ * Dispatcher type for blocking Spring AI calls.
+ */
+public enum class DispatcherType {
+    AUTO,
     IO,
 }

--- a/koog-spring-ai/koog-spring-ai-starter-chat-memory/Module.md
+++ b/koog-spring-ai/koog-spring-ai-starter-chat-memory/Module.md
@@ -9,7 +9,7 @@ providing **text-only conversation persistence** — not full Koog prompt-state 
 
 It auto-configures:
 
-- A Koog `ChatHistoryProvider` (`SpringAiChatMemoryRepositoryAdapter`) that delegates to a Spring AI `ChatMemoryRepository`
+- A Koog `ChatHistoryProvider` (`SpringAiChatHistoryProvider`) that delegates to a Spring AI `ChatMemoryRepository`
 
 This lets you reuse any Spring AI–compatible chat memory store (JDBC, Redis, Cassandra, etc.)
 as the backing storage for Koog agent conversation history.

--- a/koog-spring-ai/koog-spring-ai-starter-chat-memory/Module.md
+++ b/koog-spring-ai/koog-spring-ai-starter-chat-memory/Module.md
@@ -1,0 +1,111 @@
+# Module koog-spring-ai-starter-chat-memory
+
+Adapts a Spring AI `ChatMemoryRepository` into a Koog `ChatHistoryProvider` for **conversation text memory**.
+
+### Overview
+
+This starter bridges Spring AI's chat memory abstraction with the Koog agent framework,
+providing **text-only conversation persistence** — not full Koog prompt-state persistence.
+
+It auto-configures:
+
+- A Koog `ChatHistoryProvider` (`SpringAiChatMemoryRepositoryAdapter`) that delegates to a Spring AI `ChatMemoryRepository`
+
+This lets you reuse any Spring AI–compatible chat memory store (JDBC, Redis, Cassandra, etc.)
+as the backing storage for Koog agent conversation history.
+
+### Text-only contract
+
+Only plain-text System, User, and Assistant messages are persisted. The following are
+**silently dropped on store** (they are non-persistable transport/runtime events):
+
+- `Message.Tool.Call`
+- `Message.Tool.Result`
+- `Message.Reasoning`
+- Any message carrying attachments (images, audio, video, files)
+
+On **load**, Spring AI `TOOL` rows (e.g., from JDBC repositories that previously stored
+tool traffic) are silently skipped rather than causing an error.
+
+Metadata fields (timestamps, token counts, finish reasons, custom metadata) are **not**
+preserved through the round-trip.
+
+> **Note:** If your agent uses tools, the tool call/result exchange will not appear in
+> the persisted history. The adapter is designed for conversational text recall, not for
+> replaying full agent execution traces.
+
+### Using in your project
+
+Add the dependency alongside any Spring AI chat memory repository implementation:
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation("ai.koog:koog-agents-jvm:$koogVersion")
+    implementation("ai.koog:koog-spring-ai-starter-chat-memory:$koogVersion")
+    // e.g. JDBC-backed chat memory
+    implementation("org.springframework.ai:spring-ai-starter-model-chat-memory-repository-jdbc")
+}
+```
+
+Modifying your Spring Boot properties is not necessary, below are the default settings:
+
+```properties
+# application.properties defaults
+koog.spring.ai.chat-memory.enabled=true
+koog.spring.ai.chat-memory.dispatcher.type=AUTO
+```
+
+If you have a single `ChatMemoryRepository` bean, everything works automatically —
+the adapter wraps it into a Koog `ChatHistoryProvider`.
+
+### Example of usage
+
+Install the `ChatMemory` feature on your agent using the auto-configured `ChatHistoryProvider`:
+
+```kotlin
+@Service
+class MyAgentService(
+    private val promptExecutor: PromptExecutor,
+    private val chatHistoryProvider: ChatHistoryProvider,
+) {
+
+    suspend fun askAgent(userMessage: String): String {
+        val agent = AIAgent(
+            promptExecutor = promptExecutor,
+            llmModel = OllamaModels.Meta.LLAMA_3_2,
+            systemPrompt = "You are a helpful assistant.",
+        ) {
+            install(ChatMemory) {
+                historyProvider = chatHistoryProvider
+            }
+        }
+
+        return agent.run(userMessage)
+    }
+}
+```
+
+### Configuration properties (`koog.spring.ai.chat-memory`)
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | `Boolean` | `true` | Enable/disable the chat memory auto-configuration |
+| `chat-memory-repository-bean-name` | `String?` | `null` | Bean name of the `ChatMemoryRepository` to use (for multi-repository contexts) |
+| `dispatcher.type` | `AUTO` / `IO` | `AUTO` | Dispatcher for blocking repository calls |
+| `dispatcher.parallelism` | `Int` | `0` (= unbounded) | Max concurrency for `IO` dispatcher (0 = no limit) |
+
+### Dispatcher types
+
+- **`AUTO`** (default): Uses a Spring-managed `AsyncTaskExecutor` if available (e.g., when `spring.threads.virtual.enabled=true` in Spring Boot 3.2+), otherwise falls back to `Dispatchers.IO`. This lets you opt into virtual threads with a single standard Spring Boot property.
+- **`IO`**: Always uses `Dispatchers.IO`. When `dispatcher.parallelism` is greater than 0, uses `Dispatchers.IO.limitedParallelism(parallelism)` to cap concurrency.
+
+### Multi-repository contexts
+
+When multiple `ChatMemoryRepository` beans are registered, specify which one to use:
+
+```properties
+koog.spring.ai.chat-memory.chat-memory-repository-bean-name=jdbcChatMemoryRepository
+```
+
+Without a selector, the auto-configuration activates only when a single candidate exists.

--- a/koog-spring-ai/koog-spring-ai-starter-chat-memory/build.gradle.kts
+++ b/koog-spring-ai/koog-spring-ai-starter-chat-memory/build.gradle.kts
@@ -26,7 +26,7 @@ tasks.withType<JavaCompile>().configureEach {
 }
 dependencies {
     api(project(":koog-spring-ai:koog-spring-ai-common"))
-    api(project(":prompt:prompt-executor:prompt-executor-clients"))
+    api(project(":agents:agents-features:agents-features-memory"))
     implementation(project.dependencies.platform(libs.spring.boot.bom))
     implementation(project.dependencies.platform(libs.spring.ai.bom))
     api(libs.bundles.spring.boot.core)

--- a/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/main/kotlin/ai/koog/spring/ai/memory/KoogSpringAiChatMemoryProperties.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/main/kotlin/ai/koog/spring/ai/memory/KoogSpringAiChatMemoryProperties.kt
@@ -1,6 +1,6 @@
 package ai.koog.spring.ai.memory
 
-import ai.koog.spring.ai.common.DispatcherProperties
+import ai.koog.spring.ai.common.DispatcherConfig
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
@@ -16,5 +16,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 public data class KoogSpringAiChatMemoryProperties(
     val enabled: Boolean = true,
     val chatMemoryRepositoryBeanName: String? = null,
-    val dispatcher: DispatcherProperties = DispatcherProperties(),
+    val dispatcher: DispatcherConfig = DispatcherConfig(),
 )

--- a/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/main/kotlin/ai/koog/spring/ai/memory/KoogSpringAiChatMemoryProperties.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/main/kotlin/ai/koog/spring/ai/memory/KoogSpringAiChatMemoryProperties.kt
@@ -1,0 +1,20 @@
+package ai.koog.spring.ai.memory
+
+import ai.koog.spring.ai.common.DispatcherProperties
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Configuration properties for the Koog Spring AI Chat Memory adapter.
+ *
+ * @property enabled whether the auto-configuration is enabled (default `true`)
+ * @property chatMemoryRepositoryBeanName Optional bean name of the [org.springframework.ai.chat.memory.ChatMemoryRepository]
+ *   to use. When set, the named bean is resolved from the application context, allowing selection among multiple
+ *   repository beans. When not set, the auto-configuration falls back to `@ConditionalOnSingleCandidate`.
+ * @property dispatcher Dispatcher / threading settings for blocking Spring AI chat memory repository calls.
+ */
+@ConfigurationProperties(prefix = "koog.spring.ai.chat-memory")
+public data class KoogSpringAiChatMemoryProperties(
+    val enabled: Boolean = true,
+    val chatMemoryRepositoryBeanName: String? = null,
+    val dispatcher: DispatcherProperties = DispatcherProperties(),
+)

--- a/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/main/kotlin/ai/koog/spring/ai/memory/SpringAiChatHistoryProvider.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/main/kotlin/ai/koog/spring/ai/memory/SpringAiChatHistoryProvider.kt
@@ -5,7 +5,6 @@ import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.message.ResponseMetaInfo
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.memory.ChatMemoryRepository
@@ -47,8 +46,8 @@ import org.springframework.ai.chat.messages.Message as SpringMessage
  * @param dispatcher the [CoroutineDispatcher] used for blocking repository calls
  */
 public class SpringAiChatHistoryProvider(
-    private val repository: ChatMemoryRepository,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    internal val repository: ChatMemoryRepository,
+    private val dispatcher: CoroutineDispatcher,
 ) : ChatHistoryProvider {
 
     private val logger = LoggerFactory.getLogger(SpringAiChatHistoryProvider::class.java)
@@ -94,25 +93,25 @@ public class SpringAiChatHistoryProvider(
             }
         }
     }
-}
 
-/**
- * Converts a Spring AI [SpringMessage] to a Koog [Message].
- *
- * Only SYSTEM, USER, and ASSISTANT message types are mapped.
- * TOOL messages are skipped (returns `null`) because typical repositories
- * (e.g., JDBC) cannot round-trip them with usable payload.
- */
-internal fun springMessageToKoogMessage(springMessage: SpringMessage): Message? {
-    return when (springMessage.messageType) {
-        MessageType.SYSTEM -> Message.System(springMessage.text ?: "", RequestMetaInfo.Empty)
-        MessageType.USER -> Message.User(springMessage.text ?: "", RequestMetaInfo.Empty)
-        MessageType.ASSISTANT -> Message.Assistant(springMessage.text ?: "", ResponseMetaInfo.Empty)
-        MessageType.TOOL -> {
-            LoggerFactory.getLogger(SpringAiChatHistoryProvider::class.java).debug(
-                "Skipping Spring AI TOOL message on load; not mappable to a Koog message type"
-            )
-            null
+    /**
+     * Converts a Spring AI [SpringMessage] to a Koog [Message].
+     *
+     * Only SYSTEM, USER, and ASSISTANT message types are mapped.
+     * TOOL messages are skipped (returns `null`) because typical repositories
+     * (e.g., JDBC) cannot round-trip them with usable payload.
+     */
+    private fun springMessageToKoogMessage(springMessage: SpringMessage): Message? {
+        return when (springMessage.messageType) {
+            MessageType.SYSTEM -> Message.System(springMessage.text ?: "", RequestMetaInfo.Empty)
+            MessageType.USER -> Message.User(springMessage.text ?: "", RequestMetaInfo.Empty)
+            MessageType.ASSISTANT -> Message.Assistant(springMessage.text ?: "", ResponseMetaInfo.Empty)
+            MessageType.TOOL -> {
+                logger.debug(
+                    "Skipping Spring AI TOOL message on load; not mappable to a Koog message type"
+                )
+                null
+            }
         }
     }
 }

--- a/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/main/kotlin/ai/koog/spring/ai/memory/SpringAiChatHistoryProvider.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/main/kotlin/ai/koog/spring/ai/memory/SpringAiChatHistoryProvider.kt
@@ -1,0 +1,118 @@
+package ai.koog.spring.ai.memory
+
+import ai.koog.agents.chatMemory.feature.ChatHistoryProvider
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.RequestMetaInfo
+import ai.koog.prompt.message.ResponseMetaInfo
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.slf4j.LoggerFactory
+import org.springframework.ai.chat.memory.ChatMemoryRepository
+import org.springframework.ai.chat.messages.AssistantMessage
+import org.springframework.ai.chat.messages.MessageType
+import org.springframework.ai.chat.messages.SystemMessage
+import org.springframework.ai.chat.messages.UserMessage
+import org.springframework.ai.chat.messages.Message as SpringMessage
+
+/**
+ * A **conversation text memory** bridge between a Spring AI [ChatMemoryRepository] and a Koog [ChatHistoryProvider].
+ *
+ * This adapter targets repositories that persist only Spring AI `messageType` and `text`
+ * (e.g., `JdbcChatMemoryRepository`). It is **not** a lossless Koog persistence adapter —
+ * only plain-text conversational messages survive the round-trip.
+ *
+ * ### Persistable message types (text-only)
+ * - [Message.System]
+ * - [Message.User] (without attachments)
+ * - [Message.Assistant] (without attachments)
+ *
+ * ### Silently dropped on store
+ * The following Koog message types are non-persistable transport/runtime events and are
+ * filtered out before delegation to the underlying [ChatMemoryRepository]:
+ * - [Message.Tool.Call]
+ * - [Message.Tool.Result]
+ * - [Message.Reasoning]
+ * - Any message carrying attachments (images, audio, video, files)
+ *
+ * ### Silently skipped on load
+ * Spring AI `TOOL` rows (e.g., from JDBC repositories that previously stored tool traffic)
+ * are skipped rather than causing an error, since they cannot be meaningfully mapped back
+ * to Koog messages.
+ *
+ * Metadata fields such as timestamps, token counts, finish reasons, and custom metadata
+ * are **not** preserved through the round-trip.
+ *
+ * @param repository the Spring AI [ChatMemoryRepository] to delegate to
+ * @param dispatcher the [CoroutineDispatcher] used for blocking repository calls
+ */
+public class SpringAiChatHistoryProvider(
+    private val repository: ChatMemoryRepository,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : ChatHistoryProvider {
+
+    private val logger = LoggerFactory.getLogger(SpringAiChatHistoryProvider::class.java)
+
+    override suspend fun store(conversationId: String, messages: List<Message>) {
+        val springMessages = messages.mapNotNull { filterAndConvert(it) }
+        withContext(dispatcher) {
+            repository.saveAll(conversationId, springMessages)
+        }
+    }
+
+    override suspend fun load(conversationId: String): List<Message> {
+        val springMessages = withContext(dispatcher) {
+            repository.findByConversationId(conversationId)
+        }
+        return springMessages.mapNotNull { springMessageToKoogMessage(it) }
+    }
+
+    /**
+     * Returns a Spring AI message for persistable Koog messages, or `null` for
+     * non-persistable types (tool calls/results, reasoning, attachments).
+     */
+    private fun filterAndConvert(message: Message): SpringMessage? {
+        if (message.hasAttachments()) {
+            logger.debug(
+                "Dropping Koog message with attachments (type={}); not persistable via Spring AI ChatMemoryRepository",
+                message::class.simpleName
+            )
+            return null
+        }
+        return when (message) {
+            is Message.System -> SystemMessage(message.content)
+            is Message.User -> UserMessage(message.content)
+            is Message.Assistant -> AssistantMessage(message.content)
+            is Message.Tool.Call,
+            is Message.Tool.Result,
+            is Message.Reasoning -> {
+                logger.debug(
+                    "Dropping non-persistable Koog message (type={}); only System, User, and Assistant text messages are stored",
+                    message::class.simpleName
+                )
+                null
+            }
+        }
+    }
+}
+
+/**
+ * Converts a Spring AI [SpringMessage] to a Koog [Message].
+ *
+ * Only SYSTEM, USER, and ASSISTANT message types are mapped.
+ * TOOL messages are skipped (returns `null`) because typical repositories
+ * (e.g., JDBC) cannot round-trip them with usable payload.
+ */
+internal fun springMessageToKoogMessage(springMessage: SpringMessage): Message? {
+    return when (springMessage.messageType) {
+        MessageType.SYSTEM -> Message.System(springMessage.text ?: "", RequestMetaInfo.Empty)
+        MessageType.USER -> Message.User(springMessage.text ?: "", RequestMetaInfo.Empty)
+        MessageType.ASSISTANT -> Message.Assistant(springMessage.text ?: "", ResponseMetaInfo.Empty)
+        MessageType.TOOL -> {
+            LoggerFactory.getLogger(SpringAiChatHistoryProvider::class.java).debug(
+                "Skipping Spring AI TOOL message on load; not mappable to a Koog message type"
+            )
+            null
+        }
+    }
+}

--- a/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/main/kotlin/ai/koog/spring/ai/memory/SpringAiChatMemoryAutoConfiguration.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/main/kotlin/ai/koog/spring/ai/memory/SpringAiChatMemoryAutoConfiguration.kt
@@ -1,14 +1,14 @@
 package ai.koog.spring.ai.memory
 
 import ai.koog.agents.chatMemory.feature.ChatHistoryProvider
-import ai.koog.spring.ai.common.DispatcherType
+import ai.koog.spring.ai.common.DispatcherProperties
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher
 import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.memory.ChatMemoryRepository
 import org.springframework.beans.factory.BeanFactory
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
@@ -19,7 +19,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.task.AsyncTaskExecutor
-import org.springframework.lang.Nullable
 
 /**
  * Auto-configuration for the Koog Spring AI Chat Memory adapter.
@@ -60,10 +59,11 @@ public open class SpringAiChatMemoryAutoConfiguration {
     @ConditionalOnMissingBean(name = ["koogSpringAiChatMemoryDispatcher"])
     public open fun koogSpringAiChatMemoryDispatcher(
         properties: KoogSpringAiChatMemoryProperties,
-        @Autowired(required = false) @Qualifier("applicationTaskExecutor") @Nullable asyncTaskExecutor: AsyncTaskExecutor?,
+        @Qualifier("applicationTaskExecutor") asyncTaskExecutorProvider: ObjectProvider<AsyncTaskExecutor>,
     ): CoroutineDispatcher {
-        return when (properties.dispatcher.type) {
-            DispatcherType.AUTO -> {
+        val asyncTaskExecutor = asyncTaskExecutorProvider.ifAvailable
+        return when (val dispatcher = properties.dispatcher.toDispatcherProperties()) {
+            is DispatcherProperties.Auto -> {
                 if (asyncTaskExecutor != null) {
                     logger.info("Koog Spring AI Chat Memory: using Spring AsyncTaskExecutor as dispatcher")
                     asyncTaskExecutor.asCoroutineDispatcher()
@@ -73,9 +73,9 @@ public open class SpringAiChatMemoryAutoConfiguration {
                 }
             }
 
-            DispatcherType.IO -> {
-                val parallelism = properties.dispatcher.parallelism
-                if (parallelism > 0) {
+            is DispatcherProperties.IO -> {
+                val parallelism = dispatcher.parallelism
+                if (parallelism != null && parallelism > 0) {
                     logger.info("Koog Spring AI Chat Memory: using Dispatchers.IO.limitedParallelism($parallelism)")
                     Dispatchers.IO.limitedParallelism(parallelism)
                 } else {
@@ -87,12 +87,14 @@ public open class SpringAiChatMemoryAutoConfiguration {
     }
 
     /**
-     * Repository configuration — activated when a bean-name selector is provided.
+     * Chat memory repository configuration — activated when a bean-name selector property is provided.
+     *
+     * Resolves the [ChatMemoryRepository] from the application context by the configured bean name.
      */
-    @Configuration
+    @Configuration(proxyBeanMethods = false)
     @ConditionalOnProperty(prefix = "koog.spring.ai.chat-memory", name = ["chat-memory-repository-bean-name"])
-    public open class NamedRepositoryConfiguration {
-        private val logger = LoggerFactory.getLogger(NamedRepositoryConfiguration::class.java)
+    public open class NamedChatMemoryRepositoryConfiguration {
+        private val logger = LoggerFactory.getLogger(NamedChatMemoryRepositoryConfiguration::class.java)
 
         @Bean
         @ConditionalOnMissingBean(ChatHistoryProvider::class)
@@ -103,26 +105,42 @@ public open class SpringAiChatMemoryAutoConfiguration {
         ): ChatHistoryProvider {
             val beanName = properties.chatMemoryRepositoryBeanName!!
             logger.info("Koog Spring AI Chat Memory: resolving ChatMemoryRepository bean by name='$beanName' (text-only conversation memory)")
-            val repository = beanFactory.getBean(beanName, ChatMemoryRepository::class.java)
-            return SpringAiChatHistoryProvider(repository = repository, dispatcher = dispatcher)
+            val repo = beanFactory.getBean(beanName, ChatMemoryRepository::class.java)
+            return SpringAiChatHistoryProvider(repository = repo, dispatcher = dispatcher)
         }
     }
 
     /**
-     * Repository configuration — activated when no bean-name selector is set and a single ChatMemoryRepository candidate exists.
+     * Chat memory repository configuration — activated when no bean-name selector is set
+     * and a single [ChatMemoryRepository] candidate exists.
+     *
+     * This is the default fallback path. It is mutually exclusive with [NamedChatMemoryRepositoryConfiguration] for
+     * the common cases:
+     * - selector absent → `matchIfMissing = true` activates this config; [NamedChatMemoryRepositoryConfiguration] does not match
+     * - selector non-empty (e.g. `"myBean"`) → [NamedChatMemoryRepositoryConfiguration] matches; `havingValue = ""` does not
+     *   match a non-empty value, so this config does not activate
+     * - selector set to literal `""` → both configs activate (Spring treats `""` as a present value that satisfies
+     *   both `havingValue = ""` and the plain `@ConditionalOnProperty` on the named path); the named path then
+     *   attempts `beanFactory.getBean("", ChatMemoryRepository::class.java)` which fails at startup
      */
-    @Configuration
-    @ConditionalOnMissingBean(ChatHistoryProvider::class)
+    @Configuration(proxyBeanMethods = false)
     @ConditionalOnSingleCandidate(ChatMemoryRepository::class)
-    public open class SingleRepositoryConfiguration {
-        private val logger = LoggerFactory.getLogger(SingleRepositoryConfiguration::class.java)
+    @ConditionalOnProperty(
+        prefix = "koog.spring.ai.chat-memory",
+        name = ["chat-memory-repository-bean-name"],
+        havingValue = "",
+        matchIfMissing = true
+    )
+    public open class SingleChatMemoryRepositoryConfiguration {
+        private val logger = LoggerFactory.getLogger(SingleChatMemoryRepositoryConfiguration::class.java)
 
         @Bean
+        @ConditionalOnMissingBean(ChatHistoryProvider::class)
         public open fun springAiChatHistoryProvider(
             repository: ChatMemoryRepository,
             @Qualifier("koogSpringAiChatMemoryDispatcher") dispatcher: CoroutineDispatcher,
         ): ChatHistoryProvider {
-            logger.info("Koog Spring AI Chat Memory: creating text-only ChatHistoryProvider backed by single ChatMemoryRepository")
+            logger.info("Koog Spring AI Chat Memory: using single ChatMemoryRepository candidate as ChatHistoryProvider backend")
             return SpringAiChatHistoryProvider(repository = repository, dispatcher = dispatcher)
         }
     }

--- a/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/main/kotlin/ai/koog/spring/ai/memory/SpringAiChatMemoryAutoConfiguration.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/main/kotlin/ai/koog/spring/ai/memory/SpringAiChatMemoryAutoConfiguration.kt
@@ -1,0 +1,129 @@
+package ai.koog.spring.ai.memory
+
+import ai.koog.agents.chatMemory.feature.ChatHistoryProvider
+import ai.koog.spring.ai.common.DispatcherType
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
+import org.slf4j.LoggerFactory
+import org.springframework.ai.chat.memory.ChatMemoryRepository
+import org.springframework.beans.factory.BeanFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.task.AsyncTaskExecutor
+import org.springframework.lang.Nullable
+
+/**
+ * Auto-configuration for the Koog Spring AI Chat Memory adapter.
+ *
+ * This configuration:
+ * - Binds [KoogSpringAiChatMemoryProperties] under `koog.spring.ai.chat-memory.*`.
+ * - Creates a [ChatHistoryProvider] backed by a Spring AI [ChatMemoryRepository] when available.
+ * - Supports multi-repository contexts via property-based bean-name selection.
+ * - Provides an injectable [CoroutineDispatcher] for blocking repository calls.
+ *
+ * Gated by `koog.spring.ai.chat-memory.enabled=true` (default).
+ */
+@AutoConfiguration(
+    afterName = [
+        "org.springframework.ai.model.chat.memory.repository.cassandra.autoconfigure.CassandraChatMemoryRepositoryAutoConfiguration",
+        "org.springframework.ai.model.chat.memory.repository.cosmosdb.autoconfigure.CosmosDBChatMemoryRepositoryAutoConfiguration",
+        "org.springframework.ai.model.chat.memory.repository.jdbc.autoconfigure.JdbcChatMemoryRepositoryAutoConfiguration",
+        "org.springframework.ai.model.chat.memory.repository.neo4j.autoconfigure.Neo4jChatMemoryRepositoryAutoConfiguration",
+        "org.springframework.ai.model.chat.memory.repository.mongo.autoconfigure.MongoChatMemoryAutoConfiguration"
+    ]
+)
+@EnableConfigurationProperties(KoogSpringAiChatMemoryProperties::class)
+@ConditionalOnClass(ChatMemoryRepository::class)
+@ConditionalOnProperty(
+    prefix = "koog.spring.ai.chat-memory",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true
+)
+public open class SpringAiChatMemoryAutoConfiguration {
+
+    private val logger = LoggerFactory.getLogger(SpringAiChatMemoryAutoConfiguration::class.java)
+
+    /**
+     * Creates a [CoroutineDispatcher] for blocking Spring AI chat memory repository calls.
+     */
+    @Bean
+    @ConditionalOnMissingBean(name = ["koogSpringAiChatMemoryDispatcher"])
+    public open fun koogSpringAiChatMemoryDispatcher(
+        properties: KoogSpringAiChatMemoryProperties,
+        @Autowired(required = false) @Qualifier("applicationTaskExecutor") @Nullable asyncTaskExecutor: AsyncTaskExecutor?,
+    ): CoroutineDispatcher {
+        return when (properties.dispatcher.type) {
+            DispatcherType.AUTO -> {
+                if (asyncTaskExecutor != null) {
+                    logger.info("Koog Spring AI Chat Memory: using Spring AsyncTaskExecutor as dispatcher")
+                    asyncTaskExecutor.asCoroutineDispatcher()
+                } else {
+                    logger.info("Koog Spring AI Chat Memory: no AsyncTaskExecutor found, falling back to Dispatchers.IO")
+                    Dispatchers.IO
+                }
+            }
+
+            DispatcherType.IO -> {
+                val parallelism = properties.dispatcher.parallelism
+                if (parallelism > 0) {
+                    logger.info("Koog Spring AI Chat Memory: using Dispatchers.IO.limitedParallelism($parallelism)")
+                    Dispatchers.IO.limitedParallelism(parallelism)
+                } else {
+                    logger.info("Koog Spring AI Chat Memory: using Dispatchers.IO")
+                    Dispatchers.IO
+                }
+            }
+        }
+    }
+
+    /**
+     * Repository configuration — activated when a bean-name selector is provided.
+     */
+    @Configuration
+    @ConditionalOnProperty(prefix = "koog.spring.ai.chat-memory", name = ["chat-memory-repository-bean-name"])
+    public open class NamedRepositoryConfiguration {
+        private val logger = LoggerFactory.getLogger(NamedRepositoryConfiguration::class.java)
+
+        @Bean
+        @ConditionalOnMissingBean(ChatHistoryProvider::class)
+        public open fun springAiChatHistoryProvider(
+            beanFactory: BeanFactory,
+            properties: KoogSpringAiChatMemoryProperties,
+            @Qualifier("koogSpringAiChatMemoryDispatcher") dispatcher: CoroutineDispatcher,
+        ): ChatHistoryProvider {
+            val beanName = properties.chatMemoryRepositoryBeanName!!
+            logger.info("Koog Spring AI Chat Memory: resolving ChatMemoryRepository bean by name='$beanName' (text-only conversation memory)")
+            val repository = beanFactory.getBean(beanName, ChatMemoryRepository::class.java)
+            return SpringAiChatHistoryProvider(repository = repository, dispatcher = dispatcher)
+        }
+    }
+
+    /**
+     * Repository configuration — activated when no bean-name selector is set and a single ChatMemoryRepository candidate exists.
+     */
+    @Configuration
+    @ConditionalOnMissingBean(ChatHistoryProvider::class)
+    @ConditionalOnSingleCandidate(ChatMemoryRepository::class)
+    public open class SingleRepositoryConfiguration {
+        private val logger = LoggerFactory.getLogger(SingleRepositoryConfiguration::class.java)
+
+        @Bean
+        public open fun springAiChatHistoryProvider(
+            repository: ChatMemoryRepository,
+            @Qualifier("koogSpringAiChatMemoryDispatcher") dispatcher: CoroutineDispatcher,
+        ): ChatHistoryProvider {
+            logger.info("Koog Spring AI Chat Memory: creating text-only ChatHistoryProvider backed by single ChatMemoryRepository")
+            return SpringAiChatHistoryProvider(repository = repository, dispatcher = dispatcher)
+        }
+    }
+}

--- a/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+ai.koog.spring.ai.memory.SpringAiChatMemoryAutoConfiguration

--- a/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/test/kotlin/ai/koog/spring/ai/memory/SpringAiChatHistoryProviderTest.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/test/kotlin/ai/koog/spring/ai/memory/SpringAiChatHistoryProviderTest.kt
@@ -1,0 +1,197 @@
+package ai.koog.spring.ai.memory
+
+import ai.koog.prompt.message.AttachmentContent
+import ai.koog.prompt.message.ContentPart
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.RequestMetaInfo
+import ai.koog.prompt.message.ResponseMetaInfo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository
+import org.springframework.ai.chat.messages.MessageType
+import org.springframework.ai.chat.messages.ToolResponseMessage
+
+class SpringAiChatHistoryProviderTest {
+
+    private lateinit var repository: InMemoryChatMemoryRepository
+    private lateinit var adapter: SpringAiChatHistoryProvider
+
+    @BeforeEach
+    fun setUp() {
+        repository = InMemoryChatMemoryRepository()
+        adapter = SpringAiChatHistoryProvider(
+            repository = repository,
+            dispatcher = Dispatchers.Unconfined
+        )
+    }
+
+    // --- Passing tests: text round-trip ---
+
+    @Test
+    fun testSystemUserAssistantTextRoundTrip() = runTest {
+        val conversationId = "conv-1"
+        val messages = listOf(
+            Message.System("You are a helpful assistant.", RequestMetaInfo.Empty),
+            Message.User("Hello!", RequestMetaInfo.Empty),
+            Message.Assistant("Hi there! How can I help you?", ResponseMetaInfo.Empty)
+        )
+
+        adapter.store(conversationId, messages)
+        val loaded = adapter.load(conversationId)
+
+        assertEquals(3, loaded.size)
+
+        val system = loaded[0] as Message.System
+        assertEquals("You are a helpful assistant.", system.content)
+
+        val user = loaded[1] as Message.User
+        assertEquals("Hello!", user.content)
+
+        val assistant = loaded[2] as Message.Assistant
+        assertEquals("Hi there! How can I help you?", assistant.content)
+    }
+
+    @Test
+    fun testEmptyConversation() = runTest {
+        val result = adapter.load("unknown-conversation")
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun testStoreEmptyListClearsConversation() = runTest {
+        adapter.store("conv-clear", listOf(Message.User("Hello", RequestMetaInfo.Empty)))
+        adapter.store("conv-clear", emptyList())
+
+        val loaded = adapter.load("conv-clear")
+        assertTrue(loaded.isEmpty())
+    }
+
+    @Test
+    fun testMultipleConversationsAreIsolated() = runTest {
+        adapter.store("conv-a", listOf(Message.User("Hello from A", RequestMetaInfo.Empty)))
+        adapter.store("conv-b", listOf(Message.User("Hello from B", RequestMetaInfo.Empty)))
+
+        val loadedA = adapter.load("conv-a")
+        val loadedB = adapter.load("conv-b")
+
+        assertEquals(1, loadedA.size)
+        assertEquals("Hello from A", loadedA[0].content)
+        assertEquals(1, loadedB.size)
+        assertEquals("Hello from B", loadedB[0].content)
+    }
+
+    @Test
+    fun testOverwriteSemantics() = runTest {
+        val conversationId = "conv-overwrite"
+
+        adapter.store(conversationId, listOf(Message.User("First", RequestMetaInfo.Empty)))
+        adapter.store(conversationId, listOf(Message.User("Second", RequestMetaInfo.Empty)))
+
+        val loaded = adapter.load(conversationId)
+        assertEquals(1, loaded.size)
+        assertEquals("Second", loaded[0].content)
+    }
+
+    // --- Filtering tests: non-persistable messages are silently dropped on store ---
+
+    @Test
+    fun testToolCallMessageIsFilteredOnStore() = runTest {
+        val messages = listOf(
+            Message.User("Hello", RequestMetaInfo.Empty),
+            Message.Tool.Call(
+                id = "call-1",
+                tool = "getWeather",
+                content = """{"city":"London"}""",
+                metaInfo = ResponseMetaInfo.Empty
+            ),
+            Message.Tool.Result(
+                id = "call-1",
+                tool = "getWeather",
+                content = """{"temp":15}""",
+                metaInfo = RequestMetaInfo.Empty
+            ),
+            Message.Assistant("The weather is 15°C.", ResponseMetaInfo.Empty)
+        )
+
+        adapter.store("conv-tools", messages)
+        val loaded = adapter.load("conv-tools")
+
+        assertEquals(2, loaded.size)
+        assertEquals("Hello", loaded[0].content)
+        assertEquals("The weather is 15°C.", loaded[1].content)
+    }
+
+    @Test
+    fun testReasoningMessageIsFilteredOnStore() = runTest {
+        val messages = listOf(
+            Message.User("Explain quantum computing", RequestMetaInfo.Empty),
+            Message.Reasoning(
+                content = "Let me think step by step...",
+                metaInfo = ResponseMetaInfo.Empty
+            ),
+            Message.Assistant("Quantum computing uses qubits.", ResponseMetaInfo.Empty)
+        )
+
+        adapter.store("conv-reasoning", messages)
+        val loaded = adapter.load("conv-reasoning")
+
+        assertEquals(2, loaded.size)
+        assertEquals("Explain quantum computing", loaded[0].content)
+        assertEquals("Quantum computing uses qubits.", loaded[1].content)
+    }
+
+    @Test
+    fun testMessageWithAttachmentsIsFilteredOnStore() = runTest {
+        val imageContent = AttachmentContent.URL("https://example.com/image.png")
+        val messages = listOf(
+            Message.User(
+                parts = listOf(
+                    ContentPart.Text("Look at this"),
+                    ContentPart.Image(content = imageContent, format = "png")
+                ),
+                metaInfo = RequestMetaInfo.Empty
+            ),
+            Message.Assistant("I see an image.", ResponseMetaInfo.Empty)
+        )
+
+        adapter.store("conv-attachments", messages)
+        val loaded = adapter.load("conv-attachments")
+
+        assertEquals(1, loaded.size)
+        assertEquals("I see an image.", loaded[0].content)
+    }
+
+    @Test
+    fun testAllNonPersistableMessagesFilteredLeavesOnlyTextMessages() = runTest {
+        val messages = listOf(
+            Message.Tool.Call(id = "c1", tool = "t", content = "{}", metaInfo = ResponseMetaInfo.Empty),
+            Message.Tool.Result(id = "c1", tool = "t", content = "{}", metaInfo = RequestMetaInfo.Empty),
+            Message.Reasoning(content = "thinking", metaInfo = ResponseMetaInfo.Empty),
+        )
+
+        adapter.store("conv-all-filtered", messages)
+        val loaded = adapter.load("conv-all-filtered")
+
+        assertTrue(loaded.isEmpty())
+    }
+
+    // --- Load tests: Spring TOOL messages are skipped ---
+
+    @Test
+    fun testSpringToolMessageIsSkippedOnLoad() {
+        val toolResponse = ToolResponseMessage.ToolResponse("id-1", "search", "result")
+        val toolMessage = ToolResponseMessage.builder()
+            .responses(listOf(toolResponse))
+            .build()
+
+        assertEquals(MessageType.TOOL, toolMessage.messageType)
+
+        val result = springMessageToKoogMessage(toolMessage)
+        assertNull(result, "TOOL messages should be skipped (return null) on load")
+    }
+}

--- a/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/test/kotlin/ai/koog/spring/ai/memory/SpringAiChatHistoryProviderTest.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/test/kotlin/ai/koog/spring/ai/memory/SpringAiChatHistoryProviderTest.kt
@@ -8,12 +8,10 @@ import ai.koog.prompt.message.ResponseMetaInfo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.ai.chat.memory.InMemoryChatMemoryRepository
-import org.springframework.ai.chat.messages.MessageType
 import org.springframework.ai.chat.messages.ToolResponseMessage
 
 class SpringAiChatHistoryProviderTest {
@@ -30,7 +28,7 @@ class SpringAiChatHistoryProviderTest {
         )
     }
 
-    // --- Passing tests: text round-trip ---
+    // region Passing tests: text round-trip
 
     @Test
     fun testSystemUserAssistantTextRoundTrip() = runTest {
@@ -97,7 +95,8 @@ class SpringAiChatHistoryProviderTest {
         assertEquals("Second", loaded[0].content)
     }
 
-    // --- Filtering tests: non-persistable messages are silently dropped on store ---
+    // endregion
+    // region Filtering tests: non-persistable messages are silently dropped on store
 
     @Test
     fun testToolCallMessageIsFilteredOnStore() = runTest {
@@ -180,18 +179,22 @@ class SpringAiChatHistoryProviderTest {
         assertTrue(loaded.isEmpty())
     }
 
-    // --- Load tests: Spring TOOL messages are skipped ---
+    // region Load tests: Spring TOOL messages are skipped
 
     @Test
-    fun testSpringToolMessageIsSkippedOnLoad() {
+    fun testSpringToolMessageIsSkippedOnLoad() = runTest {
+        val conversationId = "conv-tool-skip"
         val toolResponse = ToolResponseMessage.ToolResponse("id-1", "search", "result")
         val toolMessage = ToolResponseMessage.builder()
             .responses(listOf(toolResponse))
             .build()
 
-        assertEquals(MessageType.TOOL, toolMessage.messageType)
+        // Inject a TOOL message directly into the repository, bypassing the store filter
+        repository.saveAll(conversationId, listOf(toolMessage))
 
-        val result = springMessageToKoogMessage(toolMessage)
-        assertNull(result, "TOOL messages should be skipped (return null) on load")
+        val loaded = adapter.load(conversationId)
+        assertTrue(loaded.isEmpty(), "TOOL messages should be skipped on load")
     }
+
+    // endregion
 }

--- a/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/test/kotlin/ai/koog/spring/ai/memory/SpringAiChatMemoryAutoConfigurationTest.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/test/kotlin/ai/koog/spring/ai/memory/SpringAiChatMemoryAutoConfigurationTest.kt
@@ -1,0 +1,155 @@
+package ai.koog.spring.ai.memory
+
+import ai.koog.agents.chatMemory.feature.ChatHistoryProvider
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineDispatcher
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertInstanceOf
+import org.junit.jupiter.api.assertThrows
+import org.springframework.ai.chat.memory.ChatMemoryRepository
+import org.springframework.beans.factory.NoSuchBeanDefinitionException
+import org.springframework.beans.factory.getBean
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.core.task.AsyncTaskExecutor
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SpringAiChatMemoryAutoConfigurationTest {
+
+    private fun contextRunner(): ApplicationContextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                SpringAiChatMemoryAutoConfiguration::class.java,
+            )
+        )
+
+    // ---- enabled / disabled ----
+
+    @Test
+    fun `should create dispatcher when enabled by default`() {
+        contextRunner()
+            .run { context ->
+                assertNotNull(context.getBean("koogSpringAiChatMemoryDispatcher"))
+            }
+    }
+
+    @Test
+    fun `should not create any beans when disabled`() {
+        contextRunner()
+            .withPropertyValues("koog.spring.ai.chat-memory.enabled=false")
+            .withBean(ChatMemoryRepository::class.java, { mockk<ChatMemoryRepository>(relaxed = true) })
+            .run { context ->
+                assertThrows<NoSuchBeanDefinitionException> { context.getBean<ChatHistoryProvider>() }
+                assertThrows<NoSuchBeanDefinitionException> { context.getBean("koogSpringAiChatMemoryDispatcher") }
+            }
+    }
+
+    // ---- single repository ----
+
+    @Test
+    fun `should create ChatHistoryProvider when single ChatMemoryRepository is present`() {
+        contextRunner()
+            .withBean(ChatMemoryRepository::class.java, { mockk<ChatMemoryRepository>(relaxed = true) })
+            .run { context ->
+                val provider = context.getBean<ChatHistoryProvider>()
+                assertInstanceOf<SpringAiChatHistoryProvider>(provider)
+            }
+    }
+
+    @Test
+    fun `should not create ChatHistoryProvider when no ChatMemoryRepository is present`() {
+        contextRunner()
+            .run { context ->
+                assertThrows<NoSuchBeanDefinitionException> { context.getBean<ChatHistoryProvider>() }
+            }
+    }
+
+    // ---- user-supplied ChatHistoryProvider ----
+
+    @Test
+    fun `should not create ChatHistoryProvider when user provides one`() {
+        val userProvider = mockk<ChatHistoryProvider>(relaxed = true)
+        contextRunner()
+            .withBean(ChatMemoryRepository::class.java, { mockk<ChatMemoryRepository>(relaxed = true) })
+            .withBean(ChatHistoryProvider::class.java, { userProvider })
+            .run { context ->
+                val provider = context.getBean<ChatHistoryProvider>()
+                assertSame(userProvider, provider)
+            }
+    }
+
+    // ---- multiple repositories without selector ----
+
+    @Test
+    fun `should not create ChatHistoryProvider when multiple repositories exist without selector`() {
+        contextRunner()
+            .withBean("repo1", ChatMemoryRepository::class.java, { mockk<ChatMemoryRepository>(relaxed = true) })
+            .withBean("repo2", ChatMemoryRepository::class.java, { mockk<ChatMemoryRepository>(relaxed = true) })
+            .run { context ->
+                assertThrows<NoSuchBeanDefinitionException> { context.getBean<ChatHistoryProvider>() }
+            }
+    }
+
+    // ---- named repository selection ----
+
+    @Test
+    fun `should resolve ChatMemoryRepository by bean name when configured`() {
+        contextRunner()
+            .withPropertyValues("koog.spring.ai.chat-memory.chat-memory-repository-bean-name=myRepo")
+            .withBean("myRepo", ChatMemoryRepository::class.java, { mockk<ChatMemoryRepository>(relaxed = true) })
+            .withBean("otherRepo", ChatMemoryRepository::class.java, { mockk<ChatMemoryRepository>(relaxed = true) })
+            .run { context ->
+                val provider = context.getBean<ChatHistoryProvider>()
+                assertInstanceOf<SpringAiChatHistoryProvider>(provider)
+            }
+    }
+
+    @Test
+    fun `should fail when named repository bean does not exist`() {
+        contextRunner()
+            .withPropertyValues("koog.spring.ai.chat-memory.chat-memory-repository-bean-name=nonExistent")
+            .withBean("realRepo", ChatMemoryRepository::class.java, { mockk<ChatMemoryRepository>(relaxed = true) })
+            .run { context ->
+                assertTrue(context.startupFailure != null)
+                val rootCause = generateSequence(context.startupFailure) { it.cause }.last()
+                assertInstanceOf<NoSuchBeanDefinitionException>(rootCause)
+            }
+    }
+
+    // ---- dispatcher override ----
+
+    @Test
+    fun `should use AsyncTaskExecutor as dispatcher when available`() {
+        val executor = mockk<AsyncTaskExecutor>(relaxed = true)
+        contextRunner()
+            .withBean("applicationTaskExecutor", AsyncTaskExecutor::class.java, { executor })
+            .run { context ->
+                val dispatcher = context.getBean("koogSpringAiChatMemoryDispatcher")
+                assertInstanceOf<kotlinx.coroutines.ExecutorCoroutineDispatcher>(dispatcher)
+            }
+    }
+
+    @Test
+    fun `should fall back to Dispatchers IO when no AsyncTaskExecutor`() {
+        contextRunner()
+            .run { context ->
+                val dispatcher = context.getBean("koogSpringAiChatMemoryDispatcher") as CoroutineDispatcher
+                assertSame(kotlinx.coroutines.Dispatchers.IO, dispatcher)
+            }
+    }
+
+    @Test
+    fun `should not override user-provided dispatcher`() {
+        val customDispatcher = kotlinx.coroutines.Dispatchers.Unconfined
+        contextRunner()
+            .withBean("koogSpringAiChatMemoryDispatcher", CoroutineDispatcher::class.java, { customDispatcher })
+            .run { context ->
+                val dispatcher = context.getBean("koogSpringAiChatMemoryDispatcher") as CoroutineDispatcher
+                assertSame(customDispatcher, dispatcher)
+            }
+    }
+}

--- a/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/test/kotlin/ai/koog/spring/ai/memory/SpringAiChatMemoryAutoConfigurationTest.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/test/kotlin/ai/koog/spring/ai/memory/SpringAiChatMemoryAutoConfigurationTest.kt
@@ -90,7 +90,73 @@ class SpringAiChatMemoryAutoConfigurationTest {
             .withBean("repo1", ChatMemoryRepository::class.java, { mockk<ChatMemoryRepository>(relaxed = true) })
             .withBean("repo2", ChatMemoryRepository::class.java, { mockk<ChatMemoryRepository>(relaxed = true) })
             .run { context ->
+                assertTrue(context.startupFailure == null, "Context should start without failure")
                 assertThrows<NoSuchBeanDefinitionException> { context.getBean<ChatHistoryProvider>() }
+            }
+    }
+
+    @Test
+    fun `should use named config only when single ChatMemoryRepository and selector property are both set`() {
+        val myRepo = mockk<ChatMemoryRepository>(relaxed = true)
+        contextRunner()
+            .withPropertyValues("koog.spring.ai.chat-memory.chat-memory-repository-bean-name=myRepo")
+            .withBean("myRepo", ChatMemoryRepository::class.java, { myRepo })
+            .run { context ->
+                assertTrue(context.startupFailure == null, "Context should start without failure")
+                val provider = context.getBean<ChatHistoryProvider>()
+                assertInstanceOf<SpringAiChatHistoryProvider>(provider)
+                // Only one ChatHistoryProvider bean — no duplicate
+                assertTrue(context.getBeansOfType(ChatHistoryProvider::class.java).size == 1)
+            }
+    }
+
+    // ---- mutual exclusion: single candidate + selector set ----
+    @Test
+    fun `should create exactly one ChatHistoryProvider using named path when single repo and selector are both set`() {
+        val myRepo = mockk<ChatMemoryRepository>(relaxed = true)
+        contextRunner()
+            .withPropertyValues("koog.spring.ai.chat-memory.chat-memory-repository-bean-name=myRepo")
+            .withBean("myRepo", ChatMemoryRepository::class.java, { myRepo })
+            .run { context ->
+                assertTrue(context.startupFailure == null, "Context should start without failure")
+                val providers = context.getBeansOfType(ChatHistoryProvider::class.java)
+                assertTrue(providers.size == 1, "Expected exactly one ChatHistoryProvider, got ${providers.size}")
+                val provider = providers.values.single()
+                assertInstanceOf<SpringAiChatHistoryProvider>(provider)
+                assertSame(myRepo, provider.repository)
+            }
+    }
+
+    // ---- mutual exclusion: multiple candidates + no selector ----
+    @Test
+    fun `should not create ChatHistoryProvider and not fail when multiple repos exist and no selector is set`() {
+        contextRunner()
+            .withBean("repo1", ChatMemoryRepository::class.java, { mockk<ChatMemoryRepository>(relaxed = true) })
+            .withBean("repo2", ChatMemoryRepository::class.java, { mockk<ChatMemoryRepository>(relaxed = true) })
+            .run { context ->
+                assertTrue(context.startupFailure == null, "Context should start without failure")
+                assertTrue(
+                    context.getBeansOfType(ChatHistoryProvider::class.java).isEmpty(),
+                    "Expected no ChatHistoryProvider when multiple repos exist and no selector is set"
+                )
+            }
+    }
+
+    // ---- mutual exclusion: selector set to empty string ----
+    @Test
+    fun `should fail on startup when selector is set to empty string because named path activates with empty bean name`() {
+        contextRunner()
+            .withPropertyValues("koog.spring.ai.chat-memory.chat-memory-repository-bean-name=")
+            .withBean("myRepo", ChatMemoryRepository::class.java, { mockk<ChatMemoryRepository>(relaxed = true) })
+            .run { context ->
+                // Spring treats "" as a present value equal to "", so havingValue="" on SingleChatMemoryRepositoryConfiguration
+                // matches (the condition passes), AND the plain @ConditionalOnProperty on NamedChatMemoryRepositoryConfiguration
+                // also matches (any non-false present value satisfies it). Both configs activate; the named path
+                // then calls beanFactory.getBean("", ChatMemoryRepository::class.java) with an empty name, which fails.
+                assertTrue(
+                    context.startupFailure != null,
+                    "Expected startup failure when selector is set to empty string"
+                )
             }
     }
 
@@ -98,13 +164,14 @@ class SpringAiChatMemoryAutoConfigurationTest {
 
     @Test
     fun `should resolve ChatMemoryRepository by bean name when configured`() {
+        val myRepo = mockk<ChatMemoryRepository>(relaxed = true)
         contextRunner()
             .withPropertyValues("koog.spring.ai.chat-memory.chat-memory-repository-bean-name=myRepo")
-            .withBean("myRepo", ChatMemoryRepository::class.java, { mockk<ChatMemoryRepository>(relaxed = true) })
+            .withBean("myRepo", ChatMemoryRepository::class.java, { myRepo })
             .withBean("otherRepo", ChatMemoryRepository::class.java, { mockk<ChatMemoryRepository>(relaxed = true) })
             .run { context ->
-                val provider = context.getBean<ChatHistoryProvider>()
-                assertInstanceOf<SpringAiChatHistoryProvider>(provider)
+                val provider = assertInstanceOf<SpringAiChatHistoryProvider>(context.getBean<ChatHistoryProvider>())
+                assertSame(myRepo, provider.repository)
             }
     }
 

--- a/koog-spring-ai/koog-spring-ai-starter-model-chat/build.gradle.kts
+++ b/koog-spring-ai/koog-spring-ai-starter-model-chat/build.gradle.kts
@@ -25,6 +25,7 @@ tasks.withType<JavaCompile>().configureEach {
     options.compilerArgs.add("-parameters")
 }
 dependencies {
+    api(project(":koog-spring-ai:koog-spring-ai-common"))
     api(project(":prompt:prompt-executor:prompt-executor-clients"))
     api(project(":prompt:prompt-executor:prompt-executor-model"))
     implementation(project.dependencies.platform(libs.spring.boot.bom))

--- a/koog-spring-ai/koog-spring-ai-starter-model-chat/src/main/kotlin/ai/koog/spring/ai/chat/KoogSpringAiChatProperties.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-chat/src/main/kotlin/ai/koog/spring/ai/chat/KoogSpringAiChatProperties.kt
@@ -1,5 +1,6 @@
 package ai.koog.spring.ai.chat
 
+import ai.koog.spring.ai.common.DispatcherProperties
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
@@ -27,50 +28,4 @@ public data class KoogSpringAiChatProperties(
     val moderationModelBeanName: String? = null,
     val provider: String? = null,
     val dispatcher: DispatcherProperties = DispatcherProperties(),
-) {
-    /**
-     * Dispatcher settings for blocking Spring AI model calls.
-     *
-     * @property type The dispatcher type to use. Default: [DispatcherType.AUTO].
-     * @property parallelism Maximum parallelism for the dispatcher. When greater than 0 and [DispatcherType.IO]
-     *   is selected, `Dispatchers.IO.limitedParallelism(parallelism)` is used instead of the unbounded `Dispatchers.IO`.
-     */
-    public data class DispatcherProperties(
-        val type: DispatcherType = DispatcherType.AUTO,
-        val parallelism: Int = 0,
-    )
-
-    /**
-     * Dispatcher type for blocking model calls.
-     */
-    public enum class DispatcherType {
-        /**
-         * Automatically detect the best dispatcher.
-         *
-         * When Spring Boot's `spring.threads.virtual.enabled=true` is set, an
-         * [org.springframework.core.task.AsyncTaskExecutor] backed by virtual threads
-         * is available in the application context. In [AUTO] mode the dispatcher is
-         * derived from that executor, so users only need the standard Spring Boot
-         * property to opt into virtual threads.
-         *
-         * Falls back to [kotlinx.coroutines.Dispatchers.IO] when no such executor is present.
-         *
-         * **Warning:** When `spring.threads.virtual.enabled=false` (the default before
-         * Spring Boot 3.2), the application task executor is typically a bounded
-         * `ThreadPoolTaskExecutor` (8 core threads by default). Wrapping it as a
-         * coroutine dispatcher means all blocking model calls share the same thread pool
-         * used by `@Async`, scheduled tasks, and web MVC async handlers. Under load this
-         * can cause thread starvation or deadlocks. In such setups, prefer [IO] or enable
-         * virtual threads.
-         */
-        AUTO,
-
-        /**
-         * Use [kotlinx.coroutines.Dispatchers.IO].
-         *
-         * When [DispatcherProperties.parallelism] is greater than 0, uses
-         * `Dispatchers.IO.limitedParallelism(parallelism)` to cap concurrency.
-         */
-        IO,
-    }
-}
+)

--- a/koog-spring-ai/koog-spring-ai-starter-model-chat/src/main/kotlin/ai/koog/spring/ai/chat/KoogSpringAiChatProperties.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-chat/src/main/kotlin/ai/koog/spring/ai/chat/KoogSpringAiChatProperties.kt
@@ -1,6 +1,6 @@
 package ai.koog.spring.ai.chat
 
-import ai.koog.spring.ai.common.DispatcherProperties
+import ai.koog.spring.ai.common.DispatcherConfig
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
@@ -27,5 +27,5 @@ public data class KoogSpringAiChatProperties(
     val chatModelBeanName: String? = null,
     val moderationModelBeanName: String? = null,
     val provider: String? = null,
-    val dispatcher: DispatcherProperties = DispatcherProperties(),
+    val dispatcher: DispatcherConfig = DispatcherConfig(),
 )

--- a/koog-spring-ai/koog-spring-ai-starter-model-chat/src/main/kotlin/ai/koog/spring/ai/chat/SpringAiChatAutoConfiguration.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-chat/src/main/kotlin/ai/koog/spring/ai/chat/SpringAiChatAutoConfiguration.kt
@@ -4,6 +4,7 @@ import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLMProvider
+import ai.koog.spring.ai.common.DispatcherType
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -74,7 +75,7 @@ public open class SpringAiChatAutoConfiguration {
         @Autowired(required = false) @Qualifier("applicationTaskExecutor") @Nullable asyncTaskExecutor: AsyncTaskExecutor?,
     ): CoroutineDispatcher {
         return when (properties.dispatcher.type) {
-            KoogSpringAiChatProperties.DispatcherType.AUTO -> {
+            DispatcherType.AUTO -> {
                 if (asyncTaskExecutor != null) {
                     logger.info("Koog Spring AI Chat: using Spring AsyncTaskExecutor as dispatcher for blocking model calls")
                     asyncTaskExecutor.asCoroutineDispatcher()
@@ -84,7 +85,7 @@ public open class SpringAiChatAutoConfiguration {
                 }
             }
 
-            KoogSpringAiChatProperties.DispatcherType.IO -> {
+            DispatcherType.IO -> {
                 val parallelism = properties.dispatcher.parallelism
                 if (parallelism > 0) {
                     logger.info("Koog Spring AI Chat: using Dispatchers.IO.limitedParallelism($parallelism) for blocking model calls")

--- a/koog-spring-ai/koog-spring-ai-starter-model-chat/src/main/kotlin/ai/koog/spring/ai/chat/SpringAiChatAutoConfiguration.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-chat/src/main/kotlin/ai/koog/spring/ai/chat/SpringAiChatAutoConfiguration.kt
@@ -4,7 +4,7 @@ import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLMProvider
-import ai.koog.spring.ai.common.DispatcherType
+import ai.koog.spring.ai.common.DispatcherProperties
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -13,7 +13,6 @@ import org.springframework.ai.chat.model.ChatModel
 import org.springframework.ai.moderation.ModerationModel
 import org.springframework.beans.factory.BeanFactory
 import org.springframework.beans.factory.ObjectProvider
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
@@ -25,7 +24,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.task.AsyncTaskExecutor
-import org.springframework.lang.Nullable
 
 /**
  * Auto-configuration for the Koog Spring AI Chat Model adapter.
@@ -72,10 +70,11 @@ public open class SpringAiChatAutoConfiguration {
     @ConditionalOnMissingBean(name = ["koogSpringAiChatDispatcher"])
     public open fun koogSpringAiChatDispatcher(
         properties: KoogSpringAiChatProperties,
-        @Autowired(required = false) @Qualifier("applicationTaskExecutor") @Nullable asyncTaskExecutor: AsyncTaskExecutor?,
+        @Qualifier("applicationTaskExecutor") asyncTaskExecutorProvider: ObjectProvider<AsyncTaskExecutor>,
     ): CoroutineDispatcher {
-        return when (properties.dispatcher.type) {
-            DispatcherType.AUTO -> {
+        val asyncTaskExecutor = asyncTaskExecutorProvider.ifAvailable
+        return when (val dispatcher = properties.dispatcher.toDispatcherProperties()) {
+            is DispatcherProperties.Auto -> {
                 if (asyncTaskExecutor != null) {
                     logger.info("Koog Spring AI Chat: using Spring AsyncTaskExecutor as dispatcher for blocking model calls")
                     asyncTaskExecutor.asCoroutineDispatcher()
@@ -85,9 +84,9 @@ public open class SpringAiChatAutoConfiguration {
                 }
             }
 
-            DispatcherType.IO -> {
-                val parallelism = properties.dispatcher.parallelism
-                if (parallelism > 0) {
+            is DispatcherProperties.IO -> {
+                val parallelism = dispatcher.parallelism
+                if (parallelism != null && parallelism > 0) {
                     logger.info("Koog Spring AI Chat: using Dispatchers.IO.limitedParallelism($parallelism) for blocking model calls")
                     Dispatchers.IO.limitedParallelism(parallelism)
                 } else {
@@ -99,9 +98,11 @@ public open class SpringAiChatAutoConfiguration {
     }
 
     /**
-     * Chat model configuration — activated when a bean-name selector is provided.
+     * Chat model configuration — activated when a bean-name selector property is provided.
+     *
+     * Resolves the [ChatModel] from the application context by the configured bean name.
      */
-    @Configuration
+    @Configuration(proxyBeanMethods = false)
     @ConditionalOnProperty(prefix = "koog.spring.ai.chat", name = ["chat-model-bean-name"])
     public open class NamedChatModelConfiguration {
         private val logger = LoggerFactory.getLogger(NamedChatModelConfiguration::class.java)
@@ -112,38 +113,54 @@ public open class SpringAiChatAutoConfiguration {
             beanFactory: BeanFactory,
             properties: KoogSpringAiChatProperties,
             @Qualifier("koogSpringAiChatDispatcher") dispatcher: CoroutineDispatcher,
-            @Autowired(required = false) @Nullable chatOptionsCustomizer: ChatOptionsCustomizer?,
-            @Autowired(required = false) @Nullable llmProvider: LLMProvider?,
+            chatOptionsCustomizerProvider: ObjectProvider<ChatOptionsCustomizer>,
+            llmProviderProvider: ObjectProvider<LLMProvider>,
             moderationModelProvider: ObjectProvider<ModerationModel>,
         ): LLMClient {
             val beanName = properties.chatModelBeanName!!
             logger.info("Koog Spring AI Chat: resolving ChatModel bean by name='$beanName'")
             val chatModel = beanFactory.getBean(beanName, ChatModel::class.java)
-            return createLLMClient(chatModel, beanFactory, properties, dispatcher, chatOptionsCustomizer, llmProvider, moderationModelProvider, logger)
+            return createLLMClient(chatModel, beanFactory, properties, dispatcher, chatOptionsCustomizerProvider.ifUnique, llmProviderProvider.ifUnique, moderationModelProvider, logger)
         }
     }
 
     /**
-     * Chat model configuration — activated when no bean-name selector is set and a single ChatModel candidate exists.
+     * Chat model configuration — activated when no bean-name selector is set
+     * and a single [ChatModel] candidate exists.
+     *
+     * This is the default fallback path. It is mutually exclusive with [NamedChatModelConfiguration] for
+     * the common cases:
+     * - selector absent → `matchIfMissing = true` activates this config; [NamedChatModelConfiguration] does not match
+     * - selector non-empty (e.g. `"myBean"`) → [NamedChatModelConfiguration] matches; `havingValue = ""` does not
+     *   match a non-empty value, so this config does not activate
+     * - selector set to literal `""` → both configs activate (Spring treats `""` as a present value that satisfies
+     *   both `havingValue = ""` and the plain `@ConditionalOnProperty` on the named path); the named path then
+     *   attempts `beanFactory.getBean("", ChatModel::class.java)` which fails at startup
      */
-    @Configuration
-    @ConditionalOnMissingBean(LLMClient::class)
+    @Configuration(proxyBeanMethods = false)
     @ConditionalOnSingleCandidate(ChatModel::class)
+    @ConditionalOnProperty(
+        prefix = "koog.spring.ai.chat",
+        name = ["chat-model-bean-name"],
+        havingValue = "",
+        matchIfMissing = true
+    )
     public open class SingleChatModelConfiguration {
         private val logger = LoggerFactory.getLogger(SingleChatModelConfiguration::class.java)
 
         @Bean
+        @ConditionalOnMissingBean(LLMClient::class)
         public open fun springAiChatModelLLMClient(
             chatModel: ChatModel,
             beanFactory: BeanFactory,
             properties: KoogSpringAiChatProperties,
             @Qualifier("koogSpringAiChatDispatcher") dispatcher: CoroutineDispatcher,
-            @Autowired(required = false) @Nullable chatOptionsCustomizer: ChatOptionsCustomizer?,
-            @Autowired(required = false) @Nullable llmProvider: LLMProvider?,
+            chatOptionsCustomizerProvider: ObjectProvider<ChatOptionsCustomizer>,
+            llmProviderProvider: ObjectProvider<LLMProvider>,
             moderationModelProvider: ObjectProvider<ModerationModel>,
         ): LLMClient {
             logger.info("Koog Spring AI Chat: using single ChatModel candidate as LLMClient backend")
-            return createLLMClient(chatModel, beanFactory, properties, dispatcher, chatOptionsCustomizer, llmProvider, moderationModelProvider, logger)
+            return createLLMClient(chatModel, beanFactory, properties, dispatcher, chatOptionsCustomizerProvider.ifUnique, llmProviderProvider.ifUnique, moderationModelProvider, logger)
         }
     }
 

--- a/koog-spring-ai/koog-spring-ai-starter-model-chat/src/test/kotlin/ai/koog/spring/ai/chat/SpringAiChatAutoConfigurationTest.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-chat/src/test/kotlin/ai/koog/spring/ai/chat/SpringAiChatAutoConfigurationTest.kt
@@ -112,7 +112,7 @@ class SpringAiChatAutoConfigurationTest {
             .run { context ->
                 val props = context.getBean<KoogSpringAiChatProperties>()
                 assertTrue(props.enabled)
-                assertTrue(props.dispatcher.type == KoogSpringAiChatProperties.DispatcherType.IO)
+                assertTrue(props.dispatcher.type == ai.koog.spring.ai.common.DispatcherType.IO)
             }
     }
 

--- a/koog-spring-ai/koog-spring-ai-starter-model-chat/src/test/kotlin/ai/koog/spring/ai/chat/SpringAiChatAutoConfigurationTest.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-chat/src/test/kotlin/ai/koog/spring/ai/chat/SpringAiChatAutoConfigurationTest.kt
@@ -67,7 +67,71 @@ class SpringAiChatAutoConfigurationTest {
             .withBean("chatModel1", ChatModel::class.java, { mockk<ChatModel>(relaxed = true) })
             .withBean("chatModel2", ChatModel::class.java, { mockk<ChatModel>(relaxed = true) })
             .run { context ->
+                assertTrue(context.startupFailure == null, "Context should start without failure")
                 assertThrows<NoSuchBeanDefinitionException> { context.getBean<LLMClient>() }
+            }
+    }
+
+    @Test
+    fun `should use named config only when single ChatModel and selector property are both set`() {
+        val targetModel = mockk<ChatModel>(relaxed = true)
+        contextRunner()
+            .withPropertyValues("koog.spring.ai.chat.chat-model-bean-name=myChat")
+            .withBean("myChat", ChatModel::class.java, { targetModel })
+            .run { context ->
+                assertTrue(context.startupFailure == null, "Context should start without failure")
+                val client = context.getBean<LLMClient>()
+                assertInstanceOf<SpringAiLLMClient>(client)
+                // Only one LLMClient bean — no duplicate
+                assertTrue(context.getBeansOfType(LLMClient::class.java).size == 1)
+            }
+    }
+
+    // ---- mutual exclusion: single candidate + selector set ----
+    @Test
+    fun `should create exactly one LLMClient using named path when single ChatModel and selector are both set`() {
+        val targetModel = mockk<ChatModel>(relaxed = true)
+        contextRunner()
+            .withPropertyValues("koog.spring.ai.chat.chat-model-bean-name=myChat")
+            .withBean("myChat", ChatModel::class.java, { targetModel })
+            .run { context ->
+                assertTrue(context.startupFailure == null, "Context should start without failure")
+                val clients = context.getBeansOfType(LLMClient::class.java)
+                assertTrue(clients.size == 1, "Expected exactly one LLMClient, got ${clients.size}")
+                assertInstanceOf<SpringAiLLMClient>(clients.values.single())
+            }
+    }
+
+    // ---- mutual exclusion: multiple candidates + no selector ----
+    @Test
+    fun `should not create LLMClient and not fail when multiple ChatModels exist and no selector is set`() {
+        contextRunner()
+            .withBean("chatModel1", ChatModel::class.java, { mockk<ChatModel>(relaxed = true) })
+            .withBean("chatModel2", ChatModel::class.java, { mockk<ChatModel>(relaxed = true) })
+            .run { context ->
+                assertTrue(context.startupFailure == null, "Context should start without failure")
+                assertTrue(
+                    context.getBeansOfType(LLMClient::class.java).isEmpty(),
+                    "Expected no LLMClient when multiple ChatModels exist and no selector is set"
+                )
+            }
+    }
+
+    // ---- mutual exclusion: selector set to empty string ----
+    @Test
+    fun `should fail on startup when chat-model-bean-name is set to empty string because named path activates with empty bean name`() {
+        contextRunner()
+            .withPropertyValues("koog.spring.ai.chat.chat-model-bean-name=")
+            .withBean("myChat", ChatModel::class.java, { mockk<ChatModel>(relaxed = true) })
+            .run { context ->
+                // Spring treats "" as a present value equal to "", so havingValue="" on SingleChatModelConfiguration
+                // matches (the condition passes), AND the plain @ConditionalOnProperty on NamedChatModelConfiguration
+                // also matches (any non-false present value satisfies it). Both configs activate; the named path
+                // then calls beanFactory.getBean("", ChatModel::class.java) with an empty name, which fails.
+                assertTrue(
+                    context.startupFailure != null,
+                    "Expected startup failure when chat-model-bean-name is set to empty string"
+                )
             }
     }
 
@@ -113,6 +177,7 @@ class SpringAiChatAutoConfigurationTest {
                 val props = context.getBean<KoogSpringAiChatProperties>()
                 assertTrue(props.enabled)
                 assertTrue(props.dispatcher.type == ai.koog.spring.ai.common.DispatcherType.IO)
+                assertTrue(props.dispatcher.toDispatcherProperties() is ai.koog.spring.ai.common.DispatcherProperties.IO)
             }
     }
 

--- a/koog-spring-ai/koog-spring-ai-starter-model-embedding/src/main/kotlin/ai/koog/spring/ai/embedding/KoogSpringAiEmbeddingProperties.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-embedding/src/main/kotlin/ai/koog/spring/ai/embedding/KoogSpringAiEmbeddingProperties.kt
@@ -1,5 +1,6 @@
 package ai.koog.spring.ai.embedding
 
+import ai.koog.spring.ai.common.DispatcherProperties
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
@@ -17,50 +18,4 @@ public data class KoogSpringAiEmbeddingProperties(
     val enabled: Boolean = true,
     val embeddingModelBeanName: String? = null,
     val dispatcher: DispatcherProperties = DispatcherProperties(),
-) {
-    /**
-     * Dispatcher settings for blocking Spring AI model calls.
-     *
-     * @property type The dispatcher type to use. Default: [DispatcherType.AUTO].
-     * @property parallelism Maximum parallelism for the dispatcher. When greater than 0 and [DispatcherType.IO]
-     *   is selected, `Dispatchers.IO.limitedParallelism(parallelism)` is used instead of the unbounded `Dispatchers.IO`.
-     */
-    public data class DispatcherProperties(
-        val type: DispatcherType = DispatcherType.AUTO,
-        val parallelism: Int = 0,
-    )
-
-    /**
-     * Dispatcher type for blocking model calls.
-     */
-    public enum class DispatcherType {
-        /**
-         * Automatically detect the best dispatcher.
-         *
-         * When Spring Boot's `spring.threads.virtual.enabled=true` is set, an
-         * [org.springframework.core.task.AsyncTaskExecutor] backed by virtual threads
-         * is available in the application context. In [AUTO] mode the dispatcher is
-         * derived from that executor, so users only need the standard Spring Boot
-         * property to opt into virtual threads.
-         *
-         * Falls back to [kotlinx.coroutines.Dispatchers.IO] when no such executor is present.
-         *
-         * **Warning:** When `spring.threads.virtual.enabled=false` (the default before
-         * Spring Boot 3.2), the application task executor is typically a bounded
-         * `ThreadPoolTaskExecutor` (8 core threads by default). Wrapping it as a
-         * coroutine dispatcher means all blocking model calls share the same thread pool
-         * used by `@Async`, scheduled tasks, and web MVC async handlers. Under load this
-         * can cause thread starvation or deadlocks. In such setups, prefer [IO] or enable
-         * virtual threads.
-         */
-        AUTO,
-
-        /**
-         * Use [kotlinx.coroutines.Dispatchers.IO].
-         *
-         * When [DispatcherProperties.parallelism] is greater than 0, uses
-         * `Dispatchers.IO.limitedParallelism(parallelism)` to cap concurrency.
-         */
-        IO,
-    }
-}
+)

--- a/koog-spring-ai/koog-spring-ai-starter-model-embedding/src/main/kotlin/ai/koog/spring/ai/embedding/KoogSpringAiEmbeddingProperties.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-embedding/src/main/kotlin/ai/koog/spring/ai/embedding/KoogSpringAiEmbeddingProperties.kt
@@ -1,6 +1,6 @@
 package ai.koog.spring.ai.embedding
 
-import ai.koog.spring.ai.common.DispatcherProperties
+import ai.koog.spring.ai.common.DispatcherConfig
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
@@ -17,5 +17,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 public data class KoogSpringAiEmbeddingProperties(
     val enabled: Boolean = true,
     val embeddingModelBeanName: String? = null,
-    val dispatcher: DispatcherProperties = DispatcherProperties(),
+    val dispatcher: DispatcherConfig = DispatcherConfig(),
 )

--- a/koog-spring-ai/koog-spring-ai-starter-model-embedding/src/main/kotlin/ai/koog/spring/ai/embedding/SpringAiEmbeddingAutoConfiguration.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-embedding/src/main/kotlin/ai/koog/spring/ai/embedding/SpringAiEmbeddingAutoConfiguration.kt
@@ -1,14 +1,14 @@
 package ai.koog.spring.ai.embedding
 
 import ai.koog.prompt.executor.clients.LLMEmbeddingProvider
-import ai.koog.spring.ai.common.DispatcherType
+import ai.koog.spring.ai.common.DispatcherProperties
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher
 import org.slf4j.LoggerFactory
 import org.springframework.ai.embedding.EmbeddingModel
 import org.springframework.beans.factory.BeanFactory
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
@@ -19,7 +19,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.task.AsyncTaskExecutor
-import org.springframework.lang.Nullable
 
 /**
  * Auto-configuration for the Koog Spring AI Embedding Model adapter.
@@ -63,10 +62,11 @@ public open class SpringAiEmbeddingAutoConfiguration {
     @ConditionalOnMissingBean(name = ["koogSpringAiEmbeddingDispatcher"])
     public open fun koogSpringAiEmbeddingDispatcher(
         properties: KoogSpringAiEmbeddingProperties,
-        @Autowired(required = false) @Qualifier("applicationTaskExecutor") @Nullable asyncTaskExecutor: AsyncTaskExecutor?,
+        @Qualifier("applicationTaskExecutor") asyncTaskExecutorProvider: ObjectProvider<AsyncTaskExecutor>,
     ): CoroutineDispatcher {
-        return when (properties.dispatcher.type) {
-            DispatcherType.AUTO -> {
+        val asyncTaskExecutor = asyncTaskExecutorProvider.ifAvailable
+        return when (val dispatcher = properties.dispatcher.toDispatcherProperties()) {
+            is DispatcherProperties.Auto -> {
                 if (asyncTaskExecutor != null) {
                     logger.info("Koog Spring AI Embedding: using Spring AsyncTaskExecutor as dispatcher for blocking model calls")
                     asyncTaskExecutor.asCoroutineDispatcher()
@@ -76,9 +76,9 @@ public open class SpringAiEmbeddingAutoConfiguration {
                 }
             }
 
-            DispatcherType.IO -> {
-                val parallelism = properties.dispatcher.parallelism
-                if (parallelism > 0) {
+            is DispatcherProperties.IO -> {
+                val parallelism = dispatcher.parallelism
+                if (parallelism != null && parallelism > 0) {
                     logger.info("Koog Spring AI Embedding: using Dispatchers.IO.limitedParallelism($parallelism) for blocking model calls")
                     Dispatchers.IO.limitedParallelism(parallelism)
                 } else {
@@ -92,7 +92,7 @@ public open class SpringAiEmbeddingAutoConfiguration {
     /**
      * Embedding model configuration — activated when a bean-name selector is provided.
      */
-    @Configuration
+    @Configuration(proxyBeanMethods = false)
     @ConditionalOnProperty(prefix = "koog.spring.ai.embedding", name = ["embedding-model-bean-name"])
     public open class NamedEmbeddingModelConfiguration {
         private val logger = LoggerFactory.getLogger(NamedEmbeddingModelConfiguration::class.java)
@@ -112,15 +112,31 @@ public open class SpringAiEmbeddingAutoConfiguration {
     }
 
     /**
-     * Embedding model configuration — activated when no bean-name selector is set and a single EmbeddingModel candidate exists.
+     * Embedding model configuration — activated when no bean-name selector is set
+     * and a single [EmbeddingModel] candidate exists.
+     *
+     * This is the default fallback path. It is mutually exclusive with [NamedEmbeddingModelConfiguration] for
+     * the common cases:
+     * - selector absent → `matchIfMissing = true` activates this config; [NamedEmbeddingModelConfiguration] does not match
+     * - selector non-empty (e.g. `"myBean"`) → [NamedEmbeddingModelConfiguration] matches; `havingValue = ""` does not
+     *   match a non-empty value, so this config does not activate
+     * - selector set to literal `""` → both configs activate (Spring treats `""` as a present value that satisfies
+     *   both `havingValue = ""` and the plain `@ConditionalOnProperty` on the named path); the named path then
+     *   attempts `beanFactory.getBean("", EmbeddingModel::class.java)` which fails at startup
      */
-    @Configuration
-    @ConditionalOnMissingBean(LLMEmbeddingProvider::class)
+    @Configuration(proxyBeanMethods = false)
     @ConditionalOnSingleCandidate(EmbeddingModel::class)
+    @ConditionalOnProperty(
+        prefix = "koog.spring.ai.embedding",
+        name = ["embedding-model-bean-name"],
+        havingValue = "",
+        matchIfMissing = true
+    )
     public open class SingleEmbeddingModelConfiguration {
         private val logger = LoggerFactory.getLogger(SingleEmbeddingModelConfiguration::class.java)
 
         @Bean
+        @ConditionalOnMissingBean(LLMEmbeddingProvider::class)
         public open fun springAiEmbeddingModelLLMEmbeddingProvider(
             embeddingModel: EmbeddingModel,
             @Qualifier("koogSpringAiEmbeddingDispatcher") dispatcher: CoroutineDispatcher,

--- a/koog-spring-ai/koog-spring-ai-starter-model-embedding/src/main/kotlin/ai/koog/spring/ai/embedding/SpringAiEmbeddingAutoConfiguration.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-embedding/src/main/kotlin/ai/koog/spring/ai/embedding/SpringAiEmbeddingAutoConfiguration.kt
@@ -1,6 +1,7 @@
 package ai.koog.spring.ai.embedding
 
 import ai.koog.prompt.executor.clients.LLMEmbeddingProvider
+import ai.koog.spring.ai.common.DispatcherType
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -65,7 +66,7 @@ public open class SpringAiEmbeddingAutoConfiguration {
         @Autowired(required = false) @Qualifier("applicationTaskExecutor") @Nullable asyncTaskExecutor: AsyncTaskExecutor?,
     ): CoroutineDispatcher {
         return when (properties.dispatcher.type) {
-            KoogSpringAiEmbeddingProperties.DispatcherType.AUTO -> {
+            DispatcherType.AUTO -> {
                 if (asyncTaskExecutor != null) {
                     logger.info("Koog Spring AI Embedding: using Spring AsyncTaskExecutor as dispatcher for blocking model calls")
                     asyncTaskExecutor.asCoroutineDispatcher()
@@ -75,7 +76,7 @@ public open class SpringAiEmbeddingAutoConfiguration {
                 }
             }
 
-            KoogSpringAiEmbeddingProperties.DispatcherType.IO -> {
+            DispatcherType.IO -> {
                 val parallelism = properties.dispatcher.parallelism
                 if (parallelism > 0) {
                     logger.info("Koog Spring AI Embedding: using Dispatchers.IO.limitedParallelism($parallelism) for blocking model calls")

--- a/koog-spring-ai/koog-spring-ai-starter-model-embedding/src/test/kotlin/ai/koog/spring/ai/embedding/SpringAiEmbeddingAutoConfigurationTest.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-embedding/src/test/kotlin/ai/koog/spring/ai/embedding/SpringAiEmbeddingAutoConfigurationTest.kt
@@ -91,6 +91,68 @@ class SpringAiEmbeddingAutoConfigurationTest {
     }
 
     @Test
+    fun `should use named config only when single EmbeddingModel and selector property are both set`() {
+        val targetModel = mockk<EmbeddingModel>(relaxed = true)
+        contextRunner()
+            .withPropertyValues("koog.spring.ai.embedding.embedding-model-bean-name=myEmb")
+            .withBean("myEmb", EmbeddingModel::class.java, { targetModel })
+            .run { context ->
+                assertTrue(context.startupFailure == null, "Context should start without failure")
+                val provider = context.getBean<LLMEmbeddingProvider>()
+                assertInstanceOf<SpringAiLLMEmbeddingProvider>(provider)
+                // Only one LLMEmbeddingProvider bean — no duplicate
+                assertTrue(context.getBeansOfType(LLMEmbeddingProvider::class.java).size == 1)
+            }
+    }
+
+    // ---- mutual exclusion: single candidate + selector set ----
+    @Test
+    fun `should create exactly one LLMEmbeddingProvider using named path when single EmbeddingModel and selector are both set`() {
+        contextRunner()
+            .withPropertyValues("koog.spring.ai.embedding.embedding-model-bean-name=myEmb")
+            .withBean("myEmb", EmbeddingModel::class.java, { mockk<EmbeddingModel>(relaxed = true) })
+            .run { context ->
+                assertTrue(context.startupFailure == null, "Context should start without failure")
+                val providers = context.getBeansOfType(LLMEmbeddingProvider::class.java)
+                assertTrue(providers.size == 1, "Expected exactly one LLMEmbeddingProvider, got ${providers.size}")
+                assertInstanceOf<SpringAiLLMEmbeddingProvider>(providers.values.single())
+            }
+    }
+
+    // ---- mutual exclusion: multiple candidates + no selector ----
+    @Test
+    fun `should not create LLMEmbeddingProvider and not fail when multiple EmbeddingModels exist and no selector is set`() {
+        contextRunner()
+            .withBean("embModel1", EmbeddingModel::class.java, { mockk<EmbeddingModel>(relaxed = true) })
+            .withBean("embModel2", EmbeddingModel::class.java, { mockk<EmbeddingModel>(relaxed = true) })
+            .run { context ->
+                assertTrue(context.startupFailure == null, "Context should start without failure")
+                assertTrue(
+                    context.getBeansOfType(LLMEmbeddingProvider::class.java).isEmpty(),
+                    "Expected no LLMEmbeddingProvider when multiple EmbeddingModels exist and no selector is set"
+                )
+            }
+    }
+
+    // ---- mutual exclusion: selector set to empty string ----
+    @Test
+    fun `should fail on startup when embedding-model-bean-name is set to empty string because named path activates with empty bean name`() {
+        contextRunner()
+            .withPropertyValues("koog.spring.ai.embedding.embedding-model-bean-name=")
+            .withBean("myEmb", EmbeddingModel::class.java, { mockk<EmbeddingModel>(relaxed = true) })
+            .run { context ->
+                // Spring treats "" as a present value equal to "", so havingValue="" on SingleEmbeddingModelConfiguration
+                // matches (the condition passes), AND the plain @ConditionalOnProperty on NamedEmbeddingModelConfiguration
+                // also matches (any non-false present value satisfies it). Both configs activate; the named path
+                // then calls beanFactory.getBean("", EmbeddingModel::class.java) with an empty name, which fails.
+                assertTrue(
+                    context.startupFailure != null,
+                    "Expected startup failure when embedding-model-bean-name is set to empty string"
+                )
+            }
+    }
+
+    @Test
     fun `should create dispatcher bean`() {
         contextRunner()
             .run { context ->
@@ -109,6 +171,7 @@ class SpringAiEmbeddingAutoConfigurationTest {
                 val props = context.getBean<KoogSpringAiEmbeddingProperties>()
                 assertTrue(props.enabled)
                 assertTrue(props.dispatcher.type == ai.koog.spring.ai.common.DispatcherType.IO)
+                assertTrue(props.dispatcher.toDispatcherProperties() is ai.koog.spring.ai.common.DispatcherProperties.IO)
             }
     }
 

--- a/koog-spring-ai/koog-spring-ai-starter-model-embedding/src/test/kotlin/ai/koog/spring/ai/embedding/SpringAiEmbeddingAutoConfigurationTest.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-embedding/src/test/kotlin/ai/koog/spring/ai/embedding/SpringAiEmbeddingAutoConfigurationTest.kt
@@ -108,7 +108,7 @@ class SpringAiEmbeddingAutoConfigurationTest {
             .run { context ->
                 val props = context.getBean<KoogSpringAiEmbeddingProperties>()
                 assertTrue(props.enabled)
-                assertTrue(props.dispatcher.type == KoogSpringAiEmbeddingProperties.DispatcherType.IO)
+                assertTrue(props.dispatcher.type == ai.koog.spring.ai.common.DispatcherType.IO)
             }
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -95,8 +95,10 @@ include(":serialization:serialization-jackson")
 
 include(":koog-spring-boot-starter")
 
+include(":koog-spring-ai:koog-spring-ai-common")
 include(":koog-spring-ai:koog-spring-ai-starter-model-chat")
 include(":koog-spring-ai:koog-spring-ai-starter-model-embedding")
+include(":koog-spring-ai:koog-spring-ai-starter-chat-memory")
 
 include(":koog-ktor")
 include(":docs")


### PR DESCRIPTION
It might be useful for Spring AI users to use existing ChatMemory repositories with the ChatMemory feature from Koog. The new starter handles the conversion.

closes KG-769
