### PR TITLE
feat(prompt): support structured output for bedrock anthropic models

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
@@ -563,7 +563,7 @@ public class BedrockLLMClient @JvmOverloads constructor(
             is BedrockModelFamilies.AnthropicClaude -> {
                 json.encodeToString(
                     BedrockAnthropicInvokeModel.serializer(),
-                    BedrockAnthropicClaudeSerialization.createAnthropicRequest(prompt, tools)
+                    BedrockAnthropicClaudeSerialization.createAnthropicRequest(prompt, model, tools)
                 )
             }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModels.kt
@@ -125,6 +125,11 @@ public object BedrockModels : LLModelDefinitions {
         LLMCapability.Embed
     )
 
+    private val structuredOutputCapabilities: List<LLMCapability> = listOf(
+        LLMCapability.Schema.JSON.Basic,
+        LLMCapability.Schema.JSON.Standard
+    )
+
     // Full capabilities (multimodal + tools)
     private val fullCapabilities: List<LLMCapability> =
         standardCapabilities + toolCapabilities + multimodalCapabilities
@@ -133,6 +138,13 @@ public object BedrockModels : LLModelDefinitions {
     private val novaCapabilities: List<LLMCapability> = standardCapabilities + listOf(
         LLMCapability.Tools,
     )
+
+    // Add JSON structured output capabilities to model if not present
+    private fun LLModel.withStructuredOutputCapabilities(): LLModel {
+        val existingCapabilities = this.capabilities.orEmpty()
+        val combinedCapabilities = (existingCapabilities + structuredOutputCapabilities).distinct()
+        return this.copy(capabilities = combinedCapabilities)
+    }
 
     /**
      * Claude 4 Opus - Anthropic's previous flagship model
@@ -174,7 +186,7 @@ public object BedrockModels : LLModelDefinitions {
      *
      */
     public val AnthropicClaude45Opus: LLModel = BedrockModel(
-        AnthropicModels.Opus_4_5,
+        AnthropicModels.Opus_4_5.withStructuredOutputCapabilities(),
         "anthropic.claude-opus-4-5-20251101-v1:0",
     ).effectiveModel
 
@@ -185,7 +197,7 @@ public object BedrockModels : LLModelDefinitions {
      *
      */
     public val AnthropicClaude46Opus: LLModel = BedrockModel(
-        AnthropicModels.Opus_4_6,
+        AnthropicModels.Opus_4_6.withStructuredOutputCapabilities(),
         "anthropic.claude-opus-4-6-v1",
     ).effectiveModel
 
@@ -218,7 +230,7 @@ public object BedrockModels : LLModelDefinitions {
      * - Optimized for both quality and efficiency
      */
     public val AnthropicClaude4_5Sonnet: LLModel = BedrockModel(
-        AnthropicModels.Sonnet_4_5,
+        AnthropicModels.Sonnet_4_5.withStructuredOutputCapabilities(),
         "anthropic.claude-sonnet-4-5-20250929-v1:0",
     ).effectiveModel
 
@@ -227,7 +239,7 @@ public object BedrockModels : LLModelDefinitions {
      * It’s a full upgrade of the model’s skills across coding, computer use, long-context reasoning, agent planning, knowledge work, and design.
      */
     public val AnthropicClaude4_6Sonnet: LLModel = BedrockModel(
-        AnthropicModels.Sonnet_4_6,
+        AnthropicModels.Sonnet_4_6.withStructuredOutputCapabilities(),
         "anthropic.claude-sonnet-4-6",
     ).effectiveModel
 
@@ -258,7 +270,7 @@ public object BedrockModels : LLModelDefinitions {
      * and high-volume user experiences.
      */
     public val AnthropicClaude4_5Haiku: LLModel = BedrockModel(
-        AnthropicModels.Haiku_4_5,
+        AnthropicModels.Haiku_4_5.withStructuredOutputCapabilities(),
         "anthropic.claude-haiku-4-5-20251001-v1:0",
     ).effectiveModel
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/BedrockDataClasses.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/BedrockDataClasses.kt
@@ -22,6 +22,7 @@ public data class BedrockAnthropicInvokeModel(
     val messages: List<BedrockAnthropicInvokeModelMessage> = emptyList(),
     val tools: List<BedrockAnthropicInvokeModelTool>? = null,
     @SerialName("tool_choice") val toolChoice: BedrockAnthropicToolChoice? = null,
+    @SerialName("output_config") val outputConfig: BedrockAnthropicOutputConfig? = null,
 ) {
     /**
      * Provides shared logic and utility functions for managing and interacting with the
@@ -186,6 +187,28 @@ public data class BedrockAnthropicInvokeModelToolResultContent(
 public data class BedrockAnthropicToolChoice(
     val type: String,
     val name: String? = null,
+)
+
+/**
+ * Represents the output configuration for Anthropic via Bedrock.
+ *
+ * @property format The requested output format of the response.
+ */
+@Serializable
+public data class BedrockAnthropicOutputConfig(
+    val format: BedrockAnthropicOutputConfigFormat,
+)
+
+/**
+ * Represents the output format for Anthropic via Bedrock.
+ *
+ * @property schema The output format's schema.
+ * @property type The schema's type, such as "json_schema".
+ */
+@Serializable
+public data class BedrockAnthropicOutputConfigFormat(
+    val schema: JsonObject,
+    val type: String
 )
 
 /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/anthropic/BedrockAnthropicClaudeSerialization.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/anthropic/BedrockAnthropicClaudeSerialization.kt
@@ -11,9 +11,13 @@ import ai.koog.prompt.executor.clients.bedrock.modelfamilies.BedrockAnthropicInv
 import ai.koog.prompt.executor.clients.bedrock.modelfamilies.BedrockAnthropicInvokeModelContent
 import ai.koog.prompt.executor.clients.bedrock.modelfamilies.BedrockAnthropicInvokeModelMessage
 import ai.koog.prompt.executor.clients.bedrock.modelfamilies.BedrockAnthropicInvokeModelTool
+import ai.koog.prompt.executor.clients.bedrock.modelfamilies.BedrockAnthropicOutputConfig
+import ai.koog.prompt.executor.clients.bedrock.modelfamilies.BedrockAnthropicOutputConfigFormat
 import ai.koog.prompt.executor.clients.bedrock.modelfamilies.BedrockAnthropicResponse
 import ai.koog.prompt.executor.clients.bedrock.modelfamilies.BedrockAnthropicToolChoice
 import ai.koog.prompt.executor.clients.bedrock.modelfamilies.BedrockToolSerialization
+import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.params.LLMParams
@@ -125,6 +129,7 @@ internal object BedrockAnthropicClaudeSerialization {
 
     internal fun createAnthropicRequest(
         prompt: Prompt,
+        model: LLModel,
         tools: List<ToolDescriptor>
     ): BedrockAnthropicInvokeModel {
         val systemText = prompt.messages.filterIsInstance<Message.System>().joinToString("\n") { it.content }
@@ -176,6 +181,22 @@ internal object BedrockAnthropicClaudeSerialization {
             null
         }
 
+        val bedrockOutputSchema = if (
+            model.supports(LLMCapability.Schema.JSON.Basic) ||
+            model.supports(LLMCapability.Schema.JSON.Standard)
+        ) {
+            (prompt.params.schema as? LLMParams.Schema.JSON)?.let { json ->
+                BedrockAnthropicOutputConfig(
+                    format = BedrockAnthropicOutputConfigFormat(
+                        type = "json_schema",
+                        schema = json.schema
+                    )
+                )
+            }
+        } else {
+            null
+        }
+
         return BedrockAnthropicInvokeModel(
             anthropicVersion = "bedrock-2023-05-31",
             maxTokens = maxTokens,
@@ -183,7 +204,8 @@ internal object BedrockAnthropicClaudeSerialization {
             temperature = temperature,
             messages = messages,
             tools = bedrockTools,
-            toolChoice = bedrockToolChoice
+            toolChoice = bedrockToolChoice,
+            outputConfig = bedrockOutputSchema
         )
     }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/anthropic/BedrockAnthropicClaudeSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/modelfamilies/anthropic/BedrockAnthropicClaudeSerializationTest.kt
@@ -3,7 +3,9 @@ package ai.koog.prompt.executor.clients.bedrock.modelfamilies.anthropic
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
+import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.executor.clients.bedrock.BedrockModels
 import ai.koog.prompt.executor.clients.bedrock.modelfamilies.BedrockAnthropicInvokeModel
 import ai.koog.prompt.executor.clients.bedrock.modelfamilies.BedrockAnthropicInvokeModelContent
 import ai.koog.prompt.executor.clients.bedrock.modelfamilies.BedrockAnthropicInvokeModelMessage
@@ -12,10 +14,16 @@ import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.structure.json.generator.BasicJsonSchemaGenerator
+import ai.koog.prompt.structure.json.generator.StandardJsonSchemaGenerator
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.serializer
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -38,6 +46,19 @@ class BedrockAnthropicClaudeSerializationTest {
     private val toolName = "get_weather"
     private val toolDescription = "Get current weather for a city"
     private val toolId = "toolu_01234567"
+    private val model = BedrockModels.AnthropicClaude46Opus
+
+    @Serializable
+    @SerialName("WeatherForecast")
+    @LLMDescription("Weather forecast for a given location")
+    data class WeatherForecast(
+        @property:LLMDescription("Temperature in Celsius")
+        val temperature: Int,
+        @property:LLMDescription("Weather conditions (e.g., sunny, cloudy, rainy)")
+        val conditions: String,
+        @property:LLMDescription("Chance of precipitation in percentage")
+        val precipitation: Int
+    )
 
     @Test
     fun `createAnthropicRequest with basic prompt`() {
@@ -48,7 +69,7 @@ class BedrockAnthropicClaudeSerializationTest {
             user(userMessage)
         }
 
-        val request = BedrockAnthropicClaudeSerialization.createAnthropicRequest(prompt, emptyList())
+        val request = BedrockAnthropicClaudeSerialization.createAnthropicRequest(prompt, model, emptyList())
 
         assertNotNull(request)
         assertEquals(BedrockAnthropicInvokeModel.MAX_TOKENS_DEFAULT, request.maxTokens)
@@ -72,7 +93,7 @@ class BedrockAnthropicClaudeSerializationTest {
             user(userMessage)
         }
 
-        val request = BedrockAnthropicClaudeSerialization.createAnthropicRequest(prompt, emptyList())
+        val request = BedrockAnthropicClaudeSerialization.createAnthropicRequest(prompt, model, emptyList())
 
         assertNotNull(request)
 
@@ -112,7 +133,7 @@ class BedrockAnthropicClaudeSerializationTest {
             user(userMessageQuestion)
         }
 
-        val request = BedrockAnthropicClaudeSerialization.createAnthropicRequest(prompt, tools)
+        val request = BedrockAnthropicClaudeSerialization.createAnthropicRequest(prompt, model, tools)
 
         assertNotNull(request)
 
@@ -140,27 +161,58 @@ class BedrockAnthropicClaudeSerializationTest {
         val promptAuto = Prompt.build("test", params = LLMParams(toolChoice = LLMParams.ToolChoice.Auto)) {
             user(userMessageQuestion)
         }
-        val requestAuto = BedrockAnthropicClaudeSerialization.createAnthropicRequest(promptAuto, tools)
+        val requestAuto = BedrockAnthropicClaudeSerialization.createAnthropicRequest(promptAuto, model, tools)
         assertEquals("auto", requestAuto.toolChoice?.type)
 
         val promptNone = Prompt.build("test", params = LLMParams(toolChoice = LLMParams.ToolChoice.None)) {
             user(userMessageQuestion)
         }
-        val requestNone = BedrockAnthropicClaudeSerialization.createAnthropicRequest(promptNone, tools)
+        val requestNone = BedrockAnthropicClaudeSerialization.createAnthropicRequest(promptNone, model, tools)
         assertEquals("none", requestNone.toolChoice?.type)
 
         val promptRequired = Prompt.build("test", params = LLMParams(toolChoice = LLMParams.ToolChoice.Required)) {
             user(userMessageQuestion)
         }
-        val requestRequired = BedrockAnthropicClaudeSerialization.createAnthropicRequest(promptRequired, tools)
+        val requestRequired = BedrockAnthropicClaudeSerialization.createAnthropicRequest(promptRequired, model, tools)
         assertEquals("any", requestRequired.toolChoice?.type)
 
         val promptNamed = Prompt.build("test", params = LLMParams(toolChoice = LLMParams.ToolChoice.Named(toolName))) {
             user(userMessageQuestion)
         }
-        val requestNamed = BedrockAnthropicClaudeSerialization.createAnthropicRequest(promptNamed, tools)
+        val requestNamed = BedrockAnthropicClaudeSerialization.createAnthropicRequest(promptNamed, model, tools)
         assertTrue(requestNamed.toolChoice is BedrockAnthropicToolChoice)
         assertEquals(toolName, requestNamed.toolChoice.name)
+    }
+
+    @Test
+    fun `createAnthropicRequest with json schema`() {
+        val basicSchema = BasicJsonSchemaGenerator.generate(
+            json = Json,
+            name = "WeatherForecast",
+            serializer = serializer<WeatherForecast>(),
+            descriptionOverrides = emptyMap()
+        )
+        val standardSchema = StandardJsonSchemaGenerator.generate(
+            json = Json,
+            name = "WeatherForecast",
+            serializer = serializer<WeatherForecast>(),
+            descriptionOverrides = emptyMap()
+        )
+
+        val promptBasic = Prompt.build("test", params = LLMParams(schema = basicSchema)) {
+            user(userMessageQuestion)
+        }
+        val requestBasic = BedrockAnthropicClaudeSerialization.createAnthropicRequest(promptBasic, model, emptyList())
+        assertEquals("json_schema", requestBasic.outputConfig?.format?.type)
+        assertEquals(basicSchema.schema, requestBasic.outputConfig?.format?.schema)
+
+        val promptStandard = Prompt.build("test", params = LLMParams(schema = standardSchema)) {
+            user(userMessageQuestion)
+        }
+        val requestStandard =
+            BedrockAnthropicClaudeSerialization.createAnthropicRequest(promptStandard, model, emptyList())
+        assertEquals("json_schema", requestStandard.outputConfig?.format?.type)
+        assertEquals(standardSchema.schema, requestStandard.outputConfig?.format?.schema)
     }
 
     @Test
@@ -489,7 +541,7 @@ class BedrockAnthropicClaudeSerializationTest {
         val prompt = Prompt.build("test", params = LLMParams(toolChoice = LLMParams.ToolChoice.Auto)) {
             user(userMessageQuestion)
         }
-        val request = BedrockAnthropicClaudeSerialization.createAnthropicRequest(prompt, tools)
+        val request = BedrockAnthropicClaudeSerialization.createAnthropicRequest(prompt, model, tools)
         assertNotNull(request)
         assertNotNull(request.tools)
         assertEquals(1, request.tools.size)


### PR DESCRIPTION
Anthropic models on Bedrock have added [support for structured output](https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html). In this PR, we add the Json structured output capability to the relevant models and update the prompt to Bedrock Anthropic request conversion to support it. 
