### PR TITLE
fix(agents): move reasoning prompt to strategy parameters

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentStrategies.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentStrategies.kt
@@ -122,7 +122,8 @@ public fun chatAgentStrategy(): AIAgentGraphStrategy<String, String> = strategy(
 @JvmOverloads
 public fun reActStrategy(
     reasoningInterval: Int = 1,
-    name: String = "re_act"
+    name: String = "re_act",
+    reasoningPrompt: String = "Please give your thoughts about the task and plan the next steps."
 ): AIAgentGraphStrategy<String, String> = strategy(name) {
     require(reasoningInterval > 0) { "Reasoning interval must be greater than 0" }
     val reasoningStepKey = createStorageKey<Int>("reasoning_step")
@@ -137,7 +138,6 @@ public fun reActStrategy(
     }
     val nodeExecuteTool by nodeExecuteTool()
 
-    val reasoningPrompt = "Please give your thoughts about the task and plan the next steps."
     val nodeCallLLMReasonInput by node<String, Unit> { stageInput ->
         llm.writeSession {
             appendPrompt {


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

Allowed customization of the reasoning prompt in ReAct strategy by making the prompt a parameter of the `reActStrategy` method

<!-- Include references to related issues below, e.g., closes #1, closes KG-1. Otherwise, delete it. -->
closes #1774