### PR TITLE
feat(prompt): Add java API for LLMEmbeddingProvider

### DIFF
--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/client/CapturingLLMClient.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/client/CapturingLLMClient.kt
@@ -31,6 +31,8 @@ public class CapturingLLMClient @JvmOverloads constructor(
     private val streamingChunks: List<StreamFrame> = emptyList(),
     private val choices: List<LLMChoice> = emptyList(),
     private val moderationResult: ModerationResult = ModerationResult(isHarmful = false, categories = emptyMap()),
+    private val embedResult: List<Double> = emptyList(),
+    private val batchEmbedResult: List<List<Double>> = emptyList(),
     private val llmProvider: LLMProvider = LLMProvider.OpenAI
 ) : LLMClient() {
 
@@ -63,6 +65,18 @@ public class CapturingLLMClient @JvmOverloads constructor(
 
     /** The last [LLModel] passed to [moderate], or null if it hasn't been called yet. */
     public var lastModerationModel: LLModel? = null
+
+    /** The last text passed to [embed], or null if it hasn't been called yet. */
+    public var lastEmbeddingText: String? = null
+
+    /** The last [LLModel] passed to [embed], or null if it hasn't been called yet. */
+    public var lastEmbeddingModel: LLModel? = null
+
+    /** The last batched input passed to [embed], or null if it hasn't been called yet. */
+    public var lastBatchEmbeddingInput: List<String>? = null
+
+    /** The last [LLModel] passed to [embed], or null if it hasn't been called yet. */
+    public var lastBatchEmbeddingModel: LLModel? = null
 
     override fun llmProvider(): LLMProvider = llmProvider
 
@@ -118,6 +132,32 @@ public class CapturingLLMClient @JvmOverloads constructor(
         lastModerationPrompt = prompt
         lastModerationModel = model
         return moderationResult
+    }
+
+    /**
+     * Simulates an embedding call.
+     * Captures input parameters and returns the predefined [embedResult].
+     */
+    override suspend fun embed(
+        text: String,
+        model: LLModel
+    ): List<Double> {
+        lastEmbeddingText = text
+        lastEmbeddingModel = model
+        return embedResult
+    }
+
+    /**
+     * Simulates a batch embedding call.
+     * Captures input parameters and returns the predefined [batchEmbedResult].
+     */
+    override suspend fun embed(
+        inputs: List<String>,
+        model: LLModel
+    ): List<List<Double>> {
+        lastBatchEmbeddingInput = inputs
+        lastBatchEmbeddingModel = model
+        return batchEmbedResult
     }
 
     override fun close() {

--- a/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/client/CapturingLLMClient.kt
+++ b/agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/client/CapturingLLMClient.kt
@@ -24,6 +24,8 @@ import kotlin.jvm.JvmOverloads
  * @property streamingChunks The sequence of chunks to emit from [executeStreaming].
  * @property choices The list of [LLMChoice] to return from [executeMultipleChoices].
  * @property moderationResult The [ModerationResult] to return from [moderate].
+ * @property embedResult The embedding vector to return from [embed] for a single text input.
+ * @property batchEmbedResult The list of embedding vectors to return from [embed] for batch input.
  * @property llmProvider [LLMProvider] associated with the client or [LLMProvider.OpenAI], if not defined
  */
 public class CapturingLLMClient @JvmOverloads constructor(

--- a/embeddings/embeddings-llm/src/commonTest/kotlin/ai/koog/embeddings/local/LLMEmbedderTest.kt
+++ b/embeddings/embeddings-llm/src/commonTest/kotlin/ai/koog/embeddings/local/LLMEmbedderTest.kt
@@ -76,7 +76,7 @@ class LLMEmbedderTest {
         }
     }
 
-    class MockEmbedderClient : LLMEmbeddingProvider {
+    class MockEmbedderClient : LLMEmbeddingProvider() {
         private val embeddings = mutableMapOf<String, Vector>()
 
         fun mockEmbedding(text: String, vector: Vector) {
@@ -85,6 +85,13 @@ class LLMEmbedderTest {
 
         override suspend fun embed(text: String, model: LLModel): List<Double> {
             return embeddings[text]?.values ?: throw IllegalArgumentException("No mock embedding for text: $text")
+        }
+
+        override suspend fun embed(
+            inputs: List<String>,
+            model: LLModel
+        ): List<List<Double>> {
+            return inputs.map { embed(it, model) }
         }
     }
 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentTestBase.kt
@@ -233,6 +233,20 @@ open class AIAgentTestBase {
             throw NotImplementedError("Moderation not needed for this test")
         }
 
+        override suspend fun embed(
+            text: String,
+            model: LLModel
+        ): List<Double> {
+            throw NotImplementedError("Moderation not needed for this test")
+        }
+
+        override suspend fun embed(
+            inputs: List<String>,
+            model: LLModel
+        ): List<List<Double>> {
+            throw NotImplementedError("Moderation not needed for this test")
+        }
+
         override fun close() {
             underlyingClient.close()
             eventsChannel.close()

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
@@ -37,7 +37,6 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.clients.LLMClientException
-import ai.koog.prompt.executor.clients.LLMEmbeddingProvider
 import ai.koog.prompt.executor.clients.anthropic.AnthropicParams
 import ai.koog.prompt.executor.clients.anthropic.models.AnthropicThinking
 import ai.koog.prompt.executor.clients.google.GoogleModels
@@ -879,15 +878,30 @@ abstract class ExecutorIntegrationTestBase {
 
     open fun integration_testEmbed(model: LLModel) = runTest {
         val client = getLLMClient(model)
-        if (client !is LLMEmbeddingProvider) {
-            return@runTest
-        }
         val testText = "integration test embedding"
         client.embed(testText, model) shouldNotBeNull {
             shouldNotBeEmpty()
             size shouldBeGreaterThan 100
             shouldForAll {
                 it.isFinite()
+            }
+        }
+    }
+
+    open fun integration_testEmbedBatch(model: LLModel) = runTest {
+        val client = getLLMClient(model)
+        val inputs = listOf(
+            "integration test batch embedding first",
+            "integration test batch embedding second",
+            "integration test batch embedding third",
+        )
+        val embeddings = client.embed(inputs, model)
+        embeddings shouldNotBeNull {
+            size shouldBe inputs.size
+            shouldForAll { embedding ->
+                embedding.shouldNotBeEmpty()
+                embedding.size shouldBeGreaterThan 100
+                embedding.shouldForAll { it.isFinite() }
             }
         }
     }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/MultipleLLMPromptExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/MultipleLLMPromptExecutorIntegrationTest.kt
@@ -283,6 +283,12 @@ class MultipleLLMPromptExecutorIntegrationTest : ExecutorIntegrationTestBase() {
     }
 
     @ParameterizedTest
+    @MethodSource("ai.koog.integration.tests.utils.Models#batchEmbeddingModels")
+    override fun integration_testEmbedBatch(model: LLModel) {
+        super.integration_testEmbedBatch(model)
+    }
+
+    @ParameterizedTest
     @MethodSource("ai.koog.integration.tests.utils.Models#moderationModels")
     override fun integration_testSingleMessageModeration(model: LLModel) {
         super.integration_testSingleMessageModeration(model)

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
@@ -66,6 +66,14 @@ object Models {
         )
     }
 
+    @JvmStatic
+    fun batchEmbeddingModels(): Stream<LLModel> {
+        return Stream.of(
+            MistralAIModels.Embeddings.MistralEmbed,
+            GoogleModels.Embeddings.GeminiEmbedding001,
+        )
+    }
+
     /**
      * Returns models that support content moderation capabilities.
      *

--- a/koog-spring-ai/koog-spring-ai-starter-model-chat/src/main/kotlin/ai/koog/spring/ai/chat/SpringAiLLMClient.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-chat/src/main/kotlin/ai/koog/spring/ai/chat/SpringAiLLMClient.kt
@@ -330,17 +330,33 @@ public class SpringAiLLMClient(
         return chatOptionsCustomizer.customize(options, params, model)
     }
 
+    /**
+     * Embedding via [SpringAiLLMClient] is not supported.
+     * Use `SpringAiLLMEmbeddingProvider` for embedding with Spring AI.
+     *
+     * @throws UnsupportedOperationException Always thrown.
+     */
     override suspend fun embed(
         text: String,
         model: LLModel
     ): List<Double> {
-        TODO("Not yet implemented")
+        throw UnsupportedOperationException(
+            "Embedding is not supported by SpringAiLLMClient. Use SpringAiLLMEmbeddingProvider instead."
+        )
     }
 
+    /**
+     * Batch embedding via [SpringAiLLMClient] is not supported.
+     * Use `SpringAiLLMEmbeddingProvider` for embedding with Spring AI.
+     *
+     * @throws UnsupportedOperationException Always thrown.
+     */
     override suspend fun embed(
         inputs: List<String>,
         model: LLModel
     ): List<List<Double>> {
-        TODO("Not yet implemented")
+        throw UnsupportedOperationException(
+            "Embedding is not supported by SpringAiLLMClient. Use SpringAiLLMEmbeddingProvider instead."
+        )
     }
 }

--- a/koog-spring-ai/koog-spring-ai-starter-model-chat/src/main/kotlin/ai/koog/spring/ai/chat/SpringAiLLMClient.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-chat/src/main/kotlin/ai/koog/spring/ai/chat/SpringAiLLMClient.kt
@@ -329,4 +329,18 @@ public class SpringAiLLMClient(
 
         return chatOptionsCustomizer.customize(options, params, model)
     }
+
+    override suspend fun embed(
+        text: String,
+        model: LLModel
+    ): List<Double> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun embed(
+        inputs: List<String>,
+        model: LLModel
+    ): List<List<Double>> {
+        TODO("Not yet implemented")
+    }
 }

--- a/koog-spring-ai/koog-spring-ai-starter-model-embedding/src/main/kotlin/ai/koog/spring/ai/embedding/SpringAiLLMEmbeddingProvider.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-embedding/src/main/kotlin/ai/koog/spring/ai/embedding/SpringAiLLMEmbeddingProvider.kt
@@ -78,6 +78,17 @@ public class SpringAiLLMEmbeddingProvider(
         }
     }
 
+    /**
+     * Embeds the given text using the configured Spring AI [EmbeddingModel].
+     *
+     * The [LLModel.id] is forwarded to the underlying model via [EmbeddingOptions] so that
+     * backends supporting runtime model selection can honour it.
+     *
+     * @param text The text to embed.
+     * @param model The model to use for embedding; its [LLModel.id] is passed as an embedding option.
+     * @return A list of floating-point values representing the embedding vector.
+     * @throws LLMClientException if the underlying Spring AI call fails.
+     */
     override suspend fun embed(
         text: String,
         model: LLModel
@@ -97,6 +108,17 @@ public class SpringAiLLMEmbeddingProvider(
         }
     }
 
+    /**
+     * Embeds the given inputs using the configured Spring AI [EmbeddingModel].
+     *
+     * The [LLModel.id] is forwarded to the underlying model via [EmbeddingOptions] so that
+     * backends supporting runtime model selection can honour it.
+     *
+     * @param inputs The list of texts to embed.
+     * @param model The model to use for embedding; its [LLModel.id] is passed as an embedding option.
+     * @return A list of embedding vectors, one per input string.
+     * @throws LLMClientException if the underlying Spring AI call fails.
+     */
     override suspend fun embed(
         inputs: List<String>,
         model: LLModel

--- a/koog-spring-ai/koog-spring-ai-starter-model-embedding/src/main/kotlin/ai/koog/spring/ai/embedding/SpringAiLLMEmbeddingProvider.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-embedding/src/main/kotlin/ai/koog/spring/ai/embedding/SpringAiLLMEmbeddingProvider.kt
@@ -26,7 +26,7 @@ import org.springframework.ai.embedding.EmbeddingRequest
 public class SpringAiLLMEmbeddingProvider(
     private val embeddingModel: EmbeddingModel,
     private val dispatcher: CoroutineDispatcher,
-) : LLMEmbeddingProvider {
+) : LLMEmbeddingProvider() {
 
     /**
      * Java-friendly builder access.
@@ -90,6 +90,25 @@ public class SpringAiLLMEmbeddingProvider(
         )
         try {
             embeddingModel.call(request).result.output.map { it.toDouble() }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            throw LLMClientException("spring-ai-embedding", "EmbeddingModel.call() failed: ${e.message}", e)
+        }
+    }
+
+    override suspend fun embed(
+        inputs: List<String>,
+        model: LLModel
+    ): List<List<Double>> = withContext(dispatcher) {
+        val request = EmbeddingRequest(
+            inputs,
+            EmbeddingOptions.builder()
+                .model(model.id)
+                .build()
+        )
+        try {
+            embeddingModel.call(request).results.map { result -> result.output.map { it.toDouble() } }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
@@ -718,13 +718,6 @@ public open class AnthropicLLMClient @JvmOverloads constructor(
         return response.data.map { modelsById[it.id] ?: LLModel(id = it.id, provider = LLMProvider.Anthropic) }
     }
 
-    /**
-     * Attempts to moderate the content of a given prompt using a specific language model.
-     * This method is not supported by the Anthropic API and will always throw an exception.
-     *
-     * @return This method does not return a value as it always throws an exception.
-     * @throws UnsupportedOperationException Always thrown, as moderation is not supported by the Anthropic API.
-     */
     override fun getBasicJsonSchemaGenerator(): AnthropicBasicJsonSchemaGenerator {
         return AnthropicBasicJsonSchemaGenerator
     }
@@ -733,11 +726,21 @@ public open class AnthropicLLMClient @JvmOverloads constructor(
         return AnthropicStandardJsonSchemaGenerator
     }
 
+    /**
+     * Moderation is not supported by the Anthropic API.
+     *
+     * @throws UnsupportedOperationException Always thrown.
+     */
     public override suspend fun moderate(prompt: Prompt, model: LLModel): ModerationResult {
         logger.warn { "Moderation is not supported by Anthropic API" }
         throw UnsupportedOperationException("Moderation is not supported by Anthropic API.")
     }
 
+    /**
+     * Embedding is not supported by the Anthropic API.
+     *
+     * @throws UnsupportedOperationException Always thrown.
+     */
     override suspend fun embed(
         text: String,
         model: LLModel
@@ -746,6 +749,11 @@ public open class AnthropicLLMClient @JvmOverloads constructor(
         throw UnsupportedOperationException("Embedding is not supported by Anthropic API.")
     }
 
+    /**
+     * Batch embedding is not supported by the Anthropic API.
+     *
+     * @throws UnsupportedOperationException Always thrown.
+     */
     override suspend fun embed(
         inputs: List<String>,
         model: LLModel

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
@@ -722,8 +722,6 @@ public open class AnthropicLLMClient @JvmOverloads constructor(
      * Attempts to moderate the content of a given prompt using a specific language model.
      * This method is not supported by the Anthropic API and will always throw an exception.
      *
-     * @param prompt The prompt to be moderated, containing messages and optional configuration parameters.
-     * @param model The language model to use for moderation.
      * @return This method does not return a value as it always throws an exception.
      * @throws UnsupportedOperationException Always thrown, as moderation is not supported by the Anthropic API.
      */
@@ -738,6 +736,22 @@ public open class AnthropicLLMClient @JvmOverloads constructor(
     public override suspend fun moderate(prompt: Prompt, model: LLModel): ModerationResult {
         logger.warn { "Moderation is not supported by Anthropic API" }
         throw UnsupportedOperationException("Moderation is not supported by Anthropic API.")
+    }
+
+    override suspend fun embed(
+        text: String,
+        model: LLModel
+    ): List<Double> {
+        logger.warn { "Embedding is not supported by Anthropic API" }
+        throw UnsupportedOperationException("Embedding is not supported by Anthropic API.")
+    }
+
+    override suspend fun embed(
+        inputs: List<String>,
+        model: LLModel
+    ): List<List<Double>> {
+        logger.warn { "Embedding is not supported by Anthropic API" }
+        throw UnsupportedOperationException("Embedding is not supported by Anthropic API.")
     }
 
     override fun close() {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
@@ -8,7 +8,6 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.clients.LLMClientException
-import ai.koog.prompt.executor.clients.LLMEmbeddingProviderAPI
 import ai.koog.prompt.executor.clients.bedrock.converse.BedrockConverseConverters
 import ai.koog.prompt.executor.clients.bedrock.modelfamilies.BedrockAnthropicInvokeModel
 import ai.koog.prompt.executor.clients.bedrock.modelfamilies.amazon.BedrockAmazonNovaSerialization
@@ -139,7 +138,7 @@ public class BedrockLLMClient @JvmOverloads constructor(
     private val moderationGuardrailsSettings: BedrockGuardrailsSettings? = null,
     private val fallbackModelFamily: BedrockModelFamilies? = null,
     private val clock: Clock = Clock.System,
-) : LLMClient(), LLMEmbeddingProviderAPI {
+) : LLMClient() {
 
     private val logger = KotlinLogging.logger {}
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
@@ -498,6 +498,17 @@ public class BedrockLLMClient @JvmOverloads constructor(
         }.let { BedrockConverseConverters.transformConverseStreamChunks(it, clock) }
     }
 
+    /**
+     * Embeds the given text using the AWS Bedrock InvokeModel API.
+     *
+     * Supports Amazon Titan Embed (v1 and v2) and Cohere embedding model families.
+     *
+     * @param text The text to embed.
+     * @param model The model to use for embedding. Must have the [LLMCapability.Embed] capability.
+     * @return A list of floating-point values representing the embedding vector.
+     * @throws IllegalArgumentException if the model does not have the Embed capability.
+     * @throws LLMClientException if the model family does not support embeddings.
+     */
     override suspend fun embed(text: String, model: LLModel): List<Double> {
         model.requireCapability(LLMCapability.Embed)
 
@@ -549,6 +560,11 @@ public class BedrockLLMClient @JvmOverloads constructor(
         }
     }
 
+    /**
+     * Batch embedding is not currently supported by the Bedrock client.
+     *
+     * @throws UnsupportedOperationException Always thrown.
+     */
     override suspend fun embed(
         inputs: List<String>,
         model: LLModel

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
@@ -8,7 +8,7 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.clients.LLMClientException
-import ai.koog.prompt.executor.clients.LLMEmbeddingProvider
+import ai.koog.prompt.executor.clients.LLMEmbeddingProviderAPI
 import ai.koog.prompt.executor.clients.bedrock.converse.BedrockConverseConverters
 import ai.koog.prompt.executor.clients.bedrock.modelfamilies.BedrockAnthropicInvokeModel
 import ai.koog.prompt.executor.clients.bedrock.modelfamilies.amazon.BedrockAmazonNovaSerialization
@@ -139,7 +139,7 @@ public class BedrockLLMClient @JvmOverloads constructor(
     private val moderationGuardrailsSettings: BedrockGuardrailsSettings? = null,
     private val fallbackModelFamily: BedrockModelFamilies? = null,
     private val clock: Clock = Clock.System,
-) : LLMClient(), LLMEmbeddingProvider {
+) : LLMClient(), LLMEmbeddingProviderAPI {
 
     private val logger = KotlinLogging.logger {}
 
@@ -547,6 +547,14 @@ public class BedrockLLMClient @JvmOverloads constructor(
                 )
             }
         }
+    }
+
+    override suspend fun embed(
+        inputs: List<String>,
+        model: LLModel
+    ): List<List<Double>> {
+        logger.warn { "Currently batch embedding is not supported." }
+        throw UnsupportedOperationException("Currently batch embedding is not supported.")
     }
 
     private fun createRequestBody(prompt: Prompt, model: LLModel, tools: List<ToolDescriptor>): String {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/dashscope/DashscopeLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/dashscope/DashscopeLLMClient.kt
@@ -169,6 +169,11 @@ public class DashscopeLLMClient @JvmOverloads constructor(
         throw UnsupportedOperationException("Moderation is not supported by DashScope API.")
     }
 
+    /**
+     * Embedding is not supported by the DashScope API.
+     *
+     * @throws UnsupportedOperationException Always thrown.
+     */
     override suspend fun embed(
         text: String,
         model: LLModel
@@ -177,6 +182,11 @@ public class DashscopeLLMClient @JvmOverloads constructor(
         throw UnsupportedOperationException("Embedding is not supported by DashScope API.")
     }
 
+    /**
+     * Batch embedding is not supported by the DashScope API.
+     *
+     * @throws UnsupportedOperationException Always thrown.
+     */
     override suspend fun embed(
         inputs: List<String>,
         model: LLModel

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/dashscope/DashscopeLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/dashscope/DashscopeLLMClient.kt
@@ -168,4 +168,20 @@ public class DashscopeLLMClient @JvmOverloads constructor(
         logger.warn { "Moderation is not supported by DashScope API" }
         throw UnsupportedOperationException("Moderation is not supported by DashScope API.")
     }
+
+    override suspend fun embed(
+        text: String,
+        model: LLModel
+    ): List<Double> {
+        logger.warn { "Embedding is not supported by DashScope API" }
+        throw UnsupportedOperationException("Embedding is not supported by DashScope API.")
+    }
+
+    override suspend fun embed(
+        inputs: List<String>,
+        model: LLModel
+    ): List<List<Double>> {
+        logger.warn { "Embedding is not supported by DashScope API" }
+        throw UnsupportedOperationException("Embedding is not supported by DashScope API.")
+    }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
@@ -250,6 +250,11 @@ public class DeepSeekLLMClient @JvmOverloads constructor(
         return models.data.map { modelsById[it.id] ?: LLModel(provider = llmProvider(), id = it.id) }
     }
 
+    /**
+     * Embedding is not supported by the DeepSeek API.
+     *
+     * @throws UnsupportedOperationException Always thrown.
+     */
     override suspend fun embed(
         text: String,
         model: LLModel
@@ -258,6 +263,11 @@ public class DeepSeekLLMClient @JvmOverloads constructor(
         throw UnsupportedOperationException("Embedding is not supported by DeepSeek API.")
     }
 
+    /**
+     * Batch embedding is not supported by the DeepSeek API.
+     *
+     * @throws UnsupportedOperationException Always thrown.
+     */
     override suspend fun embed(
         inputs: List<String>,
         model: LLModel

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
@@ -249,4 +249,20 @@ public class DeepSeekLLMClient @JvmOverloads constructor(
 
         return models.data.map { modelsById[it.id] ?: LLModel(provider = llmProvider(), id = it.id) }
     }
+
+    override suspend fun embed(
+        text: String,
+        model: LLModel
+    ): List<Double> {
+        logger.warn { "Embedding is not supported by DeepSeek API" }
+        throw UnsupportedOperationException("Embedding is not supported by DeepSeek API.")
+    }
+
+    override suspend fun embed(
+        inputs: List<String>,
+        model: LLModel
+    ): List<List<Double>> {
+        logger.warn { "Embedding is not supported by DeepSeek API" }
+        throw UnsupportedOperationException("Embedding is not supported by DeepSeek API.")
+    }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -830,10 +830,14 @@ public open class GoogleLLMClient @JvmOverloads constructor(
         return models.map { id -> modelsById[id] ?: LLModel(provider = llmProvider(), id = id) }
     }
 
-    override fun close() {
-        httpClient.close()
-    }
-
+    /**
+     * Embeds the given text using the Google AI embeddings API.
+     *
+     * @param text The text to embed.
+     * @param model The model to use for embedding. Must have the [LLMCapability.Embed] capability.
+     * @return A list of floating-point values representing the embedding vector.
+     * @throws IllegalArgumentException if the model does not have the Embed capability.
+     */
     override suspend fun embed(text: String, model: LLModel): List<Double> {
         require(model.supports(LLMCapability.Embed)) {
             "Model ${model.id} does not support embedding."
@@ -868,6 +872,14 @@ public open class GoogleLLMClient @JvmOverloads constructor(
         }
     }
 
+    /**
+     * Embeds the given inputs using the Google AI batch embeddings API.
+     *
+     * @param inputs The list of texts to embed.
+     * @param model The model to use for embedding. Must have the [LLMCapability.Embed] capability.
+     * @return A list of embedding vectors, one per input string.
+     * @throws IllegalArgumentException if the model does not have the Embed capability.
+     */
     override suspend fun embed(inputs: List<String>, model: LLModel): List<List<Double>> {
         require(model.supports(LLMCapability.Embed)) {
             "Model ${model.id} does not support embedding."
@@ -902,5 +914,9 @@ public open class GoogleLLMClient @JvmOverloads constructor(
                 cause = e
             )
         }
+    }
+
+    override fun close() {
+        httpClient.close()
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -76,6 +76,7 @@ public class GoogleClientSettings(
     public val generateContentMethod: String = "generateContent",
     public val streamGenerateContentMethod: String = "streamGenerateContent",
     public val embedContentMethod: String = "embedContent",
+    public val batchEmbedContentsMethod: String = "batchEmbedContents",
     public val fallbackThoughtSignature: String = "context_engineering_is_the_way_to_go",
 )
 
@@ -888,17 +889,19 @@ public open class GoogleLLMClient @JvmOverloads constructor(
         logger.debug { "Embedding input with model: ${model.id}" }
 
         val request = GoogleEmbeddingBatchRequest(
-            model = "models/${model.id}",
             requests = inputs.map {
-                GoogleContent(
-                    parts = listOf(GooglePart.Text(it))
+                GoogleEmbeddingRequest(
+                    model = "models/${model.id}",
+                    content = GoogleContent(
+                        parts = listOf(GooglePart.Text(it))
+                    )
                 )
             }
         )
 
         try {
             val response = httpClient.post(
-                path = "${settings.defaultPath}/${model.id}:${settings.embedContentMethod}",
+                path = "${settings.defaultPath}/${model.id}:${settings.batchEmbedContentsMethod}",
                 request = request,
                 requestBodyType = GoogleEmbeddingBatchRequest::class,
                 responseType = GoogleEmbeddingBatchResponse::class,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -10,10 +10,11 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.clients.LLMClientException
-import ai.koog.prompt.executor.clients.LLMEmbeddingProvider
 import ai.koog.prompt.executor.clients.google.models.GoogleCandidate
 import ai.koog.prompt.executor.clients.google.models.GoogleContent
 import ai.koog.prompt.executor.clients.google.models.GoogleData
+import ai.koog.prompt.executor.clients.google.models.GoogleEmbeddingBatchRequest
+import ai.koog.prompt.executor.clients.google.models.GoogleEmbeddingBatchResponse
 import ai.koog.prompt.executor.clients.google.models.GoogleEmbeddingRequest
 import ai.koog.prompt.executor.clients.google.models.GoogleEmbeddingResponse
 import ai.koog.prompt.executor.clients.google.models.GoogleFunctionCallingConfig
@@ -94,7 +95,7 @@ public open class GoogleLLMClient @JvmOverloads constructor(
     private val settings: GoogleClientSettings = GoogleClientSettings(),
     private val httpClient: KoogHttpClient,
     private val clock: Clock = Clock.System
-) : LLMClient(), LLMEmbeddingProvider {
+) : LLMClient() {
 
     /**
      * Secondary constructor for creating a GoogleLLMClient backed with a Ktor HTTP client.
@@ -856,6 +857,42 @@ public open class GoogleLLMClient @JvmOverloads constructor(
             )
 
             return response.embedding.values
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            throw LLMClientException(
+                clientName = clientName,
+                message = e.message,
+                cause = e
+            )
+        }
+    }
+
+    override suspend fun embed(inputs: List<String>, model: LLModel): List<List<Double>> {
+        require(model.supports(LLMCapability.Embed)) {
+            "Model ${model.id} does not support embedding."
+        }
+
+        logger.debug { "Embedding input with model: ${model.id}" }
+
+        val request = GoogleEmbeddingBatchRequest(
+            model = "models/${model.id}",
+            requests = inputs.map {
+                GoogleContent(
+                    parts = listOf(GooglePart.Text(it))
+                )
+            }
+        )
+
+        try {
+            val response = httpClient.post(
+                path = "${settings.defaultPath}/${model.id}:${settings.embedContentMethod}",
+                request = request,
+                requestBodyType = GoogleEmbeddingBatchRequest::class,
+                responseType = GoogleEmbeddingBatchResponse::class,
+            )
+
+            return response.embeddings.map { it.values }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/models/GoogleEmbedding.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/models/GoogleEmbedding.kt
@@ -14,6 +14,17 @@ internal data class GoogleEmbeddingResponse(
 )
 
 @Serializable
+internal data class GoogleEmbeddingBatchRequest(
+    val model: String,
+    val requests: List<GoogleContent>
+)
+
+@Serializable
+internal data class GoogleEmbeddingBatchResponse(
+    val embeddings: List<GoogleEmbeddingData>
+)
+
+@Serializable
 internal data class GoogleEmbeddingData(
     val values: List<Double>
 )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/models/GoogleEmbedding.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/models/GoogleEmbedding.kt
@@ -15,8 +15,7 @@ internal data class GoogleEmbeddingResponse(
 
 @Serializable
 internal data class GoogleEmbeddingBatchRequest(
-    val model: String,
-    val requests: List<GoogleContent>
+    val requests: List<GoogleEmbeddingRequest>
 )
 
 @Serializable

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAILLMClient.kt
@@ -50,8 +50,10 @@ import kotlin.time.Clock
  *
  * @property baseUrl The base URL of the Mistral AI API. Defaults to "https://api.mistral.ai".
  * @property chatCompletionsPath The path of the Mistral AI Chat Completions API. Defaults to "v1/chat/completions".
- * @property timeoutConfig Configuration for connection timeouts, including request, connect, and socket timeouts.
+ * @property embeddingsPath The path of the Mistral AI Embeddings API. Defaults to "v1/embeddings".
+ * @property moderationPath The path of the Mistral AI Moderations API. Defaults to "v1/moderations".
  * @property modelsPath The path of the Mistral AI Models API. Defaults to "v1/models".
+ * @property timeoutConfig Configuration for connection timeouts, including request, connect, and socket timeouts.
  */
 public class MistralAIClientSettings(
     baseUrl: String = "https://api.mistral.ai",
@@ -217,6 +219,14 @@ public open class MistralAILLMClient @JvmOverloads constructor(
         return embed(listOf(text), model).first()
     }
 
+    /**
+     * Embeds the given inputs using the MistralAI embeddings API.
+     *
+     * @param inputs The list of texts to embed.
+     * @param model The model to use for embedding. Must have the [LLMCapability.Embed] capability.
+     * @return A list of embedding vectors, one per input string.
+     * @throws IllegalArgumentException if the model does not have the Embed capability.
+     */
     override suspend fun embed(
         inputs: List<String>,
         model: LLModel

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAILLMClient.kt
@@ -8,7 +8,7 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.clients.LLMClientException
-import ai.koog.prompt.executor.clients.LLMEmbeddingProvider
+import ai.koog.prompt.executor.clients.LLMEmbeddingProviderAPI
 import ai.koog.prompt.executor.clients.mistralai.models.MistralAIChatCompletionRequest
 import ai.koog.prompt.executor.clients.mistralai.models.MistralAIChatCompletionRequestSerializer
 import ai.koog.prompt.executor.clients.mistralai.models.MistralAIChatCompletionResponse
@@ -82,7 +82,7 @@ public open class MistralAILLMClient @JvmOverloads constructor(
     logger = staticLogger,
     toolsConverter = toolsConverter,
 ),
-    LLMEmbeddingProvider {
+    LLMEmbeddingProviderAPI {
 
     @JvmOverloads
     public constructor(
@@ -214,11 +214,18 @@ public open class MistralAILLMClient @JvmOverloads constructor(
      * @throws IllegalArgumentException if the model does not have the Embed capability.
      */
     override suspend fun embed(text: String, model: LLModel): List<Double> {
+        return embed(listOf(text), model).first()
+    }
+
+    override suspend fun embed(
+        inputs: List<String>,
+        model: LLModel
+    ): List<List<Double>> {
         model.requireCapability(LLMCapability.Embed)
 
         logger.debug { "Embedding text with model: ${model.id}" }
 
-        val request = MistralAIEmbeddingRequest(model = model.id, input = text)
+        val request = MistralAIEmbeddingRequest(model = model.id, inputs = inputs)
 
         val mistralAIResponse = try {
             httpClient.post(
@@ -237,11 +244,10 @@ public open class MistralAILLMClient @JvmOverloads constructor(
             )
         }
 
-        return mistralAIResponse.data.firstOrNull()?.embedding ?: run {
-            val exception = LLMClientException(clientName, "Empty data in MistralAI embedding response")
-            logger.error(exception) { exception.message }
-            throw exception
-        }
+        val result = mistralAIResponse.data.map { it.embedding }
+        require(inputs.size == result.size) { "The size of input list and embedding result must match" }
+
+        return result
     }
 
     /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAILLMClient.kt
@@ -235,7 +235,7 @@ public open class MistralAILLMClient @JvmOverloads constructor(
 
         logger.debug { "Embedding text with model: ${model.id}" }
 
-        val request = MistralAIEmbeddingRequest(model = model.id, inputs = inputs)
+        val request = MistralAIEmbeddingRequest(model = model.id, input = inputs)
 
         val mistralAIResponse = try {
             httpClient.post(

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/MistralAILLMClient.kt
@@ -8,7 +8,6 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.clients.LLMClientException
-import ai.koog.prompt.executor.clients.LLMEmbeddingProviderAPI
 import ai.koog.prompt.executor.clients.mistralai.models.MistralAIChatCompletionRequest
 import ai.koog.prompt.executor.clients.mistralai.models.MistralAIChatCompletionRequestSerializer
 import ai.koog.prompt.executor.clients.mistralai.models.MistralAIChatCompletionResponse
@@ -83,8 +82,7 @@ public open class MistralAILLMClient @JvmOverloads constructor(
     clock = clock,
     logger = staticLogger,
     toolsConverter = toolsConverter,
-),
-    LLMEmbeddingProviderAPI {
+) {
 
     @JvmOverloads
     public constructor(

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/models/MistralAIEmbedding.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/models/MistralAIEmbedding.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
  * Request for Mistral AI embeddings
  *
  * @property model ID of the model to use.
- * @property input Text to embed
+ * @property inputs The list of texts to embed
  * @property outputDimension The dimension of the output embeddings.
  * @property outputDtype Default: "float"
  * Enum: "float" "int8" "uint8" "binary" "ubinary"
@@ -16,7 +16,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 internal data class MistralAIEmbeddingRequest(
     val model: String,
-    val input: String,
+    val inputs: List<String>,
     val outputDimension: Int? = null,
     val outputDtype: MistralAIEmbeddingDtype? = null
 )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/models/MistralAIEmbedding.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/mistralai/models/MistralAIEmbedding.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
  * Request for Mistral AI embeddings
  *
  * @property model ID of the model to use.
- * @property inputs The list of texts to embed
+ * @property input The list of texts to embed
  * @property outputDimension The dimension of the output embeddings.
  * @property outputDtype Default: "float"
  * Enum: "float" "int8" "uint8" "binary" "ubinary"
@@ -16,7 +16,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 internal data class MistralAIEmbeddingRequest(
     val model: String,
-    val inputs: List<String>,
+    val input: List<String>,
     val outputDimension: Int? = null,
     val outputDtype: MistralAIEmbeddingDtype? = null
 )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -11,6 +11,9 @@ import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.clients.LLMClientException
 import ai.koog.prompt.executor.clients.LLMEmbeddingProvider
+import ai.koog.prompt.executor.clients.LLMEmbeddingProviderAPI
+import ai.koog.prompt.executor.ollama.client.dto.EmbeddingBatchRequestDTO
+import ai.koog.prompt.executor.ollama.client.dto.EmbeddingBatchResponseDTO
 import ai.koog.prompt.executor.ollama.client.dto.EmbeddingRequestDTO
 import ai.koog.prompt.executor.ollama.client.dto.EmbeddingResponseDTO
 import ai.koog.prompt.executor.ollama.client.dto.OllamaChatRequestDTO
@@ -82,7 +85,7 @@ public class OllamaClient @JvmOverloads constructor(
     private val clock: Clock = Clock.System,
     private val contextWindowStrategy: ContextWindowStrategy = ContextWindowStrategy.Companion.None,
     private val toolDescriptorConverter: ToolDescriptorSchemaGenerator = OllamaToolDescriptorSchemaGenerator()
-) : LLMClient(), LLMEmbeddingProvider {
+) : LLMClient(), LLMEmbeddingProviderAPI {
 
     private companion object {
         private val logger = KotlinLogging.logger { }
@@ -353,7 +356,7 @@ public class OllamaClient @JvmOverloads constructor(
         }
 
         val response = client.post(DEFAULT_EMBEDDINGS_PATH) {
-            setBody(EmbeddingRequestDTO(model = model.id, prompt = text))
+            setBody(EmbeddingRequestDTO(model = model.id, input = text))
         }
 
         if (!response.status.isSuccess()) {
@@ -365,7 +368,25 @@ public class OllamaClient @JvmOverloads constructor(
         }
 
         val embeddingResponse = response.body<EmbeddingResponseDTO>()
-        return embeddingResponse.embedding
+        return embeddingResponse.embeddings
+    }
+
+    override suspend fun embed(
+        inputs: List<String>,
+        model: LLModel
+    ): List<List<Double>> {
+        require(model.provider == LLMProvider.Ollama) { "Model not supported by Ollama" }
+
+        if (!model.supports(LLMCapability.Embed)) {
+            throw LLMClientException(clientName, "Model ${model.id} does not have the Embed capability")
+        }
+
+        val response = client.post(DEFAULT_EMBEDDINGS_PATH) {
+            setBody(EmbeddingBatchRequestDTO(model = model.id, input = inputs))
+        }
+
+        val embeddingResponse = response.body<EmbeddingBatchResponseDTO>()
+        return embeddingResponse.embeddings
     }
 
     /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -371,6 +371,15 @@ public class OllamaClient @JvmOverloads constructor(
         return embeddingResponse.embeddings
     }
 
+    /**
+     * Embeds the given inputs using the Ollama embeddings API.
+     *
+     * @param inputs The list of texts to embed.
+     * @param model The model to use for embedding. Must have the [LLMCapability.Embed] capability
+     *   and belong to [LLMProvider.Ollama].
+     * @return A list of embedding vectors, one per input string.
+     * @throws LLMClientException if the model does not have the Embed capability.
+     */
     override suspend fun embed(
         inputs: List<String>,
         model: LLModel

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -11,7 +11,6 @@ import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.clients.LLMClientException
 import ai.koog.prompt.executor.clients.LLMEmbeddingProvider
-import ai.koog.prompt.executor.clients.LLMEmbeddingProviderAPI
 import ai.koog.prompt.executor.ollama.client.dto.EmbeddingBatchRequestDTO
 import ai.koog.prompt.executor.ollama.client.dto.EmbeddingBatchResponseDTO
 import ai.koog.prompt.executor.ollama.client.dto.EmbeddingRequestDTO
@@ -85,7 +84,7 @@ public class OllamaClient @JvmOverloads constructor(
     private val clock: Clock = Clock.System,
     private val contextWindowStrategy: ContextWindowStrategy = ContextWindowStrategy.Companion.None,
     private val toolDescriptorConverter: ToolDescriptorSchemaGenerator = OllamaToolDescriptorSchemaGenerator()
-) : LLMClient(), LLMEmbeddingProviderAPI {
+) : LLMClient() {
 
     private companion object {
         private val logger = KotlinLogging.logger { }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaModels.kt
@@ -102,12 +102,12 @@ internal data class OllamaErrorResponseDTO(val error: String)
  * The request includes the model to be used and the prompt text for which the embedding is to be generated.
  *
  * @property model The identifier of the model to be used for generating the embedding.
- * @property prompt The input text for which the embedding is to be generated.
+ * @property input The input text for which the embedding is to be generated.
  */
 @Serializable
-internal data class EmbeddingRequestDTO(
+internal data class EmbeddingBatchRequestDTO(
     val model: String,
-    val prompt: String
+    val input: List<String>
 )
 
 /**
@@ -116,13 +116,43 @@ internal data class EmbeddingRequestDTO(
  * This class is used for deserializing responses containing vector embeddings that may be
  * associated with a specific model.
  *
- * @property embedding The list of double values representing the computed embedding or vector.
+ * @property embeddings The list of list double values representing the computed embedding or vector for each input.
+ *                     Each value corresponds to a specific dimension in the generated embedding space.
+ * @property modelId An optional identifier for the model that generated the embedding.
+ */
+@Serializable
+internal data class EmbeddingBatchResponseDTO(
+    val embeddings: List<List<Double>>,
+    @SerialName("model") val modelId: String? = null
+)
+
+/**
+ * Represents a request to generate an embedding using a specific model.
+ *
+ * The request includes the model to be used and the prompt text for which the embedding is to be generated.
+ *
+ * @property model The identifier of the model to be used for generating the embedding.
+ * @property input The input text for which the embedding is to be generated.
+ */
+@Serializable
+internal data class EmbeddingRequestDTO(
+    val model: String,
+    val input: String
+)
+
+/**
+ * Represents the response for an embedding operation, containing the result of the operation.
+ *
+ * This class is used for deserializing responses containing vector embeddings that may be
+ * associated with a specific model.
+ *
+ * @property embeddings The list of list double values representing the computed embedding or vector for each input.
  *                     Each value corresponds to a specific dimension in the generated embedding space.
  * @property modelId An optional identifier for the model that generated the embedding.
  */
 @Serializable
 internal data class EmbeddingResponseDTO(
-    val embedding: List<Double>,
+    val embeddings: List<Double>,
     @SerialName("model") val modelId: String? = null
 )
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -9,7 +9,7 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.clients.LLMClientException
-import ai.koog.prompt.executor.clients.LLMEmbeddingProvider
+import ai.koog.prompt.executor.clients.LLMEmbeddingProviderAPI
 import ai.koog.prompt.executor.clients.modelsById
 import ai.koog.prompt.executor.clients.openai.base.AbstractOpenAILLMClient
 import ai.koog.prompt.executor.clients.openai.base.OpenAIBaseSettings
@@ -113,7 +113,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
     logger = staticLogger,
     toolsConverter = toolsConverter
 ),
-    LLMEmbeddingProvider {
+    LLMEmbeddingProviderAPI {
 
     @JvmOverloads
     public constructor(
@@ -527,6 +527,11 @@ public open class OpenAILLMClient @JvmOverloads constructor(
             throw exception
         }
         return openAIResponse.data.first().embedding
+    }
+
+    override suspend fun embed(inputs: List<String>, model: LLModel): List<List<Double>> {
+        logger.warn { "Batch embedding is not supported by OpenAI API" }
+        throw UnsupportedOperationException("Batch embedding is not supported by OpenAI API.")
     }
 
     /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -529,6 +529,11 @@ public open class OpenAILLMClient @JvmOverloads constructor(
         return openAIResponse.data.first().embedding
     }
 
+    /**
+     * Batch embedding is not supported by the OpenAI API.
+     *
+     * @throws UnsupportedOperationException Always thrown.
+     */
     override suspend fun embed(inputs: List<String>, model: LLModel): List<List<Double>> {
         logger.warn { "Batch embedding is not supported by OpenAI API" }
         throw UnsupportedOperationException("Batch embedding is not supported by OpenAI API.")

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -9,7 +9,6 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.clients.LLMClientException
-import ai.koog.prompt.executor.clients.LLMEmbeddingProviderAPI
 import ai.koog.prompt.executor.clients.modelsById
 import ai.koog.prompt.executor.clients.openai.base.AbstractOpenAILLMClient
 import ai.koog.prompt.executor.clients.openai.base.OpenAIBaseSettings
@@ -112,8 +111,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
     clock = clock,
     logger = staticLogger,
     toolsConverter = toolsConverter
-),
-    LLMEmbeddingProviderAPI {
+) {
 
     @JvmOverloads
     public constructor(

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
@@ -224,6 +224,14 @@ public class OpenRouterLLMClient @JvmOverloads constructor(
         return models.data.map { modelsById[it.id] ?: LLModel(provider = llmProvider(), id = it.id) }
     }
 
+    /**
+     * Embeds the given text using the OpenRouter embeddings API.
+     *
+     * @param text The text to embed.
+     * @param model The model to use for embedding. Must have the [LLMCapability.Embed] capability.
+     * @return A list of floating-point values representing the embedding vector.
+     * @throws IllegalArgumentException if the model does not have the Embed capability.
+     */
     override suspend fun embed(text: String, model: LLModel): List<Double> {
         model.requireCapability(LLMCapability.Embed)
         logger.debug { "Embedding text (${text.length} chars) with model: ${model.id}" }
@@ -259,6 +267,11 @@ public class OpenRouterLLMClient @JvmOverloads constructor(
         return embedding
     }
 
+    /**
+     * Batch embedding is not supported by the OpenRouter API.
+     *
+     * @throws UnsupportedOperationException Always thrown.
+     */
     override suspend fun embed(
         inputs: List<String>,
         model: LLModel

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
@@ -6,7 +6,6 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.clients.LLMClientException
-import ai.koog.prompt.executor.clients.LLMEmbeddingProviderAPI
 import ai.koog.prompt.executor.clients.modelsById
 import ai.koog.prompt.executor.clients.openai.base.AbstractOpenAILLMClient
 import ai.koog.prompt.executor.clients.openai.base.OpenAIBaseSettings
@@ -75,8 +74,7 @@ public class OpenRouterLLMClient @JvmOverloads constructor(
     clock = clock,
     logger = staticLogger,
     toolsConverter = toolsConverter
-),
-    LLMEmbeddingProviderAPI {
+) {
 
     @JvmOverloads
     public constructor(

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
@@ -6,7 +6,7 @@ import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.clients.LLMClientException
-import ai.koog.prompt.executor.clients.LLMEmbeddingProvider
+import ai.koog.prompt.executor.clients.LLMEmbeddingProviderAPI
 import ai.koog.prompt.executor.clients.modelsById
 import ai.koog.prompt.executor.clients.openai.base.AbstractOpenAILLMClient
 import ai.koog.prompt.executor.clients.openai.base.OpenAIBaseSettings
@@ -76,7 +76,7 @@ public class OpenRouterLLMClient @JvmOverloads constructor(
     logger = staticLogger,
     toolsConverter = toolsConverter
 ),
-    LLMEmbeddingProvider {
+    LLMEmbeddingProviderAPI {
 
     @JvmOverloads
     public constructor(
@@ -257,5 +257,13 @@ public class OpenRouterLLMClient @JvmOverloads constructor(
         val embedding = response.data.first().embedding
         logger.debug { "Received embedding with ${embedding.size} dimensions" }
         return embedding
+    }
+
+    override suspend fun embed(
+        inputs: List<String>,
+        model: LLModel
+    ): List<List<Double>> {
+        logger.warn { "Batch embedding is not supported by OpenRouter API" }
+        throw UnsupportedOperationException("Batch embedding is not supported by OpenRouter API.")
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/models/OpenRouterEmbedding.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/models/OpenRouterEmbedding.kt
@@ -18,6 +18,12 @@ internal data class OpenRouterEmbeddingResponse(
 )
 
 @Serializable
+internal data class OpenRouterEmbeddingBatchRequest(
+    val model: String,
+    val input: List<String>
+)
+
+@Serializable
 internal data class OpenRouterEmbeddingData(
     val embedding: List<Double>,
     val index: Int

--- a/prompt/prompt-executor/prompt-executor-clients/src/androidMain/kotlin/ai/koog/prompt/executor/clients/LLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/androidMain/kotlin/ai/koog/prompt/executor/clients/LLMClient.kt
@@ -8,4 +8,4 @@ package ai.koog.prompt.executor.clients
  *
  * Implements [AutoCloseable] as LLM clients typically work with IO resources. Always close it when finished.
  */
-public actual abstract class LLMClient actual constructor() : LLMClientAPI
+public actual abstract class LLMClient actual constructor() : LLMClientAPI, LLMEmbeddingProviderAPI

--- a/prompt/prompt-executor/prompt-executor-clients/src/androidMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/androidMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
@@ -6,4 +6,4 @@ package ai.koog.prompt.executor.clients
  * Extension of the LLMClient interface which includes functionality for generating text embeddings
  * in addition to executing prompts and streaming outputs.
  */
-public expect abstract class LLMEmbeddingProvider() : LLMEmbeddingProviderAPI
+public actual abstract class LLMEmbeddingProvider actual constructor() : LLMEmbeddingProviderAPI

--- a/prompt/prompt-executor/prompt-executor-clients/src/androidMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/androidMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
@@ -3,7 +3,9 @@
 package ai.koog.prompt.executor.clients
 
 /**
- * Extension of the LLMClient interface which includes functionality for generating text embeddings
- * in addition to executing prompts and streaming outputs.
+ * Abstract base class for LLM embedding providers on Android.
+ *
+ * Implements [LLMEmbeddingProviderAPI]. Platform-specific blocking wrappers are not available on
+ * this target; use the suspending [embed] methods from [LLMEmbeddingProviderAPI] directly.
  */
 public actual abstract class LLMEmbeddingProvider actual constructor() : LLMEmbeddingProviderAPI

--- a/prompt/prompt-executor/prompt-executor-clients/src/appleMain/kotlin/ai/koog/prompt/executor/clients/LLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/appleMain/kotlin/ai/koog/prompt/executor/clients/LLMClient.kt
@@ -8,4 +8,4 @@ package ai.koog.prompt.executor.clients
  *
  * Implements [AutoCloseable] as LLM clients typically work with IO resources. Always close it when finished.
  */
-public actual abstract class LLMClient actual constructor() : LLMClientAPI
+public actual abstract class LLMClient actual constructor() : LLMClientAPI, LLMEmbeddingProviderAPI

--- a/prompt/prompt-executor/prompt-executor-clients/src/appleMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/appleMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
@@ -6,4 +6,4 @@ package ai.koog.prompt.executor.clients
  * Extension of the LLMClient interface which includes functionality for generating text embeddings
  * in addition to executing prompts and streaming outputs.
  */
-public expect abstract class LLMEmbeddingProvider() : LLMEmbeddingProviderAPI
+public actual abstract class LLMEmbeddingProvider actual constructor() : LLMEmbeddingProviderAPI

--- a/prompt/prompt-executor/prompt-executor-clients/src/appleMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/appleMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
@@ -3,7 +3,9 @@
 package ai.koog.prompt.executor.clients
 
 /**
- * Extension of the LLMClient interface which includes functionality for generating text embeddings
- * in addition to executing prompts and streaming outputs.
+ * Abstract base class for LLM embedding providers on Apple platforms.
+ *
+ * Implements [LLMEmbeddingProviderAPI]. Platform-specific blocking wrappers are not available on
+ * this target; use the suspending [embed] methods from [LLMEmbeddingProviderAPI] directly.
  */
 public actual abstract class LLMEmbeddingProvider actual constructor() : LLMEmbeddingProviderAPI

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/LLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/LLMClient.kt
@@ -8,4 +8,4 @@ package ai.koog.prompt.executor.clients
  *
  * Implements [AutoCloseable] as LLM clients typically work with IO resources. Always close it when finished.
  */
-public expect abstract class LLMClient() : LLMClientAPI
+public expect abstract class LLMClient() : LLMClientAPI, LLMEmbeddingProviderAPI

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
@@ -3,7 +3,10 @@
 package ai.koog.prompt.executor.clients
 
 /**
- * Extension of the LLMClient interface which includes functionality for generating text embeddings
- * in addition to executing prompts and streaming outputs.
+ * Abstract base class for LLM embedding providers.
+ *
+ * Implements [LLMEmbeddingProviderAPI] and, on JVM platforms, also exposes blocking Java-friendly
+ * wrapper methods (`embedBlocking`) so that Java callers can invoke embedding without dealing with
+ * Kotlin coroutines directly.
  */
 public expect abstract class LLMEmbeddingProvider() : LLMEmbeddingProviderAPI

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProviderAPI.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProviderAPI.kt
@@ -1,0 +1,29 @@
+package ai.koog.prompt.executor.clients
+
+import ai.koog.prompt.llm.LLModel
+
+/**
+ * API for [LLMEmbeddingProvider]
+ */
+public interface LLMEmbeddingProviderAPI {
+    /**
+     * Embeds the given text using the given model into a vector of double-precision numbers.
+     *
+     * @param text The text to embed.
+     * @param model The model to use for embedding. Must have the Embed capability.
+     * @return A list of floating-point values representing the embedding.
+     * @throws IllegalArgumentException if the model does not have the Embed capability.
+     */
+    public suspend fun embed(text: String, model: LLModel): List<Double>
+
+    /**
+     * Embeds the given input using the given model into a vector of double-precision numbers.
+     *
+     * @param inputs The input to embed.
+     * @param model The model to use for embedding. Must have the Embed capability.
+     * @return A list of lists of floating-point values representing the embedding.
+     * Each inner list represents a single input embedding.
+     * @throws IllegalArgumentException if the model does not have the Embed capability.
+     */
+    public suspend fun embed(inputs: List<String>, model: LLModel): List<List<Double>>
+}

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProviderAPI.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProviderAPI.kt
@@ -14,7 +14,9 @@ public interface LLMEmbeddingProviderAPI {
      * @return A list of floating-point values representing the embedding.
      * @throws IllegalArgumentException if the model does not have the Embed capability.
      */
-    public suspend fun embed(text: String, model: LLModel): List<Double>
+    public suspend fun embed(text: String, model: LLModel): List<Double> {
+        throw UnsupportedOperationException("Not implemented for this client")
+    }
 
     /**
      * Embeds the given input using the given model into a vector of double-precision numbers.
@@ -25,5 +27,7 @@ public interface LLMEmbeddingProviderAPI {
      * Each inner list represents a single input embedding.
      * @throws IllegalArgumentException if the model does not have the Embed capability.
      */
-    public suspend fun embed(inputs: List<String>, model: LLModel): List<List<Double>>
+    public suspend fun embed(inputs: List<String>, model: LLModel): List<List<Double>> {
+        throw UnsupportedOperationException("Not implemented for this client")
+    }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClient.kt
@@ -120,6 +120,20 @@ public class RetryingLLMClient @JvmOverloads constructor(
         delegate.models()
     }
 
+    override suspend fun embed(
+        text: String,
+        model: LLModel
+    ): List<Double> = withRetry("embed") {
+        delegate.embed(text, model)
+    }
+
+    override suspend fun embed(
+        inputs: List<String>,
+        model: LLModel
+    ): List<List<Double>> = withRetry("embed") {
+        delegate.embed(inputs, model)
+    }
+
     private suspend fun <T> withRetry(
         operation: String,
         block: suspend () -> T

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClient.kt
@@ -120,6 +120,13 @@ public class RetryingLLMClient @JvmOverloads constructor(
         delegate.models()
     }
 
+    /**
+     * Embeds the given text, retrying on transient failures according to [config].
+     *
+     * @param text The text to embed.
+     * @param model The model to use for embedding.
+     * @return A list of floating-point values representing the embedding vector.
+     */
     override suspend fun embed(
         text: String,
         model: LLModel
@@ -127,6 +134,13 @@ public class RetryingLLMClient @JvmOverloads constructor(
         delegate.embed(text, model)
     }
 
+    /**
+     * Embeds the given inputs, retrying on transient failures according to [config].
+     *
+     * @param inputs The list of texts to embed.
+     * @param model The model to use for embedding.
+     * @return A list of embedding vectors, one per input string.
+     */
     override suspend fun embed(
         inputs: List<String>,
         model: LLModel

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClientTest.kt
@@ -386,6 +386,73 @@ class RetryingLLMClientTest {
     }
 
     @Test
+    fun testRetryEmbed() = runTest {
+        val expectedEmbedding = listOf(0.1, 0.2, 0.3)
+
+        val mockClient = MockLLMClient(
+            embedResponse = expectedEmbedding,
+            failuresBeforeSuccess = 1,
+            failureMessage = "Error: 503"
+        )
+
+        val retryingClient = RetryingLLMClient(
+            mockClient,
+            RetryConfig(
+                maxAttempts = 2,
+                initialDelay = 10.milliseconds
+            )
+        )
+
+        val result = retryingClient.embed("hello", testModel)
+
+        assertEquals(expectedEmbedding, result)
+        assertEquals(2, mockClient.embedCalls)
+    }
+
+    @Test
+    fun testRetryBatchEmbed() = runTest {
+        val expectedEmbeddings = listOf(listOf(0.1, 0.2), listOf(0.3, 0.4))
+
+        val mockClient = MockLLMClient(
+            batchEmbedResponse = expectedEmbeddings,
+            failuresBeforeSuccess = 1,
+            failureMessage = "Error: 429"
+        )
+
+        val retryingClient = RetryingLLMClient(
+            mockClient,
+            RetryConfig(
+                maxAttempts = 2,
+                initialDelay = 10.milliseconds
+            )
+        )
+
+        val result = retryingClient.embed(listOf("hello", "world"), testModel)
+
+        assertEquals(expectedEmbeddings, result)
+        assertEquals(2, mockClient.batchEmbedCalls)
+    }
+
+    @Test
+    fun testEmbedNoRetryOnUnsupportedOperation() = runTest {
+        val mockClient = MockLLMClient(
+            failuresBeforeSuccess = 1,
+            failureMessage = "Error: 400 Bad Request"
+        )
+
+        val retryingClient = RetryingLLMClient(
+            mockClient,
+            RetryConfig(maxAttempts = 3)
+        )
+
+        assertFailsWith<RuntimeException> {
+            retryingClient.embed("hello", testModel)
+        }
+
+        assertEquals(1, mockClient.embedCalls) // No retry on non-retryable error
+    }
+
+    @Test
     fun testIncompleteStreamExceptionBeforeFirstFrameTriggersRetry() = runTest {
         var callCount = 0
         val mockClient = MockLLMClient(

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonTest/kotlin/ai/koog/prompt/executor/clients/retry/RetryingLLMClientTest.kt
@@ -446,6 +446,8 @@ class RetryingLLMClientTest {
         private val streamResponse: Flow<StreamFrame> = flowOf(),
         private val multipleChoicesResponse: List<LLMChoice> = emptyList(),
         private val moderateResponse: ModerationResult = ModerationResult(false, emptyMap()),
+        private val embedResponse: List<Double> = emptyList(),
+        private val batchEmbedResponse: List<List<Double>> = emptyList(),
         private var failuresBeforeSuccess: Int = 0,
         private var streamFailuresBeforeSuccess: Int = 0,
         private val failureMessage: String = "Mock failure",
@@ -457,11 +459,15 @@ class RetryingLLMClientTest {
         var streamCalls = 0
         var multipleChoicesCalls = 0
         var moderateCalls = 0
+        var embedCalls = 0
+        var batchEmbedCalls = 0
 
         private var executeFailures = 0
         private var streamFailures = 0
         private var multipleChoicesFailures = 0
         private var moderateFailures = 0
+        private var embedFailures = 0
+        private var batchEmbedFailures = 0
 
         override fun llmProvider(): LLMProvider = llmProvider
 
@@ -523,6 +529,34 @@ class RetryingLLMClientTest {
             }
 
             return moderateResponse
+        }
+
+        override suspend fun embed(
+            text: String,
+            model: LLModel
+        ): List<Double> {
+            embedCalls++
+
+            if (embedFailures < failuresBeforeSuccess) {
+                embedFailures++
+                throw RuntimeException(failureMessage)
+            }
+
+            return embedResponse
+        }
+
+        override suspend fun embed(
+            inputs: List<String>,
+            model: LLModel
+        ): List<List<Double>> {
+            batchEmbedCalls++
+
+            if (batchEmbedFailures < failuresBeforeSuccess) {
+                batchEmbedFailures++
+                throw RuntimeException(failureMessage)
+            }
+
+            return batchEmbedResponse
         }
 
         override fun close() {

--- a/prompt/prompt-executor/prompt-executor-clients/src/jsMain/kotlin/ai/koog/prompt/executor/clients/LLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/jsMain/kotlin/ai/koog/prompt/executor/clients/LLMClient.kt
@@ -8,4 +8,4 @@ package ai.koog.prompt.executor.clients
  *
  * Implements [AutoCloseable] as LLM clients typically work with IO resources. Always close it when finished.
  */
-public actual abstract class LLMClient actual constructor() : LLMClientAPI
+public actual abstract class LLMClient actual constructor() : LLMClientAPI, LLMEmbeddingProviderAPI

--- a/prompt/prompt-executor/prompt-executor-clients/src/jsMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/jsMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
@@ -6,4 +6,4 @@ package ai.koog.prompt.executor.clients
  * Extension of the LLMClient interface which includes functionality for generating text embeddings
  * in addition to executing prompts and streaming outputs.
  */
-public expect abstract class LLMEmbeddingProvider() : LLMEmbeddingProviderAPI
+public actual abstract class LLMEmbeddingProvider actual constructor() : LLMEmbeddingProviderAPI

--- a/prompt/prompt-executor/prompt-executor-clients/src/jsMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/jsMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
@@ -3,7 +3,9 @@
 package ai.koog.prompt.executor.clients
 
 /**
- * Extension of the LLMClient interface which includes functionality for generating text embeddings
- * in addition to executing prompts and streaming outputs.
+ * Abstract base class for LLM embedding providers on JavaScript.
+ *
+ * Implements [LLMEmbeddingProviderAPI]. Platform-specific blocking wrappers are not available on
+ * this target; use the suspending [embed] methods from [LLMEmbeddingProviderAPI] directly.
  */
 public actual abstract class LLMEmbeddingProvider actual constructor() : LLMEmbeddingProviderAPI

--- a/prompt/prompt-executor/prompt-executor-clients/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/LLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/LLMClient.kt
@@ -23,7 +23,7 @@ import java.util.concurrent.Flow
  *
  * Implements [AutoCloseable] as LLM clients typically work with IO resources. Always close it when finished.
  */
-public actual abstract class LLMClient actual constructor() : LLMClientAPI {
+public actual abstract class LLMClient actual constructor() : LLMClientAPI, LLMEmbeddingProvider() {
     /**
      * Executes a prompt and returns a list of response messages.
      *

--- a/prompt/prompt-executor/prompt-executor-clients/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
@@ -10,17 +10,25 @@ import ai.koog.prompt.llm.LLModel
 import java.util.concurrent.ExecutorService
 
 /**
- * Extension of the LLMClient interface which includes functionality for generating text embeddings
- * in addition to executing prompts and streaming outputs.
+ * JVM-specific abstract base class for LLM embedding providers.
+ *
+ * Extends [LLMEmbeddingProviderAPI] with blocking Java-friendly wrapper methods so that Java
+ * callers can invoke embedding without dealing with Kotlin coroutines directly.
+ * The blocking wrappers run on an IO-bound dispatcher unless a custom [ExecutorService] is provided.
  */
 public actual abstract class LLMEmbeddingProvider actual constructor() : LLMEmbeddingProviderAPI {
 
     /**
-     * Embeds the given text using into a vector of double-precision numbers.
+     * Blocking Java-friendly wrapper around [embed] for single-text embedding.
+     *
+     * Runs the suspending [embed] call on an IO-bound dispatcher and blocks until the result
+     * is available.
      *
      * @param text The text to embed.
      * @param model The model to use for embedding. Must have the Embed capability.
-     * @return A list of floating-point values representing the embedding.
+     * @param executorService An optional [ExecutorService] to control the execution context.
+     *   If `null`, a default IO-bound dispatcher is used.
+     * @return A list of floating-point values representing the embedding vector.
      * @throws IllegalArgumentException if the model does not have the Embed capability.
      */
     @JavaAPI
@@ -33,12 +41,16 @@ public actual abstract class LLMEmbeddingProvider actual constructor() : LLMEmbe
     ): List<Double> = runOnIOBoundDispatcher(executorService) { embed(text, model) }
 
     /**
-     * Embeds the given input using the given model into a vector of double-precision numbers.
+     * Blocking Java-friendly wrapper around [embed] for batch embedding.
      *
-     * @param inputs The input to embed.
+     * Runs the suspending [embed] call on an IO-bound dispatcher and blocks until the result
+     * is available.
+     *
+     * @param inputs The list of texts to embed.
      * @param model The model to use for embedding. Must have the Embed capability.
-     * @return A list of lists of floating-point values representing the embedding.
-     * Each inner list represents a single input embedding.
+     * @param executorService An optional [ExecutorService] to control the execution context.
+     *   If `null`, a default IO-bound dispatcher is used.
+     * @return A list of embedding vectors, one per input string.
      * @throws IllegalArgumentException if the model does not have the Embed capability.
      */
     @JavaAPI

--- a/prompt/prompt-executor/prompt-executor-clients/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
@@ -1,0 +1,52 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+@file:OptIn(InternalPromptAPI::class)
+
+package ai.koog.prompt.executor.clients
+
+import ai.koog.agents.annotations.JavaAPI
+import ai.koog.prompt.annotations.InternalPromptAPI
+import ai.koog.prompt.execution.utils.runOnIOBoundDispatcher
+import ai.koog.prompt.llm.LLModel
+import java.util.concurrent.ExecutorService
+
+/**
+ * Extension of the LLMClient interface which includes functionality for generating text embeddings
+ * in addition to executing prompts and streaming outputs.
+ */
+public actual abstract class LLMEmbeddingProvider actual constructor() : LLMEmbeddingProviderAPI {
+
+    /**
+     * Embeds the given text using into a vector of double-precision numbers.
+     *
+     * @param text The text to embed.
+     * @param model The model to use for embedding. Must have the Embed capability.
+     * @return A list of floating-point values representing the embedding.
+     * @throws IllegalArgumentException if the model does not have the Embed capability.
+     */
+    @JavaAPI
+    @JvmName("embed")
+    @JvmOverloads
+    public fun embedBlocking(
+        text: String,
+        model: LLModel,
+        executorService: ExecutorService? = null
+    ): List<Double> = runOnIOBoundDispatcher(executorService) { embed(text, model) }
+
+    /**
+     * Embeds the given input using the given model into a vector of double-precision numbers.
+     *
+     * @param inputs The input to embed.
+     * @param model The model to use for embedding. Must have the Embed capability.
+     * @return A list of lists of floating-point values representing the embedding.
+     * Each inner list represents a single input embedding.
+     * @throws IllegalArgumentException if the model does not have the Embed capability.
+     */
+    @JavaAPI
+    @JvmName("embed")
+    @JvmOverloads
+    public fun embedBlocking(
+        inputs: List<String>,
+        model: LLModel,
+        executorService: ExecutorService? = null
+    ): List<List<Double>> = runOnIOBoundDispatcher(executorService) { embed(inputs, model) }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/src/wasmJsMain/kotlin/ai/koog/prompt/executor/clients/LLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/wasmJsMain/kotlin/ai/koog/prompt/executor/clients/LLMClient.kt
@@ -8,4 +8,4 @@ package ai.koog.prompt.executor.clients
  *
  * Implements [AutoCloseable] as LLM clients typically work with IO resources. Always close it when finished.
  */
-public actual abstract class LLMClient actual constructor() : LLMClientAPI
+public actual abstract class LLMClient actual constructor() : LLMClientAPI, LLMEmbeddingProviderAPI

--- a/prompt/prompt-executor/prompt-executor-clients/src/wasmJsMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/wasmJsMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
@@ -6,4 +6,4 @@ package ai.koog.prompt.executor.clients
  * Extension of the LLMClient interface which includes functionality for generating text embeddings
  * in addition to executing prompts and streaming outputs.
  */
-public expect abstract class LLMEmbeddingProvider() : LLMEmbeddingProviderAPI
+public actual abstract class LLMEmbeddingProvider actual constructor() : LLMEmbeddingProviderAPI

--- a/prompt/prompt-executor/prompt-executor-clients/src/wasmJsMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/wasmJsMain/kotlin/ai/koog/prompt/executor/clients/LLMEmbeddingProvider.kt
@@ -3,7 +3,9 @@
 package ai.koog.prompt.executor.clients
 
 /**
- * Extension of the LLMClient interface which includes functionality for generating text embeddings
- * in addition to executing prompts and streaming outputs.
+ * Abstract base class for LLM embedding providers on Wasm/JS.
+ *
+ * Implements [LLMEmbeddingProviderAPI]. Platform-specific blocking wrappers are not available on
+ * this target; use the suspending [embed] methods from [LLMEmbeddingProviderAPI] directly.
  */
 public actual abstract class LLMEmbeddingProvider actual constructor() : LLMEmbeddingProviderAPI

--- a/prompt/prompt-executor/prompt-executor-model/src/commonTest/kotlin/ai/koog/prompt/executor/llms/MockLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-model/src/commonTest/kotlin/ai/koog/prompt/executor/llms/MockLLMClient.kt
@@ -28,7 +28,9 @@ internal class MockLLMClient @JvmOverloads constructor(
         val execute: Result<List<Message.Assistant>>,
         val executeStreaming: Result<Flow<StreamFrame>>,
         val executeMultipleChoices: Result<List<LLMChoice>>,
-        val moderate: Result<ModerationResult>
+        val moderate: Result<ModerationResult>,
+        val embed: Result<List<Double>>,
+        val batchEmbed: Result<List<List<Double>>>,
     ) {
 
         companion object {
@@ -36,7 +38,9 @@ internal class MockLLMClient @JvmOverloads constructor(
                 execute = executeSuccess("${provider.display} response"),
                 executeStreaming = executeStreamingSuccess(provider.display, " streaming", " response"),
                 executeMultipleChoices = Result.success(emptyList()),
-                moderate = Result.success(ModerationResult(false, emptyMap()))
+                moderate = Result.success(ModerationResult(false, emptyMap())),
+                embed = Result.success(listOf(1.0, 1.1)),
+                batchEmbed = Result.success(listOf(listOf(1.0, 1.1), listOf(1.0, 1.1))),
             )
 
             val failingSpec = ResponseSpec(
@@ -44,7 +48,9 @@ internal class MockLLMClient @JvmOverloads constructor(
                 executeStreaming = Result.failure(IllegalStateException("Mock failed to execute streaming")),
                 executeMultipleChoices =
                 Result.failure(IllegalStateException("Mock failed to execute multiple choices")),
-                moderate = Result.failure(IllegalStateException("Mock failed to moderate"))
+                moderate = Result.failure(IllegalStateException("Mock failed to moderate")),
+                embed = Result.failure(IllegalStateException("Mock failed to embed")),
+                batchEmbed = Result.failure(IllegalStateException("Mock failed to batch embed")),
             )
 
             fun executeSuccess(vararg messages: String) =
@@ -78,6 +84,8 @@ internal class MockLLMClient @JvmOverloads constructor(
             executeStreamingSpec: Result<Flow<StreamFrame>>? = null,
             executeMultipleChoicesSpec: Result<List<LLMChoice>>? = null,
             moderateSpec: Result<ModerationResult>? = null,
+            embedSpec: Result<List<Double>>? = null,
+            batchEmbedSpec: Result<List<List<Double>>>? = null,
         ): MockLLMClient {
             val defaultSpec = ResponseSpec.defaultSpec(provider)
             return MockLLMClient(
@@ -86,7 +94,9 @@ internal class MockLLMClient @JvmOverloads constructor(
                     execute = executeSpec ?: defaultSpec.execute,
                     executeStreaming = executeStreamingSpec ?: defaultSpec.executeStreaming,
                     executeMultipleChoices = executeMultipleChoicesSpec ?: defaultSpec.executeMultipleChoices,
-                    moderate = moderateSpec ?: defaultSpec.moderate
+                    moderate = moderateSpec ?: defaultSpec.moderate,
+                    embed = embedSpec ?: defaultSpec.embed,
+                    batchEmbed = batchEmbedSpec ?: defaultSpec.batchEmbed,
                 )
             )
         }
@@ -97,6 +107,8 @@ internal class MockLLMClient @JvmOverloads constructor(
             executeStreamingContent: List<String>? = null,
             executeMultipleContent: List<LLMChoice>? = null,
             moderateContent: ModerationResult? = null,
+            embedContent: List<Double>? = null,
+            batchEmbedContent: List<List<Double>>? = null,
         ): MockLLMClient {
             val defaultSpec = ResponseSpec.defaultSpec(provider)
             return MockLLMClient(
@@ -107,7 +119,9 @@ internal class MockLLMClient @JvmOverloads constructor(
                         ?: defaultSpec.executeStreaming,
                     executeMultipleChoices = executeMultipleContent?.let { Result.success(it) }
                         ?: defaultSpec.executeMultipleChoices,
-                    moderate = moderateContent?.let { Result.success(it) } ?: defaultSpec.moderate
+                    moderate = moderateContent?.let { Result.success(it) } ?: defaultSpec.moderate,
+                    embed = embedContent?.let { Result.success(it) } ?: defaultSpec.embed,
+                    batchEmbed = batchEmbedContent?.let { Result.success(it) } ?: defaultSpec.batchEmbed,
                 )
             )
         }
@@ -135,6 +149,16 @@ internal class MockLLMClient @JvmOverloads constructor(
         prompt: Prompt,
         model: LLModel
     ): ModerationResult = moderateResponse
+
+    override suspend fun embed(
+        text: String,
+        model: LLModel
+    ): List<Double> = embedResponse
+
+    override suspend fun embed(
+        inputs: List<String>,
+        model: LLModel
+    ): List<List<Double>> = batchEmbedResponse
 
     override fun llmProvider(): LLMProvider = provider
 
@@ -170,4 +194,10 @@ internal class MockLLMClient @JvmOverloads constructor(
 
     val moderateFailure: Throwable?
         get() = responseSpec.moderate.exceptionOrNull()
+
+    val embedResponse: List<Double>
+        get() = responseSpec.embed.getOrThrow()
+
+    val batchEmbedResponse: List<List<Double>>
+        get() = responseSpec.batchEmbed.getOrThrow()
 }

--- a/prompt/prompt-executor/prompt-executor-model/src/commonTest/kotlin/ai/koog/prompt/executor/llms/RoundRobinRouterTest.kt
+++ b/prompt/prompt-executor/prompt-executor-model/src/commonTest/kotlin/ai/koog/prompt/executor/llms/RoundRobinRouterTest.kt
@@ -151,6 +151,20 @@ class RoundRobinRouterTest {
             throw NotImplementedError("Not implemented for test")
         }
 
+        override suspend fun embed(
+            text: String,
+            model: LLModel
+        ): List<Double> {
+            throw NotImplementedError("Not implemented for test")
+        }
+
+        override suspend fun embed(
+            inputs: List<String>,
+            model: LLModel
+        ): List<List<Double>> {
+            throw NotImplementedError("Not implemented for test")
+        }
+
         override fun close() {
             throw NotImplementedError("Not implemented for test")
         }


### PR DESCRIPTION
Add Java API for LLMEmbeddingProvider
* Make `LLMClient` implement `LLMEmbeddingProvider` by default to fix multiple inheritance
* Add `embed` with batching (list of string) input