### PR TITLE
feat(prompt): add LM Studio client as OpenAI-compatible provider

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -244,6 +244,7 @@ dependencies {
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-bedrock-client"))
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-deepseek-client"))
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-google-client"))
+    dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-lmstudio-client"))
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-mistralai-client"))
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-ollama-client"))
     dokka(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client"))

--- a/koog-agents/build.gradle.kts
+++ b/koog-agents/build.gradle.kts
@@ -79,6 +79,7 @@ val included = setOf(
     ":prompt:prompt-executor:prompt-executor-clients:prompt-executor-bedrock-client",
     ":prompt:prompt-executor:prompt-executor-clients:prompt-executor-deepseek-client",
     ":prompt:prompt-executor:prompt-executor-clients:prompt-executor-google-client",
+    ":prompt:prompt-executor:prompt-executor-clients:prompt-executor-lmstudio-client",
     ":prompt:prompt-executor:prompt-executor-clients:prompt-executor-mistralai-client",
     ":prompt:prompt-executor:prompt-executor-clients:prompt-executor-ollama-client",
     ":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client",

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-lmstudio-client/Module.md
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-lmstudio-client/Module.md
@@ -1,0 +1,72 @@
+# Module prompt-executor-lmstudio-client
+
+A client implementation for executing prompts against a locally running [LM Studio](https://lmstudio.ai/) server via its OpenAI-compatible API.
+
+### Overview
+
+LM Studio hosts local LLMs and exposes an [OpenAI-compatible REST API](https://lmstudio.ai/docs/app/api/endpoints/openai). This module wraps that endpoint with a thin subclass of `OpenAILLMClient`, so any model loaded into LM Studio can be used as a Koog `LLModel`. Because authentication is not required by the server, the API key is a placeholder and may be omitted.
+
+### Supported Models
+
+LM Studio loads arbitrary user-downloaded models (GGUF, MLX, etc.), so there is no fixed list. Use the `lmStudioModel(id)` helper to describe the loaded model, passing the id reported by `GET /v1/models`:
+
+```kotlin
+val model = lmStudioModel(
+    id = "qwen/qwen3-1.7b",
+    capabilities = listOf(
+        LLMCapability.Completion,
+        LLMCapability.Temperature,
+        LLMCapability.OpenAIEndpoint.Completions,
+    ),
+)
+```
+
+`LLMCapability.OpenAIEndpoint.Completions` is included by default; add extra capabilities (e.g. `Tools`, `Vision.Image`, `Schema.JSON.Full`) for models that support them.
+
+### Using in your project
+
+Add the dependency:
+
+```kotlin
+dependencies {
+    implementation("ai.koog.prompt:prompt-executor-lmstudio-client:$version")
+}
+```
+
+Point the client at the local LM Studio server (defaults to `http://localhost:1234`):
+
+```kotlin
+val client = LMStudioLLMClient()
+```
+
+Or use the aggregated executor:
+
+```kotlin
+val executor = simpleLMStudioExecutor()
+```
+
+### Example of usage
+
+```kotlin
+suspend fun main() {
+    val client = LMStudioLLMClient()
+
+    val response = client.execute(
+        prompt = prompt {
+            system("You are a helpful assistant")
+            user("Give me a one-line summary of LM Studio")
+        },
+        model = lmStudioModel(id = "qwen/qwen3-1.7b"),
+    )
+
+    println(response)
+}
+```
+
+### Custom base URL
+
+```kotlin
+val client = LMStudioLLMClient(
+    settings = LMStudioClientSettings(baseUrl = "http://192.168.1.10:1234"),
+)
+```

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-lmstudio-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-lmstudio-client/build.gradle.kts
@@ -1,0 +1,37 @@
+import ai.koog.gradle.publish.maven.Publishing.publishToMaven
+
+group = rootProject.group
+version = rootProject.version
+
+plugins {
+    id("ai.kotlin.multiplatform")
+    alias(libs.plugins.kotlin.serialization)
+}
+
+kotlin {
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client"))
+                implementation(libs.oshai.kotlin.logging)
+            }
+        }
+
+        commonTest {
+            dependencies {
+                implementation(project(":test-utils"))
+                implementation(libs.kotlinx.serialization.core)
+            }
+        }
+
+        jvmTest {
+            dependencies {
+                implementation(libs.ktor.client.mock)
+            }
+        }
+    }
+
+    explicitApi()
+}
+
+publishToMaven()

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-lmstudio-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/lmstudio/LMStudioLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-lmstudio-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/lmstudio/LMStudioLLMClient.kt
@@ -1,0 +1,126 @@
+package ai.koog.prompt.executor.clients.lmstudio
+
+import ai.koog.http.client.KoogHttpClient
+import ai.koog.prompt.executor.clients.ConnectionTimeoutConfig
+import ai.koog.prompt.executor.clients.LLMClient
+import ai.koog.prompt.executor.clients.openai.OpenAIClientSettings
+import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
+import ai.koog.prompt.executor.clients.openai.base.AbstractOpenAILLMClient
+import ai.koog.prompt.executor.clients.openai.base.OpenAICompatibleToolDescriptorSchemaGenerator
+import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.client.HttpClient
+import kotlin.jvm.JvmOverloads
+import kotlin.time.Clock
+
+/**
+ * Configuration settings for connecting to an LM Studio server.
+ *
+ * LM Studio exposes an OpenAI-compatible REST API (https://lmstudio.ai/docs/app/api/endpoints/openai),
+ * so only the base URL typically needs to change from OpenAI defaults.
+ *
+ * @property baseUrl The base URL of the LM Studio server. Defaults to `"http://localhost:1234"`.
+ * @property timeoutConfig Configuration for connection timeouts.
+ */
+public class LMStudioClientSettings(
+    baseUrl: String = "http://localhost:1234",
+    timeoutConfig: ConnectionTimeoutConfig = ConnectionTimeoutConfig(),
+    chatCompletionsPath: String = "v1/chat/completions",
+    responsesAPIPath: String = "v1/responses",
+    embeddingsPath: String = "v1/embeddings",
+    moderationsPath: String = "v1/moderations",
+    modelsPath: String = "v1/models",
+) : OpenAIClientSettings(
+    baseUrl = baseUrl,
+    timeoutConfig = timeoutConfig,
+    chatCompletionsPath = chatCompletionsPath,
+    responsesAPIPath = responsesAPIPath,
+    embeddingsPath = embeddingsPath,
+    moderationsPath = moderationsPath,
+    modelsPath = modelsPath,
+)
+
+/**
+ * Implementation of [LLMClient] for a locally running LM Studio server.
+ *
+ * LM Studio serves an OpenAI-compatible Chat Completions API, so this client extends
+ * [OpenAILLMClient] unchanged except for the reported [LLMProvider] and the default base URL.
+ *
+ * LM Studio does not require authentication; the API key is forwarded in the `Authorization`
+ * header but is ignored by the server. Callers may pass any non-empty string (or use the
+ * [httpClient]-based constructor to skip the header entirely).
+ *
+ * @param settings Connection settings, defaults to `http://localhost:1234`.
+ * @param httpClient A fully configured [KoogHttpClient] for making API requests.
+ * @param clock Clock instance used for tracking response metadata timestamps.
+ */
+public class LMStudioLLMClient @JvmOverloads constructor(
+    settings: LMStudioClientSettings = LMStudioClientSettings(),
+    httpClient: KoogHttpClient,
+    clock: Clock = Clock.System,
+    toolsConverter: OpenAICompatibleToolDescriptorSchemaGenerator = OpenAICompatibleToolDescriptorSchemaGenerator(),
+) : OpenAILLMClient(
+    settings = settings,
+    httpClient = httpClient,
+    clock = clock,
+    toolsConverter = toolsConverter,
+) {
+
+    @JvmOverloads
+    public constructor(
+        settings: LMStudioClientSettings = LMStudioClientSettings(),
+        baseClient: HttpClient = HttpClient(),
+        apiKey: String = "lm-studio",
+        clock: Clock = Clock.System,
+        toolsConverter: OpenAICompatibleToolDescriptorSchemaGenerator = OpenAICompatibleToolDescriptorSchemaGenerator(),
+    ) : this(
+        settings = settings,
+        httpClient = AbstractOpenAILLMClient.createConfiguredHttpClient(
+            apiKey = apiKey,
+            settings = settings,
+            logger = staticLogger,
+            baseClient = baseClient,
+            clientName = LMSTUDIO_CLIENT_NAME,
+        ),
+        clock = clock,
+        toolsConverter = toolsConverter,
+    )
+
+    override fun llmProvider(): LLMProvider = LLMProvider.LMStudio
+
+    private companion object {
+        private const val LMSTUDIO_CLIENT_NAME = "LMStudioLLMClient"
+        private val staticLogger = KotlinLogging.logger { }
+    }
+}
+
+/**
+ * Builds an [LLModel] for a model loaded into an LM Studio server.
+ *
+ * LM Studio speaks the OpenAI Chat Completions protocol, so [LLMCapability.OpenAIEndpoint.Completions]
+ * is included by default; callers can override [capabilities] for models that support additional
+ * features (e.g. tools, vision, JSON schema output).
+ *
+ * @param id The model identifier as reported by LM Studio (for example `qwen/qwen3-1.7b`).
+ * @param capabilities The capabilities this local model supports.
+ * @param contextLength Optional context length in tokens.
+ * @param maxOutputTokens Optional cap on generated tokens.
+ */
+public fun lmStudioModel(
+    id: String,
+    capabilities: List<LLMCapability> = listOf(
+        LLMCapability.Completion,
+        LLMCapability.Temperature,
+        LLMCapability.OpenAIEndpoint.Completions,
+    ),
+    contextLength: Long? = null,
+    maxOutputTokens: Long? = null,
+): LLModel = LLModel(
+    provider = LLMProvider.LMStudio,
+    id = id,
+    capabilities = capabilities,
+    contextLength = contextLength,
+    maxOutputTokens = maxOutputTokens,
+)

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-lmstudio-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/lmstudio/LMStudioLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-lmstudio-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/lmstudio/LMStudioLLMClientTest.kt
@@ -1,0 +1,114 @@
+package ai.koog.prompt.executor.clients.lmstudio
+
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.message.Message
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+class LMStudioLLMClientTest {
+
+    private object FixedClock : Clock {
+        override fun now(): Instant = Instant.fromEpochMilliseconds(0)
+    }
+
+    private val localModel = lmStudioModel("qwen/qwen3-1.7b")
+
+    //language=json
+    private val chatCompletionBody = """
+        {
+          "id": "chatcmpl-local",
+          "object": "chat.completion",
+          "created": 1716920005,
+          "model": "qwen/qwen3-1.7b",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "hi from lmstudio"
+              },
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {"total_tokens": 10, "prompt_tokens": 5, "completion_tokens": 5}
+        }
+    """.trimIndent()
+
+    // LM Studio's /v1/models response is missing `created` and `owned_by` on some builds.
+    //language=json
+    private val modelsBody = """
+        {
+          "object": "list",
+          "data": [
+            { "id": "qwen/qwen3-1.7b" },
+            { "id": "llama-3.2-3b-instruct", "object": "model" }
+          ]
+        }
+    """.trimIndent()
+
+    @Test
+    fun testClientReportsLMStudioProvider() {
+        val http = HttpClient(MockEngine { respond("", HttpStatusCode.OK) }) {}
+        val client = LMStudioLLMClient(baseClient = http, clock = FixedClock)
+        assertEquals(LLMProvider.LMStudio, client.llmProvider())
+    }
+
+    @Test
+    fun testChatCompletionHitsLMStudioEndpoint() = runTest {
+        var seenUrl: String? = null
+        val engine = MockEngine { request ->
+            seenUrl = request.url.toString()
+            respond(
+                content = chatCompletionBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        val http = HttpClient(engine) {}
+        val client = LMStudioLLMClient(baseClient = http, clock = FixedClock)
+
+        val prompt = Prompt.build(id = "p", clock = FixedClock) {
+            user("ping")
+        }
+
+        val responses = client.execute(prompt, localModel)
+
+        assertEquals(1, responses.size)
+        val assistant = assertIs<Message.Assistant>(responses[0])
+        assertEquals("hi from lmstudio", assistant.content)
+        assertEquals("http://localhost:1234/v1/chat/completions", seenUrl)
+    }
+
+    @Test
+    fun testListModelsToleratesMissingOptionalFields() = runTest {
+        val engine = MockEngine {
+            respond(
+                content = modelsBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        val http = HttpClient(engine) {}
+        val client = LMStudioLLMClient(baseClient = http, clock = FixedClock)
+
+        val models = client.models()
+
+        assertEquals(2, models.size)
+        assertTrue(models.all { it.provider == LLMProvider.LMStudio })
+        assertEquals("qwen/qwen3-1.7b", models[0].id)
+        assertEquals("llama-3.2-3b-instruct", models[1].id)
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -81,7 +81,7 @@ import ai.koog.prompt.executor.clients.openai.base.models.Content as OpenAIConte
  * @property moderationsPath The path of the OpenAI Moderations API. Defaults to "v1/moderations".
  * @property modelsPath The path of the OpenAI Models API. Defaults to "v1/models".
  */
-public class OpenAIClientSettings(
+public open class OpenAIClientSettings(
     baseUrl: String = "https://api.openai.com",
     timeoutConfig: ConnectionTimeoutConfig = ConnectionTimeoutConfig(),
     chatCompletionsPath: String = "v1/chat/completions",

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIModels.kt
@@ -14,8 +14,8 @@ internal data class OpenAIModelsResponse(
 internal data class OpenAIModel(
     val id: String,
     @SerialName("object")
-    val objectType: String,
-    val created: Long,
+    val objectType: String? = null,
+    val created: Long? = null,
     @SerialName("owned_by")
-    val ownedBy: String
+    val ownedBy: String? = null,
 )

--- a/prompt/prompt-executor/prompt-executor-llms-all/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-llms-all/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
                 api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-bedrock-client"))
                 api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-deepseek-client"))
                 api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-google-client"))
+                api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-lmstudio-client"))
                 api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-mistralai-client"))
                 api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-ollama-client"))
                 api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client"))

--- a/prompt/prompt-executor/prompt-executor-llms-all/src/commonMain/kotlin/ai/koog/prompt/executor/llms/all/SimplePromptExecutors.kt
+++ b/prompt/prompt-executor/prompt-executor-llms-all/src/commonMain/kotlin/ai/koog/prompt/executor/llms/all/SimplePromptExecutors.kt
@@ -2,6 +2,8 @@ package ai.koog.prompt.executor.llms.all
 
 import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
 import ai.koog.prompt.executor.clients.google.GoogleLLMClient
+import ai.koog.prompt.executor.clients.lmstudio.LMStudioClientSettings
+import ai.koog.prompt.executor.clients.lmstudio.LMStudioLLMClient
 import ai.koog.prompt.executor.clients.mistralai.MistralAILLMClient
 import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
 import ai.koog.prompt.executor.clients.openai.azure.AzureOpenAIClientSettings
@@ -98,3 +100,16 @@ public fun simpleOllamaAIExecutor(
  */
 public fun simpleMistralAIExecutor(apiKey: String): SingleLLMPromptExecutor =
     SingleLLMPromptExecutor(MistralAILLMClient(apiKey))
+
+/**
+ * Creates an instance of `SingleLLMPromptExecutor` backed by a locally running LM Studio server.
+ *
+ * LM Studio exposes an OpenAI-compatible API and does not require authentication; the api key is
+ * sent but ignored by the server.
+ *
+ * @param baseUrl The base URL of the LM Studio server. Defaults to `http://localhost:1234`.
+ */
+public fun simpleLMStudioExecutor(
+    baseUrl: String = "http://localhost:1234",
+): SingleLLMPromptExecutor =
+    SingleLLMPromptExecutor(LMStudioLLMClient(settings = LMStudioClientSettings(baseUrl = baseUrl)))

--- a/prompt/prompt-executor/prompt-executor-model/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-model/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
                 api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-anthropic-client"))
                 api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-deepseek-client"))
                 api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-google-client"))
+                api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-lmstudio-client"))
                 api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-mistralai-client"))
                 api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-ollama-client"))
                 api(project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client"))

--- a/prompt/prompt-llm/src/commonMain/kotlin/ai/koog/prompt/llm/LLMProvider.kt
+++ b/prompt/prompt-llm/src/commonMain/kotlin/ai/koog/prompt/llm/LLMProvider.kt
@@ -150,6 +150,12 @@ public abstract class LLMProvider(public val id: String, public val display: Str
          */
         @JvmField
         public val Vertex: VertexLLMProvider = VertexLLMProvider
+
+        /**
+         * Represents the LM Studio provider for locally hosted OpenAI-compatible models.
+         */
+        @JvmField
+        public val LMStudio: LMStudioLLMProvider = LMStudioLLMProvider
     }
 }
 
@@ -324,3 +330,11 @@ public object AzureLLMProvider : LLMProvider("azure", "Azure OpenAI")
  */
 @Serializable
 public object VertexLLMProvider : LLMProvider("vertex", "Google VertexAI")
+
+/**
+ * Represents the LM Studio provider for locally hosted OpenAI-compatible models.
+ *
+ * LM Studio is identified by its unique ID ("lmstudio") and display name ("LM Studio").
+ */
+@Serializable
+public object LMStudioLLMProvider : LLMProvider("lmstudio", "LM Studio")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -53,6 +53,7 @@ include(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-deepsee
 include(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-google-client")
 include(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-mistralai-client")
 include(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-ollama-client")
+include(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-lmstudio-client")
 include(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client")
 include(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client-base")
 include(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-openrouter-client")


### PR DESCRIPTION
## Summary

Closes #139.

Adds first-class support for [LM Studio](https://lmstudio.ai/) as an LLM provider. LM Studio exposes an OpenAI-compatible REST API on `http://localhost:1234/v1`, so this is implemented as a thin layer over `OpenAILLMClient` rather than a new protocol stack.

### New module: `prompt-executor-lmstudio-client`

- `LMStudioLLMClient` — subclass of `OpenAILLMClient`; overrides `llmProvider()` to return `LLMProvider.LMStudio`. No auth key required; any string is accepted and forwarded to the (ignored) `Authorization` header.
- `LMStudioClientSettings` — subclass of `OpenAIClientSettings` with `baseUrl` defaulting to `http://localhost:1234`.
- `lmStudioModel(id, ...)` helper — constructs an `LLModel` with `LLMCapability.OpenAIEndpoint.Completions` already attached, so locally-loaded models "just work" with the OpenAI chat-completions path.

### Supporting changes

- `LLMProvider`: new `LMStudioLLMProvider` + companion `LMStudio` field, mirroring the existing singleton pattern.
- `prompt-executor-llms-all`: new `simpleLMStudioExecutor(baseUrl = "http://localhost:1234")` helper alongside the existing `simpleOllamaAIExecutor`.
- `OpenAIClientSettings`: changed from `class` to `open class` so downstream clients (here, LM Studio) can extend it with their own defaults. Fields unchanged.
- `OpenAIModel` (the `/v1/models` DTO): `objectType`, `created`, and `ownedBy` are now nullable with `= null` defaults. Addresses the serialization failure @HaukeRa reported against LM Studio in #139 — the spec says these fields are optional but the code required them. OpenAI's official responses still include all three and continue to deserialize unchanged.

### Wiring

- Registered in `settings.gradle.kts`, `build.gradle.kts` (dokka), `koog-agents/build.gradle.kts` (included set), `prompt-executor-model/build.gradle.kts`, and `prompt-executor-llms-all/build.gradle.kts`.

### Not in scope

- Ktor DSL integration (`koog-ktor/KoogAgentsConfig.kt`) is not touched — users configure the LM Studio client directly. Happy to do a follow-up if you'd like it included.
- No Responses API support — LM Studio only implements the Chat Completions surface.

## Test plan

- [x] `./gradlew :prompt:prompt-executor:prompt-executor-clients:prompt-executor-lmstudio-client:jvmTest` — new `LMStudioLLMClientTest` (3 tests) covers provider identity, hitting `http://localhost:1234/v1/chat/completions` via MockEngine, and `/v1/models` parsing against an LM Studio response that omits `created` / `owned_by`.
- [x] `./gradlew :prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client:jvmTest` — unchanged OpenAI tests still pass with the now-nullable DTO fields.
- [x] `./gradlew :prompt:prompt-executor:prompt-executor-clients:prompt-executor-openrouter-client:jvmTest` and `:prompt-executor-deepseek-client:jvmTest` — no regression in other OpenAI-derived clients.
- [x] `./gradlew :koog-agents:jvmJar :prompt:prompt-executor:prompt-executor-model:jvmJar` — aggregator jars build with the new dependency.