### PR TITLE
fix(prompt): use channelFlow in buildStreamFrameFlow to fix Flow inva…

### DIFF
--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
@@ -4,6 +4,8 @@ import ai.koog.prompt.message.ResponseMetaInfo
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.channels.ProducerScope
+import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlin.concurrent.atomics.AtomicReference
@@ -115,8 +117,9 @@ public suspend fun FlowCollector<StreamFrame>.emitToolCallComplete(
  * Should be used only in case model does not produce completion events.
  */
 public fun buildStreamFrameFlow(block: suspend StreamFrameFlowBuilder.() -> Unit): Flow<StreamFrame> =
-    streamFrameFlow {
-        val builder = StreamFrameFlowBuilder(this)
+    channelFlow {
+        val collector = FlowCollector<StreamFrame> { frame -> send(frame) }
+        val builder = StreamFrameFlowBuilder(collector)
         block(builder)
     }
 

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
@@ -4,7 +4,6 @@ import ai.koog.prompt.message.ResponseMetaInfo
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map

--- a/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderTest.kt
+++ b/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderTest.kt
@@ -1,9 +1,11 @@
 package ai.koog.prompt.streaming
 
 import ai.koog.prompt.message.ResponseMetaInfo
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertFailsWith
@@ -357,6 +359,38 @@ class StreamFrameFlowBuilderTest {
             listOf(
                 StreamFrame.ToolCallDelta("call_1", "tool", "{}"),
                 StreamFrame.ToolCallComplete("call_1", "tool", "{}"),
+                StreamFrame.End("stop", ResponseMetaInfo.Empty)
+            ),
+            frames
+        )
+    }
+
+    /**
+     * Regression test for #1775.
+     *
+     * When LLM clients (e.g. OllamaClient) wrap Ktor's preparePost(...).execute { }
+     * inside buildStreamFrameFlow, the emission happens from an undispatched Ktor
+     * continuation context while collection happens from a different context. With
+     * the previous flow { } builder this violated Flow's context preservation
+     * invariant and threw IllegalStateException. The fix switches buildStreamFrameFlow
+     * to channelFlow { }, which supports cross-context emission. This test reproduces
+     * that scenario by emitting from a withContext(Dispatchers.Default) block.
+     */
+    @Test
+    fun testBuildStreamFrameFlowSupportsCrossContextEmission() = runTest {
+        val frames = buildStreamFrameFlow {
+            withContext(Dispatchers.Default) {
+                emitTextDelta("Hello", 0)
+                emitTextDelta(" World", 0)
+                emitEnd("stop")
+            }
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.TextDelta("Hello", 0),
+                StreamFrame.TextDelta(" World", 0),
+                StreamFrame.TextComplete("Hello World", 0),
                 StreamFrame.End("stop", ResponseMetaInfo.Empty)
             ),
             frames


### PR DESCRIPTION
## Summary

Fixes #1775

## Problem

`OllamaClient.executeStreaming` throws `IllegalStateException: Flow invariant is violated` when collecting stream frames. The `buildStreamFrameFlow` function delegates to `streamFrameFlow`, which uses the `flow { }` builder. The `flow { }` builder enforces strict context preservation — emission must happen in the same coroutine context as collection. When LLM clients like `OllamaClient` call `client.preparePost(...).execute { }` inside this flow, Ktor's streaming HTTP execution uses an undispatched continuation (`UndispatchedMarker`), creating a different coroutine context and violating the invariant.

## Fix

Replaced `flow { }` with `channelFlow { }` in `buildStreamFrameFlow`. `channelFlow` uses a `Channel` internally and supports emission from any coroutine context. A `FlowCollector` adapter bridges `emit()` calls to `send()` on the channel, so `StreamFrameFlowBuilder` works without changes.

## Impact

This is shared infrastructure used by all LLM clients. The change is safe because `channelFlow` is strictly more permissive than `flow` — any code that worked with `flow` will work with `channelFlow`.