### PR TITLE
fix(prompt): resolve @Contextual properties in GenericJsonSchemaGenerator

### DIFF
--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/generator/GenericJsonSchemaGenerator.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/generator/GenericJsonSchemaGenerator.kt
@@ -72,9 +72,9 @@ public abstract class GenericJsonSchemaGenerator : JsonSchemaGenerator() {
                     .getContextualDescriptor(context.descriptor)
                     ?: throw IllegalArgumentException(
                         "Cannot generate JSON schema for @Contextual type '${context.descriptor.serialName}': " +
-                        "no contextual serializer was found in the SerializersModule. " +
-                        "Register one via SerializersModule { contextual(...) }, or use " +
-                        "@Serializable(with = ...) on the property instead."
+                            "no contextual serializer was found in the SerializersModule. " +
+                            "Register one via SerializersModule { contextual(...) }, or use " +
+                            "@Serializable(with = ...) on the property instead."
                     )
                 process(context.copy(descriptor = resolvedDescriptor))
             }

--- a/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/generator/GenericJsonSchemaGenerator.kt
+++ b/prompt/prompt-structure/src/commonMain/kotlin/ai/koog/prompt/structure/json/generator/GenericJsonSchemaGenerator.kt
@@ -1,11 +1,13 @@
 package ai.koog.prompt.structure.json.generator
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.builtins.nullable
 import kotlinx.serialization.descriptors.PolymorphicKind
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialKind
 import kotlinx.serialization.descriptors.StructureKind
 import kotlinx.serialization.descriptors.elementNames
+import kotlinx.serialization.descriptors.getContextualDescriptor
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -24,6 +26,7 @@ import kotlinx.serialization.serializer
  * Note: it does not handle nullability because these might be different in different schema specs.
  * Implementations must handle these themselves.
  */
+@OptIn(ExperimentalSerializationApi::class)
 public abstract class GenericJsonSchemaGenerator : JsonSchemaGenerator() {
     /**
      * Generic implementation that provides basic routing to appropriate visit method and adds description.
@@ -60,6 +63,20 @@ public abstract class GenericJsonSchemaGenerator : JsonSchemaGenerator() {
                 } else {
                     processPolymorphic(context)
                 }
+            }
+
+            SerialKind.CONTEXTUAL -> {
+                // Resolve the actual serializer from the SerializersModule and delegate to it.
+                // This handles properties annotated with @Contextual (e.g. java.util.UUID).
+                val resolvedDescriptor = context.json.serializersModule
+                    .getContextualDescriptor(context.descriptor)
+                    ?: throw IllegalArgumentException(
+                        "Cannot generate JSON schema for @Contextual type '${context.descriptor.serialName}': " +
+                        "no contextual serializer was found in the SerializersModule. " +
+                        "Register one via SerializersModule { contextual(...) }, or use " +
+                        "@Serializable(with = ...) on the property instead."
+                    )
+                process(context.copy(descriptor = resolvedDescriptor))
             }
 
             else ->

--- a/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/json/generator/JsonSchemaGeneratorTest.kt
+++ b/prompt/prompt-structure/src/commonTest/kotlin/ai/koog/prompt/structure/json/generator/JsonSchemaGeneratorTest.kt
@@ -1,17 +1,26 @@
 package ai.koog.prompt.structure.json.generator
 
 import ai.koog.agents.core.tools.annotations.LLMDescription
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.ClassDiscriminatorMode
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
 import kotlinx.serialization.modules.polymorphic
 import kotlinx.serialization.serializer
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class JsonSchemaGeneratorTest {
     private val json = Json {
@@ -881,5 +890,118 @@ class JsonSchemaGeneratorTest {
         """.trimIndent()
 
         assertEquals(expectedSchema, schema)
+    }
+
+    // ---- @Contextual support ----
+
+    /** A non-serializable type used to exercise @Contextual resolution in tests. */
+    data class ContextualToken(val raw: String)
+
+    object ContextualTokenSerializer : KSerializer<ContextualToken> {
+        override val descriptor: SerialDescriptor =
+            PrimitiveSerialDescriptor("ContextualToken", PrimitiveKind.STRING)
+
+        override fun serialize(encoder: Encoder, value: ContextualToken) =
+            encoder.encodeString(value.raw)
+
+        override fun deserialize(decoder: Decoder): ContextualToken =
+            ContextualToken(decoder.decodeString())
+    }
+
+    @Serializable
+    @SerialName("ClassWithContextual")
+    data class ClassWithContextual(
+        @Contextual val token: ContextualToken,
+        val name: String
+    )
+
+    private val jsonWithContextual = Json {
+        prettyPrint = true
+        prettyPrintIndent = "  "
+        serializersModule = SerializersModule {
+            contextual(ContextualTokenSerializer)
+        }
+    }
+
+    @Test
+    fun testBasicSchemaContextualPropertyResolvesToString() {
+        val result = basicGenerator.generate(
+            jsonWithContextual,
+            "ClassWithContextual",
+            serializer<ClassWithContextual>(),
+            emptyMap()
+        )
+        val schema = jsonWithContextual.encodeToString(result.schema)
+
+        val expectedSchema = """
+            {
+              "type": "object",
+              "properties": {
+                "token": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "token",
+                "name"
+              ],
+              "additionalProperties": false
+            }
+        """.trimIndent()
+
+        assertEquals(expectedSchema, schema)
+    }
+
+    @Test
+    fun testStandardSchemaContextualPropertyResolvesToString() {
+        val result = standardGenerator.generate(
+            jsonWithContextual,
+            "ClassWithContextual",
+            serializer<ClassWithContextual>(),
+            emptyMap()
+        )
+        val schema = jsonWithContextual.encodeToString(result.schema)
+
+        val expectedSchema = """
+            {
+              "${"$"}id": "ClassWithContextual",
+              "${"$"}defs": {
+                "ClassWithContextual": {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "token",
+                    "name"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "${"$"}ref": "#/${"$"}defs/ClassWithContextual"
+            }
+        """.trimIndent()
+
+        assertEquals(expectedSchema, schema)
+    }
+
+    @Test
+    fun testContextualPropertyWithoutRegisteredSerializerThrowsClearError() {
+        // json has no contextual serializer for ContextualToken registered
+        val ex = assertFailsWith<IllegalArgumentException> {
+            basicGenerator.generate(json, "ClassWithContextual", serializer<ClassWithContextual>(), emptyMap())
+        }
+        assertTrue(
+            ex.message?.contains("no contextual serializer") == true,
+            "Expected a descriptive error about missing contextual serializer, got: ${ex.message}"
+        )
     }
 }


### PR DESCRIPTION
## What

Fixes #1486

`executeStructured` crashed with `IllegalArgumentException: Encountered unsupported type while generating JSON schema: CONTEXTUAL` when the response data class contained a `@Contextual` property (e.g. `java.util.UUID`, any non-`@Serializable` type registered via `SerializersModule`).

## Root cause

`GenericJsonSchemaGenerator.process()` had no branch for `SerialKind.CONTEXTUAL`, so it fell through to the `else` clause and threw immediately — before any LLM request was made.

## Fix

Added an explicit `SerialKind.CONTEXTUAL` branch that:
1. Calls `serializersModule.getContextualDescriptor(descriptor)` (stable API in kotlinx.serialization 1.7+) to resolve the actual serializer registered in the `Json` instance's module.
2. Delegates to `process()` recursively with the resolved descriptor, so the type is generated correctly (e.g. a UUID serialized as a string → `"type": "string"`).
3. If no contextual serializer is found, throws a **descriptive** `IllegalArgumentException` explaining how to fix it (register via `SerializersModule { contextual(...) }` or use `@Serializable(with = ...)`).

## Changes

| File | Change |
|---|---|
| `GenericJsonSchemaGenerator.kt` | Add `SerialKind.CONTEXTUAL` branch; `@OptIn(ExperimentalSerializationApi::class)` on class |
| `JsonSchemaGeneratorTest.kt` | 3 new test cases: basic generator, standard generator, and missing-serializer error path |

## Testing

```
./gradlew :prompt:prompt-structure:jvmTest --tests "ai.koog.prompt.structure.json.generator.JsonSchemaGeneratorTest"
BUILD SUCCESSFUL
```

All 3 new tests pass alongside the existing suite.

## Workaround (before this fix)

Use `@Serializable(with = MySerializer::class)` on the property instead of `@Contextual`, as noted in the issue.