### PR TITLE
fix(prompt): return tool calls ahead of assistant message in OllamaClient

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -285,7 +285,7 @@ public class OllamaClient @JvmOverloads constructor(
                     content = content,
                     metaInfo = responseMetadata
                 )
-                listOf(assistantMessage) + toolCallMessages
+                toolCallMessages + listOf(assistantMessage)
             }
         }
     }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClientTest.kt
@@ -1,0 +1,64 @@
+package ai.koog.prompt.executor.ollama.client
+
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.ollama.client.dto.OllamaChatMessageDTO
+import ai.koog.prompt.executor.ollama.client.dto.OllamaChatResponseDTO
+import ai.koog.prompt.executor.ollama.client.dto.OllamaToolCallDTO
+import ai.koog.prompt.message.Message
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class OllamaClientTest {
+
+    @Test
+    fun testExecuteWithContentAndToolCalls() = runTest {
+        val responseContent = "I will check the weather for you."
+        val toolName = "get_weather"
+        val toolArgs = JsonObject(mapOf("city" to JsonPrimitive("London")))
+
+        val mockServer = MockOllamaChatServer { request ->
+            OllamaChatResponseDTO(
+                model = request.model,
+                message = OllamaChatMessageDTO(
+                    role = "assistant",
+                    content = responseContent,
+                    toolCalls = listOf(
+                        OllamaToolCallDTO(
+                            function = OllamaToolCallDTO.Call(
+                                name = toolName,
+                                arguments = toolArgs
+                            )
+                        )
+                    )
+                ),
+                done = true
+            )
+        }
+
+        val ollamaClient = OllamaClient(
+            baseClient = HttpClient(mockServer.mockEngine)
+        )
+
+        val responses = ollamaClient.execute(
+            prompt = prompt("test") { },
+            model = OllamaModels.Meta.LLAMA_3_2
+        )
+
+        assertEquals(2, responses.size)
+
+        // tool call should come first and message second
+        val toolCallMessage = responses[0]
+        assertTrue(toolCallMessage is Message.Tool.Call)
+        assertEquals(toolName, toolCallMessage.tool)
+        assertTrue(toolCallMessage.content.contains("London"))
+
+        val assistantMessage = responses[1]
+        assertTrue(assistantMessage is Message.Assistant)
+        assertEquals(responseContent, assistantMessage.content)
+    }
+}


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

When a model responds with tool calls and a text message at the same time, the OllamaClient returns the message first, followed by the tool calls. 
This causes built-in strategies to terminate without executing the tool calls since they terminate as soon as the first non-reasoning response is a text message.
The simple solution is to return tool calls before the content message, which is consistent with what the OpenAIClient does.

<!-- Include BREAKING section below only if this PR introduces breaking changes. Otherwise, delete it. -->

<!-- Include DEPRECATED section below only if this PR deprecates any public APIs. Otherwise, delete it. -->

<!-- Include references to related issues below, e.g., closes #1, closes KG-1. Otherwise, delete it. -->
closes KG-811
