### PR TITLE
feat: add Opus 4.7 profile

### DIFF
--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/MediaTestScenarios.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/MediaTestScenarios.kt
@@ -43,7 +43,7 @@ object MediaTestScenarios {
     }
 
     val models = listOf(
-        AnthropicModels.Opus_4_6,
+        AnthropicModels.Sonnet_4_6,
         GoogleModels.Gemini2_5Flash,
         OpenAIModels.Chat.GPT5_1,
     )

--- a/koog-ktor/src/commonMain/kotlin/ai/koog/ktor/utils/LLMModelParser.kt
+++ b/koog-ktor/src/commonMain/kotlin/ai/koog/ktor/utils/LLMModelParser.kt
@@ -258,6 +258,7 @@ private val ANTHROPIC_MODELS_MAP = mapOf(
     "opus_4_1" to AnthropicModels.Opus_4_1,
     "opus_4_5" to AnthropicModels.Opus_4_5,
     "opus_4_6" to AnthropicModels.Opus_4_6,
+    "opus_4_7" to AnthropicModels.Opus_4_7,
     "haiku_3" to AnthropicModels.Haiku_3,
     "haiku_4_5" to AnthropicModels.Haiku_4_5,
     "sonnet_4" to AnthropicModels.Sonnet_4,

--- a/koog-ktor/src/commonTest/kotlin/ai/koog/ktor/ModelIdentifierParsingTest.kt
+++ b/koog-ktor/src/commonTest/kotlin/ai/koog/ktor/ModelIdentifierParsingTest.kt
@@ -228,6 +228,7 @@ class ModelIdentifierParsingTest {
             "anthropic.opus_4_1" to AnthropicModels.Opus_4_1,
             "anthropic.opus_4_5" to AnthropicModels.Opus_4_5,
             "anthropic.opus_4_6" to AnthropicModels.Opus_4_6,
+            "anthropic.opus_4_7" to AnthropicModels.Opus_4_7,
             "anthropic.haiku_3" to AnthropicModels.Haiku_3,
             "anthropic.haiku_4_5" to AnthropicModels.Haiku_4_5,
             "anthropic.sonnet_4" to AnthropicModels.Sonnet_4,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicModels.kt
@@ -7,6 +7,7 @@ import ai.koog.prompt.executor.clients.anthropic.AnthropicModels.Opus_4
 import ai.koog.prompt.executor.clients.anthropic.AnthropicModels.Opus_4_1
 import ai.koog.prompt.executor.clients.anthropic.AnthropicModels.Opus_4_5
 import ai.koog.prompt.executor.clients.anthropic.AnthropicModels.Opus_4_6
+import ai.koog.prompt.executor.clients.anthropic.AnthropicModels.Opus_4_7
 import ai.koog.prompt.executor.clients.anthropic.AnthropicModels.Sonnet_4
 import ai.koog.prompt.executor.clients.anthropic.AnthropicModels.Sonnet_4_5
 import ai.koog.prompt.executor.clients.anthropic.AnthropicModels.Sonnet_4_6
@@ -30,6 +31,7 @@ import kotlin.jvm.JvmField
  * | [Opus_4_1]   | Moderately fast | $15-$75      | Text, Image, Tools, Document | Text, Tools |
  * | [Opus_4_5]   | Moderately fast | $5-$25       | Text, Image, Tools, Document | Text, Tools |
  * | [Opus_4_6]   | Moderately fast | $5-$25       | Text, Image, Tools, Document | Text, Tools |
+ * | [Opus_4_7]   | Moderately fast | $5-$25       | Text, Image, Tools, Document | Text, Tools |
  */
 public object AnthropicModels : LLModelDefinitions {
     private val thinkingCapabilities: List<LLMCapability> = listOf(LLMCapability.Thinking)
@@ -275,6 +277,34 @@ public object AnthropicModels : LLModelDefinitions {
     )
 
     /**
+     * Claude Opus 4.7 is Anthropic's latest generally available Opus model.
+     * It improves on Opus 4.6 for advanced software engineering, long-running agents,
+     * knowledge work, and higher-resolution vision tasks.
+     *
+     * 1M context window
+     *
+     * @see <a href="https://www.anthropic.com/news/claude-opus-4-7">
+     * @see <a href="https://platform.claude.com/docs/en/about-claude/models/overview">
+     */
+    @JvmField
+    public val Opus_4_7: LLModel = LLModel(
+        provider = LLMProvider.Anthropic,
+        id = "claude-opus-4-7",
+        capabilities = listOf(
+            LLMCapability.Temperature,
+            LLMCapability.Tools,
+            LLMCapability.ToolChoice,
+            LLMCapability.Vision.Image,
+            LLMCapability.Document,
+            LLMCapability.Completion,
+            LLMCapability.Schema.JSON.Basic,
+            LLMCapability.Schema.JSON.Standard,
+        ) + thinkingCapabilities,
+        contextLength = 1_000_000,
+        maxOutputTokens = 128_000,
+    )
+
+    /**
      * List of the supported models by the Anthropic provider.
      */
     private val supportedModels: List<LLModel> = listOf(
@@ -286,6 +316,7 @@ public object AnthropicModels : LLModelDefinitions {
         Opus_4_1,
         Opus_4_5,
         Opus_4_6,
+        Opus_4_7,
         Haiku_4_5
     )
 
@@ -313,4 +344,5 @@ internal val DEFAULT_ANTHROPIC_MODEL_VERSIONS_MAP: Map<LLModel, String> = mapOf(
     Opus_4_1 to "claude-opus-4-1-20250805",
     Opus_4_5 to "claude-opus-4-5-20251101",
     Opus_4_6 to "claude-opus-4-6",
+    Opus_4_7 to "claude-opus-4-7",
 )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicModelsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicModelsTest.kt
@@ -35,6 +35,7 @@ class AnthropicModelsTest {
             AnthropicModels.Sonnet_4_6,
             AnthropicModels.Opus_4_5,
             AnthropicModels.Opus_4_6,
+            AnthropicModels.Opus_4_7,
         )
 
         modelsWithSchema.forEach { model ->
@@ -115,5 +116,6 @@ class AnthropicModelsTest {
         assertNotNull(AnthropicModels.Haiku_4_5.capabilities) shouldContain LLMCapability.Thinking
         assertNotNull(AnthropicModels.Sonnet_4.capabilities) shouldContain LLMCapability.Thinking
         assertNotNull(AnthropicModels.Opus_4_6.capabilities) shouldContain LLMCapability.Thinking
+        assertNotNull(AnthropicModels.Opus_4_7.capabilities) shouldContain LLMCapability.Thinking
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModels.kt
@@ -190,6 +190,17 @@ public object BedrockModels : LLModelDefinitions {
     ).effectiveModel
 
     /**
+     * Claude Opus 4.7 is Anthropic's latest generally available Opus model for advanced coding,
+     * long-running agents, knowledge work, and higher-resolution vision tasks.
+     *
+     * @see <a href="https://aws.amazon.com/blogs/aws/introducing-anthropics-claude-opus-4-7-model-in-amazon-bedrock/">
+     */
+    public val AnthropicClaude47Opus: LLModel = BedrockModel(
+        AnthropicModels.Opus_4_7,
+        "anthropic.claude-opus-4-7",
+    ).effectiveModel
+
+    /**
      * Claude 4 Sonnet - High-performance model with exceptional reasoning and efficiency
      *
      * This model offers:
@@ -658,6 +669,7 @@ public object BedrockModels : LLModelDefinitions {
         AnthropicClaude41Opus,
         AnthropicClaude45Opus,
         AnthropicClaude46Opus,
+        AnthropicClaude47Opus,
         AnthropicClaude4Sonnet,
         AnthropicClaude4_5Sonnet,
         AnthropicClaude4_6Sonnet,


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

Add support for Anthropic Opus 4.7 model via Anthropic and Bedrock clients.