### PR TITLE
feat(prompt): extend model range for bedrock

### DIFF
--- a/docs/docs/model-capabilities.md
+++ b/docs/docs/model-capabilities.md
@@ -541,31 +541,31 @@ In the tables below:
 
     ##### Moonshot Kimi (Converse-only)
 
-    | Model                  | Temperature | JSON Schema | Completion | Tools | Tool Choice | Vision (Image) |
-    |------------------------|-------------|-------------|------------|-------|-------------|----------------|
-    | MoonshotKimiK2_5 **(C)** | ✓        | -           | ✓          | ✓     | ✓           | ✓              |
-    | MoonshotKimiK2Thinking **(C)** | ✓  | -           | ✓          | ✓     | ✓           | -              |
+    | Model                          | Temperature | JSON Schema | Completion | Tools | Tool Choice | Vision (Image) | Document |
+    |--------------------------------|-------------|-------------|------------|-------|-------------|----------------|----------|
+    | MoonshotKimiK2_5 **(C)**       | ✓           | -           | ✓          | ✓     | ✓           | ✓              | -        |
+    | MoonshotKimiK2Thinking **(C)** | ✓           | -           | ✓          | ✓     | ✓           | -              | -        |
 
     ##### MiniMax (Converse-only)
 
-    | Model              | Temperature | JSON Schema | Completion | Tools | Tool Choice | Vision (Image) |
-    |--------------------|-------------|-------------|------------|-------|-------------|----------------|
-    | MiniMaxM2_5 **(C)**| ✓           | -           | ✓          | ✓     | ✓           | -              |
+    | Model               | Temperature | JSON Schema | Completion | Tools | Tool Choice | Vision (Image) | Document |
+    |---------------------|-------------|-------------|------------|-------|-------------|----------------|----------|
+    | MiniMaxM2_5 **(C)** | ✓           | -           | ✓          | ✓     | ✓           | -              | -        |
 
     ##### OpenAI GPT-OSS (Converse-only)
 
-    | Model                    | Temperature | JSON Schema | Completion | Tools | Tool Choice | Vision (Image) |
-    |--------------------------|-------------|-------------|------------|-------|-------------|----------------|
-    | OpenAIGptOss120B **(C)** | ✓           | Full        | ✓          | ✓     | ✓           | -              |
-    | OpenAIGptOss20B **(C)**  | ✓           | Full        | ✓          | ✓     | ✓           | -              |
+    | Model                    | Temperature | JSON Schema | Completion | Tools | Tool Choice | Vision (Image) | Document |
+    |--------------------------|-------------|-------------|------------|-------|-------------|----------------|----------|
+    | OpenAIGptOss120B **(C)** | ✓           | Full        | ✓          | ✓     | ✓           | -              | -        |
+    | OpenAIGptOss20B **(C)**  | ✓           | Full        | ✓          | ✓     | ✓           | -              | -        |
 
     ##### Google Gemma 3 (Converse-only)
 
     | Model                      | Temperature | JSON Schema | Completion | Tools | Tool Choice | Vision (Image) | Document |
     |----------------------------|-------------|-------------|------------|-------|-------------|----------------|----------|
-    | GoogleGemma3_27bIt **(C)** | ✓           | Full        | ✓          | ✓     | ✓           | ✓              | ✓        |
-    | GoogleGemma3_12bIt **(C)** | ✓           | Full        | ✓          | ✓     | ✓           | ✓              | ✓        |
-    | GoogleGemma3_4bIt **(C)**  | ✓           | -           | ✓          | ✓     | ✓           | ✓              | -        |
+    | GoogleGemma3_27BIt **(C)** | ✓           | Full        | ✓          | ✓     | ✓           | ✓              | ✓        |
+    | GoogleGemma3_12BIt **(C)** | ✓           | Full        | ✓          | ✓     | ✓           | ✓              | ✓        |
+    | GoogleGemma3_4BIt **(C)**  | ✓           | -           | ✓          | ✓     | ✓           | ✓              | -        |
 
     ##### Embedding Models
 

--- a/docs/docs/model-capabilities.md
+++ b/docs/docs/model-capabilities.md
@@ -493,3 +493,86 @@ In the tables below:
     | Gemini2_5FlashLite  | ✓           | Full        | ✓          | ✓           | ✓     | ✓           | ✓              |
     | Gemini2_5Flash      | ✓           | Full        | ✓          | ✓           | ✓     | ✓           | ✓              |
     | Gemini2_5Pro        | ✓           | Full        | ✓          | ✓           | ✓     | ✓           | ✓              |
+
+??? "Bedrock models"
+    #### Bedrock models
+
+    Bedrock models are accessed through AWS Bedrock and use either the InvokeModel or Converse API.
+    Models marked with **(C)** are Converse-only and require `BedrockAPIMethod.Converse`.
+
+    ##### Anthropic Claude (via Bedrock)
+
+    | Model                       | Temperature | JSON Schema | Completion | Tools | Tool Choice | Vision (Image) | Document |
+    |-----------------------------|-------------|-------------|------------|-------|-------------|----------------|----------|
+    | AnthropicClaude47Opus       | ✓           | -           | ✓          | ✓     | ✓           | ✓              | ✓        |
+    | AnthropicClaude46Opus       | ✓           | -           | ✓          | ✓     | ✓           | ✓              | ✓        |
+    | AnthropicClaude45Opus       | ✓           | -           | ✓          | ✓     | ✓           | ✓              | ✓        |
+    | AnthropicClaude41Opus       | ✓           | -           | ✓          | ✓     | ✓           | ✓              | ✓        |
+    | AnthropicClaude4Opus        | ✓           | -           | ✓          | ✓     | ✓           | ✓              | ✓        |
+    | AnthropicClaude4_6Sonnet    | ✓           | -           | ✓          | ✓     | ✓           | ✓              | ✓        |
+    | AnthropicClaude4_5Sonnet    | ✓           | -           | ✓          | ✓     | ✓           | ✓              | ✓        |
+    | AnthropicClaude4Sonnet      | ✓           | -           | ✓          | ✓     | ✓           | ✓              | ✓        |
+    | AnthropicClaude4_5Haiku     | ✓           | -           | ✓          | ✓     | ✓           | ✓              | ✓        |
+    | AnthropicClaude3Haiku       | ✓           | -           | ✓          | ✓     | ✓           | ✓              | ✓        |
+
+    ##### Amazon Nova
+
+    | Model            | Temperature | JSON Schema | Completion | Tools | Tool Choice | Vision (Image) | Document |
+    |------------------|-------------|-------------|------------|-------|-------------|----------------|----------|
+    | AmazonNovaMicro  | ✓           | -           | ✓          | ✓     | -           | -              | -        |
+    | AmazonNovaLite   | ✓           | -           | ✓          | ✓     | -           | -              | -        |
+    | AmazonNovaPro    | ✓           | -           | ✓          | ✓     | -           | -              | -        |
+    | AmazonNovaPremier| ✓           | -           | ✓          | ✓     | -           | -              | -        |
+
+    ##### Meta Llama (via Bedrock)
+
+    | Model                    | Temperature | JSON Schema | Completion | Tools | Tool Choice | Vision (Image) | Document |
+    |--------------------------|-------------|-------------|------------|-------|-------------|----------------|----------|
+    | MetaLlama3_3_70BInstruct | ✓           | -           | ✓          | ✓     | ✓           | -              | -        |
+    | MetaLlama3_2_90BInstruct | ✓           | -           | ✓          | ✓     | ✓           | ✓              | ✓        |
+    | MetaLlama3_2_11BInstruct | ✓           | -           | ✓          | ✓     | ✓           | ✓              | ✓        |
+    | MetaLlama3_2_3BInstruct  | ✓           | -           | ✓          | -     | -           | -              | -        |
+    | MetaLlama3_2_1BInstruct  | ✓           | -           | ✓          | -     | -           | -              | -        |
+    | MetaLlama3_1_405BInstruct| ✓           | -           | ✓          | -     | -           | -              | -        |
+    | MetaLlama3_1_70BInstruct | ✓           | -           | ✓          | -     | -           | -              | -        |
+    | MetaLlama3_1_8BInstruct  | ✓           | -           | ✓          | -     | -           | -              | -        |
+    | MetaLlama3_0_70BInstruct | ✓           | -           | ✓          | -     | -           | -              | -        |
+    | MetaLlama3_0_8BInstruct  | ✓           | -           | ✓          | -     | -           | -              | -        |
+
+    ##### Moonshot Kimi (Converse-only)
+
+    | Model                  | Temperature | JSON Schema | Completion | Tools | Tool Choice | Vision (Image) |
+    |------------------------|-------------|-------------|------------|-------|-------------|----------------|
+    | MoonshotKimiK2_5 **(C)** | ✓        | -           | ✓          | ✓     | ✓           | ✓              |
+    | MoonshotKimiK2Thinking **(C)** | ✓  | -           | ✓          | ✓     | ✓           | -              |
+
+    ##### MiniMax (Converse-only)
+
+    | Model              | Temperature | JSON Schema | Completion | Tools | Tool Choice | Vision (Image) |
+    |--------------------|-------------|-------------|------------|-------|-------------|----------------|
+    | MiniMaxM2_5 **(C)**| ✓           | -           | ✓          | ✓     | ✓           | -              |
+
+    ##### OpenAI GPT-OSS (Converse-only)
+
+    | Model                    | Temperature | JSON Schema | Completion | Tools | Tool Choice | Vision (Image) |
+    |--------------------------|-------------|-------------|------------|-------|-------------|----------------|
+    | OpenAIGptOss120B **(C)** | ✓           | Full        | ✓          | ✓     | ✓           | -              |
+    | OpenAIGptOss20B **(C)**  | ✓           | Full        | ✓          | ✓     | ✓           | -              |
+
+    ##### Google Gemma 3 (Converse-only)
+
+    | Model                      | Temperature | JSON Schema | Completion | Tools | Tool Choice | Vision (Image) | Document |
+    |----------------------------|-------------|-------------|------------|-------|-------------|----------------|----------|
+    | GoogleGemma3_27bIt **(C)** | ✓           | Full        | ✓          | ✓     | ✓           | ✓              | ✓        |
+    | GoogleGemma3_12bIt **(C)** | ✓           | Full        | ✓          | ✓     | ✓           | ✓              | ✓        |
+    | GoogleGemma3_4bIt **(C)**  | ✓           | -           | ✓          | ✓     | ✓           | ✓              | -        |
+
+    ##### Embedding Models
+
+    | Model                      | Embed |
+    |----------------------------|-------|
+    | CohereEmbedV4              | ✓     |
+    | CohereEmbedEnglishV3       | ✓     |
+    | CohereEmbedMultilingualV3  | ✓     |
+    | AmazonTitanEmbedTextV2     | ✓     |
+    | AmazonTitanEmbedText       | ✓     |

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/Module.md
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/Module.md
@@ -6,98 +6,125 @@ comprehensive multimodal support, tool calling, and streaming capabilities.
 ## Overview
 
 This module provides a client implementation for AWS Bedrock, Amazon's fully managed service that offers foundation
-models from leading AI companies including Anthropic, AI21 Labs, Cohere, Meta, Mistral, and Amazon. The client supports
-multimodal content (text and images), tool/function calling, streaming responses, and comprehensive error handling
-across multiple model providers.
+models from leading AI companies including Anthropic, Amazon, Meta, Moonshot AI, MiniMax, OpenAI, Google, and Cohere.
+The client supports multimodal content (text and images), tool/function calling, structured output, streaming responses,
+and comprehensive error handling across multiple model providers via both the InvokeModel and Converse APIs.
 
 ## Supported Models
 
+Models are organized by provider. All models support both the InvokeModel and Converse APIs unless noted.
+Models marked **Converse-only** require `BedrockClientSettings(apiMethod = BedrockAPIMethod.Converse)`.
+
 ### Anthropic Claude Models
 
-| Model           | Speed     | Input Support       | Output Support | Context | Pricing            | Notes                          |
-|-----------------|-----------|---------------------|----------------|---------|--------------------|--------------------------------|
-| Claude 3 Opus   | Medium    | Text, Images, Tools | Text, Tools    | 200K    | $15/$75 per 1M     | Most capable, best for complex |
-| Claude 3 Sonnet | Fast      | Text, Images, Tools | Text, Tools    | 200K    | $3/$15 per 1M      | Balanced performance and cost  |
-| Claude 3 Haiku  | Very Fast | Text, Images, Tools | Text, Tools    | 200K    | $0.25/$1.25 per 1M | Fast and efficient             |
-| Claude 2.1      | Medium    | Text                | Text           | 200K    | $8/$24 per 1M      | Previous gen, extended context |
-| Claude 2.0      | Medium    | Text                | Text           | 100K    | $8/$24 per 1M      | Previous generation            |
-| Claude Instant  | Very Fast | Text                | Text           | 100K    | $0.8/$2.4 per 1M   | Fast, cost-effective           |
+All Claude models support text, images, documents, and tool calling.
 
-### Amazon Titan Models
+| Model                    | Context | Tools | Vision | Structured Output | Notes                       |
+|--------------------------|---------|-------|--------|-------------------|-----------------------------|
+| Claude 4.7 Opus          | 200K    | Yes   | Yes    | Yes               | Latest Opus                 |
+| Claude 4.6 Opus          | 200K    | Yes   | Yes    | Yes               | Frontier model              |
+| Claude 4.5 Opus          | 200K    | Yes   | Yes    | Yes               | Best for coding and agents  |
+| Claude 4.1 Opus          | 200K    | Yes   | Yes    | -                 |                             |
+| Claude 4 Opus            | 200K    | Yes   | Yes    | -                 |                             |
+| Claude 4.6 Sonnet        | 200K    | Yes   | Yes    | Yes               | Speed and intelligence      |
+| Claude 4.5 Sonnet        | 200K    | Yes   | Yes    | Yes               | Enhanced capabilities       |
+| Claude 4 Sonnet          | 200K    | Yes   | Yes    | -                 |                             |
+| Claude 4.5 Haiku         | 200K    | Yes   | Yes    | Yes               | Fast, cost-effective        |
+| Claude 3 Haiku (deprecated) | 200K | Yes   | Yes    | -                 | Use Claude 4.5 Haiku instead |
 
-| Model              | Speed     | Input Support | Output Support | Pricing           | Notes                     |
-|--------------------|-----------|---------------|----------------|-------------------|---------------------------|
-| Titan Text Express | Fast      | Text          | Text           | $0.2/$0.6 per 1M  | Cost-effective, general   |
-| Titan Text Lite    | Very Fast | Text          | Text           | $0.15/$0.2 per 1M | Lightweight, simple tasks |
-| Titan Text Premier | Medium    | Text          | Text           | $0.5/$1.5 per 1M  | Advanced reasoning        |
+### Amazon Nova Models
 
-### AI21 Labs Jurassic Models
-
-| Model            | Speed  | Input Support | Output Support | Pricing            | Notes                  |
-|------------------|--------|---------------|----------------|--------------------|------------------------|
-| Jurassic-2 Ultra | Medium | Text          | Text           | $15/$15 per 1M     | Most powerful, complex |
-| Jurassic-2 Mid   | Fast   | Text          | Text           | $12.5/$12.5 per 1M | Balanced performance   |
-
-### Cohere Models
-
-| Model         | Speed  | Input Support | Output Support | Pricing          | Notes                 |
-|---------------|--------|---------------|----------------|------------------|-----------------------|
-| Command       | Medium | Text          | Text           | $0.75/$2 per 1M  | Instruction following |
-| Command Light | Fast   | Text          | Text           | $0.3/$0.6 per 1M | Lightweight version   |
+| Model         | Context | Tools | Vision | Notes                          |
+|---------------|---------|-------|--------|--------------------------------|
+| Nova Micro    | 128K    | Yes   | -      | Ultra-fast, low-cost           |
+| Nova Lite     | 300K    | Yes   | -      | Balanced performance and cost  |
+| Nova Pro      | 300K    | Yes   | -      | Complex reasoning              |
+| Nova Premier  | 1M      | Yes   | -      | Most capable Amazon model      |
 
 ### Meta Llama Models
 
-| Model                | Speed  | Input Support | Output Support | Pricing            | Notes                   |
-|----------------------|--------|---------------|----------------|--------------------|-------------------------|
-| Llama 3 70B Instruct | Medium | Text          | Text           | $2.65/$3.5 per 1M  | Latest arch, 70B params |
-| Llama 3 8B Instruct  | Fast   | Text          | Text           | $0.3/$0.6 per 1M   | Latest arch, 8B params  |
-| Llama 2 70B Chat     | Medium | Text          | Text           | $1.95/$2.56 per 1M | Dialogue optimized, 70B |
-| Llama 2 13B Chat     | Fast   | Text          | Text           | $0.75/$1 per 1M    | Dialogue optimized, 13B |
+| Model                   | Context | Tools | Vision | Notes                    |
+|-------------------------|---------|-------|--------|--------------------------|
+| Llama 3.3 70B Instruct  | 128K    | Yes   | -      | Latest Llama 3.x         |
+| Llama 3.2 90B Instruct  | 128K    | Yes   | Yes    | Multimodal               |
+| Llama 3.2 11B Instruct  | 128K    | Yes   | Yes    | Multimodal               |
+| Llama 3.2 3B Instruct   | 128K    | -     | -      | Compact                  |
+| Llama 3.2 1B Instruct   | 128K    | -     | -      | Edge deployment          |
+| Llama 3.1 405B Instruct | 128K    | -     | -      | Largest Llama            |
+| Llama 3.1 70B Instruct  | 128K    | -     | -      |                          |
+| Llama 3.1 8B Instruct   | 128K    | -     | -      | Efficient                |
+| Llama 3.0 70B Instruct  | 8K      | -     | -      |                          |
+| Llama 3.0 8B Instruct   | 8K      | -     | -      |                          |
 
-### Mistral Models
+### Moonshot Kimi Models (Converse-only)
 
-| Model         | Speed  | Input Support | Output Support | Pricing           | Notes                       |
-|---------------|--------|---------------|----------------|-------------------|-----------------------------|
-| Mistral Large | Medium | Text, Tools   | Text, Tools    | $4/$12 per 1M     | Most capable, multilingual  |
-| Mixtral 8x7B  | Medium | Text          | Text           | $0.45/$0.7 per 1M | Mixture of experts          |
-| Mistral 7B    | Fast   | Text          | Text           | $0.15/$0.2 per 1M | Efficient, 7B params        |
-| Mistral Small | Fast   | Text          | Text           | $1/$3 per 1M      | Lightweight, cost-effective |
+| Model            | Context | Tools | Vision | Notes                                      |
+|------------------|---------|-------|--------|--------------------------------------------|
+| Kimi K2.5        | 256K    | Yes   | Yes    | Multimodal, dual-mode reasoning             |
+| Kimi K2 Thinking | 256K    | Yes   | -      | Deep reasoning with chain-of-thought traces |
 
-### Moonshot Kimi Models
+### MiniMax Models (Converse-only)
 
-| Model           | Speed  | Input Support | Output Support | Context | Pricing          | Notes                                |
-|-----------------|--------|---------------|----------------|---------|------------------|--------------------------------------|
-| Kimi K2 Thinking| Medium | Text, Tools   | Text, Tools    | 256K    | $0.6/$2.5 per 1M | Deep reasoning, thinking traces      |
+| Model      | Context | Tools | Vision | Notes                                  |
+|------------|---------|-------|--------|----------------------------------------|
+| MiniMax M2.5 | 1M    | Yes   | -      | Agent-native, token-efficient reasoning |
 
-*Pricing shown as Input/Output per 1M tokens
+### OpenAI GPT-OSS Models (Converse-only)
+
+| Model          | Context | Tools | Vision | Structured Output | Notes                        |
+|----------------|---------|-------|--------|-------------------|------------------------------|
+| GPT-OSS 120B   | 128K    | Yes   | -      | Yes               | MoE, 5.1B active per token   |
+| GPT-OSS 20B    | 128K    | Yes   | -      | Yes               | MoE, 3.6B active per token   |
+
+### Google Gemma 3 Models (Converse-only)
+
+| Model            | Context | Tools | Vision | Structured Output | Notes                        |
+|------------------|---------|-------|--------|-------------------|------------------------------|
+| Gemma 3 27B IT   | 128K    | Yes   | Yes    | Yes               | Largest, multimodal          |
+| Gemma 3 12B IT   | 128K    | Yes   | Yes    | Yes               | Multimodal, structured output |
+| Gemma 3 4B IT    | 128K    | Yes   | Yes    | -                 | Compact, edge deployment     |
+
+### Embedding Models
+
+| Model                      | Context | Dimensions | Notes                            |
+|----------------------------|---------|------------|----------------------------------|
+| Cohere Embed v4            | 512     | 1536       | Multimodal, requires inference profile |
+| Cohere Embed English v3    | 8K      | 1024       | English text                     |
+| Cohere Embed Multilingual v3 | 8K    | 1024       | 100+ languages                   |
+| Amazon Titan Embed Text v2 | 8K      | 1024       | Amazon native                    |
+| Amazon Titan Embed Text v1 | 8K      | 1024       | Amazon native                    |
 
 ## Media Content Support
 
-| Content Type | Supported Models        | Formats              | Max Size | Notes                     |
-|--------------|-------------------------|----------------------|----------|---------------------------|
-| Images       | Claude 3 (all variants) | PNG, JPEG, WebP, GIF | 5MB      | Base64 or URL supported   |
-| Audio        | ❌ Not supported         | -                    | -        | No audio models available |
-| Documents    | ❌ Not supported         | -                    | -        | Extract text first        |
-| Video        | ❌ Not supported         | -                    | -        | -                         |
+| Content Type | Supported Models                                          | Formats              | Max Size | Notes                   |
+|--------------|-----------------------------------------------------------|----------------------|----------|-------------------------|
+| Images       | Claude (all), Kimi K2.5, Gemma 3 (all), Llama 3.2 11B/90B | PNG, JPEG, WebP, GIF | 5MB     | Base64 or URL supported |
+| Documents    | Claude (all), Gemma 3 12B/27B                             | PDF                  | -        | Via Converse API        |
+| Audio        | Not supported                                              | -                    | -        |                         |
+| Video        | Not supported                                              | -                    | -        |                         |
 
 **Important Notes:**
 
-- **Images**: Only Claude 3 models support image input
-- **Size limits**: AWS Bedrock enforces a 5MB limit for image data
-- **Tools**: Claude 3, Mistral Large, and Kimi K2 Thinking models support function calling
-- **Streaming**: All models support token streaming
-- **Kimi K2 Thinking**: Requires Bedrock Converse API (`BedrockAPIMethod.Converse`), supports reasoning traces with up to 256K context
+- **Converse-only models**: Kimi, MiniMax, GPT-OSS, and Gemma 3 models require `BedrockAPIMethod.Converse`
+- **Inference profiles**: Cohere Embed v4 requires an inference profile prefix (default: `us.`)
+- **Third-party models**: Kimi, MiniMax, GPT-OSS, and Gemma 3 do not use inference profile prefixes
+- **Tool calling**: Supported by all models except some older Llama variants
+- **Streaming**: All models support token streaming via both InvokeModel and Converse APIs
 
 ## Features
 
-- **Multi-Model Support**: Access to models from multiple providers through a single API
-- **Tool/Function Calling**: Supported for Claude 3 and Mistral Large models
+- **Multi-Model Support**: Access to 30+ models from 8 providers through a single API
+- **Dual API Support**: Both InvokeModel (provider-specific) and Converse (unified) APIs
+- **Tool/Function Calling**: Supported across Claude, Nova, Llama 3.3, Kimi, MiniMax, GPT-OSS, and Gemma 3 models
+- **Structured Output**: JSON Schema-constrained output for GPT-OSS and Gemma 3 12B/27B models
 - **Streaming Responses**: Real-time token streaming for all supported models
-- **Multimodal Input**: Image support for Claude 3 models
+- **Multimodal Input**: Image support for Claude, Kimi K2.5, Gemma 3, and Llama 3.2 11B/90B models
+- **Embeddings**: Text embedding via Titan, Cohere v3, and Cohere v4 models
+- **Prompt Caching**: Cache control support for reduced latency and cost
 - **Kotlin Multiplatform**: Works on JVM and Android (JS/Native not supported due to AWS SDK limitations)
 - **Comprehensive Error Handling**: Model-specific error messages and validation
-- **Token Usage Tracking**: Detailed token consumption metrics
-- **Region Support**: Available across multiple AWS regions
+- **Token Usage Tracking**: Detailed token consumption metrics including cache hit/miss
+- **Region Support**: Available across multiple AWS regions with inference profile routing
 
 ## Installation
 
@@ -147,7 +174,7 @@ suspend fun main() {
             system("You are a helpful assistant")
             user("What is the capital of France?")
         },
-        model = BedrockModels.AnthropicClaude3Sonnet
+        model = BedrockModels.AnthropicClaude4Sonnet
     )
 
     println(response.first().content)
@@ -159,7 +186,7 @@ suspend fun main() {
 ### Multimodal Input (Images)
 
 ```kotlin
-// Image analysis with Claude 3
+// Image analysis with Claude
 val imageResponse = client.execute(
     prompt = prompt {
         user {
@@ -167,10 +194,10 @@ val imageResponse = client.execute(
             image("/path/to/image.jpg")
         }
     },
-    model = BedrockModels.AnthropicClaude3Opus
+    model = BedrockModels.AnthropicClaude46Opus
 )
 
-// Multiple images with Claude 3
+// Multiple images with Claude
 val multiImageResponse = client.execute(
     prompt = prompt {
         user {
@@ -179,7 +206,7 @@ val multiImageResponse = client.execute(
             image("/path/to/image2.jpg")
         }
     },
-    model = BedrockModels.AnthropicClaude3Sonnet
+    model = BedrockModels.AnthropicClaude4Sonnet
 )
 ```
 
@@ -199,12 +226,12 @@ val weatherTool = ToolDescriptor(
     )
 )
 
-// Use with Claude 3 or Mistral Large
+// Use with any tool-capable model
 val toolResponse = client.execute(
     prompt = prompt {
         user("What's the weather in New York?")
     },
-    model = BedrockModels.AnthropicClaude3Sonnet,
+    model = BedrockModels.AnthropicClaude4Sonnet,
     tools = listOf(weatherTool)
 )
 
@@ -230,7 +257,7 @@ val stream = client.executeStreaming(
     prompt = prompt {
         user("Write a haiku about clouds")
     },
-    model = BedrockModels.AnthropicClaude3Haiku
+    model = BedrockModels.AnthropicClaude4_5Haiku
 )
 
 stream.collect { token ->
@@ -238,53 +265,55 @@ stream.collect { token ->
 }
 ```
 
-### Model-Specific Features
+### Converse-Only Models
+
+Kimi, MiniMax, GPT-OSS, and Gemma 3 models require the Converse API:
 
 ```kotlin
-// Use extended context with Claude 2.1
-val longContextResponse = client.execute(
-    prompt = prompt {
-        system("Analyze this document")
-        user(veryLongDocument) // Up to 200K tokens
-    },
-    model = BedrockModels.AnthropicClaude21
-)
-
-// Use Mixtral's mixture of experts
-val mixtralResponse = client.execute(
-    prompt = prompt {
-        user("Explain quantum computing")
-    },
-    model = BedrockModels.MistralMixtral8x7BInstruct
-)
-
-// Use Mistral Large with tools
-val mistralToolResponse = client.execute(
-    prompt = prompt {
-        user("Search for recent AI news")
-    },
-    model = BedrockModels.MistralLarge,
-    tools = listOf(searchTool)
-)
-
-// Use Kimi K2 Thinking with deep reasoning (requires Converse API)
-val kimiClient = createBedrockLLMClient(
+val converseClient = createBedrockLLMClient(
     awsAccessKeyId = ApiKeyService.awsAccessKey,
     awsSecretAccessKey = ApiKeyService.awsSecretAccessKey,
     settings = BedrockClientSettings(
         region = "us-east-1",
-        apiMethod = BedrockAPIMethod.Converse // Required for Kimi models
+        apiMethod = BedrockAPIMethod.Converse // Required for these models
     )
 )
 
-val kimiResponse = kimiClient.execute(
+// MiniMax M2.5 with 1M context
+val minimaxResponse = converseClient.execute(
+    prompt = prompt {
+        user(veryLongDocument) // Up to 1M tokens
+    },
+    model = BedrockModels.MiniMaxM2_5
+)
+
+// GPT-OSS with structured output
+val gptOssResponse = converseClient.execute(
+    prompt = prompt {
+        user("List the top 3 programming languages")
+    },
+    model = BedrockModels.OpenAIGptOss120B
+)
+
+// Gemma 3 with image input
+val gemmaResponse = converseClient.execute(
+    prompt = prompt {
+        user {
+            text("Describe this image")
+            image("/path/to/image.jpg")
+        }
+    },
+    model = BedrockModels.GoogleGemma3_27bIt
+)
+
+// Kimi K2 Thinking with deep reasoning traces
+val kimiResponse = converseClient.execute(
     prompt = prompt {
         user("Solve this complex problem step by step: What are the environmental impacts of quantum computing?")
     },
     model = BedrockModels.MoonshotKimiK2Thinking
 )
 
-// Kimi K2 Thinking supports reasoning traces
 kimiResponse.forEach { message ->
     when (message) {
         is Message.Reasoning -> {
@@ -358,19 +387,21 @@ try {
 
 AWS Bedrock charges per token for model usage. Monitor your usage and set up billing alerts:
 
-- **Claude 3/4 models**: Higher cost, superior performance and capabilities
-- **Titan models**: Cost-effective for general-purpose tasks
-- **Llama models**: Good balance of cost and performance
-- **Mistral models**: Competitive pricing with tool support (Large model)
+- **Claude 4.x models**: Higher cost, superior performance and capabilities
+- **Amazon Nova models**: Cost-effective for general-purpose tasks
+- **Meta Llama models**: Good balance of cost and performance
+- **Gemma 3 / GPT-OSS models**: Competitive pricing, open-weight models
+- **MiniMax M2.5 / Kimi K2.5**: Cost-efficient for agentic workloads
 
 ## Limitations
 
 1. **Model Availability**: Not all models are available in all AWS regions
 2. **Rate Limits**: AWS imposes rate limits per model and region
 3. **Context Windows**: Vary by model (see tables above)
-4. **Feature Support**: Not all models support all features (tools, vision, etc.)
+4. **Feature Support**: Not all models support all features (tools, vision, structured output, etc.)
 5. **Platform Support**: Limited to JVM and Android due to AWS SDK constraints
-6. **Media Support**: Only images supported, no audio/video/documents
+6. **Converse-only Models**: Kimi, MiniMax, GPT-OSS, and Gemma 3 models only work with the Converse API
+7. **Embedding Limitations**: Cohere Embed v4 multimodal and configurable dimensions not yet supported by this client
 
 ## Performance Tips
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/Module.md
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/Module.md
@@ -303,7 +303,7 @@ val gemmaResponse = converseClient.execute(
             image("/path/to/image.jpg")
         }
     },
-    model = BedrockModels.GoogleGemma3_27bIt
+    model = BedrockModels.GoogleGemma3_27BIt
 )
 
 // Kimi K2 Thinking with deep reasoning traces

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClient.kt
@@ -215,7 +215,13 @@ public class BedrockLLMClient @JvmOverloads constructor(
 
             model.id.contains("cohere.embed") -> BedrockModelFamilies.Cohere
 
-            model.id.contains("moonshot.kimi") -> BedrockModelFamilies.MoonshotKimi
+            model.id.contains("moonshot.kimi") || model.id.contains("moonshotai.kimi") -> BedrockModelFamilies.MoonshotKimi
+
+            model.id.contains("google.gemma") -> BedrockModelFamilies.GoogleGemma
+
+            model.id.contains("minimax.") -> BedrockModelFamilies.MiniMax
+
+            model.id.contains("openai.gpt") -> BedrockModelFamilies.OpenAI
 
             else -> {
                 if (fallbackModelFamily != null) {
@@ -293,7 +299,10 @@ public class BedrockLLMClient @JvmOverloads constructor(
                         clock
                     )
 
-                    is BedrockModelFamilies.MoonshotKimi -> throw LLMClientException(
+                    is BedrockModelFamilies.MoonshotKimi,
+                    is BedrockModelFamilies.GoogleGemma,
+                    is BedrockModelFamilies.MiniMax,
+                    is BedrockModelFamilies.OpenAI -> throw LLMClientException(
                         clientName,
                         "Model family ${modelFamily.display} requires the Bedrock Converse API. " +
                             "Please configure BedrockClientSettings with apiMethod = BedrockAPIMethod.Converse"
@@ -432,7 +441,10 @@ public class BedrockLLMClient @JvmOverloads constructor(
                     clock = clock,
                 )
 
-                is BedrockModelFamilies.MoonshotKimi -> throw LLMClientException(
+                is BedrockModelFamilies.MoonshotKimi,
+                is BedrockModelFamilies.GoogleGemma,
+                is BedrockModelFamilies.MiniMax,
+                is BedrockModelFamilies.OpenAI -> throw LLMClientException(
                     clientName,
                     "Model family ${modelFamily.display} requires the Bedrock Converse API. " +
                         "Please configure BedrockClientSettings with apiMethod = BedrockAPIMethod.Converse"
@@ -595,7 +607,10 @@ public class BedrockLLMClient @JvmOverloads constructor(
                 BedrockMetaLlamaSerialization.createLlamaRequest(prompt, model)
             )
 
-            is BedrockModelFamilies.MoonshotKimi -> throw LLMClientException(
+            is BedrockModelFamilies.MoonshotKimi,
+            is BedrockModelFamilies.GoogleGemma,
+            is BedrockModelFamilies.MiniMax,
+            is BedrockModelFamilies.OpenAI -> throw LLMClientException(
                 clientName,
                 "Model family ${getBedrockModelFamily(model).display} requires the Bedrock Converse API. " +
                     "Please configure BedrockClientSettings with apiMethod = BedrockAPIMethod.Converse"

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModelFamilies.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModelFamilies.kt
@@ -53,4 +53,22 @@ public sealed class BedrockModelFamilies(
      */
     @Serializable
     public data object MoonshotKimi : BedrockModelFamilies("bedrock.moonshot", "AWS Bedrock (Moonshot Kimi)")
+
+    /**
+     * Represents the Google sub-provider under AWS Bedrock.
+     */
+    @Serializable
+    public data object GoogleGemma : BedrockModelFamilies("bedrock.google", "AWS Bedrock (Google Gemma)")
+
+    /**
+     * Represents the MiniMax sub-provider under AWS Bedrock.
+     */
+    @Serializable
+    public data object MiniMax : BedrockModelFamilies("bedrock.minimax", "AWS Bedrock (MiniMax)")
+
+    /**
+     * Represents the OpenAI sub-provider under AWS Bedrock.
+     */
+    @Serializable
+    public data object OpenAI : BedrockModelFamilies("bedrock.openai", "AWS Bedrock (OpenAI)")
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModels.kt
@@ -584,6 +584,174 @@ public object BedrockModels : LLModelDefinitions {
     ).effectiveModel
 
     /**
+     * Moonshot Kimi K2.5 - Multimodal model with improved reasoning, coding, and multilingual capabilities
+     *
+     * Features:
+     * - 256K context window
+     * - Multimodal: text and image inputs
+     * - Tool calling with dual-mode reasoning
+     * - Strong multilingual capabilities
+     *
+     * Important: This model requires the Bedrock Converse API (apiMethod = BedrockAPIMethod.Converse).
+     *
+     * @see <a href="https://github.com/MoonshotAI/Kimi-K2.5">
+     */
+    public val MoonshotKimiK2_5: LLModel = BedrockModel(
+        LLModel(
+            provider = LLMProvider.Bedrock,
+            id = "moonshotai.kimi-k2.5",
+            capabilities = standardCapabilities + toolCapabilities + listOf(LLMCapability.Vision.Image),
+            contextLength = 256_000,
+        ),
+        inferenceProfilePrefix = null
+    ).effectiveModel
+
+    /**
+     * MiniMax M2.5 - Agent-native frontier model optimized for efficient reasoning and task decomposition
+     *
+     * Features:
+     * - 1M token context window
+     * - Trained for efficient reasoning and optimal task decomposition
+     * - Strong tool calling (76.9% on Berkeley Function Calling Leaderboard)
+     * - High inference throughput with token-efficient reasoning
+     *
+     * Important: This model requires the Bedrock Converse API (apiMethod = BedrockAPIMethod.Converse).
+     *
+     * @see <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-minimax-minimax-m2-5.html">
+     */
+    public val MiniMaxM2_5: LLModel = BedrockModel(
+        LLModel(
+            provider = LLMProvider.Bedrock,
+            id = "minimax.minimax-m2.5",
+            capabilities = standardCapabilities + toolCapabilities,
+            contextLength = 1_000_000,
+        ),
+        inferenceProfilePrefix = null
+    ).effectiveModel
+
+    /**
+     * OpenAI GPT-OSS 120B - Mixture-of-Experts model for complex reasoning tasks
+     *
+     * Features:
+     * - 128K context window
+     * - MoE architecture: 117B total params, 5.1B active per token
+     * - Strong at coding, mathematics, and agentic tool use
+     * - Structured output support
+     * - Adjustable reasoning levels (low/medium/high)
+     *
+     * Important: This model requires the Bedrock Converse API (apiMethod = BedrockAPIMethod.Converse).
+     *
+     * @see <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-oss-120b.html">
+     */
+    public val OpenAIGptOss120B: LLModel = BedrockModel(
+        LLModel(
+            provider = LLMProvider.Bedrock,
+            id = "openai.gpt-oss-120b-1:0",
+            capabilities = standardCapabilities + toolCapabilities + listOf(LLMCapability.Schema.JSON.Standard),
+            contextLength = 128_000,
+        ),
+        inferenceProfilePrefix = null
+    ).effectiveModel
+
+    /**
+     * OpenAI GPT-OSS 20B - Efficient Mixture-of-Experts model for speed-sensitive applications
+     *
+     * Features:
+     * - 128K context window
+     * - MoE architecture: 21B total params, 3.6B active per token
+     * - Runs on edge devices with 16 GB memory
+     * - Structured output support
+     * - Matches o3-mini performance
+     *
+     * Important: This model requires the Bedrock Converse API (apiMethod = BedrockAPIMethod.Converse).
+     *
+     * @see <a href="https://openai.com/index/introducing-gpt-oss/">
+     */
+    public val OpenAIGptOss20B: LLModel = BedrockModel(
+        LLModel(
+            provider = LLMProvider.Bedrock,
+            id = "openai.gpt-oss-20b-1:0",
+            capabilities = standardCapabilities + toolCapabilities + listOf(LLMCapability.Schema.JSON.Standard),
+            contextLength = 128_000,
+        ),
+        inferenceProfilePrefix = null
+    ).effectiveModel
+
+    /**
+     * Google Gemma 3 4B IT - Compact instruction-tuned model for on-device and edge deployment
+     *
+     * Features:
+     * - 128K context window
+     * - 4 billion parameters
+     * - Multimodal: text and image inputs
+     * - Tool calling support
+     * - Multilingual support (140+ languages)
+     *
+     * Important: This model requires the Bedrock Converse API (apiMethod = BedrockAPIMethod.Converse).
+     *
+     * @see <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-3-4b-it.html">
+     */
+    public val GoogleGemma3_4bIt: LLModel = BedrockModel(
+        LLModel(
+            provider = LLMProvider.Bedrock,
+            id = "google.gemma-3-4b-it",
+            capabilities = standardCapabilities + toolCapabilities + listOf(LLMCapability.Vision.Image),
+            contextLength = 128_000,
+        ),
+        inferenceProfilePrefix = null
+    ).effectiveModel
+
+    /**
+     * Google Gemma 3 12B IT - Instruction-tuned model with multimodal and structured output support
+     *
+     * Features:
+     * - 128K context window
+     * - 12 billion parameters
+     * - Multimodal: text and image inputs
+     * - Structured output support
+     * - Tool calling support
+     * - Multilingual support (140+ languages)
+     *
+     * Important: This model requires the Bedrock Converse API (apiMethod = BedrockAPIMethod.Converse).
+     *
+     * @see <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-3-12b-it.html">
+     */
+    public val GoogleGemma3_12bIt: LLModel = BedrockModel(
+        LLModel(
+            provider = LLMProvider.Bedrock,
+            id = "google.gemma-3-12b-it",
+            capabilities = fullCapabilities + listOf(LLMCapability.Schema.JSON.Standard),
+            contextLength = 128_000,
+        ),
+        inferenceProfilePrefix = null
+    ).effectiveModel
+
+    /**
+     * Google Gemma 3 27B IT - Largest Gemma 3 model with full multimodal and structured output support
+     *
+     * Features:
+     * - 128K context window
+     * - 27 billion parameters
+     * - Multimodal: text and image inputs
+     * - Structured output support
+     * - Tool calling support
+     * - Multilingual support (140+ languages)
+     *
+     * Important: This model requires the Bedrock Converse API (apiMethod = BedrockAPIMethod.Converse).
+     *
+     * @see <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-3-27b-it.html">
+     */
+    public val GoogleGemma3_27bIt: LLModel = BedrockModel(
+        LLModel(
+            provider = LLMProvider.Bedrock,
+            id = "google.gemma-3-27b-it",
+            capabilities = fullCapabilities + listOf(LLMCapability.Schema.JSON.Standard),
+            contextLength = 128_000,
+        ),
+        inferenceProfilePrefix = null
+    ).effectiveModel
+
+    /**
      * Embedding models available through the AWS Bedrock API.
      *
      * **Note:** Multimodality (image, audio, video) embeddings are currently not supported by the Bedrock client.
@@ -655,6 +823,21 @@ public object BedrockModels : LLModelDefinitions {
             ),
             inferenceProfilePrefix = null
         ).effectiveModel
+
+        /**
+         * Cohere Embed v4
+         * Multimodal embedding model supporting text, images, and complex documents.
+         * Input: Text (image/document embedding not yet supported by this client)
+         * Output: Embedding (1536 dimensions by default, configurable: 256, 512, 1024, 1536)
+         */
+        public val CohereEmbedV4: LLModel = BedrockModel(
+            LLModel(
+                provider = LLMProvider.Bedrock,
+                id = "cohere.embed-v4:0",
+                capabilities = embedCapabilities,
+                contextLength = 512,
+            ),
+        ).effectiveModel
     }
 
     /**
@@ -704,9 +887,23 @@ public object BedrockModels : LLModelDefinitions {
         Embeddings.AmazonTitanEmbedTextV2,
         Embeddings.CohereEmbedEnglishV3,
         Embeddings.CohereEmbedMultilingualV3,
+        Embeddings.CohereEmbedV4,
 
-        // Moonshot Kimi K2 Thinking
+        // Moonshot Kimi Series
         MoonshotKimiK2Thinking,
+        MoonshotKimiK2_5,
+
+        // MiniMax
+        MiniMaxM2_5,
+
+        // OpenAI GPT-OSS Series
+        OpenAIGptOss120B,
+        OpenAIGptOss20B,
+
+        // Google Gemma 3 Series
+        GoogleGemma3_4bIt,
+        GoogleGemma3_12bIt,
+        GoogleGemma3_27bIt,
     )
 
     /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModels.kt
@@ -290,6 +290,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "amazon.nova-micro-v1:0",
             capabilities = novaCapabilities,
             contextLength = 128_000,
+            maxOutputTokens = 5_000,
         ),
     ).effectiveModel
 
@@ -310,6 +311,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "amazon.nova-lite-v1:0",
             capabilities = novaCapabilities,
             contextLength = 300_000,
+            maxOutputTokens = 5_000,
         ),
     ).effectiveModel
 
@@ -330,6 +332,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "amazon.nova-pro-v1:0",
             capabilities = novaCapabilities,
             contextLength = 300_000,
+            maxOutputTokens = 5_000,
         ),
     ).effectiveModel
 
@@ -350,6 +353,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "amazon.nova-premier-v1:0",
             capabilities = novaCapabilities,
             contextLength = 1_000_000,
+            maxOutputTokens = 25_000,
         ),
     ).effectiveModel
 
@@ -370,6 +374,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "meta.llama3-8b-instruct-v1:0",
             capabilities = standardCapabilities,
             contextLength = 8_000,
+            maxOutputTokens = 8_192,
         ),
     ).effectiveModel
 
@@ -390,6 +395,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "meta.llama3-70b-instruct-v1:0",
             capabilities = standardCapabilities,
             contextLength = 8_000,
+            maxOutputTokens = 8_192,
         ),
     ).effectiveModel
 
@@ -410,6 +416,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "meta.llama3-1-8b-instruct-v1:0",
             capabilities = standardCapabilities,
             contextLength = 128_000,
+            maxOutputTokens = 4_096,
         ),
     ).effectiveModel
 
@@ -430,6 +437,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "meta.llama3-1-70b-instruct-v1:0",
             capabilities = standardCapabilities,
             contextLength = 128_000,
+            maxOutputTokens = 4_096,
         ),
     ).effectiveModel
 
@@ -450,6 +458,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "meta.llama3-1-405b-instruct-v1:0",
             capabilities = standardCapabilities,
             contextLength = 128_000,
+            maxOutputTokens = 4_096,
         ),
     ).effectiveModel
 
@@ -470,6 +479,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "meta.llama3-2-1b-instruct-v1:0",
             capabilities = standardCapabilities,
             contextLength = 128_000,
+            maxOutputTokens = 4_096,
         ),
     ).effectiveModel
 
@@ -490,6 +500,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "meta.llama3-2-3b-instruct-v1:0",
             capabilities = standardCapabilities,
             contextLength = 128_000,
+            maxOutputTokens = 4_096,
         ),
     ).effectiveModel
 
@@ -510,6 +521,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "meta.llama3-2-11b-instruct-v1:0",
             capabilities = fullCapabilities,
             contextLength = 128_000,
+            maxOutputTokens = 4_096,
         ),
     ).effectiveModel
 
@@ -530,6 +542,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "meta.llama3-2-90b-instruct-v1:0",
             capabilities = fullCapabilities,
             contextLength = 128_000,
+            maxOutputTokens = 4_096,
         ),
     ).effectiveModel
 
@@ -550,6 +563,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "meta.llama3-3-70b-instruct-v1:0",
             capabilities = standardCapabilities + toolCapabilities,
             contextLength = 128_000,
+            maxOutputTokens = 4_096,
         ),
     ).effectiveModel
 
@@ -579,6 +593,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "moonshot.kimi-k2-thinking",
             capabilities = standardCapabilities + toolCapabilities,
             contextLength = 256_000,
+            maxOutputTokens = 16_384,
         ),
         inferenceProfilePrefix = null
     ).effectiveModel
@@ -602,6 +617,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "moonshotai.kimi-k2.5",
             capabilities = standardCapabilities + toolCapabilities + listOf(LLMCapability.Vision.Image),
             contextLength = 256_000,
+            maxOutputTokens = 16_384,
         ),
         inferenceProfilePrefix = null
     ).effectiveModel
@@ -625,6 +641,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "minimax.minimax-m2.5",
             capabilities = standardCapabilities + toolCapabilities,
             contextLength = 1_000_000,
+            maxOutputTokens = 8_192,
         ),
         inferenceProfilePrefix = null
     ).effectiveModel
@@ -649,6 +666,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "openai.gpt-oss-120b-1:0",
             capabilities = standardCapabilities + toolCapabilities + listOf(LLMCapability.Schema.JSON.Standard),
             contextLength = 128_000,
+            maxOutputTokens = 16_384,
         ),
         inferenceProfilePrefix = null
     ).effectiveModel
@@ -673,6 +691,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "openai.gpt-oss-20b-1:0",
             capabilities = standardCapabilities + toolCapabilities + listOf(LLMCapability.Schema.JSON.Standard),
             contextLength = 128_000,
+            maxOutputTokens = 16_384,
         ),
         inferenceProfilePrefix = null
     ).effectiveModel
@@ -697,6 +716,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "google.gemma-3-4b-it",
             capabilities = standardCapabilities + toolCapabilities + listOf(LLMCapability.Vision.Image),
             contextLength = 128_000,
+            maxOutputTokens = 8_192,
         ),
         inferenceProfilePrefix = null
     ).effectiveModel
@@ -722,6 +742,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "google.gemma-3-12b-it",
             capabilities = fullCapabilities + listOf(LLMCapability.Schema.JSON.Standard),
             contextLength = 128_000,
+            maxOutputTokens = 8_192,
         ),
         inferenceProfilePrefix = null
     ).effectiveModel
@@ -747,6 +768,7 @@ public object BedrockModels : LLModelDefinitions {
             id = "google.gemma-3-27b-it",
             capabilities = fullCapabilities + listOf(LLMCapability.Schema.JSON.Standard),
             contextLength = 128_000,
+            maxOutputTokens = 8_192,
         ),
         inferenceProfilePrefix = null
     ).effectiveModel

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockModels.kt
@@ -609,7 +609,7 @@ public object BedrockModels : LLModelDefinitions {
      *
      * Important: This model requires the Bedrock Converse API (apiMethod = BedrockAPIMethod.Converse).
      *
-     * @see <a href="https://github.com/MoonshotAI/Kimi-K2.5">
+     * @see <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-moonshot-ai-kimi-k2-5.html">
      */
     public val MoonshotKimiK2_5: LLModel = BedrockModel(
         LLModel(
@@ -710,7 +710,7 @@ public object BedrockModels : LLModelDefinitions {
      *
      * @see <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-3-4b-it.html">
      */
-    public val GoogleGemma3_4bIt: LLModel = BedrockModel(
+    public val GoogleGemma3_4BIt: LLModel = BedrockModel(
         LLModel(
             provider = LLMProvider.Bedrock,
             id = "google.gemma-3-4b-it",
@@ -736,7 +736,7 @@ public object BedrockModels : LLModelDefinitions {
      *
      * @see <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-3-12b-it.html">
      */
-    public val GoogleGemma3_12bIt: LLModel = BedrockModel(
+    public val GoogleGemma3_12BIt: LLModel = BedrockModel(
         LLModel(
             provider = LLMProvider.Bedrock,
             id = "google.gemma-3-12b-it",
@@ -762,7 +762,7 @@ public object BedrockModels : LLModelDefinitions {
      *
      * @see <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-google-gemma-3-27b-it.html">
      */
-    public val GoogleGemma3_27bIt: LLModel = BedrockModel(
+    public val GoogleGemma3_27BIt: LLModel = BedrockModel(
         LLModel(
             provider = LLMProvider.Bedrock,
             id = "google.gemma-3-27b-it",
@@ -923,9 +923,9 @@ public object BedrockModels : LLModelDefinitions {
         OpenAIGptOss20B,
 
         // Google Gemma 3 Series
-        GoogleGemma3_4bIt,
-        GoogleGemma3_12bIt,
-        GoogleGemma3_27bIt,
+        GoogleGemma3_4BIt,
+        GoogleGemma3_12BIt,
+        GoogleGemma3_27BIt,
     )
 
     /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClientTest.kt
@@ -887,6 +887,51 @@ class BedrockLLMClientTest {
             contextLength = 256_000
         )
         assertEquals(BedrockModelFamilies.MoonshotKimi, client.getBedrockModelFamily(kimiModel))
+
+        // Kimi K2.5 (moonshotai prefix)
+        val kimiK25Model = LLModel(
+            provider = LLMProvider.Bedrock,
+            id = "moonshotai.kimi-k2.5",
+            capabilities = listOf(LLMCapability.Completion, LLMCapability.Tools),
+            contextLength = 256_000
+        )
+        assertEquals(BedrockModelFamilies.MoonshotKimi, client.getBedrockModelFamily(kimiK25Model))
+
+        // Google Gemma
+        val gemmaModel = LLModel(
+            provider = LLMProvider.Bedrock,
+            id = "google.gemma-3-12b-it",
+            capabilities = listOf(LLMCapability.Completion),
+            contextLength = 128_000
+        )
+        assertEquals(BedrockModelFamilies.GoogleGemma, client.getBedrockModelFamily(gemmaModel))
+
+        // MiniMax
+        val minimaxModel = LLModel(
+            provider = LLMProvider.Bedrock,
+            id = "minimax.minimax-m2.5",
+            capabilities = listOf(LLMCapability.Completion),
+            contextLength = 1_000_000
+        )
+        assertEquals(BedrockModelFamilies.MiniMax, client.getBedrockModelFamily(minimaxModel))
+
+        // OpenAI GPT-OSS
+        val gptOssModel = LLModel(
+            provider = LLMProvider.Bedrock,
+            id = "openai.gpt-oss-120b-1:0",
+            capabilities = listOf(LLMCapability.Completion),
+            contextLength = 128_000
+        )
+        assertEquals(BedrockModelFamilies.OpenAI, client.getBedrockModelFamily(gptOssModel))
+
+        // Cohere Embed v4 (with inference profile prefix)
+        val cohereV4Model = LLModel(
+            provider = LLMProvider.Bedrock,
+            id = "us.cohere.embed-v4:0",
+            capabilities = listOf(LLMCapability.Embed),
+            contextLength = 512
+        )
+        assertEquals(BedrockModelFamilies.Cohere, client.getBedrockModelFamily(cohereV4Model))
     }
 
     @Test
@@ -1131,5 +1176,302 @@ class BedrockLLMClientTest {
         assertFalse(model.id.startsWith("eu."))
         assertFalse(model.id.startsWith("global."))
         assertEquals("moonshot.kimi-k2-thinking", model.id)
+    }
+
+    // --- Kimi K2.5 ---
+
+    @Test
+    fun `MoonshotKimiK2_5 model has correct properties`() {
+        val model = BedrockModels.MoonshotKimiK2_5
+
+        assertEquals("moonshotai.kimi-k2.5", model.id)
+        assertEquals(LLMProvider.Bedrock, model.provider)
+        assertEquals(256_000, model.contextLength)
+        val capabilities = assertNotNull(model.capabilities)
+        assertTrue(capabilities.contains(LLMCapability.Completion))
+        assertTrue(capabilities.contains(LLMCapability.Tools))
+        assertTrue(capabilities.contains(LLMCapability.Temperature))
+        assertTrue(capabilities.contains(LLMCapability.Vision.Image))
+    }
+
+    @Test
+    fun `Kimi K2_5 model requires Converse API for execute`() = runTest {
+        val client = BedrockLLMClient(
+            identityProvider = StaticCredentialsProvider {
+                accessKeyId = "test-key"
+                secretAccessKey = "test-secret"
+            },
+            settings = BedrockClientSettings(
+                region = BedrockRegions.US_EAST_1.regionCode,
+                apiMethod = BedrockAPIMethod.InvokeModel
+            ),
+            clock = Clock.System
+        )
+
+        val prompt = Prompt.build("test") {
+            user("Hello!")
+        }
+
+        val exception = assertFailsWith<LLMClientException> {
+            client.execute(prompt, BedrockModels.MoonshotKimiK2_5, emptyList())
+        }
+
+        assertTrue(exception.message!!.contains("requires the Bedrock Converse API"))
+    }
+
+    // --- MiniMax M2.5 ---
+
+    @Test
+    fun `MiniMaxM2_5 model has correct properties`() {
+        val model = BedrockModels.MiniMaxM2_5
+
+        assertEquals("minimax.minimax-m2.5", model.id)
+        assertEquals(LLMProvider.Bedrock, model.provider)
+        assertEquals(1_000_000, model.contextLength)
+        val capabilities = assertNotNull(model.capabilities)
+        assertTrue(capabilities.contains(LLMCapability.Completion))
+        assertTrue(capabilities.contains(LLMCapability.Tools))
+        assertTrue(capabilities.contains(LLMCapability.ToolChoice))
+    }
+
+    @Test
+    fun `MiniMax M2_5 model requires Converse API for execute`() = runTest {
+        val client = BedrockLLMClient(
+            identityProvider = StaticCredentialsProvider {
+                accessKeyId = "test-key"
+                secretAccessKey = "test-secret"
+            },
+            settings = BedrockClientSettings(
+                region = BedrockRegions.US_EAST_1.regionCode,
+                apiMethod = BedrockAPIMethod.InvokeModel
+            ),
+            clock = Clock.System
+        )
+
+        val prompt = Prompt.build("test") {
+            user("Hello!")
+        }
+
+        val exception = assertFailsWith<LLMClientException> {
+            client.execute(prompt, BedrockModels.MiniMaxM2_5, emptyList())
+        }
+
+        assertTrue(exception.message!!.contains("requires the Bedrock Converse API"))
+    }
+
+    @Test
+    fun `MiniMax M2_5 model requires Converse API for executeStreaming`() = runTest {
+        val client = BedrockLLMClient(
+            identityProvider = StaticCredentialsProvider {
+                accessKeyId = "test-key"
+                secretAccessKey = "test-secret"
+            },
+            settings = BedrockClientSettings(
+                region = BedrockRegions.US_EAST_1.regionCode,
+                apiMethod = BedrockAPIMethod.InvokeModel
+            ),
+            clock = Clock.System
+        )
+
+        val prompt = Prompt.build("test") {
+            user("Hello!")
+        }
+
+        val exception = assertFailsWith<LLMClientException> {
+            client.executeStreaming(prompt, BedrockModels.MiniMaxM2_5, emptyList()).toList()
+        }
+
+        assertTrue(exception.message!!.contains("requires the Bedrock Converse API"))
+    }
+
+    // --- GPT-OSS ---
+
+    @Test
+    fun `OpenAIGptOss120B model has correct properties`() {
+        val model = BedrockModels.OpenAIGptOss120B
+
+        assertEquals("openai.gpt-oss-120b-1:0", model.id)
+        assertEquals(LLMProvider.Bedrock, model.provider)
+        assertEquals(128_000, model.contextLength)
+        val capabilities = assertNotNull(model.capabilities)
+        assertTrue(capabilities.contains(LLMCapability.Completion))
+        assertTrue(capabilities.contains(LLMCapability.Tools))
+        assertTrue(capabilities.contains(LLMCapability.Schema.JSON.Standard))
+    }
+
+    @Test
+    fun `OpenAIGptOss20B model has correct properties`() {
+        val model = BedrockModels.OpenAIGptOss20B
+
+        assertEquals("openai.gpt-oss-20b-1:0", model.id)
+        assertEquals(LLMProvider.Bedrock, model.provider)
+        assertEquals(128_000, model.contextLength)
+        val capabilities = assertNotNull(model.capabilities)
+        assertTrue(capabilities.contains(LLMCapability.Completion))
+        assertTrue(capabilities.contains(LLMCapability.Tools))
+        assertTrue(capabilities.contains(LLMCapability.Schema.JSON.Standard))
+    }
+
+    @Test
+    fun `GPT-OSS model requires Converse API for execute`() = runTest {
+        val client = BedrockLLMClient(
+            identityProvider = StaticCredentialsProvider {
+                accessKeyId = "test-key"
+                secretAccessKey = "test-secret"
+            },
+            settings = BedrockClientSettings(
+                region = BedrockRegions.US_EAST_1.regionCode,
+                apiMethod = BedrockAPIMethod.InvokeModel
+            ),
+            clock = Clock.System
+        )
+
+        val prompt = Prompt.build("test") {
+            user("Hello!")
+        }
+
+        val exception = assertFailsWith<LLMClientException> {
+            client.execute(prompt, BedrockModels.OpenAIGptOss120B, emptyList())
+        }
+
+        assertTrue(exception.message!!.contains("requires the Bedrock Converse API"))
+    }
+
+    // --- Google Gemma 3 ---
+
+    @Test
+    fun `GoogleGemma3_4bIt model has correct properties`() {
+        val model = BedrockModels.GoogleGemma3_4bIt
+
+        assertEquals("google.gemma-3-4b-it", model.id)
+        assertEquals(LLMProvider.Bedrock, model.provider)
+        assertEquals(128_000, model.contextLength)
+        val capabilities = assertNotNull(model.capabilities)
+        assertTrue(capabilities.contains(LLMCapability.Completion))
+        assertTrue(capabilities.contains(LLMCapability.Tools))
+        assertTrue(capabilities.contains(LLMCapability.Vision.Image))
+        assertFalse(capabilities.contains(LLMCapability.Schema.JSON.Standard))
+    }
+
+    @Test
+    fun `GoogleGemma3_12bIt model has correct properties`() {
+        val model = BedrockModels.GoogleGemma3_12bIt
+
+        assertEquals("google.gemma-3-12b-it", model.id)
+        assertEquals(LLMProvider.Bedrock, model.provider)
+        assertEquals(128_000, model.contextLength)
+        val capabilities = assertNotNull(model.capabilities)
+        assertTrue(capabilities.contains(LLMCapability.Completion))
+        assertTrue(capabilities.contains(LLMCapability.Tools))
+        assertTrue(capabilities.contains(LLMCapability.Vision.Image))
+        assertTrue(capabilities.contains(LLMCapability.Document))
+        assertTrue(capabilities.contains(LLMCapability.Schema.JSON.Standard))
+    }
+
+    @Test
+    fun `GoogleGemma3_27bIt model has correct properties`() {
+        val model = BedrockModels.GoogleGemma3_27bIt
+
+        assertEquals("google.gemma-3-27b-it", model.id)
+        assertEquals(LLMProvider.Bedrock, model.provider)
+        assertEquals(128_000, model.contextLength)
+        val capabilities = assertNotNull(model.capabilities)
+        assertTrue(capabilities.contains(LLMCapability.Completion))
+        assertTrue(capabilities.contains(LLMCapability.Tools))
+        assertTrue(capabilities.contains(LLMCapability.Vision.Image))
+        assertTrue(capabilities.contains(LLMCapability.Document))
+        assertTrue(capabilities.contains(LLMCapability.Schema.JSON.Standard))
+    }
+
+    @Test
+    fun `Google Gemma model requires Converse API for execute`() = runTest {
+        val client = BedrockLLMClient(
+            identityProvider = StaticCredentialsProvider {
+                accessKeyId = "test-key"
+                secretAccessKey = "test-secret"
+            },
+            settings = BedrockClientSettings(
+                region = BedrockRegions.US_EAST_1.regionCode,
+                apiMethod = BedrockAPIMethod.InvokeModel
+            ),
+            clock = Clock.System
+        )
+
+        val prompt = Prompt.build("test") {
+            user("Hello!")
+        }
+
+        val exception = assertFailsWith<LLMClientException> {
+            client.execute(prompt, BedrockModels.GoogleGemma3_12bIt, emptyList())
+        }
+
+        assertTrue(exception.message!!.contains("requires the Bedrock Converse API"))
+    }
+
+    @Test
+    fun `Google Gemma model requires Converse API for executeStreaming`() = runTest {
+        val client = BedrockLLMClient(
+            identityProvider = StaticCredentialsProvider {
+                accessKeyId = "test-key"
+                secretAccessKey = "test-secret"
+            },
+            settings = BedrockClientSettings(
+                region = BedrockRegions.US_EAST_1.regionCode,
+                apiMethod = BedrockAPIMethod.InvokeModel
+            ),
+            clock = Clock.System
+        )
+
+        val prompt = Prompt.build("test") {
+            user("Hello!")
+        }
+
+        val exception = assertFailsWith<LLMClientException> {
+            client.executeStreaming(prompt, BedrockModels.GoogleGemma3_27bIt, emptyList()).toList()
+        }
+
+        assertTrue(exception.message!!.contains("requires the Bedrock Converse API"))
+    }
+
+    // --- Cohere Embed v4 ---
+
+    @Test
+    fun `CohereEmbedV4 model has correct properties`() {
+        val model = BedrockModels.Embeddings.CohereEmbedV4
+
+        assertEquals("us.cohere.embed-v4:0", model.id)
+        assertEquals(LLMProvider.Bedrock, model.provider)
+        assertEquals(512, model.contextLength)
+        val capabilities = assertNotNull(model.capabilities)
+        assertTrue(capabilities.contains(LLMCapability.Embed))
+    }
+
+    // --- No inference profile prefix for third-party models ---
+
+    @Test
+    fun `new third-party chat models have no inference profile prefix`() {
+        val models = listOf(
+            BedrockModels.MoonshotKimiK2_5 to "moonshotai.kimi-k2.5",
+            BedrockModels.MiniMaxM2_5 to "minimax.minimax-m2.5",
+            BedrockModels.OpenAIGptOss120B to "openai.gpt-oss-120b-1:0",
+            BedrockModels.OpenAIGptOss20B to "openai.gpt-oss-20b-1:0",
+            BedrockModels.GoogleGemma3_4bIt to "google.gemma-3-4b-it",
+            BedrockModels.GoogleGemma3_12bIt to "google.gemma-3-12b-it",
+            BedrockModels.GoogleGemma3_27bIt to "google.gemma-3-27b-it",
+        )
+
+        for ((model, expectedId) in models) {
+            assertFalse(model.id.startsWith("us."), "Model ${model.id} should not have US prefix")
+            assertFalse(model.id.startsWith("eu."), "Model ${model.id} should not have EU prefix")
+            assertFalse(model.id.startsWith("global."), "Model ${model.id} should not have global prefix")
+            assertEquals(expectedId, model.id)
+        }
+    }
+
+    @Test
+    fun `CohereEmbedV4 has inference profile prefix`() {
+        val model = BedrockModels.Embeddings.CohereEmbedV4
+        assertTrue(model.id.startsWith("us."), "Cohere Embed v4 should have US inference profile prefix")
+        assertEquals("us.cohere.embed-v4:0", model.id)
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClientTest.kt
@@ -1219,6 +1219,31 @@ class BedrockLLMClientTest {
         assertTrue(exception.message!!.contains("requires the Bedrock Converse API"))
     }
 
+    @Test
+    fun `Kimi K2_5 model requires Converse API for executeStreaming`() = runTest {
+        val client = BedrockLLMClient(
+            identityProvider = StaticCredentialsProvider {
+                accessKeyId = "test-key"
+                secretAccessKey = "test-secret"
+            },
+            settings = BedrockClientSettings(
+                region = BedrockRegions.US_EAST_1.regionCode,
+                apiMethod = BedrockAPIMethod.InvokeModel
+            ),
+            clock = Clock.System
+        )
+
+        val prompt = Prompt.build("test") {
+            user("Hello!")
+        }
+
+        val exception = assertFailsWith<LLMClientException> {
+            client.executeStreaming(prompt, BedrockModels.MoonshotKimiK2_5, emptyList()).toList()
+        }
+
+        assertTrue(exception.message!!.contains("requires the Bedrock Converse API"))
+    }
+
     // --- MiniMax M2.5 ---
 
     @Test
@@ -1337,11 +1362,36 @@ class BedrockLLMClientTest {
         assertTrue(exception.message!!.contains("requires the Bedrock Converse API"))
     }
 
+    @Test
+    fun `GPT-OSS model requires Converse API for executeStreaming`() = runTest {
+        val client = BedrockLLMClient(
+            identityProvider = StaticCredentialsProvider {
+                accessKeyId = "test-key"
+                secretAccessKey = "test-secret"
+            },
+            settings = BedrockClientSettings(
+                region = BedrockRegions.US_EAST_1.regionCode,
+                apiMethod = BedrockAPIMethod.InvokeModel
+            ),
+            clock = Clock.System
+        )
+
+        val prompt = Prompt.build("test") {
+            user("Hello!")
+        }
+
+        val exception = assertFailsWith<LLMClientException> {
+            client.executeStreaming(prompt, BedrockModels.OpenAIGptOss120B, emptyList()).toList()
+        }
+
+        assertTrue(exception.message!!.contains("requires the Bedrock Converse API"))
+    }
+
     // --- Google Gemma 3 ---
 
     @Test
-    fun `GoogleGemma3_4bIt model has correct properties`() {
-        val model = BedrockModels.GoogleGemma3_4bIt
+    fun `GoogleGemma3_4BIt model has correct properties`() {
+        val model = BedrockModels.GoogleGemma3_4BIt
 
         assertEquals("google.gemma-3-4b-it", model.id)
         assertEquals(LLMProvider.Bedrock, model.provider)
@@ -1354,8 +1404,8 @@ class BedrockLLMClientTest {
     }
 
     @Test
-    fun `GoogleGemma3_12bIt model has correct properties`() {
-        val model = BedrockModels.GoogleGemma3_12bIt
+    fun `GoogleGemma3_12BIt model has correct properties`() {
+        val model = BedrockModels.GoogleGemma3_12BIt
 
         assertEquals("google.gemma-3-12b-it", model.id)
         assertEquals(LLMProvider.Bedrock, model.provider)
@@ -1369,8 +1419,8 @@ class BedrockLLMClientTest {
     }
 
     @Test
-    fun `GoogleGemma3_27bIt model has correct properties`() {
-        val model = BedrockModels.GoogleGemma3_27bIt
+    fun `GoogleGemma3_27BIt model has correct properties`() {
+        val model = BedrockModels.GoogleGemma3_27BIt
 
         assertEquals("google.gemma-3-27b-it", model.id)
         assertEquals(LLMProvider.Bedrock, model.provider)
@@ -1402,7 +1452,7 @@ class BedrockLLMClientTest {
         }
 
         val exception = assertFailsWith<LLMClientException> {
-            client.execute(prompt, BedrockModels.GoogleGemma3_12bIt, emptyList())
+            client.execute(prompt, BedrockModels.GoogleGemma3_12BIt, emptyList())
         }
 
         assertTrue(exception.message!!.contains("requires the Bedrock Converse API"))
@@ -1427,7 +1477,7 @@ class BedrockLLMClientTest {
         }
 
         val exception = assertFailsWith<LLMClientException> {
-            client.executeStreaming(prompt, BedrockModels.GoogleGemma3_27bIt, emptyList()).toList()
+            client.executeStreaming(prompt, BedrockModels.GoogleGemma3_27BIt, emptyList()).toList()
         }
 
         assertTrue(exception.message!!.contains("requires the Bedrock Converse API"))
@@ -1455,9 +1505,9 @@ class BedrockLLMClientTest {
             BedrockModels.MiniMaxM2_5 to "minimax.minimax-m2.5",
             BedrockModels.OpenAIGptOss120B to "openai.gpt-oss-120b-1:0",
             BedrockModels.OpenAIGptOss20B to "openai.gpt-oss-20b-1:0",
-            BedrockModels.GoogleGemma3_4bIt to "google.gemma-3-4b-it",
-            BedrockModels.GoogleGemma3_12bIt to "google.gemma-3-12b-it",
-            BedrockModels.GoogleGemma3_27bIt to "google.gemma-3-27b-it",
+            BedrockModels.GoogleGemma3_4BIt to "google.gemma-3-4b-it",
+            BedrockModels.GoogleGemma3_12BIt to "google.gemma-3-12b-it",
+            BedrockModels.GoogleGemma3_27BIt to "google.gemma-3-27b-it",
         )
 
         for ((model, expectedId) in models) {


### PR DESCRIPTION
Extend AWS Bedrock model range and update stale model documentation.
The AWS Bedrock supported models are missing a wide range of interesting open weight models.
This PR adds Kimi K 2.5, MiniMax 2.5, Gemma 3, and GPT OSS models for bedrock converse API.
The smaller Gemma, and GPT OSS models are especially interesting for model fixing parser usage.
The Kimi K and MiniMax model are cheaper models suitable for light agentic tasks on a budget.

This PR limits the new models to the converse API, as supporting the invoke model API would require a significant code amount of code. Please, let me know if you want a follow up to also support the invoke API.
However, I think it would make more sense for Koog to drop the invoke model API support.

I was unsure regarding the documentation updates. Let me know if you want any changes.
Happy do adjustments.

closes #1901 
