### PR TITLE
feat(spring-boot): add integration with VectorStore from Spring AI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -233,6 +233,7 @@ dependencies {
     dokka(project(":koog-spring-ai:koog-spring-ai-starter-chat-memory"))
     dokka(project(":koog-spring-ai:koog-spring-ai-starter-model-chat"))
     dokka(project(":koog-spring-ai:koog-spring-ai-starter-model-embedding"))
+    dokka(project(":koog-spring-ai:koog-spring-ai-starter-vector-store"))
     dokka(project(":koog-spring-boot-starter"))
     dokka(project(":prompt:prompt-cache:prompt-cache-files"))
     dokka(project(":prompt:prompt-cache:prompt-cache-model"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -130,6 +130,7 @@ reactor-kotlin-extensions = { module = "io.projectreactor.kotlin:reactor-kotlin-
 # Spring AI
 spring-ai-bom = { module = "org.springframework.ai:spring-ai-bom", version.ref = "spring-ai" }
 spring-ai-model = { module = "org.springframework.ai:spring-ai-model" }
+spring-ai-vectorstore = { module = "org.springframework.ai:spring-ai-vector-store" }
 
 [bundles]
 spring-boot-core = [

--- a/koog-agents/build.gradle.kts
+++ b/koog-agents/build.gradle.kts
@@ -50,6 +50,7 @@ val excluded = setOf(
     ":koog-spring-ai:koog-spring-ai-starter-model-chat",
     ":koog-spring-ai:koog-spring-ai-starter-model-embedding",
     ":koog-spring-ai:koog-spring-ai-starter-chat-memory",
+    ":koog-spring-ai:koog-spring-ai-starter-vector-store",
 
     project.path, // the current project should not depend on itself
 )

--- a/koog-spring-ai/README.md
+++ b/koog-spring-ai/README.md
@@ -19,5 +19,6 @@ Both starters are independent — pick one based on how you prefer to manage LLM
 | `koog-spring-ai-starter-model-chat` | Adapts a Spring AI `ChatModel` (with optional `ModerationModel`) into a Koog `LLMClient` and `PromptExecutor` | [Module.md](koog-spring-ai-starter-model-chat/Module.md) |
 | `koog-spring-ai-starter-model-embedding` | Adapts a Spring AI `EmbeddingModel` into a Koog `LLMEmbeddingProvider` | [Module.md](koog-spring-ai-starter-model-embedding/Module.md) |
 | `koog-spring-ai-starter-chat-memory` | Adapts a Spring AI `ChatMemoryRepository` into a Koog `ChatHistoryProvider` | [Module.md](koog-spring-ai-starter-chat-memory/Module.md) |
+| `koog-spring-ai-starter-vector-store`    | Adapts a Spring AI `VectorStore` into Koog `WriteStorage`, `SearchStorage`, and `DeletionStorage`             | [Module.md](koog-spring-ai-starter-vector-store/Module.md)    |
 
 Each submodule is a fully independent Spring Boot starter with its own auto-configuration, configuration properties, and dispatcher management. See the linked `Module.md` for usage details, configuration reference, and examples.

--- a/koog-spring-ai/README.md
+++ b/koog-spring-ai/README.md
@@ -14,11 +14,11 @@ Both starters are independent — pick one based on how you prefer to manage LLM
 
 ## Submodules
 
-| Module | Purpose | Docs |
-|---|---|---|
-| `koog-spring-ai-starter-model-chat` | Adapts a Spring AI `ChatModel` (with optional `ModerationModel`) into a Koog `LLMClient` and `PromptExecutor` | [Module.md](koog-spring-ai-starter-model-chat/Module.md) |
-| `koog-spring-ai-starter-model-embedding` | Adapts a Spring AI `EmbeddingModel` into a Koog `LLMEmbeddingProvider` | [Module.md](koog-spring-ai-starter-model-embedding/Module.md) |
-| `koog-spring-ai-starter-chat-memory` | Adapts a Spring AI `ChatMemoryRepository` into a Koog `ChatHistoryProvider` | [Module.md](koog-spring-ai-starter-chat-memory/Module.md) |
-| `koog-spring-ai-starter-vector-store`    | Adapts a Spring AI `VectorStore` into Koog `WriteStorage`, `SearchStorage`, and `DeletionStorage`             | [Module.md](koog-spring-ai-starter-vector-store/Module.md)    |
+| Module | Spring AI interfaces | Koog interfaces | Docs |
+|---|---|---|---|
+| `koog-spring-ai-starter-model-chat` | `ChatModel`, `ModerationModel` | `LLMClient`, `PromptExecutor` | [Module.md](koog-spring-ai-starter-model-chat/Module.md) |
+| `koog-spring-ai-starter-model-embedding` | `EmbeddingModel` | `LLMEmbeddingProvider` | [Module.md](koog-spring-ai-starter-model-embedding/Module.md) |
+| `koog-spring-ai-starter-chat-memory` | `ChatMemoryRepository` | `ChatHistoryProvider` | [Module.md](koog-spring-ai-starter-chat-memory/Module.md) |
+| `koog-spring-ai-starter-vector-store` | `VectorStore` | `WriteStorage`, `SearchStorage`, `FilteringDeletionStorage` | [Module.md](koog-spring-ai-starter-vector-store/Module.md) |
 
 Each submodule is a fully independent Spring Boot starter with its own auto-configuration, configuration properties, and dispatcher management. See the linked `Module.md` for usage details, configuration reference, and examples.

--- a/koog-spring-ai/koog-spring-ai-common/build.gradle.kts
+++ b/koog-spring-ai/koog-spring-ai-common/build.gradle.kts
@@ -6,6 +6,8 @@ version = rootProject.version
 plugins {
     id("ai.kotlin.jvm")
     id("ai.kotlin.jvm.publish")
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.spring.management)
 }
 kotlin {
     explicitApi()
@@ -21,5 +23,9 @@ tasks.withType<JavaCompile>().configureEach {
     sourceCompatibility = JavaVersion.VERSION_17.toString()
     targetCompatibility = JavaVersion.VERSION_17.toString()
     options.compilerArgs.add("-parameters")
+}
+dependencies {
+    implementation(project.dependencies.platform(libs.spring.boot.bom))
+    api(libs.bundles.spring.boot.core)
 }
 publishToMaven()

--- a/koog-spring-ai/koog-spring-ai-common/src/main/kotlin/ai/koog/spring/ai/common/DispatcherProperties.kt
+++ b/koog-spring-ai/koog-spring-ai-common/src/main/kotlin/ai/koog/spring/ai/common/DispatcherProperties.kt
@@ -1,5 +1,11 @@
 package ai.koog.spring.ai.common
 
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
+import org.slf4j.Logger
+import org.springframework.core.task.AsyncTaskExecutor
+
 /**
  * Dispatcher settings for blocking Spring AI calls.
  *
@@ -72,4 +78,47 @@ public data class DispatcherConfig(
 public enum class DispatcherType {
     AUTO,
     IO,
+}
+
+/**
+ * Resolves a [kotlinx.coroutines.CoroutineDispatcher] from the given [DispatcherConfig] and
+ * optional [org.springframework.core.task.AsyncTaskExecutor].
+ *
+ * This is the shared implementation behind every `koogSpringAi*Dispatcher` bean factory method.
+ *
+ * @param dispatcherConfig the dispatcher configuration bound from Spring Boot properties
+ * @param asyncTaskExecutor the Spring `AsyncTaskExecutor` if available, or `null`
+ * @param logger the SLF4J logger to use for informational messages
+ * @param componentName a human-readable component label used in log messages
+ *   (e.g. `"Koog Spring AI Chat"`)
+ * @return the resolved [kotlinx.coroutines.CoroutineDispatcher]
+ */
+public fun resolveDispatcher(
+    dispatcherConfig: DispatcherConfig,
+    asyncTaskExecutor: AsyncTaskExecutor?,
+    logger: Logger,
+    componentName: String,
+): CoroutineDispatcher {
+    return when (val dispatcher = dispatcherConfig.toDispatcherProperties()) {
+        is DispatcherProperties.Auto -> {
+            if (asyncTaskExecutor != null) {
+                logger.info("$componentName: using Spring AsyncTaskExecutor as dispatcher")
+                asyncTaskExecutor.asCoroutineDispatcher()
+            } else {
+                logger.info("$componentName: no AsyncTaskExecutor found, falling back to Dispatchers.IO")
+                Dispatchers.IO
+            }
+        }
+
+        is DispatcherProperties.IO -> {
+            val parallelism = dispatcher.parallelism
+            if (parallelism != null && parallelism > 0) {
+                logger.info("$componentName: using Dispatchers.IO.limitedParallelism($parallelism)")
+                Dispatchers.IO.limitedParallelism(parallelism)
+            } else {
+                logger.info("$componentName: using Dispatchers.IO")
+                Dispatchers.IO
+            }
+        }
+    }
 }

--- a/koog-spring-ai/koog-spring-ai-common/src/main/kotlin/ai/koog/spring/ai/common/conditions/OnPropertyNotEmptyCondition.kt
+++ b/koog-spring-ai/koog-spring-ai-common/src/main/kotlin/ai/koog/spring/ai/common/conditions/OnPropertyNotEmptyCondition.kt
@@ -1,0 +1,67 @@
+package ai.koog.spring.ai.common.conditions
+
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition
+import org.springframework.context.annotation.ConditionContext
+import org.springframework.context.annotation.Conditional
+import org.springframework.core.type.AnnotatedTypeMetadata
+import kotlin.reflect.jvm.jvmName
+
+// TODO: The code below was copied from koog-spring-boot-starter. Move it to some shared module.
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Conditional(OnPropertyNotEmptyCondition::class)
+public annotation class ConditionalOnPropertyNotEmpty(
+    val prefix: String = "",
+    val name: String
+)
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Conditional(OnPropertyMissingOrEmptyCondition::class)
+public annotation class ConditionalOnPropertyMissingOrEmpty(
+    val prefix: String = "",
+    val name: String
+)
+
+public class OnPropertyNotEmptyCondition : SpringBootCondition() {
+
+    override fun getMatchOutcome(
+        context: ConditionContext,
+        metadata: AnnotatedTypeMetadata
+    ): ConditionOutcome {
+        val propertyKey = resolvePropertyKey(metadata, ConditionalOnPropertyNotEmpty::class.jvmName)
+        val value = context.environment.getProperty(propertyKey)
+
+        return if (!value.isNullOrEmpty()) {
+            ConditionOutcome.match("Property '$propertyKey' has non-empty value")
+        } else {
+            ConditionOutcome.noMatch("Property '$propertyKey' is missing or empty")
+        }
+    }
+}
+
+public class OnPropertyMissingOrEmptyCondition : SpringBootCondition() {
+
+    override fun getMatchOutcome(
+        context: ConditionContext,
+        metadata: AnnotatedTypeMetadata
+    ): ConditionOutcome {
+        val propertyKey = resolvePropertyKey(metadata, ConditionalOnPropertyMissingOrEmpty::class.jvmName)
+        val value = context.environment.getProperty(propertyKey)
+
+        return if (value.isNullOrEmpty()) {
+            ConditionOutcome.match("Property '$propertyKey' is missing or empty")
+        } else {
+            ConditionOutcome.noMatch("Property '$propertyKey' has non-empty value")
+        }
+    }
+}
+
+private fun resolvePropertyKey(metadata: AnnotatedTypeMetadata, annotationName: String): String {
+    val attributes = metadata.getAllAnnotationAttributes(annotationName)
+    val prefix = attributes?.get("prefix")?.firstOrNull() as? String ?: ""
+    val name = attributes?.get("name")?.firstOrNull() as? String ?: ""
+    return if (prefix.isNotEmpty()) "$prefix.$name" else name
+}

--- a/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/main/kotlin/ai/koog/spring/ai/memory/SpringAiChatMemoryAutoConfiguration.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/main/kotlin/ai/koog/spring/ai/memory/SpringAiChatMemoryAutoConfiguration.kt
@@ -1,10 +1,10 @@
 package ai.koog.spring.ai.memory
 
 import ai.koog.agents.chatMemory.feature.ChatHistoryProvider
-import ai.koog.spring.ai.common.DispatcherProperties
+import ai.koog.spring.ai.common.conditions.ConditionalOnPropertyMissingOrEmpty
+import ai.koog.spring.ai.common.conditions.ConditionalOnPropertyNotEmpty
+import ai.koog.spring.ai.common.resolveDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.asCoroutineDispatcher
 import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.memory.ChatMemoryRepository
 import org.springframework.beans.factory.BeanFactory
@@ -61,29 +61,12 @@ public open class SpringAiChatMemoryAutoConfiguration {
         properties: KoogSpringAiChatMemoryProperties,
         @Qualifier("applicationTaskExecutor") asyncTaskExecutorProvider: ObjectProvider<AsyncTaskExecutor>,
     ): CoroutineDispatcher {
-        val asyncTaskExecutor = asyncTaskExecutorProvider.ifAvailable
-        return when (val dispatcher = properties.dispatcher.toDispatcherProperties()) {
-            is DispatcherProperties.Auto -> {
-                if (asyncTaskExecutor != null) {
-                    logger.info("Koog Spring AI Chat Memory: using Spring AsyncTaskExecutor as dispatcher")
-                    asyncTaskExecutor.asCoroutineDispatcher()
-                } else {
-                    logger.info("Koog Spring AI Chat Memory: no AsyncTaskExecutor found, falling back to Dispatchers.IO")
-                    Dispatchers.IO
-                }
-            }
-
-            is DispatcherProperties.IO -> {
-                val parallelism = dispatcher.parallelism
-                if (parallelism != null && parallelism > 0) {
-                    logger.info("Koog Spring AI Chat Memory: using Dispatchers.IO.limitedParallelism($parallelism)")
-                    Dispatchers.IO.limitedParallelism(parallelism)
-                } else {
-                    logger.info("Koog Spring AI Chat Memory: using Dispatchers.IO")
-                    Dispatchers.IO
-                }
-            }
-        }
+        return resolveDispatcher(
+            dispatcherConfig = properties.dispatcher,
+            asyncTaskExecutor = asyncTaskExecutorProvider.ifAvailable,
+            logger = logger,
+            componentName = "Koog Spring AI Chat Memory",
+        )
     }
 
     /**
@@ -92,7 +75,7 @@ public open class SpringAiChatMemoryAutoConfiguration {
      * Resolves the [ChatMemoryRepository] from the application context by the configured bean name.
      */
     @Configuration(proxyBeanMethods = false)
-    @ConditionalOnProperty(prefix = "koog.spring.ai.chat-memory", name = ["chat-memory-repository-bean-name"])
+    @ConditionalOnPropertyNotEmpty(prefix = "koog.spring.ai.chat-memory", name = "chat-memory-repository-bean-name")
     public open class NamedChatMemoryRepositoryConfiguration {
         private val logger = LoggerFactory.getLogger(NamedChatMemoryRepositoryConfiguration::class.java)
 
@@ -116,21 +99,13 @@ public open class SpringAiChatMemoryAutoConfiguration {
      *
      * This is the default fallback path. It is mutually exclusive with [NamedChatMemoryRepositoryConfiguration] for
      * the common cases:
-     * - selector absent → `matchIfMissing = true` activates this config; [NamedChatMemoryRepositoryConfiguration] does not match
-     * - selector non-empty (e.g. `"myBean"`) → [NamedChatMemoryRepositoryConfiguration] matches; `havingValue = ""` does not
-     *   match a non-empty value, so this config does not activate
-     * - selector set to literal `""` → both configs activate (Spring treats `""` as a present value that satisfies
-     *   both `havingValue = ""` and the plain `@ConditionalOnProperty` on the named path); the named path then
-     *   attempts `beanFactory.getBean("", ChatMemoryRepository::class.java)` which fails at startup
+     * - selector absent → [ConditionalOnPropertyMissingOrEmpty] activates this config; [NamedChatMemoryRepositoryConfiguration] does not match
+     * - selector non-empty (e.g. `"myBean"`) → [NamedChatMemoryRepositoryConfiguration] matches; [ConditionalOnPropertyMissingOrEmpty] does not activate
+     * - selector set to literal `""` → treated as missing/empty; [ConditionalOnPropertyMissingOrEmpty] activates this config; [NamedChatMemoryRepositoryConfiguration] does not match
      */
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnSingleCandidate(ChatMemoryRepository::class)
-    @ConditionalOnProperty(
-        prefix = "koog.spring.ai.chat-memory",
-        name = ["chat-memory-repository-bean-name"],
-        havingValue = "",
-        matchIfMissing = true
-    )
+    @ConditionalOnPropertyMissingOrEmpty(prefix = "koog.spring.ai.chat-memory", name = "chat-memory-repository-bean-name")
     public open class SingleChatMemoryRepositoryConfiguration {
         private val logger = LoggerFactory.getLogger(SingleChatMemoryRepositoryConfiguration::class.java)
 

--- a/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/test/kotlin/ai/koog/spring/ai/memory/SpringAiChatMemoryAutoConfigurationTest.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-chat-memory/src/test/kotlin/ai/koog/spring/ai/memory/SpringAiChatMemoryAutoConfigurationTest.kt
@@ -144,19 +144,15 @@ class SpringAiChatMemoryAutoConfigurationTest {
 
     // ---- mutual exclusion: selector set to empty string ----
     @Test
-    fun `should fail on startup when selector is set to empty string because named path activates with empty bean name`() {
+    fun `should treat empty string selector as missing and use single candidate`() {
         contextRunner()
             .withPropertyValues("koog.spring.ai.chat-memory.chat-memory-repository-bean-name=")
             .withBean("myRepo", ChatMemoryRepository::class.java, { mockk<ChatMemoryRepository>(relaxed = true) })
             .run { context ->
-                // Spring treats "" as a present value equal to "", so havingValue="" on SingleChatMemoryRepositoryConfiguration
-                // matches (the condition passes), AND the plain @ConditionalOnProperty on NamedChatMemoryRepositoryConfiguration
-                // also matches (any non-false present value satisfies it). Both configs activate; the named path
-                // then calls beanFactory.getBean("", ChatMemoryRepository::class.java) with an empty name, which fails.
-                assertTrue(
-                    context.startupFailure != null,
-                    "Expected startup failure when selector is set to empty string"
-                )
+                // @ConditionalOnPropertyMissingOrEmpty treats "" as missing/empty, so only
+                // SingleChatMemoryRepositoryConfiguration activates; NamedChatMemoryRepositoryConfiguration does not match.
+                assertTrue(context.startupFailure == null, "Context should start successfully when selector is empty string")
+                assertInstanceOf<SpringAiChatHistoryProvider>(context.getBean<ChatHistoryProvider>())
             }
     }
 

--- a/koog-spring-ai/koog-spring-ai-starter-model-chat/Module.md
+++ b/koog-spring-ai/koog-spring-ai-starter-model-chat/Module.md
@@ -102,5 +102,5 @@ Without a selector, the auto-configuration activates only when a single candidat
 
   The auto-configuration picks it up automatically via optional injection.
 
-- **Custom `LLMClient`**: Register your own `LLMClient` bean to override the auto-configured adapter entirely.
+- **Custom `LLMClient`**: Register your own `LLMClient` bean(s) — they will be composed together with the auto-configured adapter into the `MultiLLMPromptExecutor`. To suppress the auto-configured adapter, register a bean named `springAiChatModelLLMClient`.
 - **Custom `PromptExecutor`**: Register your own `PromptExecutor` bean to override the auto-configured `MultiLLMPromptExecutor`.

--- a/koog-spring-ai/koog-spring-ai-starter-model-chat/src/main/kotlin/ai/koog/spring/ai/chat/SpringAiChatAutoConfiguration.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-chat/src/main/kotlin/ai/koog/spring/ai/chat/SpringAiChatAutoConfiguration.kt
@@ -4,10 +4,10 @@ import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLMProvider
-import ai.koog.spring.ai.common.DispatcherProperties
+import ai.koog.spring.ai.common.conditions.ConditionalOnPropertyMissingOrEmpty
+import ai.koog.spring.ai.common.conditions.ConditionalOnPropertyNotEmpty
+import ai.koog.spring.ai.common.resolveDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.asCoroutineDispatcher
 import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.model.ChatModel
 import org.springframework.ai.moderation.ModerationModel
@@ -72,29 +72,12 @@ public open class SpringAiChatAutoConfiguration {
         properties: KoogSpringAiChatProperties,
         @Qualifier("applicationTaskExecutor") asyncTaskExecutorProvider: ObjectProvider<AsyncTaskExecutor>,
     ): CoroutineDispatcher {
-        val asyncTaskExecutor = asyncTaskExecutorProvider.ifAvailable
-        return when (val dispatcher = properties.dispatcher.toDispatcherProperties()) {
-            is DispatcherProperties.Auto -> {
-                if (asyncTaskExecutor != null) {
-                    logger.info("Koog Spring AI Chat: using Spring AsyncTaskExecutor as dispatcher for blocking model calls")
-                    asyncTaskExecutor.asCoroutineDispatcher()
-                } else {
-                    logger.info("Koog Spring AI Chat: no AsyncTaskExecutor found, falling back to Dispatchers.IO for blocking model calls")
-                    Dispatchers.IO
-                }
-            }
-
-            is DispatcherProperties.IO -> {
-                val parallelism = dispatcher.parallelism
-                if (parallelism != null && parallelism > 0) {
-                    logger.info("Koog Spring AI Chat: using Dispatchers.IO.limitedParallelism($parallelism) for blocking model calls")
-                    Dispatchers.IO.limitedParallelism(parallelism)
-                } else {
-                    logger.info("Koog Spring AI Chat: using Dispatchers.IO for blocking model calls")
-                    Dispatchers.IO
-                }
-            }
-        }
+        return resolveDispatcher(
+            dispatcherConfig = properties.dispatcher,
+            asyncTaskExecutor = asyncTaskExecutorProvider.ifAvailable,
+            logger = logger,
+            componentName = "Koog Spring AI Chat",
+        )
     }
 
     /**
@@ -103,12 +86,12 @@ public open class SpringAiChatAutoConfiguration {
      * Resolves the [ChatModel] from the application context by the configured bean name.
      */
     @Configuration(proxyBeanMethods = false)
-    @ConditionalOnProperty(prefix = "koog.spring.ai.chat", name = ["chat-model-bean-name"])
+    @ConditionalOnPropertyNotEmpty(prefix = "koog.spring.ai.chat", name = "chat-model-bean-name")
     public open class NamedChatModelConfiguration {
         private val logger = LoggerFactory.getLogger(NamedChatModelConfiguration::class.java)
 
         @Bean
-        @ConditionalOnMissingBean(LLMClient::class)
+        @ConditionalOnMissingBean(name = ["springAiChatModelLLMClient"])
         public open fun springAiChatModelLLMClient(
             beanFactory: BeanFactory,
             properties: KoogSpringAiChatProperties,
@@ -130,26 +113,18 @@ public open class SpringAiChatAutoConfiguration {
      *
      * This is the default fallback path. It is mutually exclusive with [NamedChatModelConfiguration] for
      * the common cases:
-     * - selector absent → `matchIfMissing = true` activates this config; [NamedChatModelConfiguration] does not match
-     * - selector non-empty (e.g. `"myBean"`) → [NamedChatModelConfiguration] matches; `havingValue = ""` does not
-     *   match a non-empty value, so this config does not activate
-     * - selector set to literal `""` → both configs activate (Spring treats `""` as a present value that satisfies
-     *   both `havingValue = ""` and the plain `@ConditionalOnProperty` on the named path); the named path then
-     *   attempts `beanFactory.getBean("", ChatModel::class.java)` which fails at startup
+     * - selector absent → [ConditionalOnPropertyMissingOrEmpty] activates this config; [NamedChatModelConfiguration] does not match
+     * - selector non-empty (e.g. `"myBean"`) → [NamedChatModelConfiguration] matches; [ConditionalOnPropertyMissingOrEmpty] does not activate
+     * - selector set to literal `""` → treated as missing/empty; [ConditionalOnPropertyMissingOrEmpty] activates this config; [NamedChatModelConfiguration] does not match
      */
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnSingleCandidate(ChatModel::class)
-    @ConditionalOnProperty(
-        prefix = "koog.spring.ai.chat",
-        name = ["chat-model-bean-name"],
-        havingValue = "",
-        matchIfMissing = true
-    )
+    @ConditionalOnPropertyMissingOrEmpty(prefix = "koog.spring.ai.chat", name = "chat-model-bean-name")
     public open class SingleChatModelConfiguration {
         private val logger = LoggerFactory.getLogger(SingleChatModelConfiguration::class.java)
 
         @Bean
-        @ConditionalOnMissingBean(LLMClient::class)
+        @ConditionalOnMissingBean(name = ["springAiChatModelLLMClient"])
         public open fun springAiChatModelLLMClient(
             chatModel: ChatModel,
             beanFactory: BeanFactory,

--- a/koog-spring-ai/koog-spring-ai-starter-model-chat/src/test/kotlin/ai/koog/spring/ai/chat/SpringAiChatAutoConfigurationTest.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-chat/src/test/kotlin/ai/koog/spring/ai/chat/SpringAiChatAutoConfigurationTest.kt
@@ -50,14 +50,28 @@ class SpringAiChatAutoConfigurationTest {
     }
 
     @Test
-    fun `should not create LLMClient when ChatModel is present but LLMClient already exists`() {
+    fun `should create auto-configured LLMClient alongside user-defined LLMClient`() {
         val existingClient = mockk<LLMClient>(relaxed = true)
         contextRunner()
             .withBean(ChatModel::class.java, { mockk<ChatModel>(relaxed = true) })
-            .withBean(LLMClient::class.java, { existingClient })
+            .withBean("userLLMClient", LLMClient::class.java, { existingClient })
             .run { context ->
-                val client = context.getBean<LLMClient>()
-                assertTrue(client === existingClient)
+                val clients = context.getBeansOfType(LLMClient::class.java)
+                assertTrue(clients.size == 2, "Expected 2 LLMClient beans (auto-configured + user), got ${clients.size}")
+                assertTrue(clients.values.any { it is SpringAiLLMClient }, "Auto-configured SpringAiLLMClient should be present")
+                assertTrue(clients.values.any { it === existingClient }, "User-defined LLMClient should be present")
+            }
+    }
+
+    @Test
+    fun `should compose all LLMClients into PromptExecutor when user-defined LLMClient coexists`() {
+        val existingClient = mockk<LLMClient>(relaxed = true)
+        contextRunner()
+            .withBean(ChatModel::class.java, { mockk<ChatModel>(relaxed = true) })
+            .withBean("userLLMClient", LLMClient::class.java, { existingClient })
+            .run { context ->
+                val executor = context.getBean<PromptExecutor>()
+                assertInstanceOf<MultiLLMPromptExecutor>(executor)
             }
     }
 
@@ -119,19 +133,15 @@ class SpringAiChatAutoConfigurationTest {
 
     // ---- mutual exclusion: selector set to empty string ----
     @Test
-    fun `should fail on startup when chat-model-bean-name is set to empty string because named path activates with empty bean name`() {
+    fun `should treat empty string selector as missing and use single candidate`() {
         contextRunner()
             .withPropertyValues("koog.spring.ai.chat.chat-model-bean-name=")
             .withBean("myChat", ChatModel::class.java, { mockk<ChatModel>(relaxed = true) })
             .run { context ->
-                // Spring treats "" as a present value equal to "", so havingValue="" on SingleChatModelConfiguration
-                // matches (the condition passes), AND the plain @ConditionalOnProperty on NamedChatModelConfiguration
-                // also matches (any non-false present value satisfies it). Both configs activate; the named path
-                // then calls beanFactory.getBean("", ChatModel::class.java) with an empty name, which fails.
-                assertTrue(
-                    context.startupFailure != null,
-                    "Expected startup failure when chat-model-bean-name is set to empty string"
-                )
+                // @ConditionalOnPropertyMissingOrEmpty treats "" as missing/empty, so only
+                // SingleChatModelConfiguration activates; NamedChatModelConfiguration does not match.
+                assertTrue(context.startupFailure == null, "Context should start successfully when selector is empty string")
+                assertInstanceOf<SpringAiLLMClient>(context.getBean<LLMClient>())
             }
     }
 

--- a/koog-spring-ai/koog-spring-ai-starter-model-embedding/src/main/kotlin/ai/koog/spring/ai/embedding/SpringAiEmbeddingAutoConfiguration.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-embedding/src/main/kotlin/ai/koog/spring/ai/embedding/SpringAiEmbeddingAutoConfiguration.kt
@@ -1,10 +1,10 @@
 package ai.koog.spring.ai.embedding
 
 import ai.koog.prompt.executor.clients.LLMEmbeddingProvider
-import ai.koog.spring.ai.common.DispatcherProperties
+import ai.koog.spring.ai.common.conditions.ConditionalOnPropertyMissingOrEmpty
+import ai.koog.spring.ai.common.conditions.ConditionalOnPropertyNotEmpty
+import ai.koog.spring.ai.common.resolveDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.asCoroutineDispatcher
 import org.slf4j.LoggerFactory
 import org.springframework.ai.embedding.EmbeddingModel
 import org.springframework.beans.factory.BeanFactory
@@ -64,36 +64,19 @@ public open class SpringAiEmbeddingAutoConfiguration {
         properties: KoogSpringAiEmbeddingProperties,
         @Qualifier("applicationTaskExecutor") asyncTaskExecutorProvider: ObjectProvider<AsyncTaskExecutor>,
     ): CoroutineDispatcher {
-        val asyncTaskExecutor = asyncTaskExecutorProvider.ifAvailable
-        return when (val dispatcher = properties.dispatcher.toDispatcherProperties()) {
-            is DispatcherProperties.Auto -> {
-                if (asyncTaskExecutor != null) {
-                    logger.info("Koog Spring AI Embedding: using Spring AsyncTaskExecutor as dispatcher for blocking model calls")
-                    asyncTaskExecutor.asCoroutineDispatcher()
-                } else {
-                    logger.info("Koog Spring AI Embedding: no AsyncTaskExecutor found, falling back to Dispatchers.IO for blocking model calls")
-                    Dispatchers.IO
-                }
-            }
-
-            is DispatcherProperties.IO -> {
-                val parallelism = dispatcher.parallelism
-                if (parallelism != null && parallelism > 0) {
-                    logger.info("Koog Spring AI Embedding: using Dispatchers.IO.limitedParallelism($parallelism) for blocking model calls")
-                    Dispatchers.IO.limitedParallelism(parallelism)
-                } else {
-                    logger.info("Koog Spring AI Embedding: using Dispatchers.IO for blocking model calls")
-                    Dispatchers.IO
-                }
-            }
-        }
+        return resolveDispatcher(
+            dispatcherConfig = properties.dispatcher,
+            asyncTaskExecutor = asyncTaskExecutorProvider.ifAvailable,
+            logger = logger,
+            componentName = "Koog Spring AI Embedding",
+        )
     }
 
     /**
      * Embedding model configuration — activated when a bean-name selector is provided.
      */
     @Configuration(proxyBeanMethods = false)
-    @ConditionalOnProperty(prefix = "koog.spring.ai.embedding", name = ["embedding-model-bean-name"])
+    @ConditionalOnPropertyNotEmpty(prefix = "koog.spring.ai.embedding", name = "embedding-model-bean-name")
     public open class NamedEmbeddingModelConfiguration {
         private val logger = LoggerFactory.getLogger(NamedEmbeddingModelConfiguration::class.java)
 
@@ -117,21 +100,13 @@ public open class SpringAiEmbeddingAutoConfiguration {
      *
      * This is the default fallback path. It is mutually exclusive with [NamedEmbeddingModelConfiguration] for
      * the common cases:
-     * - selector absent → `matchIfMissing = true` activates this config; [NamedEmbeddingModelConfiguration] does not match
-     * - selector non-empty (e.g. `"myBean"`) → [NamedEmbeddingModelConfiguration] matches; `havingValue = ""` does not
-     *   match a non-empty value, so this config does not activate
-     * - selector set to literal `""` → both configs activate (Spring treats `""` as a present value that satisfies
-     *   both `havingValue = ""` and the plain `@ConditionalOnProperty` on the named path); the named path then
-     *   attempts `beanFactory.getBean("", EmbeddingModel::class.java)` which fails at startup
+     * - selector absent → [ConditionalOnPropertyMissingOrEmpty] activates this config; [NamedEmbeddingModelConfiguration] does not match
+     * - selector non-empty (e.g. `"myBean"`) → [NamedEmbeddingModelConfiguration] matches; [ConditionalOnPropertyMissingOrEmpty] does not activate
+     * - selector set to literal `""` → treated as missing/empty; [ConditionalOnPropertyMissingOrEmpty] activates this config; [NamedEmbeddingModelConfiguration] does not match
      */
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnSingleCandidate(EmbeddingModel::class)
-    @ConditionalOnProperty(
-        prefix = "koog.spring.ai.embedding",
-        name = ["embedding-model-bean-name"],
-        havingValue = "",
-        matchIfMissing = true
-    )
+    @ConditionalOnPropertyMissingOrEmpty(prefix = "koog.spring.ai.embedding", name = "embedding-model-bean-name")
     public open class SingleEmbeddingModelConfiguration {
         private val logger = LoggerFactory.getLogger(SingleEmbeddingModelConfiguration::class.java)
 

--- a/koog-spring-ai/koog-spring-ai-starter-model-embedding/src/test/kotlin/ai/koog/spring/ai/embedding/SpringAiEmbeddingAutoConfigurationTest.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-embedding/src/test/kotlin/ai/koog/spring/ai/embedding/SpringAiEmbeddingAutoConfigurationTest.kt
@@ -136,19 +136,15 @@ class SpringAiEmbeddingAutoConfigurationTest {
 
     // ---- mutual exclusion: selector set to empty string ----
     @Test
-    fun `should fail on startup when embedding-model-bean-name is set to empty string because named path activates with empty bean name`() {
+    fun `should treat empty string selector as missing and use single candidate`() {
         contextRunner()
             .withPropertyValues("koog.spring.ai.embedding.embedding-model-bean-name=")
             .withBean("myEmb", EmbeddingModel::class.java, { mockk<EmbeddingModel>(relaxed = true) })
             .run { context ->
-                // Spring treats "" as a present value equal to "", so havingValue="" on SingleEmbeddingModelConfiguration
-                // matches (the condition passes), AND the plain @ConditionalOnProperty on NamedEmbeddingModelConfiguration
-                // also matches (any non-false present value satisfies it). Both configs activate; the named path
-                // then calls beanFactory.getBean("", EmbeddingModel::class.java) with an empty name, which fails.
-                assertTrue(
-                    context.startupFailure != null,
-                    "Expected startup failure when embedding-model-bean-name is set to empty string"
-                )
+                // @ConditionalOnPropertyMissingOrEmpty treats "" as missing/empty, so only
+                // SingleEmbeddingModelConfiguration activates; NamedEmbeddingModelConfiguration does not match.
+                assertTrue(context.startupFailure == null, "Context should start successfully when selector is empty string")
+                assertInstanceOf<SpringAiLLMEmbeddingProvider>(context.getBean<LLMEmbeddingProvider>())
             }
     }
 

--- a/koog-spring-ai/koog-spring-ai-starter-vector-store/Module.md
+++ b/koog-spring-ai/koog-spring-ai-starter-vector-store/Module.md
@@ -59,6 +59,7 @@ class MyKnowledgeBase(
 
 - If a single `VectorStore` bean exists in the context, it is used automatically.
 - If multiple `VectorStore` beans exist, set `koog.spring.ai.vectorstore.vector-store-bean-name` to select one.
+- When `vector-store-bean-name` is set, the single-candidate path is suppressed — exactly one `KoogVectorStore` is created via the named path.
 - The dispatcher for blocking VectorStore calls defaults to `AUTO`, which uses Spring's `AsyncTaskExecutor` if available, otherwise falls back to `Dispatchers.IO`.
 
 ### Configuration properties (`koog.spring.ai.vectorstore`)
@@ -69,6 +70,21 @@ class MyKnowledgeBase(
 | `vector-store-bean-name` | `String?` | `null` | Bean name of the `VectorStore` to use when multiple stores are present |
 | `dispatcher.type` | `AUTO` / `IO` | `AUTO` | Dispatcher for blocking VectorStore calls |
 | `dispatcher.parallelism` | `Int` | `0` (= unbounded) | Max concurrency for `IO` dispatcher |
+
+### Dispatcher types
+
+- **`AUTO`** (default): Uses a Spring-managed `AsyncTaskExecutor` if available (e.g., when `spring.threads.virtual.enabled=true` in Spring Boot 3.2+), otherwise falls back to `Dispatchers.IO`. This lets you opt into virtual threads with a single standard Spring Boot property.
+- **`IO`**: Always uses `Dispatchers.IO`. When `dispatcher.parallelism` is greater than 0, uses `Dispatchers.IO.limitedParallelism(parallelism)` to cap concurrency.
+
+### Multi-store contexts
+
+When multiple `VectorStore` beans are registered, specify which one to use:
+
+```properties
+koog.spring.ai.vectorstore.vector-store-bean-name=pgVectorStore
+```
+
+Without a selector, the auto-configuration activates only when a single candidate exists.
 
 ### Current limitations
 

--- a/koog-spring-ai/koog-spring-ai-starter-vector-store/Module.md
+++ b/koog-spring-ai/koog-spring-ai-starter-vector-store/Module.md
@@ -1,0 +1,78 @@
+# Module koog-spring-ai-starter-vector-store
+
+Adapts a Spring AI `VectorStore` into Koog's `KoogVectorStore`, providing ingestion, retrieval, and deletion capabilities.
+
+### Overview
+
+This starter bridges Spring AI VectorStore implementations with Koog's `rag-base` storage abstractions.
+It auto-configures a `SpringAiKoogVectorStore` adapter that delegates to a Spring AI `VectorStore`
+and exposes it as a `KoogVectorStore` — a unified interface combining:
+
+- `WriteStorage<DocumentWithMetadata>` — add and update documents
+- `SearchStorage<DocumentWithMetadata, SimilaritySearchRequest>` — similarity search with filtering and score thresholds
+- `FilteringDeletionStorage` — delete by IDs or by filter expression
+
+The adapter uses a `DocumentWithMetadata` model whose metadata values are restricted to primitive types
+(String, Number, Boolean) to match Spring AI `Document` metadata constraints.
+
+> **Note:** Namespace scoping is **not implemented**. Passing a non-null `namespace` to any method will throw `IllegalArgumentException`.
+
+### Using in your project
+
+Add the dependency alongside any Spring AI VectorStore starter (e.g., PgVector):
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation("ai.koog:koog-spring-ai-starter-vector-store:$koogVersion")
+    implementation("org.springframework.ai:spring-ai-starter-vector-store-pgvector")
+}
+```
+
+### Example of usage
+
+Inject `KoogVectorStore` (or any of its super-interfaces) directly into your Spring components:
+
+```kotlin
+@Service
+class MyKnowledgeBase(
+    private val vectorStore: KoogVectorStore,
+) {
+
+    suspend fun ingest(text: String): List<String> {
+        return vectorStore.add(
+            listOf(DocumentWithMetadata(content = text, metadata = mapOf("source" to "user")))
+        )
+    }
+
+    suspend fun search(query: String): List<SearchResult<DocumentWithMetadata>> {
+        return vectorStore.search(SimilaritySearchRequest(queryText = query, limit = 5))
+    }
+
+    suspend fun remove(ids: List<String>) {
+        vectorStore.delete(ids)
+    }
+}
+```
+
+### Auto-configuration behavior
+
+- If a single `VectorStore` bean exists in the context, it is used automatically.
+- If multiple `VectorStore` beans exist, set `koog.spring.ai.vectorstore.vector-store-bean-name` to select one.
+- The dispatcher for blocking VectorStore calls defaults to `AUTO`, which uses Spring's `AsyncTaskExecutor` if available, otherwise falls back to `Dispatchers.IO`.
+
+### Configuration properties (`koog.spring.ai.vectorstore`)
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | `Boolean` | `true` | Enable/disable the VectorStore auto-configuration |
+| `vector-store-bean-name` | `String?` | `null` | Bean name of the `VectorStore` to use when multiple stores are present |
+| `dispatcher.type` | `AUTO` / `IO` | `AUTO` | Dispatcher for blocking VectorStore calls |
+| `dispatcher.parallelism` | `Int` | `0` (= unbounded) | Max concurrency for `IO` dispatcher |
+
+### Current limitations
+
+- Spring AI's `VectorStore` contract exposes similarity search only.
+- Spring AI's `VectorStore` contract has no update API. The adapter emulates updates as `delete(ids)` followed by `add(documents)`, which is not transactional.
+- Spring AI's `VectorStore` contract has no portable read-by-id API, so `LookupStorage` is intentionally not implemented.
+- The `delete(filterExpression)` method returns an empty list because Spring AI does not return deleted IDs.

--- a/koog-spring-ai/koog-spring-ai-starter-vector-store/build.gradle.kts
+++ b/koog-spring-ai/koog-spring-ai-starter-vector-store/build.gradle.kts
@@ -31,6 +31,7 @@ tasks.withType<JavaCompile>().configureEach {
 
 dependencies {
     api(project(":rag:rag-base"))
+    api(project(":koog-spring-ai:koog-spring-ai-common"))
     implementation(project.dependencies.platform(libs.spring.boot.bom))
     implementation(project.dependencies.platform(libs.spring.ai.bom))
     api(libs.bundles.spring.boot.core)

--- a/koog-spring-ai/koog-spring-ai-starter-vector-store/build.gradle.kts
+++ b/koog-spring-ai/koog-spring-ai-starter-vector-store/build.gradle.kts
@@ -1,0 +1,47 @@
+import ai.koog.gradle.publish.maven.Publishing.publishToMaven
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
+group = rootProject.group
+version = rootProject.version
+
+plugins {
+    id("ai.kotlin.jvm")
+    id("ai.kotlin.jvm.publish")
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.spring.management)
+}
+
+kotlin {
+    explicitApi()
+}
+
+tasks.withType<KotlinJvmCompile>().configureEach {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+        javaParameters.set(true)
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    sourceCompatibility = JavaVersion.VERSION_17.toString()
+    targetCompatibility = JavaVersion.VERSION_17.toString()
+    options.compilerArgs.add("-parameters")
+}
+
+dependencies {
+    api(project(":rag:rag-base"))
+    implementation(project.dependencies.platform(libs.spring.boot.bom))
+    implementation(project.dependencies.platform(libs.spring.ai.bom))
+    api(libs.bundles.spring.boot.core)
+    api(libs.spring.ai.vectorstore)
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.serialization.json)
+
+    testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.mockk)
+    testRuntimeOnly(libs.junit.platform.launcher)
+}
+
+publishToMaven()

--- a/koog-spring-ai/koog-spring-ai-starter-vector-store/src/main/kotlin/ai/koog/spring/ai/vectorstore/DocumentWithMetadata.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-vector-store/src/main/kotlin/ai/koog/spring/ai/vectorstore/DocumentWithMetadata.kt
@@ -19,4 +19,36 @@ public data class DocumentWithMetadata @JvmOverloads constructor(
             }
         }
     }
+
+    /**
+     * Java-friendly builder for [DocumentWithMetadata].
+     *
+     * Usage from Java:
+     * ```java
+     * DocumentWithMetadata doc = new DocumentWithMetadata.Builder("Hello world")
+     *     .metadata("author", "Alice")
+     *     .metadata("year", 2024)
+     *     .id("doc-1")
+     *     .build();
+     * ```
+     */
+    public class Builder(private val content: String) {
+        private val metadata: MutableMap<String, Any> = mutableMapOf()
+        private var id: String? = null
+
+        /** Adds a single metadata entry. */
+        public fun metadata(key: String, value: Any): Builder = apply { metadata[key] = value }
+
+        /** Replaces all metadata with the given map. */
+        public fun metadata(map: Map<String, Any>): Builder = apply {
+            metadata.clear()
+            metadata.putAll(map)
+        }
+
+        /** Sets the document id. */
+        public fun id(id: String?): Builder = apply { this.id = id }
+
+        /** Builds the [DocumentWithMetadata] instance. */
+        public fun build(): DocumentWithMetadata = DocumentWithMetadata(content, metadata, id)
+    }
 }

--- a/koog-spring-ai/koog-spring-ai-starter-vector-store/src/main/kotlin/ai/koog/spring/ai/vectorstore/DocumentWithMetadata.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-vector-store/src/main/kotlin/ai/koog/spring/ai/vectorstore/DocumentWithMetadata.kt
@@ -1,0 +1,22 @@
+package ai.koog.spring.ai.vectorstore
+
+/**
+ * Vector-store document model used by this starter.
+ *
+ * Metadata values are restricted to primitive types (String, Number, Boolean)
+ * to match Spring AI [org.springframework.ai.document.Document] metadata constraints.
+ */
+public data class DocumentWithMetadata @JvmOverloads constructor(
+    public val content: String,
+    public val metadata: Map<String, Any> = emptyMap(),
+    public val id: String? = null
+) {
+    init {
+        metadata.forEach { (key, value) ->
+            require(value is String || value is Boolean || value is Number) {
+                "Metadata value for key '$key' must be a primitive type " +
+                    "(String, Number, or Boolean), but was ${value::class.qualifiedName}"
+            }
+        }
+    }
+}

--- a/koog-spring-ai/koog-spring-ai-starter-vector-store/src/main/kotlin/ai/koog/spring/ai/vectorstore/KoogSpringAiVectorStoreProperties.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-vector-store/src/main/kotlin/ai/koog/spring/ai/vectorstore/KoogSpringAiVectorStoreProperties.kt
@@ -1,0 +1,31 @@
+package ai.koog.spring.ai.vectorstore
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Configuration properties for the Koog Spring AI vector-store adapter.
+ *
+ * Prefix: `koog.spring.ai.vectorstore`
+ */
+@ConfigurationProperties(prefix = "koog.spring.ai.vectorstore")
+public data class KoogSpringAiVectorStoreProperties(
+    val enabled: Boolean = true,
+    val vectorStoreBeanName: String? = null,
+    val dispatcher: DispatcherProperties = DispatcherProperties(),
+) {
+    /**
+     * Dispatcher settings for blocking Spring AI VectorStore calls.
+     */
+    public data class DispatcherProperties(
+        val type: DispatcherType = DispatcherType.AUTO,
+        val parallelism: Int = 0,
+    )
+
+    /**
+     * Dispatcher type for blocking VectorStore calls.
+     */
+    public enum class DispatcherType {
+        AUTO,
+        IO,
+    }
+}

--- a/koog-spring-ai/koog-spring-ai-starter-vector-store/src/main/kotlin/ai/koog/spring/ai/vectorstore/KoogSpringAiVectorStoreProperties.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-vector-store/src/main/kotlin/ai/koog/spring/ai/vectorstore/KoogSpringAiVectorStoreProperties.kt
@@ -1,31 +1,20 @@
 package ai.koog.spring.ai.vectorstore
 
+import ai.koog.spring.ai.common.DispatcherConfig
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
  * Configuration properties for the Koog Spring AI vector-store adapter.
  *
- * Prefix: `koog.spring.ai.vectorstore`
+ * @property enabled whether the auto-configuration is enabled (default `true`)
+ * @property vectorStoreBeanName Optional bean name of the [org.springframework.ai.vectorstore.VectorStore]
+ *   to use. When set, the named bean is resolved from the application context, allowing selection among multiple
+ *   store beans. When not set, the auto-configuration falls back to `@ConditionalOnSingleCandidate`.
+ * @property dispatcher Dispatcher / threading settings for blocking Spring AI vector-store calls.
  */
 @ConfigurationProperties(prefix = "koog.spring.ai.vectorstore")
 public data class KoogSpringAiVectorStoreProperties(
     val enabled: Boolean = true,
     val vectorStoreBeanName: String? = null,
-    val dispatcher: DispatcherProperties = DispatcherProperties(),
-) {
-    /**
-     * Dispatcher settings for blocking Spring AI VectorStore calls.
-     */
-    public data class DispatcherProperties(
-        val type: DispatcherType = DispatcherType.AUTO,
-        val parallelism: Int = 0,
-    )
-
-    /**
-     * Dispatcher type for blocking VectorStore calls.
-     */
-    public enum class DispatcherType {
-        AUTO,
-        IO,
-    }
-}
+    val dispatcher: DispatcherConfig = DispatcherConfig(),
+)

--- a/koog-spring-ai/koog-spring-ai-starter-vector-store/src/main/kotlin/ai/koog/spring/ai/vectorstore/KoogVectorStore.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-vector-store/src/main/kotlin/ai/koog/spring/ai/vectorstore/KoogVectorStore.kt
@@ -1,0 +1,18 @@
+package ai.koog.spring.ai.vectorstore
+
+import ai.koog.rag.base.storage.FilteringDeletionStorage
+import ai.koog.rag.base.storage.SearchStorage
+import ai.koog.rag.base.storage.WriteStorage
+import ai.koog.rag.base.storage.search.SimilaritySearchRequest
+
+/**
+ * A unified storage interface that combines [WriteStorage], [SearchStorage], and [FilteringDeletionStorage]
+ * for use with Spring AI vector stores.
+ *
+ * Users can inject this single interface as a Spring Bean to access all storage
+ * capabilities (ingestion, retrieval, deletion) through one dependency.
+ */
+public interface KoogVectorStore :
+    WriteStorage<DocumentWithMetadata>,
+    SearchStorage<DocumentWithMetadata, SimilaritySearchRequest>,
+    FilteringDeletionStorage

--- a/koog-spring-ai/koog-spring-ai-starter-vector-store/src/main/kotlin/ai/koog/spring/ai/vectorstore/KoogVectorStoreException.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-vector-store/src/main/kotlin/ai/koog/spring/ai/vectorstore/KoogVectorStoreException.kt
@@ -1,0 +1,27 @@
+package ai.koog.spring.ai.vectorstore
+
+/**
+ * Exception thrown when a Koog vector-store operation fails.
+ *
+ * Wraps backend provider errors and filter-expression parsing failures
+ * with operation context so that callers receive a consistent, Koog-specific
+ * exception type instead of raw backend exceptions.
+ *
+ * @param operation a short label describing the failed operation (e.g. `"add"`, `"search"`, `"delete"`)
+ * @param message human-readable description of the failure
+ * @param cause the original exception, if any
+ */
+public class KoogVectorStoreException(
+    operation: String,
+    message: String? = null,
+    cause: Throwable? = null,
+) : Exception(
+    buildString {
+        append("Koog VectorStore operation '$operation' failed")
+        if (message != null) {
+            append(": ")
+            append(message)
+        }
+    },
+    cause
+)

--- a/koog-spring-ai/koog-spring-ai-starter-vector-store/src/main/kotlin/ai/koog/spring/ai/vectorstore/SpringAiKoogVectorStore.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-vector-store/src/main/kotlin/ai/koog/spring/ai/vectorstore/SpringAiKoogVectorStore.kt
@@ -1,0 +1,193 @@
+package ai.koog.spring.ai.vectorstore
+
+import ai.koog.rag.base.storage.search.Score
+import ai.koog.rag.base.storage.search.ScoreMetric
+import ai.koog.rag.base.storage.search.SearchResult
+import ai.koog.rag.base.storage.search.SimilaritySearchRequest
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import org.springframework.ai.document.Document
+import org.springframework.ai.vectorstore.VectorStore
+import org.springframework.ai.vectorstore.filter.FilterExpressionTextParser
+import org.springframework.ai.vectorstore.SearchRequest as SpringAiSearchRequest
+
+/**
+ * Adapts a Spring AI [VectorStore] to Koog storage abstractions.
+ */
+public class SpringAiKoogVectorStore(
+    private val vectorStore: VectorStore,
+    private val dispatcher: CoroutineDispatcher,
+) : KoogVectorStore {
+
+    /**
+     * It adds documents with randomly generated ids for null ids, otherwise it adds documents with specified ids.
+     */
+    override suspend fun add(documents: List<DocumentWithMetadata>, namespace: String?): List<String> {
+        require(namespace == null) { "Namespace scoping is not yet supported by SpringAiKoogVectorStore" }
+        documents.forEach { validateMetadata(it.metadata) }
+        return withContext(dispatcher) {
+            try {
+                val springDocs = documents.map { document ->
+                    if (document.id != null) {
+                        Document(document.id, document.content, document.metadata)
+                    } else {
+                        Document(document.content, document.metadata)
+                    }
+                }
+                vectorStore.add(springDocs)
+                springDocs.map { it.id }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                throw KoogVectorStoreException("add", e.message, e)
+            }
+        }
+    }
+
+    /**
+     * It deletes old documents by their ids and adds new documents. Spring AI VectorStore does not support transactional update.
+     */
+    override suspend fun update(documents: Map<String, DocumentWithMetadata>, namespace: String?): List<String> {
+        require(namespace == null) { "Namespace scoping is not yet supported by SpringAiKoogVectorStore" }
+        documents.values.forEach { validateMetadata(it.metadata) }
+        documents.forEach { (id, document) ->
+            require(document.id == null || document.id == id) {
+                "Document ID '${document.id}' conflicts with map key '$id'. " +
+                    "Either set document.id to null or ensure it matches the map key."
+            }
+        }
+        return withContext(dispatcher) {
+            if (documents.isEmpty()) {
+                return@withContext emptyList()
+            }
+
+            try {
+                vectorStore.delete(documents.keys.toList())
+                vectorStore.add(
+                    documents.map { (id, document) ->
+                        Document(
+                            id,
+                            document.content,
+                            document.metadata,
+                        )
+                    }
+                )
+                documents.keys.toList()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                throw KoogVectorStoreException("update", e.message, e)
+            }
+        }
+    }
+
+    /**
+     * It deletes documents by ids, but returns specified ids, because Spring AI VectorStore does not return deleted ids.
+     */
+    override suspend fun delete(ids: List<String>, namespace: String?): List<String> {
+        require(namespace == null) { "Namespace scoping is not yet supported by SpringAiKoogVectorStore" }
+        return withContext(dispatcher) {
+            if (ids.isEmpty()) {
+                return@withContext emptyList()
+            }
+
+            try {
+                vectorStore.delete(ids)
+                ids
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                throw KoogVectorStoreException("delete", e.message, e)
+            }
+        }
+    }
+
+    /**
+     * It deletes documents by filterExpression, but returns an empty list, because VectorStore does not return deleted ids.
+     */
+    override suspend fun delete(filterExpression: String, namespace: String?): List<String> {
+        require(namespace == null) { "Namespace scoping is not yet supported by SpringAiKoogVectorStore" }
+        return withContext(dispatcher) {
+            try {
+                vectorStore.delete(filterExpression)
+                emptyList()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                throw KoogVectorStoreException("delete", e.message, e)
+            }
+        }
+    }
+
+    /**
+     * Does similarity search, because Spring AI VectorStore currently supports only similaritySearch.
+     */
+    override suspend fun search(request: SimilaritySearchRequest, namespace: String?): List<SearchResult<DocumentWithMetadata>> {
+        require(namespace == null) { "Namespace scoping is not yet supported by SpringAiKoogVectorStore" }
+        require(request.limit >= 0) { "limit must be non-negative, but was ${request.limit}" }
+        require(request.offset >= 0) { "offset must be non-negative, but was ${request.offset}" }
+        if (request.limit == 0) {
+            return emptyList()
+        }
+        return withContext(dispatcher) {
+            val textQuery = request.queryText
+            val similarityThreshold = request.minScore ?: SpringAiSearchRequest.SIMILARITY_THRESHOLD_ACCEPT_ALL
+
+            try {
+                val filterExpression = request.filterExpression?.let { text ->
+                    FilterExpressionTextParser().parse(text)
+                }
+                vectorStore.similaritySearch(
+                    SpringAiSearchRequest.builder()
+                        .query(textQuery)
+                        .topK(request.limit + request.offset)
+                        .similarityThreshold(similarityThreshold)
+                        .filterExpression(filterExpression)
+                        .build()
+                )
+                    .drop(request.offset)
+                    .take(request.limit)
+                    .map { document ->
+                        SearchResult(
+                            document = DocumentWithMetadata(
+                                document.text ?: "",
+                                document.metadata,
+                                document.id
+                            ),
+                            score = Score(document.score ?: 0.0, ScoreMetric.COSINE_SIMILARITY),
+                            id = document.id,
+                            metadata = null, // Spring AI stores metadata inside the document
+                            namespace = namespace,
+                        )
+                    }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                throw KoogVectorStoreException("search", e.message, e)
+            }
+        }
+    }
+
+    private companion object {
+        private val ALLOWED_TYPES = setOf(
+            String::class,
+            Boolean::class,
+            Byte::class,
+            Short::class,
+            Int::class,
+            Long::class,
+            Float::class,
+            Double::class,
+        )
+
+        fun validateMetadata(metadata: Map<String, Any>) {
+            metadata.forEach { (key, value) ->
+                require(value::class in ALLOWED_TYPES) {
+                    "Metadata value for key '$key' must be a primitive type " +
+                        "(String, Number, or Boolean), but was ${value::class.qualifiedName}"
+                }
+            }
+        }
+    }
+}

--- a/koog-spring-ai/koog-spring-ai-starter-vector-store/src/main/kotlin/ai/koog/spring/ai/vectorstore/SpringAiVectorStoreAutoConfiguration.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-vector-store/src/main/kotlin/ai/koog/spring/ai/vectorstore/SpringAiVectorStoreAutoConfiguration.kt
@@ -1,0 +1,140 @@
+package ai.koog.spring.ai.vectorstore
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
+import org.slf4j.LoggerFactory
+import org.springframework.ai.vectorstore.VectorStore
+import org.springframework.beans.factory.BeanFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.task.AsyncTaskExecutor
+import org.springframework.lang.Nullable
+
+/**
+ * Auto-configuration for adapting a Spring AI [VectorStore] to Koog storage abstractions.
+ *
+ * This configuration:
+ * - Binds [KoogSpringAiVectorStoreProperties] under `koog.spring.ai.vectorstore.*`.
+ * - Creates a [KoogVectorStore] backed by a Spring AI [VectorStore] when available.
+ * - Supports multi-store contexts via property-based bean-name selection.
+ * - Provides an injectable [CoroutineDispatcher] for blocking vector-store calls.
+ *
+ * Gated by `koog.spring.ai.vectorstore.enabled=true` (default).
+ */
+@AutoConfiguration(
+    afterName = [
+        "org.springframework.ai.vectorstore.azure.autoconfigure.AzureVectorStoreAutoConfiguration",
+        "org.springframework.ai.vectorstore.cosmosdb.autoconfigure.CosmosDBVectorStoreAutoConfiguration",
+        "org.springframework.ai.vectorstore.cassandra.autoconfigure.CassandraVectorStoreAutoConfiguration",
+        "org.springframework.ai.vectorstore.couchbase.autoconfigure.CouchbaseSearchVectorStoreAutoConfiguration",
+        "org.springframework.ai.vectorstore.chroma.autoconfigure.ChromaVectorStoreAutoConfiguration",
+        "org.springframework.ai.vectorstore.elasticsearch.autoconfigure.ElasticsearchVectorStoreAutoConfiguration",
+        "org.springframework.ai.vectorstore.gemfire.autoconfigure.GemFireVectorStoreAutoConfiguration",
+        "org.springframework.ai.vectorstore.milvus.autoconfigure.MilvusVectorStoreAutoConfiguration",
+        "org.springframework.ai.vectorstore.mongodb.autoconfigure.MongoDBAtlasVectorStoreAutoConfiguration",
+        "org.springframework.ai.vectorstore.neo4j.autoconfigure.Neo4jVectorStoreAutoConfiguration",
+        "org.springframework.ai.vectorstore.opensearch.autoconfigure.OpenSearchVectorStoreAutoConfiguration",
+        "org.springframework.ai.vectorstore.oracle.autoconfigure.OracleVectorStoreAutoConfiguration",
+        "org.springframework.ai.vectorstore.pgvector.autoconfigure.PgVectorStoreAutoConfiguration",
+        "org.springframework.ai.vectorstore.pinecone.autoconfigure.PineconeVectorStoreAutoConfiguration",
+        "org.springframework.ai.vectorstore.qdrant.autoconfigure.QdrantVectorStoreAutoConfiguration",
+        "org.springframework.ai.vectorstore.redis.autoconfigure.RedisVectorStoreAutoConfiguration",
+        "org.springframework.ai.vectorstore.typesense.autoconfigure.TypesenseVectorStoreAutoConfiguration",
+        "org.springframework.ai.vectorstore.weaviate.autoconfigure.WeaviateVectorStoreAutoConfiguration"
+    ]
+)
+@EnableConfigurationProperties(KoogSpringAiVectorStoreProperties::class)
+@ConditionalOnClass(VectorStore::class)
+@ConditionalOnProperty(
+    prefix = "koog.spring.ai.vectorstore",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true
+)
+public open class SpringAiVectorStoreAutoConfiguration {
+
+    private val logger = LoggerFactory.getLogger(SpringAiVectorStoreAutoConfiguration::class.java)
+
+    /**
+     * Creates a [CoroutineDispatcher] for blocking Spring AI vector-store calls.
+     */
+    @Bean
+    @ConditionalOnMissingBean(name = ["koogSpringAiVectorStoreDispatcher"])
+    public open fun koogSpringAiVectorStoreDispatcher(
+        properties: KoogSpringAiVectorStoreProperties,
+        @Autowired(required = false) @Qualifier("applicationTaskExecutor") @Nullable asyncTaskExecutor: AsyncTaskExecutor?,
+    ): CoroutineDispatcher {
+        return when (properties.dispatcher.type) {
+            KoogSpringAiVectorStoreProperties.DispatcherType.AUTO -> {
+                if (asyncTaskExecutor != null) {
+                    logger.info("Koog Spring AI VectorStore: using Spring AsyncTaskExecutor as dispatcher for blocking vector-store calls")
+                    asyncTaskExecutor.asCoroutineDispatcher()
+                } else {
+                    logger.info("Koog Spring AI VectorStore: no AsyncTaskExecutor found, falling back to Dispatchers.IO")
+                    Dispatchers.IO
+                }
+            }
+
+            KoogSpringAiVectorStoreProperties.DispatcherType.IO -> {
+                val parallelism = properties.dispatcher.parallelism
+                if (parallelism > 0) {
+                    logger.info("Koog Spring AI VectorStore: using Dispatchers.IO.limitedParallelism($parallelism)")
+                    Dispatchers.IO.limitedParallelism(parallelism)
+                } else {
+                    logger.info("Koog Spring AI VectorStore: using Dispatchers.IO")
+                    Dispatchers.IO
+                }
+            }
+        }
+    }
+
+    /**
+     * VectorStore configuration — activated when a bean-name selector is provided.
+     */
+    @Configuration
+    @ConditionalOnProperty(prefix = "koog.spring.ai.vectorstore", name = ["vector-store-bean-name"])
+    public open class NamedVectorStoreConfiguration {
+        private val logger = LoggerFactory.getLogger(NamedVectorStoreConfiguration::class.java)
+
+        @Bean
+        @ConditionalOnMissingBean(KoogVectorStore::class)
+        public open fun springAiKoogVectorStore(
+            beanFactory: BeanFactory,
+            properties: KoogSpringAiVectorStoreProperties,
+            @Qualifier("koogSpringAiVectorStoreDispatcher") dispatcher: CoroutineDispatcher,
+        ): KoogVectorStore {
+            val beanName = properties.vectorStoreBeanName!!
+            logger.info("Koog Spring AI VectorStore: resolving VectorStore bean by name='{}'", beanName)
+            val vectorStore = beanFactory.getBean(beanName, VectorStore::class.java)
+            return SpringAiKoogVectorStore(vectorStore = vectorStore, dispatcher = dispatcher)
+        }
+    }
+
+    /**
+     * VectorStore configuration — activated when no bean-name selector is set and a single VectorStore candidate exists.
+     */
+    @Configuration
+    @ConditionalOnMissingBean(KoogVectorStore::class)
+    @ConditionalOnSingleCandidate(VectorStore::class)
+    public open class SingleVectorStoreConfiguration {
+        private val logger = LoggerFactory.getLogger(SingleVectorStoreConfiguration::class.java)
+
+        @Bean
+        public open fun springAiKoogVectorStore(
+            vectorStore: VectorStore,
+            @Qualifier("koogSpringAiVectorStoreDispatcher") dispatcher: CoroutineDispatcher,
+        ): KoogVectorStore {
+            logger.info("Koog Spring AI VectorStore: using single VectorStore candidate as Koog storage backend")
+            return SpringAiKoogVectorStore(vectorStore = vectorStore, dispatcher = dispatcher)
+        }
+    }
+}

--- a/koog-spring-ai/koog-spring-ai-starter-vector-store/src/main/kotlin/ai/koog/spring/ai/vectorstore/SpringAiVectorStoreAutoConfiguration.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-vector-store/src/main/kotlin/ai/koog/spring/ai/vectorstore/SpringAiVectorStoreAutoConfiguration.kt
@@ -1,12 +1,13 @@
 package ai.koog.spring.ai.vectorstore
 
+import ai.koog.spring.ai.common.conditions.ConditionalOnPropertyMissingOrEmpty
+import ai.koog.spring.ai.common.conditions.ConditionalOnPropertyNotEmpty
+import ai.koog.spring.ai.common.resolveDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.asCoroutineDispatcher
 import org.slf4j.LoggerFactory
 import org.springframework.ai.vectorstore.VectorStore
 import org.springframework.beans.factory.BeanFactory
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
@@ -17,7 +18,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.task.AsyncTaskExecutor
-import org.springframework.lang.Nullable
 
 /**
  * Auto-configuration for adapting a Spring AI [VectorStore] to Koog storage abstractions.
@@ -66,42 +66,35 @@ public open class SpringAiVectorStoreAutoConfiguration {
 
     /**
      * Creates a [CoroutineDispatcher] for blocking Spring AI vector-store calls.
+     *
+     * Dispatcher selection is controlled by [KoogSpringAiVectorStoreProperties.dispatcher]:
+     * - [ai.koog.spring.ai.common.DispatcherType.AUTO]: uses Spring's `AsyncTaskExecutor` when available
+     *   (e.g. virtual-thread executor with `spring.threads.virtual.enabled=true`), otherwise falls back to
+     *   `Dispatchers.IO`.
+     * - [ai.koog.spring.ai.common.DispatcherType.IO]: always uses `Dispatchers.IO`, optionally limited to
+     *   `dispatcher.parallelism` threads.
      */
     @Bean
     @ConditionalOnMissingBean(name = ["koogSpringAiVectorStoreDispatcher"])
     public open fun koogSpringAiVectorStoreDispatcher(
         properties: KoogSpringAiVectorStoreProperties,
-        @Autowired(required = false) @Qualifier("applicationTaskExecutor") @Nullable asyncTaskExecutor: AsyncTaskExecutor?,
+        @Qualifier("applicationTaskExecutor") asyncTaskExecutorProvider: ObjectProvider<AsyncTaskExecutor>,
     ): CoroutineDispatcher {
-        return when (properties.dispatcher.type) {
-            KoogSpringAiVectorStoreProperties.DispatcherType.AUTO -> {
-                if (asyncTaskExecutor != null) {
-                    logger.info("Koog Spring AI VectorStore: using Spring AsyncTaskExecutor as dispatcher for blocking vector-store calls")
-                    asyncTaskExecutor.asCoroutineDispatcher()
-                } else {
-                    logger.info("Koog Spring AI VectorStore: no AsyncTaskExecutor found, falling back to Dispatchers.IO")
-                    Dispatchers.IO
-                }
-            }
-
-            KoogSpringAiVectorStoreProperties.DispatcherType.IO -> {
-                val parallelism = properties.dispatcher.parallelism
-                if (parallelism > 0) {
-                    logger.info("Koog Spring AI VectorStore: using Dispatchers.IO.limitedParallelism($parallelism)")
-                    Dispatchers.IO.limitedParallelism(parallelism)
-                } else {
-                    logger.info("Koog Spring AI VectorStore: using Dispatchers.IO")
-                    Dispatchers.IO
-                }
-            }
-        }
+        return resolveDispatcher(
+            dispatcherConfig = properties.dispatcher,
+            asyncTaskExecutor = asyncTaskExecutorProvider.ifAvailable,
+            logger = logger,
+            componentName = "Koog Spring AI VectorStore",
+        )
     }
 
     /**
      * VectorStore configuration — activated when a bean-name selector is provided.
+     *
+     * Resolves the [VectorStore] from the application context by the configured bean name.
      */
-    @Configuration
-    @ConditionalOnProperty(prefix = "koog.spring.ai.vectorstore", name = ["vector-store-bean-name"])
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnPropertyNotEmpty(prefix = "koog.spring.ai.vectorstore", name = "vector-store-bean-name")
     public open class NamedVectorStoreConfiguration {
         private val logger = LoggerFactory.getLogger(NamedVectorStoreConfiguration::class.java)
 
@@ -121,14 +114,21 @@ public open class SpringAiVectorStoreAutoConfiguration {
 
     /**
      * VectorStore configuration — activated when no bean-name selector is set and a single VectorStore candidate exists.
+     *
+     * This is the default fallback path. It is mutually exclusive with [NamedVectorStoreConfiguration] for
+     * the common cases:
+     * - selector absent → [ConditionalOnPropertyMissingOrEmpty] activates this config; [NamedVectorStoreConfiguration] does not match
+     * - selector non-empty (e.g. `"myBean"`) → [NamedVectorStoreConfiguration] matches; [ConditionalOnPropertyMissingOrEmpty] does not activate
+     * - selector set to literal `""` → treated as missing/empty; [ConditionalOnPropertyMissingOrEmpty] activates this config; [NamedVectorStoreConfiguration] does not match
      */
-    @Configuration
-    @ConditionalOnMissingBean(KoogVectorStore::class)
+    @Configuration(proxyBeanMethods = false)
     @ConditionalOnSingleCandidate(VectorStore::class)
+    @ConditionalOnPropertyMissingOrEmpty(prefix = "koog.spring.ai.vectorstore", name = "vector-store-bean-name")
     public open class SingleVectorStoreConfiguration {
         private val logger = LoggerFactory.getLogger(SingleVectorStoreConfiguration::class.java)
 
         @Bean
+        @ConditionalOnMissingBean(KoogVectorStore::class)
         public open fun springAiKoogVectorStore(
             vectorStore: VectorStore,
             @Qualifier("koogSpringAiVectorStoreDispatcher") dispatcher: CoroutineDispatcher,

--- a/koog-spring-ai/koog-spring-ai-starter-vector-store/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/koog-spring-ai/koog-spring-ai-starter-vector-store/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+ai.koog.spring.ai.vectorstore.SpringAiVectorStoreAutoConfiguration

--- a/koog-spring-ai/koog-spring-ai-starter-vector-store/src/test/kotlin/ai/koog/spring/ai/vectorstore/SpringAiKoogVectorStoreTest.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-vector-store/src/test/kotlin/ai/koog/spring/ai/vectorstore/SpringAiKoogVectorStoreTest.kt
@@ -1,0 +1,433 @@
+package ai.koog.spring.ai.vectorstore
+
+import ai.koog.rag.base.storage.search.ScoreMetric
+import ai.koog.rag.base.storage.search.SimilaritySearchRequest
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.ai.document.Document
+import org.springframework.ai.embedding.Embedding
+import org.springframework.ai.embedding.EmbeddingModel
+import org.springframework.ai.embedding.EmbeddingRequest
+import org.springframework.ai.embedding.EmbeddingResponse
+import org.springframework.ai.vectorstore.SimpleVectorStore
+import org.springframework.ai.vectorstore.VectorStore
+
+class SpringAiKoogVectorStoreTest {
+
+    /**
+     * A deterministic embedding model that produces a fixed-dimension vector from the hash of the input text.
+     * This is sufficient for SimpleVectorStore which uses cosine similarity.
+     */
+    private val embeddingModel = object : EmbeddingModel {
+        private val dimensions = 8
+
+        override fun call(request: EmbeddingRequest): EmbeddingResponse {
+            val embeddings = request.instructions.mapIndexed { index, text ->
+                Embedding(embedText(text), index)
+            }
+            return EmbeddingResponse(embeddings)
+        }
+
+        override fun embed(document: Document): FloatArray = embedText(document.text ?: "")
+
+        private fun embedText(text: String): FloatArray {
+            val hash = text.hashCode().toLong() and 0xFFFFFFFFL
+            return FloatArray(dimensions) { i ->
+                val seed = (hash xor (i.toLong() * 31)) and 0xFFFFFFFFL
+                (seed % 1000).toFloat() / 1000f
+            }
+        }
+
+        override fun dimensions(): Int = dimensions
+    }
+
+    private lateinit var storage: SpringAiKoogVectorStore
+
+    @BeforeEach
+    fun setUp() {
+        val vectorStore = SimpleVectorStore.builder(embeddingModel).build()
+        storage = SpringAiKoogVectorStore(vectorStore = vectorStore, dispatcher = Dispatchers.Unconfined)
+    }
+
+    // ── Add ──
+
+    @Test
+    fun testAddReturnsGeneratedIds() = runTest {
+        val ids = storage.add(
+            listOf(
+                DocumentWithMetadata(content = "first"),
+                DocumentWithMetadata(content = "second"),
+            ),
+            namespace = null,
+        )
+
+        assertEquals(2, ids.size)
+        assertTrue(ids.all { it.isNotEmpty() })
+    }
+
+    @Test
+    fun testAddPreservesExplicitId() = runTest {
+        val ids = storage.add(
+            listOf(
+                DocumentWithMetadata(content = "a", id = "my-id-1"),
+                DocumentWithMetadata(content = "b", id = "my-id-2"),
+                DocumentWithMetadata(content = "c"), // no explicit id
+            ),
+            namespace = null,
+        )
+
+        assertEquals("my-id-1", ids[0])
+        assertEquals("my-id-2", ids[1])
+        assertTrue(ids[2].isNotEmpty())
+    }
+
+    @Test
+    fun testAddPreservesMetadata() = runTest {
+        storage.add(
+            listOf(
+                DocumentWithMetadata(
+                    content = "document with metadata",
+                    metadata = mapOf("topic" to "testing", "priority" to 1, "active" to true),
+                ),
+            ),
+            namespace = null,
+        )
+
+        val results = storage.search(
+            SimilaritySearchRequest(queryText = "metadata", limit = 1, offset = 0, minScore = 0.0),
+            namespace = null,
+        )
+
+        val meta = results.first().document.metadata
+        assertEquals("testing", meta["topic"])
+        assertEquals(1, meta["priority"])
+        assertEquals(true, meta["active"])
+    }
+
+    @Test
+    fun testAddRejectsNonPrimitiveMetadata() = runTest {
+        val ex = assertThrows<IllegalArgumentException> {
+            storage.add(
+                listOf(DocumentWithMetadata(content = "x", metadata = mapOf("bad" to listOf(1, 2)))),
+                namespace = null,
+            )
+        }
+        assertTrue(ex.message!!.contains("bad"))
+        assertTrue(ex.message!!.contains("primitive"))
+    }
+
+    @Test
+    fun testAddAcceptsPrimitiveMetadata() = runTest {
+        val ids = storage.add(
+            listOf(
+                DocumentWithMetadata(
+                    content = "x",
+                    metadata = mapOf("s" to "v", "i" to 1, "b" to true, "d" to 1.5, "l" to 1L),
+                ),
+            ),
+            namespace = null,
+        )
+        assertEquals(1, ids.size)
+    }
+
+    @Test
+    fun testAddRejectsNonNullNamespace() = runTest {
+        assertThrows<IllegalArgumentException> {
+            storage.add(listOf(DocumentWithMetadata(content = "x")), namespace = "ns")
+        }
+    }
+
+    // ── Update ──
+
+    @Test
+    fun testUpdateReplacesDocument() = runTest {
+        storage.add(
+            listOf(DocumentWithMetadata(content = "original content", id = "update-me")),
+            namespace = null,
+        )
+
+        val result = storage.update(
+            mapOf("update-me" to DocumentWithMetadata(content = "updated content", metadata = mapOf("k" to "v"))),
+            namespace = null,
+        )
+
+        assertEquals(listOf("update-me"), result)
+
+        val results = storage.search(
+            SimilaritySearchRequest(queryText = "updated content", limit = 1, offset = 0),
+            namespace = null,
+        )
+
+        assertEquals("update-me", results.first().id)
+        assertEquals("updated content", results.first().document.content)
+        assertEquals("v", results.first().document.metadata["k"])
+    }
+
+    @Test
+    fun testUpdateReturnsEmptyListForEmptyInput() = runTest {
+        val result = storage.update(emptyMap(), namespace = null)
+        assertEquals(emptyList<String>(), result)
+    }
+
+    @Test
+    fun testUpdateRejectsNonPrimitiveMetadata() = runTest {
+        val ex = assertThrows<IllegalArgumentException> {
+            storage.update(
+                mapOf("id" to DocumentWithMetadata(content = "x", metadata = mapOf("nested" to mapOf("a" to 1)))),
+                namespace = null,
+            )
+        }
+        assertTrue(ex.message!!.contains("nested"))
+        assertTrue(ex.message!!.contains("primitive"))
+    }
+
+    @Test
+    fun testUpdateRejectsNonNullNamespace() = runTest {
+        assertThrows<IllegalArgumentException> {
+            storage.update(mapOf("id" to DocumentWithMetadata(content = "x")), namespace = "ns")
+        }
+    }
+
+    // ── Delete by IDs ──
+
+    @Test
+    fun testDeleteRemovesDocuments() = runTest {
+        val ids = storage.add(
+            listOf(
+                DocumentWithMetadata(content = "to be deleted"),
+                DocumentWithMetadata(content = "to be kept"),
+            ),
+            namespace = null,
+        )
+
+        val result = storage.delete(listOf(ids[0]), namespace = null)
+        assertEquals(listOf(ids[0]), result)
+
+        val results = storage.search(
+            SimilaritySearchRequest(queryText = "deleted kept", limit = 10, offset = 0),
+            namespace = null,
+        )
+
+        val remainingIds = results.map { it.id }
+        assertTrue(ids[0] !in remainingIds)
+    }
+
+    @Test
+    fun testDeleteByIdsReturnsEmptyListForEmptyInput() = runTest {
+        val result = storage.delete(emptyList(), namespace = null)
+        assertEquals(emptyList<String>(), result)
+    }
+
+    @Test
+    fun testDeleteByIdsRejectsNonNullNamespace() = runTest {
+        assertThrows<IllegalArgumentException> {
+            storage.delete(listOf("id-1"), namespace = "ns")
+        }
+    }
+
+    // ── Delete by filter expression ──
+
+    @Test
+    fun testDeleteByFilterRejectsNonNullNamespace() = runTest {
+        assertThrows<IllegalArgumentException> {
+            storage.delete(filterExpression = "x == 'y'", namespace = "ns")
+        }
+    }
+
+    // ── Search ──
+
+    @Test
+    fun testSearchReturnsResultsWithCorrectStructure() = runTest {
+        storage.add(
+            listOf(
+                DocumentWithMetadata(content = "Kotlin is a modern programming language"),
+                DocumentWithMetadata(content = "Spring Boot simplifies Java development"),
+                DocumentWithMetadata(content = "AI agents can automate complex tasks"),
+            ),
+            namespace = null,
+        )
+
+        val results = storage.search(
+            SimilaritySearchRequest(queryText = "programming language", limit = 2, offset = 0),
+            namespace = null,
+        )
+
+        assertEquals(2, results.size)
+        results.forEach { result ->
+            assertTrue(result.document.content.isNotEmpty())
+            assertEquals(ScoreMetric.COSINE_SIMILARITY, result.score.metric)
+            assertTrue(result.id!!.isNotEmpty())
+            assertNull(result.namespace)
+            assertNull(result.metadata)
+        }
+    }
+
+    @Test
+    fun testSearchAppliesMinScoreThreshold() = runTest {
+        storage.add(
+            listOf(
+                DocumentWithMetadata(content = "exact match query text"),
+                DocumentWithMetadata(content = "completely unrelated content about cooking recipes"),
+            ),
+            namespace = null,
+        )
+
+        val allResults = storage.search(
+            SimilaritySearchRequest(queryText = "exact match query text", limit = 10, offset = 0, minScore = 0.0),
+            namespace = null,
+        )
+
+        val filteredResults = storage.search(
+            SimilaritySearchRequest(queryText = "exact match query text", limit = 10, offset = 0, minScore = 0.99),
+            namespace = null,
+        )
+
+        assertTrue(filteredResults.size <= allResults.size)
+    }
+
+    @Test
+    fun testSearchDropsOffsetResultsAndTakesLimitResults() = runTest {
+        storage.add(
+            listOf(
+                DocumentWithMetadata(content = "alpha document", id = "id-0"),
+                DocumentWithMetadata(content = "beta document", id = "id-1"),
+                DocumentWithMetadata(content = "gamma document", id = "id-2"),
+                DocumentWithMetadata(content = "delta document", id = "id-3"),
+                DocumentWithMetadata(content = "epsilon document", id = "id-4"),
+            ),
+            namespace = null,
+        )
+
+        val allResults = storage.search(
+            SimilaritySearchRequest(queryText = "document", limit = 5, offset = 0),
+            namespace = null,
+        )
+
+        val offsetResults = storage.search(
+            SimilaritySearchRequest(queryText = "document", limit = 3, offset = 2),
+            namespace = null,
+        )
+
+        assertEquals(3, offsetResults.size)
+        // The offset results should match the tail of the full results
+        assertEquals(allResults.drop(2).take(3).map { it.id }, offsetResults.map { it.id })
+    }
+
+    @Test
+    fun testSearchRejectsNonNullNamespace() = runTest {
+        assertThrows<IllegalArgumentException> {
+            storage.search(
+                SimilaritySearchRequest(queryText = "q", limit = 1, offset = 0),
+                namespace = "my-ns",
+            )
+        }
+    }
+
+    @Test
+    fun testSearchRejectsNegativeLimit() = runTest {
+        assertThrows<IllegalArgumentException> {
+            storage.search(
+                SimilaritySearchRequest(queryText = "q", limit = -1, offset = 0),
+                namespace = null,
+            )
+        }
+    }
+
+    @Test
+    fun testSearchRejectsNegativeOffset() = runTest {
+        assertThrows<IllegalArgumentException> {
+            storage.search(
+                SimilaritySearchRequest(queryText = "q", limit = 1, offset = -1),
+                namespace = null,
+            )
+        }
+    }
+
+    // ── Exception wrapping ──
+
+    @Test
+    fun testAddWrapsBackendExceptionAsKoogVectorStoreException() = runTest {
+        val failing = mockk<VectorStore>(relaxed = true)
+        every { failing.add(any<List<Document>>()) } throws RuntimeException("backend error")
+        val failingStorage = SpringAiKoogVectorStore(vectorStore = failing, dispatcher = Dispatchers.Unconfined)
+
+        val ex = assertThrows<KoogVectorStoreException> {
+            failingStorage.add(listOf(DocumentWithMetadata(content = "x")), namespace = null)
+        }
+        assertTrue(ex.message!!.contains("add"))
+        assertTrue(ex.cause is RuntimeException)
+    }
+
+    @Test
+    fun testSearchWrapsBackendExceptionAsKoogVectorStoreException() = runTest {
+        val failing = mockk<VectorStore>(relaxed = true)
+        every { failing.similaritySearch(any<org.springframework.ai.vectorstore.SearchRequest>()) } throws RuntimeException("search failed")
+        val failingStorage = SpringAiKoogVectorStore(vectorStore = failing, dispatcher = Dispatchers.Unconfined)
+
+        val ex = assertThrows<KoogVectorStoreException> {
+            failingStorage.search(
+                SimilaritySearchRequest(queryText = "q", limit = 1, offset = 0),
+                namespace = null,
+            )
+        }
+        assertTrue(ex.message!!.contains("search"))
+        assertTrue(ex.cause is RuntimeException)
+    }
+
+    @Test
+    fun testDeleteWrapsBackendExceptionAsKoogVectorStoreException() = runTest {
+        val failing = mockk<VectorStore>(relaxed = true)
+        every { failing.delete(any<List<String>>()) } throws RuntimeException("delete failed")
+        val failingStorage = SpringAiKoogVectorStore(vectorStore = failing, dispatcher = Dispatchers.Unconfined)
+
+        val ex = assertThrows<KoogVectorStoreException> {
+            failingStorage.delete(listOf("id-1"), namespace = null)
+        }
+        assertTrue(ex.message!!.contains("delete"))
+        assertTrue(ex.cause is RuntimeException)
+    }
+
+    // ── Filter parsing failure ──
+
+    @Test
+    fun testSearchWrapsFilterParsingFailureAsKoogVectorStoreException() = runTest {
+        val request = SimilaritySearchRequest(
+            queryText = "q",
+            limit = 1,
+            offset = 0,
+            filterExpression = "this is not a valid filter @@!!",
+        )
+
+        val ex = assertThrows<KoogVectorStoreException> {
+            storage.search(request, namespace = null)
+        }
+        assertTrue(ex.message!!.contains("search"))
+    }
+
+    // ── Update partial failure ──
+
+    @Test
+    fun testUpdateWrapsPartialFailureAsKoogVectorStoreException() = runTest {
+        val failing = mockk<VectorStore>(relaxed = true)
+        every { failing.delete(any<List<String>>()) } returns Unit
+        every { failing.add(any<List<Document>>()) } throws RuntimeException("add after delete failed")
+        val failingStorage = SpringAiKoogVectorStore(vectorStore = failing, dispatcher = Dispatchers.Unconfined)
+
+        val ex = assertThrows<KoogVectorStoreException> {
+            failingStorage.update(
+                mapOf("id-1" to DocumentWithMetadata(content = "updated")),
+                namespace = null,
+            )
+        }
+        assertTrue(ex.message!!.contains("update"))
+        assertTrue(ex.cause is RuntimeException)
+    }
+}

--- a/koog-spring-ai/koog-spring-ai-starter-vector-store/src/test/kotlin/ai/koog/spring/ai/vectorstore/SpringAiVectorStoreAutoConfigurationTest.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-vector-store/src/test/kotlin/ai/koog/spring/ai/vectorstore/SpringAiVectorStoreAutoConfigurationTest.kt
@@ -4,6 +4,7 @@ import ai.koog.rag.base.storage.DeletionStorage
 import ai.koog.rag.base.storage.SearchStorage
 import ai.koog.rag.base.storage.WriteStorage
 import ai.koog.rag.base.storage.search.SimilaritySearchRequest
+import ai.koog.spring.ai.common.DispatcherType
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineDispatcher
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -28,18 +29,30 @@ class SpringAiVectorStoreAutoConfigurationTest {
     private fun contextRunner(): ApplicationContextRunner = ApplicationContextRunner()
         .withConfiguration(AutoConfigurations.of(SpringAiVectorStoreAutoConfiguration::class.java))
 
+    // ---- enabled / disabled ----
+
     @Test
-    fun `should not create Koog storage beans when no VectorStore is present`() {
+    fun testCreateDispatcherWhenEnabledByDefault() {
         contextRunner().run { context ->
-            assertThrows<NoSuchBeanDefinitionException> { context.getBean<KoogVectorStore>() }
-            assertThrows<NoSuchBeanDefinitionException> { context.getBean<WriteStorage<DocumentWithMetadata>>() }
-            assertThrows<NoSuchBeanDefinitionException> { context.getBean<SearchStorage<DocumentWithMetadata, SimilaritySearchRequest>>() }
-            assertThrows<NoSuchBeanDefinitionException> { context.getBean<DeletionStorage>() }
+            assertNotNull(context.getBean("koogSpringAiVectorStoreDispatcher"))
         }
     }
 
     @Test
-    fun `should create adapter and Koog storage beans when single VectorStore is present`() {
+    fun testNotCreateAnyBeansWhenDisabled() {
+        contextRunner()
+            .withPropertyValues("koog.spring.ai.vectorstore.enabled=false")
+            .withBean(VectorStore::class.java, { mockk<VectorStore>(relaxed = true) })
+            .run { context ->
+                assertThrows<NoSuchBeanDefinitionException> { context.getBean<KoogVectorStore>() }
+                assertThrows<NoSuchBeanDefinitionException> { context.getBean("koogSpringAiVectorStoreDispatcher") }
+            }
+    }
+
+    // ---- single VectorStore ----
+
+    @Test
+    fun testCreateAdapterAndKoogStorageBeansWhenSingleVectorStoreIsPresent() {
         contextRunner()
             .withBean(VectorStore::class.java, { mockk<VectorStore>(relaxed = true) })
             .run { context ->
@@ -51,17 +64,45 @@ class SpringAiVectorStoreAutoConfigurationTest {
     }
 
     @Test
-    fun `should not create Koog storage beans when multiple VectorStores are present without selector`() {
+    fun testNotCreateKoogStorageBeansWhenNoVectorStoreIsPresent() {
+        contextRunner().run { context ->
+            assertThrows<NoSuchBeanDefinitionException> { context.getBean<KoogVectorStore>() }
+            assertThrows<NoSuchBeanDefinitionException> { context.getBean<WriteStorage<DocumentWithMetadata>>() }
+            assertThrows<NoSuchBeanDefinitionException> { context.getBean<SearchStorage<DocumentWithMetadata, SimilaritySearchRequest>>() }
+            assertThrows<NoSuchBeanDefinitionException> { context.getBean<DeletionStorage>() }
+        }
+    }
+
+    // ---- user-supplied KoogVectorStore ----
+
+    @Test
+    fun testNotCreateKoogVectorStoreWhenUserProvidesOne() {
+        val userStore = mockk<KoogVectorStore>(relaxed = true)
+        contextRunner()
+            .withBean(VectorStore::class.java, { mockk<VectorStore>(relaxed = true) })
+            .withBean(KoogVectorStore::class.java, { userStore })
+            .run { context ->
+                assertSame(userStore, context.getBean<KoogVectorStore>())
+            }
+    }
+
+    // ---- multiple VectorStores without selector ----
+
+    @Test
+    fun testNotCreateKoogStorageBeansWhenMultipleVectorStoresArePresentWithoutSelector() {
         contextRunner()
             .withBean("store1", VectorStore::class.java, { mockk<VectorStore>(relaxed = true) })
             .withBean("store2", VectorStore::class.java, { mockk<VectorStore>(relaxed = true) })
             .run { context ->
+                assertTrue(context.startupFailure == null, "Context should start without failure")
                 assertThrows<NoSuchBeanDefinitionException> { context.getBean<KoogVectorStore>() }
             }
     }
 
+    // ---- named VectorStore selection ----
+
     @Test
-    fun `should resolve VectorStore by bean name when configured`() {
+    fun testResolveVectorStoreByBeanNameWhenConfigured() {
         contextRunner()
             .withPropertyValues("koog.spring.ai.vectorstore.vector-store-bean-name=myVectorStore")
             .withBean("myVectorStore", VectorStore::class.java, { mockk<VectorStore>(relaxed = true) })
@@ -72,25 +113,59 @@ class SpringAiVectorStoreAutoConfigurationTest {
     }
 
     @Test
-    fun `should not create beans when disabled`() {
+    fun testResolveByBeanNameWhenSelectorPresentAndSingleVectorStoreExists() {
+        val store = mockk<VectorStore>(relaxed = true)
         contextRunner()
-            .withPropertyValues("koog.spring.ai.vectorstore.enabled=false")
-            .withBean(VectorStore::class.java, { mockk<VectorStore>(relaxed = true) })
+            .withPropertyValues("koog.spring.ai.vectorstore.vector-store-bean-name=myStore")
+            .withBean("myStore", VectorStore::class.java, { store })
             .run { context ->
-                assertThrows<NoSuchBeanDefinitionException> { context.getBean<KoogVectorStore>() }
-                assertThrows<NoSuchBeanDefinitionException> { context.getBean("koogSpringAiVectorStoreDispatcher") }
+                assertInstanceOf<SpringAiKoogVectorStore>(context.getBean<KoogVectorStore>())
             }
     }
 
     @Test
-    fun `should create dispatcher bean`() {
-        contextRunner().run { context ->
-            assertNotNull(context.getBean("koogSpringAiVectorStoreDispatcher"))
-        }
+    fun testFailWhenVectorStoreBeanNameRefersToNonExistentBean() {
+        contextRunner()
+            .withPropertyValues("koog.spring.ai.vectorstore.vector-store-bean-name=doesNotExist")
+            .withBean("actualStore", VectorStore::class.java, { mockk<VectorStore>(relaxed = true) })
+            .run { context ->
+                assertInstanceOf<BeanCreationException>(context.startupFailure)
+            }
     }
 
+    // ---- mutual exclusion: single candidate + selector set ----
+
     @Test
-    fun `should bind properties`() {
+    fun testCreateExactlyOneKoogVectorStoreUsingNamedPathWhenSingleStoreAndSelectorAreSet() {
+        val myStore = mockk<VectorStore>(relaxed = true)
+        contextRunner()
+            .withPropertyValues("koog.spring.ai.vectorstore.vector-store-bean-name=myStore")
+            .withBean("myStore", VectorStore::class.java, { myStore })
+            .run { context ->
+                assertTrue(context.startupFailure == null, "Context should start without failure")
+                val stores = context.getBeansOfType(KoogVectorStore::class.java)
+                assertTrue(stores.size == 1, "Expected exactly one KoogVectorStore, got ${stores.size}")
+            }
+    }
+
+    // ---- mutual exclusion: selector set to empty string ----
+    @Test
+    fun testEmptyStringSelectorTreatedAsMissingAndUsesSingleCandidate() {
+        contextRunner()
+            .withPropertyValues("koog.spring.ai.vectorstore.vector-store-bean-name=")
+            .withBean("myStore", VectorStore::class.java, { mockk<VectorStore>(relaxed = true) })
+            .run { context ->
+                // @ConditionalOnPropertyMissingOrEmpty treats "" as missing/empty, so only
+                // SingleVectorStoreConfiguration activates; NamedVectorStoreConfiguration does not match.
+                assertTrue(context.startupFailure == null, "Context should start successfully when selector is empty string")
+                assertInstanceOf<SpringAiKoogVectorStore>(context.getBean<KoogVectorStore>())
+            }
+    }
+
+    // ---- properties binding ----
+
+    @Test
+    fun testBindProperties() {
         contextRunner()
             .withPropertyValues(
                 "koog.spring.ai.vectorstore.enabled=true",
@@ -102,12 +177,14 @@ class SpringAiVectorStoreAutoConfigurationTest {
                 val properties = context.getBean<KoogSpringAiVectorStoreProperties>()
                 assertTrue(properties.enabled)
                 assertEquals("vectorStore", properties.vectorStoreBeanName)
-                assertSame(KoogSpringAiVectorStoreProperties.DispatcherType.IO, properties.dispatcher.type)
+                assertSame(DispatcherType.IO, properties.dispatcher.type)
             }
     }
 
+    // ---- dispatcher ----
+
     @Test
-    fun `AUTO dispatcher should use AsyncTaskExecutor when available`() {
+    fun testAutoDispatcherUsesAsyncTaskExecutorWhenAvailable() {
         val executor = mockk<AsyncTaskExecutor>(relaxed = true)
         contextRunner()
             .withBean("applicationTaskExecutor", AsyncTaskExecutor::class.java, { executor })
@@ -119,32 +196,21 @@ class SpringAiVectorStoreAutoConfigurationTest {
     }
 
     @Test
-    fun `AUTO dispatcher should fall back to Dispatchers_IO when no AsyncTaskExecutor`() {
+    fun testAutoDispatcherFallsBackToDispatchersIOWhenNoAsyncTaskExecutor() {
         contextRunner().run { context ->
             val dispatcher = context.getBean("koogSpringAiVectorStoreDispatcher") as CoroutineDispatcher
-            assertNotNull(dispatcher)
             assertSame(kotlinx.coroutines.Dispatchers.IO, dispatcher)
         }
     }
 
     @Test
-    fun `should resolve by bean name when selector present and single VectorStore exists`() {
-        val store = mockk<VectorStore>(relaxed = true)
+    fun testNotOverrideUserProvidedDispatcher() {
+        val customDispatcher = kotlinx.coroutines.Dispatchers.Unconfined
         contextRunner()
-            .withPropertyValues("koog.spring.ai.vectorstore.vector-store-bean-name=myStore")
-            .withBean("myStore", VectorStore::class.java, { store })
+            .withBean("koogSpringAiVectorStoreDispatcher", CoroutineDispatcher::class.java, { customDispatcher })
             .run { context ->
-                assertInstanceOf<SpringAiKoogVectorStore>(context.getBean<KoogVectorStore>())
-            }
-    }
-
-    @Test
-    fun `should fail when vector-store-bean-name refers to non-existent bean`() {
-        contextRunner()
-            .withPropertyValues("koog.spring.ai.vectorstore.vector-store-bean-name=doesNotExist")
-            .withBean("actualStore", VectorStore::class.java, { mockk<VectorStore>(relaxed = true) })
-            .run { context ->
-                assertInstanceOf<BeanCreationException>(context.startupFailure)
+                val dispatcher = context.getBean("koogSpringAiVectorStoreDispatcher") as CoroutineDispatcher
+                assertSame(customDispatcher, dispatcher)
             }
     }
 }

--- a/koog-spring-ai/koog-spring-ai-starter-vector-store/src/test/kotlin/ai/koog/spring/ai/vectorstore/SpringAiVectorStoreAutoConfigurationTest.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-vector-store/src/test/kotlin/ai/koog/spring/ai/vectorstore/SpringAiVectorStoreAutoConfigurationTest.kt
@@ -1,0 +1,150 @@
+package ai.koog.spring.ai.vectorstore
+
+import ai.koog.rag.base.storage.DeletionStorage
+import ai.koog.rag.base.storage.SearchStorage
+import ai.koog.rag.base.storage.WriteStorage
+import ai.koog.rag.base.storage.search.SimilaritySearchRequest
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineDispatcher
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertInstanceOf
+import org.junit.jupiter.api.assertThrows
+import org.springframework.ai.vectorstore.VectorStore
+import org.springframework.beans.factory.BeanCreationException
+import org.springframework.beans.factory.NoSuchBeanDefinitionException
+import org.springframework.beans.factory.getBean
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.core.task.AsyncTaskExecutor
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SpringAiVectorStoreAutoConfigurationTest {
+
+    private fun contextRunner(): ApplicationContextRunner = ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(SpringAiVectorStoreAutoConfiguration::class.java))
+
+    @Test
+    fun `should not create Koog storage beans when no VectorStore is present`() {
+        contextRunner().run { context ->
+            assertThrows<NoSuchBeanDefinitionException> { context.getBean<KoogVectorStore>() }
+            assertThrows<NoSuchBeanDefinitionException> { context.getBean<WriteStorage<DocumentWithMetadata>>() }
+            assertThrows<NoSuchBeanDefinitionException> { context.getBean<SearchStorage<DocumentWithMetadata, SimilaritySearchRequest>>() }
+            assertThrows<NoSuchBeanDefinitionException> { context.getBean<DeletionStorage>() }
+        }
+    }
+
+    @Test
+    fun `should create adapter and Koog storage beans when single VectorStore is present`() {
+        contextRunner()
+            .withBean(VectorStore::class.java, { mockk<VectorStore>(relaxed = true) })
+            .run { context ->
+                assertInstanceOf<SpringAiKoogVectorStore>(context.getBean<KoogVectorStore>())
+                assertInstanceOf<SpringAiKoogVectorStore>(context.getBean<WriteStorage<DocumentWithMetadata>>())
+                assertInstanceOf<SpringAiKoogVectorStore>(context.getBean<SearchStorage<DocumentWithMetadata, SimilaritySearchRequest>>())
+                assertInstanceOf<SpringAiKoogVectorStore>(context.getBean<DeletionStorage>())
+            }
+    }
+
+    @Test
+    fun `should not create Koog storage beans when multiple VectorStores are present without selector`() {
+        contextRunner()
+            .withBean("store1", VectorStore::class.java, { mockk<VectorStore>(relaxed = true) })
+            .withBean("store2", VectorStore::class.java, { mockk<VectorStore>(relaxed = true) })
+            .run { context ->
+                assertThrows<NoSuchBeanDefinitionException> { context.getBean<KoogVectorStore>() }
+            }
+    }
+
+    @Test
+    fun `should resolve VectorStore by bean name when configured`() {
+        contextRunner()
+            .withPropertyValues("koog.spring.ai.vectorstore.vector-store-bean-name=myVectorStore")
+            .withBean("myVectorStore", VectorStore::class.java, { mockk<VectorStore>(relaxed = true) })
+            .withBean("otherVectorStore", VectorStore::class.java, { mockk<VectorStore>(relaxed = true) })
+            .run { context ->
+                assertInstanceOf<SpringAiKoogVectorStore>(context.getBean<KoogVectorStore>())
+            }
+    }
+
+    @Test
+    fun `should not create beans when disabled`() {
+        contextRunner()
+            .withPropertyValues("koog.spring.ai.vectorstore.enabled=false")
+            .withBean(VectorStore::class.java, { mockk<VectorStore>(relaxed = true) })
+            .run { context ->
+                assertThrows<NoSuchBeanDefinitionException> { context.getBean<KoogVectorStore>() }
+                assertThrows<NoSuchBeanDefinitionException> { context.getBean("koogSpringAiVectorStoreDispatcher") }
+            }
+    }
+
+    @Test
+    fun `should create dispatcher bean`() {
+        contextRunner().run { context ->
+            assertNotNull(context.getBean("koogSpringAiVectorStoreDispatcher"))
+        }
+    }
+
+    @Test
+    fun `should bind properties`() {
+        contextRunner()
+            .withPropertyValues(
+                "koog.spring.ai.vectorstore.enabled=true",
+                "koog.spring.ai.vectorstore.vector-store-bean-name=vectorStore",
+                "koog.spring.ai.vectorstore.dispatcher.type=IO"
+            )
+            .withBean("vectorStore", VectorStore::class.java, { mockk<VectorStore>(relaxed = true) })
+            .run { context ->
+                val properties = context.getBean<KoogSpringAiVectorStoreProperties>()
+                assertTrue(properties.enabled)
+                assertEquals("vectorStore", properties.vectorStoreBeanName)
+                assertSame(KoogSpringAiVectorStoreProperties.DispatcherType.IO, properties.dispatcher.type)
+            }
+    }
+
+    @Test
+    fun `AUTO dispatcher should use AsyncTaskExecutor when available`() {
+        val executor = mockk<AsyncTaskExecutor>(relaxed = true)
+        contextRunner()
+            .withBean("applicationTaskExecutor", AsyncTaskExecutor::class.java, { executor })
+            .run { context ->
+                assertInstanceOf<kotlinx.coroutines.ExecutorCoroutineDispatcher>(
+                    context.getBean("koogSpringAiVectorStoreDispatcher")
+                )
+            }
+    }
+
+    @Test
+    fun `AUTO dispatcher should fall back to Dispatchers_IO when no AsyncTaskExecutor`() {
+        contextRunner().run { context ->
+            val dispatcher = context.getBean("koogSpringAiVectorStoreDispatcher") as CoroutineDispatcher
+            assertNotNull(dispatcher)
+            assertSame(kotlinx.coroutines.Dispatchers.IO, dispatcher)
+        }
+    }
+
+    @Test
+    fun `should resolve by bean name when selector present and single VectorStore exists`() {
+        val store = mockk<VectorStore>(relaxed = true)
+        contextRunner()
+            .withPropertyValues("koog.spring.ai.vectorstore.vector-store-bean-name=myStore")
+            .withBean("myStore", VectorStore::class.java, { store })
+            .run { context ->
+                assertInstanceOf<SpringAiKoogVectorStore>(context.getBean<KoogVectorStore>())
+            }
+    }
+
+    @Test
+    fun `should fail when vector-store-bean-name refers to non-existent bean`() {
+        contextRunner()
+            .withPropertyValues("koog.spring.ai.vectorstore.vector-store-bean-name=doesNotExist")
+            .withBean("actualStore", VectorStore::class.java, { mockk<VectorStore>(relaxed = true) })
+            .run { context ->
+                assertInstanceOf<BeanCreationException>(context.startupFailure)
+            }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -99,6 +99,7 @@ include(":koog-spring-ai:koog-spring-ai-common")
 include(":koog-spring-ai:koog-spring-ai-starter-model-chat")
 include(":koog-spring-ai:koog-spring-ai-starter-model-embedding")
 include(":koog-spring-ai:koog-spring-ai-starter-chat-memory")
+include(":koog-spring-ai:koog-spring-ai-starter-vector-store")
 
 include(":koog-ktor")
 include(":docs")


### PR DESCRIPTION
It might be useful for Spring AI users to use existing VectorStore implementations with the LongTermMemory feature from Koog or separately for RAG. The new starter handles the conversion.

closes KG-690
