### PR TITLE
fix(agents): Do not throw error for custom MCP transport type in MCPToolRegistryProvider

### DIFF
--- a/agents/agents-mcp-metadata/src/commonMain/kotlin/ai/koog/agents/mcp/metadata/McpToolSupport.kt
+++ b/agents/agents-mcp-metadata/src/commonMain/kotlin/ai/koog/agents/mcp/metadata/McpToolSupport.kt
@@ -75,4 +75,12 @@ public enum class McpTransportType(public val value: String) {
      * Suitable for distributed architectures and cloud-based MCP servers.
      */
     Tcp("tcp"),
+
+    /**
+     * Represents an unknown or undefined transport protocol type.
+     *
+     * This value is used as a fallback or default when the transport type
+     * cannot be identified or does not match any of the predefined types.
+     */
+    Unknown("unknown"),
 }

--- a/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpToolRegistryProvider.kt
+++ b/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpToolRegistryProvider.kt
@@ -107,8 +107,8 @@ public object McpToolRegistryProvider {
                     McpMetadataKeys.McpTransportType to when (mcpClient.transport) {
                         is SseClientTransport -> McpTransportType.Tcp
                         is StdioClientTransport -> McpTransportType.Stdio
-                        else -> error("Unexpected null for client transport: ${mcpClient.transport}")
-                    }.value,
+                        else -> null
+                    }?.value,
                     McpMetadataKeys.McpSessionId to "",
                     McpMetadataKeys.ServerUrl to serverInfo.url.orEmpty(),
                     McpMetadataKeys.ServerPort to getPort(serverInfo.url),

--- a/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpToolRegistryProvider.kt
+++ b/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpToolRegistryProvider.kt
@@ -107,8 +107,11 @@ public object McpToolRegistryProvider {
                     McpMetadataKeys.McpTransportType to when (mcpClient.transport) {
                         is SseClientTransport -> McpTransportType.Tcp
                         is StdioClientTransport -> McpTransportType.Stdio
-                        else -> null
-                    }?.value,
+                        else -> {
+                            logger.warn { "Unknown transport type: ${mcpClient.transport::class.simpleName}" }
+                            McpTransportType.Unknown
+                        }
+                    }.value,
                     McpMetadataKeys.McpSessionId to "",
                     McpMetadataKeys.ServerUrl to serverInfo.url.orEmpty(),
                     McpMetadataKeys.ServerPort to getPort(serverInfo.url),

--- a/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpToolRegistryProvider.kt
+++ b/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpToolRegistryProvider.kt
@@ -108,7 +108,7 @@ public object McpToolRegistryProvider {
                         is SseClientTransport -> McpTransportType.Tcp
                         is StdioClientTransport -> McpTransportType.Stdio
                         else -> {
-                            logger.warn { "Unknown transport type: ${mcpClient.transport::class.simpleName}" }
+                            logger.warn { "Unknown transport type: ${mcpClient.transport?.let { it::class.simpleName }}" }
                             McpTransportType.Unknown
                         }
                     }.value,


### PR DESCRIPTION
Was causing runtime crashes for users with non-default custom MCP transports