### PR TITLE
fix(agents): consider tool's customName in tools from callable

### DIFF
--- a/agents/agents-tools/src/jvmCommonMain/kotlin/ai/koog/agents/core/tools/reflect/ToolFromCallableExtensions.kt
+++ b/agents/agents-tools/src/jvmCommonMain/kotlin/ai/koog/agents/core/tools/reflect/ToolFromCallableExtensions.kt
@@ -65,7 +65,8 @@ public fun <T : Any> KClass<out T>.asTools(
     return this.functions.filter { m ->
         m.getPreferredToolAnnotation() != null
     }.map {
-        it.asTool(thisRef = thisRef)
+        val customName = it.getPreferredToolAnnotation()?.customName?.ifEmpty { null }
+        it.asTool(thisRef = thisRef, name = customName)
     }.apply {
         require(isNotEmpty()) { "No tools found in ${this@asTools}" }
     }

--- a/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/core/tools/reflect/ToolSetAsToolsTest.kt
+++ b/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/core/tools/reflect/ToolSetAsToolsTest.kt
@@ -1,5 +1,6 @@
 package ai.koog.agents.core.tools.reflect
 
+import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.annotations.InternalAgentToolsApi
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.core.tools.annotations.Tool
@@ -101,6 +102,22 @@ class ComplexToolsImpl : ToolSet {
     fun formatPerson(
         @LLMDescription("Person object") person: Person
     ): String = "${person.name} is ${person.age} years old"
+}
+
+class SearchToolA : ToolSet {
+    @Tool(customName = "tool_a_search")
+    @LLMDescription("Searches source A")
+    fun execute(
+        @LLMDescription("Query") query: String
+    ): String = "result A: $query"
+}
+
+class SearchToolB : ToolSet {
+    @Tool(customName = "tool_b_search")
+    @LLMDescription("Searches source B")
+    fun execute(
+        @LLMDescription("Query") query: String
+    ): String = "result B: $query"
 }
 
 @OptIn(InternalAgentToolsApi::class)
@@ -240,5 +257,25 @@ class ToolSetAsToolsTest {
             formatPersonTool.encodeResultToStringUnsafe(formatPersonResult, serializer),
             "Format tool should return formatted string"
         )
+    }
+
+    @Test
+    @OptIn(InternalAgentToolsApi::class)
+    fun testCustomToolNamesArePreservedForToolSets() {
+        val toolA = SearchToolA()
+        val toolB = SearchToolB()
+
+        val toolANames = toolA.asTools().map { it.descriptor.name }
+        val toolBNames = toolB.asTools().map { it.descriptor.name }
+
+        assertEquals(listOf("tool_a_search"), toolANames)
+        assertEquals(listOf("tool_b_search"), toolBNames)
+
+        val registry = ToolRegistry {
+            tools(toolA)
+            tools(toolB)
+        }
+
+        assertEquals(listOf("tool_a_search", "tool_b_search"), registry.tools.map { it.name }.sorted())
     }
 }


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

Fix the big "@Tool(customName = ...) is ignored when using ToolSet.asTools() / ToolRegistryBuilder.tools(ToolSet)" and add a test.

<!-- Include references to related issues below, e.g., closes #1, closes KG-1. Otherwise, delete it. -->
closes #1881 