### PR TITLE
fix(embeddings): process Ollama batch embeddings

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -387,7 +387,7 @@ public class OllamaClient @JvmOverloads constructor(
         }
 
         val embeddingResponse = response.body<EmbeddingBatchResponseDTO>()
-        return embeddingResponse.embeddings.first()
+        return embeddingResponse.normalizedEmbeddings().firstOrNull() ?: emptyList()
     }
 
     /**
@@ -414,7 +414,7 @@ public class OllamaClient @JvmOverloads constructor(
         }
 
         val embeddingResponse = response.body<EmbeddingBatchResponseDTO>()
-        return embeddingResponse.embeddings
+        return embeddingResponse.normalizedEmbeddings()
     }
 
     /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaModels.kt
@@ -122,9 +122,19 @@ internal data class EmbeddingBatchRequestDTO(
  */
 @Serializable
 internal data class EmbeddingBatchResponseDTO(
-    @SerialName("embeddings") val embeddings: List<List<Double>>,
+    @SerialName("embeddings") val embeddings: List<List<Double>>? = null,
+    @SerialName("embedding") val embedding: List<Double>? = null,
     @SerialName("model") val modelId: String? = null
-)
+) {
+    /**
+     * Normalizes Ollama's two embedding response shapes into a single batch representation.
+     *
+     * Returning `List<List<Double>>` lets the rest of the embedding pipeline treat single-item and
+     * multi-item requests the same way, which keeps downstream similarity/search code independent
+     * from transport-specific response details.
+     */
+    fun normalizedEmbeddings(): List<List<Double>> = embeddings ?: embedding?.let(::listOf) ?: emptyList()
+}
 
 /**
  * Represents a request to generate an embedding using a specific model.

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/OllamaEmbeddingClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/OllamaEmbeddingClientTest.kt
@@ -1,0 +1,111 @@
+package ai.koog.prompt.executor.ollama.client
+
+import ai.koog.prompt.executor.ollama.client.dto.EmbeddingBatchRequestDTO
+import ai.koog.prompt.executor.ollama.client.dto.EmbeddingRequestDTO
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.TextContent
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OllamaEmbeddingClientTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    @Test
+    fun `embed one string supports current api embed response`() = runTest {
+        var requestPath: String? = null
+        var requestBody: EmbeddingRequestDTO? = null
+
+        val mockEngine = MockEngine { request ->
+            requestPath = request.url.encodedPath.removePrefix("/")
+            requestBody = request.extractSingleEmbeddingRequestBody()
+            respond(
+                """
+                {
+                  "model": "nomic-embed-text",
+                  "embeddings": [[0.1, 0.2, 0.3]]
+                }
+                """.trimIndent(),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()))
+            )
+        }
+        val client = OllamaClient(baseClient = HttpClient(mockEngine))
+
+        val embedding = client.embed("sample", OllamaModels.Embeddings.NOMIC_EMBED_TEXT)
+
+        assertEquals("api/embed", requestPath)
+        assertEquals(EmbeddingRequestDTO(model = "nomic-embed-text", input = "sample"), requestBody)
+        assertEquals(listOf(0.1, 0.2, 0.3), embedding)
+    }
+
+    @Test
+    fun `embed one string supports legacy api embeddings response`() = runTest {
+        val mockEngine = MockEngine {
+            respond(
+                """
+                {
+                  "embedding": [0.4, 0.5, 0.6]
+                }
+                """.trimIndent(),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()))
+            )
+        }
+        val client = OllamaClient(baseClient = HttpClient(mockEngine))
+
+        val embedding = client.embed("sample", OllamaModels.Embeddings.NOMIC_EMBED_TEXT)
+
+        assertEquals(listOf(0.4, 0.5, 0.6), embedding)
+    }
+
+    @Test
+    fun `embed list keeps batch response shape`() = runTest {
+        var requestBody: EmbeddingBatchRequestDTO? = null
+
+        val mockEngine = MockEngine { request ->
+            requestBody = request.extractBatchEmbeddingRequestBody()
+            respond(
+                """
+                {
+                  "model": "nomic-embed-text",
+                  "embeddings": [[1.0, 2.0], [3.0, 4.0]]
+                }
+                """.trimIndent(),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()))
+            )
+        }
+        val client = OllamaClient(baseClient = HttpClient(mockEngine))
+
+        val embeddings = client.embed(listOf("one", "two"), OllamaModels.Embeddings.NOMIC_EMBED_TEXT)
+
+        assertEquals(
+            EmbeddingBatchRequestDTO(model = "nomic-embed-text", input = listOf("one", "two")),
+            requestBody
+        )
+        assertEquals(listOf(listOf(1.0, 2.0), listOf(3.0, 4.0)), embeddings)
+    }
+
+    private fun HttpRequestData.extractSingleEmbeddingRequestBody(): EmbeddingRequestDTO {
+        val requestContent = body as TextContent
+        return json.decodeFromString(requestContent.text)
+    }
+
+    private fun HttpRequestData.extractBatchEmbeddingRequestBody(): EmbeddingBatchRequestDTO {
+        val requestContent = body as TextContent
+        return json.decodeFromString(requestContent.text)
+    }
+}


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

Fix Ollama embeddings compatibility with both current and legacy API response formats.

<!-- Include references to related issues below, e.g., closes #1, closes KG-1. Otherwise, delete it. -->
closes #1874 
