### PR TITLE
feat(agents): pass guardrail settings to Bedrock Converse API (#1713)

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
@@ -325,7 +325,7 @@ public class BedrockLLMClient @JvmOverloads constructor(
         model: LLModel,
         tools: List<ToolDescriptor>
     ): List<Message.Response> {
-        val converseRequest = BedrockConverseConverters.createConverseRequest(prompt, model, tools)
+        val converseRequest = BedrockConverseConverters.createConverseRequest(prompt, model, tools, moderationGuardrailsSettings)
 
         return withContext(Dispatchers.SuitableForIO) {
             try {
@@ -475,7 +475,7 @@ public class BedrockLLMClient @JvmOverloads constructor(
         model: LLModel,
         tools: List<ToolDescriptor>
     ): Flow<StreamFrame> {
-        val converseRequest = BedrockConverseConverters.createConverseStreamRequest(prompt, model, tools)
+        val converseRequest = BedrockConverseConverters.createConverseStreamRequest(prompt, model, tools, moderationGuardrailsSettings)
 
         return channelFlow {
             withContext(Dispatchers.SuitableForIO) {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseConverters.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseConverters.kt
@@ -2,6 +2,7 @@ package ai.koog.prompt.executor.clients.bedrock.converse
 
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.executor.clients.bedrock.BedrockGuardrailsSettings
 import ai.koog.prompt.executor.clients.bedrock.modelfamilies.BedrockToolSerialization
 import ai.koog.prompt.executor.clients.bedrock.util.JsonDocumentConverters
 import ai.koog.prompt.llm.LLMCapability
@@ -28,6 +29,8 @@ import aws.sdk.kotlin.services.bedrockruntime.model.ConverseResponse
 import aws.sdk.kotlin.services.bedrockruntime.model.ConverseStreamOutput
 import aws.sdk.kotlin.services.bedrockruntime.model.ConverseStreamRequest
 import aws.sdk.kotlin.services.bedrockruntime.model.DocumentBlock
+import aws.sdk.kotlin.services.bedrockruntime.model.GuardrailConfiguration
+import aws.sdk.kotlin.services.bedrockruntime.model.GuardrailStreamConfiguration
 import aws.sdk.kotlin.services.bedrockruntime.model.DocumentFormat
 import aws.sdk.kotlin.services.bedrockruntime.model.DocumentSource
 import aws.sdk.kotlin.services.bedrockruntime.model.ImageBlock
@@ -103,6 +106,7 @@ internal object BedrockConverseConverters {
         val toolConfig: ToolConfiguration?,
         val system: List<SystemContentBlock>,
         val messages: List<BedrockMessage>,
+        val guardrailSettings: BedrockGuardrailsSettings?,
     )
 
     /**
@@ -111,7 +115,8 @@ internal object BedrockConverseConverters {
     private fun createConverseRequestParams(
         prompt: Prompt,
         model: LLModel,
-        tools: List<ToolDescriptor>
+        tools: List<ToolDescriptor>,
+        guardrailSettings: BedrockGuardrailsSettings? = null,
     ): ConverseRequestParams {
         val params = prompt.params.toBedrockConverseParams()
 
@@ -244,6 +249,7 @@ internal object BedrockConverseConverters {
             },
             system = systemMessages,
             messages = messages,
+            guardrailSettings = guardrailSettings,
         )
     }
 
@@ -253,9 +259,10 @@ internal object BedrockConverseConverters {
     fun createConverseRequest(
         prompt: Prompt,
         model: LLModel,
-        tools: List<ToolDescriptor>
+        tools: List<ToolDescriptor>,
+        guardrailSettings: BedrockGuardrailsSettings? = null,
     ): ConverseRequest {
-        val params = createConverseRequestParams(prompt, model, tools)
+        val params = createConverseRequestParams(prompt, model, tools, guardrailSettings)
 
         @Suppress("DuplicatedCode") // AWS SDK requires duplication
         return ConverseRequest {
@@ -267,6 +274,12 @@ internal object BedrockConverseConverters {
             this.toolConfig = params.toolConfig
             this.system = params.system
             this.messages = params.messages
+            params.guardrailSettings?.let { gs ->
+                this.guardrailConfig = GuardrailConfiguration {
+                    this.guardrailIdentifier = gs.guardrailIdentifier
+                    this.guardrailVersion = gs.guardrailVersion
+                }
+            }
         }
     }
 
@@ -276,9 +289,10 @@ internal object BedrockConverseConverters {
     fun createConverseStreamRequest(
         prompt: Prompt,
         model: LLModel,
-        tools: List<ToolDescriptor>
+        tools: List<ToolDescriptor>,
+        guardrailSettings: BedrockGuardrailsSettings? = null,
     ): ConverseStreamRequest {
-        val params = createConverseRequestParams(prompt, model, tools)
+        val params = createConverseRequestParams(prompt, model, tools, guardrailSettings)
 
         @Suppress("DuplicatedCode") // AWS SDK requires duplication
         return ConverseStreamRequest {
@@ -290,6 +304,12 @@ internal object BedrockConverseConverters {
             this.toolConfig = params.toolConfig
             this.system = params.system
             this.messages = params.messages
+            params.guardrailSettings?.let { gs ->
+                this.guardrailConfig = GuardrailStreamConfiguration {
+                    this.guardrailIdentifier = gs.guardrailIdentifier
+                    this.guardrailVersion = gs.guardrailVersion
+                }
+            }
         }
     }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseConverters.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseConverters.kt
@@ -29,10 +29,10 @@ import aws.sdk.kotlin.services.bedrockruntime.model.ConverseResponse
 import aws.sdk.kotlin.services.bedrockruntime.model.ConverseStreamOutput
 import aws.sdk.kotlin.services.bedrockruntime.model.ConverseStreamRequest
 import aws.sdk.kotlin.services.bedrockruntime.model.DocumentBlock
-import aws.sdk.kotlin.services.bedrockruntime.model.GuardrailConfiguration
-import aws.sdk.kotlin.services.bedrockruntime.model.GuardrailStreamConfiguration
 import aws.sdk.kotlin.services.bedrockruntime.model.DocumentFormat
 import aws.sdk.kotlin.services.bedrockruntime.model.DocumentSource
+import aws.sdk.kotlin.services.bedrockruntime.model.GuardrailConfiguration
+import aws.sdk.kotlin.services.bedrockruntime.model.GuardrailStreamConfiguration
 import aws.sdk.kotlin.services.bedrockruntime.model.ImageBlock
 import aws.sdk.kotlin.services.bedrockruntime.model.ImageFormat
 import aws.sdk.kotlin.services.bedrockruntime.model.ImageSource

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseGuardrailsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseGuardrailsTest.kt
@@ -1,0 +1,55 @@
+package ai.koog.prompt.executor.clients.bedrock.converse
+
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.executor.clients.bedrock.BedrockGuardrailsSettings
+import ai.koog.prompt.executor.clients.bedrock.BedrockModels
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class BedrockConverseGuardrailsTest {
+
+    private val model = BedrockModels.AnthropicClaude4Sonnet
+
+    private val guardrailSettings = BedrockGuardrailsSettings(
+        guardrailIdentifier = "test-guardrail-id",
+        guardrailVersion = "2"
+    )
+
+    @Test
+    fun testConverseRequestWithGuardrailSettings() {
+        val prompt = Prompt.build("test") { user("Hello") }
+        val request = BedrockConverseConverters.createConverseRequest(prompt, model, emptyList(), guardrailSettings)
+
+        val config = assertNotNull(request.guardrailConfig)
+        assertEquals("test-guardrail-id", config.guardrailIdentifier)
+        assertEquals("2", config.guardrailVersion)
+    }
+
+    @Test
+    fun testConverseRequestWithoutGuardrailSettings() {
+        val prompt = Prompt.build("test") { user("Hello") }
+        val request = BedrockConverseConverters.createConverseRequest(prompt, model, emptyList())
+
+        assertNull(request.guardrailConfig)
+    }
+
+    @Test
+    fun testConverseStreamRequestWithGuardrailSettings() {
+        val prompt = Prompt.build("test") { user("Hello") }
+        val request = BedrockConverseConverters.createConverseStreamRequest(prompt, model, emptyList(), guardrailSettings)
+
+        val config = assertNotNull(request.guardrailConfig)
+        assertEquals("test-guardrail-id", config.guardrailIdentifier)
+        assertEquals("2", config.guardrailVersion)
+    }
+
+    @Test
+    fun testConverseStreamRequestWithoutGuardrailSettings() {
+        val prompt = Prompt.build("test") { user("Hello") }
+        val request = BedrockConverseConverters.createConverseStreamRequest(prompt, model, emptyList())
+
+        assertNull(request.guardrailConfig)
+    }
+}


### PR DESCRIPTION
`BedrockClientSettings` already had `moderationGuardrailsSettings` and it worked fine for the `moderate()` method, but `createConverseRequest()` and `createConverseStreamRequest()` in `BedrockConverseConverters` never wired it into the actual AWS SDK request builders. So guardrails were silently ignored when using the Converse API.

This passes `BedrockGuardrailsSettings` through to both `ConverseRequest` (via `GuardrailConfiguration`) and `ConverseStreamRequest` (via `GuardrailStreamConfiguration`), setting `guardrailIdentifier` and `guardrailVersion` on the request builders.

The new parameter defaults to `null` so all existing call sites and tests are unaffected.

Fixes #1713