### PR TITLE
fix(agents): KG-814. Add the 'type' parameter into the AIAgentError data class

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/AIAgentError.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/AIAgentError.kt
@@ -3,39 +3,49 @@ package ai.koog.agents.core.feature.model
 import kotlinx.serialization.Serializable
 
 /**
- * Represents an error encountered by an AI agent, encapsulating error details such as
- * the message, stack trace, and an optional cause.
+ * Retrieves the class name of the current [Throwable] instance.
+ *
+ * On the JVM platform, this property returns the fully qualified class name of the throwable.
+ * On other platforms, it falls back to the simple class name of the throwable.
+ *
+ * This property is used to provide a platform-specific representation of the throwable's type,
+ * which helps in categorizing or identifying the type of error.
+ *
+ * @receiver The [Throwable] whose type name is being accessed.
+ * @return The class name of the throwable as a nullable string, or null if the type cannot be determined.
+ */
+internal expect val Throwable.typeName: String?
+
+/**
+ * Represents an error encountered by an AI agent, encapsulating error details.
  *
  * This class provides essential information to understand and debug errors occurring
  * during the execution of AI agent strategies, tools, or nodes.
  *
- * Instances of this class can be created directly from a `Throwable`.
- *
- * @property message A human-readable description of the error. Defaults to "Unknown error"
- *           if not provided by the originating throwable.
- * @property stackTrace The stack trace of the error as a string, providing a detailed
- *           representation of where the error occurred.
- * @property cause The stack trace of the root cause if available, or null if no cause is set.
- *           This helps trace back the chain of exceptions leading to the current error.
+ * @property message An error message of the original throwable;
+ * @property stackTrace The stack trace of the error as a string;
+ * @property cause The stack trace of the root cause if available, or null if no cause is set;
+ * @property type The class name of the type of the error, if available. On JVM this is the fully
+ *           qualified name; on other platforms it falls back to the simple class name.
  */
 @Serializable
 public data class AIAgentError(
     public val message: String,
     public val stackTrace: String,
-    public val cause: String? = null
+    public val cause: String? = null,
+    public val type: String? = null,
 ) {
+
     /**
      * Secondary constructor that allows creating an instance of the class using a [Throwable].
      *
      * @param throwable The [Throwable] from which the error message, stack trace, and cause will be retrieved.
-     * The error message is derived from `throwable.message`, defaulting to "Unknown error" if null.
-     * The stack trace is converted to a string using `throwable.stackTraceToString()`.
-     * The cause is determined from `throwable.cause`, and its stack trace is converted to a string if not null.
      */
     public constructor(throwable: Throwable) : this(
         message = throwable.message ?: "Unknown error",
         stackTrace = throwable.stackTraceToString(),
-        cause = throwable.cause?.stackTraceToString()
+        cause = throwable.cause?.stackTraceToString(),
+        type = throwable.typeName
     )
 }
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/events/toolExecutionEvents.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/events/toolExecutionEvents.kt
@@ -118,7 +118,12 @@ public data class ToolValidationFailedEvent(
         toolArgs = toolArgs,
         toolDescription = null,
         message = error,
-        error = AIAgentError(error, "", null)
+        error = AIAgentError(
+            message = error,
+            stackTrace = "",
+            cause = null,
+            type = null
+        )
     )
 }
 

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/feature/message/FeatureMessageProcessorTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/feature/message/FeatureMessageProcessorTest.kt
@@ -361,7 +361,8 @@ class FeatureMessageProcessorTest {
             val testError = AIAgentError(
                 message = "Test error message",
                 stackTrace = "Test stack trace",
-                cause = "Test cause"
+                cause = "Test cause",
+                type = "Test error type"
             )
 
             // Node Execution Failed Event

--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/feature/model/AIAgentErrorPlatform.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/feature/model/AIAgentErrorPlatform.kt
@@ -1,0 +1,15 @@
+package ai.koog.agents.core.feature.model
+
+/**
+ * Retrieves the fully qualified class name of the [Throwable], or null if unavailable.
+ *
+ * The `typeName` property provides information about the specific type of the [Throwable]
+ * instance. On the JVM, this returns the fully qualified class name, giving precise details
+ * about the exception's originating class. On other platforms, it defaults to the simple class name.
+ *
+ * This property is particularly useful for debugging and error handling, allowing developers to
+ * programmatically access and log the type of exception without requiring additional reflection
+ * or runtime logic.
+ */
+internal actual val Throwable.typeName: String?
+    get() = this::class.qualifiedName

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/feature/AIAgentFeatureTestAPI.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/feature/AIAgentFeatureTestAPI.kt
@@ -94,7 +94,8 @@ internal object AIAgentFeatureTestAPI {
         error = AIAgentError(
             message = "test-error-message",
             stackTrace = "test-error-stacktrace",
-            cause = "test-error-cause"
+            cause = "test-error-cause",
+            type = "test-error-type"
         ),
         timestamp = testClock.now().toEpochMilliseconds()
     )
@@ -173,7 +174,8 @@ internal object AIAgentFeatureTestAPI {
             error = AIAgentError(
                 message = "test-error-message",
                 stackTrace = "test-error-stacktrace",
-                cause = "test-error-cause"
+                cause = "test-error-cause",
+                type = "test-error-type"
             ),
             timestamp = testClock.now().toEpochMilliseconds()
         )
@@ -215,7 +217,8 @@ internal object AIAgentFeatureTestAPI {
             error = AIAgentError(
                 message = "test-error-message",
                 stackTrace = "test-error-stacktrace",
-                cause = "test-error-cause"
+                cause = "test-error-cause",
+                type = "test-error-type"
             ),
             timestamp = testClock.now().toEpochMilliseconds()
         )
@@ -240,7 +243,12 @@ internal object AIAgentFeatureTestAPI {
         toolArgs = JSONObject(mapOf("test-argument-key" to JSONPrimitive("test-argument-value"))),
         toolDescription = "test-tool-description",
         message = "test-error-message",
-        error = AIAgentError("test-error-message", "test-error-stacktrace", "test-error-cause"),
+        error = AIAgentError(
+            message = "test-error-message",
+            stackTrace = "test-error-stacktrace",
+            cause = "test-error-cause",
+            type = "test-error-type"
+        ),
         timestamp = testClock.now().toEpochMilliseconds()
     )
 
@@ -255,7 +263,8 @@ internal object AIAgentFeatureTestAPI {
         error = AIAgentError(
             message = "test-error-message",
             stackTrace = "test-error-stacktrace",
-            cause = "test-error-cause"
+            cause = "test-error-cause",
+            type = "test-error-type"
         ),
         timestamp = testClock.now().toEpochMilliseconds()
     )
@@ -371,7 +380,8 @@ internal object AIAgentFeatureTestAPI {
         error = AIAgentError(
             message = "test-error-message",
             stackTrace = "test-error-stacktrace",
-            cause = "test-error-cause"
+            cause = "test-error-cause",
+            type = "test-error-type"
         ),
         timestamp = testClock.now().toEpochMilliseconds(),
     )

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerStreamingTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerStreamingTest.kt
@@ -37,6 +37,7 @@ import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.llm.toModelInfo
 import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.serialization.kotlinx.KotlinxSerializer
 import ai.koog.utils.io.use
@@ -48,7 +49,6 @@ import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
-import org.junit.jupiter.api.Disabled
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -56,7 +56,6 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
-@Disabled("Flaky, see #1124")
 class DebuggerStreamingTest {
     private val serializer = KotlinxSerializer()
 
@@ -197,7 +196,25 @@ class DebuggerStreamingTest {
                             runId = clientEventsCollector.runId,
                             prompt = expectedLLMCallPrompt,
                             model = mockLLModel.toModelInfo(),
-                            frame = StreamFrame.TextDelta(testLLMResponse),
+                            frame = StreamFrame.TextDelta(testLLMResponse, index = 0),
+                            timestamp = testClock.now().toEpochMilliseconds(),
+                        ),
+                        LLMStreamingFrameReceivedEvent(
+                            eventId = actualStreamingStartingEvent.eventId,
+                            executionInfo = agentExecutionInfo(agentId, strategyName, nodeLLMRequestStreamingName),
+                            runId = clientEventsCollector.runId,
+                            prompt = expectedLLMCallPrompt,
+                            model = mockLLModel.toModelInfo(),
+                            frame = StreamFrame.TextComplete(testLLMResponse, index = 0),
+                            timestamp = testClock.now().toEpochMilliseconds(),
+                        ),
+                        LLMStreamingFrameReceivedEvent(
+                            eventId = actualStreamingStartingEvent.eventId,
+                            executionInfo = agentExecutionInfo(agentId, strategyName, nodeLLMRequestStreamingName),
+                            runId = clientEventsCollector.runId,
+                            prompt = expectedLLMCallPrompt,
+                            model = mockLLModel.toModelInfo(),
+                            frame = StreamFrame.End(null, ResponseMetaInfo.Empty),
                             timestamp = testClock.now().toEpochMilliseconds(),
                         ),
                         LLMStreamingCompletedEvent(
@@ -266,8 +283,10 @@ class DebuggerStreamingTest {
         )
 
         // Executor
-        val testStreamingErrorMessage = "Test streaming error"
-        var testStreamingStackTrace = ""
+        val expectedErrorMessage = "Test streaming error"
+        var expectedStackTrace = ""
+        var expectedCause: String? = null
+        var expectedType: String? = null
 
         val testStreamingExecutor = object : PromptExecutor() {
             override suspend fun execute(
@@ -281,8 +300,10 @@ class DebuggerStreamingTest {
                 model: LLModel,
                 tools: List<ToolDescriptor>
             ): Flow<StreamFrame> = flow {
-                val testException = IllegalStateException(testStreamingErrorMessage)
-                testStreamingStackTrace = testException.stackTraceToString()
+                val testException = IllegalStateException(expectedErrorMessage)
+                expectedStackTrace = testException.stackTraceToString()
+                expectedCause = testException.cause?.toString()
+                expectedType = testException::class.qualifiedName
                 throw testException
             }
 
@@ -346,7 +367,7 @@ class DebuggerStreamingTest {
                 }
             }
 
-            assertEquals(testStreamingErrorMessage, throwable.message)
+            assertEquals(expectedErrorMessage, throwable.message)
         }
 
         // Client
@@ -397,7 +418,12 @@ class DebuggerStreamingTest {
                             runId = clientEventsCollector.runId,
                             prompt = expectedLLMCallPrompt,
                             model = testModel.toModelInfo(),
-                            error = AIAgentError(testStreamingErrorMessage, testStreamingStackTrace),
+                            error = AIAgentError(
+                                message = expectedErrorMessage,
+                                stackTrace = expectedStackTrace,
+                                cause = expectedCause,
+                                type = expectedType,
+                            ),
                             timestamp = testClock.now().toEpochMilliseconds()
                         ),
                         LLMStreamingCompletedEvent(

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerSubgraphTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerSubgraphTest.kt
@@ -306,6 +306,7 @@ class DebuggerSubgraphTest {
                                 message = nodeSubgraphErrorMessage,
                                 stackTrace = actualFailedEvent.error.stackTrace,
                                 cause = actualFailedEvent.error.cause,
+                                type = actualFailedEvent.error.type,
                             ),
                             timestamp = testClock.now().toEpochMilliseconds()
                         ),

--- a/agents/agents-core/src/nonJvmCommonMain/kotlin/ai/koog/agents/core/feature/model/AIAgentErrorPlatform.kt
+++ b/agents/agents-core/src/nonJvmCommonMain/kotlin/ai/koog/agents/core/feature/model/AIAgentErrorPlatform.kt
@@ -1,0 +1,13 @@
+package ai.koog.agents.core.feature.model
+
+/**
+ * Provides the simple class name of the current [Throwable] instance.
+ *
+ * This property retrieves the simple name of the class corresponding to the `Throwable`
+ * instance. On platforms where the fully qualified name is unavailable or impractical
+ * to use, this property ensures that at least the simplified class name is accessible.
+ *
+ * @return The simple class name of the [Throwable], or `null` if it cannot be determined.
+ */
+internal actual val Throwable.typeName: String?
+    get() = this::class.simpleName

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
@@ -280,10 +280,12 @@ class TraceFeatureMessageTestWriterTest {
     fun `test agent with node execution error`() = runBlocking {
         val agentId = "test-agent-id"
         val nodeWithErrorName = "node-with-error"
-        val testErrorMessage = "Test error"
         val strategyName = "test-strategy"
 
+        val testErrorMessage = "Test error"
         var expectedStackTrace = ""
+        var expectedCause: String? = null
+        var expectedType: String? = null
 
         val strategy = strategy(strategyName) {
             val nodeWithError by node<String, String>(nodeWithErrorName) {
@@ -292,6 +294,8 @@ class TraceFeatureMessageTestWriterTest {
                     throw IllegalStateException(testErrorMessage)
                 } catch (t: IllegalStateException) {
                     expectedStackTrace = t.stackTraceToString()
+                    expectedCause = t.cause?.toString()
+                    expectedType = t::class.qualifiedName
                     throw t
                 }
             }
@@ -301,40 +305,45 @@ class TraceFeatureMessageTestWriterTest {
         }
 
         TestFeatureMessageWriter().use { writer ->
-            createAgent(
+            val agent = createAgent(
                 agentId = agentId,
                 strategy = strategy
             ) {
                 install(Tracing) {
                     addMessageProcessor(writer)
                 }
-            }.use { agent ->
-                val throwable = assertFails { agent.run("", null) }
-                assertEquals(testErrorMessage, throwable.message)
-
-                val actualEvents = writer.messages.filterIsInstance<NodeExecutionFailedEvent>().toList()
-
-                val actualNodeWithErrorEvent = writer.messages.singleNodeEvent(nodeWithErrorName)
-
-                val expectedEvents = listOf(
-                    NodeExecutionFailedEvent(
-                        eventId = actualNodeWithErrorEvent.eventId,
-                        executionInfo = agentExecutionInfo(agentId, strategyName, nodeWithErrorName),
-                        runId = writer.runId,
-                        nodeName = nodeWithErrorName,
-                        input = @OptIn(InternalAgentsApi::class)
-                        serializer.encodeToJSONElement(
-                            "",
-                            typeToken<String>()
-                        ),
-                        error = AIAgentError(testErrorMessage, expectedStackTrace, null),
-                        timestamp = testClock.now().toEpochMilliseconds()
-                    )
-                )
-
-                assertEquals(expectedEvents.size, actualEvents.size)
-                assertContentEquals(expectedEvents, actualEvents)
             }
+
+            val throwable = assertFails { agent.run("", null) }
+            assertEquals(testErrorMessage, throwable.message)
+
+            val actualEvents = writer.messages.filterIsInstance<NodeExecutionFailedEvent>().toList()
+
+            val actualNodeWithErrorEvent = writer.messages.singleNodeEvent(nodeWithErrorName)
+
+            val expectedEvents = listOf(
+                NodeExecutionFailedEvent(
+                    eventId = actualNodeWithErrorEvent.eventId,
+                    executionInfo = agentExecutionInfo(agentId, strategyName, nodeWithErrorName),
+                    runId = writer.runId,
+                    nodeName = nodeWithErrorName,
+                    input = @OptIn(InternalAgentsApi::class)
+                    serializer.encodeToJSONElement(
+                        "",
+                        typeToken<String>()
+                    ),
+                    error = AIAgentError(
+                        message = testErrorMessage,
+                        stackTrace = expectedStackTrace,
+                        cause = expectedCause,
+                        type = expectedType
+                    ),
+                    timestamp = testClock.now().toEpochMilliseconds()
+                )
+            )
+
+            assertEquals(expectedEvents.size, actualEvents.size)
+            assertContentEquals(expectedEvents, actualEvents)
         }
     }
 
@@ -475,13 +484,15 @@ class TraceFeatureMessageTestWriterTest {
 
         val toolRegistry = ToolRegistry { tool(DummyTool()) }
 
-        val testStreamingErrorMessage = "Test streaming error"
-        var testStreamingStackTrace = ""
+        val expectedErrorMessage = "Test streaming error"
+        var expectedStackTrace = ""
+        var expectedCause: String? = null
+        var expectedType: String? = null
 
         val testStreamingExecutor = object : PromptExecutor() {
             override suspend fun execute(
                 prompt: Prompt,
-                model: ai.koog.prompt.llm.LLModel,
+                model: LLModel,
                 tools: List<ToolDescriptor>
             ): List<Message.Response> = emptyList()
 
@@ -490,8 +501,10 @@ class TraceFeatureMessageTestWriterTest {
                 model: LLModel,
                 tools: List<ToolDescriptor>
             ): Flow<StreamFrame> = flow {
-                val testException = IllegalStateException(testStreamingErrorMessage)
-                testStreamingStackTrace = testException.stackTraceToString()
+                val testException = IllegalStateException(expectedErrorMessage)
+                expectedStackTrace = testException.stackTraceToString()
+                expectedCause = testException.cause?.toString()
+                expectedType = testException::class.qualifiedName
                 throw testException
             }
 
@@ -526,7 +539,7 @@ class TraceFeatureMessageTestWriterTest {
                     agent.run("", null)
                 }
 
-                assertEquals(testStreamingErrorMessage, throwable.message)
+                assertEquals(expectedErrorMessage, throwable.message)
 
                 val expectedPrompt = Prompt(
                     messages = listOf(
@@ -560,7 +573,12 @@ class TraceFeatureMessageTestWriterTest {
                         runId = writer.runId,
                         prompt = expectedPrompt,
                         model = model.toModelInfo(),
-                        error = AIAgentError(testStreamingErrorMessage, testStreamingStackTrace),
+                        error = AIAgentError(
+                            message = expectedErrorMessage,
+                            stackTrace = expectedStackTrace,
+                            cause = expectedCause,
+                            type = expectedType
+                        ),
                         timestamp = testClock.now().toEpochMilliseconds()
                     ),
                     LLMStreamingCompletedEvent(
@@ -674,25 +692,27 @@ class TraceFeatureMessageTestWriterTest {
         }
 
         TestFeatureMessageWriter().use { writer ->
-            var expectedStackTrace: String = ""
+            var expectedStackTrace = ""
             var expectedCause: String? = null
+            var expectedType: String? = null
 
-            val agentThrowable = createAgent(
+            val agent = createAgent(
                 agentId = agentId,
                 strategy = strategy,
             ) {
                 install(Tracing) {
                     addMessageProcessor(writer)
                 }
-            }.use { agent ->
-                assertFails {
-                    try {
-                        agent.run(inputRequest, null)
-                    } catch (t: Throwable) {
-                        expectedStackTrace = t.stackTraceToString()
-                        expectedCause = t.cause?.stackTraceToString()
-                        throw t
-                    }
+            }
+
+            val agentThrowable = assertFails {
+                try {
+                    agent.run(inputRequest, null)
+                } catch (t: Throwable) {
+                    expectedStackTrace = t.stackTraceToString()
+                    expectedCause = t.cause?.stackTraceToString()
+                    expectedType = t::class.qualifiedName
+                    throw t
                 }
             }
 
@@ -734,6 +754,7 @@ class TraceFeatureMessageTestWriterTest {
                         message = subgraphNodeErrorMessage,
                         stackTrace = expectedStackTrace,
                         cause = expectedCause,
+                        type = expectedType
                     ),
                     timestamp = testClock.now().toEpochMilliseconds()
                 )


### PR DESCRIPTION
- Include 'type' parameter to the AIAgentError class to use this information on the receiver side. This can be used in the Open Telemetry feature to add a necessary span attribute.

closes: [KG-814](https://youtrack.jetbrains.com/issue/KG-814)