### PR TITLE
fix(agents): KG-750. Fix deadlock when agent.run() is called from within executor.submit()

### DIFF
--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/utils/CoroutineUtils.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/utils/CoroutineUtils.kt
@@ -7,6 +7,7 @@ import ai.koog.agents.core.annotation.InternalAgentsApi
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.asExecutor
 import kotlinx.coroutines.runBlocking
@@ -81,22 +82,23 @@ public fun <T> AIAgentConfig.runOnStrategyDispatcher(
 internal val AGENT_CONTEXT_ELEMENT: ThreadLocal<CoroutineContext> = ThreadLocal()
 
 /**
- * Executes a suspending [block] by either using [runBlocking] or immediately executing it if already
- * on the target dispatcher.
+ * Executes a suspending [block] as a bridge from blocking (Java) code into the coroutine world.
+ * It uses [AGENT_CONTEXT_ELEMENT] to track the current logical dispatcher across blocking boundaries
+ * and avoid deadlocks in two scenarios:
  *
- * This function handles the "bridge" between the non-suspending Java API and the suspending internal logic.
- * It uses [AGENT_CONTEXT_ELEMENT] to track the execution state across blocking boundaries.
+ * **Re-entrant call (AGENT_CONTEXT_ELEMENT is set):** the current thread is already inside a
+ * `runBlocking` started by this function. If the target dispatcher matches the existing one,
+ * using `runBlocking(context)` would try to re-dispatch onto the same executor — which may be
+ * single-threaded and already blocked. `runBlocking(EmptyCoroutineContext)` avoids the re-dispatch
+ * by running inline on the current thread's event loop instead.
  *
- * ### Deadlock Prevention Logic:
- * If the current thread is already associated with a [CoroutineContext] (stored in [AGENT_CONTEXT_ELEMENT]):
- * 1. It compares the [targetDispatcher] with the [existingDispatcher].
- * 2. If they match (or [targetDispatcher] is null), it uses `runBlocking(EmptyCoroutineContext)`.
- *    This starts a nested event loop on the **current thread** without trying to reschedule the task
- *    on the dispatcher's executor service. This is vital because the executor might be single-threaded
- *    and currently blocked by the outer `runBlocking` call.
- *
- * If the dispatchers differ, it performs a standard `runBlocking(context)`, which may block the current
- * thread while the block executes on a different thread pool (e.g., switching from Strategy to LLM pool).
+ * **First entry (AGENT_CONTEXT_ELEMENT is null):** the calling thread may itself be a worker of
+ * the target executor (e.g. `agent.run()` called from inside `executor.submit()`). In that case,
+ * `runBlocking(context)` would dispatch the coroutine onto the executor and then park the calling
+ * thread waiting for it — but the calling thread IS the only worker, so the coroutine never runs.
+ * `runBlocking(EmptyCoroutineContext)` runs the coroutine inline on the current thread, bypassing
+ * the executor queue entirely. The TARGET context is stored in [AGENT_CONTEXT_ELEMENT] (not the
+ * actual `coroutineContext`) so that nested calls can still compare dispatchers correctly.
  *
  * @param context The coroutine context to use for execution. Defaults to [EmptyCoroutineContext].
  * @param block The suspending block to execute.
@@ -113,18 +115,28 @@ public fun <T> runBlockingIfRequired(context: CoroutineContext = EmptyCoroutineC
         val existingDispatcher = existingContext[ContinuationInterceptor] as? CoroutineDispatcher
 
         if (targetDispatcher == null || targetDispatcher == existingDispatcher) {
-            // We are already on the same dispatcher.
-            // Using a new runBlocking with EmptyCoroutineContext will block the current thread
-            // but won't try to dispatch to the executor again, avoiding deadlock.
+            // Same dispatcher: running runBlocking(context) would re-dispatch onto the same
+            // executor that is already blocked waiting for us — deadlock. Run inline instead.
             return runBlocking(EmptyCoroutineContext) {
                 block()
             }
         }
     }
 
-    return runBlocking(context) {
+    // First entry from non-coroutine code (AGENT_CONTEXT_ELEMENT == null).
+    // runBlocking(context) would dispatch the coroutine onto the executor and park this thread.
+    //
+    // If this thread is itself a worker of that executor, the coroutine would sit in the queue
+    // with no thread available to run it - deadlock.
+    //
+    // runBlocking(EmptyCoroutineContext) runs the coroutine inline on the current thread, so
+    // the executor queue is never involved.
+    //
+    // Note: we store the TARGET context (not coroutineContext) in AGENT_CONTEXT_ELEMENT so that
+    // nested calls compare against the intended dispatcher, not the BlockingEventLoop.
+    return runBlocking(EmptyCoroutineContext) {
         val old = AGENT_CONTEXT_ELEMENT.get()
-        AGENT_CONTEXT_ELEMENT.set(coroutineContext)
+        AGENT_CONTEXT_ELEMENT.set(context)
         try {
             block()
         } finally {
@@ -145,6 +157,18 @@ public fun <T> runBlockingIfRequired(context: CoroutineContext = EmptyCoroutineC
  */
 @InternalAgentsApi
 public suspend fun <T> AIAgentConfig.submitToMainDispatcher(block: () -> T): T {
+    // If the current thread is a worker of strategyExecutorService and is blocked inside
+    // runBlocking's event loop, it cannot drain the executor's task queue. Submitting block()
+    // via executor.execute would queue it there and suspend waiting, but nobody can pick it.
+    // Detect this case and run block() directly on the current thread instead.
+    val existingContext = AGENT_CONTEXT_ELEMENT.get()
+    if (existingContext != null) {
+        val existingExecutor = (existingContext[ContinuationInterceptor] as? ExecutorCoroutineDispatcher)?.executor
+        if (existingExecutor != null && existingExecutor === strategyExecutorService) {
+            return block()
+        }
+    }
+
     val result = CompletableDeferred<T>()
 
     (strategyExecutorService ?: Dispatchers.Default.asExecutor()).execute {

--- a/agents/agents-core/src/jvmTest/java/ai/koog/agents/core/agent/JavaExecutorTest.java
+++ b/agents/agents-core/src/jvmTest/java/ai/koog/agents/core/agent/JavaExecutorTest.java
@@ -1,0 +1,60 @@
+package ai.koog.agents.core.agent;
+
+import ai.koog.agents.core.agent.config.AIAgentConfig;
+import ai.koog.agents.testing.tools.MockExecutorBuilder;
+import ai.koog.prompt.dsl.Prompt;
+import ai.koog.prompt.executor.clients.openai.OpenAIModels;
+import ai.koog.serialization.JSONSerializer;
+import ai.koog.serialization.jackson.JacksonSerializer;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JavaExecutorTest {
+    private static final JSONSerializer serializer = new JacksonSerializer();
+
+    @Test
+    public void sharedExecutorUsingSameExecutorsTest() throws Exception {
+        var mockExecutor = new MockExecutorBuilder(serializer)
+            .mockLLMAnswer("ok").asDefaultResponse()
+            .build();
+
+        ExecutorService sharedExecutor = Executors.newSingleThreadExecutor();
+
+        try {
+            AIAgentConfig config = new AIAgentConfig(
+                Prompt.builder("deadlock-prompt").system("system").build(),
+                OpenAIModels.Chat.GPT4o,
+                3,
+                sharedExecutor,
+                sharedExecutor
+            );
+
+            AIAgent<String, String> agent = AIAgent.builder()
+                .promptExecutor(mockExecutor)
+                .agentConfig(config)
+                .functionalStrategy(new NonSuspendAIAgentFunctionalStrategy<String, String>("same-executor-run") {
+                    @Override
+                    public String executeStrategy(ai.koog.agents.core.agent.context.@NotNull AIAgentFunctionalContext context, String input) {
+                        return input;
+                    }
+                })
+                .build();
+
+            Future<String> future = sharedExecutor.submit(() ->
+                agent.run("ok", null, sharedExecutor)
+            );
+
+            assertEquals("ok", future.get(2, TimeUnit.SECONDS));
+            future.cancel(true);
+        } finally {
+            sharedExecutor.shutdownNow();
+        }
+    }
+}

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/LLMReadSessionJavaApiTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/LLMReadSessionJavaApiTest.kt
@@ -13,51 +13,17 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 
-class LLMWriteSessionJavaApiTest {
+class LLMReadSessionJavaApiTest {
     private val serializer = KotlinxSerializer()
 
     @Test
-    fun writeSession_allowsPromptSwapAndRequest() {
-        val executor = getMockExecutor(serializer) { }
-
-        val config = AIAgentConfig(
-            prompt = Prompt.builder("write-session")
-                .system("base")
-                .build(),
-            model = OpenAIModels.Chat.GPT4o,
-            maxAgentIterations = 3
-        )
-
-        val agent = AIAgent.builder()
-            .agentConfig(config)
-            .functionalStrategy<String, String>(
-                "useWriteSession"
-            ) { ctx: AIAgentFunctionalContext, input: String ->
-                // Mutate prompt inside writeSession and ensure it restores back
-                ctx.llm().writeSession { session ->
-                    val orig = session.prompt
-                    session.prompt = Prompt.builder("temp").system("temporary").user(input).build()
-                    // restore immediately to validate restoration path without invoking suspend APIs here
-                    session.prompt = orig
-                }
-                // Return a deterministic string to prove strategy executed without using suspend APIs
-                "mutated:$input"
-            }
-            .promptExecutor(executor)
-            .build()
-
-        val result = agent.javaNonSuspendRun("hello", null, null)
-        assertEquals("mutated:hello", result)
-    }
-
-    @Test
-    fun javaNonSuspendRunWithSameThreadExecutorWrite() {
+    fun javaNonSuspendRunWithSameThreadExecutorRead() {
         val executor = getMockExecutor(serializer) {
             mockLLMAnswer("ok").asDefaultResponse
         }
 
         val config = AIAgentConfig(
-            prompt = Prompt.builder("write")
+            prompt = Prompt.builder("read")
                 .system("test")
                 .build(),
             model = OpenAIModels.Chat.GPT4o,
@@ -69,9 +35,9 @@ class LLMWriteSessionJavaApiTest {
             val agent = AIAgent.builder()
                 .agentConfig(config)
                 .functionalStrategy(
-                    "write"
+                    "read"
                 ) { ctx: AIAgentFunctionalContext, _: String ->
-                    val response = ctx.llm().writeSession { session ->
+                    val response = ctx.llm().readSession { session ->
                         session.requestLLM(sharedExecutor)
                     }
                     (response as Message.Assistant).content

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/utils/JavaApiTestUtils.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/utils/JavaApiTestUtils.kt
@@ -1,0 +1,19 @@
+package ai.koog.agents.core.utils
+
+import ai.koog.agents.core.agent.AIAgent
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Future
+
+fun submitRun(
+    sharedExecutor: ExecutorService,
+    agent: AIAgent<String, String>
+): Future<String> {
+    return sharedExecutor.submit<String> {
+        try {
+            agent.javaNonSuspendRun("hello", null, sharedExecutor)
+        } catch (e: ExecutionException) {
+            throw e.cause ?: e
+        }
+    }
+}


### PR DESCRIPTION
Fix deadlock when agent.run() is called from within executor.submit()

- When agent.run() was invoked from a thread that is itself a worker of
the configured ExecutorService runBlocking(context) would dispatch the
coroutine back onto that executor and park the calling thread, but no
other thread existed to run it.

closes: [KG-750](https://youtrack.jetbrains.com/issue/KG-750)