### PR TITLE
docs(agents): KG-787. Add Java code snippets for Agent Events documentation

### DIFF
--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/feature/message/FeatureMessageProcessor.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/feature/message/FeatureMessageProcessor.kt
@@ -1,0 +1,156 @@
+package ai.koog.agents.core.feature.message
+
+import ai.koog.agents.annotations.JavaAPI
+import ai.koog.agents.core.annotation.InternalAgentsApi
+import ai.koog.agents.core.utils.runBlockingIfRequired
+import ai.koog.utils.io.Closeable
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.util.concurrent.ExecutorService
+
+/**
+ * Abstract class responsible for processing feature messages within the system.
+ *
+ * The `FeatureMessageProcessor` provides functionality for filtering and handling
+ * incoming feature messages. Classes inheriting from this abstract class are expected
+ * to implement the necessary logic for processing messages.
+ *
+ * This class provides Java-friendly APIs for initializing and processing messages
+ * synchronously, in addition to its coroutine-based methods for use in Kotlin.
+ *
+ * Java subclasses should override [handleMessage] and [handleClose] instead of the
+ * suspend [processMessage] and [close] methods to avoid dealing with Kotlin coroutine internals.
+ */
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+public actual abstract class FeatureMessageProcessor actual constructor() : Closeable {
+    /**
+     * A filter for messages to be sent to message processors.
+     *
+     * This function is called for each event before it's sent to the message processors.
+     * If the function returns true, the event is processed; if it returns false, the event is ignored.
+     *
+     * By default, all messages are processed (the filter returns true for all messages).
+     */
+    public actual var messageFilter: (FeatureMessage) -> Boolean = { true }
+        private set
+
+    /**
+     * Sets the message filter used to determine which feature messages should be processed.
+     *
+     * The provided filter function is invoked for each incoming feature message. If the filter
+     * function returns `true`, the message is deemed to meet the criteria for further processing.
+     *
+     * @param filter A lambda function that accepts a [FeatureMessage] and returns a boolean
+     * indicating whether the message should be processed (`true`) or ignored (`false`).
+     */
+    public actual fun setMessageFilter(filter: (FeatureMessage) -> Boolean) {
+        messageFilter = filter
+    }
+
+    private val _isOpen: MutableStateFlow<Boolean> = MutableStateFlow(false)
+
+    /** A [StateFlow] representing the current open state of the processor. */
+    public actual open val isOpen: StateFlow<Boolean> = _isOpen.asStateFlow()
+
+    // JAVA Unique methods:
+
+    /**
+     * Initializes the feature output stream provider to ensure it is ready for use.
+     * This is a blocking version of [initialize] for use from Java code.
+     *
+     * @param executorService An optional [ExecutorService] to provide a coroutine context for execution.
+     *                        If not provided, [Dispatchers.Default] is used.
+     */
+    @JavaAPI
+    @JvmOverloads
+    @JvmName("initialize")
+    @OptIn(InternalAgentsApi::class)
+    public fun javaNonSuspendInitialize(executorService: ExecutorService? = null) {
+        runBlockingIfRequired(executorService?.asCoroutineDispatcher() ?: Dispatchers.Default) {
+            initialize()
+        }
+    }
+
+    /**
+     * Receives and processes an incoming feature message.
+     * This is a blocking version of [onMessage] for use from Java code.
+     *
+     * @param message The incoming feature message to be evaluated and potentially processed.
+     * @param executorService An optional [ExecutorService] to provide a coroutine context for execution.
+     *                        If not provided, [Dispatchers.Default] is used.
+     */
+    @JavaAPI
+    @JvmOverloads
+    @JvmName("onMessage")
+    @OptIn(InternalAgentsApi::class)
+    public fun javaNonSuspendOnMessage(message: FeatureMessage, executorService: ExecutorService? = null) {
+        runBlockingIfRequired(executorService?.asCoroutineDispatcher() ?: Dispatchers.Default) {
+            onMessage(message)
+        }
+    }
+
+    /**
+     * Handles an incoming feature message or event for processing.
+     * This is a non-suspend version of [processMessage] for overriding from Java code.
+     *
+     * Java subclasses should override this method instead of [processMessage] to avoid
+     * dealing with Kotlin coroutine internals (Continuation parameter).
+     *
+     * @param message the feature message to be handled.
+     */
+    @JavaAPI
+    protected open fun handleMessage(message: FeatureMessage) {}
+
+    /**
+     * Releases resources held by this processor.
+     * This is a non-suspend version of [close] for overriding from Java code.
+     *
+     * Java subclasses should override this method instead of to suspend [close] to avoid
+     * dealing with Kotlin coroutine internals (Continuation parameter).
+     */
+    @JavaAPI
+    public open fun handleClose() {}
+
+    // Common (multiplatform) methods:
+
+    /** Initializes the feature output stream provider to ensure it is ready for use. */
+    public actual open suspend fun initialize() {
+        _isOpen.value = true
+    }
+
+    /**
+     * Handles an incoming feature message or event for processing.
+     * The default implementation delegates to [handleMessage].
+     *
+     * @param message the feature message to be handled.
+     */
+    protected actual open suspend fun processMessage(message: FeatureMessage) {
+        handleMessage(message)
+    }
+
+    /**
+     * Releases resources held by this processor.
+     * The default implementation delegates to [handleClose].
+     */
+    actual override suspend fun close() {
+        handleClose()
+        _isOpen.value = false
+    }
+
+    /**
+     * Receives and processes an incoming feature message.
+     *
+     * This method evaluates the provided message using the configured message filter.
+     * If the message passes the filter, it is forwarded for further processing.
+     *
+     * @param message The incoming feature message to be evaluated and potentially processed.
+     */
+    public actual suspend fun onMessage(message: FeatureMessage) {
+        if (messageFilter(message)) {
+            processMessage(message)
+        }
+    }
+}

--- a/agents/agents-core/src/nonJvmCommonMain/kotlin/ai/koog/agents/core/feature/message/FeatureMessageProcessor.kt
+++ b/agents/agents-core/src/nonJvmCommonMain/kotlin/ai/koog/agents/core/feature/message/FeatureMessageProcessor.kt
@@ -1,24 +1,22 @@
 package ai.koog.agents.core.feature.message
 
 import ai.koog.utils.io.Closeable
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
- * Represents a provider responsible for handling outbound feature messages or events.
+ * Abstract class responsible for processing feature messages or events within the system.
  *
- * Feature processors are used to encapsulate feature-related logic and provide a common interface
- * for handling feature messages and events, such as
- *   - Node started
- *   - Node finished
- *   - Strategy started, etc.
+ * The `FeatureMessageProcessor` serves as a foundational interface for implementing processors
+ * that handle various feature-related messages. These messages, represented by the [FeatureMessage]
+ * type, encapsulate relevant information about events or updates in the system.
  *
- * Implementations of this interface are designed to process feature messages,
- * which are encapsulated in the [FeatureMessage] type and presented as a model
- * for an event to be sent to a target stream. These messages carry
- * information about various events or updates related to features in the system.
+ * This class provides mechanisms to filter incoming messages, manage processing states, and ensure
+ * proper handling through a defined workflow.
  */
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
-public expect abstract class FeatureMessageProcessor() : Closeable {
+public actual abstract class FeatureMessageProcessor actual constructor() : Closeable {
     /**
      * A filter for messages to be sent to message processors.
      *
@@ -27,7 +25,7 @@ public expect abstract class FeatureMessageProcessor() : Closeable {
      *
      * By default, all messages are processed (the filter returns true for all messages).
      */
-    public var messageFilter: (FeatureMessage) -> Boolean
+    public actual var messageFilter: (FeatureMessage) -> Boolean = { true }
         private set
 
     /**
@@ -38,33 +36,25 @@ public expect abstract class FeatureMessageProcessor() : Closeable {
      *
      * @param filter A lambda function that accepts a [FeatureMessage] and returns a boolean
      * indicating whether the message should be processed (`true`) or ignored (`false`).
-     *
-     * Example:
-     * ```kotlin
-     *   processor.setMessageFilter { message ->
-     *     message is LLMCallStartingEvent ||
-     *     message is LLMCallCompletedEvent
-     *   }
-     * ```
      */
-    public fun setMessageFilter(filter: (FeatureMessage) -> Boolean)
+    public actual fun setMessageFilter(filter: (FeatureMessage) -> Boolean) {
+        messageFilter = filter
+    }
 
-    /**
-     * A [StateFlow] representing the current open state of the processor.
-     */
-    public open val isOpen: StateFlow<Boolean>
+    private val _isOpen: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
-    /**
-     * Initializes the feature output stream provider to ensure it is ready for use.
-     */
-    public open suspend fun initialize()
+    /** A [StateFlow] representing the current open state of the processor. */
+    public actual open val isOpen: StateFlow<Boolean> = _isOpen.asStateFlow()
+
+    /** Initializes the feature output stream provider to ensure it is ready for use. */
+    public actual open suspend fun initialize() {}
 
     /**
      * Handles an incoming feature message or event for processing.
      *
      * @param message the feature message to be handled.
      */
-    protected open suspend fun processMessage(message: FeatureMessage)
+    protected actual open suspend fun processMessage(message: FeatureMessage) {}
 
     /**
      * Receives and processes an incoming feature message.
@@ -74,10 +64,12 @@ public expect abstract class FeatureMessageProcessor() : Closeable {
      *
      * @param message The incoming feature message to be evaluated and potentially processed.
      */
-    public suspend fun onMessage(message: FeatureMessage)
+    public actual suspend fun onMessage(message: FeatureMessage) {
+        if (messageFilter(message)) {
+            processMessage(message)
+        }
+    }
 
-    /**
-     * Releases resources held by this processor.
-     */
-    public open override suspend fun close()
+    /** Releases resources held by this processor. */
+    actual override suspend fun close() {}
 }

--- a/docs/docs/agent-events.md
+++ b/docs/docs/agent-events.md
@@ -390,9 +390,6 @@ Use the `messageFilter` property to filter events. For example, to trace only no
     import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
     import ai.koog.prompt.executor.ollama.client.OllamaModels
     import kotlinx.coroutines.runBlocking
-    import kotlinx.io.buffered
-    import kotlinx.io.files.Path
-    import kotlinx.io.files.SystemFileSystem
     const val input = "What's the weather like in New York?"
     fun main() {
     runBlocking {
@@ -401,10 +398,6 @@ Use the `messageFilter` property to filter events. For example, to trace only no
     promptExecutor = simpleOllamaAIExecutor(),
     llmModel = OllamaModels.Meta.LLAMA_3_2,
     ) {
-    val writer = TraceFeatureMessageFileWriter(
-    outputPath,
-    { path: Path -> SystemFileSystem.sink(path).buffered() }
-    )
     -->
     <!--- SUFFIX
             }
@@ -413,10 +406,7 @@ Use the `messageFilter` property to filter events. For example, to trace only no
     -->
     ```kotlin
     install(Tracing) {
-        val fileWriter = TraceFeatureMessageFileWriter(
-            outputPath, 
-            { path: Path -> SystemFileSystem.sink(path).buffered() }
-        )
+        val fileWriter = TraceFeatureMessageFileWriter.create(outputPath)
         addMessageProcessor(fileWriter)
         
         // Only trace LLM calls
@@ -430,14 +420,39 @@ Use the `messageFilter` property to filter events. For example, to trace only no
 === "Java"
 
     <!--- INCLUDE
-    /**
+    import ai.koog.agents.core.agent.AIAgent;
+    import ai.koog.agents.core.feature.model.events.LLMCallCompletedEvent;
+    import ai.koog.agents.core.feature.model.events.LLMCallStartingEvent;
+    import ai.koog.agents.features.tracing.feature.Tracing;
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageFileWriter;
+    import ai.koog.prompt.executor.model.PromptExecutor;
+    import ai.koog.prompt.executor.ollama.client.OllamaModels;
+    import java.nio.file.Files;
+    import java.nio.file.Path;
+    public class exampleEventsJava01 {
+        public static void main(String[] args) {
+            var outputPath = Path.of("/path/to/trace.log");
+            var agent = AIAgent.builder()
+                .promptExecutor(PromptExecutor.builder().ollama().build())
+                .llmModel(OllamaModels.Meta.LLAMA_3_2)
     -->
     <!--- SUFFIX
-    **/
+            .build();
+        }
+    }
     -->
     ```java
+    .install(Tracing.Feature, config -> {
+        var fileWriter = TraceFeatureMessageFileWriter.create(outputPath);
+        config.addMessageProcessor(fileWriter);
+
+        // Only trace LLM calls
+        fileWriter.setMessageFilter(message ->
+            message instanceof LLMCallStartingEvent || message instanceof LLMCallCompletedEvent
+        );
+    })
     ```
-    <!--- KNIT example-events-java-01.java -->
+    <!--- KNIT exampleEventsJava01.java -->
 
 ### Can I use multiple message processors?
 
@@ -461,7 +476,6 @@ Yes, you can add multiple message processors to trace to different destinations 
     import kotlinx.io.files.Path
     import kotlinx.io.files.SystemFileSystem
     const val input = "What's the weather like in New York?"
-    val syncOpener = { path: Path -> SystemFileSystem.sink(path).buffered() }
     val logger = KotlinLogging.logger {}
     val connectionConfig = DefaultServerConnectionConfig(host = ai.koog.agents.example.exampleTracing06.host, port = ai.koog.agents.example.exampleTracing06.port)
     fun main() {
@@ -480,7 +494,7 @@ Yes, you can add multiple message processors to trace to different destinations 
     ```kotlin
     install(Tracing) {
         addMessageProcessor(TraceFeatureMessageLogWriter(logger))
-        addMessageProcessor(TraceFeatureMessageFileWriter(outputPath, syncOpener))
+        addMessageProcessor(TraceFeatureMessageFileWriter.create(outputPath))
         addMessageProcessor(TraceFeatureMessageRemoteWriter(connectionConfig))
     }
     ```
@@ -489,14 +503,37 @@ Yes, you can add multiple message processors to trace to different destinations 
 === "Java"
 
     <!--- INCLUDE
-    /**
+    import ai.koog.agents.core.agent.AIAgent;
+    import ai.koog.agents.features.tracing.feature.Tracing;
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageFileWriter;
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageLogWriter;
+    import ai.koog.agents.features.tracing.writer.TraceFeatureMessageRemoteWriter;
+    import ai.koog.prompt.executor.model.PromptExecutor;
+    import ai.koog.prompt.executor.ollama.client.OllamaModels;
+    import org.slf4j.LoggerFactory;
+    import java.nio.file.Files;
+    import java.nio.file.Path;
+    public class exampleEventsJava02 {
+        public static void main(String[] args) {
+            var logger = LoggerFactory.getLogger("tracing");
+            var outputPath = Path.of("/path/to/trace.log");
+            var agent = AIAgent.builder()
+                .promptExecutor(PromptExecutor.builder().ollama().build())
+                .llmModel(OllamaModels.Meta.LLAMA_3_2)
     -->
     <!--- SUFFIX
-    **/
+            .build();
+        }
+    }
     -->
     ```java
+    .install(Tracing.Feature, config -> {
+        config.addMessageProcessor(TraceFeatureMessageLogWriter.create(logger));
+        config.addMessageProcessor(TraceFeatureMessageFileWriter.create(outputPath));
+        config.addMessageProcessor(new TraceFeatureMessageRemoteWriter());
+    })
     ```
-    <!--- KNIT example-events-java-02.java -->
+    <!--- KNIT exampleEventsJava02.java -->
 
 ### How can I create a custom message processor?
 
@@ -513,54 +550,44 @@ Implement the `FeatureMessageProcessor` interface:
     import ai.koog.agents.features.tracing.feature.Tracing
     import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
     import ai.koog.prompt.executor.ollama.client.OllamaModels
-    import kotlinx.coroutines.runBlocking
     import kotlinx.coroutines.flow.MutableStateFlow
     import kotlinx.coroutines.flow.StateFlow
     import kotlinx.coroutines.flow.asStateFlow
+    import kotlinx.coroutines.runBlocking
     fun main() {
     runBlocking {
-    // Creating an agent
-    val agent = AIAgent(
-    promptExecutor = simpleOllamaAIExecutor(),
-    llmModel = OllamaModels.Meta.LLAMA_3_2,
-    ) {
     -->
     <!--- SUFFIX
-            }
         }
     }
     -->
     ```kotlin
     class CustomTraceProcessor : FeatureMessageProcessor() {
 
-        // Current open state of the processor
-        private var _isOpen = MutableStateFlow(false)
-
-        override val isOpen: StateFlow<Boolean>
-            get() = _isOpen.asStateFlow()
-        
         override suspend fun processMessage(message: FeatureMessage) {
             // Custom processing logic
-            when (message) {
-                is NodeExecutionStartingEvent -> {
-                    // Process node start event
-                }
-
-                is LLMCallCompletedEvent -> {
-                    // Process LLM call end event 
-                }
-                // Handle other event types 
+            if (message is NodeExecutionStartingEvent) {
+                // Process node start event
+            } else if (message is LLMCallCompletedEvent) {
+                // Process LLM call end event
+            } else {
+                // Handle other event types
             }
         }
 
         override suspend fun close() {
-            // Close connections of established
+            // Close connections if established
         }
     }
 
-    // Use your custom processor
-    install(Tracing) {
-        addMessageProcessor(CustomTraceProcessor())
+    val agent = AIAgent(
+        promptExecutor = simpleOllamaAIExecutor(),
+        llmModel = OllamaModels.Meta.LLAMA_3_2,
+    ) {
+        install(Tracing) {
+            // Use your custom processor
+            addMessageProcessor(CustomTraceProcessor())
+        }
     }
     ```
     <!--- KNIT example-events-03.kt -->
@@ -568,13 +595,52 @@ Implement the `FeatureMessageProcessor` interface:
 === "Java"
 
     <!--- INCLUDE
-    /**
+    import ai.koog.agents.core.agent.AIAgent;
+    import ai.koog.agents.core.feature.message.FeatureMessage;
+    import ai.koog.agents.core.feature.message.FeatureMessageProcessor;
+    import ai.koog.agents.core.feature.model.events.NodeExecutionStartingEvent;
+    import ai.koog.agents.core.feature.model.events.LLMCallCompletedEvent;
+    import ai.koog.agents.features.tracing.feature.Tracing;
+    import ai.koog.prompt.executor.model.PromptExecutor;
+    import ai.koog.prompt.executor.ollama.client.OllamaModels;
+    public class exampleEventsJava03 {
+        public static void main(String[] args) {
     -->
     <!--- SUFFIX
-    **/
+        }
+    }
     -->
     ```java
+    class CustomTraceProcessor extends FeatureMessageProcessor {
+
+        @Override
+        protected void handleMessage(FeatureMessage message) {
+            // Custom processing logic
+            if (message instanceof NodeExecutionStartingEvent) {
+                // Process node start event
+            } else if (message instanceof LLMCallCompletedEvent) {
+                // Process LLM call end event
+            } else {
+                // Handle other event types
+            }
+        }
+
+        @Override
+        public void handleClose() {
+            // Close connections if established
+        }
+    }
+
+    var agent = AIAgent.builder()
+        .promptExecutor(PromptExecutor.builder().ollama().build())
+        .llmModel(OllamaModels.Meta.LLAMA_3_2)
+
+        .install(Tracing.Feature, config -> {
+            // Use your custom processor
+            config.addMessageProcessor(new CustomTraceProcessor());
+        })
+        .build();
     ```
-    <!--- KNIT example-events-java-03.java -->
+    <!--- KNIT exampleEventsJava03.java -->
 
 For more information about existing event types that can be handled by message processors, see [Predefined event types](#predefined-event-types).


### PR DESCRIPTION
KG-787. Add Java code snippets for Agent Events documentation

- Split FeatureMessageProcessor into expect/actual with JVM and non-JVM implementations;
- Add Java-friendly APIs: handleMessage, handleClose, blocking initialize/onMessage wrappers;
- Add Java code snippets for event filtering, multiple processors, and custom processor examples;
- Update Kotlin examples to use TraceFeatureMessageFileWriterJvm.create() factory method.

closes: [KG-787](https://youtrack.jetbrains.com/issue/KG-787)
