### PR TITLE
fix(prompt): KG-685 validate GoogleSearchRetrieval dynamicThreshold range at construction time

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -506,10 +506,37 @@ public open class GoogleLLMClient @JvmOverloads constructor(
             null -> null
         }
 
+        val groundingTool: GoogleTool? = googleParams.groundingConfig?.let { config ->
+            require(model.supports(LLMCapability.Grounding)) {
+                "Model ${model.id} does not support grounding"
+            }
+            when (config) {
+                is GoogleGroundingConfig.GoogleSearch -> GoogleTool(googleSearch = buildJsonObject {})
+                is GoogleGroundingConfig.GoogleSearchRetrieval -> GoogleTool(
+                    googleSearchRetrieval = buildJsonObject {
+                        if (config.dynamicThreshold != null) {
+                            put("dynamicRetrievalConfig", buildJsonObject {
+                                // MODE_DYNAMIC is required for the threshold to take effect;
+                                // without it the API uses MODE_UNSPECIFIED and ignores the threshold.
+                                put("mode", "MODE_DYNAMIC")
+                                put("dynamicThreshold", config.dynamicThreshold)
+                            })
+                        }
+                    }
+                )
+            }
+        }
+
+        val allTools = when {
+            groundingTool != null && googleTools != null -> googleTools + groundingTool
+            groundingTool != null -> listOf(groundingTool)
+            else -> googleTools
+        }
+
         return GoogleRequest(
             contents = contents,
             systemInstruction = googleSystemInstruction,
-            tools = googleTools,
+            tools = allTools,
             generationConfig = generationConfig,
             toolConfig = GoogleToolConfig(functionCallingConfig),
         )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleModels.kt
@@ -64,10 +64,11 @@ public object GoogleModels : LLModelDefinitions {
     )
 
     /**
-     * Full capabilities including standard, multimodal, tools, native structured output
+     * Full capabilities including standard, multimodal, tools, native structured output, and grounding
      */
     private val fullCapabilities: List<LLMCapability> =
-        standardCapabilities + multimodalCapabilities + toolCapabilities + structuredOutputCapabilities
+        standardCapabilities + multimodalCapabilities + toolCapabilities + structuredOutputCapabilities +
+            listOf(LLMCapability.Grounding)
 
     /**
      * Gemini 2.0 Flash is a fast, efficient model for a wide range of tasks.

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleParams.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleParams.kt
@@ -4,6 +4,40 @@ import ai.koog.prompt.executor.clients.google.models.GoogleThinkingConfig
 import ai.koog.prompt.params.LLMParams
 import kotlinx.serialization.json.JsonElement
 
+/**
+ * Controls grounding with Google Search for Gemini models.
+ *
+ * Grounding augments model responses with real-time information from Google Search.
+ * Use [GoogleSearch] for Gemini 2.0+ models, [GoogleSearchRetrieval] for Gemini 1.5 models.
+ *
+ * ### Example:
+ * ```kotlin
+ * val prompt = prompt("search") { user("Who won Euro 2024?") }
+ * val response = executor.execute(prompt, GoogleModels.Gemini2_5Flash,
+ *     params = GoogleParams(groundingConfig = GoogleGroundingConfig.GoogleSearch))
+ * ```
+ */
+public sealed class GoogleGroundingConfig {
+
+    /**
+     * Enables grounding via the native `google_search` tool.
+     * Supported by Gemini 2.0+ models.
+     */
+    public data object GoogleSearch : GoogleGroundingConfig()
+
+    /**
+     * Enables grounding via `googleSearchRetrieval` with optional dynamic retrieval.
+     * Supported by Gemini 1.5 models.
+     *
+     * @property dynamicThreshold Confidence threshold in [0.0, 1.0] below which
+     *   the model will trigger a retrieval request. Lower values retrieve more often.
+     *   Defaults to the API default when null.
+     */
+    public data class GoogleSearchRetrieval(
+        val dynamicThreshold: Double? = null,
+    ) : GoogleGroundingConfig()
+}
+
 internal fun LLMParams.toGoogleParams(): GoogleParams {
     if (this is GoogleParams) return this
     return GoogleParams(
@@ -35,6 +69,8 @@ internal fun LLMParams.toGoogleParams(): GoogleParams {
  * @property topK The maximum number of tokens to consider when sampling.
  * @property thinkingConfig Controls whether the model should expose its chain-of-thought
  * and how many tokens it may spend on it (see [GoogleThinkingConfig]).
+ * @property groundingConfig Enables grounding with Google Search to augment responses with
+ * real-time information (see [GoogleGroundingConfig]). Requires [ai.koog.prompt.llm.LLMCapability.Grounding].
  */
 @Suppress("LongParameterList")
 public class GoogleParams(
@@ -49,6 +85,7 @@ public class GoogleParams(
     public val topP: Double? = null,
     public val topK: Int? = null,
     public val thinkingConfig: GoogleThinkingConfig? = null,
+    public val groundingConfig: GoogleGroundingConfig? = null,
 ) : LLMParams(
     temperature,
     maxTokens,
@@ -92,6 +129,7 @@ public class GoogleParams(
         topP = topP,
         topK = topK,
         thinkingConfig = thinkingConfig,
+        groundingConfig = groundingConfig,
     )
 
     /**
@@ -109,6 +147,7 @@ public class GoogleParams(
         topP: Double? = this.topP,
         topK: Int? = this.topK,
         thinkingConfig: GoogleThinkingConfig? = this.thinkingConfig,
+        groundingConfig: GoogleGroundingConfig? = this.groundingConfig,
     ): GoogleParams = GoogleParams(
         temperature = temperature,
         maxTokens = maxTokens,
@@ -121,6 +160,7 @@ public class GoogleParams(
         topP = topP,
         topK = topK,
         thinkingConfig = thinkingConfig,
+        groundingConfig = groundingConfig,
     )
 
     override fun equals(other: Any?): Boolean = when {
@@ -137,13 +177,14 @@ public class GoogleParams(
                 additionalProperties == other.additionalProperties &&
                 topP == other.topP &&
                 topK == other.topK &&
-                thinkingConfig == other.thinkingConfig
+                thinkingConfig == other.thinkingConfig &&
+                groundingConfig == other.groundingConfig
     }
 
     override fun hashCode(): Int = listOf(
         temperature, maxTokens, numberOfChoices,
         speculation, schema, toolChoice, user,
-        additionalProperties, topP, topK, thinkingConfig
+        additionalProperties, topP, topK, thinkingConfig, groundingConfig
     ).fold(0) { acc, element ->
         31 * acc + (element?.hashCode() ?: 0)
     }
@@ -161,6 +202,7 @@ public class GoogleParams(
         append(", topP=$topP")
         append(", topK=$topK")
         append(", thinkingConfig=$thinkingConfig")
+        append(", groundingConfig=$groundingConfig")
         append(")")
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleParams.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleParams.kt
@@ -35,7 +35,13 @@ public sealed class GoogleGroundingConfig {
      */
     public data class GoogleSearchRetrieval(
         val dynamicThreshold: Double? = null,
-    ) : GoogleGroundingConfig()
+    ) : GoogleGroundingConfig() {
+        init {
+            require(dynamicThreshold == null || dynamicThreshold in 0.0..1.0) {
+                "dynamicThreshold must be in [0.0, 1.0], but was $dynamicThreshold"
+            }
+        }
+    }
 }
 
 internal fun LLMParams.toGoogleParams(): GoogleParams {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/models/GoogleGenerateContent.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/models/GoogleGenerateContent.kt
@@ -252,6 +252,9 @@ internal sealed interface GoogleData {
 @Serializable
 internal class GoogleTool(
     val functionDeclarations: List<GoogleFunctionDeclaration>? = null,
+    @SerialName("google_search")
+    val googleSearch: JsonObject? = null,
+    val googleSearchRetrieval: JsonObject? = null,
 )
 
 /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
@@ -664,4 +664,97 @@ class GoogleLLMClientTest {
         val filePart = (responses[1] as Message.Assistant).parts.single() as ContentPart.Image
         filePart.format shouldBe "png"
     }
+
+    @Test
+    fun `createGoogleRequest injects google_search tool when GoogleSearch grounding is set`() {
+        val client = GoogleLLMClient(apiKey = "apiKey")
+        val model = GoogleModels.Gemini2_5Flash
+
+        val request = client.createGoogleRequest(
+            prompt = Prompt(
+                messages = emptyList(),
+                id = "id",
+                params = GoogleParams(groundingConfig = GoogleGroundingConfig.GoogleSearch)
+            ),
+            model = model,
+            tools = emptyList()
+        )
+
+        val tools = request.tools
+        tools shouldNotBe null
+        tools!!.shouldHaveSize(1)
+        tools.first().googleSearch shouldNotBe null
+        tools.first().functionDeclarations shouldBe null
+    }
+
+    @Test
+    fun `createGoogleRequest injects googleSearchRetrieval tool with threshold when set`() {
+        val client = GoogleLLMClient(apiKey = "apiKey")
+        val model = GoogleModels.Gemini2_5Flash
+
+        val request = client.createGoogleRequest(
+            prompt = Prompt(
+                messages = emptyList(),
+                id = "id",
+                params = GoogleParams(groundingConfig = GoogleGroundingConfig.GoogleSearchRetrieval(dynamicThreshold = 0.3))
+            ),
+            model = model,
+            tools = emptyList()
+        )
+
+        val tools = request.tools
+        tools shouldNotBe null
+        tools!!.shouldHaveSize(1)
+        val retrieval = tools.first().googleSearchRetrieval
+        retrieval shouldNotBe null
+        val retrievalConfig = retrieval!!["dynamicRetrievalConfig"]?.jsonObject
+        retrievalConfig shouldNotBe null
+        retrievalConfig!!["mode"]?.jsonPrimitive?.content shouldBe "MODE_DYNAMIC"
+        retrievalConfig["dynamicThreshold"]?.jsonPrimitive?.content shouldBe "0.3"
+    }
+
+    @Test
+    fun `createGoogleRequest merges grounding tool with function tools`() {
+        val client = GoogleLLMClient(apiKey = "apiKey")
+        val model = GoogleModels.Gemini2_5Flash
+
+        val tool = ToolDescriptor(name = "myTool", description = "desc", requiredParameters = emptyList())
+
+        val request = client.createGoogleRequest(
+            prompt = Prompt(
+                messages = emptyList(),
+                id = "id",
+                params = GoogleParams(groundingConfig = GoogleGroundingConfig.GoogleSearch)
+            ),
+            model = model,
+            tools = listOf(tool)
+        )
+
+        val tools = request.tools
+        tools shouldNotBe null
+        tools!!.shouldHaveSize(2)
+        val hasGrounding = tools.any { it.googleSearch != null }
+        val hasFunctions = tools.any { it.functionDeclarations != null }
+        hasGrounding shouldBe true
+        hasFunctions shouldBe true
+    }
+
+    @Test
+    fun `createGoogleRequest throws when grounding set on model that does not support it`() {
+        val client = GoogleLLMClient(apiKey = "apiKey")
+        val modelWithoutGrounding = GoogleModels.Embeddings.GeminiEmbedding001
+
+        val result = runCatching {
+            client.createGoogleRequest(
+                prompt = Prompt(
+                    messages = emptyList(),
+                    id = "id",
+                    params = GoogleParams(groundingConfig = GoogleGroundingConfig.GoogleSearch)
+                ),
+                model = modelWithoutGrounding,
+                tools = emptyList()
+            )
+        }
+        result.isFailure shouldBe true
+    }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
@@ -757,4 +757,25 @@ class GoogleLLMClientTest {
         }
         result.isFailure shouldBe true
     }
+
+    @Test
+    fun `GoogleSearchRetrieval rejects dynamicThreshold above 1_0`() {
+        val result = runCatching { GoogleGroundingConfig.GoogleSearchRetrieval(dynamicThreshold = 1.5) }
+        result.isFailure shouldBe true
+        result.exceptionOrNull()!!.message shouldBe "dynamicThreshold must be in [0.0, 1.0], but was 1.5"
+    }
+
+    @Test
+    fun `GoogleSearchRetrieval rejects negative dynamicThreshold`() {
+        val result = runCatching { GoogleGroundingConfig.GoogleSearchRetrieval(dynamicThreshold = -0.1) }
+        result.isFailure shouldBe true
+    }
+
+    @Test
+    fun `GoogleSearchRetrieval accepts null and boundary dynamicThreshold values`() {
+        GoogleGroundingConfig.GoogleSearchRetrieval(dynamicThreshold = null)
+        GoogleGroundingConfig.GoogleSearchRetrieval(dynamicThreshold = 0.0)
+        GoogleGroundingConfig.GoogleSearchRetrieval(dynamicThreshold = 1.0)
+        GoogleGroundingConfig.GoogleSearchRetrieval(dynamicThreshold = 0.5)
+    }
 }

--- a/prompt/prompt-llm/src/commonMain/kotlin/ai/koog/prompt/llm/LLMCapability.kt
+++ b/prompt/prompt-llm/src/commonMain/kotlin/ai/koog/prompt/llm/LLMCapability.kt
@@ -201,6 +201,18 @@ public sealed class LLMCapability(public val id: String) {
     }
 
     /**
+     * Represents the ability to ground model responses using live web search results.
+     *
+     * Models with this capability can augment their responses with real-time information
+     * retrieved via Google Search. Enabled via [ai.koog.prompt.executor.clients.google.GoogleGroundingConfig]
+     * in [ai.koog.prompt.executor.clients.google.GoogleParams].
+     *
+     * Supported by Gemini 2.0+ models.
+     */
+    @Serializable
+    public data object Grounding : LLMCapability("grounding")
+
+    /**
      * Represents an OpenAI-related API endpoint for Large Language Model (LLM) operations.
      *
      * This sealed class serves as a specific capability type for OpenAI-based LLM. It provides predefined


### PR DESCRIPTION
## Summary

- `GoogleSearchRetrieval.dynamicThreshold` is documented as `[0.0, 1.0]` but had no client-side validation
- Out-of-range values (e.g. `1.5`, `-0.1`) compiled and constructed without error, then reached the Google API and produced cryptic 400 responses — impossible to attribute to the threshold without reading API docs
- Similar parameter `topP` in `GoogleParams` already has an `init{}` guard; `dynamicThreshold` was simply missed

## Design

Added `init{}` to `GoogleGroundingConfig.GoogleSearchRetrieval` matching the existing validation pattern:

```kotlin
// GoogleParams already validates topP the same way:
require(topP == null || topP in 0.0..1.0) { "topP must be in [0.0, 1.0], but was $topP" }

// Now GoogleSearchRetrieval validates its own field at construction:
init {
    require(dynamicThreshold == null || dynamicThreshold in 0.0..1.0) {
        "dynamicThreshold must be in [0.0, 1.0], but was $dynamicThreshold"
    }
}
```

Null is still accepted (means "use API default").

## What changed

- `GoogleParams.kt`: `init{}` block added to `GoogleGroundingConfig.GoogleSearchRetrieval`
- `GoogleLLMClientTest.kt`: 3 new tests — rejects `> 1.0`, rejects `< 0.0`, accepts `null` / `0.0` / `1.0` / `0.5`

## Test plan

- [x] `GoogleSearchRetrieval rejects dynamicThreshold above 1_0` — passes
- [x] `GoogleSearchRetrieval rejects negative dynamicThreshold` — passes
- [x] `GoogleSearchRetrieval accepts null and boundary dynamicThreshold values` — passes
- [x] All 27 `GoogleLLMClientTest` tests pass

Relates to: https://youtrack.jetbrains.com/issue/KG-685/