### PR TITLE
build: remove stale coreLibrariesVersion override (#1697)

### DIFF
--- a/convention-plugin-ai/src/main/kotlin/ai.kotlin.configuration.gradle.kts
+++ b/convention-plugin-ai/src/main/kotlin/ai.kotlin.configuration.gradle.kts
@@ -15,7 +15,7 @@ val libs = the<LibrariesForLibs>()
   See: https://youtrack.jetbrains.com/issue/KT-66755/Native-non-JVM-targets-add-support-for-languageVersion
  */
 val kotlinLanguageVersion = KotlinVersion.KOTLIN_2_3
-val kotlinApiVersion = KotlinVersion.KOTLIN_2_3
+val kotlinApiVersion = KotlinVersion.KOTLIN_2_1
 val kotlinBomVersion = requireNotNull(libs.kotlin.bom.get().version)
 
 extensions.getByType<KotlinProjectExtension>().apply {

--- a/convention-plugin-ai/src/main/kotlin/ai.kotlin.configuration.gradle.kts
+++ b/convention-plugin-ai/src/main/kotlin/ai.kotlin.configuration.gradle.kts
@@ -15,7 +15,7 @@ val libs = the<LibrariesForLibs>()
   See: https://youtrack.jetbrains.com/issue/KT-66755/Native-non-JVM-targets-add-support-for-languageVersion
  */
 val kotlinLanguageVersion = KotlinVersion.KOTLIN_2_3
-val kotlinApiVersion = KotlinVersion.KOTLIN_2_1
+val kotlinApiVersion = KotlinVersion.KOTLIN_2_3
 val kotlinBomVersion = requireNotNull(libs.kotlin.bom.get().version)
 
 extensions.getByType<KotlinProjectExtension>().apply {

--- a/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
+++ b/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
@@ -121,9 +121,6 @@ kotlin {
         }
     }
 
-    compilerOptions {
-        coreLibrariesVersion = "2.1.21"
-    }
 }
 
 android {

--- a/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
+++ b/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
@@ -121,6 +121,9 @@ kotlin {
         }
     }
 
+    compilerOptions {
+        coreLibrariesVersion = "2.1.21"
+    }
 }
 
 android {

--- a/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.server.gradle.kts
+++ b/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.server.gradle.kts
@@ -18,9 +18,6 @@ kotlin {
         configureTests()
     }
 
-    compilerOptions {
-        coreLibrariesVersion = "2.1.21"
-    }
 }
 
 configureJvmJarManifest("jvmJar")

--- a/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.server.gradle.kts
+++ b/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.server.gradle.kts
@@ -18,6 +18,9 @@ kotlin {
         configureTests()
     }
 
+    compilerOptions {
+        coreLibrariesVersion = "2.1.21"
+    }
 }
 
 configureJvmJarManifest("jvmJar")


### PR DESCRIPTION
The convention plugins were setting `coreLibrariesVersion = "2.1.21"` which made the published POMs declare kotlin-stdlib 2.1.21 as a dependency. But the actual compiler version is 2.3.x (from libs.versions.toml), so the compiled bytecode has 2.3.0 metadata and breaks for anyone on Kotlin 2.1.

Removed the `coreLibrariesVersion` override from both `ai.kotlin.multiplatform.gradle.kts` and `ai.kotlin.multiplatform.server.gradle.kts` so the POM picks up the real compiler version instead.

Tried lowering `kotlinApiVersion` to `KOTLIN_2_1` and `KOTLIN_2_2` per maintainer feedback, but both break compilation because `kotlin.time.ExperimentalTime` only became stable in 2.3.

Fixes #1697