### PR TITLE
fix(agents)!: remove ToolRegistry.Builder, unify everything under expect/actual ToolRegistryBuilder. Remove `tools(Any)` that was interfering with `tools(List)` causing unexpected bugs

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/TraceStructureTestBase.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/TraceStructureTestBase.kt
@@ -15,7 +15,6 @@ import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.core.tools.annotations.Tool
 import ai.koog.agents.core.tools.reflect.asTool
-import ai.koog.agents.core.tools.reflect.tool
 import ai.koog.agents.ext.agent.subgraphWithTask
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.assistantMessage
 import ai.koog.agents.features.opentelemetry.OpenTelemetryTestAPI.createAgent

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolRegistry.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolRegistry.kt
@@ -29,7 +29,7 @@ import kotlin.jvm.JvmStatic
  *
  * @property tools The list of tools contained in this registry
  */
-public class ToolRegistry private constructor(tools: List<Tool<*, *>> = emptyList()) {
+public class ToolRegistry internal constructor(tools: List<Tool<*, *>> = emptyList()) {
 
     private val _tools: MutableList<Tool<*, *>> = tools.toMutableList()
 
@@ -121,47 +121,6 @@ public class ToolRegistry private constructor(tools: List<Tool<*, *>> = emptyLis
     }
 
     /**
-     * Builder class to construct and manage a registry of tools.
-     *
-     * This class allows for the registration of tools in a controlled manner.
-     * It ensures that each tool added to the registry has a unique name.
-     */
-    @JavaAPI
-    public class Builder internal constructor() {
-        private val tools = mutableListOf<Tool<*, *>>()
-
-        /**
-         * Add a tool to the registry
-         */
-        @JavaAPI
-        public fun tool(tool: Tool<*, *>) {
-            require(tool.name !in tools.map { it.name }) { "Tool \"${tool.name}\" is already defined" }
-            tools.add(tool)
-        }
-
-        /**
-         * Add multiple tools to the registry
-         */
-        @JavaAPI
-        public fun tools(toolsList: List<Tool<*, *>>) {
-            toolsList.forEach { tool(it) }
-        }
-
-        /**
-         * Finalizes the tool registration process and constructs a `ToolRegistry`.
-         *
-         * This method collects all tools previously added using the builder
-         * and returns a new instance of `ToolRegistry` containing those tools.
-         *
-         * @return A new `ToolRegistry` instance containing the registered tools.
-         */
-        @JavaAPI
-        public fun build(): ToolRegistry {
-            return ToolRegistry(tools)
-        }
-    }
-
-    /**
      * Companion object providing factory methods and constants for ToolRegistry.
      */
     public companion object {
@@ -182,7 +141,7 @@ public class ToolRegistry private constructor(tools: List<Tool<*, *>> = emptyLis
          * @param init A lambda that configures the registry by adding tools
          * @return A new ToolRegistry instance configured according to the initialization block
          */
-        public operator fun invoke(init: Builder.() -> Unit): ToolRegistry = Builder().apply(init).build()
+        public operator fun invoke(init: ToolRegistryBuilder.() -> Unit): ToolRegistry = ToolRegistryBuilder().apply(init).build()
 
         /**
          * A constant representing an empty registry with no tools.

--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolRegistryBuilder.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/ToolRegistryBuilder.kt
@@ -1,37 +1,29 @@
 package ai.koog.agents.core.tools
 
 /**
- * A builder class for creating a `ToolRegistry` instance. This class provides methods to configure
+ * A builder class for creating a [ToolRegistry] instance. This class provides methods to configure
  * and register tools, either individually or as a list, and then constructs a registry containing
  * the defined tools.
  */
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 public expect class ToolRegistryBuilder() {
     /**
-     * Registers a tool to the ToolRegistryBuilder.
-     *
-     * @param tool The tool to be registered. This should be an instance of the `Tool` class,
-     *             parameterized with argument and result types.
-     * @return The updated `ToolRegistryBuilder` instance, allowing for further tool registration
-     *         or subsequent actions.
+     * Add a tool to the registry
      */
     public fun tool(tool: Tool<*, *>): ToolRegistryBuilder
 
     /**
-     * Registers a list of tools into the tool registry.
-     *
-     * @param toolsList A list of tools to be registered, where each tool is an instance of the `Tool` class.
-     * @return A `ToolRegistryBuilder` instance for further configuration or building.
+     * Add multiple tools to the registry
      */
     public fun tools(toolsList: List<Tool<*, *>>): ToolRegistryBuilder
 
     /**
-     * Finalizes the configuration of the `ToolRegistryBuilder` and constructs a `ToolRegistry` instance.
-     *
-     * This method aggregates all the tools that have been added using the builder methods
-     * and creates a new `ToolRegistry` object containing these tools.
-     *
-     * @return A `ToolRegistry` instance with the configured tools from the builder.
+     * Builds a [ToolRegistry] instance containing the tools added to the builder.
      */
     public fun build(): ToolRegistry
+}
+
+internal fun MutableList<Tool<*, *>>.addTool(tool: Tool<*, *>) {
+    require(tool.name !in this.map { it.name }) { "Tool \"${tool.name}\" is already defined" }
+    this.add(tool)
 }

--- a/agents/agents-tools/src/jvmCommonMain/kotlin/ai/koog/agents/core/tools/ToolRegistryBuilder.kt
+++ b/agents/agents-tools/src/jvmCommonMain/kotlin/ai/koog/agents/core/tools/ToolRegistryBuilder.kt
@@ -1,22 +1,61 @@
-@file:Suppress("MissingKDocForPublicAPI")
+@file:Suppress("MissingKDocForPublicAPI", "EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 
 package ai.koog.agents.core.tools
 
 import ai.koog.agents.annotations.JavaAPI
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
+import ai.koog.agents.core.tools.reflect.ToolSet
+import ai.koog.agents.core.tools.reflect.asTool
 import ai.koog.agents.core.tools.reflect.asTools
 import ai.koog.agents.core.tools.reflect.java.asTool
 import java.lang.reflect.Method
+import kotlin.reflect.KFunction
 
-@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 public actual class ToolRegistryBuilder {
-    private val builder = ToolRegistry.Builder()
+    private val tools = mutableListOf<Tool<*, *>>()
 
-    public actual fun tool(tool: Tool<*, *>): ToolRegistryBuilder = apply { builder.tool(tool) }
+    /**
+     * Add a tool to the registry
+     */
+    public actual fun tool(tool: Tool<*, *>): ToolRegistryBuilder = apply {
+        tools.addTool(tool)
+    }
 
-    public actual fun tools(toolsList: List<Tool<*, *>>): ToolRegistryBuilder = apply { builder.tools(toolsList) }
+    /**
+     * Add multiple tools to the registry
+     */
+    public actual fun tools(toolsList: List<Tool<*, *>>): ToolRegistryBuilder = apply {
+        toolsList.forEach { tool(it) }
+    }
 
-    public actual fun build(): ToolRegistry = builder.build()
+    public actual fun build(): ToolRegistry {
+        return ToolRegistry(tools.toList())
+    }
+
+    /**
+     * Registers a set of tools from the [instance] in the [ToolRegistry] .
+     */
+    @OptIn(InternalAgentToolsApi::class)
+    public fun tools(
+        instance: ToolSet,
+    ): ToolRegistryBuilder = apply {
+        tools(instance::class.asTools(instance))
+    }
+
+    /**
+     * Registers [toolFunction] as a tool in the [ToolRegistry].
+     *
+     * @see asTool
+     */
+    @OptIn(InternalAgentToolsApi::class)
+    public fun tool(
+        toolFunction: KFunction<*>,
+        thisRef: Any? = null,
+        name: String? = null,
+        description: String? = null
+    ): ToolRegistryBuilder = apply {
+        tool(toolFunction.asTool(thisRef, name, description))
+    }
 
     /**
      * Registers [toolFunction] as a tool in the [ToolRegistry].
@@ -26,22 +65,12 @@ public actual class ToolRegistryBuilder {
     @OptIn(InternalAgentToolsApi::class)
     @JvmOverloads
     @JavaAPI
-    public fun ToolRegistry.Builder.tool(
+    public fun tool(
         toolFunction: Method,
         thisRef: Any? = null,
         name: String? = null,
         description: String? = null
-    ): ToolRegistry.Builder = apply {
-        tool(toolFunction.asTool(thisRef, name, description))
-    }
-
-    /**
-     * Registers a set of tools from the [instance] in the [ToolRegistry] .
-     */
-    @JavaAPI
-    public fun tools(
-        instance: Any,
     ): ToolRegistryBuilder = apply {
-        tools(instance::class.asTools(instance))
+        tool(toolFunction.asTool(thisRef, name, description))
     }
 }

--- a/agents/agents-tools/src/jvmCommonMain/kotlin/ai/koog/agents/core/tools/reflect/ToolFromCallableExtensions.kt
+++ b/agents/agents-tools/src/jvmCommonMain/kotlin/ai/koog/agents/core/tools/reflect/ToolFromCallableExtensions.kt
@@ -1,6 +1,5 @@
 package ai.koog.agents.core.tools.reflect
 
-import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.core.tools.annotations.Tool
@@ -105,31 +104,6 @@ public fun <T : Any> KClass<out T>.asTools(
 @OptIn(InternalAgentToolsApi::class)
 public inline fun <reified T : Any> T.asToolsByClass(): List<ToolFromCallable<*>> {
     return T::class.asTools(thisRef = this)
-}
-
-/**
- * Registers [toolFunction] as a tool in the [ToolRegistry].
- *
- * @see asTool
- */
-@OptIn(InternalAgentToolsApi::class)
-public fun ToolRegistry.Builder.tool(
-    toolFunction: KFunction<*>,
-    thisRef: Any? = null,
-    name: String? = null,
-    description: String? = null
-): ToolRegistry.Builder = apply {
-    tool(toolFunction.asTool(thisRef, name, description))
-}
-
-/**
- * Registers a set of tools from the [instance] in the [ToolRegistry] .
- */
-@OptIn(InternalAgentToolsApi::class)
-public fun ToolRegistry.Builder.tools(
-    instance: Any,
-) {
-    tools(instance::class.asTools(instance))
 }
 
 /**

--- a/agents/agents-tools/src/nonJvmCommonMain/kotlin/ai/koog/agents/core/tools/ToolRegistryBuilder.kt
+++ b/agents/agents-tools/src/nonJvmCommonMain/kotlin/ai/koog/agents/core/tools/ToolRegistryBuilder.kt
@@ -1,14 +1,19 @@
-@file:Suppress("MissingKDocForPublicAPI")
+@file:Suppress("MissingKDocForPublicAPI", "EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 
 package ai.koog.agents.core.tools
 
-@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 public actual class ToolRegistryBuilder {
-    private val builder = ToolRegistry.Builder()
+    private val tools = mutableListOf<Tool<*, *>>()
 
-    public actual fun tool(tool: Tool<*, *>): ToolRegistryBuilder = apply { builder.tool(tool) }
+    public actual fun tool(tool: Tool<*, *>): ToolRegistryBuilder = apply {
+        tools.addTool(tool)
+    }
 
-    public actual fun tools(toolsList: List<Tool<*, *>>): ToolRegistryBuilder = apply { builder.tools(toolsList) }
+    public actual fun tools(toolsList: List<Tool<*, *>>): ToolRegistryBuilder = apply {
+        toolsList.forEach { tool(it) }
+    }
 
-    public actual fun build(): ToolRegistry = builder.build()
+    public actual fun build(): ToolRegistry {
+        return ToolRegistry(tools.toList())
+    }
 }

--- a/docs/docs/agents/basic-agents.md
+++ b/docs/docs/agents/basic-agents.md
@@ -239,7 +239,6 @@ First, create a tool by annotating a function (Kotlin) or method (Java) with the
     import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
     import ai.koog.agents.core.tools.annotations.LLMDescription
     import ai.koog.agents.core.tools.annotations.Tool
-    import ai.koog.agents.core.tools.reflect.tool
     -->
     ```kotlin
     @Tool
@@ -372,7 +371,6 @@ For example, a simple agent described here is not likely to require more than 10
     import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
     import ai.koog.agents.core.tools.annotations.LLMDescription
     import ai.koog.agents.core.tools.annotations.Tool
-    import ai.koog.agents.core.tools.reflect.tool
     @Tool
     @LLMDescription("Asks the user a question by sending it to stdout and returns the answer from stdin")
     fun askUser(
@@ -471,7 +469,6 @@ Koog provides the [EventHandler](https://api.koog.ai/agents/agents-features/agen
     import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
     import ai.koog.agents.core.tools.annotations.LLMDescription
     import ai.koog.agents.core.tools.annotations.Tool
-    import ai.koog.agents.core.tools.reflect.tool
     @Tool
     @LLMDescription("Asks the user a question by sending it to stdout and returns the answer from stdin")
     fun askUser(

--- a/docs/docs/agents/functional-agents.md
+++ b/docs/docs/agents/functional-agents.md
@@ -181,7 +181,6 @@ Here is what you need to do:
     import ai.koog.agents.core.tools.annotations.LLMDescription
     import ai.koog.agents.core.tools.annotations.Tool
     import ai.koog.agents.core.tools.reflect.ToolSet
-    import ai.koog.agents.core.tools.reflect.tool
     import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
     import ai.koog.prompt.executor.ollama.client.OllamaModels
     import kotlinx.coroutines.runBlocking

--- a/docs/docs/agents/graph-based-agents.md
+++ b/docs/docs/agents/graph-based-agents.md
@@ -361,7 +361,6 @@ Define [tools](../tools-overview.md) for performing math operations and add them
     import ai.koog.agents.core.tools.annotations.LLMDescription
     import ai.koog.agents.core.tools.annotations.Tool
     import ai.koog.agents.core.tools.reflect.ToolSet
-    import ai.koog.agents.core.tools.reflect.tools
     -->
     ```kotlin
     @LLMDescription("Tools for performing math operations")
@@ -444,7 +443,6 @@ Add the tool registry to the agent configuration:
     import ai.koog.agents.core.tools.annotations.LLMDescription
     import ai.koog.agents.core.tools.annotations.Tool
     import ai.koog.agents.core.tools.reflect.ToolSet
-    import ai.koog.agents.core.tools.reflect.tools
     import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
     import ai.koog.prompt.executor.ollama.client.OllamaModels
     import kotlinx.coroutines.runBlocking
@@ -624,7 +622,6 @@ In our example, it is important to describe how the agent should process complex
     import ai.koog.agents.core.tools.annotations.LLMDescription
     import ai.koog.agents.core.tools.annotations.Tool
     import ai.koog.agents.core.tools.reflect.ToolSet
-    import ai.koog.agents.core.tools.reflect.tools
     import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
     import ai.koog.prompt.executor.ollama.client.OllamaModels
     import kotlinx.coroutines.runBlocking

--- a/docs/docs/annotation-based-tools.md
+++ b/docs/docs/annotation-based-tools.md
@@ -335,7 +335,6 @@ Now you can use your tools with an agent:
     <!--- INCLUDE
     import ai.koog.agents.core.agent.AIAgent
     import ai.koog.agents.core.tools.ToolRegistry
-    import ai.koog.agents.core.tools.reflect.tools
     import ai.koog.agents.example.exampleAnnotationBasedTools06.MyFirstToolSet
     import ai.koog.prompt.executor.clients.openai.OpenAIModels
     import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor

--- a/docs/docs/tools-overview.md
+++ b/docs/docs/tools-overview.md
@@ -41,7 +41,6 @@ Here is an example of how to create the tool registry and add the tool to it:
     import ai.koog.agents.core.tools.ToolRegistry
     import ai.koog.agents.core.tools.annotations.Tool
     import ai.koog.agents.core.tools.reflect.ToolSet
-    import ai.koog.agents.core.tools.reflect.tools
     class MyToolSet : ToolSet {
         @Tool
         fun myTool(): String {
@@ -85,7 +84,6 @@ To merge multiple tool registries, do the following:
     import ai.koog.agents.core.tools.ToolRegistry
     import ai.koog.agents.core.tools.annotations.Tool
     import ai.koog.agents.core.tools.reflect.ToolSet
-    import ai.koog.agents.core.tools.reflect.tools
     class FirstToolSet : ToolSet {
         @Tool
         fun firstSampleTool(): String {

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/features/opentelemetry/langfuse/LangfuseExample.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/features/opentelemetry/langfuse/LangfuseExample.kt
@@ -4,7 +4,6 @@ import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.core.tools.annotations.Tool
-import ai.koog.agents.core.tools.reflect.tool
 import ai.koog.agents.example.ApiKeyService
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
 import ai.koog.agents.mcp.McpToolRegistryProvider

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/ktor/KtorIntegrationExample.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/ktor/KtorIntegrationExample.kt
@@ -2,7 +2,6 @@ package ai.koog.agents.example.ktor
 
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.core.tools.annotations.Tool
-import ai.koog.agents.core.tools.reflect.tool
 import ai.koog.agents.ext.agent.reActStrategy
 import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
 import ai.koog.ktor.Koog

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/tone/ToneTools.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/tone/ToneTools.kt
@@ -1,7 +1,7 @@
 package ai.koog.agents.example.tone
 
 import ai.koog.agents.core.tools.SimpleTool
-import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.core.tools.ToolRegistryBuilder
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.example.ApiKeyService
 import ai.koog.prompt.dsl.prompt
@@ -87,7 +87,7 @@ object ToneTools {
     /**
      * Helper function to add all tone tools to a ToolStage.Builder.
      */
-    fun ToolRegistry.Builder.tools() {
+    fun ToolRegistryBuilder.tools() {
         tool(PositiveToneTool)
         tool(NegativeToneTool)
         tool(NeutralToneTool)

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/websearch/WebSearchAgent.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/websearch/WebSearchAgent.kt
@@ -7,7 +7,6 @@ import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.core.tools.annotations.Tool
 import ai.koog.agents.core.tools.reflect.ToolSet
-import ai.koog.agents.core.tools.reflect.tools
 import ai.koog.agents.example.ApiKeyService
 import ai.koog.agents.features.eventHandler.feature.handleEvents
 import ai.koog.prompt.dsl.prompt

--- a/koog-ktor/src/commonMain/kotlin/ai/koog/ktor/KoogAgentsConfig.kt
+++ b/koog-ktor/src/commonMain/kotlin/ai/koog/ktor/KoogAgentsConfig.kt
@@ -6,6 +6,7 @@ import ai.koog.agents.core.agent.config.ToolCallDescriber
 import ai.koog.agents.core.feature.AIAgentGraphFeature
 import ai.koog.agents.core.feature.config.FeatureConfig
 import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.core.tools.ToolRegistryBuilder
 import ai.koog.ktor.KoogAgentsConfig.TimeoutConfiguration.Companion.DEFAULT_TIMEOUT
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.dsl.PromptBuilder
@@ -384,7 +385,7 @@ public class KoogAgentsConfig(private val scope: CoroutineScope) {
          *
          * @param build A lambda function for configuring the tool registry using the `ToolRegistry.Builder`.
          */
-        public fun registerTools(build: ToolRegistry.Builder.() -> Unit) {
+        public fun registerTools(build: ToolRegistryBuilder.() -> Unit) {
             toolRegistry += ToolRegistry {
                 build()
             }


### PR DESCRIPTION
Unify two tool registry builders - `ToolRegistry.Builder` and `ToolRegistryBuilder` - into just one `ToolRegistryBuilder` with expect/actual declarations. Replace `tools(Any)` with `tools(ToolSet)`, since the former clashed with `tools(List)`, thus preventing from using lists of tools to construct the `ToolRegistry`

BREAKING:
* `ToolRegistry.Builder` is removed, all `tool`/`tools` extension functions are moved as member functions inside `ToolRegistryBuilder`
* `tools(Any)` turned back into `tools(List)`
