### PR TITLE
feat(agents): add Oracle Database support for Chat History Provider

### DIFF
--- a/agents/agents-features/agents-features-chat-history-jdbc/build.gradle.kts
+++ b/agents/agents-features/agents-features-chat-history-jdbc/build.gradle.kts
@@ -26,10 +26,12 @@ dependencies {
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.testcontainers.mysql)
+    testImplementation("org.testcontainers:oracle-xe:${libs.versions.testcontainers.get()}")
 
     testImplementation(libs.h2)
     testImplementation(libs.postgresql)
     testImplementation(libs.mysql)
+    testImplementation("com.oracle.database.jdbc:ojdbc11:23.7.0.25.01")
 }
 
 kotlin {

--- a/agents/agents-features/agents-features-chat-history-jdbc/src/main/kotlin/ai/koog/agents/features/chathistory/jdbc/OracleJdbcChatHistoryProvider.kt
+++ b/agents/agents-features/agents-features-chat-history-jdbc/src/main/kotlin/ai/koog/agents/features/chathistory/jdbc/OracleJdbcChatHistoryProvider.kt
@@ -1,0 +1,63 @@
+package ai.koog.agents.features.chathistory.jdbc
+
+import ai.koog.agents.features.chatmemory.sql.SQLChatHistorySchemaMigrator
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import javax.sql.DataSource
+
+/**
+ * Oracle JDBC implementation of [JdbcChatHistoryProvider].
+ *
+ * @param dataSource  The JDBC [DataSource] for Oracle connections.
+ * @param tableName   Name of the table to store chat history (default: `"chat_history"`).
+ * @param ttlSeconds  Optional TTL for history entries in seconds (`null` = no expiration).
+ * @param migrator    Schema migrator for creating/updating the table.
+ * @param json        JSON serializer instance for message serialization.
+ */
+public class OracleJdbcChatHistoryProvider @JvmOverloads constructor(
+    dataSource: DataSource,
+    tableName: String = "chat_history",
+    ttlSeconds: Long? = null,
+    migrator: SQLChatHistorySchemaMigrator = OracleJdbcChatHistorySchemaMigrator(dataSource, tableName),
+    json: Json = defaultJson
+) : JdbcChatHistoryProvider(dataSource, migrator, ttlSeconds, tableName) {
+
+    /**
+     * Bind parameter order matches the base class [JdbcChatHistoryProvider.upsert]:
+     * 1. `conversation_id`
+     * 2. `messages_json`
+     * 3. `updated_at`
+     * 4. `ttl_timestamp`
+     */
+    override val upsertSql: String = """
+        MERGE INTO $tableName tgt
+        USING (
+            SELECT ? AS conversation_id,
+                   ? AS messages_json,
+                   ? AS updated_at,
+                   ? AS ttl_timestamp
+              FROM dual
+        ) src ON (tgt.conversation_id = src.conversation_id)
+        WHEN MATCHED THEN
+            UPDATE SET
+                tgt.messages_json  = src.messages_json,
+                tgt.updated_at     = src.updated_at,
+                tgt.ttl_timestamp  = src.ttl_timestamp
+        WHEN NOT MATCHED THEN
+            INSERT (conversation_id, messages_json, updated_at, ttl_timestamp)
+            VALUES (src.conversation_id, src.messages_json, src.updated_at, src.ttl_timestamp)
+    """.trimIndent()
+
+    /**
+     * Blocking variant of [migrate] for Java callers.
+     *
+     * Kotlin callers should use `migrate()` directly from a coroutine.
+     *
+     * ```java
+     * OracleJdbcChatHistoryProvider provider =
+     *     new OracleJdbcChatHistoryProvider(dataSource, "chat_history");
+     * provider.migrateBlocking();
+     * ```
+     */
+    public fun migrateBlocking(): Unit = runBlocking { migrate() }
+}

--- a/agents/agents-features/agents-features-chat-history-jdbc/src/main/kotlin/ai/koog/agents/features/chathistory/jdbc/OracleJdbcChatHistorySchemaMigrator.kt
+++ b/agents/agents-features/agents-features-chat-history-jdbc/src/main/kotlin/ai/koog/agents/features/chathistory/jdbc/OracleJdbcChatHistorySchemaMigrator.kt
@@ -1,0 +1,90 @@
+package ai.koog.agents.features.chathistory.jdbc
+
+import ai.koog.agents.features.chatmemory.sql.SQLChatHistorySchemaMigrator
+import java.sql.SQLException
+import javax.sql.DataSource
+
+/**
+ * Oracle JDBC implementation of [SQLChatHistorySchemaMigrator].
+ *
+ * Creates the chat history table and its indexes.
+ *
+ * **Requires Oracle 23ai.** `CREATE TABLE IF NOT EXISTS` was introduced in 23ai;
+ * earlier versions are not supported.
+ **
+ * @param dataSource  The JDBC [DataSource] to use for obtaining connections.
+ * @param tableName   Name of the table to create (default: `"chat_history"`).
+ */
+public class OracleJdbcChatHistorySchemaMigrator @JvmOverloads constructor(
+    private val dataSource: DataSource,
+    private val tableName: String = "chat_history"
+) : SQLChatHistorySchemaMigrator {
+
+    override suspend fun migrate() {
+        dataSource.connection.use { connection ->
+            connection.autoCommit = false
+            try {
+                // Requires Oracle 23ai — IF NOT EXISTS for CREATE TABLE is a 23ai feature.
+                // conversation_id is the primary key (one row per conversation).
+                // messages_json holds the full serialised message list as CLOB.
+                // updated_at / ttl_timestamp are epoch-millisecond integers (NUMBER).
+                connection.createStatement().use { stmt ->
+                    stmt.execute(
+                        """
+                        CREATE TABLE IF NOT EXISTS $tableName (
+                            conversation_id VARCHAR2(255) NOT NULL,
+                            messages_json   CLOB          NOT NULL,
+                            updated_at      NUMBER        NOT NULL,
+                            ttl_timestamp   NUMBER        NULL,
+                            CONSTRAINT ${tableName}_pkey PRIMARY KEY (conversation_id)
+                        )
+                        """.trimIndent()
+                    )
+                }
+
+                // Note: CREATE INDEX IF NOT EXISTS is not supported, even in Oracle 23ai.
+                // We catch ORA-00955 (name already used by an existing object) and
+                // treat it as a no-op, which is the standard workaround.
+                runCatching {
+                    connection.createStatement().use { stmt ->
+                        stmt.execute(
+                            "CREATE INDEX idx_${tableName}_updated_at ON $tableName (updated_at)"
+                        )
+                    }
+                }.onFailure { e -> if (!isNameAlreadyUsed(e)) throw e }
+
+                // ── Index: ttl_timestamp (expired-row cleanup) ────────────────
+                runCatching {
+                    connection.createStatement().use { stmt ->
+                        stmt.execute(
+                            "CREATE INDEX idx_${tableName}_ttl_timestamp ON $tableName (ttl_timestamp)"
+                        )
+                    }
+                }.onFailure { e -> if (!isNameAlreadyUsed(e)) throw e }
+
+                connection.commit()
+            } catch (e: Exception) {
+                connection.rollback()
+                throw e
+            }
+        }
+    }
+
+    /**
+     * Returns `true` if the exception is Oracle error ORA-00955:
+     * "name is already used by an existing object".
+     *
+     * Used to emulate `CREATE INDEX IF NOT EXISTS`, which Oracle does not
+     * support even in 23ai.
+     */
+    private fun isNameAlreadyUsed(e: Throwable): Boolean {
+        var current: Throwable? = e
+        while (current != null) {
+            if (current is SQLException && current.errorCode == 955) {
+                return true
+            }
+            current = current.cause
+        }
+        return false
+    }
+}

--- a/agents/agents-features/agents-features-chat-history-jdbc/src/test/kotlin/ai/koog/agents/features/chathistory/jdbc/OracleJdbcChatHistoryProviderTest.kt
+++ b/agents/agents-features/agents-features-chat-history-jdbc/src/test/kotlin/ai/koog/agents/features/chathistory/jdbc/OracleJdbcChatHistoryProviderTest.kt
@@ -1,0 +1,111 @@
+package ai.koog.agents.features.chathistory.jdbc
+
+import ai.koog.test.utils.DockerAvailableCondition
+import kotlinx.coroutines.runBlocking
+import oracle.jdbc.pool.OracleDataSource
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import java.time.Duration
+import java.util.Properties
+import kotlin.test.assertEquals
+
+@TestInstance(Lifecycle.PER_CLASS)
+@ExtendWith(DockerAvailableCondition::class)
+@Execution(ExecutionMode.SAME_THREAD)
+class OracleJdbcChatHistoryProviderTest : AbstractJdbcChatHistoryProviderTest() {
+
+    private val fallbackHosts: List<String> = listOf("127.0.0.1")
+    private lateinit var oracle: GenericContainer<*>
+    private lateinit var dataSource: OracleDataSource
+
+    @BeforeAll
+    fun setUp() {
+        val imageName = DockerImageName.parse("gvenzl/oracle-free:23-slim-faststart")
+
+        oracle = GenericContainer(imageName)
+            .withEnv("ORACLE_PASSWORD", "test")
+            .withExposedPorts(1521)
+            .waitingFor(Wait.forLogMessage("(?s).*DATABASE IS READY TO USE!.*", 1))
+        oracle.start()
+
+        val jdbcUrl = waitForDatabaseReady(oracle.host, oracle.getMappedPort(1521))
+        dataSource = OracleDataSource().apply {
+            setURL(jdbcUrl)
+            setUser("system")
+            setPassword("test")
+        }
+    }
+
+    @AfterAll
+    fun tearDown() {
+        oracle.stop()
+    }
+
+    override fun provider(tableName: String, ttlSeconds: Long?): OracleJdbcChatHistoryProvider {
+        return OracleJdbcChatHistoryProvider(
+            dataSource = dataSource,
+            tableName = tableName,
+            ttlSeconds = ttlSeconds
+        )
+    }
+
+    @Test
+    fun testMigrateTwiceIsIdempotent() = runBlocking {
+        val p = provider(tableName = "chat_oracle_idempotent_test")
+        p.migrate()
+        p.migrate()
+
+        p.store("oracle-conv-1", createTestMessages())
+        assertEquals(1, p.getConversationCount())
+    }
+
+    private fun waitForDatabaseReady(host: String, port: Int): String {
+        val timeoutAt = System.currentTimeMillis() + Duration.ofMinutes(15).toMillis()
+        var lastError: Throwable? = null
+        val hostsToTry = buildList {
+            add(host)
+            addAll(fallbackHosts)
+        }.distinct()
+
+        while (System.currentTimeMillis() < timeoutAt) {
+            for (probeHost in hostsToTry) {
+                val url = "jdbc:oracle:thin:@//$probeHost:$port/freepdb1"
+                try {
+                    val probeDataSource = OracleDataSource().apply {
+                        setURL(url)
+                        setUser("system")
+                        setPassword("test")
+                        connectionProperties = Properties().apply {
+                            setProperty("oracle.net.CONNECT_TIMEOUT", "5000")
+                            setProperty("oracle.jdbc.ReadTimeout", "10000")
+                        }
+                    }
+                    probeDataSource.connection.use { connection ->
+                        connection.prepareStatement("SELECT 1 FROM dual").use { stmt ->
+                            stmt.executeQuery().use { rs ->
+                                if (rs.next()) return url
+                            }
+                        }
+                    }
+                } catch (t: Throwable) {
+                    lastError = t
+                }
+            }
+            Thread.sleep(2_000)
+        }
+
+        throw IllegalStateException(
+            "Oracle DB did not become ready",
+            lastError
+        )
+    }
+}


### PR DESCRIPTION
Adding support for Chat History using the Oracle Database
https://youtrack.jetbrains.com/issue/KG-772/Adding-Oracle-Database-for-Chat-Memory-and-Chat-History