### PR TITLE
fix(prompt): accept text/plain Content-Type on Ollama non-streaming responses

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -151,6 +151,10 @@ public class OllamaClient @JvmOverloads constructor(
         }
         install(ContentNegotiation) {
             json(ollamaJson)
+            // Ollama sometimes returns non-streaming responses with `Content-Type: text/plain`
+            // (see https://github.com/JetBrains/koog/issues/1237). Register the same JSON
+            // deserializer for that content type so the body is still parsed correctly.
+            json(ollamaJson, ContentType.Text.Plain)
         }
         install(HttpTimeout) {
             requestTimeoutMillis = timeoutConfig.requestTimeoutMillis

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/MockOllamaChatServer.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/MockOllamaChatServer.kt
@@ -12,6 +12,7 @@ import io.ktor.http.headersOf
 import kotlinx.serialization.json.Json
 
 internal class MockOllamaChatServer(
+    private val contentType: String = "application/json",
     private val handler: (OllamaChatRequestDTO) -> OllamaChatResponseDTO,
 ) {
     val mockEngine = MockEngine.Companion { requestData ->
@@ -20,7 +21,7 @@ internal class MockOllamaChatServer(
         respond(
             content = Json.encodeToString<OllamaChatResponseDTO>(response),
             status = HttpStatusCode.Companion.OK,
-            headers = headersOf(HttpHeaders.ContentType to listOf("application/json")),
+            headers = headersOf(HttpHeaders.ContentType to listOf(contentType)),
         )
     }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/OllamaContentTypeTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/OllamaContentTypeTest.kt
@@ -1,0 +1,44 @@
+package ai.koog.prompt.executor.ollama.client
+
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.ollama.client.dto.OllamaChatMessageDTO
+import ai.koog.prompt.executor.ollama.client.dto.OllamaChatResponseDTO
+import ai.koog.prompt.message.Message
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+/**
+ * Regression tests for https://github.com/JetBrains/koog/issues/1237.
+ *
+ * Ollama can reply to a non-streaming chat request with `Content-Type: text/plain; charset=utf-8`
+ * even though the body is valid JSON. The client must still be able to deserialize such responses.
+ */
+class OllamaContentTypeTest {
+
+    @Test
+    fun `test non-streaming chat response with text-plain content type is parsed`() = runTest {
+        val responseContent = "Hello from Ollama"
+
+        val mockServer = MockOllamaChatServer(contentType = "text/plain; charset=utf-8") { request ->
+            OllamaChatResponseDTO(
+                model = request.model,
+                message = OllamaChatMessageDTO(role = "assistant", content = responseContent),
+                done = true
+            )
+        }
+
+        val ollamaClient = OllamaClient(baseClient = HttpClient(mockServer.mockEngine))
+
+        val responses = ollamaClient.execute(
+            prompt = prompt("test") { user("Hi") },
+            model = OllamaModels.Meta.LLAMA_3_2
+        )
+
+        assertEquals(1, responses.size)
+        val assistant = assertIs<Message.Assistant>(responses.first())
+        assertEquals(responseContent, assistant.content)
+    }
+}


### PR DESCRIPTION
Ollama sometimes replies to non-streaming `/api/chat` requests with `Content-Type: text/plain; charset=utf-8` even though the body is valid JSON. Ktor's `ContentNegotiation` plugin was only registered for `application/json`, so the response failed with `NoTransformationFoundException` before reaching `OllamaChatResponseDTO`.

### Change
Register the same JSON deserializer for `text/plain` alongside `application/json` in the Ollama client's `ContentNegotiation` config. Streaming responses are unaffected — they read the body as a raw channel and bypass content negotiation.

### Test
- Extended `MockOllamaChatServer` to allow overriding the response `Content-Type`.
- Added `OllamaContentTypeTest` that sends a `text/plain; charset=utf-8` reply and asserts the body is still parsed into an assistant message. The test fails on `develop` without the fix and passes with it.

closes #1237