### PR TITLE
fix(prompt): stop additionalProperties leaking as additional_properties to OpenAI

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIRequestSnakeCaseSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIRequestSnakeCaseSerializationTest.kt
@@ -1,0 +1,114 @@
+package ai.koog.prompt.executor.clients.openai.models
+
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNamingStrategy
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+
+/**
+ * Reproduces the snake_case serialization path used by [OpenAILLMClient] to guard the fix
+ * for an additional-properties leak in the outbound request body.
+ */
+class OpenAIRequestSnakeCaseSerializationTest {
+
+    private val snakeCaseJson = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+        explicitNulls = false
+        namingStrategy = JsonNamingStrategy.SnakeCase
+    }
+
+    @Test
+    fun `responses request flattens additionalProperties under snake_case naming`() {
+        // Regression for #1878: with JsonNamingStrategy.SnakeCase the additionalProperties field
+        // was being emitted verbatim as `additional_properties` at the top level of the request,
+        // which OpenAI rejects with `400 unknown_parameter`.
+        val request = OpenAIResponsesAPIRequest(
+            model = "gpt-4o",
+            instructions = "Please help with this task",
+            temperature = 0.7,
+            additionalProperties = mapOf(
+                "reasoning" to buildJsonObject { put("effort", JsonPrimitive("none")) },
+            ),
+        )
+
+        val encoded = snakeCaseJson.encodeToString(OpenAIResponsesAPIRequestSerializer, request)
+        val tree = snakeCaseJson.parseToJsonElement(encoded).jsonObject
+
+        tree.keys.shouldNotContain("additional_properties")
+        tree.keys.shouldNotContain("additionalProperties")
+        tree.keys.shouldContain("reasoning")
+
+        tree["model"]?.jsonPrimitive?.content shouldBe "gpt-4o"
+        tree["reasoning"].shouldNotBeNull().jsonObject["effort"]?.jsonPrimitive?.content shouldBe "none"
+    }
+
+    @Test
+    fun `responses request preserves snake_case for native fields when flattening`() {
+        val request = OpenAIResponsesAPIRequest(
+            model = "gpt-4o",
+            maxOutputTokens = 256,
+            parallelToolCalls = true,
+            additionalProperties = mapOf("custom_extra" to JsonPrimitive("value")),
+        )
+
+        snakeCaseJson.encodeToString(OpenAIResponsesAPIRequestSerializer, request) shouldEqualJson
+            """
+            {
+                "model": "gpt-4o",
+                "max_output_tokens": 256,
+                "parallel_tool_calls": true,
+                "custom_extra": "value"
+            }
+            """.trimIndent()
+    }
+
+    @Test
+    fun `chat completion request flattens additionalProperties under snake_case naming`() {
+        val request = OpenAIChatCompletionRequest(
+            model = "gpt-4o",
+            messages = emptyList(),
+            additionalProperties = mapOf(
+                "reasoning" to buildJsonObject { put("effort", JsonPrimitive("none")) },
+            ),
+        )
+
+        val encoded = snakeCaseJson.encodeToString(OpenAIChatCompletionRequestSerializer, request)
+        val tree = snakeCaseJson.parseToJsonElement(encoded).jsonObject
+
+        tree.keys.shouldNotContain("additional_properties")
+        tree.keys.shouldNotContain("additionalProperties")
+        tree["reasoning"].shouldNotBeNull().jsonObject["effort"]?.jsonPrimitive?.content shouldBe "none"
+    }
+
+    @Test
+    fun `responses request round trip with snake_case naming preserves additional properties`() {
+        val original = OpenAIResponsesAPIRequest(
+            model = "gpt-4o",
+            maxOutputTokens = 256,
+            additionalProperties = mapOf(
+                "custom_extra" to JsonPrimitive("value"),
+                "custom_number" to JsonPrimitive(7),
+            ),
+        )
+
+        val encoded = snakeCaseJson.encodeToString(OpenAIResponsesAPIRequestSerializer, original)
+        val decoded = snakeCaseJson.decodeFromString(OpenAIResponsesAPIRequestSerializer, encoded)
+
+        decoded.model shouldBe "gpt-4o"
+        decoded.maxOutputTokens shouldBe 256
+        decoded.additionalProperties.shouldNotBeNull {
+            this["custom_extra"]?.jsonPrimitive?.content shouldBe "value"
+            this["custom_number"]?.jsonPrimitive?.content?.toInt() shouldBe 7
+        }
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/serialization/AdditionalPropertiesFlatteningSerializer.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/src/commonMain/kotlin/ai/koog/prompt/executor/clients/serialization/AdditionalPropertiesFlatteningSerializer.kt
@@ -3,6 +3,7 @@ package ai.koog.prompt.executor.clients.serialization
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.elementNames
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonTransformingSerializer
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
@@ -13,7 +14,11 @@ import kotlinx.serialization.json.jsonObject
  * On serialization: flattens `additionalProperties` to root level.
  * On deserialization: collects unknown properties into `additionalProperties` field.
  *
- * @param knownProperties Set of known property names for the type
+ * Compatible with `JsonNamingStrategy.SnakeCase`: field names are matched against both their
+ * declared form and their snake_case form, and the additional-properties key is emitted in the
+ * form that matches the payload's naming so the inner serializer can read it back.
+ *
+ * @param tSerializer Underlying serializer for type [T].
  * @param additionalPropertiesField The name of the field to use for additional properties, defaults to "additionalProperties".
  */
 public abstract class AdditionalPropertiesFlatteningSerializer<T>(
@@ -22,27 +27,48 @@ public abstract class AdditionalPropertiesFlatteningSerializer<T>(
 ) :
     JsonTransformingSerializer<T>(tSerializer) {
 
-    private val knownProperties = tSerializer.descriptor.elementNames
+    private val additionalPropertiesFieldSnakeCase: String = additionalPropertiesField.toSnakeCase()
+
+    private val additionalPropertiesFieldCandidates: Set<String> =
+        setOf(additionalPropertiesField, additionalPropertiesFieldSnakeCase)
+
+    private val declaredNames: Set<String> = tSerializer.descriptor.elementNames.toSet()
+
+    private val knownProperties: Set<String> = buildSet {
+        declaredNames.forEach { name ->
+            add(name)
+            add(name.toSnakeCase())
+        }
+    }
 
     override fun transformSerialize(element: JsonElement): JsonElement {
         val obj = element.jsonObject
 
         return buildJsonObject {
-            // Add all properties except additionalProperties
+            // Add all properties except additionalProperties (in any naming form)
             obj.entries.asSequence()
-                .filterNot { (key, _) -> key == additionalPropertiesField }
+                .filterNot { (key, _) -> key in additionalPropertiesFieldCandidates }
                 .forEach { (key, value) -> put(key, value) }
 
             // Merge additional properties into the root level (avoiding conflicts)
-            obj[additionalPropertiesField]?.jsonObject?.entries
-                ?.filterNot { (key, _) -> obj.containsKey(key) }
-                ?.forEach { (key, value) -> put(key, value) }
+            val sourceKey = additionalPropertiesFieldCandidates.firstOrNull(obj::containsKey)
+            if (sourceKey != null) {
+                (obj[sourceKey] as? JsonObject)?.entries
+                    ?.filterNot { (key, _) -> obj.containsKey(key) }
+                    ?.forEach { (key, value) -> put(key, value) }
+            }
         }
     }
 
     override fun transformDeserialize(element: JsonElement): JsonElement {
         val obj = element.jsonObject
         val (known, additional) = obj.entries.partition { (key, _) -> key in knownProperties }
+
+        // If any recognized key is in snake_case form (i.e., not the declared name), the Json
+        // instance is using a naming strategy, so emit the additional-properties key in the
+        // same form for the inner serializer to pick it up.
+        val usesSnakeCase = known.any { (key, _) -> key !in declaredNames }
+        val outputKey = if (usesSnakeCase) additionalPropertiesFieldSnakeCase else additionalPropertiesField
 
         return buildJsonObject {
             // Add known properties efficiently
@@ -51,7 +77,7 @@ public abstract class AdditionalPropertiesFlatteningSerializer<T>(
             // Group additional properties under an additionalProperties key if any exist
             if (additional.isNotEmpty()) {
                 put(
-                    additionalPropertiesField,
+                    outputKey,
                     buildJsonObject {
                         additional.forEach { (key, value) -> put(key, value) }
                     }
@@ -59,4 +85,19 @@ public abstract class AdditionalPropertiesFlatteningSerializer<T>(
             }
         }
     }
+}
+
+private fun String.toSnakeCase(): String {
+    if (isEmpty()) return this
+    val result = StringBuilder(length + 4)
+    for (i in indices) {
+        val c = this[i]
+        if (c.isUpperCase()) {
+            if (i > 0 && this[i - 1].isLowerCase()) result.append('_')
+            result.append(c.lowercaseChar())
+        } else {
+            result.append(c)
+        }
+    }
+    return result.toString()
 }


### PR DESCRIPTION
## Summary
- `AdditionalPropertiesFlatteningSerializer` looked up the flatten key by its declared form only, so under `JsonNamingStrategy.SnakeCase` (used by every OpenAI-compatible client) the key became `additional_properties` before `transformSerialize` ran, the filter missed it, and the whole map leaked to the request root — OpenAI then rejected the call with `400 unknown_parameter`.
- Match both camelCase and snake_case forms on encode/decode and emit the additional-properties key in the form the payload uses, so round-trips work under either naming strategy without touching any request class.

Fixes #1878. Also addresses the KG-531 note left in `OpenRouterSerializationTest`.

## Test plan
- [x] New `OpenAIRequestSnakeCaseSerializationTest` — fails against the old serializer (leaks `additional_properties`, drops fields on round-trip) and passes with the fix.
- [x] `./gradlew :prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client:jvmTest` and all other clients that consume the serializer (anthropic, google, openrouter, mistralai, deepseek, dashscope, ollama, openai-client-base, prompt-executor-clients) — green.
- [x] `compileKotlinJs` and `compileKotlinWasmJs` for `prompt-executor-clients` — green (change lives in `commonMain`).