### PR TITLE
fix(prompt): RetryingLLMClient delegates for json schema generators

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClient.kt
@@ -10,6 +10,8 @@ import ai.koog.prompt.message.LLMChoice
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.streaming.IncompleteStreamException
 import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.structure.json.generator.BasicJsonSchemaGenerator
+import ai.koog.prompt.structure.json.generator.StandardJsonSchemaGenerator
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
@@ -185,6 +187,14 @@ public class RetryingLLMClient @JvmOverloads constructor(
 
     override fun close() {
         delegate.close()
+    }
+
+    override fun getStandardJsonSchemaGenerator(): StandardJsonSchemaGenerator {
+        return delegate.getStandardJsonSchemaGenerator()
+    }
+
+    override fun getBasicJsonSchemaGenerator(): BasicJsonSchemaGenerator {
+        return delegate.getBasicJsonSchemaGenerator()
     }
 }
 

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClientTest.kt
@@ -16,6 +16,8 @@ import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.streaming.emitTextDelta
 import ai.koog.prompt.streaming.streamFrameFlow
 import ai.koog.prompt.streaming.streamFrameFlowOf
+import ai.koog.prompt.structure.json.generator.BasicJsonSchemaGenerator
+import ai.koog.prompt.structure.json.generator.StandardJsonSchemaGenerator
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
@@ -440,6 +442,28 @@ class RetryingLLMClientTest {
         assertEquals(1, mockClient.streamCalls) // No retry after first frame
     }
 
+    @Test
+    fun testBasicJsonSchemaGeneratorDelegation() = runTest {
+        val mockClient = MockLLMClient()
+
+        val retryingClient = RetryingLLMClient(mockClient)
+
+        val result = retryingClient.getBasicJsonSchemaGenerator()
+
+        assertEquals(mockClient.basicJsonSchemaGeneratorDefault, result)
+    }
+
+    @Test
+    fun testStandardJsonSchemaGeneratorDelegation() = runTest {
+        val mockClient = MockLLMClient()
+
+        val retryingClient = RetryingLLMClient(mockClient)
+
+        val result = retryingClient.getStandardJsonSchemaGenerator()
+
+        assertEquals(mockClient.standardJsonSchemaGeneratorDefault, result)
+    }
+
     // Mock LLMClient for testing
     private class MockLLMClient(
         private val executeResponse: List<Message.Response> = emptyList(),
@@ -452,6 +476,9 @@ class RetryingLLMClientTest {
         private val throwCancellation: Boolean = false,
         private val llmProvider: LLMProvider = LLMProvider.OpenAI,
     ) : LLMClient() {
+
+        val basicJsonSchemaGeneratorDefault = object : BasicJsonSchemaGenerator() {}
+        val standardJsonSchemaGeneratorDefault = object : StandardJsonSchemaGenerator() {}
 
         var executeCalls = 0
         var streamCalls = 0
@@ -527,6 +554,14 @@ class RetryingLLMClientTest {
 
         override fun close() {
             // No resources to close
+        }
+
+        override fun getBasicJsonSchemaGenerator(): BasicJsonSchemaGenerator {
+            return basicJsonSchemaGeneratorDefault
+        }
+
+        override fun getStandardJsonSchemaGenerator(): StandardJsonSchemaGenerator {
+            return standardJsonSchemaGeneratorDefault
         }
     }
 }


### PR DESCRIPTION
Fixes an issue where the correct JsonSchemaGenerator implementation is lost when using the RetryingLLMClient.