### PR TITLE
fix(agents): KG-751 align JVM AIAgentConfig builder default serializer with common default

### DIFF
--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/config/AIAgentConfig.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/config/AIAgentConfig.kt
@@ -6,7 +6,7 @@ import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.processor.ResponseProcessor
 import ai.koog.serialization.JSONSerializer
-import ai.koog.serialization.jackson.JacksonSerializer
+import ai.koog.serialization.kotlinx.KotlinxSerializer
 import java.util.concurrent.ExecutorService
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "MissingKDocForPublicAPI")
@@ -47,7 +47,7 @@ public actual class AIAgentConfig actual constructor(
         missingToolsConversionStrategy: MissingToolsConversionStrategy =
             MissingToolsConversionStrategy.Missing(ToolCallDescriber.JSON),
         responseProcessor: ResponseProcessor? = null,
-        serializer: JSONSerializer = JacksonSerializer()
+        serializer: JSONSerializer = KotlinxSerializer()
     ) : this(prompt, model, maxAgentIterations, missingToolsConversionStrategy, responseProcessor, serializer) {
         this.strategyExecutorService = agentStrategyExecutorService
         this.llmRequestExecutorService = llmRequestExecutorService
@@ -130,10 +130,11 @@ public actual class AIAgentConfig actual constructor(
             public var responseProcessor: ResponseProcessor? = null,
             internal var strategyExecutorService: ExecutorService? = null,
             internal var llmRequestExecutorService: ExecutorService? = null,
-            internal var serializer: JSONSerializer = JacksonSerializer()
+            internal var serializer: JSONSerializer? = null
         ) {
             /**
-             * Sets serializer for underlying tool calls and LLM requests
+             * Sets serializer for underlying tool calls and LLM requests.
+             * If not called, the default from [AIAgentConfig] is used (kotlinx serialization).
              *
              * @param serializer The JSON serializer to configure the AI agent with.
              * @return The updated instance of [Companion.AIAgentConfigBuilder]
@@ -204,17 +205,22 @@ public actual class AIAgentConfig actual constructor(
              *
              * @return a fully constructed and validated [AIAgentConfig] instance
              */
-            public fun build(): AIAgentConfig = AIAgentConfig(
-                model = model,
-                prompt = prompt ?: Prompt.Empty,
-                maxAgentIterations = maxAgentIterations ?: 100,
-                missingToolsConversionStrategy = missingToolsConversionStrategy
-                    ?: MissingToolsConversionStrategy.Missing(ToolCallDescriber.JSON),
-                responseProcessor = responseProcessor,
-                agentStrategyExecutorService = strategyExecutorService,
-                llmRequestExecutorService = llmRequestExecutorService,
-                serializer = serializer
-            )
+            public fun build(): AIAgentConfig {
+                // Construct without serializer so the constructor default (KotlinxSerializer)
+                // is used when the caller never called .serializer(...). This keeps the default
+                // in one place — the secondary constructor — rather than duplicating it here.
+                val config = AIAgentConfig(
+                    model = model,
+                    prompt = prompt ?: Prompt.Empty,
+                    maxAgentIterations = maxAgentIterations ?: 100,
+                    missingToolsConversionStrategy = missingToolsConversionStrategy
+                        ?: MissingToolsConversionStrategy.Missing(ToolCallDescriber.JSON),
+                    responseProcessor = responseProcessor,
+                    agentStrategyExecutorService = strategyExecutorService,
+                    llmRequestExecutorService = llmRequestExecutorService,
+                )
+                return serializer?.let { config.copy(serializer = it) } ?: config
+            }
         }
     }
 }

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/JavaAPIAgentBuilderTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/JavaAPIAgentBuilderTest.kt
@@ -13,6 +13,7 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import org.junit.jupiter.api.Test
 import java.util.concurrent.Executors
 import kotlin.test.assertNotNull
@@ -40,6 +41,19 @@ class JavaAPIAgentBuilderTest {
         // Test that AIAgent.builder() static method is accessible
         val builder = AIAgent.builder()
         builder.shouldNotBeNull()
+    }
+
+    @Test
+    fun testAIAgentConfigBuilderDefaultsToKotlinxSerializer() {
+        // KG-751: builder() must default to KotlinxSerializer, not JacksonSerializer,
+        // so that KSerializerTypeToken-based tool arg decoding works out of the box.
+        val config = AIAgentConfig.builder()
+            .model(OpenAIModels.Chat.GPT4o)
+            .prompt(builder("test").system("sys").build())
+            .maxAgentIterations(10)
+            .build()
+
+        config.serializer.shouldBeInstanceOf<KotlinxSerializer>()
     }
 
     @Test


### PR DESCRIPTION
## Summary

- The JVM `AIAgentConfig` builder initialised `serializer` with `JacksonSerializer()`, diverging from the `commonMain` `expect` default (`KotlinxSerializer()`)
- Callers using `AIAgentConfig.builder()...build()` without `.serializer(...)` got `KSerializerTypeToken is not supported for JacksonSerializer` when tools used `@Serializable` arg types
- Root fix: **single source of truth** — the JVM secondary constructor default is `KotlinxSerializer()` (matching the `expect` declaration); the builder field is now nullable so `build()` defers to the constructor default rather than duplicating it

## Design

Before: builder duplicated the default serializer, which diverged:
```kotlin
// Builder had its own hardcoded default — diverged from constructor
internal var serializer: JSONSerializer = JacksonSerializer()  // BUG
```

After: builder field is null = "caller didn't set one", `build()` defers to the constructor:
```kotlin
internal var serializer: JSONSerializer? = null  // no duplicated default

public fun build(): AIAgentConfig {
    val config = AIAgentConfig(/* no serializer arg → uses constructor default KotlinxSerializer */)
    return serializer?.let { config.copy(serializer = it) } ?: config
}
```

If the common default ever changes, only the secondary constructor needs updating — the builder automatically picks it up.

## What changed

- `AIAgentConfig.kt` (jvmCommonMain): secondary constructor default changed to `KotlinxSerializer()`; builder field made nullable; `build()` no longer passes `serializer` unless explicitly set by caller
- `JavaAPIAgentBuilderTest.kt`: regression test `testAIAgentConfigBuilderDefaultsToKotlinxSerializer` asserts the default is `KotlinxSerializer` without any `.serializer(...)` call

## Test plan

- [x] `testAIAgentConfigBuilderDefaultsToKotlinxSerializer` — passes  
- [x] All existing `JavaAPIAgentBuilderTest` tests — passing

closes https://youtrack.jetbrains.com/issue/KG-751