### PR TITLE
feat: Add support for subgraphs and nested subgraphs in Mermaid diagram generator

### DIFF
--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/MermaidDiagramGenerator.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/MermaidDiagramGenerator.kt
@@ -1,10 +1,13 @@
 package ai.koog.agents.core.agent
 
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
-import ai.koog.agents.core.agent.entity.AIAgentNodeBase
-import ai.koog.agents.core.agent.entity.AIAgentSubgraphBase
-import ai.koog.agents.core.agent.entity.FinishNode
-import ai.koog.agents.core.agent.entity.StartNode
+
+private val MERMAID_ID_REGEX = Regex("[^a-zA-Z0-9_]")
+
+/**
+ * Sanitizes a string for use as a Mermaid state diagram identifier.
+ */
+private fun String.toMermaidId(): String = replace(MERMAID_ID_REGEX, "_")
 
 /**
  * Extension function to convert GraphData to mermaid diagram string.
@@ -28,18 +31,17 @@ private fun renderGraphContent(
     graphData: GraphData,
     indent: String,
 ) {
-    // Render regular nodes (skip start, finish, and subgraph nodes)
+    // Render regular nodes only. Start/Finish use [*] syntax in edges, and subgraphs
+    // are rendered separately below as composite states with their own inner content.
     graphData.nodes.values
-        .filterNot { it is StartNode }
-        .filterNot { it is FinishNode }
-        .filterNot { it is AIAgentSubgraphBase<*, *> }
+        .filter { it.type == NodeType.REGULAR }
         .forEach { node ->
             sb.appendLine("$indent${node.toMermaidNode()}")
         }
 
     // Render subgraphs as composite states
     graphData.subgraphs.forEach { subgraph ->
-        val sgId = subgraph.id.replace("-", "_")
+        val sgId = subgraph.id.toMermaidId()
         sb.appendLine("${indent}state \"${subgraph.name}\" as $sgId {")
         renderGraphContent(sb, subgraph.innerData, indent = "$indent    ")
         sb.appendLine("$indent}")
@@ -61,7 +63,7 @@ private fun EdgeInfo.toMermaidEdge(): String {
     val fromId = fromNode.toMermaidNodeRef()
     val toId = toNode.toMermaidNodeRef()
 
-    return if (condition != null && condition.isNotBlank()) {
+    return if (!condition.isNullOrBlank()) {
         "$fromId --> $toId : $condition"
     } else {
         "$fromId --> $toId"
@@ -69,40 +71,30 @@ private fun EdgeInfo.toMermaidEdge(): String {
 }
 
 /**
- * Extension function to render an AIAgentNodeBase as a mermaid node declaration string.
+ * Extension function to render a NodeInfo as a mermaid node declaration string.
  */
-private fun AIAgentNodeBase<*, *>.toMermaidNode(): String =
-    when (this) {
-        is StartNode -> "[*]"
-        is FinishNode -> "[*]"
-        else -> "state \"${name}\" as ${id.replace("-", "_")}"
+private fun NodeInfo.toMermaidNode(): String =
+    when (type) {
+        NodeType.START, NodeType.FINISH -> "[*]"
+        NodeType.REGULAR, NodeType.SUBGRAPH -> "state \"${name}\" as ${id.toMermaidId()}"
     }
 
 /**
- * Converts an AIAgentNodeBase to its mermaid node reference representation.
- *
- * @return A string representing the mermaid node reference. For StartNode and FinishNode,
- * it returns "[*]". For other nodes, it converts the node ID by replacing dashes with underscores.
+ * Converts a NodeInfo to its mermaid node reference representation.
  */
-private fun AIAgentNodeBase<*, *>.toMermaidNodeRef(): String =
-    when (this) {
-        is StartNode -> "[*]"
-        is FinishNode -> "[*]"
-        else -> id.replace("-", "_")
+private fun NodeInfo.toMermaidNodeRef(): String =
+    when (type) {
+        NodeType.START, NodeType.FINISH -> "[*]"
+        NodeType.REGULAR, NodeType.SUBGRAPH -> id.toMermaidId()
     }
 
 /**
- * AIAgentGraphStrategy utility for generating Mermaid diagrams from agent strategies.
+ * Extension function to generate a Mermaid diagram from an agent graph strategy.
  *
  * References: https://docs.koog.ai/complex-workflow-agents/
  */
 public fun <I : Any, O : Any> AIAgentGraphStrategy<I, O>.asMermaidDiagram(): String =
-    try {
-        val graphData = collectGraphData()
-        graphData.toMermaidDiagram()
-    } catch (e: Exception) {
-        throw RuntimeException("Can't generate Mermaid diagram for graph", e)
-    }
+    MermaidDiagramGenerator.generate(this)
 
 public object MermaidDiagramGenerator : DiagramGenerator {
 
@@ -111,7 +103,7 @@ public object MermaidDiagramGenerator : DiagramGenerator {
             val graphData = graph.collectGraphData()
             return graphData.toMermaidDiagram()
         } catch (e: Exception) {
-            throw RuntimeException("Can't generate Mermaid diagram for graph", e)
+            throw RuntimeException("Can't generate Mermaid diagram for graph '${graph.name}'", e)
         }
     }
 }

--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/MermaidDiagramGenerator.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/MermaidDiagramGenerator.kt
@@ -1,7 +1,8 @@
 package ai.koog.agents.core.agent
 
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
-import ai.koog.agents.core.agent.entity.AIAgentNode
+import ai.koog.agents.core.agent.entity.AIAgentNodeBase
+import ai.koog.agents.core.agent.entity.AIAgentSubgraphBase
 import ai.koog.agents.core.agent.entity.FinishNode
 import ai.koog.agents.core.agent.entity.StartNode
 
@@ -15,23 +16,43 @@ private fun GraphData.toMermaidDiagram(): String =
         appendLine("---")
         appendLine("stateDiagram")
 
-        // Render nodes
-        nodes.values
-            .filterNot { it is StartNode }
-            .filterNot { it is FinishNode }
-            .forEach { node ->
-                appendLine("    ${node.toMermaidNode()}")
-            }
-
-        // Add blank line before edges if there are any
-        if (edges.isNotEmpty()) {
-            appendLine()
-            // Render edges
-            edges.forEach { edge ->
-                appendLine("    ${edge.toMermaidEdge()}")
-            }
-        }
+        renderGraphContent(this, this@toMermaidDiagram, indent = "    ")
     }.trimEnd()
+
+/**
+ * Renders graph content (nodes, subgraphs, edges) at a given indentation level.
+ * Used recursively for nested subgraphs.
+ */
+private fun renderGraphContent(
+    sb: StringBuilder,
+    graphData: GraphData,
+    indent: String,
+) {
+    // Render regular nodes (skip start, finish, and subgraph nodes)
+    graphData.nodes.values
+        .filterNot { it is StartNode }
+        .filterNot { it is FinishNode }
+        .filterNot { it is AIAgentSubgraphBase<*, *> }
+        .forEach { node ->
+            sb.appendLine("$indent${node.toMermaidNode()}")
+        }
+
+    // Render subgraphs as composite states
+    graphData.subgraphs.forEach { subgraph ->
+        val sgId = subgraph.id.replace("-", "_")
+        sb.appendLine("${indent}state \"${subgraph.name}\" as $sgId {")
+        renderGraphContent(sb, subgraph.innerData, indent = "$indent    ")
+        sb.appendLine("$indent}")
+    }
+
+    // Add blank line before edges if there are any
+    if (graphData.edges.isNotEmpty()) {
+        sb.appendLine()
+        graphData.edges.forEach { edge ->
+            sb.appendLine("$indent${edge.toMermaidEdge()}")
+        }
+    }
+}
 
 /**
  * Extension function to render an EdgeInfo as a mermaid edge string.
@@ -48,42 +69,26 @@ private fun EdgeInfo.toMermaidEdge(): String {
 }
 
 /**
- * Extension function to render an AIAgentNode as a mermaid node string.
+ * Extension function to render an AIAgentNodeBase as a mermaid node declaration string.
  */
-private fun AIAgentNode<*, *>.toMermaidNode(): String =
+private fun AIAgentNodeBase<*, *>.toMermaidNode(): String =
     when (this) {
-        is StartNode -> {
-            "[*]"
-        }
-
-        is FinishNode -> {
-            "[*]"
-        }
-
-        else -> {
-            "state \"${name}\" as ${id.replace("-", "_")}"
-        }
+        is StartNode -> "[*]"
+        is FinishNode -> "[*]"
+        else -> "state \"${name}\" as ${id.replace("-", "_")}"
     }
 
 /**
- * Converts an AIAgentNode to its mermaid node reference representation.
+ * Converts an AIAgentNodeBase to its mermaid node reference representation.
  *
  * @return A string representing the mermaid node reference. For StartNode and FinishNode,
  * it returns "[*]". For other nodes, it converts the node ID by replacing dashes with underscores.
  */
-private fun AIAgentNode<*, *>.toMermaidNodeRef(): String =
+private fun AIAgentNodeBase<*, *>.toMermaidNodeRef(): String =
     when (this) {
-        is StartNode -> {
-            "[*]"
-        }
-
-        is FinishNode -> {
-            "[*]"
-        }
-
-        else -> {
-            id.replace("-", "_")
-        }
+        is StartNode -> "[*]"
+        is FinishNode -> "[*]"
+        else -> id.replace("-", "_")
     }
 
 /**

--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/graphModel.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/graphModel.kt
@@ -6,9 +6,6 @@ import ai.koog.agents.core.agent.entity.AIAgentNodeBase
 import ai.koog.agents.core.agent.entity.AIAgentSubgraphBase
 import ai.koog.agents.core.agent.entity.FinishNode
 import ai.koog.agents.core.agent.entity.StartNode
-import io.github.oshai.kotlinlogging.KotlinLogging
-
-private val logger = KotlinLogging.logger {}
 
 /**
  * The type of a node in the diagram model.
@@ -74,7 +71,7 @@ internal fun AIAgentGraphStrategy<*, *>.collectGraphData(): GraphData {
 }
 
 /**
- * Collects graph data for a single level (strategy or subgraph) by traversing from start node.
+ * Collects graph data for a single level (strategy or subgraph) by traversing from the start node.
  * Subgraphs encountered during traversal are collected recursively.
  */
 private fun collectGraphLevel(
@@ -148,13 +145,8 @@ private data class RawEdgeInfo(
  * Extension function to extract edges from a node using public API only.
  */
 private fun AIAgentNodeBase<*, *>.extractEdges(): List<RawEdgeInfo> =
-    try {
-        this.edges.mapNotNull { edge ->
-            extractEdgeInfo(edge)
-        }
-    } catch (e: ReflectiveOperationException) {
-        logger.warn(e) { "Could not extract edges from node '$name'" }
-        emptyList()
+    this.edges.map { edge ->
+        extractEdgeInfo(edge)
     }
 
 /**
@@ -175,17 +167,12 @@ private fun extractConditionLabel(str: String?): String? =
  * Extracts edge information from an AIAgentEdge.
  * Uses the public `toNode` property directly; reflection only for `forwardOutput` (internal).
  */
-private fun extractEdgeInfo(edge: AIAgentEdge<*, *>): RawEdgeInfo? {
+private fun extractEdgeInfo(edge: AIAgentEdge<*, *>): RawEdgeInfo {
     val toNode = edge.toNode
 
-    val forwardOutput =
-        try {
-            edge::class.java.methods
-                .firstOrNull { it.name == "getForwardOutput\$agents_core" || it.name == "getForwardOutput" }
-                ?.invoke(edge)
-        } catch (_: ReflectiveOperationException) {
-            null
-        }
+    val forwardOutput = edge::class.java.methods
+        .firstOrNull { it.name == $$"getForwardOutput$agents_core" || it.name == "getForwardOutput" }
+        ?.invoke(edge)
 
     return RawEdgeInfo(toNode, extractConditionFromForwardOutput(forwardOutput))
 }

--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/graphModel.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/graphModel.kt
@@ -1,15 +1,36 @@
 package ai.koog.agents.core.agent
 
+import ai.koog.agents.core.agent.entity.AIAgentEdge
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.agent.entity.AIAgentNodeBase
 import ai.koog.agents.core.agent.entity.AIAgentSubgraphBase
+import ai.koog.agents.core.agent.entity.FinishNode
+import ai.koog.agents.core.agent.entity.StartNode
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * The type of a node in the diagram model.
+ */
+internal enum class NodeType { START, FINISH, REGULAR, SUBGRAPH }
+
+/**
+ * Lightweight representation of a graph node for diagram generation.
+ * Decoupled from framework types so the data model and rendering are independent.
+ */
+internal data class NodeInfo(
+    val id: String,
+    val name: String,
+    val type: NodeType,
+)
 
 /**
  * Data class representing collected graph information for diagram generation.
  */
 internal data class GraphData(
     val title: String,
-    val nodes: Map<String, AIAgentNodeBase<*, *>>,
+    val nodes: Map<String, NodeInfo>,
     val edges: List<EdgeInfo>,
     val subgraphs: List<SubgraphGraphData> = emptyList(),
 )
@@ -27,17 +48,22 @@ internal data class SubgraphGraphData(
  * Data class representing edge information with condition.
  */
 internal data class EdgeInfo(
-    val fromNode: AIAgentNodeBase<*, *>,
-    val toNode: AIAgentNodeBase<*, *>,
+    val fromNode: NodeInfo,
+    val toNode: NodeInfo,
     val condition: String?,
 )
 
 /**
- * Data class representing raw edge information extracted from reflection.
+ * Converts a framework node to its lightweight diagram representation.
  */
-private data class RawEdgeInfo(
-    val toNode: AIAgentNodeBase<*, *>?,
-    val condition: String?,
+private fun AIAgentNodeBase<*, *>.toNodeInfo(): NodeInfo = NodeInfo(
+    id = id,
+    name = name,
+    type = when (this) {
+        is StartNode -> NodeType.START
+        is FinishNode -> NodeType.FINISH
+        else -> NodeType.REGULAR
+    },
 )
 
 /**
@@ -56,28 +82,33 @@ private fun collectGraphLevel(
     start: AIAgentNodeBase<*, *>,
     finish: AIAgentNodeBase<*, *>,
 ): GraphData {
-    val nodes = mutableMapOf<String, AIAgentNodeBase<*, *>>()
+    val nodes = mutableMapOf<String, NodeInfo>()
     val edges = mutableListOf<EdgeInfo>()
     val subgraphs = mutableListOf<SubgraphGraphData>()
 
-    nodes[start.id] = start
-    nodes[finish.id] = finish
+    nodes[start.id] = start.toNodeInfo()
+    nodes[finish.id] = finish.toNodeInfo()
 
     // BFS traversal from start
-    val visited = mutableSetOf<AIAgentNodeBase<*, *>>()
+    val visited = mutableSetOf<String>()
     val queue = ArrayDeque<AIAgentNodeBase<*, *>>()
     queue.add(start)
 
     while (queue.isNotEmpty()) {
         val current = queue.removeFirst()
-        if (current in visited) continue
-        visited.add(current)
+        if (current.id in visited) continue
+        visited.add(current.id)
 
         // Add node
-        nodes[current.id] = current
+        var currentInfo = nodes.getOrPut(current.id) { current.toNodeInfo() }
 
-        // If this is a subgraph (but not the top-level strategy), collect its inner structure
+        // Collect inner structure for subgraph nodes. AIAgentGraphStrategy is excluded because
+        // it represents the top-level strategy itself (which we are already traversing), not a
+        // nested subgraph. Note: Planner strategies (AIAgentPlannerStrategy) are not graph-based
+        // and don't extend AIAgentSubgraphBase, so they are not encountered during traversal.
         if (current is AIAgentSubgraphBase<*, *> && current !is AIAgentGraphStrategy<*, *>) {
+            currentInfo = currentInfo.copy(type = NodeType.SUBGRAPH)
+            nodes[current.id] = currentInfo
             subgraphs.add(
                 SubgraphGraphData(
                     name = current.name,
@@ -88,18 +119,12 @@ private fun collectGraphLevel(
         }
 
         // Collect edges from current node
-        try {
-            val nodeEdges = current.extractEdges()
-            nodeEdges.forEach { rawEdge ->
-                rawEdge.toNode?.let { toNode ->
-                    edges.add(EdgeInfo(current, toNode, rawEdge.condition))
-                    if (toNode !in visited) {
-                        queue.add(toNode)
-                    }
-                }
+        for (rawEdge in current.extractEdges()) {
+            val toInfo = nodes.getOrPut(rawEdge.toNode.id) { rawEdge.toNode.toNodeInfo() }
+            edges.add(EdgeInfo(currentInfo, toInfo, rawEdge.condition))
+            if (rawEdge.toNode.id !in visited) {
+                queue.add(rawEdge.toNode)
             }
-        } catch (_: Exception) {
-            // Skip nodes that don't have edges or can't be processed
         }
     }
 
@@ -112,6 +137,14 @@ private fun collectGraphLevel(
 }
 
 /**
+ * Raw edge info used internally during BFS collection.
+ */
+private data class RawEdgeInfo(
+    val toNode: AIAgentNodeBase<*, *>,
+    val condition: String?,
+)
+
+/**
  * Extension function to extract edges from a node using public API only.
  */
 private fun AIAgentNodeBase<*, *>.extractEdges(): List<RawEdgeInfo> =
@@ -119,46 +152,40 @@ private fun AIAgentNodeBase<*, *>.extractEdges(): List<RawEdgeInfo> =
         this.edges.mapNotNull { edge ->
             extractEdgeInfo(edge)
         }
-    } catch (_: Exception) {
+    } catch (e: ReflectiveOperationException) {
+        logger.warn(e) { "Could not extract edges from node '$name'" }
         emptyList()
     }
 
 /**
- * Extracts condition information from the ForwardOutput class name.
+ * Extracts a condition label from a string by checking for known edge DSL keywords.
  */
-private fun extractConditionFromClassName(className: String?): String? =
+private fun extractConditionLabel(str: String?): String? =
     when {
-        className == null -> null
-
-        className.contains("onCondition") -> "onCondition"
-
-        className.contains("onToolCall") -> "onToolCall"
-
-        className.contains("onAssistantMessage") -> "onAssistantMessage"
-
-        className.contains("transformed") -> "transformed"
-
-        className.contains("forwardTo") -> null
-
-        // Simple forward, no condition
+        str == null -> null
+        str.contains("onCondition") -> "onCondition"
+        str.contains("onToolCall") -> "onToolCall"
+        str.contains("onAssistantMessage") -> "onAssistantMessage"
+        str.contains("transformed") -> "transformed"
+        str.contains("forwardTo") -> null
         else -> null
     }
 
 /**
- * Extracts edge information from an AIAgentEdge using public API only.
+ * Extracts edge information from an AIAgentEdge.
+ * Uses the public `toNode` property directly; reflection only for `forwardOutput` (internal).
  */
-private fun extractEdgeInfo(edge: Any): RawEdgeInfo? {
-    val toNode =
-        runCatching {
-            edge::class.java.getMethod("getToNode").invoke(edge) as? AIAgentNodeBase<*, *>
-        }.getOrElse { return null }
+private fun extractEdgeInfo(edge: AIAgentEdge<*, *>): RawEdgeInfo? {
+    val toNode = edge.toNode
 
     val forwardOutput =
-        runCatching {
+        try {
             edge::class.java.methods
                 .firstOrNull { it.name == "getForwardOutput\$agents_core" || it.name == "getForwardOutput" }
                 ?.invoke(edge)
-        }.getOrNull()
+        } catch (_: ReflectiveOperationException) {
+            null
+        }
 
     return RawEdgeInfo(toNode, extractConditionFromForwardOutput(forwardOutput))
 }
@@ -167,28 +194,12 @@ private fun extractEdgeInfo(edge: Any): RawEdgeInfo? {
  * Extracts condition information from the ForwardOutput function.
  */
 private fun extractConditionFromForwardOutput(forwardOutput: Any?): String? {
-    return try {
-        if (forwardOutput == null) return null
+    if (forwardOutput == null) return null
 
-        // The ForwardOutput is a function, we need to examine its class name or toString
-        val className = forwardOutput::class.java.name
-        val toString = forwardOutput.toString()
+    // The ForwardOutput is a function, we need to examine its class name or toString
+    val className = forwardOutput::class.java.name
+    val toString = forwardOutput.toString()
 
-        // Try to extract condition from class name or string representation
-        extractConditionFromClassName(className) ?: extractConditionFromString(toString)
-    } catch (_: Exception) {
-        null
-    }
+    // Try to extract condition from class name or string representation
+    return extractConditionLabel(className) ?: extractConditionLabel(toString)
 }
-
-/**
- * Extracts condition information from string representation.
- */
-private fun extractConditionFromString(str: String): String? =
-    when {
-        str.contains("onCondition") -> "onCondition"
-        str.contains("onToolCall") -> "onToolCall"
-        str.contains("onAssistantMessage") -> "onAssistantMessage"
-        str.contains("transformed") -> "transformed"
-        else -> null
-    }

--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/graphModel.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/graphModel.kt
@@ -1,23 +1,34 @@
 package ai.koog.agents.core.agent
 
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
-import ai.koog.agents.core.agent.entity.AIAgentNode
+import ai.koog.agents.core.agent.entity.AIAgentNodeBase
+import ai.koog.agents.core.agent.entity.AIAgentSubgraphBase
 
 /**
- * Data class representing collected graph information for mermaid diagram generation.
+ * Data class representing collected graph information for diagram generation.
  */
 internal data class GraphData(
     val title: String,
-    val nodes: Map<String, AIAgentNode<*, *>>,
+    val nodes: Map<String, AIAgentNodeBase<*, *>>,
     val edges: List<EdgeInfo>,
+    val subgraphs: List<SubgraphGraphData> = emptyList(),
+)
+
+/**
+ * Data class representing a subgraph's collected graph information.
+ */
+internal data class SubgraphGraphData(
+    val name: String,
+    val id: String,
+    val innerData: GraphData,
 )
 
 /**
  * Data class representing edge information with condition.
  */
 internal data class EdgeInfo(
-    val fromNode: AIAgentNode<*, *>,
-    val toNode: AIAgentNode<*, *>,
+    val fromNode: AIAgentNodeBase<*, *>,
+    val toNode: AIAgentNodeBase<*, *>,
     val condition: String?,
 )
 
@@ -25,7 +36,7 @@ internal data class EdgeInfo(
  * Data class representing raw edge information extracted from reflection.
  */
 private data class RawEdgeInfo(
-    val toNode: AIAgentNode<*, *>?,
+    val toNode: AIAgentNodeBase<*, *>?,
     val condition: String?,
 )
 
@@ -33,73 +44,78 @@ private data class RawEdgeInfo(
  * Collects all graph data (nodes and edges) from the strategy.
  */
 internal fun AIAgentGraphStrategy<*, *>.collectGraphData(): GraphData {
-    val nodes = mutableMapOf<String, AIAgentNode<*, *>>()
+    return collectGraphLevel(this.name, this.nodeStart, this.nodeFinish)
+}
+
+/**
+ * Collects graph data for a single level (strategy or subgraph) by traversing from start node.
+ * Subgraphs encountered during traversal are collected recursively.
+ */
+private fun collectGraphLevel(
+    title: String,
+    start: AIAgentNodeBase<*, *>,
+    finish: AIAgentNodeBase<*, *>,
+): GraphData {
+    val nodes = mutableMapOf<String, AIAgentNodeBase<*, *>>()
     val edges = mutableListOf<EdgeInfo>()
+    val subgraphs = mutableListOf<SubgraphGraphData>()
 
-    // Add essential nodes
-    nodes[nodeStart.id] = nodeStart
-    nodes[nodeFinish.id] = nodeFinish
+    nodes[start.id] = start
+    nodes[finish.id] = finish
 
-    // Collect all nodes from metadata
-    metadata.nodesMap.forEach { (_, node) ->
-        if (node is AIAgentNode<*, *>) {
-            nodes[node.id] = node
+    // BFS traversal from start
+    val visited = mutableSetOf<AIAgentNodeBase<*, *>>()
+    val queue = ArrayDeque<AIAgentNodeBase<*, *>>()
+    queue.add(start)
+
+    while (queue.isNotEmpty()) {
+        val current = queue.removeFirst()
+        if (current in visited) continue
+        visited.add(current)
+
+        // Add node
+        nodes[current.id] = current
+
+        // If this is a subgraph (but not the top-level strategy), collect its inner structure
+        if (current is AIAgentSubgraphBase<*, *> && current !is AIAgentGraphStrategy<*, *>) {
+            subgraphs.add(
+                SubgraphGraphData(
+                    name = current.name,
+                    id = current.id,
+                    innerData = collectGraphLevel(current.name, current.start, current.finish),
+                )
+            )
+        }
+
+        // Collect edges from current node
+        try {
+            val nodeEdges = current.extractEdges()
+            nodeEdges.forEach { rawEdge ->
+                rawEdge.toNode?.let { toNode ->
+                    edges.add(EdgeInfo(current, toNode, rawEdge.condition))
+                    if (toNode !in visited) {
+                        queue.add(toNode)
+                    }
+                }
+            }
+        } catch (_: Exception) {
+            // Skip nodes that don't have edges or can't be processed
         }
     }
 
-    // Edges are extracted from individual nodes using their public API
-
-    // Collect edges from all nodes
-    val allNodes =
-        listOf(nodeStart as AIAgentNode<*, *>) +
-            metadata.nodesMap.values.filterIsInstance<AIAgentNode<*, *>>()
-
-    collectEdgesRecursively(allNodes, edges, nodes)
-
     return GraphData(
-        title = this.name,
+        title = title,
         nodes = nodes.toMap(),
         edges = edges.toList(),
+        subgraphs = subgraphs.toList(),
     )
 }
 
 /**
- * Recursively collect edges from nodes using tail recursion optimization.
+ * Extension function to extract edges from a node using public API only.
  */
-private tailrec fun collectEdgesRecursively(
-    remainingNodes: List<AIAgentNode<*, *>>,
-    edges: MutableList<EdgeInfo>,
-    nodes: MutableMap<String, AIAgentNode<*, *>>,
-) {
-    if (remainingNodes.isEmpty()) return
-
-    val currentNode = remainingNodes.first()
-    val restNodes = remainingNodes.drop(1)
-
-    // Extract edges from current node
+private fun AIAgentNodeBase<*, *>.extractEdges(): List<RawEdgeInfo> =
     try {
-        val nodeEdges = currentNode.extractEdges()
-        nodeEdges.forEach { edge ->
-            edge.toNode?.let { toNode ->
-                nodes[currentNode.id] = currentNode
-                nodes[toNode.id] = toNode
-                edges.add(EdgeInfo(currentNode, toNode, edge.condition))
-            }
-        }
-    } catch (_: Exception) {
-        // Skip nodes that don't have edges or can't be processed
-    }
-
-    // Tail recursive call
-    collectEdgesRecursively(restNodes, edges, nodes)
-}
-
-/**
- * Extension function to extract edges from an AIAgentNode using public API only.
- */
-private fun AIAgentNode<*, *>.extractEdges(): List<RawEdgeInfo> =
-    try {
-        // Use the public edges property to get edge information
         this.edges.mapNotNull { edge ->
             extractEdgeInfo(edge)
         }
@@ -113,11 +129,18 @@ private fun AIAgentNode<*, *>.extractEdges(): List<RawEdgeInfo> =
 private fun extractConditionFromClassName(className: String?): String? =
     when {
         className == null -> null
+
         className.contains("onCondition") -> "onCondition"
+
         className.contains("onToolCall") -> "onToolCall"
+
         className.contains("onAssistantMessage") -> "onAssistantMessage"
+
         className.contains("transformed") -> "transformed"
-        className.contains("forwardTo") -> null // Simple forward, no condition
+
+        className.contains("forwardTo") -> null
+
+        // Simple forward, no condition
         else -> null
     }
 
@@ -127,7 +150,7 @@ private fun extractConditionFromClassName(className: String?): String? =
 private fun extractEdgeInfo(edge: Any): RawEdgeInfo? {
     val toNode =
         runCatching {
-            edge::class.java.getMethod("getToNode").invoke(edge) as? AIAgentNode<*, *>
+            edge::class.java.getMethod("getToNode").invoke(edge) as? AIAgentNodeBase<*, *>
         }.getOrElse { return null }
 
     val forwardOutput =

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/MermaidDiagramGeneratorTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/MermaidDiagramGeneratorTest.kt
@@ -1,5 +1,7 @@
 package ai.koog.agents.core.agent
 
+import ai.koog.agents.core.agent.entity.ToolSelectionStrategy
+import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.builder.subgraph
@@ -9,6 +11,8 @@ import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResult
 import ai.koog.agents.core.dsl.extension.onAssistantMessage
 import ai.koog.agents.core.dsl.extension.onToolCall
+import ai.koog.agents.ext.agent.CriticResult
+import ai.koog.agents.ext.agent.subgraphWithVerification
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
@@ -214,6 +218,133 @@ class MermaidDiagramGeneratorTest {
                 [*] --> node1
                 node1 --> sg1
                 sg1 --> [*]
+            """.trimIndent()
+    }
+
+    @Test
+    fun `Should generate diagram via MermaidDiagramGenerator object`() {
+        val myStrategy = strategy<String, String>("object-test") {
+            val nodeCallLLM by nodeLLMRequest()
+            edge(nodeStart forwardTo nodeCallLLM)
+            edge(nodeCallLLM forwardTo nodeFinish onAssistantMessage { true })
+        }
+
+        val fromExtension = myStrategy.asMermaidDiagram()
+        val fromObject = MermaidDiagramGenerator.generate(myStrategy)
+
+        fromObject shouldBe fromExtension
+    }
+
+    @Test
+    fun `Should generate diagram for minimal graph with no intermediate nodes`() {
+        val myStrategy = strategy<String, String>("minimal-strategy") {
+            nodeStart then nodeFinish
+        }
+
+        val diagram = myStrategy.asMermaidDiagram()
+
+        diagram shouldBe
+            // language=mermaid
+            """
+            ---
+            title: minimal-strategy
+            ---
+            stateDiagram
+
+                [*] --> [*]
+            """.trimIndent()
+    }
+
+    @Test
+    fun `Should sanitize special characters in node names for Mermaid IDs`() {
+        val myStrategy = strategy<String, String>("special-chars") {
+            val node1 by node<String, String>("node-with-dashes") { it }
+            val node2 by node<String, String>("node.with.dots") { it }
+
+            nodeStart then node1 then node2 then nodeFinish
+        }
+
+        val diagram = myStrategy.asMermaidDiagram()
+
+        diagram shouldBe
+            // language=mermaid
+            """
+            ---
+            title: special-chars
+            ---
+            stateDiagram
+                state "node-with-dashes" as node_with_dashes
+                state "node.with.dots" as node_with_dots
+
+                [*] --> node_with_dashes
+                node_with_dashes --> node_with_dots
+                node_with_dots --> [*]
+            """.trimIndent()
+    }
+
+    @OptIn(InternalAgentsApi::class)
+    @Test
+    fun `Should generate diagram for strategy with subgraphWithVerification`() {
+        val myStrategy = strategy<String, String>("verification-strategy") {
+            val node1 by node<String, String>("prepare") { it }
+
+            val verify by subgraphWithVerification<String>(
+                toolSelectionStrategy = ToolSelectionStrategy.NONE,
+            ) { input -> "Verify: $input" }
+
+            val extractResult by node<CriticResult<String>, String>("extractResult") {
+                it.input
+            }
+
+            nodeStart then node1 then verify then extractResult then nodeFinish
+        }
+
+        val diagram = myStrategy.asMermaidDiagram()
+
+        diagram shouldBe
+            // language=mermaid
+            """
+            ---
+            title: verification-strategy
+            ---
+            stateDiagram
+                state "prepare" as prepare
+                state "extractResult" as extractResult
+                state "verify" as verify {
+                    state "saveInput" as saveInput
+                    state "provideResult" as provideResult
+                    state "verifyTask" as verifyTask {
+                        state "setupTask" as setupTask
+                        state "nodeCallLLM" as nodeCallLLM
+                        state "nodeDecide" as nodeDecide
+                        state "callToolsHacked" as callToolsHacked
+                        state "handleAssistantMessage" as handleAssistantMessage
+                        state "finalizeTask" as finalizeTask
+                        state "sendToolsResults" as sendToolsResults
+
+                        [*] --> setupTask
+                        setupTask --> nodeCallLLM
+                        nodeCallLLM --> nodeDecide
+                        nodeDecide --> callToolsHacked : transformed
+                        nodeDecide --> handleAssistantMessage : transformed
+                        nodeDecide --> [*] : transformed
+                        callToolsHacked --> finalizeTask : transformed
+                        callToolsHacked --> sendToolsResults
+                        handleAssistantMessage --> nodeDecide
+                        finalizeTask --> [*]
+                        sendToolsResults --> nodeDecide
+                    }
+
+                    [*] --> saveInput
+                    saveInput --> verifyTask
+                    verifyTask --> provideResult
+                    provideResult --> [*]
+                }
+
+                [*] --> prepare
+                prepare --> verify
+                verify --> extractResult
+                extractResult --> [*]
             """.trimIndent()
     }
 }

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/MermaidDiagramGeneratorTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/MermaidDiagramGeneratorTest.kt
@@ -1,7 +1,8 @@
 package ai.koog.agents.core.agent
 
-import ai.koog.agents.core.dsl.builder.forwardTo
+import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.core.dsl.builder.subgraph
 import ai.koog.agents.core.dsl.extension.nodeExecuteTool
 import ai.koog.agents.core.dsl.extension.nodeLLMModerateMessage
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
@@ -34,6 +35,7 @@ class MermaidDiagramGeneratorTest {
         val diagram = myStrategy.asMermaidDiagram()
 
         diagram shouldBe
+            // language=mermaid
             """
             ---
             title: my-strategy
@@ -53,7 +55,7 @@ class MermaidDiagramGeneratorTest {
     }
 
     @Test
-    fun `Should create a diagram for advanced`() {
+    fun `Should create a diagram for advanced strategy`() {
         val strategy = strategy<String, String>(
             name = "test-strategy",
         ) {
@@ -94,6 +96,7 @@ class MermaidDiagramGeneratorTest {
         val diagram = strategy.asMermaidDiagram()
 
         diagram shouldBe
+            // language=mermaid
             """
             ---
             title: test-strategy
@@ -112,6 +115,105 @@ class MermaidDiagramGeneratorTest {
                 ExecuteTool --> SendToolResult
                 SendToolResult --> [*] : transformed
                 SendToolResult --> ExecuteTool : onCondition
+            """.trimIndent()
+    }
+
+    @Test
+    fun `Should generate a diagram for strategy with subgraph`() {
+        val myStrategy = strategy<String, String>("subgraph-strategy") {
+            val node1 by node<String, String>("node1") { it }
+            val node2 by node<String, String>("node2") { it }
+
+            val sg by subgraph<String, String>("sg1") {
+                val sgNode1 by node<String, String>("sgNode1") { it }
+                val sgNode2 by node<String, String>("sgNode2") { it }
+
+                nodeStart then sgNode1 then sgNode2 then nodeFinish
+            }
+
+            nodeStart then node1 then sg then node2 then nodeFinish
+        }
+
+        val diagram = myStrategy.asMermaidDiagram()
+
+        diagram shouldBe
+            // language=mermaid
+            """
+            ---
+            title: subgraph-strategy
+            ---
+            stateDiagram
+                state "node1" as node1
+                state "node2" as node2
+                state "sg1" as sg1 {
+                    state "sgNode1" as sgNode1
+                    state "sgNode2" as sgNode2
+
+                    [*] --> sgNode1
+                    sgNode1 --> sgNode2
+                    sgNode2 --> [*]
+                }
+
+                [*] --> node1
+                node1 --> sg1
+                sg1 --> node2
+                node2 --> [*]
+            """.trimIndent()
+    }
+
+    @Test
+    fun `Should generate a diagram for strategy with nested subgraphs`() {
+        val myStrategy = strategy<String, String>("nested-strategy") {
+            val node1 by node<String, String>("node1") { it }
+
+            val sg by subgraph<String, String>("sg1") {
+                val sgNode1 by node<String, String>("sgNode1") { it }
+                val sgNode2 by node<String, String>("sgNode2") { it }
+
+                val innerSg by subgraph<String, String>("sg2") {
+                    val sg2Node1 by node<String, String>("sg2Node1") { it }
+                    val sg2Node2 by node<String, String>("sg2Node2") { it }
+
+                    nodeStart then sg2Node1 then sg2Node2 then nodeFinish
+                }
+
+                nodeStart then sgNode1 then innerSg then sgNode2 then nodeFinish
+            }
+
+            nodeStart then node1 then sg then nodeFinish
+        }
+
+        val diagram = myStrategy.asMermaidDiagram()
+
+        diagram shouldBe
+            // language=mermaid
+            """
+            ---
+            title: nested-strategy
+            ---
+            stateDiagram
+                state "node1" as node1
+                state "sg1" as sg1 {
+                    state "sgNode1" as sgNode1
+                    state "sgNode2" as sgNode2
+                    state "sg2" as sg2 {
+                        state "sg2Node1" as sg2Node1
+                        state "sg2Node2" as sg2Node2
+
+                        [*] --> sg2Node1
+                        sg2Node1 --> sg2Node2
+                        sg2Node2 --> [*]
+                    }
+
+                    [*] --> sgNode1
+                    sgNode1 --> sg2
+                    sg2 --> sgNode2
+                    sgNode2 --> [*]
+                }
+
+                [*] --> node1
+                node1 --> sg1
+                sg1 --> [*]
             """.trimIndent()
     }
 }


### PR DESCRIPTION
## Add support for subgraphs and nested subgraphs in Mermaid diagram generation

### Summary                                                                                                                                                                                                       
  - Add support for subgraphs and nested subgraphs in Mermaid diagram generation                                                                                                                                   
  - Decouple diagram data model from framework types (`NodeInfo`/`EdgeInfo` instead of `AIAgentNodeBase` references)                                                                                               
  - Sanitize node IDs for valid Mermaid identifiers (handles dashes, dots, special chars)                                                                                                                          
  - Improve robustness: narrow exception handling, remove unnecessary reflection for `toNode`, eliminate silent error swallowing                                                                                   
                                                                                                                                                                                                                   
### Changes      
  - Introduce lightweight `NodeInfo`/`NodeType` model — collection phase uses framework types, rendering phase is framework-agnostic
  - BFS traversal discovers subgraphs recursively and renders them as composite states                                                                                                                             
  - `asMermaidDiagram()` delegates to `MermaidDiagramGenerator.generate()` (no duplication)
  - Unify condition label extraction into single `extractConditionLabel` function                 

### Test

Unit tests generate following state diagrams:

<details>
<summary>State Diagrams</summary>

```mermaid
---
title: nested-strategy
---
stateDiagram
    state "node1" as node1
    state "sg1" as sg1  {
        state "sgNode1" as sgNode1
        state "sgNode2" as sgNode2
        state "sg2" as sg2 {
            state "sg2Node1" as sg2Node1
            state "sg2Node2" as sg2Node2

            [*] --> sg2Node1
            sg2Node1 --> sg2Node2
            sg2Node2 --> [*]
        }

        [*] --> sgNode1
        sgNode1 --> sg2
        sg2 --> sgNode2
        sgNode2 --> [*]
    }

    [*] --> node1
    node1 --> sg1
    sg1 --> [*]
```

```mermaid
---
title: subgraph-strategy
---
stateDiagram
    state "node1" as node1
    state "node2" as node2
    state "sg1" as sg1 {
        state "sgNode1" as sgNode1
        state "sgNode2" as sgNode2

        [*] --> sgNode1
        sgNode1 --> sgNode2
        sgNode2 --> [*]
    }

    [*] --> node1
    node1 --> sg1
    sg1 --> node2
    node2 --> [*]
```

```mermaid
---
title: minimal-strategy
---
stateDiagram

    [*] --> [*]
```

```mermaid
---
title: verification-strategy
---
stateDiagram
    state "prepare" as prepare
    state "extractResult" as extractResult
    state "verify" as verify {
        state "saveInput" as saveInput
        state "provideResult" as provideResult
        state "verifyTask" as verifyTask {
            state "setupTask" as setupTask
            state "nodeCallLLM" as nodeCallLLM
            state "nodeDecide" as nodeDecide
            state "callToolsHacked" as callToolsHacked
            state "handleAssistantMessage" as handleAssistantMessage
            state "finalizeTask" as finalizeTask
            state "sendToolsResults" as sendToolsResults

            [*] --> setupTask
            setupTask --> nodeCallLLM
            nodeCallLLM --> nodeDecide
            nodeDecide --> callToolsHacked : transformed
            nodeDecide --> handleAssistantMessage : transformed
            nodeDecide --> [*] : transformed
            callToolsHacked --> finalizeTask : transformed
            callToolsHacked --> sendToolsResults
            handleAssistantMessage --> nodeDecide
            finalizeTask --> [*]
            sendToolsResults --> nodeDecide
        }

        [*] --> saveInput
        saveInput --> verifyTask
        verifyTask --> provideResult
        provideResult --> [*]
    }

    [*] --> prepare
    prepare --> verify
    verify --> extractResult
    extractResult --> [*]
```

</details