### PR TITLE
feat(agents): upgrade sdk to 0.11.1, add streamable transport 

### DIFF
--- a/agents/agents-mcp-metadata/src/commonMain/kotlin/ai/koog/agents/mcp/metadata/McpToolSupport.kt
+++ b/agents/agents-mcp-metadata/src/commonMain/kotlin/ai/koog/agents/mcp/metadata/McpToolSupport.kt
@@ -77,6 +77,15 @@ public enum class McpTransportType(public val value: String) {
     Tcp("tcp"),
 
     /**
+     * HTTP-based Streamable HTTP transport.
+     *
+     * This transport uses HTTP POST for sending messages and SSE for receiving,
+     * supporting bidirectional communication, session management, and reconnection.
+     * It is the recommended transport for remote MCP servers, replacing the legacy SSE transport.
+     */
+    StreamableHttp("http"),
+
+    /**
      * Represents an unknown or undefined transport protocol type.
      *
      * This value is used as a fallback or default when the transport type

--- a/agents/agents-mcp-server/src/commonMain/kotlin/ai/koog/agents/mcp/server/McpServer.kt
+++ b/agents/agents-mcp-server/src/commonMain/kotlin/ai/koog/agents/mcp/server/McpServer.kt
@@ -25,6 +25,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonObjectBuilder
@@ -34,6 +35,7 @@ import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration.Companion.milliseconds
 import io.modelcontextprotocol.kotlin.sdk.types.Tool as SdkTool
 
 /**
@@ -93,7 +95,6 @@ public suspend fun startMcpServer(
 /**
  * Starts a new MCP server with the passed [tools] that listens to and writes
  * to the specified [port] on the passed [host] using SSE transport.
- * A port can be obtained from the returned list of [EngineConnectorConfig].
  */
 @Deprecated(
     "SSE transport is deprecated. Use startMcpServer() which defaults to Streamable HTTP.",
@@ -156,6 +157,7 @@ private suspend fun EmbeddedServer<*, *>.connectors(): List<EngineConnectorConfi
         if (connectors.isNotEmpty()) {
             return@coroutineScope connectors
         }
+        delay(50.milliseconds)
     }
 
     return@coroutineScope emptyList()

--- a/agents/agents-mcp-server/src/commonMain/kotlin/ai/koog/agents/mcp/server/McpServer.kt
+++ b/agents/agents-mcp-server/src/commonMain/kotlin/ai/koog/agents/mcp/server/McpServer.kt
@@ -9,6 +9,7 @@ import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.serialization.JSONSerializer
 import ai.koog.serialization.kotlinx.KotlinxSerializer
 import ai.koog.serialization.kotlinx.toKoogJSONObject
+import io.ktor.server.application.Application
 import io.ktor.server.engine.ApplicationEngineFactory
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.EngineConnectorConfig
@@ -16,6 +17,7 @@ import io.ktor.server.engine.embeddedServer
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 import io.modelcontextprotocol.kotlin.sdk.server.mcp
+import io.modelcontextprotocol.kotlin.sdk.server.mcpStreamableHttp
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.EmptyJsonObject
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
@@ -35,50 +37,89 @@ import kotlin.coroutines.cancellation.CancellationException
 import io.modelcontextprotocol.kotlin.sdk.types.Tool as SdkTool
 
 /**
+ * Supported MCP server transport types for the Ktor-based [startMcpServer].
+ *
+ * For stdio transport use the platform-specific `startStdioMcpServer(tools)` entry point.
+ */
+public enum class McpServerTransportType {
+    /** Streamable HTTP transport. */
+    StreamableHttp,
+
+    /** SSE transport. */
+    SSE,
+}
+
+/**
+ * Starts a new MCP server with the given [tools] on the specified [port] and [host].
+ * Defaults to Streamable HTTP transport.
+ *
+ * @param factory The Ktor application engine factory to use (e.g., CIO, Netty).
+ * @param tools The tools to expose via the MCP server.
+ * @param port The port to listen on.
+ * @param host The host to bind to.
+ * @param transport The transport type to use.
+ * @return The MCP [Server].
+ */
+public suspend fun startMcpServer(
+    factory: ApplicationEngineFactory<*, *>,
+    tools: ToolRegistry,
+    port: Int = 3000,
+    host: String = "localhost",
+    transport: McpServerTransportType = McpServerTransportType.StreamableHttp,
+): Server = doStartMcpServer(factory, port, host, tools) { server ->
+    when (transport) {
+        McpServerTransportType.StreamableHttp -> mcpStreamableHttp { server }
+        McpServerTransportType.SSE -> mcp { server }
+    }
+}.first
+
+/**
  * Starts a new MCP server with the passed [tools] that listens to and writes
- * to the specified [port] on the passed [host].
+ * to the specified [port] on the passed [host] using SSE transport.
  * A port can be obtained from the returned list of [EngineConnectorConfig].
  */
+@Deprecated(
+    "SSE transport is deprecated. Use startMcpServer() which defaults to Streamable HTTP.",
+    ReplaceWith("startMcpServer(factory, tools, port, host)"),
+    level = DeprecationLevel.WARNING,
+)
 public suspend fun startSseMcpServer(
     factory: ApplicationEngineFactory<*, *>,
     port: Int = 3000,
     host: String = "localhost",
     tools: ToolRegistry,
-): Server = doStartSseMcpServer(factory, port, host, tools, true).first
+): Server = doStartMcpServer(factory, port, host, tools) { server -> mcp { server } }.first
 
 /**
  * Starts a new MCP server with the passed [tools] that listens to and writes
- * to the allocated port on the passed [host].
+ * to the allocated port on the passed [host] using SSE transport.
  * A port can be obtained from the returned list of [EngineConnectorConfig].
  */
+@Deprecated(
+    "SSE transport is deprecated. Use startMcpServer() which defaults to Streamable HTTP.",
+    level = DeprecationLevel.WARNING,
+)
 public suspend fun startSseMcpServer(
     factory: ApplicationEngineFactory<*, *>,
     host: String = "localhost",
     tools: ToolRegistry,
-): Pair<Server, List<EngineConnectorConfig>> = doStartSseMcpServer(factory, 0, host, tools, false)
+): Pair<Server, List<EngineConnectorConfig>> =
+    doStartMcpServer(factory, 0, host, tools) { server -> mcp { server } }
 
-private suspend fun doStartSseMcpServer(
+private suspend fun doStartMcpServer(
     factory: ApplicationEngineFactory<*, *>,
     port: Int,
     host: String,
     tools: ToolRegistry,
-    skipConnectors: Boolean,
+    install: Application.(Server) -> Unit,
 ): Pair<Server, List<EngineConnectorConfig>> {
     val server = configureMcpServer(tools)
 
-    val emb = embeddedServer(factory = factory, host = host, port = port) {
-        mcp { server }
-    }
+    val emb = embeddedServer(factory = factory, host = host, port = port) { install(server) }
         .also { emb -> server.onClose { emb.stop(1000, 1000) } }
         .startSuspend(wait = false)
 
-    val connectors = if (skipConnectors) {
-        emptyList()
-    } else {
-        emb.connectors()
-    }
-
-    return server to connectors
+    return server to emb.connectors()
 }
 
 private suspend fun EmbeddedServer<*, *>.connectors(): List<EngineConnectorConfig> = coroutineScope {

--- a/agents/agents-mcp-server/src/commonMain/kotlin/ai/koog/agents/mcp/server/McpServer.kt
+++ b/agents/agents-mcp-server/src/commonMain/kotlin/ai/koog/agents/mcp/server/McpServer.kt
@@ -67,11 +67,28 @@ public suspend fun startMcpServer(
     host: String = "localhost",
     transport: McpServerTransportType = McpServerTransportType.StreamableHttp,
 ): Server = doStartMcpServer(factory, port, host, tools) { server ->
-    when (transport) {
-        McpServerTransportType.StreamableHttp -> mcpStreamableHttp { server }
-        McpServerTransportType.SSE -> mcp { server }
-    }
+    installMcpTransport(server, transport)
 }.first
+
+/**
+ * Starts a new MCP server with the given [tools] on an OS-allocated port on the passed [host].
+ * The actual port can be obtained from the returned list of [EngineConnectorConfig].
+ * Defaults to Streamable HTTP transport.
+ *
+ * @param factory The Ktor application engine factory to use (e.g., CIO, Netty).
+ * @param tools The tools to expose via the MCP server.
+ * @param host The host to bind to.
+ * @param transport The transport type to use.
+ * @return A pair of the MCP [Server] and the list of connectors (used to discover the allocated port).
+ */
+public suspend fun startMcpServer(
+    factory: ApplicationEngineFactory<*, *>,
+    tools: ToolRegistry,
+    host: String = "localhost",
+    transport: McpServerTransportType = McpServerTransportType.StreamableHttp,
+): Pair<Server, List<EngineConnectorConfig>> = doStartMcpServer(factory, 0, host, tools) { server ->
+    installMcpTransport(server, transport)
+}
 
 /**
  * Starts a new MCP server with the passed [tools] that listens to and writes
@@ -97,6 +114,7 @@ public suspend fun startSseMcpServer(
  */
 @Deprecated(
     "SSE transport is deprecated. Use startMcpServer() which defaults to Streamable HTTP.",
+    ReplaceWith("startMcpServer(factory, tools, host)"),
     level = DeprecationLevel.WARNING,
 )
 public suspend fun startSseMcpServer(
@@ -105,6 +123,13 @@ public suspend fun startSseMcpServer(
     tools: ToolRegistry,
 ): Pair<Server, List<EngineConnectorConfig>> =
     doStartMcpServer(factory, 0, host, tools) { server -> mcp { server } }
+
+private fun Application.installMcpTransport(server: Server, transport: McpServerTransportType) {
+    when (transport) {
+        McpServerTransportType.StreamableHttp -> mcpStreamableHttp { server }
+        McpServerTransportType.SSE -> mcp { server }
+    }
+}
 
 private suspend fun doStartMcpServer(
     factory: ApplicationEngineFactory<*, *>,

--- a/agents/agents-mcp-server/src/jvmMain/kotlin/ai/koog/agents/mcp/server/McpServer.jvm.kt
+++ b/agents/agents-mcp-server/src/jvmMain/kotlin/ai/koog/agents/mcp/server/McpServer.jvm.kt
@@ -13,7 +13,7 @@ import kotlinx.io.buffered
 public suspend fun startStdioMcpServer(tools: ToolRegistry): Server {
     return configureMcpServer(tools)
         .apply {
-            connect(
+            createSession(
                 StdioServerTransport(
                     inputStream = System.`in`.asSource().buffered(),
                     outputStream = System.out.asSink().buffered()

--- a/agents/agents-mcp-server/src/jvmTest/kotlin/ai/koog/agents/mcp/server/KoogToolAsMcpToolTest.kt
+++ b/agents/agents-mcp-server/src/jvmTest/kotlin/ai/koog/agents/mcp/server/KoogToolAsMcpToolTest.kt
@@ -222,14 +222,15 @@ class KoogToolAsMcpToolTest {
     ) = runTest(timeout = 30.seconds) {
         assertIsNot<McpTool>(tool)
 
-        val port = 3003
-        val server = startMcpServer(
+        val (server, connectors) = startMcpServer(
             factory = CIO,
             tools = ToolRegistry {
                 tool(tool)
             },
-            port = port,
         )
+
+        val port = connectors.firstOrNull()?.port ?: 0
+        assertNotEquals(0, port, "Port should not be 0")
 
         val httpClient = HttpClient { install(SSE) }
 

--- a/agents/agents-mcp-server/src/jvmTest/kotlin/ai/koog/agents/mcp/server/KoogToolAsMcpToolTest.kt
+++ b/agents/agents-mcp-server/src/jvmTest/kotlin/ai/koog/agents/mcp/server/KoogToolAsMcpToolTest.kt
@@ -11,6 +11,8 @@ import ai.koog.agents.testing.tools.RandomNumberTool
 import ai.koog.serialization.kotlinx.KotlinxSerializer
 import ai.koog.serialization.kotlinx.toKoogJSONObject
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.sse.SSE
 import io.ktor.server.cio.CIO
 import io.modelcontextprotocol.kotlin.sdk.types.EmptyJsonObject
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
@@ -47,7 +49,7 @@ class KoogToolAsMcpToolTest {
 
         logger.info { "Result: ${mcpTool.encodeResultToString(result, serializer)}" }
 
-        val content = result?.content?.first() as TextContent
+        val content = result.content.first() as TextContent
         assertEquals("${origin.last}", content.text)
     }
 
@@ -64,7 +66,7 @@ class KoogToolAsMcpToolTest {
 
         logger.info { "Result: ${mcpTool.encodeResultToString(result, serializer)}" }
 
-        val content = result?.content?.first() as TextContent
+        val content = result.content.first() as TextContent
         assertEquals("${origin.last}", content.text)
     }
 
@@ -80,7 +82,7 @@ class KoogToolAsMcpToolTest {
                 }
             }
 
-            assertTrue(errorResult?.isError ?: false)
+            assertTrue(errorResult.isError ?: false)
         }
 
         // check that the server is still working
@@ -95,7 +97,7 @@ class KoogToolAsMcpToolTest {
 
             logger.info { "Result: ${mcpTool.encodeResultToString(result, serializer)}" }
 
-            val content = result?.content?.first() as TextContent
+            val content = result.content.first() as TextContent
             assertEquals("${origin.last}", content.text)
         }
     }
@@ -117,7 +119,7 @@ class KoogToolAsMcpToolTest {
                     }
                 }
 
-                assertTrue(errorResult?.isError ?: false)
+                assertTrue(errorResult.isError ?: false)
 
                 val last = origin.last
                 assertNotNull(last)
@@ -144,6 +146,23 @@ class KoogToolAsMcpToolTest {
         }
     }
 
+    @Test
+    fun testKoogToolAsMcpToolViaStreamableHttp() = testMcpToolStreamableHttp(RandomNumberTool()) { mcpTool, origin ->
+        val args = buildJsonObject { put("seed", "42") }
+
+        val result = withContext(Dispatchers.Default.limitedParallelism(1)) {
+            withTimeout(20.seconds) {
+                mcpTool.execute(args.toKoogJSONObject())
+            }
+        }
+
+        logger.info { "Result (Streamable HTTP): ${mcpTool.encodeResultToString(result, serializer)}" }
+
+        val content = result.content.first() as TextContent
+        assertEquals("${origin.last}", content.text)
+    }
+
+    @Suppress("DEPRECATION")
     private fun <T : Tool<*, *>> testMcpTool(
         tool: T,
         block: suspend (McpTool, T) -> Unit,
@@ -176,6 +195,64 @@ class KoogToolAsMcpToolTest {
             block(mcpTool, tool)
         } finally {
             server.close()
+
+            withContext(Dispatchers.Default.limitedParallelism(1)) {
+                var result = Result.success(Unit)
+
+                for (attempt in 1..3) {
+                    result = runCatching {
+                        assertTrue(isPortAvailable(port), "Port $port should be available")
+                    }
+
+                    if (result.isSuccess) {
+                        break
+                    } else {
+                        delay(1.seconds)
+                    }
+                }
+
+                result.getOrThrow()
+            }
+        }
+    }
+
+    private fun <T : Tool<*, *>> testMcpToolStreamableHttp(
+        tool: T,
+        block: suspend (McpTool, T) -> Unit,
+    ) = runTest(timeout = 30.seconds) {
+        assertIsNot<McpTool>(tool)
+
+        val port = 3003
+        val server = startMcpServer(
+            factory = CIO,
+            tools = ToolRegistry {
+                tool(tool)
+            },
+            port = port,
+        )
+
+        val httpClient = HttpClient { install(SSE) }
+
+        try {
+            val toolRegistry = withContext(Dispatchers.Default.limitedParallelism(1)) {
+                withTimeout(20.seconds) {
+                    McpToolRegistryProvider.streamableHttp {
+                        url = "http://localhost:$port/mcp"
+                        this.httpClient = httpClient
+                    }
+                }
+            }
+
+            assertEquals(
+                listOf(tool.descriptor),
+                toolRegistry.tools.map { it.descriptor },
+            )
+
+            val mcpTool = toolRegistry.getTool(tool.name) as McpTool
+            block(mcpTool, tool)
+        } finally {
+            server.close()
+            httpClient.close()
 
             withContext(Dispatchers.Default.limitedParallelism(1)) {
                 var result = Result.success(Unit)

--- a/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpTool.kt
+++ b/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpTool.kt
@@ -75,10 +75,19 @@ public class McpTool(
      * Postprocess result string representation for LLMs a bit, removing unnecessary meta fields.
      * When the result indicates an error (isError == true), returns a clearly prefixed error string
      * so the LLM can recognize the failure and adjust its strategy.
+     *
+     * If the error result has no [TextContent] (or only blank text), falls back to encoding the full
+     * [CallToolResult] as JSON so non-text content (e.g. images, embedded resources) is not silently
+     * dropped.
      */
     override fun encodeResultToString(result: CallToolResult?, serializer: JSONSerializer): String {
         if (result?.isError == true) {
-            return "Error: ${result.content.filterIsInstance<TextContent>().joinToString("\n") { it.text }}"
+            val errorText = result.content.filterIsInstance<TextContent>().joinToString("\n") { it.text }
+            if (errorText.isNotBlank()) {
+                return "Error: $errorText"
+            }
+            val fallbackJson = json.encodeToJsonElement(resultSerializer, result).toKoogJSONElement()
+            return "Error: ${serializer.encodeJSONElementToString(fallbackJson)}"
         }
 
         val preparedResultJson: JsonElement = result

--- a/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpTool.kt
+++ b/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpTool.kt
@@ -12,6 +12,7 @@ import ai.koog.serialization.kotlinx.toKotlinxJsonObject
 import ai.koog.serialization.typeToken
 import io.modelcontextprotocol.kotlin.sdk.client.Client
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -72,8 +73,14 @@ public class McpTool(
 
     /**
      * Postprocess result string representation for LLMs a bit, removing unnecessary meta fields.
+     * When the result indicates an error (isError == true), returns a clearly prefixed error string
+     * so the LLM can recognize the failure and adjust its strategy.
      */
     override fun encodeResultToString(result: CallToolResult?, serializer: JSONSerializer): String {
+        if (result?.isError == true) {
+            return "Error: ${result.content.filterIsInstance<TextContent>().joinToString("\n") { it.text }}"
+        }
+
         val preparedResultJson: JsonElement = result
             ?.let {
                 JsonObject(

--- a/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpToolDefinitionParser.kt
+++ b/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpToolDefinitionParser.kt
@@ -4,6 +4,8 @@ import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
 import io.modelcontextprotocol.kotlin.sdk.types.EmptyJsonObject
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.boolean
@@ -42,8 +44,10 @@ public object DefaultMcpToolDescriptorParser : McpToolDescriptorParser {
      * @return A ToolDescriptor representing the MCP tool.
      */
     override fun parse(sdkTool: SDKTool): ToolDescriptor {
+        val defs = sdkTool.inputSchema.defs
+
         // Parse all parameters from the input schema
-        val parameters = parseParameters(sdkTool.inputSchema.properties ?: EmptyJsonObject)
+        val parameters = parseParameters(sdkTool.inputSchema.properties ?: EmptyJsonObject, defs)
 
         // Get the list of required parameters
         val requiredParameters = sdkTool.inputSchema.required ?: emptyList()
@@ -57,7 +61,7 @@ public object DefaultMcpToolDescriptorParser : McpToolDescriptorParser {
         )
     }
 
-    private fun parseParameterType(element: JsonObject, depth: Int = 0): ToolParameterType {
+    private fun parseParameterType(element: JsonObject, defs: JsonObject?, depth: Int = 0): ToolParameterType {
         if (depth > MAX_DEPTH) {
             throw IllegalArgumentException(
                 "Maximum recursion depth ($MAX_DEPTH) exceeded. " +
@@ -65,8 +69,15 @@ public object DefaultMcpToolDescriptorParser : McpToolDescriptorParser {
             )
         }
 
-        // Extract the type string from the JSON object
-        val typeStr = element["type"]?.jsonPrimitive?.content
+        // Handle $ref resolution
+        val ref = element["\$ref"]?.jsonPrimitive?.content
+        if (ref != null) {
+            val resolved = resolveRef(ref, defs)
+            return parseParameterType(resolved, defs, depth + 1)
+        }
+
+        // Extract the type - can be a string or an array of strings (JSON Schema type-array)
+        val (typeStr, isNullableTypeArray) = parseTypeInfo(element["type"])
 
         if (typeStr == null) {
             val anyOf = element["anyOf"]?.jsonArray
@@ -89,7 +100,7 @@ public object DefaultMcpToolDescriptorParser : McpToolDescriptorParser {
                         ToolParameterDescriptor(
                             name = "",
                             description = it["description"]?.jsonPrimitive?.content.orEmpty(),
-                            type = parseParameterType(it.jsonObject)
+                            type = parseParameterType(it.jsonObject, defs)
                         )
                     }.toTypedArray()
                 )
@@ -119,7 +130,7 @@ public object DefaultMcpToolDescriptorParser : McpToolDescriptorParser {
         }
 
         // Convert the type string to a ToolParameterType
-        return when (typeStr.lowercase()) {
+        val parsedType = when (typeStr.lowercase()) {
             // Primitive types
             "string" -> ToolParameterType.String
 
@@ -138,7 +149,7 @@ public object DefaultMcpToolDescriptorParser : McpToolDescriptorParser {
                 val items = element["items"]?.jsonObject
                     ?: throw IllegalArgumentException("Array type parameters must have items property")
 
-                val itemType = parseParameterType(items, depth + 1)
+                val itemType = parseParameterType(items, defs, depth + 1)
 
                 ToolParameterType.List(itemsType = itemType)
             }
@@ -150,7 +161,11 @@ public object DefaultMcpToolDescriptorParser : McpToolDescriptorParser {
                     rawProperties.map { (name, property) ->
                         // Description is optional
                         val description = property.jsonObject["description"]?.jsonPrimitive?.content.orEmpty()
-                        ToolParameterDescriptor(name, description, parseParameterType(property.jsonObject, depth + 1))
+                        ToolParameterDescriptor(
+                            name,
+                            description,
+                            parseParameterType(property.jsonObject, defs, depth + 1)
+                        )
                     }
                 } ?: emptyList()
 
@@ -170,6 +185,7 @@ public object DefaultMcpToolDescriptorParser : McpToolDescriptorParser {
                     when (element.getValue("additionalProperties")) {
                         is JsonObject -> parseParameterType(
                             element.getValue("additionalProperties").jsonObject,
+                            defs,
                             depth + 1
                         )
 
@@ -192,9 +208,58 @@ public object DefaultMcpToolDescriptorParser : McpToolDescriptorParser {
             // Unsupported type
             else -> throw IllegalArgumentException("Unsupported parameter type: $typeStr")
         }
+
+        // Wrap in AnyOf(Null, type) for type-arrays containing "null", e.g. ["integer", "null"]
+        return if (isNullableTypeArray && parsedType != ToolParameterType.Null) {
+            ToolParameterType.AnyOf(
+                types = arrayOf(
+                    ToolParameterDescriptor(name = "", description = "", type = ToolParameterType.Null),
+                    ToolParameterDescriptor(name = "", description = "", type = parsedType),
+                )
+            )
+        } else {
+            parsedType
+        }
     }
 
-    private fun parseParameters(properties: JsonObject): List<ToolParameterDescriptor> {
+    /**
+     * Parses the JSON Schema `type` keyword, which can be either a single string
+     * (e.g. `"string"`) or an array of strings (e.g. `["string", "null"]`).
+     *
+     * @return the primary non-null type name (or `"null"` if the array contains only `"null"`,
+     *   or `null` if no type is specified), and a flag indicating whether the type-array
+     *   included `"null"` (meaning the parameter is nullable).
+     */
+    private fun parseTypeInfo(typeElement: JsonElement?): TypeInfo = when (typeElement) {
+        is JsonPrimitive -> TypeInfo(typeStr = typeElement.content, isNullableTypeArray = false)
+        is JsonArray -> {
+            val types = typeElement.map { it.jsonPrimitive.content }
+            val nonNullTypes = types.filter { it != "null" }
+            TypeInfo(
+                typeStr = if (nonNullTypes.isEmpty()) "null" else nonNullTypes.first(),
+                isNullableTypeArray = types.size != nonNullTypes.size,
+            )
+        }
+        else -> TypeInfo(typeStr = null, isNullableTypeArray = false)
+    }
+
+    private data class TypeInfo(val typeStr: String?, val isNullableTypeArray: Boolean)
+
+    /**
+     * Resolves a JSON Schema `$ref` reference against the `$defs` (or `definitions`) block.
+     * Only local references (starting with `#/`) are supported.
+     */
+    private fun resolveRef(ref: String, defs: JsonObject?): JsonObject {
+        val path = ref.removePrefix("#/").split("/")
+        require(path.size == 2 && path[0] in listOf("\$defs", "definitions")) {
+            "Unsupported \$ref format: $ref. Only local references like #/\$defs/TypeName are supported."
+        }
+        val defName = path[1]
+        return defs?.get(defName)?.jsonObject
+            ?: throw IllegalArgumentException("Definition '$defName' not found in \$defs for \$ref: $ref")
+    }
+
+    private fun parseParameters(properties: JsonObject, defs: JsonObject?): List<ToolParameterDescriptor> {
         return properties.mapNotNull { (name, element) ->
             require(element is JsonObject) { "Parameter $name must be a JSON object" }
 
@@ -202,7 +267,7 @@ public object DefaultMcpToolDescriptorParser : McpToolDescriptorParser {
             val description = element["description"]?.jsonPrimitive?.content.orEmpty()
 
             // Parse the parameter type
-            val type = parseParameterType(element)
+            val type = parseParameterType(element, defs)
 
             // Create a ToolParameterDescriptor
             ToolParameterDescriptor(

--- a/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpToolDefinitionParser.kt
+++ b/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpToolDefinitionParser.kt
@@ -121,7 +121,7 @@ public object DefaultMcpToolDescriptorParser : McpToolDescriptorParser {
              */
             val enum = element["enum"]?.jsonArray
             if (enum != null && enum.isNotEmpty()) {
-                return ToolParameterType.Enum(enum.map { it.jsonPrimitive.content }.toTypedArray())
+                return ToolParameterType.Enum(enum.map(::enumEntryToString).toTypedArray())
             }
 
             val title =
@@ -141,7 +141,7 @@ public object DefaultMcpToolDescriptorParser : McpToolDescriptorParser {
             "boolean" -> ToolParameterType.Boolean
 
             "enum" -> ToolParameterType.Enum(
-                element.getValue("enum").jsonArray.map { it.jsonPrimitive.content }.toTypedArray()
+                element.getValue("enum").jsonArray.map(::enumEntryToString).toTypedArray()
             )
 
             // Array type
@@ -182,12 +182,10 @@ public object DefaultMcpToolDescriptorParser : McpToolDescriptorParser {
                 }
 
                 val additionalPropertiesType = if ("additionalProperties" in element) {
-                    when (element.getValue("additionalProperties")) {
-                        is JsonObject -> parseParameterType(
-                            element.getValue("additionalProperties").jsonObject,
-                            defs,
-                            depth + 1
-                        )
+                    when (val ap = element.getValue("additionalProperties")) {
+                        // Empty schema `{}` is equivalent to `true`: allow any additional property
+                        // without a type constraint. Recursing would fail on missing `type`.
+                        is JsonObject -> if (ap.isEmpty()) null else parseParameterType(ap, defs, depth + 1)
 
                         else -> null
                     }
@@ -244,6 +242,19 @@ public object DefaultMcpToolDescriptorParser : McpToolDescriptorParser {
     }
 
     private data class TypeInfo(val typeStr: String?, val isNullableTypeArray: Boolean)
+
+    /**
+     * Converts an individual JSON Schema `enum` entry to its [String] representation.
+     *
+     * JSON Schema allows mixed value types in `enum` (strings, numbers, booleans, `null`, arrays, objects).
+     * Since [ToolParameterType.Enum] stores entries as strings, non-string primitives and composite
+     * values are serialized to their canonical JSON form (e.g. `42`, `null`, `["a","b"]`, `{"k":"v"}`),
+     * and string primitives are returned unquoted so they remain directly usable.
+     */
+    private fun enumEntryToString(element: JsonElement): String = when (element) {
+        is JsonPrimitive -> if (element.isString) element.content else element.toString()
+        else -> element.toString()
+    }
 
     /**
      * Resolves a JSON Schema `$ref` reference against the `$defs` (or `definitions`) block.

--- a/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpToolRegistryProvider.kt
+++ b/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpToolRegistryProvider.kt
@@ -42,7 +42,20 @@ public object McpToolRegistryProvider {
     public const val DEFAULT_MCP_CLIENT_VERSION: String = "1.0.0"
 
     /**
-     * Configuration for connecting to an MCP server via Streamable HTTP transport.
+     * Configuration for connecting to an MCP server over the Streamable HTTP transport.
+     *
+     * Used as the receiver of the configuration lambda passed to [streamableHttp]. The [url] and
+     * [httpClient] properties are required and must be set before the configuration block returns;
+     * the remaining properties have sensible defaults and are optional.
+     *
+     * Example:
+     * ```kotlin
+     * val httpClient = HttpClient { install(SSE) }
+     * val registry = McpToolRegistryProvider.streamableHttp {
+     *     url = "http://localhost:3000/mcp"
+     *     this.httpClient = httpClient
+     * }
+     * ```
      */
     public class StreamableHttpConfig {
         /** MCP server URL (required). */

--- a/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpToolRegistryProvider.kt
+++ b/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpToolRegistryProvider.kt
@@ -44,16 +44,13 @@ public object McpToolRegistryProvider {
     /**
      * Configuration for connecting to an MCP server over the Streamable HTTP transport.
      *
-     * Used as the receiver of the configuration lambda passed to [streamableHttp]. The [url] and
-     * [httpClient] properties are required and must be set before the configuration block returns;
-     * the remaining properties have sensible defaults and are optional.
+     * Used as the receiver of the configuration lambda passed to [streamableHttp]. The [url] property
+     * is required; the remaining properties have sensible defaults and are optional.
      *
      * Example:
      * ```kotlin
-     * val httpClient = HttpClient { install(SSE) }
      * val registry = McpToolRegistryProvider.streamableHttp {
      *     url = "http://localhost:3000/mcp"
-     *     this.httpClient = httpClient
      * }
      * ```
      */
@@ -62,16 +59,19 @@ public object McpToolRegistryProvider {
         public lateinit var url: String
 
         /**
-         * HttpClient used for the MCP connection (required). Must have the Ktor `SSE` plugin installed
-         * (the Streamable HTTP transport relies on it). Lifecycle is managed by the caller — we do not
-         * close this client.
+         * HttpClient used for the MCP connection. Must have the Ktor `SSE` plugin installed
+         * (the Streamable HTTP transport relies on it).
+         *
+         * If `null` (default), a private [HttpClient] is created internally and closed automatically
+         * when the underlying MCP transport closes. If a custom client is provided, the caller
+         * retains full responsibility for its lifecycle (we do not close it).
          *
          * Example:
          * ```kotlin
          * val httpClient = HttpClient { install(SSE) }
          * ```
          */
-        public lateinit var httpClient: HttpClient
+        public var httpClient: HttpClient? = null
 
         /** Custom MCP tool descriptor parser. */
         public var mcpToolParser: McpToolDescriptorParser = DefaultMcpToolDescriptorParser
@@ -89,9 +89,10 @@ public object McpToolRegistryProvider {
      * This is the recommended way to connect to remote MCP servers. Streamable HTTP supports
      * bidirectional communication, session management, and reconnection.
      *
-     * The caller is responsible for providing an [HttpClient][io.ktor.client.HttpClient] with the
-     * Ktor `SSE` plugin installed and for closing it when no longer needed. The same client can be
-     * reused across multiple MCP connections.
+     * If [StreamableHttpConfig.httpClient] is not set, a default [HttpClient] with the `SSE` plugin
+     * is created internally and closed automatically when the MCP transport closes. To reuse a
+     * single client across multiple MCP connections, set it explicitly — in that case the caller
+     * is responsible for closing it.
      *
      * @param block Configuration block for the Streamable HTTP connection.
      * @return A ToolRegistry containing all tools from the MCP server.
@@ -100,7 +101,12 @@ public object McpToolRegistryProvider {
         block: StreamableHttpConfig.() -> Unit
     ): ToolRegistry {
         val config = StreamableHttpConfig().apply(block)
-        val transport = config.httpClient.mcpStreamableHttpTransport(config.url)
+        val httpClient = config.httpClient ?: HttpClient { install(SSE) }
+        val ownsClient = config.httpClient == null
+        val transport = httpClient.mcpStreamableHttpTransport(config.url)
+        if (ownsClient) {
+            transport.onClose { httpClient.close() }
+        }
         val mcpClient = Client(clientInfo = Implementation(config.name, config.version))
         mcpClient.connect(transport)
         return fromClient(

--- a/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpToolRegistryProvider.kt
+++ b/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpToolRegistryProvider.kt
@@ -12,6 +12,8 @@ import io.ktor.http.Url
 import io.modelcontextprotocol.kotlin.sdk.client.Client
 import io.modelcontextprotocol.kotlin.sdk.client.SseClientTransport
 import io.modelcontextprotocol.kotlin.sdk.client.StdioClientTransport
+import io.modelcontextprotocol.kotlin.sdk.client.StreamableHttpClientTransport
+import io.modelcontextprotocol.kotlin.sdk.client.mcpStreamableHttpTransport
 import io.modelcontextprotocol.kotlin.sdk.shared.Transport
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.LATEST_PROTOCOL_VERSION
@@ -21,7 +23,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.Tool
  * A provider for creating tool registries that connect to Model Context Protocol (MCP) servers.
  *
  * This class facilitates the integration of MCP tools into the agent framework by:
- * 1. Connecting to MCP servers through various transport mechanisms (stdio, SSE)
+ * 1. Connecting to MCP servers through various transport mechanisms (Streamable HTTP, stdio, SSE)
  * 2. Retrieving available tools from the MCP server
  * 3. Transforming MCP tools into the agent framework's Tool interface
  * 4. Registering the transformed tools in a ToolRegistry
@@ -38,6 +40,62 @@ public object McpToolRegistryProvider {
      * Default version for the MCP client when connecting to an MCP server.
      */
     public const val DEFAULT_MCP_CLIENT_VERSION: String = "1.0.0"
+
+    /**
+     * Configuration for connecting to an MCP server via Streamable HTTP transport.
+     */
+    public class StreamableHttpConfig {
+        /** MCP server URL (required). */
+        public lateinit var url: String
+
+        /**
+         * HttpClient used for the MCP connection (required). Must have the Ktor `SSE` plugin installed
+         * (the Streamable HTTP transport relies on it). Lifecycle is managed by the caller — we do not
+         * close this client.
+         *
+         * Example:
+         * ```kotlin
+         * val httpClient = HttpClient { install(SSE) }
+         * ```
+         */
+        public lateinit var httpClient: HttpClient
+
+        /** Custom MCP tool descriptor parser. */
+        public var mcpToolParser: McpToolDescriptorParser = DefaultMcpToolDescriptorParser
+
+        /** Client name reported to the server. */
+        public var name: String = DEFAULT_MCP_CLIENT_NAME
+
+        /** Client version reported to the server. */
+        public var version: String = DEFAULT_MCP_CLIENT_VERSION
+    }
+
+    /**
+     * Creates a ToolRegistry from a Streamable HTTP MCP server.
+     *
+     * This is the recommended way to connect to remote MCP servers. Streamable HTTP supports
+     * bidirectional communication, session management, and reconnection.
+     *
+     * The caller is responsible for providing an [HttpClient][io.ktor.client.HttpClient] with the
+     * Ktor `SSE` plugin installed and for closing it when no longer needed. The same client can be
+     * reused across multiple MCP connections.
+     *
+     * @param block Configuration block for the Streamable HTTP connection.
+     * @return A ToolRegistry containing all tools from the MCP server.
+     */
+    public suspend fun streamableHttp(
+        block: StreamableHttpConfig.() -> Unit
+    ): ToolRegistry {
+        val config = StreamableHttpConfig().apply(block)
+        val transport = config.httpClient.mcpStreamableHttpTransport(config.url)
+        val mcpClient = Client(clientInfo = Implementation(config.name, config.version))
+        mcpClient.connect(transport)
+        return fromClient(
+            mcpClient = mcpClient,
+            serverInfo = McpServerInfo(url = config.url),
+            mcpToolParser = config.mcpToolParser,
+        )
+    }
 
     /**
      * Creates a default server-sent events (SSE) transport from a provided URL.
@@ -105,6 +163,7 @@ public object McpToolRegistryProvider {
                     McpMetadataKeys.ToolId to sdkTool.name,
                     McpMetadataKeys.McpProtocolVersion to LATEST_PROTOCOL_VERSION,
                     McpMetadataKeys.McpTransportType to when (mcpClient.transport) {
+                        is StreamableHttpClientTransport -> McpTransportType.StreamableHttp
                         is SseClientTransport -> McpTransportType.Tcp
                         is StdioClientTransport -> McpTransportType.Stdio
                         else -> {

--- a/agents/agents-mcp/src/commonTest/kotlin/ai/koog/agents/mcp/DefaultMcpToolDescriptorParserTest.kt
+++ b/agents/agents-mcp/src/commonTest/kotlin/ai/koog/agents/mcp/DefaultMcpToolDescriptorParserTest.kt
@@ -826,19 +826,312 @@ class DefaultMcpToolDescriptorParserTest {
         assertEquals(expectedToolDescriptor, toolDescriptor)
     }
 
+    // ====== Type-array tests ======
+
+    @Test
+    fun `test parsing type array with nullable integer`() {
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "A test tool",
+            properties = buildJsonObject {
+                putJsonObject("count") {
+                    putJsonArray("type") {
+                        add("integer")
+                        add("null")
+                    }
+                    put("description", "Nullable count")
+                }
+            },
+            required = emptyList()
+        )
+
+        val toolDescriptor = parser.parse(sdkTool)
+        val param = toolDescriptor.optionalParameters.single()
+        assertEquals("count", param.name)
+        assertTrue(param.type is ToolParameterType.AnyOf)
+        val anyOf = param.type as ToolParameterType.AnyOf
+        assertEquals(2, anyOf.types.size)
+        assertEquals(ToolParameterType.Null, anyOf.types[0].type)
+        assertEquals(ToolParameterType.Integer, anyOf.types[1].type)
+    }
+
+    @Test
+    fun `test parsing type array with nullable string`() {
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "A test tool",
+            properties = buildJsonObject {
+                putJsonObject("label") {
+                    putJsonArray("type") {
+                        add("string")
+                        add("null")
+                    }
+                    put("description", "Nullable label")
+                }
+            },
+            required = emptyList()
+        )
+
+        val toolDescriptor = parser.parse(sdkTool)
+        val param = toolDescriptor.optionalParameters.single()
+        val anyOf = param.type as ToolParameterType.AnyOf
+        assertEquals(ToolParameterType.Null, anyOf.types[0].type)
+        assertEquals(ToolParameterType.String, anyOf.types[1].type)
+    }
+
+    @Test
+    fun `test parsing single element type array`() {
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "A test tool",
+            properties = buildJsonObject {
+                putJsonObject("name") {
+                    putJsonArray("type") {
+                        add("string")
+                    }
+                    put("description", "A name")
+                }
+            },
+            required = emptyList()
+        )
+
+        val toolDescriptor = parser.parse(sdkTool)
+        val param = toolDescriptor.optionalParameters.single()
+        // Single-element array without "null" should not be wrapped in AnyOf
+        assertEquals(ToolParameterType.String, param.type)
+    }
+
+    @Test
+    fun `test parsing type array with null only`() {
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "A test tool",
+            properties = buildJsonObject {
+                putJsonObject("nothing") {
+                    putJsonArray("type") {
+                        add("null")
+                    }
+                    put("description", "Always null")
+                }
+            },
+            required = emptyList()
+        )
+
+        val toolDescriptor = parser.parse(sdkTool)
+        val param = toolDescriptor.optionalParameters.single()
+        assertEquals(ToolParameterType.Null, param.type)
+    }
+
+    // ====== $ref/$defs tests ======
+
+    @Test
+    fun `test parsing ref defs simple resolution`() {
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "A test tool with ${'$'}ref",
+            properties = buildJsonObject {
+                putJsonObject("address") {
+                    put("\$ref", "#/\$defs/Address")
+                }
+            },
+            required = listOf("address"),
+            defs = buildJsonObject {
+                putJsonObject("Address") {
+                    put("type", "object")
+                    putJsonObject("properties") {
+                        putJsonObject("street") {
+                            put("type", "string")
+                            put("description", "Street name")
+                        }
+                        putJsonObject("city") {
+                            put("type", "string")
+                            put("description", "City name")
+                        }
+                    }
+                    putJsonArray("required") {
+                        add("street")
+                        add("city")
+                    }
+                }
+            }
+        )
+
+        val toolDescriptor = parser.parse(sdkTool)
+        assertEquals(1, toolDescriptor.requiredParameters.size)
+        val param = toolDescriptor.requiredParameters.single()
+        assertEquals("address", param.name)
+        assertTrue(param.type is ToolParameterType.Object)
+        val objType = param.type as ToolParameterType.Object
+        assertEquals(2, objType.properties.size)
+        assertEquals("street", objType.properties[0].name)
+        assertEquals("city", objType.properties[1].name)
+        assertEquals(listOf("street", "city"), objType.requiredProperties)
+    }
+
+    @Test
+    fun `test parsing ref defs with enum type`() {
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "A test tool with enum ref",
+            properties = buildJsonObject {
+                putJsonObject("region") {
+                    put("\$ref", "#/\$defs/Region")
+                    put("description", "Search region")
+                }
+            },
+            required = listOf("region"),
+            defs = buildJsonObject {
+                putJsonObject("Region") {
+                    put("type", "enum")
+                    putJsonArray("enum") {
+                        add("us")
+                        add("eu")
+                        add("asia")
+                    }
+                }
+            }
+        )
+
+        val toolDescriptor = parser.parse(sdkTool)
+        val param = toolDescriptor.requiredParameters.single()
+        assertTrue(param.type is ToolParameterType.Enum)
+        val enumType = param.type as ToolParameterType.Enum
+        assertEquals(listOf("us", "eu", "asia"), enumType.entries.toList())
+    }
+
+    @Test
+    fun `test parsing ref defs nested resolution`() {
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "A test tool with nested refs",
+            properties = buildJsonObject {
+                putJsonObject("person") {
+                    put("\$ref", "#/\$defs/Person")
+                }
+            },
+            required = listOf("person"),
+            defs = buildJsonObject {
+                putJsonObject("Person") {
+                    put("type", "object")
+                    putJsonObject("properties") {
+                        putJsonObject("name") {
+                            put("type", "string")
+                            put("description", "Person name")
+                        }
+                        putJsonObject("address") {
+                            put("\$ref", "#/\$defs/Address")
+                        }
+                    }
+                }
+                putJsonObject("Address") {
+                    put("type", "object")
+                    putJsonObject("properties") {
+                        putJsonObject("city") {
+                            put("type", "string")
+                            put("description", "City")
+                        }
+                    }
+                }
+            }
+        )
+
+        val toolDescriptor = parser.parse(sdkTool)
+        val person = toolDescriptor.requiredParameters.single()
+        val personObj = person.type as ToolParameterType.Object
+        assertEquals(2, personObj.properties.size)
+        val addressProp = personObj.properties[1]
+        assertEquals("address", addressProp.name)
+        assertTrue(addressProp.type is ToolParameterType.Object)
+        val addressObj = addressProp.type as ToolParameterType.Object
+        assertEquals("city", addressObj.properties.single().name)
+    }
+
+    @Test
+    fun `test parsing ref defs cycle detection`() {
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "Circular ref test",
+            properties = buildJsonObject {
+                putJsonObject("node") {
+                    put("\$ref", "#/\$defs/Node")
+                }
+            },
+            required = emptyList(),
+            defs = buildJsonObject {
+                // Node references itself — should hit MAX_DEPTH
+                putJsonObject("Node") {
+                    put("type", "object")
+                    putJsonObject("properties") {
+                        putJsonObject("child") {
+                            put("\$ref", "#/\$defs/Node")
+                        }
+                    }
+                }
+            }
+        )
+
+        assertFailsWith<IllegalArgumentException>("Should fail on circular ref") {
+            parser.parse(sdkTool)
+        }
+    }
+
+    @Test
+    fun `test parsing ref with definitions key`() {
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "Legacy definitions test",
+            properties = buildJsonObject {
+                putJsonObject("item") {
+                    put("\$ref", "#/definitions/Item")
+                }
+            },
+            required = listOf("item"),
+            defs = buildJsonObject {
+                putJsonObject("Item") {
+                    put("type", "string")
+                }
+            }
+        )
+
+        val toolDescriptor = parser.parse(sdkTool)
+        val param = toolDescriptor.requiredParameters.single()
+        assertEquals(ToolParameterType.String, param.type)
+    }
+
+    @Test
+    fun `test parsing ref with missing definition throws`() {
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "Missing def test",
+            properties = buildJsonObject {
+                putJsonObject("item") {
+                    put("\$ref", "#/\$defs/NonExistent")
+                }
+            },
+            required = emptyList(),
+            defs = buildJsonObject { }
+        )
+
+        assertFailsWith<IllegalArgumentException>("Should fail on missing definition") {
+            parser.parse(sdkTool)
+        }
+    }
+
     // Helper function to create an SDK Tool for testing
     private fun createSdkTool(
         name: String,
         description: String,
         properties: JsonObject,
-        required: List<String>
+        required: List<String>,
+        defs: JsonObject? = null,
     ): Tool {
         return Tool(
             name = name,
             description = description,
             inputSchema = ToolSchema(
                 properties = properties,
-                required = required
+                required = required,
+                defs = defs,
             ),
             outputSchema = null,
             annotations = null,

--- a/agents/agents-mcp/src/commonTest/kotlin/ai/koog/agents/mcp/DefaultMcpToolDescriptorParserTest.kt
+++ b/agents/agents-mcp/src/commonTest/kotlin/ai/koog/agents/mcp/DefaultMcpToolDescriptorParserTest.kt
@@ -5,6 +5,7 @@ import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
 import io.modelcontextprotocol.kotlin.sdk.types.Tool
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.addJsonArray
@@ -13,7 +14,6 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -384,8 +384,6 @@ class DefaultMcpToolDescriptorParserTest {
         }
     }
 
-    // Ignore until https://github.com/JetBrains/koog/issues/307 is fixed
-    @Ignore
     @Test
     fun `test parsing enum parameter type with complex values`() {
         // Create an SDK Tool with an enum parameter that has complex values (JsonArray)
@@ -432,6 +430,127 @@ class DefaultMcpToolDescriptorParserTest {
         assertEquals("option1", enumType.entries[0])
         assertEquals("[\"nested1\",\"nested2\"]", enumType.entries[1])
         assertEquals("{\"key\":\"value\"}", enumType.entries[2])
+    }
+
+    @Test
+    fun `test parsing enum parameter with mixed primitive types`() {
+        // Covers the JSON Schema example from issue #307:
+        //   { "color": { "enum": ["red", "amber", "green", null, 42] } }
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "A test tool with mixed enum values",
+            properties = buildJsonObject {
+                putJsonObject("color") {
+                    putJsonArray("enum") {
+                        add("red")
+                        add("amber")
+                        add("green")
+                        add(JsonNull)
+                        add(42)
+                    }
+                }
+            },
+            required = listOf("color")
+        )
+
+        val toolDescriptor = parser.parse(sdkTool)
+        val param = toolDescriptor.requiredParameters.single()
+        val enumType = param.type as ToolParameterType.Enum
+
+        assertEquals(
+            listOf("red", "amber", "green", "null", "42"),
+            enumType.entries.toList()
+        )
+    }
+
+    @Test
+    fun `test parsing enum parameter with boolean values`() {
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "A test tool with boolean enum",
+            properties = buildJsonObject {
+                putJsonObject("flag") {
+                    putJsonArray("enum") {
+                        add(true)
+                        add(false)
+                    }
+                }
+            },
+            required = emptyList()
+        )
+
+        val toolDescriptor = parser.parse(sdkTool)
+        val enumType = toolDescriptor.optionalParameters.single().type as ToolParameterType.Enum
+        assertEquals(listOf("true", "false"), enumType.entries.toList())
+    }
+
+    @Test
+    fun `test parsing object parameter with empty additionalProperties schema`() {
+        // Covers issue #1676: `"additionalProperties": {}` must not throw.
+        // An empty schema is equivalent to `true` — any additional property is allowed
+        // without a type constraint.
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "A test tool",
+            properties = buildJsonObject {
+                putJsonObject("payload") {
+                    put("type", "object")
+                    putJsonObject("properties") {
+                        putJsonObject("id") {
+                            put("type", "string")
+                        }
+                    }
+                    putJsonObject("additionalProperties") { }
+                }
+            },
+            required = listOf("payload")
+        )
+
+        val toolDescriptor = parser.parse(sdkTool)
+        val param = toolDescriptor.requiredParameters.single()
+        val objType = param.type as ToolParameterType.Object
+        assertEquals(true, objType.additionalProperties)
+        assertEquals(null, objType.additionalPropertiesType)
+    }
+
+    @Test
+    fun `test parsing object parameter with additionalProperties true`() {
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "A test tool",
+            properties = buildJsonObject {
+                putJsonObject("payload") {
+                    put("type", "object")
+                    put("additionalProperties", true)
+                }
+            },
+            required = emptyList()
+        )
+
+        val toolDescriptor = parser.parse(sdkTool)
+        val objType = toolDescriptor.optionalParameters.single().type as ToolParameterType.Object
+        assertEquals(true, objType.additionalProperties)
+        assertEquals(null, objType.additionalPropertiesType)
+    }
+
+    @Test
+    fun `test parsing object parameter with additionalProperties false`() {
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "A test tool",
+            properties = buildJsonObject {
+                putJsonObject("payload") {
+                    put("type", "object")
+                    put("additionalProperties", false)
+                }
+            },
+            required = emptyList()
+        )
+
+        val toolDescriptor = parser.parse(sdkTool)
+        val objType = toolDescriptor.optionalParameters.single().type as ToolParameterType.Object
+        assertEquals(false, objType.additionalProperties)
+        assertEquals(null, objType.additionalPropertiesType)
     }
 
     @Test

--- a/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/StreamableHttpMcpToolTest.kt
+++ b/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/StreamableHttpMcpToolTest.kt
@@ -9,10 +9,9 @@ import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.serialization.kotlinx.KotlinxSerializer
 import ai.koog.serialization.kotlinx.toKoogJSONObject
 import io.kotest.assertions.json.shouldEqualJson
-import io.modelcontextprotocol.kotlin.sdk.client.Client
-import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.sse.SSE
 import io.modelcontextprotocol.kotlin.sdk.types.EmptyJsonObject
-import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
@@ -28,19 +27,22 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 @OptIn(InternalAgentsApi::class)
-class McpToolTest {
+class StreamableHttpMcpToolTest {
     companion object {
-        private val testServer = TestMcpServer()
+        private val testServer = TestMcpServer(transportMode = TestTransportMode.StreamableHttp)
+        private lateinit var httpClient: HttpClient
 
         @BeforeAll
         @JvmStatic
         fun setup() {
             testServer.start()
+            httpClient = HttpClient { install(SSE) }
         }
 
         @JvmStatic
         @AfterAll
         fun tearDown() {
+            httpClient.close()
             testServer.stop()
         }
     }
@@ -50,7 +52,10 @@ class McpToolTest {
     private suspend fun testMcpTools(action: suspend (toolRegistry: ToolRegistry) -> Unit) {
         val toolRegistry = withContext(Dispatchers.Default.limitedParallelism(1)) {
             withTimeout(1.minutes) {
-                McpToolRegistryProvider.fromSseUrl("http://localhost:${testServer.resolvedPort}")
+                McpToolRegistryProvider.streamableHttp {
+                    url = "http://localhost:${testServer.resolvedPort}/mcp"
+                    httpClient = StreamableHttpMcpToolTest.httpClient
+                }
             }
         }
 
@@ -58,7 +63,7 @@ class McpToolTest {
     }
 
     @Test
-    fun `test McpToolRegistry provides all tools`() = runTest(timeout = 30.seconds) {
+    fun `test McpToolRegistry provides all tools via Streamable HTTP`() = runTest(timeout = 30.seconds) {
         testMcpTools { toolRegistry ->
             val expectedToolDescriptors = listOf(
                 ToolDescriptor(
@@ -90,7 +95,6 @@ class McpToolTest {
                 )
             )
 
-            // Actual list of tools provided
             val actualToolDescriptor = toolRegistry.tools.map { it.descriptor }
             assertEquals(expectedToolDescriptors, actualToolDescriptor)
         }
@@ -98,7 +102,7 @@ class McpToolTest {
 
     @OptIn(InternalAgentToolsApi::class)
     @Test
-    fun `test greeting tool`() = runTest(timeout = 30.seconds) {
+    fun `test greeting tool via Streamable HTTP`() = runTest(timeout = 30.seconds) {
         testMcpTools { toolRegistry ->
             val greetingTool = toolRegistry.getTool("greeting") as McpTool
             val args = buildJsonObject { put("name", "Test") }
@@ -112,26 +116,13 @@ class McpToolTest {
             val content = result.content.single() as TextContent
             assertEquals("Hello, Test!", content.text)
 
-            val argsWithTitle = buildJsonObject {
-                put("name", "Test")
-                put("title", "Mr.")
-            }
-            val resultWithTitle = withContext(Dispatchers.Default.limitedParallelism(1)) {
-                withTimeout(1.minutes) {
-                    greetingTool.execute(argsWithTitle.toKoogJSONObject())
-                }
-            }
-
-            val contentWithTitle = resultWithTitle.content.single() as TextContent
-            assertEquals("Hello, Mr. Test!", contentWithTitle.text)
-
             val encodedResult = greetingTool.encodeResultToString(result, serializer)
             encodedResult shouldEqualJson """{"content":[{"text":"Hello, Test!","type":"text"}]}"""
         }
     }
 
     @Test
-    fun `test empty tool`() = runTest(timeout = 30.seconds) {
+    fun `test empty tool via Streamable HTTP`() = runTest(timeout = 30.seconds) {
         testMcpTools { toolRegistry ->
             val emptyTool = toolRegistry.getTool("empty") as McpTool
             val args = EmptyJsonObject
@@ -142,100 +133,6 @@ class McpToolTest {
                 }
             }
             assertEquals(emptyList(), result.content)
-
-            val encodedResult = emptyTool.encodeResultToString(result, serializer)
-            encodedResult shouldEqualJson """{"content":[]}"""
         }
-    }
-
-    @Test
-    fun `test encode result`() {
-        val result = CallToolResult(listOf(TextContent("Hello world")))
-        val toolDescriptor = ToolDescriptor(
-            name = "test-tool",
-            description = "A test tool",
-            requiredParameters = emptyList(),
-            optionalParameters = emptyList()
-        )
-        val mcpTool = McpTool(
-            mcpClient = Client(clientInfo = Implementation(name = "Test", version = "1.0")),
-            metadata = emptyMap(),
-            descriptor = toolDescriptor,
-        )
-        val encodedResult = mcpTool.encodeResultToString(result, serializer)
-
-        encodedResult shouldEqualJson """{"content":[{"text":"Hello world","type":"text"}]}"""
-    }
-
-    @Test
-    fun `test encode error result`() {
-        val result = CallToolResult(
-            content = listOf(TextContent("Something went wrong")),
-            isError = true,
-        )
-        val toolDescriptor = ToolDescriptor(
-            name = "test-tool",
-            description = "A test tool",
-            requiredParameters = emptyList(),
-            optionalParameters = emptyList()
-        )
-        val mcpTool = McpTool(
-            mcpClient = Client(clientInfo = Implementation(name = "Test", version = "1.0")),
-            metadata = emptyMap(),
-            descriptor = toolDescriptor,
-        )
-        val encodedResult = mcpTool.encodeResultToString(result, serializer)
-
-        assertEquals(
-            expected = "Error: Something went wrong",
-            actual = encodedResult
-        )
-    }
-
-    @Test
-    fun `test encode error result with multiple text contents`() {
-        val result = CallToolResult(
-            content = listOf(TextContent("Error line 1"), TextContent("Error line 2")),
-            isError = true,
-        )
-        val toolDescriptor = ToolDescriptor(
-            name = "test-tool",
-            description = "A test tool",
-            requiredParameters = emptyList(),
-            optionalParameters = emptyList()
-        )
-        val mcpTool = McpTool(
-            mcpClient = Client(clientInfo = Implementation(name = "Test", version = "1.0")),
-            metadata = emptyMap(),
-            descriptor = toolDescriptor,
-        )
-        val encodedResult = mcpTool.encodeResultToString(result, serializer)
-
-        assertEquals(
-            expected = "Error: Error line 1\nError line 2",
-            actual = encodedResult
-        )
-    }
-
-    @Test
-    fun `test encode null result`() {
-        val result: CallToolResult? = null
-        val toolDescriptor = ToolDescriptor(
-            name = "test-tool",
-            description = "A test tool",
-            requiredParameters = emptyList(),
-            optionalParameters = emptyList()
-        )
-        val mcpTool = McpTool(
-            mcpClient = Client(clientInfo = Implementation(name = "Test", version = "1.0")),
-            metadata = emptyMap(),
-            descriptor = toolDescriptor,
-        )
-        val encodedResult = mcpTool.encodeResultToString(result, serializer)
-
-        assertEquals(
-            expected = "null",
-            actual = encodedResult
-        )
     }
 }

--- a/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/TestMcpServer.kt
+++ b/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/TestMcpServer.kt
@@ -160,6 +160,7 @@ class TestMcpServer(
     fun stop() {
         if (!isRunning) return
 
+        embeddedServer?.stop(gracePeriodMillis = 1000, timeoutMillis = 1000)
         serverJob?.cancel()
         serverJob = null
         embeddedServer = null

--- a/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/TestMcpServer.kt
+++ b/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/TestMcpServer.kt
@@ -7,6 +7,7 @@ import io.ktor.server.engine.embeddedServer
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 import io.modelcontextprotocol.kotlin.sdk.server.mcp
+import io.modelcontextprotocol.kotlin.sdk.server.mcpStreamableHttp
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
@@ -19,6 +20,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -26,14 +28,33 @@ import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Transport mode for the test MCP server.
+ */
+enum class TestTransportMode {
+    SSE,
+    StreamableHttp,
+}
 
 /**
  * A simple MCP server for testing purposes.
  * This server provides a simple tool that returns a greeting message.
+ *
+ * Pass [port] = 0 (default) to let the OS allocate a free port; read [resolvedPort] after [start].
  */
-class TestMcpServer(private val port: Int) {
+class TestMcpServer(
+    private val port: Int = 0,
+    private val transportMode: TestTransportMode = TestTransportMode.SSE,
+) {
     private var serverJob: Job? = null
+    private var embeddedServer: EmbeddedServer<*, *>? = null
     private var isRunning = false
+
+    /** The actual port the server is listening on. Valid after [start] returns. */
+    var resolvedPort: Int = 0
+        private set
 
     /**
      * Configures the MCP server with a simple greeting tool.
@@ -98,29 +119,39 @@ class TestMcpServer(private val port: Int) {
     }
 
     /**
-     * Starts the MCP server on the specified port.
+     * Starts the MCP server and blocks until it is listening.
      */
     fun start() = runBlocking {
         if (isRunning) return@runBlocking
 
-        var embeddedServer: EmbeddedServer<*, *>? = null
         serverJob = CoroutineScope(Dispatchers.SuitableForIO).launch {
-            embeddedServer = embeddedServer(CIO, host = "0.0.0.0", port = port) {
-                mcp {
-                    return@mcp configureServer()
+            val emb = embeddedServer(CIO, host = "0.0.0.0", port = port) {
+                when (transportMode) {
+                    TestTransportMode.SSE -> mcp { configureServer() }
+                    TestTransportMode.StreamableHttp -> mcpStreamableHttp { configureServer() }
                 }
             }
-            embeddedServer.start(wait = true)
+            embeddedServer = emb
+            emb.start(wait = true)
             isRunning = false
         }
 
-        while (embeddedServer == null || !embeddedServer.application.isActive) {
-            println("Waiting for the server to start...")
-            delay(100.milliseconds)
+        withTimeout(10.seconds) {
+            while (embeddedServer == null || !embeddedServer!!.application.isActive) {
+                delay(100.milliseconds)
+            }
+            while (isActive) {
+                val connectors = embeddedServer!!.engine.resolvedConnectors()
+                if (connectors.isNotEmpty()) {
+                    resolvedPort = connectors.first().port
+                    break
+                }
+                delay(50.milliseconds)
+            }
         }
 
         isRunning = true
-        println("Test MCP server started on port $port")
+        println("Test MCP server started on port $resolvedPort (transport: $transportMode)")
     }
 
     /**
@@ -131,6 +162,7 @@ class TestMcpServer(private val port: Int) {
 
         serverJob?.cancel()
         serverJob = null
+        embeddedServer = null
         isRunning = false
         println("Test MCP server stopped")
     }

--- a/examples/simple-examples/gradle/libs.versions.toml
+++ b/examples/simple-examples/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ mockk = "1.13.8"
 opentelemetry = "1.51.0"
 postgresql = "42.7.4"
 oshai-logging = "7.0.7"
-mcp = "0.8.1"
+mcp = "0.11.1"
 
 [libraries]
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ ktlint = "14.2.0"
 ktor3 = "3.2.2"
 lettuce = "7.2.1.RELEASE"
 logback = "1.5.13"
-mcp = "0.8.1"
+mcp = "0.11.1"
 mockito = "5.21.0"
 mockk = "1.14.7"
 mokksy = "0.5.1"
@@ -72,7 +72,6 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor3" 
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor3" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor3" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor3" }
-ktor-client-sse = { module = "io.ktor:ktor-client-sse", version.ref = "ktor3" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor3" }
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor3" }
 ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor3" }

--- a/koog-ktor/src/jvmMain/kotlin/ai/koog/ktor/KoogKtorServerPluginJvm.kt
+++ b/koog-ktor/src/jvmMain/kotlin/ai/koog/ktor/KoogKtorServerPluginJvm.kt
@@ -8,6 +8,7 @@ import ai.koog.agents.mcp.McpToolRegistryProvider.DEFAULT_MCP_CLIENT_NAME
 import ai.koog.agents.mcp.McpToolRegistryProvider.DEFAULT_MCP_CLIENT_VERSION
 import ai.koog.agents.mcp.fromProcess
 import ai.koog.agents.mcp.metadata.McpServerInfo
+import io.ktor.client.HttpClient
 import io.modelcontextprotocol.kotlin.sdk.client.Client
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import kotlinx.coroutines.launch
@@ -53,6 +54,39 @@ public class McpToolsConfig(private val agentConfig: KoogAgentsConfig.AgentConfi
                 mcpToolParser = mcpToolParser
             )
             mutex.withLock { agentConfig.toolRegistry += transport }
+        }
+    }
+
+    /**
+     * Registers tools from an MCP server via Streamable HTTP transport.
+     *
+     * This is the recommended way to connect to remote MCP servers. Streamable HTTP supports
+     * bidirectional communication, session management, and reconnection.
+     *
+     * @param url The URL of the MCP server (e.g., "http://localhost:3000/mcp").
+     * @param httpClient The [HttpClient] to use for the MCP connection. Must have the Ktor `SSE`
+     *     plugin installed. Lifecycle is managed by the caller — the same client can be reused
+     *     across multiple MCP connections.
+     * @param mcpToolParser A parser for converting the MCP SDK tool definitions into a standardized format.
+     * @param name The name of the MCP client.
+     * @param version The version of the MCP client.
+     */
+    public fun streamableHttp(
+        url: String,
+        httpClient: HttpClient,
+        mcpToolParser: McpToolDescriptorParser = DefaultMcpToolDescriptorParser,
+        name: String = DEFAULT_MCP_CLIENT_NAME,
+        version: String = DEFAULT_MCP_CLIENT_VERSION,
+    ) {
+        agentConfig.scope.launch {
+            val registry = McpToolRegistryProvider.streamableHttp {
+                this.url = url
+                this.httpClient = httpClient
+                this.mcpToolParser = mcpToolParser
+                this.name = name
+                this.version = version
+            }
+            mutex.withLock { agentConfig.toolRegistry += registry }
         }
     }
 


### PR DESCRIPTION
Upgrades MCP kotlin-sdk from 0.8.1 to 0.11.1 and makes Streamable HTTP the primary MCP transport for both client and server

closes #1674 
closes [KG-792](https://youtrack.jetbrains.com/issue/KG-792)
closes [KG-756](https://youtrack.jetbrains.com/issue/KG-756)
closes [KG-49](https://youtrack.jetbrains.com/issue/KG-49)
closes [KG-755](https://youtrack.jetbrains.com/issue/KG-755)
### DEPRECATED:                                                                                                                                                                                                                                                
* `startSseMcpServer(factory, port, host, tools)` -- use `startMcpServer(factory, tools, port, host)`
* `startSseMcpServer(factory, host, tools)` -- use `startMcpServer(factory, tools, host)`