### PR TITLE
fix(mcp): accept empty additionalProperties in tool schema parser

### DIFF
--- a/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpToolDefinitionParser.kt
+++ b/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpToolDefinitionParser.kt
@@ -167,12 +167,8 @@ public object DefaultMcpToolDescriptorParser : McpToolDescriptorParser {
                 }
 
                 val additionalPropertiesType = if ("additionalProperties" in element) {
-                    when (element.getValue("additionalProperties")) {
-                        is JsonObject -> parseParameterType(
-                            element.getValue("additionalProperties").jsonObject,
-                            depth + 1
-                        )
-
+                    when (val value = element.getValue("additionalProperties")) {
+                        is JsonObject -> if (value.isEmpty()) null else parseParameterType(value, depth + 1)
                         else -> null
                     }
                 } else {

--- a/agents/agents-mcp/src/commonTest/kotlin/ai/koog/agents/mcp/DefaultMcpToolDescriptorParserTest.kt
+++ b/agents/agents-mcp/src/commonTest/kotlin/ai/koog/agents/mcp/DefaultMcpToolDescriptorParserTest.kt
@@ -501,6 +501,34 @@ class DefaultMcpToolDescriptorParserTest {
     }
 
     @Test
+    fun `test parsing object parameter with empty additional properties`() {
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "A test tool with empty additionalProperties",
+            properties = buildJsonObject {
+                putJsonObject("objectParam") {
+                    put("type", "object")
+                    put("description", "Object parameter")
+                    putJsonObject("properties") {
+                        putJsonObject("name") {
+                            put("type", "string")
+                        }
+                    }
+                    putJsonObject("additionalProperties") { }
+                }
+            },
+            required = emptyList()
+        )
+
+        val toolDescriptor = parser.parse(sdkTool)
+
+        val objectParam = toolDescriptor.optionalParameters.single()
+        val objectType = objectParam.type as ToolParameterType.Object
+        assertEquals(true, objectType.additionalProperties)
+        assertEquals(null, objectType.additionalPropertiesType)
+    }
+
+    @Test
     fun `test parameter type is missing`() {
         val missingTypeToolSdk = createSdkTool(
             name = "test-tool",


### PR DESCRIPTION
## Summary
- Treat `additionalProperties: {}` as unconstrained rather than crashing while recursing into the empty object.
- Matches JSON Schema semantics: an empty schema `{}` accepts any value, so `additionalProperties` is allowed but the type is unknown.
- Fixes `IllegalArgumentException: Parameter  must have type property` reported against real MCP servers (Mapbox, Rovo).

Closes #1676.

## Test plan
- [x] Added `test parsing object parameter with empty additional properties` in `DefaultMcpToolDescriptorParserTest`.
- [x] `./gradlew :agents:agents-mcp:jvmTest --tests "ai.koog.agents.mcp.DefaultMcpToolDescriptorParserTest"` — all tests pass.
- [x] Existing tests (including `test parsing object parameter with additional properties`, `test parameter type is missing`) continue to pass — behavior for non-empty `additionalProperties` and for top-level properties without a type is unchanged.