### PR TITLE
docs(agents): KG-786. Add Java code snippets for tracing feature

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/remote/server/config/DefaultServerConnectionConfig.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/remote/server/config/DefaultServerConnectionConfig.kt
@@ -3,6 +3,7 @@ package ai.koog.agents.core.feature.remote.server.config
 import ai.koog.agents.core.feature.remote.server.config.DefaultServerConnectionConfig.Companion.DEFAULT_AWAIT_INITIAL_CONNECTION
 import ai.koog.agents.core.feature.remote.server.config.DefaultServerConnectionConfig.Companion.DEFAULT_HOST
 import ai.koog.agents.core.feature.remote.server.config.DefaultServerConnectionConfig.Companion.DEFAULT_PORT
+import kotlin.jvm.JvmOverloads
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -19,7 +20,7 @@ import kotlin.time.Duration.Companion.seconds
  *        Set to 'false' by default.
  * @param awaitInitialConnectionTimeout The timeout duration for waiting for the first connection.
  */
-public class DefaultServerConnectionConfig(
+public class DefaultServerConnectionConfig @JvmOverloads constructor(
     host: String? = null,
     port: Int? = null,
     awaitInitialConnection: Boolean? = null,

--- a/agents/agents-features/agents-features-trace/build.gradle.kts
+++ b/agents/agents-features/agents-features-trace/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
             }
         }
 
-        jvmMain {
+        jvmCommonMain {
             dependencies {
                 api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client"))
             }

--- a/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageFileWriter.kt
+++ b/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageFileWriter.kt
@@ -43,7 +43,16 @@ import kotlin.jvm.JvmOverloads
  * @param sinkOpener Returns a [Sink] for writing to the file, this class manages its lifecycle.
  * @param format Optional custom formatter for trace events
  */
-public class TraceFeatureMessageFileWriter<Path> @JvmOverloads constructor(
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+public expect class TraceFeatureMessageFileWriter<Path> @JvmOverloads constructor(
+    targetPath: Path,
+    sinkOpener: (Path) -> Sink,
+    format: ((FeatureMessage) -> String)? = null,
+) : FeatureMessageFileWriter<Path> {
+    override fun FeatureMessage.toFileString(): String
+}
+
+internal class TraceFeatureMessageFileWriterImpl<Path> @JvmOverloads constructor(
     targetPath: Path,
     sinkOpener: (Path) -> Sink,
     private val format: ((FeatureMessage) -> String)? = null,

--- a/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageLogWriter.kt
+++ b/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageLogWriter.kt
@@ -47,7 +47,17 @@ import kotlin.jvm.JvmOverloads
  * @param logLevel The log level to use for trace events (default: INFO)
  * @param format Optional custom formatter for trace events
  */
-public class TraceFeatureMessageLogWriter @JvmOverloads constructor(
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+public expect class TraceFeatureMessageLogWriter @JvmOverloads constructor(
+    targetLogger: KLogger,
+    logLevel: LogLevel = LogLevel.INFO,
+    format: ((FeatureMessage) -> String)? = null,
+) : FeatureMessageLogWriter {
+
+    override fun FeatureMessage.toLoggerMessage(): String
+}
+
+internal class TraceFeatureMessageLogWriterImpl @JvmOverloads constructor(
     targetLogger: KLogger,
     logLevel: LogLevel = LogLevel.INFO,
     private val format: ((FeatureMessage) -> String)? = null,

--- a/agents/agents-features/agents-features-trace/src/jvmCommonMain/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageFileWriter.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmCommonMain/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageFileWriter.kt
@@ -1,0 +1,93 @@
+package ai.koog.agents.features.tracing.writer
+
+import ai.koog.agents.annotations.JavaAPI
+import ai.koog.agents.core.feature.message.FeatureMessage
+import ai.koog.agents.core.feature.writer.FeatureMessageFileWriter
+import kotlinx.io.Sink
+import kotlinx.io.asSink
+import kotlinx.io.buffered
+import kotlinx.io.files.SystemFileSystem
+import java.io.OutputStream
+import java.nio.file.Files
+import java.nio.file.Path as JavaPath
+import kotlinx.io.files.Path as KotlinPath
+
+/**
+ * A specialized implementation of [FeatureMessageFileWriter] for tracing and writing feature messages
+ * to a target file, with customizable formatting and sink handling.
+ *
+ * This class supports writing feature messages to a file using a specified sink opener
+ * and an optional formatting function. It serves as an adapter for delegating the core
+ * functionality to [TraceFeatureMessageFileWriterImpl].
+ *
+ * @param targetPath The path where feature messages will be written.
+ * @param sinkOpener A function responsible for opening a [Sink] for file writing. This function ensures
+ *                   the lifecycle of the sink is properly managed. A default sink opener is available if not provided.
+ * @param format An optional lambda function for customizing the formatting of [FeatureMessage] instances
+ *               before writing them to the file. If not provided, a default formatting strategy is used.
+ */
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+public actual class TraceFeatureMessageFileWriter<Path> @JvmOverloads actual constructor(
+    targetPath: Path,
+    sinkOpener: (Path) -> Sink,
+    format: ((FeatureMessage) -> String)?
+) : FeatureMessageFileWriter<Path>(targetPath, sinkOpener) {
+
+    private val delegate = TraceFeatureMessageFileWriterImpl(targetPath, sinkOpener, format)
+
+    actual override fun FeatureMessage.toFileString(): String = with(delegate) { toFileString() }
+
+    /**
+     * Companion object with factories for [TraceFeatureMessageFileWriter]
+     * */
+    public companion object {
+
+        /**
+         * Creates an instance of [TraceFeatureMessageFileWriter] for writing feature messages to a file.
+         *
+         * @param targetPath The path where feature messages will be written.
+         * @param sinkOpener A lambda function that opens a [Sink] for writing files, managing its lifecycle.
+         *                   If not provided, a default sink opener using the system file system will be used.
+         * @param format Optional lambda function for custom formatting of [FeatureMessage] instances.
+         *               If not provided, a default formatting strategy will be used.
+         * @return A new instance of [TraceFeatureMessageFileWriter] configured with the specified parameters.
+         */
+        public fun create(
+            targetPath: KotlinPath,
+            sinkOpener: ((path: KotlinPath) -> Sink)? = null,
+            format: ((FeatureMessage) -> String)? = null
+        ): TraceFeatureMessageFileWriter<KotlinPath> {
+            return TraceFeatureMessageFileWriter(
+                targetPath = targetPath,
+                sinkOpener = sinkOpener ?: { path -> SystemFileSystem.sink(path).buffered() },
+                format = format
+            )
+        }
+
+        /**
+         * Creates a [TraceFeatureMessageFileWriter] that writes to the given [java.nio.file.Path]
+         * using a custom [OutputStream] opener.
+         *
+         * @param targetPath The file path where trace events will be written.
+         * @param streamOpener A function that opens an [OutputStream] for the given path.
+         *                     Defaults to [Files.newOutputStream].
+         * @param format Optional custom formatter for trace events.
+         * @return A new [TraceFeatureMessageFileWriter] instance.
+         */
+        @JavaAPI
+        @JvmStatic
+        @JvmOverloads
+        public fun create(
+            targetPath: JavaPath,
+            streamOpener: ((path: JavaPath) -> OutputStream)? = null,
+            format: ((FeatureMessage) -> String)? = null,
+        ): TraceFeatureMessageFileWriter<JavaPath> {
+            val outputStreamOpener = streamOpener ?: { path -> Files.newOutputStream(path) }
+            return TraceFeatureMessageFileWriter(
+                targetPath = targetPath,
+                sinkOpener = { path -> outputStreamOpener.invoke(path).asSink().buffered() },
+                format = format,
+            )
+        }
+    }
+}

--- a/agents/agents-features/agents-features-trace/src/jvmCommonMain/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageLogWriter.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmCommonMain/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageLogWriter.kt
@@ -1,0 +1,71 @@
+package ai.koog.agents.features.tracing.writer
+
+import ai.koog.agents.annotations.JavaAPI
+import ai.koog.agents.core.feature.message.FeatureMessage
+import ai.koog.agents.core.feature.writer.FeatureMessageLogWriter
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.slf4j.toKLogger
+import org.slf4j.Logger
+
+/**
+ * Implementation of [FeatureMessageLogWriter] that handles logging of feature messages
+ * with trace-level detail using a standardized or custom log message format.
+ *
+ * @constructor Initializes an instance of [TraceFeatureMessageLogWriter].
+ * @param targetLogger The [KLogger] instance to output trace logs.
+ * @param logLevel The log level used for trace events. Defaults to [LogLevel.INFO].
+ * @param format A lambda function for custom formatting of [FeatureMessage] into
+ * a loggable string, or `null` to use a default format.
+ */
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+public actual class TraceFeatureMessageLogWriter @JvmOverloads actual constructor(
+    targetLogger: KLogger,
+    logLevel: LogLevel,
+    format: ((FeatureMessage) -> String)?
+) : FeatureMessageLogWriter(targetLogger, logLevel) {
+    private val delegate = TraceFeatureMessageLogWriterImpl(targetLogger, logLevel, format)
+
+    actual override fun FeatureMessage.toLoggerMessage(): String = with(delegate) { toLoggerMessage() }
+
+    /**
+     * Companion object with factories for [TraceFeatureMessageLogWriter]
+     * */
+    public companion object {
+
+        /**
+         * Creates a new instance of [TraceFeatureMessageLogWriter] for handling trace events.
+         *
+         * @param logger The SLF4J-compatible logger ([KLogger]) used to log trace events.
+         * @param logLevel The logging level to apply for trace events. Defaults to [LogLevel.INFO].
+         * @param format An optional custom formatter for converting [FeatureMessage] objects to log messages.
+         * If `null`, a default formatting strategy is used.
+         * @return A new instance of [TraceFeatureMessageLogWriter].
+         */
+        public fun create(
+            logger: KLogger,
+            logLevel: LogLevel = LogLevel.INFO,
+            format: ((FeatureMessage) -> String)? = null,
+        ): TraceFeatureMessageLogWriter = TraceFeatureMessageLogWriter(logger, logLevel, format)
+
+        /**
+         * Creates a [TraceFeatureMessageLogWriter] that writes trace events to the given SLF4J [Logger].
+         *
+         * @param logger The SLF4J logger to write trace events to.
+         * @param logLevel The log level to use for trace events (default: INFO).
+         * @param format Optional custom formatter for trace events.
+         * @return A new [TraceFeatureMessageLogWriter] instance.
+         */
+        @JavaAPI
+        @JvmStatic
+        @JvmOverloads
+        public fun create(
+            logger: Logger,
+            logLevel: LogLevel = LogLevel.INFO,
+            format: ((FeatureMessage) -> String)? = null,
+        ): TraceFeatureMessageLogWriter = TraceFeatureMessageLogWriter(
+            targetLogger = logger.toKLogger(),
+            logLevel = logLevel,
+            format = format,
+        )
+    }
+}

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
@@ -1,7 +1,6 @@
 package ai.koog.agents.features.tracing.writer
 
 import ai.koog.agents.core.annotation.InternalAgentsApi
-import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.builder.subgraph
@@ -40,6 +39,7 @@ import ai.koog.agents.testing.tools.getMockExecutor
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.llm.toModelInfo
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.ResponseMetaInfo
@@ -487,7 +487,7 @@ class TraceFeatureMessageTestWriterTest {
 
             override fun executeStreaming(
                 prompt: Prompt,
-                model: ai.koog.prompt.llm.LLModel,
+                model: LLModel,
                 tools: List<ToolDescriptor>
             ): Flow<StreamFrame> = flow {
                 val testException = IllegalStateException(testStreamingErrorMessage)
@@ -497,7 +497,7 @@ class TraceFeatureMessageTestWriterTest {
 
             override suspend fun moderate(
                 prompt: Prompt,
-                model: ai.koog.prompt.llm.LLModel
+                model: LLModel
             ): ai.koog.prompt.dsl.ModerationResult {
                 throw UnsupportedOperationException("Not used in test")
             }

--- a/agents/agents-features/agents-features-trace/src/nonJvmCommonMain/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageFileWriter.kt
+++ b/agents/agents-features/agents-features-trace/src/nonJvmCommonMain/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageFileWriter.kt
@@ -1,0 +1,28 @@
+package ai.koog.agents.features.tracing.writer
+
+import ai.koog.agents.core.feature.message.FeatureMessage
+import ai.koog.agents.core.feature.writer.FeatureMessageFileWriter
+import kotlinx.io.Sink
+import kotlin.jvm.JvmOverloads
+
+/**
+ * A specialized implementation of [FeatureMessageFileWriter] designed for handling trace-related feature messages.
+ * This class facilitates writing trace-specific feature messages to a file, supporting custom formatting logic if needed.
+ *
+ * @param Path The type representing the file path supported by the file system provider.
+ * @param targetPath The file where feature messages will be written.
+ * @param sinkOpener A lambda function that returns a [Sink] for writing to the file. The lifecycle of the sink is managed by this class.
+ * @param format An optional lambda function for custom formatting of [FeatureMessage] instances into their string representations.
+ * This can be used to apply specific serialization logic if required. If not provided, the default message trace representation is used.
+ */
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+public actual class TraceFeatureMessageFileWriter<Path> @JvmOverloads actual constructor(
+    targetPath: Path,
+    sinkOpener: (Path) -> Sink,
+    format: ((FeatureMessage) -> String)?
+) : FeatureMessageFileWriter<Path>(targetPath, sinkOpener) {
+
+    private val delegate = TraceFeatureMessageFileWriterImpl(targetPath, sinkOpener, format)
+
+    actual override fun FeatureMessage.toFileString(): String = with(delegate) { toFileString() }
+}

--- a/agents/agents-features/agents-features-trace/src/nonJvmCommonMain/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageLogWriter.kt
+++ b/agents/agents-features/agents-features-trace/src/nonJvmCommonMain/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageLogWriter.kt
@@ -1,0 +1,31 @@
+package ai.koog.agents.features.tracing.writer
+
+import ai.koog.agents.core.feature.message.FeatureMessage
+import ai.koog.agents.core.feature.writer.FeatureMessageLogWriter
+import io.github.oshai.kotlinlogging.KLogger
+import kotlin.jvm.JvmOverloads
+
+/**
+ * A concrete implementation of [FeatureMessageLogWriter] that handles logging of feature messages
+ * specifically for trace-level operations.
+ *
+ * This class utilizes a delegate implementation, [TraceFeatureMessageLogWriterImpl],
+ * to handle the formatting and processing of messages while maintaining a consistent API.
+ *
+ * @constructor Creates an instance with the specified logger, log level, and optional message formatter.
+ * @param targetLogger The [KLogger] instance used for logging feature messages.
+ * @param logLevel The level at which messages will be logged. Defaults to [LogLevel.INFO].
+ * @param format An optional lambda used to format [FeatureMessage] instances into strings
+ * for logging. If not provided, a default implementation will be used.
+ */
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+public actual class TraceFeatureMessageLogWriter @JvmOverloads actual constructor(
+    targetLogger: KLogger,
+    logLevel: LogLevel,
+    format: ((FeatureMessage) -> String)?
+) : FeatureMessageLogWriter(targetLogger, logLevel) {
+
+    private val delegate = TraceFeatureMessageLogWriterImpl(targetLogger, logLevel, format)
+
+    actual override fun FeatureMessage.toLoggerMessage(): String = with(delegate) { toLoggerMessage() }
+}

--- a/docs/docs/features/tracing.md
+++ b/docs/docs/features/tracing.md
@@ -35,42 +35,77 @@ To use the Tracing feature, you need to:
 3. Configure the message filter (optional).
 4. Add the message processors to the feature.
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.feature.model.events.LLMCallCompletedEvent
-import ai.koog.agents.core.feature.model.events.ToolCallStartingEvent
-import ai.koog.agents.features.tracing.feature.Tracing
-import ai.koog.agents.features.tracing.writer.TraceFeatureMessageFileWriter
-import ai.koog.agents.features.tracing.writer.TraceFeatureMessageLogWriter
-import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
-import ai.koog.prompt.executor.ollama.client.OllamaModels
-import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.io.buffered
-import kotlinx.io.files.Path
-import kotlinx.io.files.SystemFileSystem
--->
-```kotlin
-// Defining a logger/file that will be used as a destination of trace messages 
-val logger = KotlinLogging.logger { }
-val outputPath = Path("/path/to/trace.log")
+=== "Kotlin"
 
-// Creating an agent
-val agent = AIAgent(
-    promptExecutor = simpleOllamaAIExecutor(),
-    llmModel = OllamaModels.Meta.LLAMA_3_2,
-) {
-    install(Tracing) {
-
-        // Configure message processors to handle trace events
-        addMessageProcessor(TraceFeatureMessageLogWriter(logger))
-        addMessageProcessor(TraceFeatureMessageFileWriter(
-            outputPath,
-            { path: Path -> SystemFileSystem.sink(path).buffered() }
-        ))
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.feature.model.events.LLMCallCompletedEvent
+    import ai.koog.agents.core.feature.model.events.ToolCallStartingEvent
+    import ai.koog.agents.features.tracing.feature.Tracing
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageFileWriter;
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageLogWriter
+    import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    import io.github.oshai.kotlinlogging.KotlinLogging
+    import kotlinx.io.buffered
+    import kotlinx.io.files.Path
+    import kotlinx.io.files.SystemFileSystem
+    -->
+    ```kotlin
+    // Defining a logger/file that will be used as a destination of trace messages 
+    val logger = KotlinLogging.logger { }
+    val outputPath = Path("/path/to/trace.log")
+    
+    // Creating an agent
+    val agent = AIAgent(
+        promptExecutor = simpleOllamaAIExecutor(),
+        llmModel = OllamaModels.Meta.LLAMA_3_2,
+    ) {
+        install(Tracing) {
+            // Configure message processors to handle trace events
+            addMessageProcessor(TraceFeatureMessageLogWriter(logger))
+            addMessageProcessor(TraceFeatureMessageFileWriter.create(outputPath))
+        }
     }
-}
-```
-<!--- KNIT example-tracing-01.kt -->
+    ```
+    <!--- KNIT example-tracing-01.kt -->
+
+=== "Java"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent;
+    import ai.koog.agents.features.tracing.feature.Tracing;
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageFileWriter;
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageLogWriter;
+    import ai.koog.prompt.executor.model.PromptExecutor;
+    import ai.koog.prompt.executor.ollama.client.OllamaModels;
+    import org.slf4j.LoggerFactory;
+    import java.nio.file.Path;
+    public class exampleTracingJava01 {
+        public static void main(String[] args) {
+    -->
+    <!--- SUFFIX
+        }
+    }
+    -->
+    ```java
+    // Defining a logger/file that will be used as a destination of trace messages
+    var logger = LoggerFactory.getLogger("tracing");
+    var outputPath = Path.of("/path/to/trace.log");
+
+    // Creating an agent
+    var agent = AIAgent.builder()
+        .promptExecutor(PromptExecutor.builder().ollama().build())
+        .llmModel(OllamaModels.Meta.LLAMA_3_2)
+
+        .install(Tracing.Feature, config -> {
+            // Configure message processors to handle trace events
+            config.addMessageProcessor(TraceFeatureMessageLogWriter.create(logger));
+            config.addMessageProcessor(TraceFeatureMessageFileWriter.create(outputPath));
+        })
+        .build();
+    ```
+    <!--- KNIT exampleTracingJava01.java -->
 
 ### Message filtering
 
@@ -78,56 +113,112 @@ You can process all existing events or select some of them based on specific cri
 The message filter lets you control which events are processed. This is useful for focusing on specific aspects of
 agent runs:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.feature.model.events.*
-import ai.koog.agents.example.exampleTracing01.outputPath
-import ai.koog.agents.features.tracing.feature.Tracing
-import ai.koog.agents.features.tracing.writer.TraceFeatureMessageFileWriter
-import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
-import ai.koog.prompt.executor.ollama.client.OllamaModels
-import kotlinx.io.buffered
-import kotlinx.io.files.Path
-import kotlinx.io.files.SystemFileSystem
+=== "Kotlin"
 
-val agent = AIAgent(
-    promptExecutor = simpleOllamaAIExecutor(),
-    llmModel = OllamaModels.Meta.LLAMA_3_2,
-) {
-    install(Tracing) {
--->
-<!--- SUFFIX
-   }
-}
--->
-```kotlin
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.feature.model.events.*
+    import ai.koog.agents.example.exampleTracing01.outputPath
+    import ai.koog.agents.features.tracing.feature.Tracing
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageFileWriter
+    import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    import kotlinx.io.buffered
+    import kotlinx.io.files.Path
+    import kotlinx.io.files.SystemFileSystem
+    val agent = AIAgent(
+        promptExecutor = simpleOllamaAIExecutor(),
+        llmModel = OllamaModels.Meta.LLAMA_3_2,
+    ) {
+        install(Tracing) {
+    -->
+    <!--- SUFFIX
+       }
+    }
+    -->
+    ```kotlin
+    
+    val fileWriter = TraceFeatureMessageFileWriter(
+        outputPath,
+        { path: Path -> SystemFileSystem.sink(path).buffered() }
+    )
+    
+    addMessageProcessor(fileWriter)
+    
+    // Filter for LLM-related events only
+    fileWriter.setMessageFilter { message ->
+        message is LLMCallStartingEvent || message is LLMCallCompletedEvent
+    }
+    
+    // Filter for tool-related events only
+    fileWriter.setMessageFilter { message -> 
+        message is ToolCallStartingEvent ||
+            message is ToolCallCompletedEvent ||
+            message is ToolValidationFailedEvent ||
+            message is ToolCallFailedEvent
+    }
+    
+    // Filter for node execution events only
+    fileWriter.setMessageFilter { message -> 
+        message is NodeExecutionStartingEvent || message is NodeExecutionCompletedEvent
+    }
+    ```
+    <!--- KNIT example-tracing-02.kt -->
 
-val fileWriter = TraceFeatureMessageFileWriter(
-    outputPath,
-    { path: Path -> SystemFileSystem.sink(path).buffered() }
-)
+=== "Java"
 
-addMessageProcessor(fileWriter)
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent;
+    import ai.koog.agents.core.feature.model.events.*;
+    import ai.koog.agents.features.tracing.feature.Tracing;
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageFileWriter;
+    import ai.koog.prompt.executor.model.PromptExecutor;
+    import ai.koog.prompt.executor.ollama.client.OllamaModels;
+    import java.io.IOException;
+    import java.io.UncheckedIOException;
+    import java.nio.file.Files;
+    import java.nio.file.Path;
+    public class exampleTracingJava02 {
+        public static void main(String[] args) {
+            var outputPath = Path.of("/path/to/trace.log");
+            var agent = AIAgent.builder()
+                .promptExecutor(PromptExecutor.builder().ollama().build())
+                .llmModel(OllamaModels.Meta.LLAMA_3_2)
+                .install(Tracing.Feature, config -> {
+    -->
+    <!--- SUFFIX
+                })
+                .build();
+        }
+    }
+    -->
+    ```java
+    var fileWriter = TraceFeatureMessageFileWriter.create(
+        outputPath,
+        path -> { try { return Files.newOutputStream(path); } catch (IOException e) { throw new UncheckedIOException(e); }}
+    );
 
-// Filter for LLM-related events only
-fileWriter.setMessageFilter { message ->
-    message is LLMCallStartingEvent || message is LLMCallCompletedEvent
-}
+    config.addMessageProcessor(fileWriter);
 
-// Filter for tool-related events only
-fileWriter.setMessageFilter { message -> 
-    message is ToolCallStartingEvent ||
-           message is ToolCallCompletedEvent ||
-           message is ToolValidationFailedEvent ||
-           message is ToolCallFailedEvent
-}
+    // Filter for LLM-related events only
+    fileWriter.setMessageFilter(message ->
+        message instanceof LLMCallStartingEvent || message instanceof LLMCallCompletedEvent
+    );
 
-// Filter for node execution events only
-fileWriter.setMessageFilter { message -> 
-    message is NodeExecutionStartingEvent || message is NodeExecutionCompletedEvent
-}
-```
-<!--- KNIT example-tracing-02.kt -->
+    // Filter for tool-related events only
+    fileWriter.setMessageFilter(message ->
+        message instanceof ToolCallStartingEvent ||
+            message instanceof ToolCallCompletedEvent ||
+            message instanceof ToolValidationFailedEvent ||
+            message instanceof ToolCallFailedEvent
+    );
+
+    // Filter for node execution events only
+    fileWriter.setMessageFilter(message ->
+        message instanceof NodeExecutionStartingEvent || message instanceof NodeExecutionCompletedEvent
+    );
+    ```
+    <!--- KNIT exampleTracingJava02.java -->
 
 ### Large trace volumes
 
@@ -184,37 +275,74 @@ Tracing
 
 ### Basic tracing to logger
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.features.tracing.feature.Tracing
-import ai.koog.agents.features.tracing.writer.TraceFeatureMessageLogWriter
-import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
-import ai.koog.prompt.executor.ollama.client.OllamaModels
-import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.runBlocking
--->
-```kotlin
-// Create a logger
-val logger = KotlinLogging.logger { }
+=== "Kotlin"
 
-fun main() {
-    runBlocking {
-       // Create an agent with tracing
-       val agent = AIAgent(
-          promptExecutor = simpleOllamaAIExecutor(),
-          llmModel = OllamaModels.Meta.LLAMA_3_2,
-       ) {
-          install(Tracing) {
-             addMessageProcessor(TraceFeatureMessageLogWriter(logger))
-          }
-       }
-
-       // Run the agent
-       agent.run("Hello, agent!")
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.features.tracing.feature.Tracing
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageLogWriter
+    import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    import io.github.oshai.kotlinlogging.KotlinLogging
+    import kotlinx.coroutines.runBlocking
+    fun main() = runBlocking {
+    -->
+    <!--- SUFFIX
     }
-}
-```
-<!--- KNIT example-tracing-03.kt -->
+    -->
+    ```kotlin
+    // Create a logger
+    val logger = KotlinLogging.logger { }
+
+    // Create an agent with tracing
+    val agent = AIAgent(
+        promptExecutor = simpleOllamaAIExecutor(),
+        llmModel = OllamaModels.Meta.LLAMA_3_2,
+    ) {
+        install(Tracing) {
+            addMessageProcessor(TraceFeatureMessageLogWriter(logger))
+        }
+    }
+
+    // Run the agent
+    agent.run("Hello, agent!")
+    ```
+    <!--- KNIT example-tracing-03.kt -->
+
+=== "Java"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent;
+    import ai.koog.agents.features.tracing.feature.Tracing;
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageLogWriter;
+    import ai.koog.prompt.executor.model.PromptExecutor;
+    import ai.koog.prompt.executor.ollama.client.OllamaModels;
+    import org.slf4j.LoggerFactory;
+    public class exampleTracingJava03 {
+        public static void main(String[] args) {
+    -->
+    <!--- SUFFIX
+        }
+    }
+    -->
+    ```java
+    // Create a logger
+    var logger = LoggerFactory.getLogger("tracing");
+
+    // Create an agent with tracing
+    var agent = AIAgent.builder()
+        .promptExecutor(PromptExecutor.builder().ollama().build())
+        .llmModel(OllamaModels.Meta.LLAMA_3_2)
+
+        .install(Tracing.Feature, config -> {
+            config.addMessageProcessor(TraceFeatureMessageLogWriter.create(logger));
+        })
+        .build();
+
+    // Run the agent
+    agent.run("Hello, agent!");
+    ```
+    <!--- KNIT exampleTracingJava03.java -->
 
 
 ## Error handling and edge cases
@@ -235,100 +363,188 @@ The feature will still intercept events, but they will not be processed or outpu
 Message processors may hold resources (like file handles) that need to be properly released. Use the `use` extension
 function to ensure proper cleanup:
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.example.exampleTracing01.outputPath
-import ai.koog.agents.features.tracing.feature.Tracing
-import ai.koog.agents.features.tracing.writer.TraceFeatureMessageFileWriter
-import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
-import ai.koog.prompt.executor.ollama.client.OllamaModels
-import kotlinx.coroutines.runBlocking
-import kotlinx.io.buffered
-import kotlinx.io.files.Path
-import kotlinx.io.files.SystemFileSystem
+=== "Kotlin"
 
-const val input = "What's the weather like in New York?"
-
-fun main() {
-   runBlocking {
--->
-<!--- SUFFIX
-   }
-}
--->
-```kotlin
-// Creating an agent
-val agent = AIAgent(
-    promptExecutor = simpleOllamaAIExecutor(),
-    llmModel = OllamaModels.Meta.LLAMA_3_2,
-) {
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.example.exampleTracing01.outputPath
+    import ai.koog.agents.features.tracing.feature.Tracing
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageFileWriter
+    import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    import kotlinx.coroutines.runBlocking
+    import kotlinx.io.buffered
+    import kotlinx.io.files.Path
+    import kotlinx.io.files.SystemFileSystem
+    const val input = "What's the weather like in New York?"
+    fun main() {
+       runBlocking {
+    -->
+    <!--- SUFFIX
+        }
+    }
+    -->
+    ```kotlin
     val writer = TraceFeatureMessageFileWriter(
         outputPath,
         { path: Path -> SystemFileSystem.sink(path).buffered() }
     )
 
-    install(Tracing) {
-        addMessageProcessor(writer)
+    // Creating an agent
+    val agent = AIAgent(
+        promptExecutor = simpleOllamaAIExecutor(),
+        llmModel = OllamaModels.Meta.LLAMA_3_2,
+    ) {
+        install(Tracing) {
+            addMessageProcessor(writer)
+        }
     }
-}
-// Run the agent
-agent.run(input)
-// Writer will be automatically closed when the block exits
-```
-<!--- KNIT example-tracing-04.kt -->
+
+    // Run the agent
+    agent.run(input)
+
+    // Writer will be automatically closed when the block exits
+    ```
+    <!--- KNIT example-tracing-04.kt -->
+
+=== "Java"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent;
+    import ai.koog.agents.features.tracing.feature.Tracing;
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageFileWriter;
+    import ai.koog.prompt.executor.model.PromptExecutor;
+    import ai.koog.prompt.executor.ollama.client.OllamaModels;
+    import java.io.IOException;
+    import java.io.UncheckedIOException;
+    import java.nio.file.Files;
+    import java.nio.file.Path;
+    public class exampleTracingJava04 {
+        public static void main(String[] args) {
+            var outputPath = Path.of("/path/to/trace.log");
+            String input = "What's the weather like in New York?";
+    -->
+    <!--- SUFFIX
+        }
+    }
+    -->
+    ```java
+    var writer = TraceFeatureMessageFileWriter.create(
+        outputPath,
+        path -> { try { return Files.newOutputStream(path); } catch (IOException e) { throw new UncheckedIOException(e); }}
+    );
+
+    // Creating an agent
+    var agent = AIAgent.builder()
+        .promptExecutor(PromptExecutor.builder().ollama().build())
+        .llmModel(OllamaModels.Meta.LLAMA_3_2)
+
+        .install(Tracing.Feature, config -> {
+            config.addMessageProcessor(writer);
+        })
+        .build();
+
+    // Run the agent
+    agent.run(input);
+
+    // Writer will be automatically closed when the block exits
+    ```
+    <!--- KNIT exampleTracingJava04.java -->
 
 ### Tracing specific events to file
 
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.feature.model.events.LLMCallCompletedEvent
-import ai.koog.agents.core.feature.model.events.LLMCallStartingEvent
-import ai.koog.agents.example.exampleTracing01.outputPath
-import ai.koog.agents.features.tracing.feature.Tracing
-import ai.koog.agents.features.tracing.writer.TraceFeatureMessageFileWriter
-import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
-import ai.koog.prompt.executor.ollama.client.OllamaModels
-import kotlinx.coroutines.runBlocking
-import kotlinx.io.buffered
-import kotlinx.io.files.Path
-import kotlinx.io.files.SystemFileSystem
+=== "Kotlin"
 
-const val input = "What's the weather like in New York?"
-
-fun main() {
-    runBlocking {
-        // Creating an agent
-        val agent = AIAgent(
-            promptExecutor = simpleOllamaAIExecutor(),
-            llmModel = OllamaModels.Meta.LLAMA_3_2,
-        ) {
-            val writer = TraceFeatureMessageFileWriter(
-                outputPath,
-                { path: Path -> SystemFileSystem.sink(path).buffered() }
-            )
--->
-<!--- SUFFIX
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.feature.model.events.LLMCallCompletedEvent
+    import ai.koog.agents.core.feature.model.events.LLMCallStartingEvent
+    import ai.koog.agents.example.exampleTracing01.outputPath
+    import ai.koog.agents.features.tracing.feature.Tracing
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageFileWriter
+    import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    import kotlinx.coroutines.runBlocking
+    import kotlinx.io.buffered
+    import kotlinx.io.files.Path
+    import kotlinx.io.files.SystemFileSystem
+    const val input = "What's the weather like in New York?"
+    fun main() {
+        runBlocking {
+    -->
+    <!--- SUFFIX
         }
     }
-}
--->
-```kotlin
-install(Tracing) {
-    
+    -->
+    ```kotlin
     val fileWriter = TraceFeatureMessageFileWriter(
-        outputPath, 
+        outputPath,
         { path: Path -> SystemFileSystem.sink(path).buffered() }
     )
-    addMessageProcessor(fileWriter)
-    
-    // Only trace LLM calls
-    fileWriter.setMessageFilter { message ->
-        message is LLMCallStartingEvent || message is LLMCallCompletedEvent
+
+    // Creating an agent
+    val agent = AIAgent(
+        promptExecutor = simpleOllamaAIExecutor(),
+        llmModel = OllamaModels.Meta.LLAMA_3_2,
+    ) {
+        install(Tracing) {
+            addMessageProcessor(fileWriter)
+
+            // Only trace LLM calls
+            fileWriter.setMessageFilter { message ->
+                message is LLMCallStartingEvent || message is LLMCallCompletedEvent
+            }
+        }
     }
-}
-```
-<!--- KNIT example-tracing-05.kt -->
+    ```
+    <!--- KNIT example-tracing-05.kt -->
+
+=== "Java"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent;
+    import ai.koog.agents.core.feature.model.events.LLMCallCompletedEvent;
+    import ai.koog.agents.core.feature.model.events.LLMCallStartingEvent;
+    import ai.koog.agents.features.tracing.feature.Tracing;
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageFileWriter;
+    import ai.koog.prompt.executor.model.PromptExecutor;
+    import ai.koog.prompt.executor.ollama.client.OllamaModels;
+    import java.io.IOException;
+    import java.io.UncheckedIOException;
+    import java.nio.file.Files;
+    import java.nio.file.Path;
+    public class exampleTracingJava05 {
+        public static void main(String[] args) {
+            var outputPath = Path.of("/path/to/trace.log");
+            String input = "What's the weather like in New York?";
+    -->
+    <!--- SUFFIX
+        }
+    }
+    -->
+    ```java
+    var fileWriter = TraceFeatureMessageFileWriter.create(
+        outputPath,
+        path -> { try { return Files.newOutputStream(path); } catch (IOException e) { throw new UncheckedIOException(e); }}
+    );
+
+    // Creating an agent
+    var agent = AIAgent.builder()
+        .promptExecutor(PromptExecutor.builder().ollama().build())
+        .llmModel(OllamaModels.Meta.LLAMA_3_2)
+
+        .install(Tracing.Feature, config -> {
+            config.addMessageProcessor(fileWriter);
+
+            // Only trace LLM calls
+            fileWriter.setMessageFilter(message ->
+                message instanceof LLMCallStartingEvent || message instanceof LLMCallCompletedEvent
+            );
+        })
+        .build();
+    ```
+    <!--- KNIT exampleTracingJava05.java -->
 
 ### Tracing specific events to remote endpoint
 
@@ -336,96 +552,138 @@ You use tracing to remote endpoints when you need to send event data via the net
 remote endpoint launches a light server at the specified port number and sends events via Kotlin Server-Sent Events 
 (SSE).
 
-<!--- INCLUDE
-import ai.koog.agents.core.agent.AIAgent
-import ai.koog.agents.core.feature.remote.server.config.DefaultServerConnectionConfig
-import ai.koog.agents.features.tracing.feature.Tracing
-import ai.koog.agents.features.tracing.writer.TraceFeatureMessageRemoteWriter
-import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
-import ai.koog.prompt.executor.ollama.client.OllamaModels
-import kotlinx.coroutines.runBlocking
+=== "Kotlin"
 
-const val input = "What's the weather like in New York?"
-const val port = 4991
-const val host = "localhost"
-
-fun main() {
-   runBlocking {
--->
-<!--- SUFFIX
-   }
-}
--->
-```kotlin
-// Creating an agent
-val agent = AIAgent(
-    promptExecutor = simpleOllamaAIExecutor(),
-    llmModel = OllamaModels.Meta.LLAMA_3_2,
-) {
-    val connectionConfig = DefaultServerConnectionConfig(host = host, port = port)
-    val writer = TraceFeatureMessageRemoteWriter(
-        connectionConfig = connectionConfig
-    )
-
-    install(Tracing) {
-        addMessageProcessor(writer)
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.agents.core.feature.remote.server.config.DefaultServerConnectionConfig
+    import ai.koog.agents.features.tracing.feature.Tracing
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageRemoteWriter
+    import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
+    import ai.koog.prompt.executor.ollama.client.OllamaModels
+    import kotlinx.coroutines.runBlocking
+    const val input = "What's the weather like in New York?"
+    const val port = 4991
+    const val host = "localhost"
+    fun main() {
+       runBlocking {
+    -->
+    <!--- SUFFIX
+       }
     }
-}
-// Run the agent
-agent.run(input)
-// Writer will be automatically closed when the block exits
-```
-<!--- KNIT example-tracing-06.kt -->
+    -->
+    ```kotlin
+    val connectionConfig = DefaultServerConnectionConfig(host = host, port = port)
+    val writer = TraceFeatureMessageRemoteWriter(connectionConfig)
+
+    // Creating an agent
+    val agent = AIAgent(
+        promptExecutor = simpleOllamaAIExecutor(),
+        llmModel = OllamaModels.Meta.LLAMA_3_2,
+    ) {
+        install(Tracing) {
+            addMessageProcessor(writer)
+        }
+    }
+
+    // Run the agent
+    agent.run(input)
+
+    // Writer will be automatically closed when the block exits
+    ```
+    <!--- KNIT example-tracing-06.kt -->
+
+=== "Java"
+
+    <!--- INCLUDE
+    import ai.koog.agents.core.agent.AIAgent;
+    import ai.koog.agents.core.feature.remote.server.config.DefaultServerConnectionConfig;
+    import ai.koog.agents.features.tracing.feature.Tracing;
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageRemoteWriter;
+    import ai.koog.prompt.executor.model.PromptExecutor;
+    import ai.koog.prompt.executor.ollama.client.OllamaModels;
+    import java.io.IOException;
+    import java.io.UncheckedIOException;
+    public class exampleTracingJava06 {
+        public static void main(String[] args) {
+            String input = "What's the weather like in New York?";
+            int port = 4991;
+            String host = "localhost";
+    -->
+    <!--- SUFFIX
+        }
+    }
+    -->
+    ```java
+    var connectionConfig = new DefaultServerConnectionConfig(host, port);
+    var writer = new TraceFeatureMessageRemoteWriter(connectionConfig);
+
+    // Creating an agent
+    var agent = AIAgent.builder()
+        .promptExecutor(PromptExecutor.builder().ollama().build())
+        .llmModel(OllamaModels.Meta.LLAMA_3_2)
+
+        .install(Tracing.Feature, config -> {
+            config.addMessageProcessor(writer);
+        })
+        .build();
+
+    // Run the agent
+    agent.run(input);
+
+    // Writer will be automatically closed when the block exits
+    ```
+    <!--- KNIT exampleTracingJava06.java -->
 
 On the client side, you can use `FeatureMessageRemoteClient` to receive events and deserialize them.
 
-<!--- INCLUDE
-import ai.koog.agents.core.feature.model.events.AgentCompletedEvent
-import ai.koog.agents.core.feature.model.events.DefinedFeatureEvent
-import ai.koog.agents.core.feature.remote.client.config.DefaultClientConnectionConfig
-import ai.koog.agents.core.feature.remote.client.FeatureMessageRemoteClient
-import ai.koog.utils.io.use
-import io.ktor.http.*
-import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.consumeAsFlow
+=== "Kotlin"
 
-const val input = "What's the weather like in New York?"
-const val port = 4991
-const val host = "localhost"
-
-fun main() {
-   runBlocking {
--->
-<!--- SUFFIX
-   }
-}
--->
-```kotlin
-val clientConfig = DefaultClientConnectionConfig(host = host, port = port, protocol = URLProtocol.HTTP)
-val agentEvents = mutableListOf<DefinedFeatureEvent>()
-
-val clientJob = launch {
-    FeatureMessageRemoteClient(connectionConfig = clientConfig, scope = this).use { client ->
-        val collectEventsJob = launch {
-            client.receivedMessages.consumeAsFlow().collect { event ->
-                // Collect events from server
-                agentEvents.add(event as DefinedFeatureEvent)
-
-                // Stop collecting events on agent finished
-                if (event is AgentCompletedEvent) {
-                    cancel()
+    <!--- INCLUDE
+    import ai.koog.agents.core.feature.model.events.AgentCompletedEvent
+    import ai.koog.agents.core.feature.model.events.DefinedFeatureEvent
+    import ai.koog.agents.core.feature.remote.client.config.DefaultClientConnectionConfig
+    import ai.koog.agents.core.feature.remote.client.FeatureMessageRemoteClient
+    import ai.koog.utils.io.use
+    import io.ktor.http.*
+    import kotlinx.coroutines.*
+    import kotlinx.coroutines.flow.consumeAsFlow
+    const val input = "What's the weather like in New York?"
+    const val port = 4991
+    const val host = "localhost"
+    fun main() {
+       runBlocking {
+    -->
+    <!--- SUFFIX
+       }
+    }
+    -->
+    ```kotlin
+    val clientConfig = DefaultClientConnectionConfig(host = host, port = port, protocol = URLProtocol.HTTP)
+    val agentEvents = mutableListOf<DefinedFeatureEvent>()
+    
+    val clientJob = launch {
+        FeatureMessageRemoteClient(connectionConfig = clientConfig, scope = this).use { client ->
+            val collectEventsJob = launch {
+                client.receivedMessages.consumeAsFlow().collect { event ->
+                    // Collect events from server
+                    agentEvents.add(event as DefinedFeatureEvent)
+    
+                    // Stop collecting events on agent finished
+                    if (event is AgentCompletedEvent) {
+                        cancel()
+                    }
                 }
             }
+            client.connect()
+            collectEventsJob.join()
+            client.healthCheck()
         }
-        client.connect()
-        collectEventsJob.join()
-        client.healthCheck()
     }
-}
-
-listOf(clientJob).joinAll()
-```
-<!--- KNIT example-tracing-07.kt -->
+    
+    listOf(clientJob).joinAll()
+    ```
+    <!--- KNIT example-tracing-07.kt -->
 
 ## API documentation
 


### PR DESCRIPTION
KG-786. Add Java code snippets for tracing feature

- Add convenient Java API for adding message processors in Tracing feature;
- Update the Tracing feature MD file with Java code snippets for corresponding code example blocks.

closes [KG-786](https://youtrack.jetbrains.com/issue/KG-449/issue/KG-786/Add-missing-Java-examples-in-Tracing-documentation)
