### PR TITLE
docs(spring-boot): Add docs about all four Spring AI integration starters

### DIFF
--- a/docs/docs/spring-ai-integration.md
+++ b/docs/docs/spring-ai-integration.md
@@ -117,8 +117,6 @@ Inject the `PromptExecutor` and use it to run a Koog agent:
     import ai.koog.agents.core.agent.AIAgent
     import ai.koog.prompt.executor.clients.openai.OpenAIModels
     import ai.koog.prompt.executor.model.PromptExecutor
-    import ai.koog.prompt.llm.LLModel
-    import ai.koog.prompt.llm.LLMProvider
     import org.springframework.stereotype.Service
 
     @Service

--- a/docs/docs/spring-ai-integration.md
+++ b/docs/docs/spring-ai-integration.md
@@ -1,28 +1,41 @@
 # Spring AI Integration
 
-Koog provides Spring AI integration starters that bridge Spring AI's model abstractions with the Koog agent framework.
-If you already use Spring AI for model access, these starters let you plug Koog's agent orchestration on top —
+Koog provides Spring AI integration starters that bridge Spring AI's abstractions with the Koog agent framework.
+If you already use Spring AI for model access, memory, or vector storage, these starters let you plug Koog on top
 without replacing your existing Spring AI configuration.
 
 ## How it differs from `koog-spring-boot-starter`
 
 | | `koog-spring-boot-starter` | `koog-spring-ai` starters |
 |---|---|---|
-| **LLM transport** | Koog's own HTTP clients (one per provider: OpenAI, Anthropic, Google, etc.) | Delegates to Spring AI's `ChatModel` / `EmbeddingModel` — any provider that Spring AI supports works automatically |
-| **Configuration** | `ai.koog.*` properties per provider | Standard `spring.ai.*` properties managed by Spring AI starters |
-| **When to use** | You want Koog to manage LLM connections directly | You already use Spring AI for model access and want to plug Koog's agent orchestration on top |
+| **LLM transport** | Koog's own HTTP clients | Delegates to Spring AI beans such as `ChatModel` and `EmbeddingModel` |
+| **Configuration** | `ai.koog.*` properties per provider | Standard `spring.ai.*` properties managed by Spring AI starters, plus `koog.spring.ai.*` adapter properties |
+| **When to use** | You want Koog to manage model connectivity directly | You already use Spring AI and want Koog agents, memory, or RAG on top |
 
-Both approaches are independent — pick one based on how you prefer to manage LLM connectivity.
+Both approaches are independent.
 For the direct Koog starter approach, see [Spring Boot Integration](spring-boot.md).
 
 ## Available Starters
 
 | Module | Purpose |
 |---|---|
-| `koog-spring-ai-starter-model-chat` | Adapts a Spring AI `ChatModel` (with optional `ModerationModel`) into a Koog `LLMClient` and `PromptExecutor` |
+| `koog-spring-ai-starter-model-chat` | Adapts a Spring AI `ChatModel` with optional `ModerationModel` into a Koog `LLMClient` and `PromptExecutor` |
 | `koog-spring-ai-starter-model-embedding` | Adapts a Spring AI `EmbeddingModel` into a Koog `LLMEmbeddingProvider` |
+| `koog-spring-ai-starter-chat-memory` | Adapts a Spring AI `ChatMemoryRepository` into a Koog `ChatHistoryProvider` |
+| `koog-spring-ai-starter-vector-store` | Adapts a Spring AI `VectorStore` into Koog `KoogVectorStore` for ingestion, search, and deletion |
 
-Each starter is a fully independent Spring Boot starter with its own auto-configuration, configuration properties, and dispatcher management.
+Each starter is an independent Spring Boot starter with its own auto-configuration and configuration properties.
+You can use one starter or combine several in the same application.
+
+## Dispatcher Types
+
+All four starters support the same dispatcher configuration pattern:
+
+- **`AUTO`** (default): Uses a Spring-managed `AsyncTaskExecutor` if available, otherwise falls back to `Dispatchers.IO`.
+- **`IO`**: Always uses `Dispatchers.IO`.
+- **`dispatcher.parallelism`**: When greater than `0` and `type=IO`, uses `Dispatchers.IO.limitedParallelism(parallelism)`.
+
+`AUTO` is usually the simplest choice, especially when you use Spring Boot virtual threads.
 
 ## Chat Model Starter
 
@@ -34,22 +47,20 @@ It auto-configures:
 - A Koog `LLMClient` (`SpringAiLLMClient`) that delegates to a Spring AI `ChatModel`
 - A `PromptExecutor` (`MultiLLMPromptExecutor`) assembled from all available `LLMClient` beans
 
-Tools are always executed by the Koog agent framework — Spring AI receives only tool
-definitions/schema. The `internalToolExecutionEnabled` flag is set to `false` on all
-tool-carrying requests.
+Tools are always executed by the Koog agent framework.
+Spring AI receives only tool definitions and schemas, and `internalToolExecutionEnabled` is set to `false`.
 
 ### Add Dependency
 
-Add the dependency alongside any Spring AI model starter (e.g., for Google):
+Add the dependency alongside any Spring AI chat model starter:
 
 === "Gradle (Kotlin DSL)"
 
     ```kotlin
-    // build.gradle.kts
     dependencies {
         implementation("ai.koog:koog-agents-jvm:$koogVersion")
         implementation("ai.koog:koog-spring-ai-starter-model-chat:$koogVersion")
-        implementation("org.springframework.ai:spring-ai-starter-model-google-genai")
+        implementation("org.springframework.ai:spring-ai-starter-model-openai")
     }
     ```
 
@@ -69,35 +80,32 @@ Add the dependency alongside any Spring AI model starter (e.g., for Google):
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-starter-model-google-genai</artifactId>
+            <artifactId>spring-ai-starter-model-openai</artifactId>
         </dependency>
     </dependencies>
     ```
 
-Make sure that your project has:
-
-- Spring Boot 3 (it requires Java 17 or higher)
-- Kotlin libraries with version 2.3.10+ (kotlin-stdlib)
-- A Spring AI model starter for your chosen provider
-
 ### Available providers
-Anthropic, Azure OpenAI, Bedrock Converse, Deepseek, Google GenAI, HuggingFace, MiniMax, Mistral AI, OCI GenAI, Ollama, OpenAI, Vertex AI, ZhiPu AI
+
+The starter works with any provider for which Spring AI creates a `ChatModel`, including:
+Anthropic, Azure OpenAI, Bedrock Converse, DeepSeek, Google GenAI, HuggingFace, MiniMax,
+Mistral AI, OCI GenAI, Ollama, OpenAI, Vertex AI, and ZhiPu AI.
 
 ### Configure
 
-Modify your Spring Boot properties if needed:
+Configure your provider through the matching Spring AI starter, then add Koog properties if needed:
 
 ```properties
-# put your API key for Gemini Developer API or pass it via an environment variable
-spring.ai.google.genai.api-key=YOUR_GOOGLE_API_KEY
-# default values
-spring.ai.model.chat=google-genai
+# example Spring AI provider configuration
+spring.ai.openai.api-key=${OPENAI_API_KEY}
+
+# Koog chat starter defaults
 koog.spring.ai.chat.enabled=true
 koog.spring.ai.chat.dispatcher.type=AUTO
 ```
 
-If you have a single `ChatModel` bean, everything works automatically —
-the adapter wraps it into a Koog `LLMClient` and creates a ready-to-use `PromptExecutor`.
+If you have a single `ChatModel` bean, everything works automatically.
+The adapter wraps it into a Koog `LLMClient` and creates a ready-to-use `PromptExecutor`.
 
 ### Usage Example
 
@@ -107,8 +115,10 @@ Inject the `PromptExecutor` and use it to run a Koog agent:
 
     ```kotlin
     import ai.koog.agents.core.agent.AIAgent
-    import ai.koog.prompt.executor.clients.google.GoogleModels
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
     import ai.koog.prompt.executor.model.PromptExecutor
+    import ai.koog.prompt.llm.LLModel
+    import ai.koog.prompt.llm.LLMProvider
     import org.springframework.stereotype.Service
 
     @Service
@@ -117,7 +127,7 @@ Inject the `PromptExecutor` and use it to run a Koog agent:
         suspend fun askAgent(userMessage: String): String {
             val agent = AIAgent(
                 promptExecutor = promptExecutor,
-                llmModel = GoogleModels.Gemini2_5Flash,
+                llmModel = OpenAIModels.Chat.GPT5Nano,
                 systemPrompt = "You are a helpful assistant."
             )
 
@@ -130,7 +140,7 @@ Inject the `PromptExecutor` and use it to run a Koog agent:
 
     ```java
     import ai.koog.agents.core.agent.AIAgent;
-    import ai.koog.prompt.executor.clients.google.GoogleModels;
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels;
     import ai.koog.prompt.executor.model.PromptExecutor;
     import org.springframework.stereotype.Service;
 
@@ -145,7 +155,7 @@ Inject the `PromptExecutor` and use it to run a Koog agent:
         public String askAgent(String userMessage) {
             var agent = AIAgent.builder()
                     .promptExecutor(promptExecutor)
-                    .llmModel(GoogleModels.Gemini2_5Flash)
+                    .llmModel(OpenAIModels.Chat.GPT5Nano)
                     .systemPrompt("You are a helpful assistant.")
                     .build();
 
@@ -160,17 +170,12 @@ Or provide your own `PromptExecutor` bean to override the auto-configured one en
 
 | Property | Type | Default | Description |
 |---|---|---|---|
-| `enabled` | `Boolean` | `true` | Enable/disable the chat auto-configuration |
-| `chat-model-bean-name` | `String?` | `null` | Bean name of the `ChatModel` to use (for multi-model contexts) |
-| `moderation-model-bean-name` | `String?` | `null` | Bean name of the `ModerationModel` to use (for multi-model contexts) |
-| `provider` | `String?` | `null` | LLM provider id (e.g. `openai`, `anthropic`, `google`). When set, overrides auto-detection from the `ChatModel` class name. Falls back to `spring-ai` if auto-detection fails. |
+| `enabled` | `Boolean` | `true` | Enable or disable the chat auto-configuration |
+| `chat-model-bean-name` | `String?` | `null` | Bean name of the `ChatModel` to use when multiple models are present |
+| `moderation-model-bean-name` | `String?` | `null` | Bean name of the `ModerationModel` to use |
+| `provider` | `String?` | `null` | Koog provider id to expose instead of auto-detecting from the `ChatModel` class |
 | `dispatcher.type` | `AUTO` / `IO` | `AUTO` | Dispatcher for blocking model calls |
-| `dispatcher.parallelism` | `Int` | `0` (= unbounded) | Max concurrency for `IO` dispatcher (0 = no limit) |
-
-### Dispatcher Types
-
-- **`AUTO`** (default): Uses a Spring-managed `AsyncTaskExecutor` if available (e.g., when `spring.threads.virtual.enabled=true` in Spring Boot 3.2+), otherwise falls back to `Dispatchers.IO`. This lets you opt into virtual threads with a single standard Spring Boot property.
-- **`IO`**: Always uses `Dispatchers.IO`. When `dispatcher.parallelism` is greater than 0, uses `Dispatchers.IO.limitedParallelism(parallelism)` to cap concurrency.
+| `dispatcher.parallelism` | `Int` | `0` (= unbounded) | Max concurrency for `IO` dispatcher |
 
 ### Multi-model Contexts
 
@@ -185,14 +190,13 @@ Without a selector, the auto-configuration activates only when a single candidat
 
 ### Extension Points
 
-- **`ChatOptionsCustomizer`**: Register a Spring bean implementing this functional interface to apply provider-specific `ChatOptions` tuning:
+- **`ChatOptionsCustomizer`**: Register a Spring bean implementing this interface to customize `ChatOptions`
 
 === "Kotlin"
 
     ```kotlin
     @Bean
     fun chatOptionsCustomizer() = ChatOptionsCustomizer { options, params, model ->
-        // Apply custom options based on the model or request parameters
         options
     }
     ```
@@ -202,22 +206,434 @@ Without a selector, the auto-configuration activates only when a single candidat
     ```java
     @Bean
     public ChatOptionsCustomizer chatOptionsCustomizer() {
-        return (options, params, model) -> {
-            // Apply custom options based on the model or request parameters
-            return options;
-        };
+        return (options, params, model) -> options;
     }
     ```
 
-  The auto-configuration picks it up automatically via optional injection.
-
-- **Custom `LLMClient`**: Register your own `LLMClient` bean to override the auto-configured adapter entirely.
+- **Custom `LLMClient`**: Register your own `LLMClient` bean. It will be composed together with the auto-configured adapter unless you replace the bean named `springAiChatModelLLMClient`.
 - **Custom `PromptExecutor`**: Register your own `PromptExecutor` bean to override the auto-configured `MultiLLMPromptExecutor`.
+
+## Embedding Model Starter
+
+### Overview
+
+The `koog-spring-ai-starter-model-embedding` starter bridges Spring AI's embedding model abstraction with the Koog agent framework.
+It auto-configures:
+
+- A Koog `LLMEmbeddingProvider` (`SpringAiLLMEmbeddingProvider`) that delegates to a Spring AI `EmbeddingModel`
+
+The adapter forwards the Koog model id into Spring AI `EmbeddingOptions`, so backends that support runtime model selection can honor it.
+
+### Add Dependency
+
+Add the dependency alongside any Spring AI embedding model starter:
+
+=== "Gradle (Kotlin DSL)"
+
+    ```kotlin
+    dependencies {
+        implementation("ai.koog:koog-agents-jvm:$koogVersion")
+        implementation("ai.koog:koog-spring-ai-starter-model-embedding:$koogVersion")
+        implementation("org.springframework.ai:spring-ai-starter-model-openai")
+    }
+    ```
+
+=== "Maven"
+
+    ```xml
+    <dependencies>
+        <dependency>
+            <groupId>ai.koog</groupId>
+            <artifactId>koog-agents-jvm</artifactId>
+            <version>${koog.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ai.koog</groupId>
+            <artifactId>koog-spring-ai-starter-model-embedding</artifactId>
+            <version>${koog.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-openai</artifactId>
+        </dependency>
+    </dependencies>
+    ```
+
+### Available providers
+
+The starter works with any provider for which Spring AI creates an `EmbeddingModel`, including:
+Anthropic, Azure OpenAI, Bedrock, Google GenAI, HuggingFace, Mistral AI, OCI GenAI,
+Ollama, OpenAI, Transformers, Vertex AI, and ZhiPu AI.
+
+### Configure
+
+Configure your embedding provider through Spring AI, then add Koog properties if needed:
+
+```properties
+# example Spring AI provider configuration
+spring.ai.openai.api-key=${OPENAI_API_KEY}
+
+# Koog embedding starter defaults
+koog.spring.ai.embedding.enabled=true
+koog.spring.ai.embedding.dispatcher.type=AUTO
+```
+
+If you have a single `EmbeddingModel` bean, everything works automatically.
+The adapter wraps it into a Koog `LLMEmbeddingProvider`.
+
+### Usage Example
+
+Inject `LLMEmbeddingProvider` and use it for embedding operations:
+
+=== "Kotlin"
+
+    ```kotlin
+    import ai.koog.prompt.executor.clients.LLMEmbeddingProvider
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import org.springframework.stereotype.Service
+
+    @Service
+    class MyEmbeddingService(private val embeddingProvider: LLMEmbeddingProvider) {
+
+        suspend fun getEmbedding(text: String): List<Double> {
+            return embeddingProvider.embed(
+                text,
+                OpenAIModels.Embeddings.TextEmbedding3Small
+            )
+        }
+    }
+    ```
+
+=== "Java"
+
+    ```java
+    import ai.koog.prompt.executor.clients.LLMEmbeddingProvider;
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels;
+    import org.springframework.stereotype.Service;
+    import java.util.List;
+
+    @Service
+    public class MyEmbeddingService {
+        private final LLMEmbeddingProvider embeddingProvider;
+
+        public MyEmbeddingService(LLMEmbeddingProvider embeddingProvider) {
+            this.embeddingProvider = embeddingProvider;
+        }
+
+        public List<Double> getEmbedding(String text) {
+            return embeddingProvider.embed(
+                    text,
+                    OpenAIModels.Embeddings.TextEmbedding3Small
+            );
+        }
+    }
+    ```
+
+Or provide your own `LLMEmbeddingProvider` bean to override the auto-configured adapter entirely.
+
+### Configuration Properties (`koog.spring.ai.embedding`)
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | `Boolean` | `true` | Enable or disable the embedding auto-configuration |
+| `embedding-model-bean-name` | `String?` | `null` | Bean name of the `EmbeddingModel` to use when multiple models are present |
+| `dispatcher.type` | `AUTO` / `IO` | `AUTO` | Dispatcher for blocking embedding calls |
+| `dispatcher.parallelism` | `Int` | `0` (= unbounded) | Max concurrency for `IO` dispatcher |
+
+### Multi-model Contexts
+
+When multiple `EmbeddingModel` beans are registered, specify which one to use:
+
+```properties
+koog.spring.ai.embedding.embedding-model-bean-name=openAiEmbeddingModel
+```
+
+Without a selector, the auto-configuration activates only when a single candidate exists.
+
+### Extension Points
+
+- **Custom `LLMEmbeddingProvider`**: Register your own bean to override the auto-configured adapter entirely.
+
+## Chat Memory Starter
+
+### Overview
+
+The `koog-spring-ai-starter-chat-memory` starter bridges Spring AI's chat memory abstraction with the Koog agent framework.
+It auto-configures:
+
+- A Koog `ChatHistoryProvider` (`SpringAiChatHistoryProvider`) that delegates to a Spring AI `ChatMemoryRepository`
+
+This starter provides text-only conversation persistence, not full Koog execution-state persistence.
+
+### Text-only contract
+
+Only plain-text `System`, `User`, and `Assistant` messages are persisted.
+The following are silently dropped on store:
+
+- `Message.Tool.Call`
+- `Message.Tool.Result`
+- `Message.Reasoning`
+- any message carrying attachments
+
+On load, Spring AI `TOOL` rows are silently skipped.
+Metadata such as timestamps, token counts, finish reasons, and custom metadata is not preserved.
+
+### Add Dependency
+
+Add the dependency alongside a Spring AI chat memory repository implementation:
+
+=== "Gradle (Kotlin DSL)"
+
+    ```kotlin
+    dependencies {
+        implementation("ai.koog:koog-agents-jvm:$koogVersion")
+        implementation("ai.koog:koog-spring-ai-starter-chat-memory:$koogVersion")
+        implementation("org.springframework.ai:spring-ai-starter-model-chat-memory-repository-jdbc")
+    }
+    ```
+
+=== "Maven"
+
+    ```xml
+    <dependencies>
+        <dependency>
+            <groupId>ai.koog</groupId>
+            <artifactId>koog-agents-jvm</artifactId>
+            <version>${koog.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ai.koog</groupId>
+            <artifactId>koog-spring-ai-starter-chat-memory</artifactId>
+            <version>${koog.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-chat-memory-repository-jdbc</artifactId>
+        </dependency>
+    </dependencies>
+    ```
+
+### Available providers
+
+This starter works with any Spring AI chat memory repository implementation that exposes `ChatMemoryRepository`,
+including JDBC, Redis, Cassandra, Cosmos DB, MongoDB, and Neo4j based repositories.
+
+### Configure
+
+Usually no extra configuration is required beyond your Spring AI repository setup:
+
+```properties
+# Koog chat-memory starter defaults
+koog.spring.ai.chat-memory.enabled=true
+koog.spring.ai.chat-memory.dispatcher.type=AUTO
+```
+
+If you have a single `ChatMemoryRepository` bean, everything works automatically.
+The adapter wraps it into a Koog `ChatHistoryProvider`.
+
+### Usage Example
+
+Install the `ChatMemory` feature on your agent using the auto-configured `ChatHistoryProvider`:
+
+=== "Kotlin"
+
+    ```kotlin
+    import ai.koog.agents.chatMemory.feature.ChatMemory
+    import ai.koog.agents.chatMemory.feature.ChatHistoryProvider
+    import ai.koog.agents.core.agent.AIAgent
+    import ai.koog.prompt.executor.clients.openai.OpenAIModels
+    import ai.koog.prompt.executor.model.PromptExecutor
+    import org.springframework.stereotype.Service
+
+    @Service
+    class MyAgentService(
+        private val promptExecutor: PromptExecutor,
+        private val chatStorage: ChatHistoryProvider,
+    ) {
+
+        suspend fun askAgent(userMessage: String, sessionId: String): String {
+            val agent = AIAgent(
+                promptExecutor = promptExecutor,
+                llmModel = OpenAIModels.Chat.GPT5Nano,
+                systemPrompt = "You are a helpful assistant.",
+            ) {
+                install(ChatMemory) {
+                    chatHistoryProvider = chatStorage
+                }
+            }
+
+            return agent.run(userMessage, sessionId)
+        }
+    }
+    ```
+
+### Configuration Properties (`koog.spring.ai.chat-memory`)
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | `Boolean` | `true` | Enable or disable the chat-memory auto-configuration |
+| `chat-memory-repository-bean-name` | `String?` | `null` | Bean name of the `ChatMemoryRepository` to use when multiple repositories are present |
+| `dispatcher.type` | `AUTO` / `IO` | `AUTO` | Dispatcher for blocking repository calls |
+| `dispatcher.parallelism` | `Int` | `0` (= unbounded) | Max concurrency for `IO` dispatcher |
+
+### Multi-repository Contexts
+
+When multiple `ChatMemoryRepository` beans are registered, specify which one to use:
+
+```properties
+koog.spring.ai.chat-memory.chat-memory-repository-bean-name=jdbcChatMemoryRepository
+```
+
+Without a selector, the auto-configuration activates only when a single candidate exists.
+
+### Current limitations
+
+- Only text conversation history is persisted
+- Tool calls, tool results, reasoning messages, and attachments are not persisted
+- Spring AI `TOOL` messages are skipped on load
+- Message metadata is not preserved through the round-trip
+
+## Vector Store Starter
+
+### Overview
+
+The `koog-spring-ai-starter-vector-store` starter bridges Spring AI vector-store abstractions with Koog's RAG storage interfaces.
+It auto-configures:
+
+- A `SpringAiKoogVectorStore` adapter exposed as Koog `KoogVectorStore`
+
+`KoogVectorStore` combines:
+
+- `WriteStorage<TextDocument>`
+- `SearchStorage<TextDocument, SimilaritySearchRequest>`
+- `FilteringDeletionStorage`
+
+Examples typically use `DocumentWithMetadata` as the concrete document type.
+
+### Add Dependency
+
+Add the dependency alongside a Spring AI vector-store starter:
+
+=== "Gradle (Kotlin DSL)"
+
+    ```kotlin
+    dependencies {
+        implementation("ai.koog:koog-spring-ai-starter-vector-store:$koogVersion")
+        implementation("org.springframework.ai:spring-ai-starter-vector-store-pgvector")
+    }
+    ```
+
+=== "Maven"
+
+    ```xml
+    <dependencies>
+        <dependency>
+            <groupId>ai.koog</groupId>
+            <artifactId>koog-spring-ai-starter-vector-store</artifactId>
+            <version>${koog.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-vector-store-pgvector</artifactId>
+        </dependency>
+    </dependencies>
+    ```
+
+### Available providers
+
+The starter works with any Spring AI implementation that exposes `VectorStore`, including PgVector,
+Azure AI Search, Cassandra, Chroma, Elasticsearch, Milvus, MongoDB Atlas, Neo4j, OpenSearch,
+Oracle, Pinecone, Qdrant, Redis, Typesense, and Weaviate.
+
+### Configure
+
+Usually no extra Koog configuration is required beyond your Spring AI vector-store setup:
+
+```properties
+# Koog vector-store starter defaults
+koog.spring.ai.vectorstore.enabled=true
+koog.spring.ai.vectorstore.dispatcher.type=AUTO
+```
+
+If you have a single `VectorStore` bean, everything works automatically.
+The adapter wraps it into a Koog `KoogVectorStore`.
+
+### Usage Example
+
+Inject `KoogVectorStore` directly into your Spring components:
+
+=== "Kotlin"
+
+    ```kotlin
+    import ai.koog.rag.base.TextDocument
+    import ai.koog.rag.base.storage.search.SearchResult
+    import ai.koog.rag.base.storage.search.SimilaritySearchRequest
+    import ai.koog.spring.ai.vectorstore.DocumentWithMetadata
+    import ai.koog.spring.ai.vectorstore.KoogVectorStore
+    import org.springframework.stereotype.Service
+
+    @Service
+    class MyKnowledgeBase(
+        private val vectorStore: KoogVectorStore,
+    ) {
+
+        suspend fun ingest(text: String): List<String> {
+            return vectorStore.add(
+                listOf(
+                    DocumentWithMetadata(
+                        content = text,
+                        metadata = mapOf("source" to "user")
+                    )
+                )
+            )
+        }
+
+        suspend fun search(query: String): List<SearchResult<TextDocument>> {
+            return vectorStore.search(
+                SimilaritySearchRequest(queryText = query, limit = 5)
+            )
+        }
+
+        suspend fun remove(ids: List<String>) {
+            vectorStore.delete(ids)
+        }
+    }
+    ```
+
+### Configuration Properties (`koog.spring.ai.vectorstore`)
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | `Boolean` | `true` | Enable or disable the vector-store auto-configuration |
+| `vector-store-bean-name` | `String?` | `null` | Bean name of the `VectorStore` to use when multiple stores are present |
+| `dispatcher.type` | `AUTO` / `IO` | `AUTO` | Dispatcher for blocking vector-store calls |
+| `dispatcher.parallelism` | `Int` | `0` (= unbounded) | Max concurrency for `IO` dispatcher |
+
+### Multi-store Contexts
+
+When multiple `VectorStore` beans are registered, specify which one to use:
+
+```properties
+koog.spring.ai.vectorstore.vector-store-bean-name=pgVectorStore
+```
+
+Without a selector, the auto-configuration activates only when a single candidate exists.
+
+### Current limitations
+
+- Spring AI's `VectorStore` contract exposes similarity search only
+- Update is implemented as `delete(ids)` followed by `add(documents)`, so it is not transactional
+- `LookupStorage` is not implemented because Spring AI has no portable read-by-id API
+- `delete(ids)` returns the input ids unchanged; Spring AI does not confirm which documents were actually deleted
+- `delete(filterExpression)` returns an empty list; Spring AI does not return the ids of matched documents
+- Namespace scoping is not implemented
+- Metadata values must be primitive values such as `String`, `Number`, or `Boolean`
 
 ## Next Steps
 
-- Learn about the [basic agents](agents/basic-agents.md) to build minimal AI workflows
+- Learn about [basic agents](agents/basic-agents.md) to build minimal AI workflows
 - Explore [graph-based agents](agents/graph-based-agents.md) for advanced use cases
 - See the [tools overview](tools-overview.md) to extend your agents' capabilities
-- Check out [examples](examples.md) for real-world implementations
+- Read [retrieval-augmented generation](retrieval-augmented-generation.md) for RAG concepts
+- Check [examples](examples.md) for real-world implementations
 - Read the [Spring Boot Integration](spring-boot.md) guide for the direct Koog starter approach

--- a/docs/docs/why-koog.md
+++ b/docs/docs/why-koog.md
@@ -34,7 +34,7 @@ Koog includes pre-built, composable solutions to simplify and speed up the devel
 
 Koog supports the development and deployment of agentic applications across a variety of platforms and environments:
 
-*  **Spring Boot, Sprig AI and Ktor integrations**. Koog integrates with widely used enterprise environments.
+*  **Spring Boot, Spring AI and Ktor integrations**. Koog integrates with widely used enterprise environments.
       * For Spring Boot, Koog provides ready-to-use beans and auto-configured LLM clients, making it easy to start building AI-powered workflows.
       * If you're already using Spring AI for LLM and RAG capabilities, Koog can be layered on top as an orchestration and agentic framework. This allows you to leverage Spring AI’s extensive integrations while benefiting from Koog’s advanced, reliable, and cost-efficient AI workflows.
       * If you have a Ktor server, you can install Koog as a plugin, configure providers using configuration files, and call agents directly from any route without manually connecting LLM clients.


### PR DESCRIPTION
Previously it only covered ChatModel starter.