### PR TITLE
fix: process blank tool call ID in StreamFrameFlowBuilder.emitToolCallDelta

### DIFF
--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
@@ -195,10 +195,11 @@ public class StreamFrameFlowBuilder(
     ) {
         tryEmitPendingText()
         tryEmitPendingReasoning()
+        val sanitizedId = id?.takeUnless { it.isBlank() }
         val previous: PendingToolCall? = pendingToolCallRef.load()
-        val new: PendingToolCall = if (id != null || index != previous?.index) {
+        val new: PendingToolCall = if (sanitizedId != null || index != previous?.index) {
             tryEmitPendingToolCall()
-            PendingToolCall(id, name, args, index)
+            PendingToolCall(sanitizedId, name, args, index)
         } else {
             when {
                 previous == null ->
@@ -212,7 +213,7 @@ public class StreamFrameFlowBuilder(
             }
         }
         pendingToolCallRef.store(new)
-        flowCollector.emitToolCallDelta(id, name, args, index)
+        flowCollector.emitToolCallDelta(sanitizedId, name, args, index)
     }
 
     /**

--- a/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderTest.kt
+++ b/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderTest.kt
@@ -182,6 +182,25 @@ class StreamFrameFlowBuilderTest {
     }
 
     @Test
+    fun testEmitToolCallDeltaWithBlankIdAppendsToExisting() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitToolCallDelta(id = "call_abc123", name = "my_tool", args = "{\"param\":", index = 0)
+            emitToolCallDelta(id = "", args = " \"value\"}", index = 0)
+            emitEnd()
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.ToolCallDelta("call_abc123", "my_tool", "{\"param\":", 0),
+                StreamFrame.ToolCallDelta(null, null, " \"value\"}", 0),
+                StreamFrame.ToolCallComplete("call_abc123", "my_tool", "{\"param\": \"value\"}", 0),
+                StreamFrame.End(null, ResponseMetaInfo.Empty)
+            ),
+            frames
+        )
+    }
+
+    @Test
     fun testEmitToolCallDeltaWithIdCreatesNewPendingToolCall() = runTest {
         val frames = buildStreamFrameFlow {
             emitToolCallDelta(id = "call_1", name = "calculator", args = "{\"a\":", index = 0)


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

Handle blank tool call IDs in emitToolCallDelta in StreamFrameFlowBuilder; add a corresponding test.

Closes #1900