### PR TITLE
docs: Restore Koog on Slack page

### DIFF
--- a/docs/docs/koog-slack-channel.md
+++ b/docs/docs/koog-slack-channel.md
@@ -1,0 +1,9 @@
+# Koog on Slack
+
+The Koog Slack channel is part of the Kotlin Slack workspace.
+
+* If you already have an account in the workspace,
+  sign in to [Kotlin Slack](http://kotlinlang.slack.com/) and join the `#koog-agentic-framework` channel.
+* If you don't have an account,
+  open the Slack channel in your [browser](https://slack-chats.kotlinlang.org/c/koog-agentic-framework) or request an invitation by providing your email address on the [Kotlin Slack Sign-up](https://surveys.jetbrains.com/s3/kotlin-slack-sign-up) page.
+

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -138,7 +138,7 @@ plugins:
       redirect_maps:
         'getting-started.md': 'quickstart.md'
         'simple-api-getting-started.md': 'quickstart.md'
-        'getting-started/index.md': 'quickstart/index.md'
+        'getting-started/index.md': 'quickstart.md'
         'advanced-tool-implementation.md': 'class-based-tools.md'
         'key-concepts.md': 'glossary.md'
         'single-run-agents.md': 'agents/basic-agents.md'
@@ -296,6 +296,9 @@ hooks:
 
 exclude_docs: |
   /snippets/
+
+not_in_nav: |
+  koog-slack-channel.md
 
 validation:
   omitted_files: warn


### PR DESCRIPTION
Restore the Koog on Slack page and update `mkdocs.yml `to suppress the warning that this page is not included in the `nav` config.

<!-- Include BREAKING section below only if this PR introduces breaking changes. Otherwise, delete it. -->
BREAKING:
*

<!-- Include DEPRECATED section below only if this PR deprecates any public APIs. Otherwise, delete it. -->
DEPRECATED:
*

<!-- Include references to related issues below, e.g., closes #1, closes KG-1. Otherwise, delete it. -->
closes
