### PR TITLE
example: Remove Calculator V2 Example References

### DIFF
--- a/examples/simple-examples/README.md
+++ b/examples/simple-examples/README.md
@@ -48,7 +48,6 @@ Welcome to the **Koog Framework Simple Examples** collection! This project showc
 | Example                     | Description                                                       | Gradle Task                         | Notebook                                             |
 |-----------------------------|-------------------------------------------------------------------|-------------------------------------|------------------------------------------------------|
 | **Calculator**              | Basic calculator agent with parallel tool calls and event logging | `runExampleCalculator`              | [📓 Calculator.ipynb](../notebooks/Calculator.ipynb) |
-| **Calculator V2**           | Enhanced calculator with improved functionality                   | `runExampleCalculatorV2`            | -                                                    |
 | **Calculator Local**        | Calculator using local LLM models                                 | `runExampleCalculatorLocal`         | -                                                    |
 | **Streaming with Tools**    | Agent demonstrating streaming responses while using tools         | `runExampleStreamingWithTools`      | -                                                    |
 | **Streaming Ktor Server**   | HTTP server streaming LLM responses in real-time via Ktor         | `runExampleStreamingKtorServer`     | -                                                    |

--- a/examples/simple-examples/build.gradle.kts
+++ b/examples/simple-examples/build.gradle.kts
@@ -81,7 +81,6 @@ fun registerRunExampleTask(
 }
 
 registerRunExampleTask("runExampleCalculator", "ai.koog.agents.example.calculator.CalculatorKt")
-registerRunExampleTask("runExampleCalculatorV2", "ai.koog.agents.example.calculator.v2.CalculatorKt")
 registerRunExampleTask(
     "runExampleCalculatorLocal",
     "ai.koog.agents.example.calculator.CalculatorKt",


### PR DESCRIPTION
This example seems to no longer exist but is still referenced. Removing it to cleanup and prevent confusion. 
