### PR TITLE
fix(agents): Add ids for reasoning messages and improve reasoning process to fix status 400 from openai

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilder.kt
@@ -80,6 +80,18 @@ public class GraphAgentBuilder<Input, Output>(
     }
 
     /**
+     * Installs a new feature into the GraphAgentBuilder.
+     *
+     * @param featureInstaller A lambda function that utilizes the FeatureContext to define the feature to be installed.
+     * @return The updated instance of GraphAgentBuilder with the newly added feature.
+     */
+    public fun install(
+        featureInstaller: FeatureContext.() -> Unit,
+    ): GraphAgentBuilder<Input, Output> = apply {
+        this.featureInstallers += featureInstaller
+    }
+
+    /**
      * Builds and returns an instance of `AIAgent` configured using the parameters
      * provided to the `GraphAgentBuilder`.
      *

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilder.kt
@@ -79,6 +79,12 @@ public class GraphAgentBuilder<Input, Output>(
         }
     }
 
+    public fun install(
+        featureInstaller: FeatureContext.() -> Unit,
+    ): GraphAgentBuilder<Input, Output> = apply {
+        this.featureInstallers += featureInstaller
+    }
+
     /**
      * Builds and returns an instance of `AIAgent` configured using the parameters
      * provided to the `GraphAgentBuilder`.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilder.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentBuilder.kt
@@ -79,12 +79,6 @@ public class GraphAgentBuilder<Input, Output>(
         }
     }
 
-    public fun install(
-        featureInstaller: FeatureContext.() -> Unit,
-    ): GraphAgentBuilder<Input, Output> = apply {
-        this.featureInstallers += featureInstaller
-    }
-
     /**
      * Builds and returns an instance of `AIAgent` configured using the parameters
      * provided to the `GraphAgentBuilder`.

--- a/examples/simple-examples/build.gradle.kts
+++ b/examples/simple-examples/build.gradle.kts
@@ -24,10 +24,6 @@ dependencies {
     //noinspection UseTomlInstead
     implementation("ai.koog:agents-features-chat-memory-sql")
     //noinspection UseTomlInstead
-    implementation("ai.koog:agents-features-chat-history-jdbc")
-    //noinspection UseTomlInstead
-    implementation("ai.koog:agents-features-persistence-jdbc")
-    //noinspection UseTomlInstead
     implementation("ai.koog:agents-features-a2a-server")
     //noinspection UseTomlInstead
     implementation("ai.koog:agents-features-a2a-client")

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/streaming/StreamingAgentWithTools.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/streaming/StreamingAgentWithTools.kt
@@ -2,6 +2,7 @@ package ai.koog.agents.example.streaming
 
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.GraphAIAgent.FeatureContext
+import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.nodeExecuteMultipleTools
@@ -13,8 +14,10 @@ import ai.koog.agents.example.ApiKeyService
 import ai.koog.agents.example.simpleapi.Switch
 import ai.koog.agents.example.simpleapi.SwitchTools
 import ai.koog.agents.features.eventHandler.feature.handleEvents
+import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import ai.koog.prompt.executor.clients.openai.OpenAIResponsesParams
 import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.message.Message
@@ -68,15 +71,16 @@ private fun openAiAgent(
     toolRegistry: ToolRegistry,
     executor: PromptExecutor,
     installFeatures: FeatureContext.() -> Unit = {}
-) = AIAgent(
-    promptExecutor = executor,
-    strategy = streamingWithToolsStrategy(),
-    llmModel = OpenAIModels.Chat.GPT4oMini,
-    systemPrompt = "You're responsible for running a Switch and perform operations on it by request",
-    temperature = 0.0,
-    toolRegistry = toolRegistry,
-    installFeatures = installFeatures
-)
+) = AIAgent.builder()
+    .graphStrategy { streamingWithToolsStrategy() }
+    .promptExecutor(executor)
+    .prompt(prompt("agent", OpenAIResponsesParams(temperature = 0.0)) {
+        system("You're responsible for running a Switch and perform operations on it by request")
+    })
+    .llmModel(OpenAIModels.Chat.GPT4oMini)
+    .toolRegistry(toolRegistry)
+    .install(installFeatures)
+    .build()
 
 @Suppress("unused")
 private fun anthropicAgent(

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/streaming/StreamingAgentWithTools.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/streaming/StreamingAgentWithTools.kt
@@ -2,7 +2,6 @@ package ai.koog.agents.example.streaming
 
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.GraphAIAgent.FeatureContext
-import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.nodeExecuteMultipleTools
@@ -18,6 +17,9 @@ import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.anthropic.AnthropicModels
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.clients.openai.OpenAIResponsesParams
+import ai.koog.prompt.executor.clients.openai.base.models.ReasoningEffort
+import ai.koog.prompt.executor.clients.openai.models.ReasoningConfig
+import ai.koog.prompt.executor.clients.openai.models.ReasoningSummary
 import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.message.Message
@@ -38,8 +40,14 @@ suspend fun main() {
                     println("\n🔧 Using ${context.toolName} with ${context.toolArgs}... ")
                 }
                 onLLMStreamingFrameReceived { context ->
-                    (context.streamFrame as? StreamFrame.TextDelta)?.let { frame ->
-                        print(frame.text)
+                    when (val frame = context.streamFrame) {
+                        is StreamFrame.ReasoningComplete -> println("Reasoning complete:id=${frame.id}\ntext=${frame.text}\nsummary=${frame.summary}")
+                        is StreamFrame.TextComplete -> println("Text complete")
+                        is StreamFrame.ToolCallComplete -> println("Tool call complete")
+                        is StreamFrame.ReasoningDelta -> println("Reasoning delta:id=${frame.id}\ntext=${frame.text}\nsummary=${frame.summary}")
+                        is StreamFrame.TextDelta -> println("Text delta:\n${frame.text}")
+                        is StreamFrame.ToolCallDelta -> println("Tool call delta:\n${frame.content}")
+                        is StreamFrame.End -> println("End")
                     }
                 }
                 onLLMStreamingFailed {
@@ -74,10 +82,14 @@ private fun openAiAgent(
 ) = AIAgent.builder()
     .graphStrategy { streamingWithToolsStrategy() }
     .promptExecutor(executor)
-    .prompt(prompt("agent", OpenAIResponsesParams(temperature = 0.0)) {
+    .prompt(prompt("agent", OpenAIResponsesParams(
+        temperature = 1.0,
+        reasoning = ReasoningConfig(effort = ReasoningEffort.MEDIUM, summary = ReasoningSummary.AUTO)
+    ))
+    {
         system("You're responsible for running a Switch and perform operations on it by request")
     })
-    .llmModel(OpenAIModels.Chat.GPT4oMini)
+    .llmModel(OpenAIModels.Chat.GPT5_1)
     .toolRegistry(toolRegistry)
     .install(installFeatures)
     .build()

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
@@ -103,6 +103,7 @@ abstract class ExecutorIntegrationTestBase {
     private val testScope = TestScope()
     private val basicLimit = 256
     private val extendedLimit = 512
+    private val reasoningLimit = 10000
 
     @AfterEach
     fun cleanup() {
@@ -136,22 +137,22 @@ abstract class ExecutorIntegrationTestBase {
                     summary = ReasoningSummary.AUTO
                 ),
                 include = listOf(OpenAIInclude.REASONING_ENCRYPTED_CONTENT),
-                maxTokens = basicLimit
+                maxTokens = reasoningLimit
             )
 
             is GoogleLLMProvider -> {
                 val thinkingConfig = GoogleThinkingConfig(
                     includeThoughts = true,
-                    thinkingBudget = extendedLimit
+                    thinkingBudget = reasoningLimit
                 )
                 GoogleParams(
                     thinkingConfig = thinkingConfig,
                     // Slightly higher limit to avoid truncation in multi-step reasoning tests
-                    maxTokens = extendedLimit
+                    maxTokens = reasoningLimit
                 )
             }
 
-            else -> LLMParams(maxTokens = basicLimit)
+            else -> LLMParams(maxTokens = reasoningLimit)
         }
     }
 
@@ -214,8 +215,9 @@ abstract class ExecutorIntegrationTestBase {
         )
 
         val executor = getExecutor(model)
+        val params = createReasoningParams(model)
 
-        val prompt = Prompt.build("test-streaming") {
+        val prompt = Prompt.build("test-streaming", params = params) {
             system("You are a helpful assistant.")
             user("Count from 1 to 5. Like 1, 2, 3 ...")
         }
@@ -1100,17 +1102,11 @@ abstract class ExecutorIntegrationTestBase {
     open fun integration_testReasoningStreamingSummaryDeltas(model: LLModel) = runTest(timeout = 300.seconds) {
         Models.assumeAvailable(model.provider)
 
-        val params = OpenAIResponsesParams(
-            reasoning = ReasoningConfig(
-                effort = ReasoningEffort.MEDIUM,
-                summary = ReasoningSummary.DETAILED
-            ),
-            include = listOf(OpenAIInclude.REASONING_ENCRYPTED_CONTENT),
-            maxTokens = basicLimit
-        )
+        val params = createReasoningParams(model)
+
         val prompt = Prompt.build("reasoning-streaming-test", params = params) {
             system("You are a helpful assistant.")
-            user("Think about this step by step: What is 12 * 15?")
+            user("Reason about what is 8 * 9?. Include summary.")
         }
 
         val executor = getExecutor(model)
@@ -1137,7 +1133,7 @@ abstract class ExecutorIntegrationTestBase {
             (reasoningText + reasoningSummary).length shouldBeGreaterThan 0
 
             val finalAnswer = textDeltaFrames.joinToString("") { it.text }
-            finalAnswer.shouldContain("180")
+            finalAnswer.shouldContain("72")
         }
     }
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/MultipleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/MultipleLLMPromptExecutorIntegrationTest.kt
@@ -12,7 +12,6 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
 import org.junit.jupiter.api.Assumptions.assumeTrue
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -139,6 +138,18 @@ class MultipleLLMPromptExecutorIntegrationTest : ExecutorIntegrationTestBase() {
     @MethodSource("ai.koog.integration.tests.utils.Models#latestModels")
     override fun integration_testExecuteStreamingWithTools(model: LLModel) {
         super.integration_testExecuteStreamingWithTools(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("ai.koog.integration.tests.utils.Models#openAIReasoningModels")
+    override fun integration_testReasoningStreamingSummaryDeltas(model: LLModel) {
+        super.integration_testReasoningStreamingSummaryDeltas(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("ai.koog.integration.tests.utils.Models#openAIReasoningModels")
+    override fun integration_testReasoningStreamingWithEncryptedContent(model: LLModel) {
+        super.integration_testReasoningStreamingWithEncryptedContent(model)
     }
 
     @ParameterizedTest
@@ -293,19 +304,6 @@ class MultipleLLMPromptExecutorIntegrationTest : ExecutorIntegrationTestBase() {
     @MethodSource("ai.koog.integration.tests.utils.Models#reasoningCapableModels")
     override fun integration_testReasoningWithEncryption(model: LLModel) {
         super.integration_testReasoningWithEncryption(model)
-    }
-
-    @Disabled("KG-767 OpenAILLMClient loses Responses API reasoning summary stream events")
-    @ParameterizedTest
-    @MethodSource("ai.koog.integration.tests.utils.Models#openAIReasoningModels")
-    override fun integration_testReasoningStreamingSummaryDeltas(model: LLModel) {
-        super.integration_testReasoningStreamingSummaryDeltas(model)
-    }
-
-    @ParameterizedTest
-    @MethodSource("ai.koog.integration.tests.utils.Models#openAIReasoningModels")
-    override fun integration_testReasoningStreamingWithEncryptedContent(model: LLModel) {
-        super.integration_testReasoningStreamingWithEncryptedContent(model)
     }
 
     @ParameterizedTest

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
@@ -119,7 +119,7 @@ object Models {
     @JvmStatic
     fun openAIReasoningModels(): Stream<LLModel> {
         return Stream.of(
-            OpenAIModels.Chat.GPT5_2,
+            OpenAIModels.Chat.GPT5_4,
         )
     }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicModels.kt
@@ -105,7 +105,7 @@ public object AnthropicModels : LLModelDefinitions {
             LLMCapability.ToolChoice,
             LLMCapability.Vision.Image,
             LLMCapability.Document,
-            LLMCapability.Completion
+            LLMCapability.Completion,
         ) + thinkingCapabilities,
         contextLength = 200_000,
         maxOutputTokens = 64_000,
@@ -184,7 +184,7 @@ public object AnthropicModels : LLModelDefinitions {
             LLMCapability.ToolChoice,
             LLMCapability.Vision.Image,
             LLMCapability.Document,
-            LLMCapability.Completion
+            LLMCapability.Completion,
         ) + thinkingCapabilities,
         contextLength = 200_000,
         maxOutputTokens = 32_000,
@@ -209,7 +209,7 @@ public object AnthropicModels : LLModelDefinitions {
             LLMCapability.ToolChoice,
             LLMCapability.Vision.Image,
             LLMCapability.Document,
-            LLMCapability.Completion
+            LLMCapability.Completion,
         ) + thinkingCapabilities,
         contextLength = 200_000,
         maxOutputTokens = 32_000,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekModels.kt
@@ -63,6 +63,7 @@ public object DeepSeekModels : LLModelDefinitions {
             LLMCapability.Schema.JSON.Basic,
             LLMCapability.Schema.JSON.Standard,
             LLMCapability.MultipleChoices,
+            LLMCapability.Reasoning,
         ),
         contextLength = 64_000,
         maxOutputTokens = 64_000

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekModels.kt
@@ -63,7 +63,7 @@ public object DeepSeekModels : LLModelDefinitions {
             LLMCapability.Schema.JSON.Basic,
             LLMCapability.Schema.JSON.Standard,
             LLMCapability.MultipleChoices,
-            LLMCapability.Reasoning,
+            LLMCapability.Thinking,
         ),
         contextLength = 64_000,
         maxOutputTokens = 64_000

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleModels.kt
@@ -144,7 +144,7 @@ public object GoogleModels : LLModelDefinitions {
     public val Gemini2_5Flash: LLModel = LLModel(
         provider = LLMProvider.Google,
         id = "gemini-2.5-flash",
-        capabilities = fullCapabilities + LLMCapability.Reasoning,
+        capabilities = fullCapabilities + LLMCapability.Thinking,
         contextLength = 1_048_576,
         maxOutputTokens = 65_536,
     )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleModels.kt
@@ -64,7 +64,7 @@ public object GoogleModels : LLModelDefinitions {
     )
 
     /**
-     * Full capabilities including standard, multimodal, tools and native structured output
+     * Full capabilities including standard, multimodal, tools, native structured output
      */
     private val fullCapabilities: List<LLMCapability> =
         standardCapabilities + multimodalCapabilities + toolCapabilities + structuredOutputCapabilities
@@ -130,7 +130,7 @@ public object GoogleModels : LLModelDefinitions {
     public val Gemini2_5Pro: LLModel = LLModel(
         provider = LLMProvider.Google,
         id = "gemini-2.5-pro",
-        capabilities = fullCapabilities,
+        capabilities = fullCapabilities + LLMCapability.Thinking,
         contextLength = 1_048_576,
         maxOutputTokens = 65_536,
     )
@@ -144,7 +144,7 @@ public object GoogleModels : LLModelDefinitions {
     public val Gemini2_5Flash: LLModel = LLModel(
         provider = LLMProvider.Google,
         id = "gemini-2.5-flash",
-        capabilities = fullCapabilities,
+        capabilities = fullCapabilities + LLMCapability.Reasoning,
         contextLength = 1_048_576,
         maxOutputTokens = 65_536,
     )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAIModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAIModels.kt
@@ -123,7 +123,7 @@ public object MistralAIModels : LLModelDefinitions {
                 LLMCapability.Vision.Image,
                 LLMCapability.Document,
                 LLMCapability.MultipleChoices,
-                LLMCapability.Reasoning,
+                LLMCapability.Thinking,
             ),
             contextLength = 128_000
         )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAIModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAIModels.kt
@@ -122,7 +122,8 @@ public object MistralAIModels : LLModelDefinitions {
                 LLMCapability.Speculation,
                 LLMCapability.Vision.Image,
                 LLMCapability.Document,
-                LLMCapability.MultipleChoices
+                LLMCapability.MultipleChoices,
+                LLMCapability.Reasoning,
             ),
             contextLength = 128_000
         )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -302,10 +302,10 @@ public class OllamaClient @JvmOverloads constructor(
                     val chunk = ollamaJson.decodeFromString<OllamaChatResponseDTO>(line)
                     chunk.message?.let { message ->
                         if (message.content.isNotEmpty()) {
-                            emitTextDelta(message.content)
+                            emitTextDelta(text = message.content)
                         }
                         if (message.thinking.isNullOrEmpty().not()) {
-                            emitReasoningDelta(message.thinking)
+                            emitReasoningDelta(text = message.thinking)
                         }
                         message.toolCalls?.forEachIndexed { index, toolCall ->
                             val name = toolCall.function.name

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaModels.kt
@@ -226,7 +226,8 @@ public object OllamaModels : LLModelDefinitions {
             capabilities = listOf(
                 LLMCapability.Temperature,
                 LLMCapability.Schema.JSON.Basic,
-                LLMCapability.Tools
+                LLMCapability.Tools,
+                LLMCapability.Reasoning,
             ),
             contextLength = 40_960,
         )
@@ -250,7 +251,8 @@ public object OllamaModels : LLModelDefinitions {
             capabilities = listOf(
                 LLMCapability.Temperature,
                 LLMCapability.Schema.JSON.Basic,
-                LLMCapability.Tools
+                LLMCapability.Tools,
+                LLMCapability.Reasoning,
             ),
             contextLength = 40_960,
         )
@@ -359,7 +361,8 @@ public object OllamaModels : LLModelDefinitions {
             capabilities = listOf(
                 LLMCapability.Temperature,
                 LLMCapability.Schema.JSON.Basic,
-                LLMCapability.Tools
+                LLMCapability.Tools,
+                LLMCapability.Reasoning,
             ),
             contextLength = 32_768,
         )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaModels.kt
@@ -227,7 +227,7 @@ public object OllamaModels : LLModelDefinitions {
                 LLMCapability.Temperature,
                 LLMCapability.Schema.JSON.Basic,
                 LLMCapability.Tools,
-                LLMCapability.Reasoning,
+                LLMCapability.Thinking,
             ),
             contextLength = 40_960,
         )
@@ -252,7 +252,7 @@ public object OllamaModels : LLModelDefinitions {
                 LLMCapability.Temperature,
                 LLMCapability.Schema.JSON.Basic,
                 LLMCapability.Tools,
-                LLMCapability.Reasoning,
+                LLMCapability.Thinking,
             ),
             contextLength = 40_960,
         )
@@ -362,7 +362,7 @@ public object OllamaModels : LLModelDefinitions {
                 LLMCapability.Temperature,
                 LLMCapability.Schema.JSON.Basic,
                 LLMCapability.Tools,
-                LLMCapability.Reasoning,
+                LLMCapability.Thinking,
             ),
             contextLength = 32_768,
         )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -64,7 +64,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.withContext
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.jvm.JvmOverloads
@@ -427,7 +426,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                         else -> null
                     }
                 }
-            ).filterNotNull().requireEndFrame()
+            ).requireEndFrame()
         } catch (e: Exception) {
             throw LLMClientException(
                 clientName = clientName,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -185,7 +185,8 @@ public open class OpenAILLMClient @JvmOverloads constructor(
             parallelToolCalls = chatParams.parallelToolCalls,
             prediction = chatParams.speculation?.let { OpenAIStaticContent(OpenAIContent.Text(it)) },
             presencePenalty = chatParams.presencePenalty,
-            promptCacheKey = chatParams.promptCacheKey, reasoningEffort = model.takeIf { it.supports(LLMCapability.Thinking) }
+            promptCacheKey = chatParams.promptCacheKey,
+            reasoningEffort = model.takeIf { it.supports(LLMCapability.Thinking) }
                 ?.let { chatParams.reasoningEffort },
             responseFormat = responseFormat,
             safetyIdentifier = chatParams.safetyIdentifier,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -185,7 +185,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
             parallelToolCalls = chatParams.parallelToolCalls,
             prediction = chatParams.speculation?.let { OpenAIStaticContent(OpenAIContent.Text(it)) },
             presencePenalty = chatParams.presencePenalty,
-            promptCacheKey = chatParams.promptCacheKey, reasoningEffort = model.takeIf { it.supports(LLMCapability.Reasoning) }
+            promptCacheKey = chatParams.promptCacheKey, reasoningEffort = model.takeIf { it.supports(LLMCapability.Thinking) }
                 ?.let { chatParams.reasoningEffort },
             responseFormat = responseFormat,
             safetyIdentifier = chatParams.safetyIdentifier,
@@ -239,7 +239,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
             model = model.id,
             parallelToolCalls = params.parallelToolCalls,
             promptCacheKey = params.promptCacheKey,
-            reasoning = model.takeIf { it.supports(LLMCapability.Reasoning) }
+            reasoning = model.takeIf { it.supports(LLMCapability.Thinking) }
                 ?.let { params.reasoning },
             safetyIdentifier = params.safetyIdentifier,
             serviceTier = params.serviceTier,
@@ -794,7 +794,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
 
                     is Message.Reasoning -> {
                         flushPendingCalls()
-                        if (model.supports(LLMCapability.Reasoning)) {
+                        if (model.supports(LLMCapability.Thinking)) {
                             add(
                                 Item.Reasoning(
                                     id = message.id ?: Uuid.random().toString(),

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -318,7 +318,10 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                     processResponsesAPIResponse(response)
                 }
 
-                is OpenAIChatParams -> super.execute(prompt, model, tools)
+                is OpenAIChatParams -> {
+                    model.requireCapability(LLMCapability.OpenAIEndpoint.Completions)
+                    super.execute(prompt, model, tools)
+                }
             }
         }
     }
@@ -401,7 +404,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
 
                                 is Item.Reasoning -> {
                                     // https://developers.openai.com/api/reference/resources/responses/streaming-events#response.reasoning_text.done
-                                    if (item.summary.isEmpty() && item.content?.isEmpty() ?: true) {
+                                    if (item.summary.isEmpty() && item.content.isNullOrEmpty()) {
                                         logger.debug { "Got and empty (hidden) reasoning from the model, ignoring it." }
                                         null
                                     } else {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -185,7 +185,8 @@ public open class OpenAILLMClient @JvmOverloads constructor(
             parallelToolCalls = chatParams.parallelToolCalls,
             prediction = chatParams.speculation?.let { OpenAIStaticContent(OpenAIContent.Text(it)) },
             presencePenalty = chatParams.presencePenalty,
-            promptCacheKey = chatParams.promptCacheKey, reasoningEffort = chatParams.reasoningEffort,
+            promptCacheKey = chatParams.promptCacheKey, reasoningEffort = model.takeIf { it.supports(LLMCapability.Reasoning) }
+                ?.let { chatParams.reasoningEffort },
             responseFormat = responseFormat,
             safetyIdentifier = chatParams.safetyIdentifier,
             serviceTier = chatParams.serviceTier,
@@ -238,7 +239,8 @@ public open class OpenAILLMClient @JvmOverloads constructor(
             model = model.id,
             parallelToolCalls = params.parallelToolCalls,
             promptCacheKey = params.promptCacheKey,
-            reasoning = params.reasoning,
+            reasoning = model.takeIf { it.supports(LLMCapability.Reasoning) }
+                ?.let { params.reasoning },
             safetyIdentifier = params.safetyIdentifier,
             serviceTier = params.serviceTier,
             store = params.store,
@@ -311,6 +313,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
         return selectExecutionStrategy(prompt, model) { params ->
             when (params) {
                 is OpenAIResponsesParams -> {
+                    model.requireCapability(LLMCapability.OpenAIEndpoint.Responses)
                     val response = getResponseWithResponsesAPI(prompt, params, model, tools)
                     processResponsesAPIResponse(response)
                 }
@@ -362,7 +365,9 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                 path = settings.responsesAPIPath,
                 request = request,
                 requestBodyType = String::class,
-                decodeStreamingResponse = { json.decodeFromString<OpenAIStreamEvent>(it) },
+                decodeStreamingResponse = {
+                    json.decodeFromString<OpenAIStreamEvent>(it)
+                },
                 processStreamingChunk = {
                     when (it) {
                         is OpenAIStreamEvent.ResponseOutputTextDelta -> {
@@ -370,11 +375,13 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                         }
 
                         is OpenAIStreamEvent.ResponseReasoningTextDelta -> {
-                            StreamFrame.ReasoningDelta(text = it.delta, index = it.outputIndex)
+                            // https://developers.openai.com/api/reference/resources/responses/streaming-events#response.reasoning_text.delta
+                            StreamFrame.ReasoningDelta(id = it.itemId, text = it.delta, index = it.outputIndex)
                         }
 
                         is OpenAIStreamEvent.ResponseReasoningSummaryTextDelta -> {
-                            StreamFrame.ReasoningDelta(summary = it.delta, index = it.outputIndex)
+                            // https://developers.openai.com/api/reference/resources/responses/streaming-events#response.reasoning_text.delta
+                            StreamFrame.ReasoningDelta(id = it.itemId, summary = it.delta, index = it.outputIndex)
                         }
 
                         is OpenAIStreamEvent.ResponseFunctionCallArgumentsDelta -> {
@@ -388,22 +395,34 @@ public open class OpenAILLMClient @JvmOverloads constructor(
 
                         is OpenAIStreamEvent.ResponseOutputItemDone -> {
                             when (val item = it.item) {
-                                is Item.Text -> StreamFrame.TextComplete(item.value, it.outputIndex)
+                                is Item.Text -> {
+                                    StreamFrame.TextComplete(item.value, it.outputIndex)
+                                }
+
                                 is Item.Reasoning -> {
-                                    StreamFrame.ReasoningComplete(
-                                        text = item.content?.map { content -> content.text } ?: emptyList(),
-                                        summary = item.summary.map { content -> content.text },
-                                        encrypted = item.encryptedContent,
+                                    // https://developers.openai.com/api/reference/resources/responses/streaming-events#response.reasoning_text.done
+                                    if (item.summary.isEmpty() && item.content?.isEmpty() ?: true) {
+                                        logger.debug { "Got and empty (hidden) reasoning from the model, ignoring it." }
+                                        null
+                                    } else {
+                                        StreamFrame.ReasoningComplete(
+                                            id = item.id,
+                                            text = item.content?.map { content -> content.text } ?: emptyList(),
+                                            summary = item.summary.map { content -> content.text },
+                                            encrypted = item.encryptedContent,
+                                            index = it.outputIndex
+                                        )
+                                    }
+                                }
+
+                                is Item.FunctionToolCall -> {
+                                    StreamFrame.ToolCallComplete(
+                                        id = item.callId,
+                                        name = item.name,
+                                        content = item.arguments,
                                         index = it.outputIndex
                                     )
                                 }
-
-                                is Item.FunctionToolCall -> StreamFrame.ToolCallComplete(
-                                    id = item.id,
-                                    name = item.name,
-                                    content = item.arguments,
-                                    index = it.outputIndex
-                                )
 
                                 else -> null
                             }
@@ -423,7 +442,9 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                             )
                         }
 
-                        else -> null
+                        else -> {
+                            null
+                        }
                     }
                 }
             ).requireEndFrame()
@@ -732,9 +753,11 @@ public open class OpenAILLMClient @JvmOverloads constructor(
         val pendingCalls = mutableListOf<Item.FunctionToolCall>()
 
         fun flushPendingCalls() {
-            if (pendingCalls.isNotEmpty()) {
-                messages += pendingCalls
-                pendingCalls.clear()
+            if (model.supports(LLMCapability.Tools)) {
+                if (pendingCalls.isNotEmpty()) {
+                    messages += pendingCalls
+                    pendingCalls.clear()
+                }
             }
         }
 
@@ -753,7 +776,9 @@ public open class OpenAILLMClient @JvmOverloads constructor(
 
                     is Message.User -> {
                         flushPendingCalls()
-                        add(Item.InputMessage(role = "user", content = message.toInputMessage(model)))
+                        add(
+                            Item.InputMessage(role = "user", content = message.toInputMessage(model))
+                        )
                     }
 
                     is Message.Assistant -> {
@@ -769,31 +794,44 @@ public open class OpenAILLMClient @JvmOverloads constructor(
 
                     is Message.Reasoning -> {
                         flushPendingCalls()
-                        add(
-                            Item.Reasoning(
-                                id = message.id ?: Uuid.random().toString(),
-                                encryptedContent = message.encrypted,
-                                summary = listOf(Item.Reasoning.Summary(message.content))
+                        if (model.supports(LLMCapability.Reasoning)) {
+                            add(
+                                Item.Reasoning(
+                                    id = message.id ?: Uuid.random().toString(),
+                                    content = message.parts.map { Item.Reasoning.Content(text = it.text) }.ifEmpty { null },
+                                    encryptedContent = message.encrypted,
+                                    summary = message.summary?.map { Item.Reasoning.Summary(text = it.text) } ?: emptyList(),
+                                )
                             )
-                        )
+                        } else {
+                            logger.debug { "Model does not support reasoning, ignoring reasoning message" }
+                        }
                     }
 
                     is Message.Tool.Result -> {
                         flushPendingCalls()
-                        add(
-                            Item.FunctionToolCallOutput(
-                                callId = message.id ?: Uuid.random().toString(),
-                                output = message.content
+                        if (model.supports(LLMCapability.Tools)) {
+                            add(
+                                Item.FunctionToolCallOutput(
+                                    callId = message.id ?: Uuid.random().toString(),
+                                    output = message.content
+                                )
                             )
-                        )
+                        } else {
+                            logger.debug { "Model does not support tools, ignoring tool result message" }
+                        }
                     }
 
                     is Message.Tool.Call -> {
-                        pendingCalls += Item.FunctionToolCall(
-                            callId = message.id ?: Uuid.random().toString(),
-                            name = message.tool,
-                            arguments = message.content
-                        )
+                        if (model.supports(LLMCapability.Tools)) {
+                            pendingCalls += Item.FunctionToolCall(
+                                callId = message.id ?: Uuid.random().toString(),
+                                name = message.tool,
+                                arguments = message.content
+                            )
+                        } else {
+                            logger.debug { "Model does not support tools, ignoring tool call message" }
+                        }
                     }
                 }
             }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIModels.kt
@@ -741,7 +741,7 @@ public object OpenAIModels : LLModelDefinitions {
                 LLMCapability.Document,
                 LLMCapability.MultipleChoices,
                 LLMCapability.OpenAIEndpoint.Responses,
-            ),
+            ) + reasoningCapabilities,
             contextLength = 400_000,
             maxOutputTokens = 128_000,
         )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterModels.kt
@@ -37,7 +37,7 @@ public object OpenRouterModels : LLModelDefinitions {
     public val Phi4Reasoning: LLModel = LLModel(
         provider = LLMProvider.OpenRouter,
         id = "microsoft/phi-4-reasoning:free",
-        capabilities = standardCapabilities,
+        capabilities = standardCapabilities + LLMCapability.Reasoning,
         contextLength = 32_768,
     )
 
@@ -107,7 +107,7 @@ public object OpenRouterModels : LLModelDefinitions {
     public val Claude3_7Sonnet: LLModel = LLModel(
         provider = LLMProvider.OpenRouter,
         id = "anthropic/claude-3.7-sonnet",
-        capabilities = multimodalCapabilities,
+        capabilities = multimodalCapabilities + LLMCapability.Reasoning,
         contextLength = 200_000,
         maxOutputTokens = 64_000,
     )
@@ -120,7 +120,7 @@ public object OpenRouterModels : LLModelDefinitions {
     public val Claude4Sonnet: LLModel = LLModel(
         provider = LLMProvider.OpenRouter,
         id = "anthropic/claude-sonnet-4",
-        capabilities = multimodalCapabilities,
+        capabilities = multimodalCapabilities + LLMCapability.Reasoning,
         contextLength = 200_000,
         maxOutputTokens = 64_000,
     )
@@ -133,7 +133,7 @@ public object OpenRouterModels : LLModelDefinitions {
     public val Claude4_1Opus: LLModel = LLModel(
         provider = LLMProvider.OpenRouter,
         id = "anthropic/claude-opus-4.1",
-        capabilities = multimodalCapabilities,
+        capabilities = multimodalCapabilities + LLMCapability.Reasoning,
         contextLength = 200_000,
         maxOutputTokens = 32_000,
     )
@@ -149,7 +149,8 @@ public object OpenRouterModels : LLModelDefinitions {
         capabilities = multimodalCapabilities + listOf(
             LLMCapability.Schema.JSON.Basic,
             LLMCapability.Schema.JSON.Standard,
-            LLMCapability.ToolChoice
+            LLMCapability.ToolChoice,
+            LLMCapability.Reasoning,
         ),
         contextLength = 200_000,
         maxOutputTokens = 64_000,
@@ -166,7 +167,8 @@ public object OpenRouterModels : LLModelDefinitions {
         capabilities = multimodalCapabilities + listOf(
             LLMCapability.Schema.JSON.Basic,
             LLMCapability.Schema.JSON.Standard,
-            LLMCapability.ToolChoice
+            LLMCapability.ToolChoice,
+            LLMCapability.Reasoning,
         ),
         contextLength = 1_000_000,
         maxOutputTokens = 64_000,
@@ -183,7 +185,8 @@ public object OpenRouterModels : LLModelDefinitions {
         capabilities = multimodalCapabilities + listOf(
             LLMCapability.Schema.JSON.Basic,
             LLMCapability.Schema.JSON.Standard,
-            LLMCapability.ToolChoice
+            LLMCapability.ToolChoice,
+            LLMCapability.Reasoning,
         ),
         contextLength = 200_000,
         maxOutputTokens = 32_000,
@@ -565,7 +568,8 @@ public object OpenRouterModels : LLModelDefinitions {
         id = "google/gemini-2.5-flash-lite",
         capabilities = multimodalCapabilities + listOf(
             LLMCapability.Schema.JSON.Standard,
-            LLMCapability.ToolChoice
+            LLMCapability.ToolChoice,
+            LLMCapability.Reasoning,
         ),
         contextLength = 1_048_576,
         maxOutputTokens = 65_600,
@@ -581,7 +585,8 @@ public object OpenRouterModels : LLModelDefinitions {
         id = "google/gemini-2.5-flash",
         capabilities = multimodalCapabilities + listOf(
             LLMCapability.Schema.JSON.Standard,
-            LLMCapability.ToolChoice
+            LLMCapability.ToolChoice,
+            LLMCapability.Reasoning,
         ),
         contextLength = 1_048_576,
         maxOutputTokens = 65_600,
@@ -597,7 +602,8 @@ public object OpenRouterModels : LLModelDefinitions {
         id = "google/gemini-2.5-pro",
         capabilities = multimodalCapabilities + listOf(
             LLMCapability.Schema.JSON.Standard,
-            LLMCapability.ToolChoice
+            LLMCapability.ToolChoice,
+            LLMCapability.Reasoning,
         ),
         contextLength = 1_048_576,
         maxOutputTokens = 65_600,
@@ -628,7 +634,8 @@ public object OpenRouterModels : LLModelDefinitions {
         provider = LLMProvider.OpenRouter,
         id = "qwen/qwen3-vl-8b-instruct",
         capabilities = multimodalCapabilities + listOf(
-            LLMCapability.ToolChoice
+            LLMCapability.ToolChoice,
+            LLMCapability.Reasoning,
         ),
         contextLength = 131_072,
         maxOutputTokens = 33_000,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterModels.kt
@@ -37,7 +37,7 @@ public object OpenRouterModels : LLModelDefinitions {
     public val Phi4Reasoning: LLModel = LLModel(
         provider = LLMProvider.OpenRouter,
         id = "microsoft/phi-4-reasoning:free",
-        capabilities = standardCapabilities + LLMCapability.Reasoning,
+        capabilities = standardCapabilities + LLMCapability.Thinking,
         contextLength = 32_768,
     )
 
@@ -107,7 +107,7 @@ public object OpenRouterModels : LLModelDefinitions {
     public val Claude3_7Sonnet: LLModel = LLModel(
         provider = LLMProvider.OpenRouter,
         id = "anthropic/claude-3.7-sonnet",
-        capabilities = multimodalCapabilities + LLMCapability.Reasoning,
+        capabilities = multimodalCapabilities + LLMCapability.Thinking,
         contextLength = 200_000,
         maxOutputTokens = 64_000,
     )
@@ -120,7 +120,7 @@ public object OpenRouterModels : LLModelDefinitions {
     public val Claude4Sonnet: LLModel = LLModel(
         provider = LLMProvider.OpenRouter,
         id = "anthropic/claude-sonnet-4",
-        capabilities = multimodalCapabilities + LLMCapability.Reasoning,
+        capabilities = multimodalCapabilities + LLMCapability.Thinking,
         contextLength = 200_000,
         maxOutputTokens = 64_000,
     )
@@ -133,7 +133,7 @@ public object OpenRouterModels : LLModelDefinitions {
     public val Claude4_1Opus: LLModel = LLModel(
         provider = LLMProvider.OpenRouter,
         id = "anthropic/claude-opus-4.1",
-        capabilities = multimodalCapabilities + LLMCapability.Reasoning,
+        capabilities = multimodalCapabilities + LLMCapability.Thinking,
         contextLength = 200_000,
         maxOutputTokens = 32_000,
     )
@@ -150,7 +150,7 @@ public object OpenRouterModels : LLModelDefinitions {
             LLMCapability.Schema.JSON.Basic,
             LLMCapability.Schema.JSON.Standard,
             LLMCapability.ToolChoice,
-            LLMCapability.Reasoning,
+            LLMCapability.Thinking,
         ),
         contextLength = 200_000,
         maxOutputTokens = 64_000,
@@ -168,7 +168,7 @@ public object OpenRouterModels : LLModelDefinitions {
             LLMCapability.Schema.JSON.Basic,
             LLMCapability.Schema.JSON.Standard,
             LLMCapability.ToolChoice,
-            LLMCapability.Reasoning,
+            LLMCapability.Thinking,
         ),
         contextLength = 1_000_000,
         maxOutputTokens = 64_000,
@@ -186,7 +186,7 @@ public object OpenRouterModels : LLModelDefinitions {
             LLMCapability.Schema.JSON.Basic,
             LLMCapability.Schema.JSON.Standard,
             LLMCapability.ToolChoice,
-            LLMCapability.Reasoning,
+            LLMCapability.Thinking,
         ),
         contextLength = 200_000,
         maxOutputTokens = 32_000,
@@ -569,7 +569,7 @@ public object OpenRouterModels : LLModelDefinitions {
         capabilities = multimodalCapabilities + listOf(
             LLMCapability.Schema.JSON.Standard,
             LLMCapability.ToolChoice,
-            LLMCapability.Reasoning,
+            LLMCapability.Thinking,
         ),
         contextLength = 1_048_576,
         maxOutputTokens = 65_600,
@@ -586,7 +586,7 @@ public object OpenRouterModels : LLModelDefinitions {
         capabilities = multimodalCapabilities + listOf(
             LLMCapability.Schema.JSON.Standard,
             LLMCapability.ToolChoice,
-            LLMCapability.Reasoning,
+            LLMCapability.Thinking,
         ),
         contextLength = 1_048_576,
         maxOutputTokens = 65_600,
@@ -603,7 +603,7 @@ public object OpenRouterModels : LLModelDefinitions {
         capabilities = multimodalCapabilities + listOf(
             LLMCapability.Schema.JSON.Standard,
             LLMCapability.ToolChoice,
-            LLMCapability.Reasoning,
+            LLMCapability.Thinking,
         ),
         contextLength = 1_048_576,
         maxOutputTokens = 65_600,
@@ -635,7 +635,7 @@ public object OpenRouterModels : LLModelDefinitions {
         id = "qwen/qwen3-vl-8b-instruct",
         capabilities = multimodalCapabilities + listOf(
             LLMCapability.ToolChoice,
-            LLMCapability.Reasoning,
+            LLMCapability.Thinking,
         ),
         contextLength = 131_072,
         maxOutputTokens = 33_000,

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrame.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrame.kt
@@ -51,10 +51,14 @@ public sealed interface StreamFrame {
     /**
      * Represents a frame of a streaming response from a LLM with reasoning text delta.
      *
+     * @property id The id of the reasoning text.
      * @property text The text to append to the reasoning text.
+     * @property summary The summary of the reasoning text.
+     * @property index The index of the frame in the list of frames.
      */
     @Serializable
     public data class ReasoningDelta(
+        val id: String? = null,
         val text: String? = null,
         val summary: String? = null,
         override val index: Int? = null
@@ -63,10 +67,15 @@ public sealed interface StreamFrame {
     /**
      * Represents a frame of a streaming response from a LLM with reasoning text delta.
      *
+     * @property id The id of the reasoning text.
      * @property text The text to append to the reasoning text.
+     * @property summary The summary of the reasoning text.
+     * @param encrypted The encrypted text of the reasoning text.
+     * @property index The index of the frame in the list of frames.
      */
     @Serializable
     public data class ReasoningComplete(
+        val id: String?,
         val text: List<String>,
         val summary: List<String>? = null,
         public val encrypted: String? = null,

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameExt.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameExt.kt
@@ -28,10 +28,11 @@ public fun Message.Response.toStreamFrames(index: Int? = null): List<StreamFrame
             }
 
             is Message.Reasoning -> {
-                parts.forEach { add(StreamFrame.ReasoningDelta(it.text, null, index)) }
-                summary?.forEach { add(StreamFrame.ReasoningDelta(null, it.text, index)) }
+                parts.forEach { add(StreamFrame.ReasoningDelta(id = id, text = it.text, summary = null, index = index)) }
+                summary?.forEach { add(StreamFrame.ReasoningDelta(id = id, text = null, summary = it.text, index = index)) }
                 add(
                     StreamFrame.ReasoningComplete(
+                        id = id,
                         parts.map { it.text },
                         summary?.map { it.text },
                         encrypted,
@@ -75,6 +76,7 @@ public fun Iterable<StreamFrame>.toMessageResponses(): List<Message.Response> {
         reasoningCompleteFrames.forEach {
             add(
                 Message.Reasoning(
+                    id = it.id,
                     parts = it.text.map { textPart -> ContentPart.Text(textPart) },
                     summary = it.summary?.map { summaryPart -> ContentPart.Text(summaryPart) },
                     encrypted = it.encrypted,

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
@@ -48,33 +48,36 @@ public suspend fun FlowCollector<StreamFrame>.emitTextComplete(text: String, ind
  * Emits a [StreamFrame.ReasoningDelta] with the given [text] and [summary].
  */
 public suspend fun FlowCollector<StreamFrame>.emitReasoningDelta(
+    id: String? = null,
     text: String? = null,
     summary: String? = null,
     index: Int? = null
 ): Unit =
-    emit(StreamFrame.ReasoningDelta(text, summary, index))
+    emit(StreamFrame.ReasoningDelta(id, text, summary, index))
 
 /**
  * Emits a [StreamFrame.ReasoningComplete] with the given [text].
  */
 public suspend fun FlowCollector<StreamFrame>.emitReasoningComplete(
+    id: String? = null,
     text: String,
     summary: String? = null,
     encrypted: String? = null,
     index: Int? = null
 ): Unit =
-    emitReasoningComplete(listOf(text), summary?.let { listOf(it) }, encrypted, index)
+    emitReasoningComplete(id, listOf(text), summary?.let { listOf(it) }, encrypted, index)
 
 /**
  * Emits a [StreamFrame.ReasoningComplete] with the given [text].
  */
 public suspend fun FlowCollector<StreamFrame>.emitReasoningComplete(
+    id: String? = null,
     text: List<String>,
     summary: List<String>? = null,
     encrypted: String? = null,
     index: Int? = null
 ): Unit =
-    emit(StreamFrame.ReasoningComplete(text, summary, encrypted, index))
+    emit(StreamFrame.ReasoningComplete(id, text, summary, encrypted, index))
 
 /**
  * Emits a [StreamFrame.End] with the given [finishReason].
@@ -151,16 +154,19 @@ public class StreamFrameFlowBuilder(
     /**
      * Emits a [StreamFrame.ReasoningDelta] with the given [text].
      */
-    public suspend fun emitReasoningDelta(text: String? = null, summary: String? = null, index: Int? = null) {
+    public suspend fun emitReasoningDelta(id: String? = null, text: String? = null, summary: String? = null, index: Int? = null) {
         tryEmitPendingToolCall()
         tryEmitPendingText()
         val previous: PendingReasoning? = pendingReasoningRef.load()
         if (previous == null) {
-            pendingReasoningRef.store(PendingReasoning(textDelta = text, summaryDelta = summary, index = index))
+            pendingReasoningRef.store(PendingReasoning(id = id, textDelta = text, summaryDelta = summary, index = index))
+        } else if (id != previous.id) {
+            tryEmitPendingReasoning()
+            pendingReasoningRef.store(PendingReasoning(id = id, textDelta = text, summaryDelta = summary, index = index))
         } else {
-            pendingReasoningRef.store(previous.appendDelta(text, summary, index))
+            pendingReasoningRef.store(previous.appendDelta(id, text, summary, index))
         }
-        flowCollector.emitReasoningDelta(text, summary, index)
+        flowCollector.emitReasoningDelta(id, text, summary, index)
     }
 
     /**
@@ -227,6 +233,7 @@ public class StreamFrameFlowBuilder(
         val pendingReasoning = pendingReasoningRef.exchange(null)
         if (pendingReasoning != null) {
             flowCollector.emitReasoningComplete(
+                id = pendingReasoning.id,
                 text = pendingReasoning.textDelta ?: "",
                 summary = pendingReasoning.summaryDelta,
                 index = pendingReasoning.index
@@ -256,6 +263,7 @@ public class StreamFrameFlowBuilder(
         val index: Int?,
     ) {
         fun appendArgumentsDelta(argumentsDelta: String?): PendingToolCall {
+            require(this.index == index)
             val newArgs =
                 if (argumentsDelta == null) this.argumentsDelta else (this.argumentsDelta ?: "") + argumentsDelta
             return copy(argumentsDelta = newArgs)
@@ -274,15 +282,17 @@ public class StreamFrameFlowBuilder(
     }
 
     private data class PendingReasoning(
+        val id: String?,
         val textDelta: String?,
         val summaryDelta: String?,
         val index: Int?
     ) {
-        fun appendDelta(textDelta: String?, summaryDelta: String?, index: Int?): PendingReasoning {
+        fun appendDelta(id: String?, textDelta: String?, summaryDelta: String?, index: Int?): PendingReasoning {
             require(this.index == index)
-            val textDelta = if (textDelta == null) this.textDelta else (this.textDelta ?: "") + textDelta
-            val summaryDelta = if (summaryDelta == null) this.summaryDelta else (this.summaryDelta ?: "") + summaryDelta
-            return copy(textDelta = textDelta, summaryDelta = summaryDelta)
+            require(this.id == id)
+            val newTextDelta = if (textDelta == null) this.textDelta else (this.textDelta ?: "") + textDelta
+            val newSummaryDelta = if (summaryDelta == null) this.summaryDelta else (this.summaryDelta ?: "") + summaryDelta
+            return copy(textDelta = newTextDelta, summaryDelta = newSummaryDelta)
         }
     }
 }

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
@@ -234,8 +234,8 @@ public class StreamFrameFlowBuilder(
         if (pendingReasoning != null) {
             flowCollector.emitReasoningComplete(
                 id = pendingReasoning.id,
-                text = pendingReasoning.textDelta ?: "",
-                summary = pendingReasoning.summaryDelta,
+                text = pendingReasoning.textDelta?.let { listOf(pendingReasoning.textDelta) } ?: emptyList(),
+                summary = pendingReasoning.summaryDelta?.let { listOf(pendingReasoning.summaryDelta) },
                 index = pendingReasoning.index
             )
         }

--- a/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameExtTest.kt
+++ b/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameExtTest.kt
@@ -48,6 +48,7 @@ internal class StreamFrameExtTest {
     @Test
     fun testMessageReasoningToStreamFrames() {
         val message = Message.Reasoning(
+            id = "rs_123",
             parts = listOf(
                 ContentPart.Text("Thinking step 1"),
                 ContentPart.Text("Thinking step 2")
@@ -60,10 +61,11 @@ internal class StreamFrameExtTest {
         )
 
         val expectedFrames = listOf(
-            StreamFrame.ReasoningDelta(text = "Thinking step 1"),
-            StreamFrame.ReasoningDelta(text = "Thinking step 2"),
-            StreamFrame.ReasoningDelta(summary = "Summary"),
+            StreamFrame.ReasoningDelta(id = "rs_123", text = "Thinking step 1"),
+            StreamFrame.ReasoningDelta(id = "rs_123", text = "Thinking step 2"),
+            StreamFrame.ReasoningDelta(id = "rs_123", summary = "Summary"),
             StreamFrame.ReasoningComplete(
+                id = "rs_123",
                 listOf("Thinking step 1", "Thinking step 2"),
                 listOf("Summary"),
                 "encrypted_content"
@@ -94,6 +96,7 @@ internal class StreamFrameExtTest {
     fun testListOfMessageResponsesToStreamFrames() {
         val messages = listOf(
             Message.Reasoning(
+                id = "rs_123",
                 parts = listOf(
                     ContentPart.Text("Thinking step 1"),
                     ContentPart.Text("Thinking step 2")
@@ -120,10 +123,11 @@ internal class StreamFrameExtTest {
         )
 
         val expectedFrames = listOf(
-            StreamFrame.ReasoningDelta(text = "Thinking step 1", index = 0),
-            StreamFrame.ReasoningDelta(text = "Thinking step 2", index = 0),
-            StreamFrame.ReasoningDelta(summary = "Summary", index = 0),
+            StreamFrame.ReasoningDelta(id = "rs_123", text = "Thinking step 1", index = 0),
+            StreamFrame.ReasoningDelta(id = "rs_123", text = "Thinking step 2", index = 0),
+            StreamFrame.ReasoningDelta(id = "rs_123", summary = "Summary", index = 0),
             StreamFrame.ReasoningComplete(
+                id = "rs_123",
                 listOf("Thinking step 1", "Thinking step 2"),
                 listOf("Summary"),
                 "encrypted_content",
@@ -183,10 +187,11 @@ internal class StreamFrameExtTest {
     @Test
     fun testStreamFramesToMessageReasoning() {
         val frames = listOf(
-            StreamFrame.ReasoningDelta("Thinking step 1"),
-            StreamFrame.ReasoningDelta("Thinking step 2"),
-            StreamFrame.ReasoningDelta(summary = "Summary"),
+            StreamFrame.ReasoningDelta(id = "rs_123", "Thinking step 1"),
+            StreamFrame.ReasoningDelta(id = "rs_123", "Thinking step 2"),
+            StreamFrame.ReasoningDelta(id = "rs_123", summary = "Summary"),
             StreamFrame.ReasoningComplete(
+                id = "rs_123",
                 listOf("Thinking step 1", "Thinking step 2"),
                 listOf("Summary"),
                 "encrypted_content"
@@ -233,10 +238,11 @@ internal class StreamFrameExtTest {
     @Test
     fun testStreamFramesToListOfMessageResponses() {
         val frames = listOf(
-            StreamFrame.ReasoningDelta(text = "Thinking step 1", index = 0),
-            StreamFrame.ReasoningDelta(text = "Thinking step 2", index = 0),
-            StreamFrame.ReasoningDelta(summary = "Summary", index = 0),
+            StreamFrame.ReasoningDelta(id = "rs_123", text = "Thinking step 1", index = 0),
+            StreamFrame.ReasoningDelta(id = "rs_123", text = "Thinking step 2", index = 0),
+            StreamFrame.ReasoningDelta(id = "rs_123", summary = "Summary", index = 0),
             StreamFrame.ReasoningComplete(
+                id = "rs_123",
                 listOf("Thinking step 1", "Thinking step 2"),
                 listOf("Summary"),
                 "encrypted_content",
@@ -304,7 +310,7 @@ internal class StreamFrameExtTest {
     @Test
     fun testToReasoningMessageOrNull() {
         val framesWithReasoning = listOf(
-            StreamFrame.ReasoningComplete(listOf("Thinking")),
+            StreamFrame.ReasoningComplete(id = "rs_123", listOf("Thinking")),
             StreamFrame.End(null, ResponseMetaInfo.Empty)
         )
 

--- a/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameExtTest.kt
+++ b/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameExtTest.kt
@@ -201,6 +201,7 @@ internal class StreamFrameExtTest {
 
         val expectedMessages = listOf(
             Message.Reasoning(
+                id = "rs_123",
                 parts = listOf(ContentPart.Text("Thinking step 1"), ContentPart.Text("Thinking step 2")),
                 summary = listOf(ContentPart.Text("Summary")),
                 encrypted = "encrypted_content",
@@ -258,6 +259,7 @@ internal class StreamFrameExtTest {
 
         val expectedMessages = listOf(
             Message.Reasoning(
+                id = "rs_123",
                 parts = listOf(ContentPart.Text("Thinking step 1"), ContentPart.Text("Thinking step 2")),
                 summary = listOf(ContentPart.Text("Summary")),
                 encrypted = "encrypted_content",

--- a/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderTest.kt
+++ b/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderTest.kt
@@ -15,12 +15,15 @@ class StreamFrameFlowBuilderTest {
         val frames = buildStreamFrameFlow {
             emitTextDelta("Hello", 0)
             emitTextDelta(" World", 0)
+            emitEnd()
         }.toList()
 
         assertContentEquals(
             listOf(
                 StreamFrame.TextDelta("Hello", 0),
-                StreamFrame.TextDelta(" World", 0)
+                StreamFrame.TextDelta(" World", 0),
+                StreamFrame.TextComplete("Hello World", 0),
+                StreamFrame.End(null, ResponseMetaInfo.Empty)
             ),
             frames
         )
@@ -31,12 +34,15 @@ class StreamFrameFlowBuilderTest {
         val frames = buildStreamFrameFlow {
             emitReasoningDelta(text = "Thinking...", index = 0)
             emitReasoningDelta(text = " step 2", index = 0)
+            emitEnd()
         }.toList()
 
         assertContentEquals(
             listOf(
                 StreamFrame.ReasoningDelta(text = "Thinking...", index = 0),
-                StreamFrame.ReasoningDelta(text = " step 2", index = 0)
+                StreamFrame.ReasoningDelta(text = " step 2", index = 0),
+                StreamFrame.ReasoningComplete(id = null, text = listOf("Thinking... step 2"), index = 0),
+                StreamFrame.End(null, ResponseMetaInfo.Empty)
             ),
             frames
         )
@@ -47,12 +53,76 @@ class StreamFrameFlowBuilderTest {
         val frames = buildStreamFrameFlow {
             emitReasoningDelta(summary = "Summary part 1", index = 0)
             emitReasoningDelta(summary = " part 2", index = 0)
+            emitEnd()
         }.toList()
 
         assertContentEquals(
             listOf(
                 StreamFrame.ReasoningDelta(summary = "Summary part 1", index = 0),
-                StreamFrame.ReasoningDelta(summary = " part 2", index = 0)
+                StreamFrame.ReasoningDelta(summary = " part 2", index = 0),
+                StreamFrame.ReasoningComplete(
+                    id = null,
+                    text = emptyList(),
+                    summary = listOf("Summary part 1 part 2"),
+                    index = 0
+                ),
+                StreamFrame.End(null, ResponseMetaInfo.Empty)
+            ),
+            frames
+        )
+    }
+
+    @Test
+    fun testEmitReasoningTextAndSummary() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitReasoningDelta(text = "Thinking...", index = 0)
+            emitReasoningDelta(text = " step 2", index = 0)
+            emitReasoningDelta(summary = "Summary part 1", index = 0)
+            emitReasoningDelta(summary = " part 2", index = 0)
+            emitEnd()
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.ReasoningDelta(text = "Thinking...", index = 0),
+                StreamFrame.ReasoningDelta(text = " step 2", index = 0),
+                StreamFrame.ReasoningDelta(summary = "Summary part 1", index = 0),
+                StreamFrame.ReasoningDelta(summary = " part 2", index = 0),
+                StreamFrame.ReasoningComplete(
+                    id = null,
+                    text = listOf("Thinking... step 2"),
+                    summary = listOf("Summary part 1 part 2"),
+                    index = 0
+                ),
+                StreamFrame.End(null, ResponseMetaInfo.Empty)
+            ),
+            frames
+        )
+    }
+
+    @Test
+    fun testEmitReasoningTextAndSummaryWithIds() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitReasoningDelta(id = "rs_123", text = "Thinking...", index = 0)
+            emitReasoningDelta(id = "rs_123", text = " step 2", index = 0)
+            emitReasoningDelta(id = "rs_123", summary = "Summary part 1", index = 0)
+            emitReasoningDelta(id = "rs_123", summary = " part 2", index = 0)
+            emitEnd()
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.ReasoningDelta(id = "rs_123", text = "Thinking...", index = 0),
+                StreamFrame.ReasoningDelta(id = "rs_123", text = " step 2", index = 0),
+                StreamFrame.ReasoningDelta(id = "rs_123", summary = "Summary part 1", index = 0),
+                StreamFrame.ReasoningDelta(id = "rs_123", summary = " part 2", index = 0),
+                StreamFrame.ReasoningComplete(
+                    id = "rs_123",
+                    text = listOf("Thinking... step 2"),
+                    summary = listOf("Summary part 1 part 2"),
+                    index = 0
+                ),
+                StreamFrame.End(null, ResponseMetaInfo.Empty)
             ),
             frames
         )
@@ -175,6 +245,30 @@ class StreamFrameFlowBuilderTest {
             StreamFrame.ToolCallComplete("call_1", "search", "{}", 0),
             StreamFrame.ReasoningDelta(id = "rs_123", text = "Now thinking...", index = 1),
             StreamFrame.ReasoningComplete(id = "rs_123", listOf("Now thinking..."), null, null, 1),
+            StreamFrame.End(null, ResponseMetaInfo.Empty)
+        )
+
+        assertContentEquals(expectedFrames, frames)
+    }
+
+    @Test
+    fun testSwitchBetweenReasoningWithDifferentIds() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitReasoningDelta(id = "rs_12", summary = "Summary part 1", index = 0)
+            emitReasoningDelta(id = "rs_123", summary = " part 2", index = 1)
+            emitEnd()
+        }.toList()
+
+        val expectedFrames = listOf(
+            StreamFrame.ReasoningDelta(id = "rs_12", summary = "Summary part 1", index = 0),
+            StreamFrame.ReasoningComplete(
+                id = "rs_12",
+                text = emptyList(),
+                summary = listOf("Summary part 1"),
+                index = 0
+            ),
+            StreamFrame.ReasoningDelta(id = "rs_123", summary = " part 2", index = 1),
+            StreamFrame.ReasoningComplete(id = "rs_123", text = emptyList(), summary = listOf(" part 2"), index = 1),
             StreamFrame.End(null, ResponseMetaInfo.Empty)
         )
 

--- a/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderTest.kt
+++ b/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderTest.kt
@@ -166,20 +166,19 @@ class StreamFrameFlowBuilderTest {
     fun testSwitchingFromToolCallToReasoningEmitsPendingToolCall() = runTest {
         val frames = buildStreamFrameFlow {
             emitToolCallDelta(id = "call_1", name = "search", args = "{}", 0)
-            emitReasoningDelta(text = "Now thinking...", index = 1)
+            emitReasoningDelta(id = "rs_123", text = "Now thinking...", index = 1)
             emitEnd()
         }.toList()
 
-        assertContentEquals(
-            listOf(
-                StreamFrame.ToolCallDelta("call_1", "search", "{}", 0),
-                StreamFrame.ToolCallComplete("call_1", "search", "{}", 0),
-                StreamFrame.ReasoningDelta(text = "Now thinking...", index = 1),
-                StreamFrame.ReasoningComplete(listOf("Now thinking..."), null, null, 1),
-                StreamFrame.End(null, ResponseMetaInfo.Empty)
-            ),
-            frames
+        val expectedFrames = listOf(
+            StreamFrame.ToolCallDelta("call_1", "search", "{}", 0),
+            StreamFrame.ToolCallComplete("call_1", "search", "{}", 0),
+            StreamFrame.ReasoningDelta(id = "rs_123", text = "Now thinking...", index = 1),
+            StreamFrame.ReasoningComplete(id = "rs_123", listOf("Now thinking..."), null, null, 1),
+            StreamFrame.End(null, ResponseMetaInfo.Empty)
         )
+
+        assertContentEquals(expectedFrames, frames)
     }
 
     @Test
@@ -188,47 +187,48 @@ class StreamFrameFlowBuilderTest {
             emitTextDelta("Start with text", 0)
             emitToolCallDelta(id = "call_1", name = "calculator", args = "{\"a\": 5}", 1)
             emitTextDelta("Continue after tool with text", 2)
-            emitReasoningDelta(text = "Now switch from text to thinking...", index = 3)
-            emitReasoningDelta(summary = "Summary thinking", index = 3)
+            emitReasoningDelta(id = "rs_12", text = "Now switch from text to thinking...", index = 3)
+            emitReasoningDelta(id = "rs_12", summary = "Summary thinking", index = 3)
             emitToolCallDelta(id = "call_2", name = "search", args = "{}", 4)
-            emitReasoningDelta(text = "Now switch from tool to thinking...", index = 5)
-            emitReasoningDelta(summary = "Summary thinking", index = 5)
+            emitReasoningDelta(id = "rs_123", text = "Now switch from tool to thinking...", index = 5)
+            emitReasoningDelta(id = "rs_123", summary = "Summary thinking", index = 5)
             emitTextDelta("Finally switch from reasoning to text ", 6)
             emitEnd()
         }.toList()
 
-        assertContentEquals(
-            listOf(
-                StreamFrame.TextDelta("Start with text", 0),
-                StreamFrame.TextComplete("Start with text", 0),
-                StreamFrame.ToolCallDelta("call_1", "calculator", "{\"a\": 5}", 1),
-                StreamFrame.ToolCallComplete("call_1", "calculator", "{\"a\": 5}", 1),
-                StreamFrame.TextDelta("Continue after tool with text", 2),
-                StreamFrame.TextComplete("Continue after tool with text", 2),
-                StreamFrame.ReasoningDelta(text = "Now switch from text to thinking...", index = 3),
-                StreamFrame.ReasoningDelta(summary = "Summary thinking", index = 3),
-                StreamFrame.ReasoningComplete(
-                    listOf("Now switch from text to thinking..."),
-                    listOf("Summary thinking"),
-                    null,
-                    3
-                ),
-                StreamFrame.ToolCallDelta("call_2", "search", "{}", 4),
-                StreamFrame.ToolCallComplete("call_2", "search", "{}", 4),
-                StreamFrame.ReasoningDelta(text = "Now switch from tool to thinking...", index = 5),
-                StreamFrame.ReasoningDelta(summary = "Summary thinking", index = 5),
-                StreamFrame.ReasoningComplete(
-                    listOf("Now switch from tool to thinking..."),
-                    listOf("Summary thinking"),
-                    null,
-                    5
-                ),
-                StreamFrame.TextDelta("Finally switch from reasoning to text ", 6),
-                StreamFrame.TextComplete("Finally switch from reasoning to text ", 6),
-                StreamFrame.End(null, ResponseMetaInfo.Empty)
+        val expectedFrames = listOf(
+            StreamFrame.TextDelta("Start with text", 0),
+            StreamFrame.TextComplete("Start with text", 0),
+            StreamFrame.ToolCallDelta("call_1", "calculator", "{\"a\": 5}", 1),
+            StreamFrame.ToolCallComplete("call_1", "calculator", "{\"a\": 5}", 1),
+            StreamFrame.TextDelta("Continue after tool with text", 2),
+            StreamFrame.TextComplete("Continue after tool with text", 2),
+            StreamFrame.ReasoningDelta(id = "rs_12", text = "Now switch from text to thinking...", index = 3),
+            StreamFrame.ReasoningDelta(id = "rs_12", summary = "Summary thinking", index = 3),
+            StreamFrame.ReasoningComplete(
+                id = "rs_12",
+                listOf("Now switch from text to thinking..."),
+                listOf("Summary thinking"),
+                null,
+                3
             ),
-            frames
+            StreamFrame.ToolCallDelta("call_2", "search", "{}", 4),
+            StreamFrame.ToolCallComplete("call_2", "search", "{}", 4),
+            StreamFrame.ReasoningDelta(id = "rs_123", text = "Now switch from tool to thinking...", index = 5),
+            StreamFrame.ReasoningDelta(id = "rs_123", summary = "Summary thinking", index = 5),
+            StreamFrame.ReasoningComplete(
+                id = "rs_123",
+                listOf("Now switch from tool to thinking..."),
+                listOf("Summary thinking"),
+                null,
+                5
+            ),
+            StreamFrame.TextDelta("Finally switch from reasoning to text ", 6),
+            StreamFrame.TextComplete("Finally switch from reasoning to text ", 6),
+            StreamFrame.End(null, ResponseMetaInfo.Empty)
         )
+
+        assertContentEquals(expectedFrames, frames)
     }
 
     @Test


### PR DESCRIPTION
Bugs:
* The ID of incoming reasoning messages was ignored, but it's required for outgoing messages. We generated it manually, but it didn't match the format `rs_***`, so we got 400 from OpenAI. The right approach here is to store the original ids of the reasoning messages
* For codex models, the reasoning is hidden, so we received empty text and summary, and while trying to send it back with the response, we also got 400 from OpenAI. The right fix here is to ignore empty reasoning, as it's hidden and makes no sense for the user.

Fixes:
* Add ids to reasoning messages
* Fix the reasoning messages response content, the text was ignored
* Ignore empty reasoning messages
* Add reasoning capability to control which models support reasoning
* Increase tokens limit in tests for reasoning as in case of end of tokens, no end of conversation is received and the test fails

closes #1712
and bug reported in Slack https://kotlinlang.slack.com/archives/C08SLB97W23/p1773062179788829 
