### PR TITLE
fix(prompt): withPrompt method now uses writeLock instead of readLock

### DIFF
--- a/a2a/a2a-core/src/commonMain/kotlin/ai/koog/a2a/utils/RWLock.kt
+++ b/a2a/a2a-core/src/commonMain/kotlin/ai/koog/a2a/utils/RWLock.kt
@@ -7,9 +7,32 @@ import kotlinx.coroutines.sync.withLock
 // FIXME copied from agents-core module, because a2a does not depend on other Koog modules.
 //  Do we want to make a global utils module for cases like this?
 /**
- * A KMP read-write lock implementation that allows concurrent read access but ensures exclusive write access.
+ * A Kotlin Multiplatform read-write lock that allows concurrent read access while guaranteeing
+ * exclusive write access.
  *
- * This implementation uses [Mutex] to coordinate access for both readers and writers.
+ * The implementation uses two [Mutex] instances:
+ * - [writeMutex] is held while a writer runs, or while there is at least one active reader.
+ *   The first reader acquires it and the last reader releases it.
+ * - [readersCountMutex] protects [readersCount] so that reader acquisition/release is atomic.
+ *
+ * Concurrency caveats:
+ *
+ * 1. **Not reentrant.** The underlying [Mutex] has no notion of an owning coroutine, and this
+ *    lock does not track owners either. Calling [withWriteLock] from inside another
+ *    [withWriteLock], or calling [withWriteLock] from inside [withReadLock] on the same instance,
+ *    will deadlock. Nested [withReadLock] calls from the same coroutine do not deadlock but
+ *    still serialize briefly on [readersCountMutex] at entry and exit.
+ * 2. **Fairness / writer starvation.** A writer suspended on [writeMutex] does not block new
+ *    readers from joining an already active read section — new readers only contend for
+ *    [writeMutex] on the first-reader transition. Steady overlapping reader traffic can therefore
+ *    delay a pending writer.
+ * 3. **Cancellation safety.** The reader path uses `try { ... } finally { ... }`, so cancellation
+ *    or exceptions inside the block still decrement [readersCount] and release [writeMutex].
+ *    Cancellation while suspended on either mutex is propagated and the lock is not acquired.
+ * 4. **Suspension inside critical sections.** The `block` may suspend; keep critical sections
+ *    short and avoid launching child coroutines that re-acquire the same lock.
+ * 5. **Suspend-only.** There is no blocking or `tryLock` API; this lock is usable only from
+ *    coroutine code.
  */
 @InternalA2AApi
 public class RWLock {
@@ -18,7 +41,9 @@ public class RWLock {
     private val readersCountMutex = Mutex()
 
     /**
-     * Run the given [block] of code while holding the read lock.
+     * Run the given [block] of code while holding the read lock. Multiple coroutines may run
+     * their read blocks concurrently. See the class-level KDoc for reentrancy and cancellation
+     * caveats.
      */
     public suspend fun <T> withReadLock(block: suspend () -> T): T {
         readersCountMutex.withLock {
@@ -39,7 +64,10 @@ public class RWLock {
     }
 
     /**
-     * Run the given [block] of code while holding the write lock.
+     * Run the given [block] of code while holding the write lock. Only one coroutine at a time
+     * may run under the write lock, and no readers are active while it runs. Must not be called
+     * from a coroutine that already holds the read or write lock on this instance — see the
+     * class-level KDoc for reentrancy caveats.
      */
     public suspend fun <T> withWriteLock(block: suspend () -> T): T {
         writeMutex.withLock {

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentContext.kt
@@ -75,7 +75,7 @@ public interface AIAgentContext {
     public val llm: AIAgentLLMContext
 
     /**
-     * Manages and tracks the state of aт AI agent within the context of its execution.
+     * Manages and tracks the state of an AI agent within the context of its execution.
      *
      * This variable provides synchronized access to the agent's state to ensure thread safety
      * and consistent state transitions during concurrent operations. It acts as a central

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContext.kt
@@ -57,22 +57,21 @@ public class AIAgentFunctionalContext(
 
     /**
      * Creates a copy of the current [AIAgentFunctionalContext], allowing for selective overriding of its properties.
-     * This method is particularly useful for creating modified contexts during agent execution without mutating
-     * the original context - perfect for when you need to experiment with different configurations or
-     * pass tweaked contexts down the execution pipeline while keeping the original pristine!
+     * This method is useful for creating modified contexts during agent execution without mutating the original context.
      *
-     * @param environment The [AIAgentEnvironment] to be used in the new context, or retain the current playground if not specified.
-     * @param agentId The unique agent identifier, or keep the same identity if you're feeling attached.
-     * @param runId The run identifier for this execution adventure, or stick with the current journey.
-     * @param agentInput The input data for the agent - fresh data or the same trusty input, your choice!
-     * @param config The [AIAgentConfig] for the new context, or keep the current rulebook.
-     * @param llm The [AIAgentLLMContext] to be used, or maintain the current AI conversation partner.
-     * @param stateManager The [AIAgentStateManager] to be used, or preserve the current state keeper.
-     * @param storage The [AIAgentStorage] to be used, or stick with the current memory bank.
-     * @param strategyName The strategy name, or maintain the current game plan.
-     * @param pipeline The [AIAgentFunctionalPipeline] to be used, or keep the current pipeline.
-     * @param parentRootContext The parent root context, or maintain the current family tree.
-     * @return A new [AIAgentFunctionalContext] with your desired modifications applied!
+     * @param environment The [AIAgentEnvironment] to be used in the new context, or the current one if not specified.
+     * @param agentId The unique agent identifier, or the current one if not specified.
+     * @param runId The run identifier, or the current run ID if not specified.
+     * @param agentInput The input data for the agent, or the current input if not specified.
+     * @param config The [AIAgentConfig] for the new context, or the current configuration if not specified.
+     * @param llm The [AIAgentLLMContext] to be used, or the current LLM context if not specified.
+     * @param stateManager The [AIAgentStateManager] to be used, or the current state manager if not specified.
+     * @param storage The [AIAgentStorage] to be used, or the current storage if not specified.
+     * @param strategyName The strategy name, or the current strategy name if not specified.
+     * @param pipeline The [AIAgentFunctionalPipeline] to be used, or the current pipeline if not specified.
+     * @param executionInfo The [AgentExecutionInfo] to be used, or the current execution info if not specified.
+     * @param parentRootContext The parent context, or the current parent context if not specified.
+     * @return A new [AIAgentFunctionalContext] with the specified modifications applied.
      */
     public fun copy(
         environment: AIAgentEnvironment = this.environment,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBaseCommon.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBaseCommon.kt
@@ -439,7 +439,6 @@ public open class AIAgentFunctionalContextBaseCommon<Pipeline : AIAgentPipeline>
      * based on its correctness and feedback.
      *
      * @param taskDescription The subtask to be executed by AIAgent.
-     * @param input The input data for the subtask, which will be used to create and execute the task.
      * @param tools An optional list of tools that can be used during the execution of the subtask.
      * @param llmModel An optional parameter specifying the LLM model to be used for the subtask.
      * @param llmParams Optional configuration parameters for the LLM, such as temperature and token limits.
@@ -485,7 +484,6 @@ public open class AIAgentFunctionalContextBaseCommon<Pipeline : AIAgentPipeline>
      * This method allows defining a specific task to be performed with the given input, tools, and optional configuration.
      *
      * @param taskDescription The subtask to be executed by AIAgent.
-     * @param input The input data required for the subtask execution.
      * @param outputClass The output type expected from the subtask.
      * @param tools A list of tools available for use within the subtask.
      * @param llmModel The optional large language model to be used during the subtask, if different from the default one.
@@ -524,7 +522,6 @@ public open class AIAgentFunctionalContextBaseCommon<Pipeline : AIAgentPipeline>
      * This method enables the use of tools to achieve a specific task based on the input provided.
      *
      * @param taskDescription The subtask to be executed by AIAgent.
-     * @param input The input data required to define and execute the subtask.
      * @param tools An optional list of tools that can be used to achieve the task, excluding the finishing tool.
      * @param finishTool A mandatory tool that determines the final result of the subtask by producing and transforming output.
      * @param llmModel An optional specific LLM to use for executing the subtask.
@@ -605,7 +602,6 @@ public open class AIAgentFunctionalContextBaseCommon<Pipeline : AIAgentPipeline>
      * This method allows defining a specific task to be performed with the given input, tools, and optional configuration.
      *
      * @param taskDescription The subtask to be executed by AIAgent.
-     * @param input The input data required for the subtask execution.
      * @param tools A list of tools available for use within the subtask.
      * @param llmModel The optional large language model to be used during the subtask, if different from the default one.
      * @param llmParams The configuration parameters for the large language model, such as temperature.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentGraphContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentGraphContext.kt
@@ -8,18 +8,17 @@ import ai.koog.agents.core.agent.execution.AgentExecutionInfo
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.environment.AIAgentEnvironment
 import ai.koog.agents.core.feature.pipeline.AIAgentGraphPipeline
-import ai.koog.agents.core.feature.pipeline.AIAgentPipeline
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.utils.RWLock
 import ai.koog.prompt.message.Message
 import ai.koog.serialization.TypeToken
 
 /**
- * The `AIAgentGraphContextBase` interface extends the `AIAgentContextBase` interface
+ * The `AIAgentGraphContextBase` interface extends the [AIAgentContext] interface
  * to provide a foundational context specifically tailored for AI agents operating
  * within a graph structure.
  *
- * This interface inherits the core capabilities from `AIAgentContextBase`, including
+ * This interface inherits the core capabilities from [AIAgentContext], including
  * environment management, configuration access, session tracking, state management,
  * and custom workflows. By building upon these features, it serves as a base for
  * defining additional constructs and behaviors that facilitate the agent's execution
@@ -41,14 +40,19 @@ public interface AIAgentGraphContextBase : AIAgentContext {
     /**
      * Creates a copy of the current [AIAgentGraphContext], allowing for selective overriding of its properties.
      *
-     * @param environment The [AIAgentEnvironment] to be used in the new context, or `null` to retain the current one.
-     * @param config The [AIAgentConfig] for the new context, or `null` to retain the current configuration.
-     * @param llm The [AIAgentLLMContext] to be used, or `null` to retain the current LLM context.
-     * @param stateManager The [AIAgentStateManager] to be used, or `null` to retain the current state manager.
-     * @param storage The [AIAgentStorage] to be used, or `null` to retain the current storage.
-     * @param runId The run identifier, or `null` to retain the current run ID.
-     * @param strategyName The strategy name, or `null` to retain the current identifier.
-     * @param pipeline The [AIAgentPipeline] to be used, or `null` to retain the current pipeline.
+     * @param environment The [AIAgentEnvironment] to be used in the new context, or the current one if not specified.
+     * @param agentId The unique agent identifier, or the current one if not specified.
+     * @param agentInput The input data for the agent, or the current input if not specified.
+     * @param agentInputType The [TypeToken] representing the type of [agentInput], or the current type if not specified.
+     * @param config The [AIAgentConfig] for the new context, or the current configuration if not specified.
+     * @param llm The [AIAgentLLMContext] to be used, or the current LLM context if not specified.
+     * @param stateManager The [AIAgentStateManager] to be used, or the current state manager if not specified.
+     * @param storage The [AIAgentStorage] to be used, or the current storage if not specified.
+     * @param runId The run identifier, or the current run ID if not specified.
+     * @param strategyName The strategy name, or the current strategy name if not specified.
+     * @param pipeline The [AIAgentGraphPipeline] to be used, or the current pipeline if not specified.
+     * @param executionInfo The [AgentExecutionInfo] to be used, or the current execution info if not specified.
+     * @param parentContext The parent context, or the current instance if not specified.
      */
     public fun copy(
         environment: AIAgentEnvironment = this.environment,
@@ -155,7 +159,18 @@ public class AIAgentGraphContext(
         }
 
     /**
-     * Mutable wrapper for AI agent context properties.
+     * Mutable wrapper around the context's stateful fields ([llm], [stateManager], [storage], [environment],
+     * [executionInfo]), protected by an internal [RWLock].
+     *
+     * Concurrency caveats:
+     * - The lock is **not reentrant**. In particular [copy] must not be called from inside [replace] on the
+     *   same instance (and vice versa) — doing so will deadlock (see [ai.koog.agents.core.utils.RWLock]).
+     * - Direct reads of the `var` fields through the getters of the enclosing [AIAgentGraphContext]
+     *   ([AIAgentGraphContext.llm], [AIAgentGraphContext.storage], …) **bypass** the lock and may observe a
+     *   value that is concurrently being swapped by [replace]. If a consistent snapshot is required, obtain it
+     *   via [copy] or via a higher-level context operation such as [AIAgentGraphContext.fork].
+     * - [copy] delegates to [AIAgentLLMContext.copy], [AIAgentStateManager.copy], [AIAgentStorage.copy] and
+     *   [AgentExecutionInfo.copy]; those downstream copies may themselves suspend on their own locks.
      */
     internal class MutableAIAgentContext(
         var llm: AIAgentLLMContext,
@@ -200,6 +215,15 @@ public class AIAgentGraphContext(
         }
     }
 
+    /**
+     * Plain in-memory map backing [store], [get] and [remove].
+     *
+     * Concurrency caveat: this is a plain [mutableMapOf], it is **not** thread-safe. Unlike [storage] (which is
+     * an [AIAgentStorage] that provides its own synchronization), concurrent access to [store], [get] or
+     * [remove] from different coroutines/threads on the same [AIAgentGraphContext] is not synchronized and may
+     * lead to data races. Callers must externally serialize access, or use the concurrent-safe [storage]
+     * property for shared data.
+     */
     private val storeMap: MutableMap<AIAgentStorageKey<*>, Any> = mutableMapOf()
 
     override fun store(key: AIAgentStorageKey<*>, value: Any) {
@@ -233,6 +257,19 @@ public class AIAgentGraphContext(
         return this.copy(llm = llm.copy(tools = tools))
     }
 
+    /**
+     * Creates an independent fork of this context, taking consistent snapshots of the LLM context, storage,
+     * state manager and execution info. Each `copy()` is performed under the corresponding lock of the source
+     * object, so the returned context is safe to mutate concurrently with the original.
+     *
+     * Concurrency caveat: each downstream `copy()` acquires its own read lock (or equivalent); these locks are
+     * acquired sequentially, and the snapshot of the whole context is therefore **not** atomic across all four
+     * fields. Two fields may be observed at slightly different points in time if another coroutine is
+     * concurrently mutating this context.
+     *
+     * Note also that the in-memory [storeMap] (populated via [store]) is **not** copied here — the returned
+     * context starts with an empty local store.
+     */
     override suspend fun fork(): AIAgentGraphContextBase = copy(
         llm = this.llm.copy(),
         storage = this.storage.copy(),
@@ -240,6 +277,17 @@ public class AIAgentGraphContext(
         executionInfo = this.executionInfo.copy(),
     )
 
+    /**
+     * Atomically replaces the stateful fields of this context with those of [context], under the write lock of
+     * [mutableAIAgentContext].
+     *
+     * Concurrency caveats:
+     * - [mutableAIAgentContext]'s lock is not reentrant; do not call [replace] from inside another operation
+     *   that already holds it (e.g. from within a transformation running under [MutableAIAgentContext.copy]).
+     * - Consumers that read fields directly (e.g. `ctx.llm`, `ctx.storage`) without going through the
+     *   [MutableAIAgentContext] lock may observe a non-atomic mix of old and new values while a concurrent
+     *   [replace] is in progress.
+     */
     override suspend fun replace(context: AIAgentContext) {
         mutableAIAgentContext.replace(
             context.llm,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContext.kt
@@ -41,8 +41,7 @@ public annotation class DetachedPromptExecutorAPI
  * through sessions, ensuring thread safety.
  *
  * It inherits all shared behavior from [AIAgentLLMContextCommon].
- */
-/**
+ *
  * Constructs a new instance of `AIAgentLLMContext` with the provided parameters.
  *
  * @param tools A list of tools described by [ToolDescriptor] that the agent can interact with.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContextCommon.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentLLMContextCommon.kt
@@ -95,10 +95,15 @@ public abstract class AIAgentLLMContextCommon internal constructor(
      * The current prompt used within the `AIAgentLLMContext`.
      *
      * This property defines the main [Prompt] instance used by the context and is updated as needed to reflect
-     * modifications or new inputs for the language model operations. It is thread-safe, ensuring that updates
-     * and access are managed correctly within concurrent environments.
+     * modifications or new inputs for the language model operations. It is modified internally only from within
+     * [withPrompt] and [writeSession], both of which run under the write portion of an internal read-write lock.
      *
-     * This variable can only be modified internally via specific methods, maintaining control over state changes.
+     * Concurrency caveats:
+     * - A **direct read** of this property (as well as [tools], [model] and [responseProcessor]) does **not**
+     *   acquire the read lock; it returns whatever snapshot happens to be installed. For a consistent view that
+     *   is safe against a concurrent [withPrompt] / [writeSession], read it inside a [readSession].
+     * - Reads performed from inside a [readSession] or [writeSession] are consistent with the current critical
+     *   section.
      */
     @get:JvmName("prompt")
     public var prompt: Prompt = initialPrompt
@@ -106,16 +111,30 @@ public abstract class AIAgentLLMContextCommon internal constructor(
     private val rwLock: RWLock = RWLock()
 
     /**
-     * Updates the current `AIAgentLLMContext` with a new prompt and ensures thread-safe access using a read lock.
+     * Atomically replaces [prompt] with the result of applying [block] to the current prompt while holding the
+     * internal write lock. Callers waiting for read or write access will be suspended until the transformation
+     * completes.
+     *
+     * Concurrency caveats:
+     * - Must not be invoked from inside another [withPrompt], [writeSession], or [readSession] on the same
+     *   context — the underlying lock is **not reentrant** and doing so will deadlock (see
+     *   [ai.koog.agents.core.utils.RWLock]).
+     * - [block] should be a pure, fast transformation; it runs while holding the write lock and will block all
+     *   concurrent readers and writers until it returns.
      *
      * @param block transformation to produce the next [Prompt].
      */
-    public open suspend fun withPrompt(block: Prompt.() -> Prompt): Unit = rwLock.withReadLock {
+    public open suspend fun withPrompt(block: Prompt.() -> Prompt): Unit = rwLock.withWriteLock {
         this.prompt = prompt.block()
     }
 
     /**
-     * Creates a deep copy of this LLM context.
+     * Creates a copy of this LLM context, taking a consistent snapshot of its mutable fields under the
+     * internal read lock. Multiple concurrent [copy] / [readSession] calls may proceed in parallel, but any
+     * concurrent [writeSession] / [withPrompt] will serialize against them.
+     *
+     * Concurrency caveat: must not be invoked from inside a [writeSession] or [withPrompt] on the same
+     * context — the underlying lock is not reentrant (see [ai.koog.agents.core.utils.RWLock]).
      *
      * @return A new instance of [AIAgentLLMContext] with deep copies of mutable properties.
      */
@@ -145,8 +164,18 @@ public abstract class AIAgentLLMContextCommon internal constructor(
     }
 
     /**
-     * Executes a write session on the [AIAgentLLMContext], ensuring that all active write and read sessions
-     * are completed before initiating the write session.
+     * Executes a write session on the [AIAgentLLMContext], suspending until all other active write and read
+     * sessions on this context complete, then running [block] under exclusive access. At the end of the
+     * session, [prompt], [tools] and [model] are overwritten with the values mutated inside the session.
+     *
+     * Concurrency caveats:
+     * - The underlying lock is **not reentrant**. Do not call [writeSession], [readSession], [withPrompt] or
+     *   [copy] on the same context from inside [block] — doing so will deadlock (see
+     *   [ai.koog.agents.core.utils.RWLock]).
+     * - [block] runs while holding the write lock; keep it as short as possible and avoid launching
+     *   long-running child coroutines that need to re-acquire this lock.
+     * - Cancellation inside [block] is propagated; partial mutations made on the session before cancellation
+     *   will not be committed to the outer context.
      */
     @OptIn(ExperimentalStdlibApi::class)
     public open suspend fun <T> writeSession(block: suspend AIAgentLLMWriteSession.() -> T): T =
@@ -176,8 +205,15 @@ public abstract class AIAgentLLMContextCommon internal constructor(
         }
 
     /**
-     * Executes a read session within the [AIAgentLLMContext], ensuring concurrent safety
-     * with active write session and other read sessions.
+     * Executes a read session on the [AIAgentLLMContext]. Multiple read sessions may run concurrently, while
+     * any concurrent [writeSession] or [withPrompt] is serialized against them.
+     *
+     * Concurrency caveats:
+     * - The underlying lock is **not reentrant for writers**: nested [readSession] calls from the same
+     *   coroutine are safe, but calling [writeSession] or [withPrompt] from inside a [readSession] will
+     *   deadlock (see [ai.koog.agents.core.utils.RWLock]).
+     * - Mutations performed on fields exposed through the session are not persisted back to this context
+     *   (unlike [writeSession]).
      */
     @OptIn(ExperimentalStdlibApi::class)
     public open suspend fun <T> readSession(block: suspend AIAgentLLMReadSession.() -> T): T = rwLock.withReadLock {
@@ -186,9 +222,19 @@ public abstract class AIAgentLLMContextCommon internal constructor(
     }
 
     /**
-     * Returns the current prompt used in the LLM context.
+     * Creates a non-suspending copy of this LLM context with the given overrides. Unlike the suspending [copy]
+     * overload, this variant does **not** acquire the internal read lock and therefore does not guarantee a
+     * consistent snapshot if another coroutine is concurrently mutating this context.
      *
-     * @return The current [Prompt] instance.
+     * @param tools The list of [ToolDescriptor] tools to use, or the current tools if not specified.
+     * @param prompt The [Prompt] to use, or the current prompt if not specified.
+     * @param model The [LLModel] to use, or the current model if not specified.
+     * @param responseProcessor The [ResponseProcessor] to use, or the current one if not specified.
+     * @param promptExecutor The [PromptExecutor] to use, or the current one if not specified.
+     * @param environment The [AIAgentEnvironment] to use, or the current one if not specified.
+     * @param config The [AIAgentConfig] to use, or the current configuration if not specified.
+     * @param clock The [Clock] to use, or the current clock if not specified.
+     * @return A new [AIAgentLLMContext] instance with the specified overrides applied.
      */
     public open fun copy(
         tools: List<ToolDescriptor> = this.tools,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentPlannerContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentPlannerContext.kt
@@ -54,23 +54,22 @@ public class AIAgentPlannerContext(
 ) {
 
     /**
-     * Creates a copy of the current [AIAgentFunctionalContext], allowing for selective overriding of its properties.
-     * This method is particularly useful for creating modified contexts during agent execution without mutating
-     * the original context - perfect for when you need to experiment with different configurations or
-     * pass tweaked contexts down the execution pipeline while keeping the original pristine!
+     * Creates a copy of the current [AIAgentPlannerContext], allowing for selective overriding of its properties.
+     * This method is useful for creating modified contexts during agent execution without mutating the original context.
      *
-     * @param environment The [AIAgentEnvironment] to be used in the new context, or retain the current playground if not specified.
-     * @param agentId The unique agent identifier, or keep the same identity if you're feeling attached.
-     * @param runId The run identifier for this execution adventure, or stick with the current journey.
-     * @param agentInput The input data for the agent - fresh data or the same trusty input, your choice!
-     * @param config The [AIAgentConfig] for the new context, or keep the current rulebook.
-     * @param llm The [AIAgentLLMContext] to be used, or maintain the current AI conversation partner.
-     * @param stateManager The [AIAgentStateManager] to be used, or preserve the current state keeper.
-     * @param storage The [AIAgentStorage] to be used, or stick with the current memory bank.
-     * @param strategyName The strategy name, or maintain the current game plan.
-     * @param pipeline The [AIAgentPlannerContext] to be used, or keep the current execution superhighway.
-     * @param parentRootContext The parent root context, or maintain the current family tree.
-     * @return A new [AIAgentFunctionalContext] with your desired modifications applied!
+     * @param environment The [AIAgentEnvironment] to be used in the new context, or the current one if not specified.
+     * @param agentId The unique agent identifier, or the current one if not specified.
+     * @param runId The run identifier, or the current run ID if not specified.
+     * @param agentInput The input data for the agent, or the current input if not specified.
+     * @param config The [AIAgentConfig] for the new context, or the current configuration if not specified.
+     * @param llm The [AIAgentLLMContext] to be used, or the current LLM context if not specified.
+     * @param stateManager The [AIAgentStateManager] to be used, or the current state manager if not specified.
+     * @param storage The [AIAgentStorage] to be used, or the current storage if not specified.
+     * @param strategyName The strategy name, or the current strategy name if not specified.
+     * @param pipeline The [AIAgentPlannerPipeline] to be used, or the current pipeline if not specified.
+     * @param executionInfo The [AgentExecutionInfo] to be used, or the current execution info if not specified.
+     * @param parentRootContext The parent context, or the current parent context if not specified.
+     * @return A new [AIAgentPlannerContext] with the specified modifications applied.
      */
     public fun copy(
         environment: AIAgentEnvironment = this.environment,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/utils/RWLock.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/utils/RWLock.kt
@@ -4,15 +4,58 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 /**
- * A KMP read-write lock implementation that allows concurrent read access but ensures exclusive write access.
+ * A Kotlin Multiplatform read-write lock that allows concurrent read access while guaranteeing
+ * exclusive write access.
  *
- * This implementation uses `kotlinx.coroutines.sync.Mutex` to coordinate access for both readers and writers.
+ * The implementation is based on two [kotlinx.coroutines.sync.Mutex] instances:
+ * - [writeMutex] is held while any writer runs, or while there is at least one active reader.
+ *   The first reader acquires it and the last reader releases it (a classic "readers hold the
+ *   write mutex" scheme).
+ * - [readersCountMutex] protects [readersCount] so that reader acquisition/release is atomic.
+ *
+ * Concurrency caveats (applies equally to all call sites):
+ *
+ * 1. **Not reentrant.** Coroutines do not have thread/owner identity associated with a
+ *    [kotlinx.coroutines.sync.Mutex], and this lock does not track owners either. Therefore:
+ *    - Calling [withWriteLock] from inside another [withWriteLock] on the same instance will
+ *      deadlock.
+ *    - Calling [withWriteLock] from inside [withReadLock] will deadlock (the write mutex is
+ *      already held by the outer read section).
+ *    - Nested [withReadLock] calls from the same coroutine do **not** deadlock (they only bump
+ *      [readersCount]), but they still serialize briefly on [readersCountMutex] at entry/exit.
+ *    Do not rely on reentrancy in any of these cases.
+ *
+ * 2. **Fairness / writer starvation.** Fairness follows [kotlinx.coroutines.sync.Mutex]'s FIFO
+ *    policy. A writer waits until all current readers release the lock, but because readers
+ *    acquire the write mutex only on the first-reader transition, a steady stream of overlapping
+ *    readers can briefly extend the critical section. A waiting writer on [writeMutex] does not
+ *    block new readers from incrementing [readersCount] — new readers that arrive while another
+ *    reader is already active will proceed without contending for [writeMutex] at all, which can
+ *    delay a pending writer.
+ *
+ * 3. **Cancellation safety.** The `block` runs inside a `try { ... } finally { ... }` pair, so a
+ *    cancellation or exception thrown from within the block will correctly decrement
+ *    [readersCount] and release [writeMutex] when appropriate. However, cancellation occurring
+ *    while suspended on [readersCountMutex] or [writeMutex] is propagated by the underlying
+ *    mutex and the lock is not acquired — callers must be prepared for [kotlinx.coroutines.CancellationException].
+ *
+ * 4. **Suspension inside critical sections.** Because `block` is `suspend`, the lock may be held
+ *    across arbitrary suspension points. Keep critical sections short and avoid launching
+ *    long-running child coroutines that depend on re-acquiring the same lock.
+ *
+ * 5. **Not safe for non-suspending / blocking use.** This lock is only usable from suspending
+ *    code; there is no `tryLock` or blocking API.
  */
 internal class RWLock {
     private val writeMutex = Mutex()
     private var readersCount = 0
     private val readersCountMutex = Mutex()
 
+    /**
+     * Executes [block] while holding the read lock. Multiple coroutines may execute their
+     * [block]s concurrently. See the class-level documentation for reentrancy and cancellation
+     * caveats.
+     */
     suspend fun <T> withReadLock(block: suspend () -> T): T {
         readersCountMutex.withLock {
             if (++readersCount == 1) {
@@ -31,6 +74,13 @@ internal class RWLock {
         }
     }
 
+    /**
+     * Executes [block] while holding the write lock. Only one coroutine at a time may execute
+     * its [block] under the write lock, and no readers are active while it runs. See the
+     * class-level documentation for reentrancy and cancellation caveats — in particular, this
+     * method must **not** be called from a coroutine that already holds either the read or the
+     * write lock on the same [RWLock] instance, as doing so will deadlock.
+     */
     suspend fun <T> withWriteLock(block: suspend () -> T): T {
         writeMutex.withLock {
             return block()


### PR DESCRIPTION
withPrompt method now uses writeLock instead of readLock


<!-- Include BREAKING section below only if this PR introduces breaking changes. Otherwise, delete it. -->
BREAKING:
*

<!-- Include DEPRECATED section below only if this PR deprecates any public APIs. Otherwise, delete it. -->
DEPRECATED:
*

<!-- Include references to related issues below, e.g., closes #1, closes KG-1. Otherwise, delete it. -->
closes
