### PR TITLE
example: fix local Koog publishing in simple-examples-java to make it work with debugger in IntelliJ

### DIFF
--- a/examples/simple-examples-java/build.gradle.kts
+++ b/examples/simple-examples-java/build.gradle.kts
@@ -17,18 +17,6 @@ dependencies {
     implementation(libs.logback.classic)
 }
 
-/*
- Java code doesn't complete well and produces false positive red code when it depends on a Kotlin project via Gradle composite build,
- so hacking our own "composite build" version via publishing to maven local
-*/
-
-interface ExecOps {
-    @get:Inject
-    val execOps: ExecOperations
-}
-
-val execOps = objects.newInstance<ExecOps>().execOps
-
 /**
  * Gradle composite build with direct dependency on Koog breaks intellisense in IntelliJ when writing Java (false positive red code, etc.).
  * So for Java simple examples this "publish to maven local" hack is used.
@@ -43,33 +31,40 @@ val koogLocalMarker = File(
     ".m2/repository/ai/koog/koog-agents/$koogVersion/koog-agents-$koogVersion.pom"
 )
 
-fun ExecSpec.doPublishKoogToMavenLocal() {
-    workingDir = koogRootDir
-    commandLine(
-        "${koogRootDir.resolve("gradlew").absolutePath}",
-        // KMP modules: root metadata module and only JVM artifacts
+fun doPublishKoogToMavenLocal() {
+    val process = ProcessBuilder(
+        koogRootDir.resolve("gradlew").absolutePath,
         "publishKotlinMultiplatformPublicationToMavenLocal",
         "publishJvmPublicationToMavenLocal",
-        // JVM-only modules
         "publishMavenPublicationToMavenLocal",
         "-Pversion=${koogVersion.removeSuffix("-SNAPSHOT")}",
-    )
+    ).directory(koogRootDir)
+        .start()
+
+    process.inputStream.bufferedReader().forEachLine { line ->
+        logger.lifecycle(line)
+    }
+
+    val exitCode = process.waitFor()
+    if (exitCode != 0) {
+        throw GradleException("publishKoogToMavenLocal failed with exit code $exitCode")
+    }
 }
 
 // Check if koog artifacts exist in mavenLocal. If not, publish them when initializing the script
 if (!koogLocalMarker.exists()) {
     logger.lifecycle("Koog $koogVersion not found in mavenLocal — publishing")
-    execOps.exec {
-        doPublishKoogToMavenLocal()
-    }
+    doPublishKoogToMavenLocal()
     logger.lifecycle("Koog $koogVersion published")
 }
 
-val publishKoogToMavenLocal by tasks.registering(Exec::class) {
+val publishKoogToMavenLocal by tasks.registering {
     group = "setup"
     description = "Publishes the main Koog project to mavenLocal with version $koogVersion (cached by Gradle)"
 
-    doPublishKoogToMavenLocal()
+    doLast {
+        doPublishKoogToMavenLocal()
+    }
 }
 
 //endregion


### PR DESCRIPTION
When you run something in `simple-examples-java` in debug mode in IntelliJ, it hangs at `publishKoogtoMavenLocal`. Update Gradle configs to use a separate process using `ProcessBuilder` to publish local Koog artifacts from the root project