### PR TITLE
refactor(prompt): decouple LLMClient constructors from Ktor

### DIFF
--- a/http-client/http-client-ktor/build.gradle.kts
+++ b/http-client/http-client-ktor/build.gradle.kts
@@ -15,6 +15,8 @@ kotlin {
                 api(project(":http-client:http-client-core"))
                 implementation(project(":utils"))
                 implementation(libs.ktor.client.core)
+                implementation(libs.ktor.client.content.negotiation)
+                implementation(libs.ktor.serialization.kotlinx.json)
                 implementation(libs.oshai.kotlin.logging)
             }
         }
@@ -23,6 +25,7 @@ kotlin {
             dependencies {
                 implementation(project(":http-client:http-client-test"))
                 implementation(libs.ktor.client.cio)
+                implementation(libs.ktor.client.mock)
                 implementation(libs.ktor.serialization.kotlinx.json)
                 implementation(libs.ktor.client.content.negotiation)
                 implementation(kotlin("test-junit5"))

--- a/http-client/http-client-ktor/src/commonMain/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClient.kt
+++ b/http-client/http-client-ktor/src/commonMain/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClient.kt
@@ -8,10 +8,15 @@ import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.call.body
 import io.ktor.client.engine.HttpClientEngineConfig
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.plugins.sse.SSE
 import io.ktor.client.plugins.sse.SSEClientException
 import io.ktor.client.plugins.sse.sse
 import io.ktor.client.request.accept
 import io.ktor.client.request.get
+import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -20,14 +25,17 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
+import io.ktor.http.contentType
 import io.ktor.http.headers
 import io.ktor.http.isSuccess
+import io.ktor.serialization.kotlinx.json.json
 import io.ktor.util.reflect.TypeInfo
 import io.ktor.utils.io.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
 import org.jetbrains.annotations.ApiStatus.Experimental
 import kotlin.jvm.JvmOverloads
 import kotlin.reflect.KClass
@@ -212,3 +220,63 @@ public fun KoogHttpClient.Companion.fromKtorClient(
     baseClient: HttpClient = HttpClient(),
     configurer: HttpClientConfig<out HttpClientEngineConfig>.() -> Unit = {}
 ): KoogHttpClient = KtorKoogHttpClient(clientName, logger, baseClient, configurer)
+
+/**
+ * Creates an instance of `KoogHttpClient` using Ktor's `HttpClient` and additional configuration options.
+ *
+ * This method combines a base `HttpClient` with predefined configurations for request handling,
+ * such as timeouts, headers, query parameters, content type, and optional Server-Sent Events (SSE) support.
+ *
+ * @param clientName The name assigned to the client instance, used for logging and traceability purposes.
+ * @param logger A `KLogger` instance for logging client operations and errors.
+ * @param baseClient The base Ktor `HttpClient` instance to be used. Defaults to a new `HttpClient` instance.
+ * @param baseUrl The base URL for all HTTP requests made through this client.
+ * @param requestTimeoutMillis The timeout in milliseconds for HTTP requests.
+ * @param connectTimeoutMillis The timeout in milliseconds for establishing a connection.
+ * @param socketTimeoutMillis The timeout in milliseconds for socket operations.
+ * @param json A `Json` instance used for serializing request bodies and deserializing responses.
+ * @param headers A map of default HTTP headers to include in every request. Defaults to an empty map.
+ * @param queryParameters A map of default query parameters to include in every request. Defaults to an empty map.
+ * @param withSse A flag indicating whether the client should support Server-Sent Events (SSE). Defaults to `true`.
+ * @return A `KoogHttpClient` instance configured with the specified parameters and options.
+ */
+@Experimental
+@JvmOverloads
+public fun KoogHttpClient.Companion.fromKtorClient(
+    clientName: String,
+    logger: KLogger,
+    baseClient: HttpClient = HttpClient(),
+    baseUrl: String,
+    requestTimeoutMillis: Long,
+    connectTimeoutMillis: Long,
+    socketTimeoutMillis: Long,
+    json: Json,
+    headers: Map<String, String> = emptyMap(),
+    queryParameters: Map<String, String> = emptyMap(),
+    withSse: Boolean = true,
+): KoogHttpClient = KoogHttpClient.fromKtorClient(
+    clientName = clientName,
+    logger = logger,
+    baseClient = baseClient
+) {
+    defaultRequest {
+        url(baseUrl)
+        contentType(ContentType.Application.Json)
+        headers.forEach { (name, value) -> header(name, value) }
+        queryParameters.forEach { (name, value) -> url.parameters.append(name, value) }
+    }
+
+    if (withSse) {
+        install(SSE)
+    }
+
+    install(ContentNegotiation) {
+        json(json)
+    }
+
+    install(HttpTimeout) {
+        this.requestTimeoutMillis = requestTimeoutMillis
+        this.connectTimeoutMillis = connectTimeoutMillis
+        this.socketTimeoutMillis = socketTimeoutMillis
+    }
+}

--- a/koog-spring-boot-starter/src/test/kotlin/ai/koog/spring/KoogAutoConfigurationTest.kt
+++ b/koog-spring-boot-starter/src/test/kotlin/ai/koog/spring/KoogAutoConfigurationTest.kt
@@ -8,7 +8,6 @@ import ai.koog.prompt.executor.clients.google.GoogleClientSettings
 import ai.koog.prompt.executor.clients.google.GoogleLLMClient
 import ai.koog.prompt.executor.clients.mistralai.MistralAILLMClient
 import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
-import ai.koog.prompt.executor.clients.openai.base.AbstractOpenAILLMClient
 import ai.koog.prompt.executor.clients.openai.base.OpenAIBaseSettings
 import ai.koog.prompt.executor.clients.openrouter.OpenRouterLLMClient
 import ai.koog.prompt.executor.clients.retry.RetryConfig
@@ -64,7 +63,7 @@ class KoogAutoConfigurationTest {
         )
 
     @Test
-    fun `should not supply executor beans if no apiKey is provided`() {
+    fun `should not supply executor beans if no api key property is provided`() {
         createApplicationContextRunner()
             .run { context ->
                 assertThrows<NoSuchBeanDefinitionException> { context.getBean<SingleLLMPromptExecutor>() }
@@ -72,7 +71,7 @@ class KoogAutoConfigurationTest {
     }
 
     @Test
-    fun `should supply OpenAI executor bean with provided apiKey and default baseUrl`() {
+    fun `should supply OpenAI executor bean with default baseUrl`() {
         val configApiKey = "some_api_key"
         createApplicationContextRunner()
             .withPropertyValues(
@@ -82,9 +81,6 @@ class KoogAutoConfigurationTest {
                 val executor = context.getBean<SingleLLMPromptExecutor>()
                 val llmClient = getPrivateFieldValue(executor, "llmClient")
                 assertInstanceOf<OpenAILLMClient>(llmClient)
-
-                val apiKey = getPrivateFieldValue(llmClient as AbstractOpenAILLMClient<*, *>, "apiKey")
-                assertEquals(configApiKey, apiKey)
 
                 val settings = getPrivateFieldValue(llmClient, "settings") as OpenAIBaseSettings
                 val baseUrl = getPrivateFieldValue(settings, "baseUrl")
@@ -245,7 +241,7 @@ class KoogAutoConfigurationTest {
     }
 
     @Test
-    fun `should supply Anthropic executor bean with provided apiKey and default baseUrl`() {
+    fun `should supply Anthropic executor bean with default baseUrl`() {
         val configApiKey = "some_api_key"
         createApplicationContextRunner()
             .withPropertyValues(
@@ -255,9 +251,6 @@ class KoogAutoConfigurationTest {
                 val executor = context.getBean<SingleLLMPromptExecutor>()
                 val llmClient = getPrivateFieldValue(executor, "llmClient")
                 assertInstanceOf<AnthropicLLMClient>(llmClient)
-
-                val apiKey = getPrivateFieldValue(llmClient, "apiKey")
-                assertEquals(configApiKey, apiKey)
 
                 val settings = getPrivateFieldValue(llmClient, "settings") as AnthropicClientSettings
                 val baseUrl = getPrivateFieldValue(settings, "baseUrl")
@@ -307,7 +300,7 @@ class KoogAutoConfigurationTest {
     }
 
     @Test
-    fun `should supply Google executor bean with provided apiKey and default baseUrl`() {
+    fun `should supply Google executor bean with default baseUrl`() {
         val configApiKey = "some_api_key"
         createApplicationContextRunner()
             .withPropertyValues(
@@ -317,9 +310,6 @@ class KoogAutoConfigurationTest {
                 val executor = context.getBean<SingleLLMPromptExecutor>()
                 val llmClient = getPrivateFieldValue(executor, "llmClient")
                 assertInstanceOf<GoogleLLMClient>(llmClient)
-
-                val apiKey = getPrivateFieldValue(llmClient, "apiKey")
-                assertEquals(configApiKey, apiKey)
 
                 val settings = getPrivateFieldValue(llmClient, "settings") as GoogleClientSettings
                 val baseUrl = getPrivateFieldValue(settings, "baseUrl")
@@ -368,7 +358,7 @@ class KoogAutoConfigurationTest {
     }
 
     @Test
-    fun `should supply OpenRouter executor bean with provided apiKey and default baseUrl`() {
+    fun `should supply OpenRouter executor bean with default baseUrl`() {
         val configApiKey = "some_api_key"
         createApplicationContextRunner()
             .withPropertyValues(
@@ -379,9 +369,6 @@ class KoogAutoConfigurationTest {
                 val executor = context.getBean<SingleLLMPromptExecutor>()
                 val llmClient = getPrivateFieldValue(executor, "llmClient")
                 assertInstanceOf<OpenRouterLLMClient>(llmClient)
-
-                val apiKey = getPrivateFieldValue(llmClient as AbstractOpenAILLMClient<*, *>, "apiKey")
-                assertEquals(configApiKey, apiKey)
 
                 val settings = getPrivateFieldValue(llmClient, "settings") as OpenAIBaseSettings
                 val baseUrl = getPrivateFieldValue(settings, "baseUrl")
@@ -432,7 +419,7 @@ class KoogAutoConfigurationTest {
     }
 
     @Test
-    fun `should supply DeepSeek executor bean with provided apiKey and default baseUrl`() {
+    fun `should supply DeepSeek executor bean with default baseUrl`() {
         val configApiKey = "some_api_key"
         createApplicationContextRunner()
             .withPropertyValues(
@@ -442,9 +429,6 @@ class KoogAutoConfigurationTest {
                 val executor = context.getBean<SingleLLMPromptExecutor>()
                 val llmClient = getPrivateFieldValue(executor, "llmClient")
                 assertInstanceOf<DeepSeekLLMClient>(llmClient)
-
-                val apiKey = getPrivateFieldValue(llmClient as AbstractOpenAILLMClient<*, *>, "apiKey")
-                assertEquals(configApiKey, apiKey)
 
                 val settings = getPrivateFieldValue(llmClient, "settings") as OpenAIBaseSettings
                 val baseUrl = getPrivateFieldValue(settings, "baseUrl")
@@ -492,7 +476,7 @@ class KoogAutoConfigurationTest {
     }
 
     @Test
-    fun `should supply MistralAI executor bean with provided apiKey and default baseUrl`() {
+    fun `should supply MistralAI executor bean with default baseUrl`() {
         val configApiKey = "some_api_key"
         createApplicationContextRunner()
             .withPropertyValues(
@@ -502,9 +486,6 @@ class KoogAutoConfigurationTest {
                 val executor = context.getBean<SingleLLMPromptExecutor>()
                 val llmClient = getPrivateFieldValue(executor, "llmClient")
                 assertInstanceOf<MistralAILLMClient>(llmClient)
-
-                val apiKey = getPrivateFieldValue(llmClient as AbstractOpenAILLMClient<*, *>, "apiKey")
-                assertEquals(configApiKey, apiKey)
 
                 val settings = getPrivateFieldValue(llmClient, "settings") as OpenAIBaseSettings
                 val baseUrl = getPrivateFieldValue(settings, "baseUrl")

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
@@ -40,14 +40,6 @@ import ai.koog.prompt.streaming.buildStreamFrameFlow
 import ai.koog.prompt.streaming.requireEndFrame
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
-import io.ktor.client.plugins.HttpTimeout
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.plugins.sse.SSE
-import io.ktor.client.request.header
-import io.ktor.http.ContentType
-import io.ktor.http.contentType
-import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.json.Json
@@ -86,53 +78,64 @@ public class AnthropicClientSettings(
  * It leverages Kotlin Coroutines to handle asynchronous operations and provides full support for configuring HTTP
  * requests, including timeout handling and JSON serialization.
  *
- * @constructor Creates an instance of the AnthropicSuspendableDirectClient.
- * @param apiKey The API key required to authenticate with the Anthropic service.
  * @param settings Configurable settings for the Anthropic client, which include the base URL and other options.
- * @param baseClient An optional custom configuration for the underlying HTTP client, defaulting to a Ktor client.
+ * @param httpClient A preconfigured Koog HTTP client used for API calls. Must have authentication and other
+ *   request defaults already embedded. To use a Ktor-backed client with standard defaults, use the secondary
+ *   constructor that accepts an API key and an [io.ktor.client.HttpClient].
  * @param clock Clock instance used for tracking response metadata timestamps.
  */
 public open class AnthropicLLMClient @JvmOverloads constructor(
-    private val apiKey: String,
     private val settings: AnthropicClientSettings = AnthropicClientSettings(),
-    baseClient: HttpClient = HttpClient(),
+    protected val httpClient: KoogHttpClient,
     private val clock: Clock = Clock.System
 ) : LLMClient() {
 
     private companion object {
+        private const val ANTHROPIC_CLIENT_NAME = "AnthropicLLMClient"
+
         private val logger = KotlinLogging.logger { }
+        private val json = Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+            encodeDefaults = true // Ensure default values are included in serialization
+            explicitNulls = false
+            namingStrategy = JsonNamingStrategy.SnakeCase
+        }
+
+        private fun createConfiguredHttpClient(
+            apiKey: String,
+            settings: AnthropicClientSettings,
+            baseClient: HttpClient = HttpClient()
+        ): KoogHttpClient = KoogHttpClient.fromKtorClient(
+            clientName = ANTHROPIC_CLIENT_NAME,
+            logger = logger,
+            baseClient = baseClient,
+            baseUrl = settings.baseUrl,
+            requestTimeoutMillis = settings.timeoutConfig.requestTimeoutMillis,
+            connectTimeoutMillis = settings.timeoutConfig.connectTimeoutMillis,
+            socketTimeoutMillis = settings.timeoutConfig.socketTimeoutMillis,
+            json = json,
+            headers = mapOf(
+                "x-api-key" to apiKey,
+                "anthropic-version" to settings.apiVersion
+            ),
+        )
     }
 
-    private val json = Json {
-        ignoreUnknownKeys = true
-        isLenient = true
-        encodeDefaults = true // Ensure default values are included in serialization
-        explicitNulls = false
-        namingStrategy = JsonNamingStrategy.SnakeCase
-    }
-
-    // Configures HTTP client with timeouts, headers, and JSON handling
-    protected val httpClient: KoogHttpClient = KoogHttpClient.fromKtorClient(
-        clientName = clientName,
-        logger = logger,
-        baseClient = baseClient
-    ) {
-        defaultRequest {
-            url(settings.baseUrl)
-            contentType(ContentType.Application.Json)
-            header("x-api-key", apiKey)
-            header("anthropic-version", settings.apiVersion)
-        }
-        install(SSE)
-        install(ContentNegotiation) {
-            json(json)
-        }
-        install(HttpTimeout) {
-            requestTimeoutMillis = settings.timeoutConfig.requestTimeoutMillis // Increase timeout to 60 seconds
-            connectTimeoutMillis = settings.timeoutConfig.connectTimeoutMillis
-            socketTimeoutMillis = settings.timeoutConfig.socketTimeoutMillis
-        }
-    }
+    /**
+     * Secondary constructor for creating an Anthropic client from a base Ktor HTTP client.
+     */
+    @JvmOverloads
+    public constructor(
+        apiKey: String,
+        settings: AnthropicClientSettings = AnthropicClientSettings(),
+        baseClient: HttpClient = HttpClient(),
+        clock: Clock = Clock.System
+    ) : this(
+        settings = settings,
+        httpClient = createConfiguredHttpClient(apiKey, settings, baseClient),
+        clock = clock
+    )
 
     /**
      * Provides the specific Large Language Model (LLM) provider used by the client.
@@ -142,6 +145,8 @@ public open class AnthropicLLMClient @JvmOverloads constructor(
      *
      * @return The LLM provider associated with this client, specifically `LLMProvider.Anthropic`.
      */
+    override val clientName: String = ANTHROPIC_CLIENT_NAME
+
     override fun llmProvider(): LLMProvider = LLMProvider.Anthropic
 
     override suspend fun execute(prompt: Prompt, model: LLModel, tools: List<ToolDescriptor>): List<Message.Response> {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/dashscope/DashscopeLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/dashscope/DashscopeLLMClient.kt
@@ -1,5 +1,6 @@
 package ai.koog.prompt.executor.clients.dashscope
 
+import ai.koog.http.client.KoogHttpClient
 import ai.koog.prompt.dsl.ModerationResult
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
@@ -44,28 +45,43 @@ public class DashscopeClientSettings(
 /**
  * Implementation of [AbstractOpenAILLMClient] for DashScope API using OpenAI-compatible endpoints.
  *
- * @param apiKey The API key for the DashScope API
  * @param settings The base URL, chat completion path, and timeouts for the DashScope API,
  * defaults to "https://dashscope-intl.aliyuncs.com/compatible-mode/v1" and 900s
- * @param baseClient HTTP client for making requests
+ * @param httpClient A fully configured [KoogHttpClient] for making API requests. Use the secondary constructor
+ *   to create a Ktor-backed client configured with an API key.
  * @param clock Clock instance used for tracking response metadata timestamps
  */
 public class DashscopeLLMClient @JvmOverloads constructor(
-    apiKey: String,
     private val settings: DashscopeClientSettings = DashscopeClientSettings(),
-    baseClient: HttpClient = HttpClient(),
+    httpClient: KoogHttpClient,
     clock: Clock = Clock.System,
     toolsConverter: OpenAICompatibleToolDescriptorSchemaGenerator = OpenAICompatibleToolDescriptorSchemaGenerator()
 ) : AbstractOpenAILLMClient<DashscopeChatCompletionResponse, DashscopeChatCompletionStreamResponse>(
-    apiKey = apiKey,
     settings = settings,
-    baseClient = baseClient,
+    httpClient = httpClient,
     clock = clock,
     logger = staticLogger,
     toolsConverter = toolsConverter
 ) {
 
+    @JvmOverloads
+    public constructor(
+        apiKey: String,
+        settings: DashscopeClientSettings = DashscopeClientSettings(),
+        baseClient: HttpClient = HttpClient(),
+        clock: Clock = Clock.System,
+        toolsConverter: OpenAICompatibleToolDescriptorSchemaGenerator = OpenAICompatibleToolDescriptorSchemaGenerator()
+    ) : this(
+        settings = settings,
+        httpClient = createConfiguredHttpClient(apiKey, settings, staticLogger, baseClient, clientName = DASHSCOPE_CLIENT_NAME),
+        clock = clock,
+        toolsConverter = toolsConverter
+    )
+
+    override val clientName: String = DASHSCOPE_CLIENT_NAME
+
     private companion object {
+        private const val DASHSCOPE_CLIENT_NAME = "DashscopeLLMClient"
         private val staticLogger = KotlinLogging.logger { }
     }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
@@ -1,5 +1,6 @@
 package ai.koog.prompt.executor.clients.deepseek
 
+import ai.koog.http.client.KoogHttpClient
 import ai.koog.prompt.dsl.ModerationResult
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
@@ -49,27 +50,43 @@ public class DeepSeekClientSettings(
 /**
  * Implementation of [LLMClient] for DeepSeek API.
  *
- * @param apiKey The API key for the DeepSeek API
  * @param settings The base URL, chat completion path, and timeouts for the DeepSeek API,
  * defaults to "https://api.deepseek.com" and 900s
+ * @param httpClient A fully configured [KoogHttpClient] for making API requests. Use the secondary constructor
+ *   to create a Ktor-backed client configured with an API key.
  * @param clock Clock instance used for tracking response metadata timestamps.
  */
 public class DeepSeekLLMClient @JvmOverloads constructor(
-    apiKey: String,
     private val settings: DeepSeekClientSettings = DeepSeekClientSettings(),
-    baseClient: HttpClient = HttpClient(),
+    httpClient: KoogHttpClient,
     clock: Clock = Clock.System,
     toolsConverter: OpenAICompatibleToolDescriptorSchemaGenerator = OpenAICompatibleToolDescriptorSchemaGenerator()
 ) : AbstractOpenAILLMClient<DeepSeekChatCompletionResponse, DeepSeekChatCompletionStreamResponse>(
-    apiKey = apiKey,
     settings = settings,
-    baseClient = baseClient,
+    httpClient = httpClient,
     clock = clock,
     logger = staticLogger,
     toolsConverter = toolsConverter
 ) {
 
+    @JvmOverloads
+    public constructor(
+        apiKey: String,
+        settings: DeepSeekClientSettings = DeepSeekClientSettings(),
+        baseClient: HttpClient = HttpClient(),
+        clock: Clock = Clock.System,
+        toolsConverter: OpenAICompatibleToolDescriptorSchemaGenerator = OpenAICompatibleToolDescriptorSchemaGenerator()
+    ) : this(
+        settings = settings,
+        httpClient = createConfiguredHttpClient(apiKey, settings, staticLogger, baseClient, clientName = DEEPSEEK_CLIENT_NAME),
+        clock = clock,
+        toolsConverter = toolsConverter
+    )
+
+    override val clientName: String = DEEPSEEK_CLIENT_NAME
+
     private companion object {
+        private const val DEEPSEEK_CLIENT_NAME = "DeepSeekLLMClient"
         private val staticLogger = KotlinLogging.logger { }
     }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -45,13 +45,6 @@ import ai.koog.prompt.streaming.requireEndFrame
 import ai.koog.prompt.structure.annotations.InternalStructuredOutputApi
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
-import io.ktor.client.plugins.HttpTimeout
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.plugins.sse.SSE
-import io.ktor.http.ContentType
-import io.ktor.http.contentType
-import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.json.Json
@@ -91,21 +84,65 @@ public class GoogleClientSettings(
  * This client supports both standard and streaming text generation with
  * optional tool calling capabilities.
  *
- * @param apiKey The API key for the Google AI API
  * @param settings Custom client settings, defaults to standard API endpoint and timeouts
- * @param baseClient Optional custom HTTP client
+ * @param httpClient A preconfigured Koog HTTP client used for API calls. Must have authentication and other
+ *   request defaults already embedded. To use a Ktor-backed client with standard defaults, use the secondary
+ *   constructor that accepts an API key and an [io.ktor.client.HttpClient].
  * @param clock Clock instance used for tracking response metadata timestamps.
  */
 public open class GoogleLLMClient @JvmOverloads constructor(
-    private val apiKey: String,
     private val settings: GoogleClientSettings = GoogleClientSettings(),
-    baseClient: HttpClient = HttpClient(),
+    private val httpClient: KoogHttpClient,
     private val clock: Clock = Clock.System
 ) : LLMClient(), LLMEmbeddingProvider {
 
+    /**
+     * Secondary constructor for creating a GoogleLLMClient backed with a Ktor HTTP client.
+     *
+     * @param apiKey The API key for the Google AI API
+     * @param settings Custom client settings, defaults to standard API endpoint and timeouts
+     * @param baseClient Ktor HTTP client used for making API requests.
+     * @param clock Clock instance used for tracking response metadata timestamps.
+     */
+    @JvmOverloads
+    public constructor(
+        apiKey: String,
+        settings: GoogleClientSettings = GoogleClientSettings(),
+        baseClient: HttpClient = HttpClient(),
+        clock: Clock = Clock.System
+    ) : this(
+        settings,
+        createConfiguredHttpClient(apiKey, settings, baseClient),
+        clock
+    )
+
     @OptIn(InternalStructuredOutputApi::class)
     private companion object {
+        private const val GOOGLE_CLIENT_NAME = "GoogleLLMClient"
+
         private val logger = KotlinLogging.logger { }
+        private val json = Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+            encodeDefaults = true
+            explicitNulls = false
+        }
+
+        private fun createConfiguredHttpClient(
+            apiKey: String,
+            settings: GoogleClientSettings,
+            baseClient: HttpClient = HttpClient()
+        ): KoogHttpClient = KoogHttpClient.fromKtorClient(
+            clientName = GOOGLE_CLIENT_NAME,
+            logger = logger,
+            baseClient = baseClient,
+            baseUrl = settings.baseUrl,
+            requestTimeoutMillis = settings.timeoutConfig.requestTimeoutMillis,
+            connectTimeoutMillis = settings.timeoutConfig.connectTimeoutMillis,
+            socketTimeoutMillis = settings.timeoutConfig.socketTimeoutMillis,
+            json = json,
+            queryParameters = mapOf("key" to apiKey),
+        )
     }
 
     override fun getBasicJsonSchemaGenerator(): GoogleBasicJsonSchemaGenerator {
@@ -116,39 +153,13 @@ public open class GoogleLLMClient @JvmOverloads constructor(
         return GoogleStandardJsonSchemaGenerator
     }
 
-    private val json = Json {
-        ignoreUnknownKeys = true
-        isLenient = true
-        encodeDefaults = true
-        explicitNulls = false
-    }
-
-    private val httpClient: KoogHttpClient = KoogHttpClient.fromKtorClient(
-        clientName = clientName,
-        logger = logger,
-        baseClient = baseClient
-    ) {
-        defaultRequest {
-            url(settings.baseUrl)
-            url.parameters.append("key", apiKey)
-            contentType(ContentType.Application.Json)
-        }
-        install(SSE)
-        install(ContentNegotiation) {
-            json(json)
-        }
-        install(HttpTimeout) {
-            requestTimeoutMillis = settings.timeoutConfig.requestTimeoutMillis
-            connectTimeoutMillis = settings.timeoutConfig.connectTimeoutMillis
-            socketTimeoutMillis = settings.timeoutConfig.socketTimeoutMillis
-        }
-    }
-
     /**
      * Provides the Large Language Model (LLM) provider associated with this client.
      *
      * @return The LLM provider, which is Google for this implementation.
      */
+    override val clientName: String = GOOGLE_CLIENT_NAME
+
     override fun llmProvider(): LLMProvider = LLMProvider.Google
 
     override suspend fun execute(prompt: Prompt, model: LLModel, tools: List<ToolDescriptor>): List<Message.Response> {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAILLMClient.kt
@@ -1,5 +1,6 @@
 package ai.koog.prompt.executor.clients.mistralai
 
+import ai.koog.http.client.KoogHttpClient
 import ai.koog.prompt.dsl.ModerationCategory
 import ai.koog.prompt.dsl.ModerationCategoryResult
 import ai.koog.prompt.dsl.ModerationResult
@@ -41,6 +42,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
+import kotlin.jvm.JvmOverloads
 import kotlin.time.Clock
 
 /**
@@ -63,27 +65,43 @@ public class MistralAIClientSettings(
 /**
  * Implementation of [LLMClient] for Mistral AI.
  *
- * @param apiKey The API key for the Mistral AI API
  * @param settings The base URL, chat completion path, and timeouts for the Mistral AI
+ * @param httpClient A fully configured [KoogHttpClient] for making API requests. Use the secondary constructor
+ *   to create a Ktor-backed client configured with an API key.
  * @param clock Clock instance used for tracking response metadata timestamps
  */
-public open class MistralAILLMClient(
-    apiKey: String,
+public open class MistralAILLMClient @JvmOverloads constructor(
     private val settings: MistralAIClientSettings = MistralAIClientSettings(),
-    baseClient: HttpClient = HttpClient(),
+    httpClient: KoogHttpClient,
     clock: Clock = Clock.System,
     toolsConverter: OpenAICompatibleToolDescriptorSchemaGenerator = OpenAICompatibleToolDescriptorSchemaGenerator()
 ) : AbstractOpenAILLMClient<MistralAIChatCompletionResponse, MistralAIChatCompletionStreamResponse>(
-    apiKey = apiKey,
     settings = settings,
-    baseClient = baseClient,
+    httpClient = httpClient,
     clock = clock,
     logger = staticLogger,
     toolsConverter = toolsConverter,
 ),
     LLMEmbeddingProvider {
 
+    @JvmOverloads
+    public constructor(
+        apiKey: String,
+        settings: MistralAIClientSettings = MistralAIClientSettings(),
+        baseClient: HttpClient = HttpClient(),
+        clock: Clock = Clock.System,
+        toolsConverter: OpenAICompatibleToolDescriptorSchemaGenerator = OpenAICompatibleToolDescriptorSchemaGenerator()
+    ) : this(
+        settings = settings,
+        httpClient = AbstractOpenAILLMClient.createConfiguredHttpClient(apiKey, settings, staticLogger, baseClient, clientName = MISTRALAI_CLIENT_NAME),
+        clock = clock,
+        toolsConverter = toolsConverter
+    )
+
+    override val clientName: String = MISTRALAI_CLIENT_NAME
+
     private companion object {
+        private const val MISTRALAI_CLIENT_NAME = "MistralAILLMClient"
         private val staticLogger = KotlinLogging.logger { }
     }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
@@ -34,14 +34,6 @@ import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.streaming.requireEndFrame
 import io.github.oshai.kotlinlogging.KLogger
 import io.ktor.client.HttpClient
-import io.ktor.client.plugins.HttpTimeout
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.plugins.sse.SSE
-import io.ktor.client.request.header
-import io.ktor.http.ContentType
-import io.ktor.http.contentType
-import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
@@ -71,16 +63,15 @@ public abstract class OpenAIBaseSettings(
  * Abstract base class for OpenAI-compatible LLM clients.
  * Provides common functionality for communicating with OpenAI and OpenAI-compatible APIs.
  *
- * @param apiKey The API key for authentication with the OpenAI-compatible API.
  * @param settings Configuration settings including base URL, API paths, and timeout configuration.
- * @param baseClient The HTTP client to use for API requests. Defaults to a new HttpClient instance.
+ * @param httpClient A fully configured [KoogHttpClient] for making API requests. Must have authentication
+ *   and other request defaults (base URL, timeouts, headers) already embedded. To use a Ktor-backed client
+ *   with standard OpenAI-compatible defaults, use the secondary constructor that accepts an [HttpClient] and an API key.
  * @param clock Clock instance used for tracking response metadata timestamps. Defaults to Clock.System.
  */
-public abstract class AbstractOpenAILLMClient<TResponse : OpenAIBaseLLMResponse, TStreamResponse : OpenAIBaseLLMStreamResponse>
-@JvmOverloads constructor(
-    private val apiKey: String,
+public abstract class AbstractOpenAILLMClient<TResponse : OpenAIBaseLLMResponse, TStreamResponse : OpenAIBaseLLMStreamResponse>(
     settings: OpenAIBaseSettings,
-    baseClient: HttpClient = HttpClient(),
+    protected val httpClient: KoogHttpClient,
     protected val clock: Clock = Clock.System,
     protected val logger: KLogger,
     private val toolsConverter: OpenAICompatibleToolDescriptorSchemaGenerator,
@@ -96,31 +87,56 @@ public abstract class AbstractOpenAILLMClient<TResponse : OpenAIBaseLLMResponse,
 
     private val chatCompletionsPath: String = settings.chatCompletionsPath
 
-    protected val json: Json = Json {
-        ignoreUnknownKeys = true
-        isLenient = true
-        encodeDefaults = true
-        explicitNulls = false
-        namingStrategy = JsonNamingStrategy.SnakeCase
-    }
+    protected val json: Json = defaultJson
 
-    protected val httpClient: KoogHttpClient = KoogHttpClient.fromKtorClient(
-        clientName = clientName,
+    /**
+     * Secondary constructor for creating a client backed by a Ktor [HttpClient].
+     * Configures authentication, base URL, timeouts, and JSON serialization automatically from [apiKey] and [settings].
+     */
+    @JvmOverloads
+    public constructor(
+        apiKey: String,
+        settings: OpenAIBaseSettings,
+        baseClient: HttpClient = HttpClient(),
+        clientName: String = "OpenAICompatibleClient",
+        clock: Clock = Clock.System,
+        logger: KLogger,
+        toolsConverter: OpenAICompatibleToolDescriptorSchemaGenerator,
+    ) : this(
+        settings = settings,
+        httpClient = createConfiguredHttpClient(apiKey, settings, logger, baseClient, clientName),
+        clock = clock,
         logger = logger,
-        baseClient = baseClient
-    ) {
-        defaultRequest {
-            url(settings.baseUrl)
-            contentType(ContentType.Application.Json)
-            header("Authorization", "Bearer $apiKey")
+        toolsConverter = toolsConverter
+    )
+
+    public companion object {
+
+        private val defaultJson = Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+            encodeDefaults = true
+            explicitNulls = false
+            namingStrategy = JsonNamingStrategy.SnakeCase
         }
-        install(SSE)
-        install(ContentNegotiation) { json(json) }
-        install(HttpTimeout) {
-            requestTimeoutMillis = settings.timeoutConfig.requestTimeoutMillis // Increase timeout to 60 seconds
-            connectTimeoutMillis = settings.timeoutConfig.connectTimeoutMillis
-            socketTimeoutMillis = settings.timeoutConfig.socketTimeoutMillis
-        }
+
+        public fun createConfiguredHttpClient(
+            apiKey: String,
+            settings: OpenAIBaseSettings,
+            logger: KLogger,
+            baseClient: HttpClient = HttpClient(),
+            clientName: String
+        ): KoogHttpClient = KoogHttpClient.fromKtorClient(
+            clientName = clientName,
+            logger = logger,
+            baseClient = baseClient,
+            baseUrl = settings.baseUrl,
+            requestTimeoutMillis = settings.timeoutConfig.requestTimeoutMillis,
+            connectTimeoutMillis = settings.timeoutConfig.connectTimeoutMillis,
+            socketTimeoutMillis = settings.timeoutConfig.socketTimeoutMillis,
+            json = defaultJson,
+            headers = mapOf("Authorization" to "Bearer $apiKey"),
+        )
     }
 
     /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -1,6 +1,7 @@
 package ai.koog.prompt.executor.clients.openai
 
 import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.http.client.KoogHttpClient
 import ai.koog.prompt.dsl.ModerationCategory
 import ai.koog.prompt.dsl.ModerationCategoryResult
 import ai.koog.prompt.dsl.ModerationResult
@@ -94,28 +95,46 @@ public class OpenAIClientSettings(
 
 /**
  * Implementation of [LLMClient] for OpenAI API.
- * Uses Ktor HttpClient to communicate with the OpenAI API.
  *
- * @param apiKey The API key for the OpenAI API
  * @param settings The base URL and timeouts for the OpenAI API, defaults to "https://api.openai.com" and 900 s
+ * @param httpClient A fully configured [KoogHttpClient] for making API requests. Use the secondary constructor
+ *   to create a Ktor-backed client configured with an API key.
  * @param clock Clock instance used for tracking response metadata timestamps.
  */
 @OptIn(ExperimentalAtomicApi::class)
 public open class OpenAILLMClient @JvmOverloads constructor(
-    apiKey: String,
     private val settings: OpenAIClientSettings = OpenAIClientSettings(),
-    baseClient: HttpClient = HttpClient(),
+    httpClient: KoogHttpClient,
     clock: Clock = Clock.System,
     private val toolsConverter: OpenAICompatibleToolDescriptorSchemaGenerator = OpenAICompatibleToolDescriptorSchemaGenerator(),
 ) : AbstractOpenAILLMClient<OpenAIChatCompletionResponse, OpenAIChatCompletionStreamResponse>(
-    apiKey,
-    settings,
-    baseClient,
-    clock,
-    staticLogger,
-    toolsConverter
+    settings = settings,
+    httpClient = httpClient,
+    clock = clock,
+    logger = staticLogger,
+    toolsConverter = toolsConverter
 ),
     LLMEmbeddingProvider {
+
+    @JvmOverloads
+    public constructor(
+        apiKey: String,
+        settings: OpenAIClientSettings = OpenAIClientSettings(),
+        baseClient: HttpClient = HttpClient(),
+        clock: Clock = Clock.System,
+        toolsConverter: OpenAICompatibleToolDescriptorSchemaGenerator = OpenAICompatibleToolDescriptorSchemaGenerator(),
+    ) : this(
+        settings = settings,
+        httpClient = createConfiguredHttpClient(
+            apiKey = apiKey,
+            settings = settings,
+            logger = staticLogger,
+            baseClient = baseClient,
+            clientName = OPENAI_CLIENT_NAME
+        ),
+        clock = clock,
+        toolsConverter = toolsConverter
+    )
 
     /**
      * Returns the specific implementation of the `LLMProvider` associated with this client.
@@ -167,8 +186,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
             parallelToolCalls = chatParams.parallelToolCalls,
             prediction = chatParams.speculation?.let { OpenAIStaticContent(OpenAIContent.Text(it)) },
             presencePenalty = chatParams.presencePenalty,
-            promptCacheKey = chatParams.promptCacheKey,
-            reasoningEffort = chatParams.reasoningEffort,
+            promptCacheKey = chatParams.promptCacheKey, reasoningEffort = chatParams.reasoningEffort,
             responseFormat = responseFormat,
             safetyIdentifier = chatParams.safetyIdentifier,
             serviceTier = chatParams.serviceTier,
@@ -240,7 +258,10 @@ public open class OpenAILLMClient @JvmOverloads constructor(
         return json.encodeToString(OpenAIResponsesAPIRequestSerializer, request)
     }
 
+    override val clientName: String = OPENAI_CLIENT_NAME
+
     private companion object {
+        private const val OPENAI_CLIENT_NAME = "OpenAILLMClient"
         private val staticLogger = KotlinLogging.logger { }
     }
 
@@ -358,7 +379,12 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                         }
 
                         is OpenAIStreamEvent.ResponseFunctionCallArgumentsDelta -> {
-                            StreamFrame.ToolCallDelta(id = it.itemId, name = null, content = it.delta, index = it.outputIndex)
+                            StreamFrame.ToolCallDelta(
+                                id = it.itemId,
+                                name = null,
+                                content = it.delta,
+                                index = it.outputIndex
+                            )
                         }
 
                         is OpenAIStreamEvent.ResponseOutputItemDone -> {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
@@ -1,5 +1,6 @@
 package ai.koog.prompt.executor.clients.openrouter
 
+import ai.koog.http.client.KoogHttpClient
 import ai.koog.prompt.dsl.ModerationResult
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
@@ -58,27 +59,43 @@ public class OpenRouterClientSettings(
  * Implementation of [LLMClient] for OpenRouter API.
  * OpenRouter is an API that routes requests to multiple LLM providers.
  *
- * @param apiKey The API key for the OpenRouter API
  * @param settings The base URL and timeouts for the OpenRouter API, defaults to "https://openrouter.ai" and 900s
+ * @param httpClient A fully configured [KoogHttpClient] for making API requests. Use the secondary constructor
+ *   to create a Ktor-backed client configured with an API key.
  * @param clock Clock instance used for tracking response metadata timestamps.
  */
 public class OpenRouterLLMClient @JvmOverloads constructor(
-    apiKey: String,
     private val settings: OpenRouterClientSettings = OpenRouterClientSettings(),
-    baseClient: HttpClient = HttpClient(),
+    httpClient: KoogHttpClient,
     clock: Clock = Clock.System,
     toolsConverter: OpenAICompatibleToolDescriptorSchemaGenerator = OpenAICompatibleToolDescriptorSchemaGenerator(),
 ) : AbstractOpenAILLMClient<OpenRouterChatCompletionResponse, OpenRouterChatCompletionStreamResponse>(
-    apiKey = apiKey,
     settings = settings,
-    baseClient = baseClient,
+    httpClient = httpClient,
     clock = clock,
     logger = staticLogger,
     toolsConverter = toolsConverter
 ),
     LLMEmbeddingProvider {
 
+    @JvmOverloads
+    public constructor(
+        apiKey: String,
+        settings: OpenRouterClientSettings = OpenRouterClientSettings(),
+        baseClient: HttpClient = HttpClient(),
+        clock: Clock = Clock.System,
+        toolsConverter: OpenAICompatibleToolDescriptorSchemaGenerator = OpenAICompatibleToolDescriptorSchemaGenerator(),
+    ) : this(
+        settings = settings,
+        httpClient = AbstractOpenAILLMClient.createConfiguredHttpClient(apiKey, settings, staticLogger, baseClient, clientName = OPENROUTER_CLIENT_NAME),
+        clock = clock,
+        toolsConverter = toolsConverter
+    )
+
+    override val clientName: String = OPENROUTER_CLIENT_NAME
+
     private companion object {
+        private const val OPENROUTER_CLIENT_NAME = "OpenRouterLLMClient"
         private val staticLogger = KotlinLogging.logger { }
     }
 


### PR DESCRIPTION
Changes constructor of specific `LLMClient` implementations so that the primary constructor uses generic `KoogHttpClient` and not the `io.ktor.client.HttpClient`.
Introduced a secondary constructor backed with a Ktor client for backward compatibility—there are users and integrations (i.e. Spring) that rely on it.