### PR TITLE
fix(agents): Fix AIAgentTool to support simple agents

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentService.kt
@@ -2,6 +2,8 @@
 
 package ai.koog.agents.core.agent
 
+import ai.koog.agents.core.agent.AIAgentTool.AgentToolInput
+import ai.koog.agents.core.agent.AIAgentTool.AgentToolResult
 import ai.koog.agents.core.agent.GraphAIAgent.FeatureContext
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
@@ -458,10 +460,11 @@ public inline fun <reified Input, reified Output> AIAgentService<Input, Output, 
     outputType: TypeToken = typeToken<Output>(),
     parentAgentId: String? = null,
     clock: Clock = Clock.System
-): Tool<Input, AIAgentTool.AgentToolResult<Output>> = AIAgentTool(
+): Tool<AgentToolInput<Input>, AgentToolResult<Output>> = AIAgentTool(
     agentService = this,
     agentName = agentName,
     agentDescription = agentDescription,
+    inputDescription = inputDescription,
     inputType = inputType,
     outputType = outputType,
     parentAgentId = parentAgentId
@@ -492,7 +495,7 @@ public inline fun <reified Input, reified Output> AIAgentService<Input, Output, 
     outputSerializer: KSerializer<Output>,
     parentAgentId: String? = null,
     clock: Clock = Clock.System
-): Tool<Input, AIAgentTool.AgentToolResult<Output>> = createAgentTool(
+): Tool<AgentToolInput<Input>, AgentToolResult<Output>> = createAgentTool(
     agentName = agentName,
     agentDescription = agentDescription,
     inputDescription = inputDescription,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentTool.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentTool.kt
@@ -1,9 +1,13 @@
 package ai.koog.agents.core.agent
 
+import ai.koog.agents.core.agent.AIAgentTool.AgentToolInput
 import ai.koog.agents.core.agent.AIAgentTool.AgentToolResult
 import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
-import ai.koog.agents.core.tools.schema.getToolDescriptor
+import ai.koog.agents.core.tools.schema.getJsonSchema
+import ai.koog.agents.core.tools.schema.toToolParameter
 import ai.koog.serialization.JSONElement
 import ai.koog.serialization.JSONSerializer
 import ai.koog.serialization.KSerializerTypeToken
@@ -50,7 +54,7 @@ public inline fun <reified Input, reified Output> AIAgent<Input, Output>.asTool(
     inputSerializer: KSerializer<Input> = serializer(),
     outputSerializer: KSerializer<Output> = serializer(),
     json: Json = Json.Default,
-): Tool<Input, AgentToolResult<Output>> {
+): Tool<AgentToolInput<Input>, AgentToolResult<Output>> {
     val service = when (this) {
         is GraphAIAgent -> AIAgentService.fromAgent(this)
         is FunctionalAIAgent -> AIAgentService.fromAgent(this)
@@ -88,13 +92,29 @@ public class AIAgentTool<Input, Output> @OptIn(InternalAgentToolsApi::class) con
     private val agentService: AIAgentService<Input, Output, *>,
     private val agentName: String,
     private val agentDescription: String,
+    private val inputDescription: String? = null,
     private val inputType: TypeToken,
     private val outputType: TypeToken,
     private val parentAgentId: String? = null
-) : Tool<Input, AgentToolResult<Output>>(
-    argsType = inputType,
+) : Tool<AgentToolInput<Input>, AgentToolResult<Output>>(
+    argsType = typeToken(AgentToolInput::class, listOf(inputType)),
     resultType = typeToken(AgentToolResult::class, listOf(outputType)),
-    descriptor = getToolDescriptor(inputType, agentName, agentDescription)
+    descriptor = run {
+        val inputSchema = getJsonSchema(inputType)
+        val inputToolParameter = inputSchema.toToolParameter(inputSchema.defs)
+
+        ToolDescriptor(
+            name = agentName,
+            description = agentDescription,
+            requiredParameters = listOf(
+                ToolParameterDescriptor(
+                    name = "input",
+                    description = inputDescription ?: "input",
+                    type = inputToolParameter.type,
+                )
+            )
+        )
+    }
 ) {
     private companion object {
         private val json = Json.Default
@@ -106,6 +126,7 @@ public class AIAgentTool<Input, Output> @OptIn(InternalAgentToolsApi::class) con
         agentService: AIAgentService<Input, Output, *>,
         agentName: String,
         agentDescription: String,
+        inputDescription: String,
         inputSerializer: KSerializer<Input>,
         outputSerializer: KSerializer<Output>,
         parentAgentId: String? = null
@@ -113,6 +134,7 @@ public class AIAgentTool<Input, Output> @OptIn(InternalAgentToolsApi::class) con
         agentService = agentService,
         agentName = agentName,
         agentDescription = agentDescription,
+        inputDescription = inputDescription,
         inputType = KSerializerTypeToken(inputSerializer),
         outputType = KSerializerTypeToken(outputSerializer),
         parentAgentId = parentAgentId
@@ -138,6 +160,17 @@ public class AIAgentTool<Input, Output> @OptIn(InternalAgentToolsApi::class) con
         val result: Output? = null
     )
 
+    /**
+     * Represents the input for [AIAgent] used as [Tool] (see [AIAgent.asTool])
+     *
+     * @param Input The type of the input data expected by the tool.
+     * @property input The input data provided to the agent tool for processing.
+     */
+    @Serializable
+    public data class AgentToolInput<Input>(
+        val input: Input
+    )
+
     @OptIn(InternalKoogSerializationApi::class)
     override fun decodeResult(rawResult: JSONElement, serializer: JSONSerializer): AgentToolResult<Output> {
         return json.decodeFromJsonElement(
@@ -159,9 +192,11 @@ public class AIAgentTool<Input, Output> @OptIn(InternalAgentToolsApi::class) con
     }
 
     @OptIn(InternalAgentToolsApi::class)
-    override suspend fun execute(args: Input): AgentToolResult<Output> {
+    override suspend fun execute(args: AgentToolInput<Input>): AgentToolResult<Output> {
+        val input = args.input
+
         return try {
-            val result = agentService.createAgentAndRun(args, id = nextToolAgentID())
+            val result = agentService.createAgentAndRun(input, id = nextToolAgentID())
 
             AgentToolResult(
                 successful = true,

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/AIAgentToolTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/AIAgentToolTest.kt
@@ -12,7 +12,9 @@ import ai.koog.prompt.executor.ollama.client.OllamaModels
 import ai.koog.serialization.kotlinx.KotlinxSerializer
 import ai.koog.serialization.kotlinx.toKoogJSONObject
 import ai.koog.serialization.typeToken
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeTypeOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.buildJsonObject
@@ -80,11 +82,19 @@ class AIAgentToolTest {
             agentDescription = "Test agent description",
         )
 
-        assertEquals("testAgent", tool.descriptor.name)
-        assertEquals("Test agent description", tool.descriptor.description)
-        assertEquals(1, tool.descriptor.requiredParameters.size)
-        assertEquals("Test request description", tool.descriptor.requiredParameters[0].description)
-        assertEquals(ToolParameterType.String, tool.descriptor.requiredParameters[0].type)
+        tool.descriptor should {
+            it.name shouldBe "testAgent"
+            it.description shouldBe "Test agent description"
+            it.requiredParameters.size shouldBe 1
+
+            it.requiredParameters[0].type.shouldBeTypeOf<ToolParameterType.Object> {
+                it.properties.size shouldBe 1
+                it.properties[0] should {
+                    it.description shouldBe "Test request description"
+                    it.type shouldBe ToolParameterType.String
+                }
+            }
+        }
     }
 
     @OptIn(InternalAgentToolsApi::class)

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/AIAgentToolTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/AIAgentToolTest.kt
@@ -1,7 +1,7 @@
 package ai.koog.agents.core.agent
 
+import ai.koog.agents.core.agent.AIAgentTool.AgentToolInput
 import ai.koog.agents.core.agent.config.AIAgentConfig
-import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.tools.ToolParameterType
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
@@ -69,7 +69,7 @@ class AIAgentToolTest {
             agentDescription = "Test agent description",
         )
 
-        val argsJson = tool.encodeArgs(SimpleData("Test input"), serializer)
+        val argsJson = tool.encodeArgs(AgentToolInput(SimpleData("Test input")), serializer)
     }
 
     @OptIn(InternalAgentToolsApi::class)


### PR DESCRIPTION
After #1588 , `AIAgentTool` stopped working for agents that accept primitives as an input. This PR introduces `AIAgentToolInput` wrapper to support primitive inputs, similar to `FinishTool`