### PR TITLE
fix(agents): preserve system prompt in ChatMemory across conversation turns

### DIFF
--- a/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/chatMemory/feature/ChatMemory.kt
+++ b/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/chatMemory/feature/ChatMemory.kt
@@ -36,6 +36,12 @@ import ai.koog.prompt.message.Message
  *     }
  * }
  * ```
+ *
+ * The system prompt is owned by the live agent: when history is loaded it is restored after the
+ * current agent's system messages and any system messages present in the loaded history are
+ * ignored, so the agent's configured system prompt is never lost across turns. Use
+ * [ChatMemoryConfig.dropSystemMessages] if you also want to keep system messages out of stored
+ * history.
  */
 public class ChatMemory {
 
@@ -91,13 +97,23 @@ public class ChatMemory {
         private fun installInternal(config: ChatMemoryConfig, pipeline: AIAgentPipeline) {
             pipeline.interceptStrategyStarting(this) { ctx ->
                 val history = config.chatHistoryProvider.load(ctx.context.runId)
+                val historyMessages = applyPreProcessors(history, config.preprocessors)
 
                 ctx.context.llm.writeSession {
-                    val historyMessages = applyPreProcessors(history, config.preprocessors)
-                    val initialMessages = ctx.context.llm.prompt.messages
-                    prompt = prompt.withMessages {
-                        historyMessages.ifEmpty {
-                            initialMessages + historyMessages
+                    prompt = prompt.withMessages { currentMessages ->
+                        if (historyMessages.isEmpty()) {
+                            // First run (no stored history): keep the initial prompt intact,
+                            // including the system prompt and any setup messages.
+                            currentMessages
+                        } else {
+                            // Subsequent runs: the system prompt is owned by the live agent and
+                            // always takes precedence. Keep the current system messages and drop
+                            // any system messages carried in stored history, then append the rest
+                            // of the conversation. Without this, replacing the prompt with history
+                            // drops the agent's system prompt after the first turn.
+                            val currentSystemMessages = currentMessages.filterIsInstance<Message.System>()
+                            val historyWithoutSystem = historyMessages.filterNot { it is Message.System }
+                            currentSystemMessages + historyWithoutSystem
                         }
                     }
                 }

--- a/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/chatMemory/feature/ChatMemoryConfig.kt
+++ b/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/chatMemory/feature/ChatMemoryConfig.kt
@@ -110,6 +110,29 @@ public class ChatMemoryConfig : FeatureConfig() {
         addPreProcessor(FilterMessagesPreProcessor(predicate))
         return this
     }
+
+    /**
+     * Adds a [DropSystemMessagesPreProcessor] that removes system messages from stored history.
+     *
+     * The system prompt is owned by the live agent and re-applied on each agent creation, so it is
+     * usually redundant to persist. [ChatMemory] always keeps the live agent's system prompt and
+     * ignores any system messages in loaded history regardless of this setting, so adding this
+     * preprocessor only affects what is written to the [ChatHistoryProvider].
+     *
+     * Example:
+     * ```kotlin
+     * installChatMemory {
+     *     chatHistoryProvider = MyChatHistoryProvider()
+     *     dropSystemMessages()
+     * }
+     * ```
+     *
+     * @return This [ChatMemoryConfig] instance for fluent chaining.
+     */
+    public fun dropSystemMessages(): ChatMemoryConfig {
+        addPreProcessor(DropSystemMessagesPreProcessor())
+        return this
+    }
 }
 
 /**

--- a/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/chatMemory/feature/ChatMemoryPreProcessor.kt
+++ b/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/chatMemory/feature/ChatMemoryPreProcessor.kt
@@ -22,9 +22,36 @@ import ai.koog.prompt.message.Message
  *
  * @see WindowSizePreProcessor
  * @see FilterMessagesPreProcessor
+ * @see DropSystemMessagesPreProcessor
  */
 public interface ChatMemoryPreProcessor {
     public fun preprocess(messages: List<Message>): List<Message>
+}
+
+/**
+ * A [ChatMemoryPreProcessor] that removes all [Message.System] messages from the list.
+ *
+ * The system prompt is owned by the live agent and re-applied on each agent creation, so it is
+ * usually redundant to persist it in conversation history. Adding this preprocessor keeps the
+ * stored history free of system messages. This is opt-in: by default [ChatMemory] persists
+ * messages as-is.
+ *
+ * Note that [ChatMemory] already ignores any system messages found in loaded history and keeps
+ * the live agent's system prompt instead, so adding this preprocessor never changes the prompt
+ * the model sees — it only controls what gets written to the [ChatHistoryProvider].
+ *
+ * Example usage:
+ * ```kotlin
+ * installChatMemory {
+ *     chatHistoryProvider = MyChatHistoryProvider()
+ *     dropSystemMessages()
+ * }
+ * ```
+ */
+public class DropSystemMessagesPreProcessor : ChatMemoryPreProcessor {
+    override fun preprocess(messages: List<Message>): List<Message> {
+        return messages.filterNot { it is Message.System }
+    }
 }
 
 /**

--- a/agents/agents-features/agents-features-memory/src/jvmTest/kotlin/ai/koog/agents/chatMemory/ChatMemoryTest.kt
+++ b/agents/agents-features/agents-features-memory/src/jvmTest/kotlin/ai/koog/agents/chatMemory/ChatMemoryTest.kt
@@ -2,6 +2,7 @@ package ai.koog.agents.chatMemory
 
 import ai.koog.agents.chatMemory.feature.ChatHistoryProvider
 import ai.koog.agents.chatMemory.feature.ChatMemory
+import ai.koog.agents.chatMemory.feature.DropSystemMessagesPreProcessor
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.functionalStrategy
@@ -1311,5 +1312,149 @@ class ChatMemoryTest {
 
         assertEquals(expectedMessages.size, savedMessages.size)
         assertContentEquals(expectedMessages, savedMessages)
+    }
+
+    // ---- System prompt preservation across turns ----
+
+    /**
+     * Regression test for the bug where `ChatMemory.installInternal` replaced the prompt
+     * with loaded history, dropping the live agent's system prompt on every turn after
+     * the first when the stored history had no system message of its own.
+     */
+    @Test
+    fun testSystemPromptPreservedWhenLoadedHistoryHasNoSystemMessage() = runTest {
+        val sessionId = "system-preserved-session"
+        val historyProvider = InMemoryChatHistoryProvider(
+            history = mutableMapOf(
+                sessionId to listOf(
+                    Message.User("Earlier question", RequestMetaInfo.Empty),
+                    Message.Assistant("Earlier answer", ResponseMetaInfo(Instant.DISTANT_PAST)),
+                )
+            )
+        )
+
+        val agent = AIAgent(
+            promptExecutor = getMockExecutor(serializer) {
+                mockLLMAnswer("mock reply").asDefaultResponse
+            },
+            llmModel = OpenAIModels.Chat.GPT4oMini,
+            strategy = dumpHistoryStrategy,
+            systemPrompt = "You are a helpful geography assistant.",
+            maxIterations = 10,
+        ) {
+            install(ChatMemory) {
+                chatHistoryProvider = historyProvider
+            }
+        }
+
+        val seen = agent.run("New question", sessionId)
+
+        val systemMessages = seen.filterIsInstance<Message.System>()
+        assertEquals(
+            1,
+            systemMessages.size,
+            "Agent system prompt must be present in the prompt even when loaded history has none"
+        )
+        assertTrue(
+            systemMessages.single().parts.filterIsInstance<MessagePart.Text>()
+                .joinToString("\n") { it.text }
+                .contains("geography assistant"),
+            "The live agent's system prompt should be the one the model sees"
+        )
+    }
+
+    /**
+     * The live agent's system prompt always wins: a stale system message carried inside the
+     * loaded history is dropped so the model never sees an out-of-date prompt.
+     */
+    @Test
+    fun testCurrentSystemPromptReplacesStaleStoredOne() = runTest {
+        val sessionId = "stale-system-session"
+        val historyProvider = InMemoryChatHistoryProvider(
+            history = mutableMapOf(
+                sessionId to listOf(
+                    Message.System("OUTDATED system prompt", RequestMetaInfo.Empty),
+                    Message.User("Earlier question", RequestMetaInfo.Empty),
+                    Message.Assistant("Earlier answer", ResponseMetaInfo(Instant.DISTANT_PAST)),
+                )
+            )
+        )
+
+        val agent = AIAgent(
+            promptExecutor = getMockExecutor(serializer) {
+                mockLLMAnswer("mock reply").asDefaultResponse
+            },
+            llmModel = OpenAIModels.Chat.GPT4oMini,
+            strategy = dumpHistoryStrategy,
+            systemPrompt = "CURRENT system prompt",
+            maxIterations = 10,
+        ) {
+            install(ChatMemory) {
+                chatHistoryProvider = historyProvider
+            }
+        }
+
+        val seen = agent.run("New question", sessionId)
+
+        val systemTexts = seen.filterIsInstance<Message.System>()
+            .map { it.parts.filterIsInstance<MessagePart.Text>().joinToString("\n") { p -> p.text } }
+        assertEquals(1, systemTexts.size, "Only the live agent's system prompt should be present")
+        assertTrue(systemTexts.single().contains("CURRENT"), "Live agent's system prompt should win")
+        assertTrue(
+            systemTexts.none { it.contains("OUTDATED") },
+            "Stale stored system prompt should be ignored on load"
+        )
+    }
+
+    // ---- dropSystemMessages opt-in ----
+
+    @Test
+    fun testDropSystemMessagesPreProcessorRemovesSystemMessages() {
+        val processor = DropSystemMessagesPreProcessor()
+        val input = listOf(
+            Message.System("sys", RequestMetaInfo.Empty),
+            Message.User("u", RequestMetaInfo.Empty),
+            Message.Assistant("a", ResponseMetaInfo(Instant.DISTANT_PAST)),
+        )
+        val result = processor.preprocess(input)
+        assertEquals(2, result.size, "System message should be removed")
+        assertTrue(result.none { it is Message.System }, "No system messages should remain")
+        assertIs<Message.User>(result[0])
+        assertIs<Message.Assistant>(result[1])
+    }
+
+    @Test
+    fun testDropSystemMessagesExcludesSystemFromStoredHistory() = runTest {
+        val sessionId = "drop-system-session"
+        val historyProvider = InMemoryChatHistoryProvider()
+
+        val agent = AIAgent(
+            promptExecutor = getMockExecutor(serializer) {
+                mockLLMAnswer("Paris is the capital of France.") onRequestContains "France"
+                mockLLMAnswer("Berlin is the capital of Germany.") onRequestContains "Germany"
+                mockLLMAnswer("mock reply").asDefaultResponse
+            },
+            llmModel = OpenAIModels.Chat.GPT4oMini,
+            systemPrompt = "You are a helpful geography assistant.",
+            maxIterations = 10,
+        ) {
+            install(ChatMemory) {
+                chatHistoryProvider = historyProvider
+                dropSystemMessages()
+            }
+        }
+
+        agent.run("What is the capital of France?", sessionId)
+        val secondRun = agent.run("What is the capital of Germany?", sessionId)
+
+        // The agent still works across turns — the system prompt comes from the live agent.
+        assertEquals("Berlin is the capital of Germany.", secondRun)
+
+        val saved = historyProvider.history[sessionId]!!
+        assertTrue(saved.none { it is Message.System }, "System messages should be excluded from stored history")
+        assertTrue(saved.isNotEmpty(), "Non-system messages should still be stored")
+        val contents = saved.map { it.parts.filterIsInstance<MessagePart.Text>().joinToString("\n") { p -> p.text } }
+        assertTrue(contents.any { it.contains("France") }, "User/assistant France messages should be persisted")
+        assertTrue(contents.any { it.contains("Germany") }, "User/assistant Germany messages should be persisted")
     }
 }


### PR DESCRIPTION
ChatMemory.installInternal replaces all prompt messages with loaded history via withMessages, which drops the system prompt set on the current agent. After the first turn of any conversation with persistent history, the model receives an empty system field in the API request.

Found while building a multi-agent app using Koog + H2JdbcChatHistoryProvider. Specialist agents with detailed system prompts appeared to ignore them entirely after the first conversation turn.

## Fix

**Load side (unconditional):** on subsequent turns, the prompt becomes `currentSystemMessages + historyWithoutSystem`. The live agent's system prompt always takes precedence, and any system messages carried in stored history are ignored on load. First run (empty history) is unchanged.

This is framed as "the live agent owns the system prompt" rather than "delete stored data." The store side never deletes anything by default.

**Store side (opt-in):** added `DropSystemMessagesPreProcessor` and a `ChatMemoryConfig.dropSystemMessages()` config DSL method, in the same shape as the existing `WindowSizePreProcessor` / `windowSize()` and `FilterMessagesPreProcessor` / `filterMessages()`. Users who want stored history free of system messages opt in; everyone else gets the default behavior.

The develop branch has a partial workaround (`historyMessages.ifEmpty { initialMessages + historyMessages }`) that preserves initial messages on the first run but still drops the system prompt on all subsequent runs when history is non-empty.

## Tests

No existing test assertions are modified.

Four new tests added:
- regression: system prompt survives when loaded history has no system message
- live agent's system prompt replaces a stale one carried in history
- `DropSystemMessagesPreProcessor` unit test
- `dropSystemMessages()` keeps stored history free of system messages while multi-turn conversation still works end-to-end

All 43 tests in `ChatMemoryTest` pass locally.

## Revision history

The first revision of this PR mandatorily stripped system messages on store. Per reviewer feedback that this contradicted the feature description, the store side is now untouched by default and the filtering is an opt-in preprocessor.
