### PR TITLE
fix(prompt): Opus 4.6 maxOutputTokens from 1M to 128K

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicModels.kt
@@ -271,7 +271,7 @@ public object AnthropicModels : LLModelDefinitions {
             LLMCapability.Schema.JSON.Standard,
         ) + thinkingCapabilities,
         contextLength = 200_000,
-        maxOutputTokens = 1_000_000,
+        maxOutputTokens = 128_000,
     )
 
     /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterModels.kt
@@ -220,7 +220,7 @@ public object OpenRouterModels : LLModelDefinitions {
             LLMCapability.ToolChoice
         ),
         contextLength = 200_000,
-        maxOutputTokens = 1_000_000,
+        maxOutputTokens = 128_000,
     )
 
     /**


### PR DESCRIPTION
- Fix `maxOutputTokens` for Claude Opus 4.6 from `1_000_000` to `128_000` in `AnthropicModels` and `OpenRouterModels`
- The incorrect value causes 400 errors from the API when users rely on the model's max output tokens
- Bedrock inherits from `AnthropicModels.Opus_4_6` so it is fixed transitively

closes #1824
