### PR TITLE
test: follow-up for decoupling LLMClient constructors from Ktor

### DIFF
--- a/http-client/http-client-ktor/src/commonMain/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClient.kt
+++ b/http-client/http-client-ktor/src/commonMain/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClient.kt
@@ -259,8 +259,10 @@ public fun KoogHttpClient.Companion.fromKtorClient(
     logger = logger,
     baseClient = baseClient
 ) {
+    val normalizedBaseUrl = if (baseUrl.endsWith("/")) baseUrl else "$baseUrl/"
+
     defaultRequest {
-        url(baseUrl)
+        url(normalizedBaseUrl)
         contentType(ContentType.Application.Json)
         headers.forEach { (name, value) -> header(name, value) }
         queryParameters.forEach { (name, value) -> url.parameters.append(name, value) }

--- a/http-client/http-client-ktor/src/commonMain/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClient.kt
+++ b/http-client/http-client-ktor/src/commonMain/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClient.kt
@@ -25,9 +25,12 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
+import io.ktor.http.URLBuilder
 import io.ktor.http.contentType
+import io.ktor.http.encodedPath
 import io.ktor.http.headers
 import io.ktor.http.isSuccess
+import io.ktor.http.takeFrom
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.util.reflect.TypeInfo
 import io.ktor.utils.io.CancellationException
@@ -259,10 +262,14 @@ public fun KoogHttpClient.Companion.fromKtorClient(
     logger = logger,
     baseClient = baseClient
 ) {
-    val normalizedBaseUrl = if (baseUrl.endsWith("/")) baseUrl else "$baseUrl/"
+    val normalizedBaseUrl = URLBuilder(baseUrl).apply {
+        if (!encodedPath.endsWith("/")) {
+            encodedPath += "/"
+        }
+    }.buildString()
 
     defaultRequest {
-        url(normalizedBaseUrl)
+        url.takeFrom(normalizedBaseUrl)
         contentType(ContentType.Application.Json)
         headers.forEach { (name, value) -> header(name, value) }
         queryParameters.forEach { (name, value) -> url.parameters.append(name, value) }

--- a/http-client/http-client-ktor/src/jvmTest/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClientFactoryTest.kt
+++ b/http-client/http-client-ktor/src/jvmTest/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClientFactoryTest.kt
@@ -1,0 +1,106 @@
+package ai.koog.http.client.ktor
+
+import ai.koog.http.client.KoogHttpClient
+import ai.koog.http.client.post
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.plugin
+import io.ktor.client.plugins.sse.SSE
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.TextContent
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class KtorKoogHttpClientFactoryTest {
+    @Serializable
+    private data class TestRequest(val message: String)
+
+    @Serializable
+    private data class TestResponse(val status: String)
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+        explicitNulls = false
+    }
+
+    @Test
+    fun `factory overload should configure base url headers query parameters and json serialization`() = runTest {
+        var capturedRequest: HttpRequestData? = null
+        var capturedBody: String? = null
+        val engine = MockEngine { request ->
+            capturedRequest = request
+            capturedBody = (request.body as TextContent).text
+
+            respond(
+                content = """{"status":"ok"}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val client = KoogHttpClient.fromKtorClient(
+            clientName = "FactoryTestClient",
+            logger = KotlinLogging.logger("FactoryTestLogger"),
+            baseClient = HttpClient(engine),
+            baseUrl = "https://example.test/api",
+            requestTimeoutMillis = 1_000,
+            connectTimeoutMillis = 2_000,
+            socketTimeoutMillis = 3_000,
+            json = json,
+            headers = mapOf("Authorization" to "Bearer token"),
+            queryParameters = mapOf("tenant" to "acme")
+        )
+
+        val response = client.post<TestRequest, TestResponse>(
+            path = "v1/messages",
+            request = TestRequest("hello")
+        )
+
+        assertEquals("ok", response.status)
+        val request = requireNotNull(capturedRequest)
+        assertEquals("https://example.test/api/v1/messages?tenant=acme", request.url.toString())
+        assertEquals("Bearer token", request.headers[HttpHeaders.Authorization])
+        assertEquals("""{"message":"hello"}""", capturedBody)
+
+        val ktorClient = (client as KtorKoogHttpClient).ktorClient
+        assertNotNull(ktorClient.plugin(HttpTimeout))
+        assertNotNull(ktorClient.plugin(SSE))
+        client.close()
+    }
+
+    @Test
+    fun `factory overload should not install sse plugin when disabled`() {
+        val client = KoogHttpClient.fromKtorClient(
+            clientName = "NoSseClient",
+            logger = KotlinLogging.logger("NoSseLogger"),
+            baseClient = HttpClient(MockEngine { error("No HTTP call expected") }),
+            baseUrl = "https://example.test/api",
+            requestTimeoutMillis = 1_000,
+            connectTimeoutMillis = 2_000,
+            socketTimeoutMillis = 3_000,
+            json = json,
+            withSse = false
+        )
+
+        val ktorClient = (client as KtorKoogHttpClient).ktorClient
+        val exception = assertFails { ktorClient.plugin(SSE) }
+
+        assertTrue(exception.message?.contains("SSE") == true || exception::class.simpleName?.contains("Plugin") == true)
+        assertFalse(runCatching { ktorClient.plugin(SSE) }.isSuccess)
+        client.close()
+    }
+}

--- a/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentIntegrationTest.java
+++ b/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentIntegrationTest.java
@@ -427,11 +427,11 @@ public class JavaAIAgentIntegrationTest extends KoogJavaTestBase {
                 new ContentPart.Text("Please identify the image format."),
                 new ContentPart.Image(
                     new AttachmentContent.URL(
-                        "https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png"
+                        "https://raw.githubusercontent.com/JetBrains/koog/develop/integration-tests/src/jvmTest/resources/media/test.png"
                     ),
                     "png",
                     "image/png",
-                    "PNG_transparency_demonstration_1.png"
+                    "test.png"
                 )
             ))
             .build();

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentMultipleLLMIntegrationTest.kt
@@ -51,7 +51,7 @@ import kotlin.time.Duration.Companion.minutes
 class AIAgentMultipleLLMIntegrationTest : AIAgentTestBase() {
     companion object {
         @JvmStatic
-        fun getLatestModels(): Stream<LLModel> = AIAgentTestBase.latestModels()
+        fun getLatestModels(): Stream<LLModel> = latestModels()
     }
 
     private val openAIApiKey: String get() = readTestOpenAIKeyFromEnv()
@@ -308,7 +308,7 @@ class AIAgentMultipleLLMIntegrationTest : AIAgentTestBase() {
                     br()
                     +"Please analyze this image and identify the image format if possible."
                 }
-                image("https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg")
+                image("https://raw.githubusercontent.com/JetBrains/koog/develop/integration-tests/src/jvmTest/resources/media/test.png")
             }
         }
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
@@ -666,7 +666,7 @@ abstract class ExecutorIntegrationTestBase {
         )
 
         val imageUrl =
-            "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/PNG_Test.png/200px-PNG_Test.png"
+            "https://raw.githubusercontent.com/JetBrains/koog/develop/integration-tests/src/jvmTest/resources/media/test.png"
 
         val prompt = prompt("url-based-attachments-test") {
             system("You are a helpful assistant that can analyze images.")

--- a/koog-spring-boot-starter/src/test/kotlin/ai/koog/spring/KoogAutoConfigurationTest.kt
+++ b/koog-spring-boot-starter/src/test/kotlin/ai/koog/spring/KoogAutoConfigurationTest.kt
@@ -1,5 +1,6 @@
 package ai.koog.spring
 
+import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.clients.anthropic.AnthropicClientSettings
 import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
@@ -8,12 +9,15 @@ import ai.koog.prompt.executor.clients.google.GoogleClientSettings
 import ai.koog.prompt.executor.clients.google.GoogleLLMClient
 import ai.koog.prompt.executor.clients.mistralai.MistralAILLMClient
 import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.executor.clients.openai.base.OpenAIBaseSettings
 import ai.koog.prompt.executor.clients.openrouter.OpenRouterLLMClient
 import ai.koog.prompt.executor.clients.retry.RetryConfig
 import ai.koog.prompt.executor.clients.retry.RetryingLLMClient
-import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
+import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.executor.ollama.client.OllamaClient
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.spring.prompt.executor.MultiLLMAutoConfiguration
 import ai.koog.spring.prompt.executor.clients.anthropic.AnthropicLLMAutoConfiguration
 import ai.koog.spring.prompt.executor.clients.deepseek.DeepSeekLLMAutoConfiguration
 import ai.koog.spring.prompt.executor.clients.google.GoogleLLMAutoConfiguration
@@ -21,19 +25,20 @@ import ai.koog.spring.prompt.executor.clients.mistralai.MistralAILLMAutoConfigur
 import ai.koog.spring.prompt.executor.clients.ollama.OllamaLLMAutoConfiguration
 import ai.koog.spring.prompt.executor.clients.openai.OpenAILLMAutoConfiguration
 import ai.koog.spring.prompt.executor.clients.openrouter.OpenRouterLLMAutoConfiguration
+import com.sun.net.httpserver.HttpServer
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertInstanceOf
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
-import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.beans.factory.getBean
-import org.springframework.beans.factory.getBeanNamesForType
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration.Companion.seconds
 
 private const val PROVIDERS = """
@@ -59,14 +64,83 @@ class KoogAutoConfigurationTest {
                 OllamaLLMAutoConfiguration::class.java,
                 OpenAILLMAutoConfiguration::class.java,
                 OpenRouterLLMAutoConfiguration::class.java,
+                MultiLLMAutoConfiguration::class.java,
             )
         )
+
+    @Test
+    fun `should send OpenAI request with configured baseUrl and authorization header`() {
+        val requestPath = AtomicReference<String>()
+        val authorization = AtomicReference<String>()
+        val requestBody = AtomicReference<String>()
+        val server = HttpServer.create(InetSocketAddress(0), 0).apply {
+            createContext("/v1/chat/completions") { exchange ->
+                requestPath.set(exchange.requestURI.toString())
+                authorization.set(exchange.requestHeaders.getFirst("Authorization"))
+                requestBody.set(exchange.requestBody.reader().readText())
+
+                val response = """
+                    {
+                      "id": "chatcmpl-spring",
+                      "object": "chat.completion",
+                      "created": 1716920005,
+                      "model": "gpt-4o",
+                      "choices": [
+                        {
+                          "index": 0,
+                          "message": {
+                            "role": "assistant",
+                            "content": "Spring says hi"
+                          },
+                          "finish_reason": "stop"
+                        }
+                      ],
+                      "usage": {"total_tokens": 9, "prompt_tokens": 4, "completion_tokens": 5}
+                    }
+                """.trimIndent().toByteArray()
+
+                exchange.responseHeaders.add("Content-Type", "application/json")
+                exchange.sendResponseHeaders(200, response.size.toLong())
+                exchange.responseBody.use { it.write(response) }
+            }
+            start()
+        }
+
+        try {
+            createApplicationContextRunner()
+                .withPropertyValues(
+                    "ai.koog.openai.enabled=true",
+                    "ai.koog.openai.api-key=some_api_key",
+                    "ai.koog.openai.base-url=http://localhost:${server.address.port}",
+                    "ai.koog.openai.retry.enabled=false"
+                )
+                .run { context ->
+                    val executor = context.getBean<MultiLLMPromptExecutor>()
+
+                    val responses = runBlocking {
+                        executor.execute(
+                            prompt = prompt("spring-test") { user("Hello from Spring?") },
+                            model = OpenAIModels.Chat.GPT4o
+                        )
+                    }
+
+                    assertEquals("/v1/chat/completions", requestPath.get())
+                    assertEquals("Bearer some_api_key", authorization.get())
+                    assertTrue(requestBody.get().contains("Hello from Spring?"))
+                    assertEquals("Spring says hi", responses.single().content)
+                }
+        } finally {
+            server.stop(0)
+        }
+    }
 
     @Test
     fun `should not supply executor beans if no api key property is provided`() {
         createApplicationContextRunner()
             .run { context ->
-                assertThrows<NoSuchBeanDefinitionException> { context.getBean<SingleLLMPromptExecutor>() }
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val llmClients = getLlmClients(executor)
+                assertTrue(llmClients.isEmpty())
             }
     }
 
@@ -78,8 +152,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.openai.api-key=$configApiKey"
             )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val llmClient = getPrivateFieldValue(executor, "llmClient")
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val llmClient = getLlmClient(executor, "openai")
                 assertInstanceOf<OpenAILLMClient>(llmClient)
 
                 val settings = getPrivateFieldValue(llmClient, "settings") as OpenAIBaseSettings
@@ -98,8 +172,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.openai.base-url=$configBaseUrl",
             )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val llmClient = getPrivateFieldValue(executor, "llmClient") as OpenAILLMClient
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val llmClient = getLlmClient(executor, "openai") as OpenAILLMClient
 
                 val settings = getPrivateFieldValue(llmClient, "settings") as OpenAIBaseSettings
                 val baseUrl = getPrivateFieldValue(settings, "baseUrl")
@@ -122,8 +196,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.$provider.base-url=http://localhost:9876"
             )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val retryingClient = getPrivateFieldValue(executor, "llmClient")
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val retryingClient = getLlmClient(executor, provider)
                 assertInstanceOf<RetryingLLMClient>(retryingClient)
 
                 val config = getPrivateFieldValue(retryingClient, "config") as RetryConfig
@@ -162,8 +236,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.$provider.retry.jitter-factor=$jitterFactor"
             )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val retryingClient = getPrivateFieldValue(executor, "llmClient")
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val retryingClient = getLlmClient(executor, provider)
                 assertInstanceOf<RetryingLLMClient>(retryingClient)
 
                 val config = getPrivateFieldValue(retryingClient, "config") as RetryConfig
@@ -201,7 +275,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.$provider.retry.jitter-factor=$jitterFactor"
             )
             .run { context ->
-                assertTrue { context.getBeansOfType(SingleLLMPromptExecutor::class.java).isEmpty() }
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                assertTrue(getLlmClients(executor).isEmpty())
                 assertTrue { context.getBeansOfType(RetryingLLMClient::class.java).isEmpty() }
                 assertTrue { context.getBeansOfType(LLMClient::class.java).isEmpty() }
             }
@@ -224,8 +299,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.$provider.retry.initial-delay=$initialDelay"
             )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val retryingClient = getPrivateFieldValue(executor, "llmClient")
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val retryingClient = getLlmClient(executor, provider)
                 assertInstanceOf<RetryingLLMClient>(retryingClient)
 
                 val config = getPrivateFieldValue(retryingClient, "config") as RetryConfig
@@ -248,8 +323,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.anthropic.api-key=$configApiKey"
             )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val llmClient = getPrivateFieldValue(executor, "llmClient")
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val llmClient = getLlmClient(executor, "anthropic")
                 assertInstanceOf<AnthropicLLMClient>(llmClient)
 
                 val settings = getPrivateFieldValue(llmClient, "settings") as AnthropicClientSettings
@@ -262,14 +337,14 @@ class KoogAutoConfigurationTest {
     @Test
     fun `should supply Anthropic executor bean with retry client and default config`() {
         ApplicationContextRunner()
-            .withConfiguration(AutoConfigurations.of(AnthropicLLMAutoConfiguration::class.java))
+            .withConfiguration(AutoConfigurations.of(AnthropicLLMAutoConfiguration::class.java, MultiLLMAutoConfiguration::class.java))
             .withPropertyValues(
                 "ai.koog.anthropic.api-key=some_api_key",
                 "ai.koog.anthropic.retry.enabled=true"
             )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val retryingClient = getPrivateFieldValue(executor, "llmClient")
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val retryingClient = getLlmClient(executor, "anthropic")
                 assertInstanceOf<RetryingLLMClient>(retryingClient)
 
                 val config = getPrivateFieldValue(retryingClient, "config")
@@ -289,8 +364,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.anthropic.base-url=$configBaseUrl",
             )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val llmClient = getPrivateFieldValue(executor, "llmClient") as AnthropicLLMClient
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val llmClient = getLlmClient(executor, "anthropic") as AnthropicLLMClient
 
                 val settings = getPrivateFieldValue(llmClient, "settings") as AnthropicClientSettings
                 val baseUrl = getPrivateFieldValue(settings, "baseUrl")
@@ -307,8 +382,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.google.api-key=$configApiKey"
             )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val llmClient = getPrivateFieldValue(executor, "llmClient")
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val llmClient = getLlmClient(executor, "google")
                 assertInstanceOf<GoogleLLMClient>(llmClient)
 
                 val settings = getPrivateFieldValue(llmClient, "settings") as GoogleClientSettings
@@ -327,8 +402,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.google.base-url=$configBaseUrl",
             )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val llmClient = getPrivateFieldValue(executor, "llmClient") as GoogleLLMClient
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val llmClient = getLlmClient(executor, "google") as GoogleLLMClient
 
                 val settings = getPrivateFieldValue(llmClient, "settings") as GoogleClientSettings
                 val baseUrl = getPrivateFieldValue(settings, "baseUrl")
@@ -345,8 +420,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.google.retry.enabled=true"
             )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val retryingClient = getPrivateFieldValue(executor, "llmClient")
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val retryingClient = getLlmClient(executor, "google")
                 assertInstanceOf<RetryingLLMClient>(retryingClient)
 
                 val config = getPrivateFieldValue(retryingClient, "config")
@@ -366,8 +441,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.openrouter.api-key=$configApiKey"
             )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val llmClient = getPrivateFieldValue(executor, "llmClient")
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val llmClient = getLlmClient(executor, "openrouter")
                 assertInstanceOf<OpenRouterLLMClient>(llmClient)
 
                 val settings = getPrivateFieldValue(llmClient, "settings") as OpenAIBaseSettings
@@ -387,8 +462,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.openrouter.base-url=$configBaseUrl",
             )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val llmClient = getPrivateFieldValue(executor, "llmClient") as OpenRouterLLMClient
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val llmClient = getLlmClient(executor, "openrouter") as OpenRouterLLMClient
 
                 val settings = getPrivateFieldValue(llmClient, "settings") as OpenAIBaseSettings
                 val baseUrl = getPrivateFieldValue(settings, "baseUrl")
@@ -406,8 +481,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.openrouter.retry.enabled=true"
             )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val retryingClient = getPrivateFieldValue(executor, "llmClient")
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val retryingClient = getLlmClient(executor, "openrouter")
                 assertInstanceOf<RetryingLLMClient>(retryingClient)
 
                 val config = getPrivateFieldValue(retryingClient, "config")
@@ -426,8 +501,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.deepseek.api-key=$configApiKey"
             )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val llmClient = getPrivateFieldValue(executor, "llmClient")
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val llmClient = getLlmClient(executor, "deepseek")
                 assertInstanceOf<DeepSeekLLMClient>(llmClient)
 
                 val settings = getPrivateFieldValue(llmClient, "settings") as OpenAIBaseSettings
@@ -445,8 +520,8 @@ class KoogAutoConfigurationTest {
             "ai.koog.deepseek.base-url=$configBaseUrl",
         )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val llmClient = getPrivateFieldValue(executor, "llmClient") as DeepSeekLLMClient
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val llmClient = getLlmClient(executor, "deepseek") as DeepSeekLLMClient
 
                 val settings = getPrivateFieldValue(llmClient, "settings") as OpenAIBaseSettings
                 val baseUrl = getPrivateFieldValue(settings, "baseUrl")
@@ -463,8 +538,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.deepseek.retry.enabled=true"
             )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val retryingClient = getPrivateFieldValue(executor, "llmClient")
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val retryingClient = getLlmClient(executor, "deepseek")
                 assertInstanceOf<RetryingLLMClient>(retryingClient)
 
                 val config = getPrivateFieldValue(retryingClient, "config")
@@ -483,8 +558,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.mistral.api-key=$configApiKey"
             )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val llmClient = getPrivateFieldValue(executor, "llmClient")
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val llmClient = getLlmClient(executor, "mistral")
                 assertInstanceOf<MistralAILLMClient>(llmClient)
 
                 val settings = getPrivateFieldValue(llmClient, "settings") as OpenAIBaseSettings
@@ -502,8 +577,8 @@ class KoogAutoConfigurationTest {
             "ai.koog.mistral.base-url=$configBaseUrl",
         )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val llmClient = getPrivateFieldValue(executor, "llmClient") as MistralAILLMClient
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val llmClient = getLlmClient(executor, "mistral") as MistralAILLMClient
 
                 val settings = getPrivateFieldValue(llmClient, "settings") as OpenAIBaseSettings
                 val baseUrl = getPrivateFieldValue(settings, "baseUrl")
@@ -520,8 +595,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.mistral.retry.enabled=true"
             )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val retryingClient = getPrivateFieldValue(executor, "llmClient")
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val retryingClient = getLlmClient(executor, "mistral")
                 assertInstanceOf<RetryingLLMClient>(retryingClient)
 
                 val config = getPrivateFieldValue(retryingClient, "config")
@@ -540,8 +615,8 @@ class KoogAutoConfigurationTest {
             "ai.koog.ollama.base-url=$configBaseUrl"
         )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val llmClient = getPrivateFieldValue(executor, "llmClient")
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val llmClient = getLlmClient(executor, "ollama")
                 assertInstanceOf<OllamaClient>(llmClient)
 
                 val baseUrl = getPrivateFieldValue(llmClient, "baseUrl")
@@ -553,15 +628,15 @@ class KoogAutoConfigurationTest {
     @Test
     fun `should supply Ollama executor bean with retry client and default config`() {
         ApplicationContextRunner()
-            .withConfiguration(AutoConfigurations.of(OllamaLLMAutoConfiguration::class.java))
+            .withConfiguration(AutoConfigurations.of(OllamaLLMAutoConfiguration::class.java, MultiLLMAutoConfiguration::class.java))
             .withPropertyValues(
                 "ai.koog.ollama.enabled=true",
                 "ai.koog.ollama.base-url=https://some-url.com",
                 "ai.koog.ollama.retry.enabled=true"
             )
             .run { context ->
-                val executor = context.getBean<SingleLLMPromptExecutor>()
-                val retryingClient = getPrivateFieldValue(executor, "llmClient")
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val retryingClient = getLlmClient(executor, "ollama")
                 assertInstanceOf<RetryingLLMClient>(retryingClient)
 
                 val config = getPrivateFieldValue(retryingClient, "config")
@@ -584,15 +659,26 @@ class KoogAutoConfigurationTest {
                 "ai.koog.ollama.enabled=true",
             )
             .run { context ->
-                val beanNames = context.getBeanNamesForType<SingleLLMPromptExecutor>()
-                assertEquals(6, beanNames.size)
-                assertTrue("openAIExecutor" in beanNames)
-                assertTrue("anthropicExecutor" in beanNames)
-                assertTrue("googleExecutor" in beanNames)
-                assertTrue("mistralAIExecutor" in beanNames)
-                assertTrue("deepSeekExecutor" in beanNames)
-                assertTrue("ollamaExecutor" in beanNames)
+                val executor = context.getBean<MultiLLMPromptExecutor>()
+                val llmClients = getLlmClients(executor)
+                assertEquals(6, llmClients.size)
+                assertTrue(llmClients.keys.any { it.id == "openai" })
+                assertTrue(llmClients.keys.any { it.id == "anthropic" })
+                assertTrue(llmClients.keys.any { it.id == "google" })
+                assertTrue(llmClients.keys.any { it.id == "mistral" })
+                assertTrue(llmClients.keys.any { it.id == "deepseek" })
+                assertTrue(llmClients.keys.any { it.id == "ollama" })
             }
+    }
+
+    private fun getLlmClients(executor: MultiLLMPromptExecutor): Map<LLMProvider, LLMClient> {
+        @Suppress("UNCHECKED_CAST")
+        return getPrivateFieldValue(executor, "llmClients") as Map<LLMProvider, LLMClient>
+    }
+
+    private fun getLlmClient(executor: MultiLLMPromptExecutor, providerId: String): LLMClient {
+        return getLlmClients(executor).entries.firstOrNull { it.key.id == providerId }?.value
+            ?: error("No client registered for provider $providerId")
     }
 
     private inline fun <reified T> getPrivateFieldValue(instance: T, fieldName: String): Any? {

--- a/koog-spring-boot-starter/src/test/kotlin/ai/koog/spring/KoogAutoConfigurationTest.kt
+++ b/koog-spring-boot-starter/src/test/kotlin/ai/koog/spring/KoogAutoConfigurationTest.kt
@@ -15,6 +15,7 @@ import ai.koog.prompt.executor.clients.openrouter.OpenRouterLLMClient
 import ai.koog.prompt.executor.clients.retry.RetryConfig
 import ai.koog.prompt.executor.clients.retry.RetryingLLMClient
 import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
+import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
 import ai.koog.prompt.executor.ollama.client.OllamaClient
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.spring.prompt.executor.MultiLLMAutoConfiguration
@@ -196,8 +197,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.$provider.base-url=http://localhost:9876"
             )
             .run { context ->
-                val executor = context.getBean<MultiLLMPromptExecutor>()
-                val retryingClient = getLlmClient(executor, provider)
+                val executor = context.getBean<SingleLLMPromptExecutor>()
+                val retryingClient = getPrivateFieldValue(executor, "llmClient")
                 assertInstanceOf<RetryingLLMClient>(retryingClient)
 
                 val config = getPrivateFieldValue(retryingClient, "config") as RetryConfig
@@ -236,8 +237,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.$provider.retry.jitter-factor=$jitterFactor"
             )
             .run { context ->
-                val executor = context.getBean<MultiLLMPromptExecutor>()
-                val retryingClient = getLlmClient(executor, provider)
+                val executor = context.getBean<SingleLLMPromptExecutor>()
+                val retryingClient = getPrivateFieldValue(executor, "llmClient")
                 assertInstanceOf<RetryingLLMClient>(retryingClient)
 
                 val config = getPrivateFieldValue(retryingClient, "config") as RetryConfig
@@ -299,8 +300,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.$provider.retry.initial-delay=$initialDelay"
             )
             .run { context ->
-                val executor = context.getBean<MultiLLMPromptExecutor>()
-                val retryingClient = getLlmClient(executor, provider)
+                val executor = context.getBean<SingleLLMPromptExecutor>()
+                val retryingClient = getPrivateFieldValue(executor, "llmClient")
                 assertInstanceOf<RetryingLLMClient>(retryingClient)
 
                 val config = getPrivateFieldValue(retryingClient, "config") as RetryConfig
@@ -337,14 +338,14 @@ class KoogAutoConfigurationTest {
     @Test
     fun `should supply Anthropic executor bean with retry client and default config`() {
         ApplicationContextRunner()
-            .withConfiguration(AutoConfigurations.of(AnthropicLLMAutoConfiguration::class.java, MultiLLMAutoConfiguration::class.java))
+            .withConfiguration(AutoConfigurations.of(AnthropicLLMAutoConfiguration::class.java))
             .withPropertyValues(
                 "ai.koog.anthropic.api-key=some_api_key",
                 "ai.koog.anthropic.retry.enabled=true"
             )
             .run { context ->
-                val executor = context.getBean<MultiLLMPromptExecutor>()
-                val retryingClient = getLlmClient(executor, "anthropic")
+                val executor = context.getBean<SingleLLMPromptExecutor>()
+                val retryingClient = getPrivateFieldValue(executor, "llmClient")
                 assertInstanceOf<RetryingLLMClient>(retryingClient)
 
                 val config = getPrivateFieldValue(retryingClient, "config")
@@ -420,8 +421,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.google.retry.enabled=true"
             )
             .run { context ->
-                val executor = context.getBean<MultiLLMPromptExecutor>()
-                val retryingClient = getLlmClient(executor, "google")
+                val executor = context.getBean<SingleLLMPromptExecutor>()
+                val retryingClient = getPrivateFieldValue(executor, "llmClient")
                 assertInstanceOf<RetryingLLMClient>(retryingClient)
 
                 val config = getPrivateFieldValue(retryingClient, "config")
@@ -481,8 +482,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.openrouter.retry.enabled=true"
             )
             .run { context ->
-                val executor = context.getBean<MultiLLMPromptExecutor>()
-                val retryingClient = getLlmClient(executor, "openrouter")
+                val executor = context.getBean<SingleLLMPromptExecutor>()
+                val retryingClient = getPrivateFieldValue(executor, "llmClient")
                 assertInstanceOf<RetryingLLMClient>(retryingClient)
 
                 val config = getPrivateFieldValue(retryingClient, "config")
@@ -538,8 +539,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.deepseek.retry.enabled=true"
             )
             .run { context ->
-                val executor = context.getBean<MultiLLMPromptExecutor>()
-                val retryingClient = getLlmClient(executor, "deepseek")
+                val executor = context.getBean<SingleLLMPromptExecutor>()
+                val retryingClient = getPrivateFieldValue(executor, "llmClient")
                 assertInstanceOf<RetryingLLMClient>(retryingClient)
 
                 val config = getPrivateFieldValue(retryingClient, "config")
@@ -559,7 +560,7 @@ class KoogAutoConfigurationTest {
             )
             .run { context ->
                 val executor = context.getBean<MultiLLMPromptExecutor>()
-                val llmClient = getLlmClient(executor, "mistral")
+                val llmClient = getLlmClient(executor, "mistralai")
                 assertInstanceOf<MistralAILLMClient>(llmClient)
 
                 val settings = getPrivateFieldValue(llmClient, "settings") as OpenAIBaseSettings
@@ -578,7 +579,7 @@ class KoogAutoConfigurationTest {
         )
             .run { context ->
                 val executor = context.getBean<MultiLLMPromptExecutor>()
-                val llmClient = getLlmClient(executor, "mistral") as MistralAILLMClient
+                val llmClient = getLlmClient(executor, "mistralai") as MistralAILLMClient
 
                 val settings = getPrivateFieldValue(llmClient, "settings") as OpenAIBaseSettings
                 val baseUrl = getPrivateFieldValue(settings, "baseUrl")
@@ -595,8 +596,8 @@ class KoogAutoConfigurationTest {
                 "ai.koog.mistral.retry.enabled=true"
             )
             .run { context ->
-                val executor = context.getBean<MultiLLMPromptExecutor>()
-                val retryingClient = getLlmClient(executor, "mistral")
+                val executor = context.getBean<SingleLLMPromptExecutor>()
+                val retryingClient = getPrivateFieldValue(executor, "llmClient")
                 assertInstanceOf<RetryingLLMClient>(retryingClient)
 
                 val config = getPrivateFieldValue(retryingClient, "config")
@@ -628,15 +629,15 @@ class KoogAutoConfigurationTest {
     @Test
     fun `should supply Ollama executor bean with retry client and default config`() {
         ApplicationContextRunner()
-            .withConfiguration(AutoConfigurations.of(OllamaLLMAutoConfiguration::class.java, MultiLLMAutoConfiguration::class.java))
+            .withConfiguration(AutoConfigurations.of(OllamaLLMAutoConfiguration::class.java))
             .withPropertyValues(
                 "ai.koog.ollama.enabled=true",
                 "ai.koog.ollama.base-url=https://some-url.com",
                 "ai.koog.ollama.retry.enabled=true"
             )
             .run { context ->
-                val executor = context.getBean<MultiLLMPromptExecutor>()
-                val retryingClient = getLlmClient(executor, "ollama")
+                val executor = context.getBean<SingleLLMPromptExecutor>()
+                val retryingClient = getPrivateFieldValue(executor, "llmClient")
                 assertInstanceOf<RetryingLLMClient>(retryingClient)
 
                 val config = getPrivateFieldValue(retryingClient, "config")
@@ -665,7 +666,7 @@ class KoogAutoConfigurationTest {
                 assertTrue(llmClients.keys.any { it.id == "openai" })
                 assertTrue(llmClients.keys.any { it.id == "anthropic" })
                 assertTrue(llmClients.keys.any { it.id == "google" })
-                assertTrue(llmClients.keys.any { it.id == "mistral" })
+                assertTrue(llmClients.keys.any { it.id == "mistralai" })
                 assertTrue(llmClients.keys.any { it.id == "deepseek" })
                 assertTrue(llmClients.keys.any { it.id == "ollama" })
             }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GooglePrimaryConstructorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GooglePrimaryConstructorTest.kt
@@ -1,0 +1,113 @@
+package ai.koog.prompt.executor.clients.google
+
+import ai.koog.http.client.KoogHttpClient
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.clients.google.models.GooglePart
+import ai.koog.prompt.executor.clients.google.models.GoogleRequest
+import ai.koog.prompt.executor.clients.google.models.GoogleResponse
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.message.Message
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.reflect.KClass
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class GooglePrimaryConstructorTest {
+    private val responseJson = """
+        {
+          "candidates": [
+            {
+              "content": {
+                "role": "model",
+                "parts": [
+                  {
+                    "text": "Hello from Google KoogHttpClient"
+                  }
+                ]
+              },
+              "finishReason": "STOP",
+              "index": 0
+            }
+          ],
+          "usageMetadata": {
+            "promptTokenCount": 3,
+            "totalTokenCount": 8
+          },
+          "modelVersion": "gemini-2.5-pro"
+        }
+    """.trimIndent()
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+        explicitNulls = false
+    }
+
+    @Test
+    fun `primary constructor should execute through koog http client`() = runTest {
+        val transport = CapturingKoogHttpClient { _ ->
+            json.decodeFromString<GoogleResponse>(responseJson)
+        }
+        val client = GoogleLLMClient(
+            settings = GoogleClientSettings(baseUrl = "https://unused.test"),
+            httpClient = transport
+        )
+
+        val responses = client.execute(
+            prompt = prompt("test") { user("Hello?") },
+            model = GoogleModels.Gemini2_5Pro
+        )
+
+        assertEquals("v1beta/models/gemini-2.5-pro:generateContent", transport.lastPath)
+        assertEquals(LLMProvider.Google, client.llmProvider())
+        val request = transport.lastRequest
+        assertTrue(request is GoogleRequest)
+        val userPart = request.contents.single().parts!!.single() as GooglePart.Text
+        assertEquals("Hello?", userPart.text)
+        val message = assertIs<Message.Assistant>(responses.single())
+        assertEquals("Hello from Google KoogHttpClient", message.content)
+    }
+
+    private class CapturingKoogHttpClient(
+        private val responder: (KClass<*>) -> Any
+    ) : KoogHttpClient {
+        override val clientName: String = "CapturingGoogleClient"
+        var lastPath: String? = null
+        var lastRequest: Any? = null
+
+        override suspend fun <R : Any> get(path: String, responseType: KClass<R>, parameters: Map<String, String>): R {
+            error("GET is not expected in this test")
+        }
+
+        override suspend fun <T : Any, R : Any> post(
+            path: String,
+            request: T,
+            requestBodyType: KClass<T>,
+            responseType: KClass<R>,
+            parameters: Map<String, String>
+        ): R {
+            lastPath = path
+            lastRequest = request
+            @Suppress("UNCHECKED_CAST")
+            return responder(responseType) as R
+        }
+
+        override fun <T : Any, R : Any, O : Any> sse(
+            path: String,
+            request: T,
+            requestBodyType: KClass<T>,
+            dataFilter: (String?) -> Boolean,
+            decodeStreamingResponse: (String) -> R,
+            processStreamingChunk: (R) -> O?,
+            parameters: Map<String, String>
+        ): Flow<O> = emptyFlow()
+
+        override fun close() = Unit
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GooglePrimaryConstructorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GooglePrimaryConstructorTest.kt
@@ -1,17 +1,14 @@
 package ai.koog.prompt.executor.clients.google
 
-import ai.koog.http.client.KoogHttpClient
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.google.models.GooglePart
 import ai.koog.prompt.executor.clients.google.models.GoogleRequest
 import ai.koog.prompt.executor.clients.google.models.GoogleResponse
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.message.Message
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
+import ai.koog.test.utils.CapturingKoogHttpClient
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
-import kotlin.reflect.KClass
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -51,7 +48,7 @@ class GooglePrimaryConstructorTest {
 
     @Test
     fun `primary constructor should execute through koog http client`() = runTest {
-        val transport = CapturingKoogHttpClient { _ ->
+        val transport = CapturingKoogHttpClient(clientName = "CapturingGoogleClient") { _ ->
             json.decodeFromString<GoogleResponse>(responseJson)
         }
         val client = GoogleLLMClient(
@@ -72,42 +69,5 @@ class GooglePrimaryConstructorTest {
         assertEquals("Hello?", userPart.text)
         val message = assertIs<Message.Assistant>(responses.single())
         assertEquals("Hello from Google KoogHttpClient", message.content)
-    }
-
-    private class CapturingKoogHttpClient(
-        private val responder: (KClass<*>) -> Any
-    ) : KoogHttpClient {
-        override val clientName: String = "CapturingGoogleClient"
-        var lastPath: String? = null
-        var lastRequest: Any? = null
-
-        override suspend fun <R : Any> get(path: String, responseType: KClass<R>, parameters: Map<String, String>): R {
-            error("GET is not expected in this test")
-        }
-
-        override suspend fun <T : Any, R : Any> post(
-            path: String,
-            request: T,
-            requestBodyType: KClass<T>,
-            responseType: KClass<R>,
-            parameters: Map<String, String>
-        ): R {
-            lastPath = path
-            lastRequest = request
-            @Suppress("UNCHECKED_CAST")
-            return responder(responseType) as R
-        }
-
-        override fun <T : Any, R : Any, O : Any> sse(
-            path: String,
-            request: T,
-            requestBodyType: KClass<T>,
-            dataFilter: (String?) -> Boolean,
-            decodeStreamingResponse: (String) -> R,
-            processStreamingChunk: (R) -> O?,
-            parameters: Map<String, String>
-        ): Flow<O> = emptyFlow()
-
-        override fun close() = Unit
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIPrimaryConstructorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIPrimaryConstructorTest.kt
@@ -1,0 +1,98 @@
+package ai.koog.prompt.executor.clients.openai
+
+import ai.koog.http.client.KoogHttpClient
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.message.Message
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.reflect.KClass
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class OpenAIPrimaryConstructorTest {
+    private val responseJson = """
+        {
+          "id": "chatcmpl-123",
+          "object": "chat.completion",
+          "created": 1716920005,
+          "model": "gpt-4o",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "Hello from KoogHttpClient"
+              },
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {"total_tokens": 10, "prompt_tokens": 4, "completion_tokens": 6}
+        }
+    """.trimIndent()
+
+    @Test
+    fun `primary constructor should execute through provided koog http client`() = runTest {
+        val transport = CapturingKoogHttpClient { responseType ->
+            when (responseType) {
+                String::class -> responseJson
+                else -> error("Unexpected response type: $responseType")
+            }
+        }
+        val client = OpenAILLMClient(
+            settings = OpenAIClientSettings(baseUrl = "https://unused.test"),
+            httpClient = transport
+        )
+
+        val responses = client.execute(
+            prompt = prompt("test") { user("Hello?") },
+            model = OpenAIModels.Chat.GPT4o
+        )
+
+        assertEquals("v1/chat/completions", transport.lastPath)
+        assertEquals(LLMProvider.OpenAI, client.llmProvider())
+        assertEquals("""{"role":"user","content":"Hello?"}""", transport.lastRequest!!.substringAfter("\"messages\":[").substringBefore("]"))
+        assertEquals(1, responses.size)
+        val message = assertIs<Message.Assistant>(responses.single())
+        assertEquals("Hello from KoogHttpClient", message.content)
+    }
+
+    private class CapturingKoogHttpClient(
+        private val responder: (KClass<*>) -> Any
+    ) : KoogHttpClient {
+        override val clientName: String = "CapturingOpenAIClient"
+        var lastPath: String? = null
+        var lastRequest: String? = null
+
+        override suspend fun <R : Any> get(path: String, responseType: KClass<R>, parameters: Map<String, String>): R {
+            error("GET is not expected in this test")
+        }
+
+        override suspend fun <T : Any, R : Any> post(
+            path: String,
+            request: T,
+            requestBodyType: KClass<T>,
+            responseType: KClass<R>,
+            parameters: Map<String, String>
+        ): R {
+            lastPath = path
+            lastRequest = request.toString()
+            @Suppress("UNCHECKED_CAST")
+            return responder(responseType) as R
+        }
+
+        override fun <T : Any, R : Any, O : Any> sse(
+            path: String,
+            request: T,
+            requestBodyType: KClass<T>,
+            dataFilter: (String?) -> Boolean,
+            decodeStreamingResponse: (String) -> R,
+            processStreamingChunk: (R) -> O?,
+            parameters: Map<String, String>
+        ): Flow<O> = emptyFlow()
+
+        override fun close() = Unit
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIPrimaryConstructorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIPrimaryConstructorTest.kt
@@ -1,13 +1,10 @@
 package ai.koog.prompt.executor.clients.openai
 
-import ai.koog.http.client.KoogHttpClient
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.message.Message
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
+import ai.koog.test.utils.CapturingKoogHttpClient
 import kotlinx.coroutines.test.runTest
-import kotlin.reflect.KClass
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -35,7 +32,7 @@ class OpenAIPrimaryConstructorTest {
 
     @Test
     fun `primary constructor should execute through provided koog http client`() = runTest {
-        val transport = CapturingKoogHttpClient { responseType ->
+        val transport = CapturingKoogHttpClient(clientName = "CapturingOpenAIClient") { responseType ->
             when (responseType) {
                 String::class -> responseJson
                 else -> error("Unexpected response type: $responseType")
@@ -53,46 +50,12 @@ class OpenAIPrimaryConstructorTest {
 
         assertEquals("v1/chat/completions", transport.lastPath)
         assertEquals(LLMProvider.OpenAI, client.llmProvider())
-        assertEquals("""{"role":"user","content":"Hello?"}""", transport.lastRequest!!.substringAfter("\"messages\":[").substringBefore("]"))
+        assertEquals(
+            """{"role":"user","content":"Hello?"}""",
+            transport.lastRequest.toString().substringAfter("\"messages\":[").substringBefore("]")
+        )
         assertEquals(1, responses.size)
         val message = assertIs<Message.Assistant>(responses.single())
         assertEquals("Hello from KoogHttpClient", message.content)
-    }
-
-    private class CapturingKoogHttpClient(
-        private val responder: (KClass<*>) -> Any
-    ) : KoogHttpClient {
-        override val clientName: String = "CapturingOpenAIClient"
-        var lastPath: String? = null
-        var lastRequest: String? = null
-
-        override suspend fun <R : Any> get(path: String, responseType: KClass<R>, parameters: Map<String, String>): R {
-            error("GET is not expected in this test")
-        }
-
-        override suspend fun <T : Any, R : Any> post(
-            path: String,
-            request: T,
-            requestBodyType: KClass<T>,
-            responseType: KClass<R>,
-            parameters: Map<String, String>
-        ): R {
-            lastPath = path
-            lastRequest = request.toString()
-            @Suppress("UNCHECKED_CAST")
-            return responder(responseType) as R
-        }
-
-        override fun <T : Any, R : Any, O : Any> sse(
-            path: String,
-            request: T,
-            requestBodyType: KClass<T>,
-            dataFilter: (String?) -> Boolean,
-            decodeStreamingResponse: (String) -> R,
-            processStreamingChunk: (R) -> O?,
-            parameters: Map<String, String>
-        ): Flow<O> = emptyFlow()
-
-        override fun close() = Unit
     }
 }

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
                 api(libs.kotlinx.serialization.json)
                 api(libs.kotest.assertions.json)
                 api(libs.kotest.assertions.core)
+                api(project(":http-client:http-client-core"))
             }
         }
 

--- a/test-utils/src/commonMain/kotlin/ai/koog/test/utils/CapturingKoogHttpClient.kt
+++ b/test-utils/src/commonMain/kotlin/ai/koog/test/utils/CapturingKoogHttpClient.kt
@@ -1,0 +1,60 @@
+package ai.koog.test.utils
+
+import ai.koog.http.client.KoogHttpClient
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlin.reflect.KClass
+
+/**
+ * Test double for [KoogHttpClient] that captures the last POST request details.
+ *
+ * This client is intended for tests where you want to:
+ * - verify the requested path,
+ * - inspect the request payload,
+ * - and return a controlled response based on the requested response type.
+ *
+ * GET requests are not expected and will fail fast.
+ * SSE calls are intentionally inert and return an empty flow.
+ *
+ * @property clientName The logical name of the client instance.
+ * @property responder A function that produces a response object for the requested response type.
+ */
+public class CapturingKoogHttpClient(
+    override val clientName: String,
+    private val responder: (KClass<*>) -> Any,
+) : KoogHttpClient {
+    /** Captured path from the most recent POST request. */
+    public var lastPath: String? = null
+
+    /** Captured request body from the most recent POST request. */
+    public var lastRequest: Any? = null
+
+    override suspend fun <R : Any> get(path: String, responseType: KClass<R>, parameters: Map<String, String>): R {
+        error("GET is not expected in this test")
+    }
+
+    override suspend fun <T : Any, R : Any> post(
+        path: String,
+        request: T,
+        requestBodyType: KClass<T>,
+        responseType: KClass<R>,
+        parameters: Map<String, String>,
+    ): R {
+        lastPath = path
+        lastRequest = request
+        @Suppress("UNCHECKED_CAST")
+        return responder(responseType) as R
+    }
+
+    override fun <T : Any, R : Any, O : Any> sse(
+        path: String,
+        request: T,
+        requestBodyType: KClass<T>,
+        dataFilter: (String?) -> Boolean,
+        decodeStreamingResponse: (String) -> R,
+        processStreamingChunk: (R) -> O?,
+        parameters: Map<String, String>,
+    ): Flow<O> = emptyFlow()
+
+    override fun close(): Unit = Unit
+}


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

Add tests follow-up for decoupling LLMClient constructors from Ktor (#1742) and fix the factory overload bug.
