### PR TITLE
test: update Ollama default model in the integration tests

### DIFF
--- a/integration-tests/src/jvmMain/kotlin/ai/koog/integration/tests/OllamaTestFixture.kt
+++ b/integration-tests/src/jvmMain/kotlin/ai/koog/integration/tests/OllamaTestFixture.kt
@@ -38,12 +38,12 @@ class OllamaTestFixture {
     lateinit var executor: MultiLLMPromptExecutor
         private set
 
-    val model = OllamaModels.Meta.LLAMA_3_2
+    val model = OllamaModels.Alibaba.QWEN_3_5_9B
     val embeddingsModel = OllamaModels.Embeddings.NOMIC_EMBED_TEXT
     val visionModel = OllamaModels.Granite.GRANITE_3_2_VISION
     val moderationModel = OllamaModels.Meta.LLAMA_GUARD_3
     val thinkingModel = OllamaModels.DeepSeek.DEEPSEEK_R1_DISTILL_LLAMA_1_5B
-    val modelsWithHallucinations = listOf(OllamaModels.Meta.LLAMA_3_2, OllamaModels.Groq.LLAMA_3_GROK_TOOL_USE_8B)
+    val modelsWithHallucinations = listOf(model, OllamaModels.Groq.LLAMA_3_GROK_TOOL_USE_8B)
 
     private lateinit var ollamaContainer: GenericContainer<*>
 
@@ -104,7 +104,7 @@ class OllamaTestFixture {
             withExposedPorts(PORT)
             withCreateContainerCmdModifier { cmd ->
                 cmd.hostConfig?.apply {
-                    withMemory(4L * 1024 * 1024 * 1024) // 4GB RAM
+                    withMemory(12L * 1024 * 1024 * 1024) // 12GB RAM for qwen3.5:9b
                     withCpuCount(2L)
                     // Mount the external volume
                     withBinds(

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/OllamaAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/OllamaAgentIntegrationTest.kt
@@ -30,7 +30,6 @@ import ai.koog.integration.tests.utils.tools.GeographyQueryTool
 import ai.koog.prompt.dsl.Prompt
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.model.PromptExecutor
-import ai.koog.prompt.executor.ollama.client.OllamaModels
 import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.markdown.markdown
@@ -76,11 +75,11 @@ class OllamaAgentIntegrationTest : AIAgentTestBase() {
 
     private val toolCalls = mutableListOf<String>()
 
-    private fun createTestStrategy() = strategy<String, String>("test-ollama") {
+    private fun createTestStrategy(llmModel: LLModel = model) = strategy<String, String>("test-ollama") {
         val askCapitalSubgraph by subgraph<String, String>("ask-capital") {
             val definePrompt by node<Unit, Unit> {
                 llm.writeSession {
-                    model = OllamaModels.Meta.LLAMA_3_2
+                    model = llmModel
                     rewritePrompt {
                         prompt("test-ollama") {
                             system(
@@ -121,7 +120,7 @@ class OllamaAgentIntegrationTest : AIAgentTestBase() {
         val askVerifyAnswer by subgraph<String, String>("verify-answer") {
             val definePrompt by node<Unit, Unit> {
                 llm.writeSession {
-                    model = OllamaModels.Meta.LLAMA_3_2
+                    model = llmModel
                     appendPrompt {
                         system(
                             """"

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/OllamaSimpleAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/OllamaSimpleAgentIntegrationTest.kt
@@ -1,8 +1,10 @@
 package ai.koog.integration.tests.agent
 
 import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.ToolRegistry
-import ai.koog.agents.ext.tool.SayToUser
+import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.features.eventHandler.feature.EventHandler
 import ai.koog.agents.features.eventHandler.feature.EventHandlerConfig
 import ai.koog.integration.tests.InjectOllamaTestFixture
@@ -10,9 +12,16 @@ import ai.koog.integration.tests.OllamaTestFixture
 import ai.koog.integration.tests.OllamaTestFixtureExtension
 import ai.koog.integration.tests.utils.annotations.Retry
 import ai.koog.integration.tests.utils.annotations.RetryExtension
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.params.LLMParams
+import ai.koog.prompt.params.LLMParams.ToolChoice
+import ai.koog.serialization.typeToken
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotBeBlank
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.Serializable
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -26,54 +35,68 @@ class OllamaSimpleAgentIntegrationTest : AIAgentTestBase() {
         private lateinit var fixture: OllamaTestFixture
         private val ollamaSimpleExecutor get() = fixture.executor
         private val ollamaModel get() = fixture.model
+        private const val WORD = "Wiedergabegeschwindigkeitsmesserverwendungserlaubnis"
+    }
+
+    class GiveMeWordTool(name: String) : SimpleTool<GiveMeWordTool.Args>(
+        argsType = typeToken<Args>(),
+        name = name,
+        description = "A tool that returns a very specific German word.",
+    ) {
+        @Serializable
+        data class Args(
+            @property:LLMDescription("The question to ask")
+            val question: String
+        )
+
+        override suspend fun execute(args: Args): String = WORD
     }
 
     val eventHandlerConfig: EventHandlerConfig.() -> Unit = {
         onToolCallStarting { eventContext ->
             actualToolCalls.add(eventContext.toolName)
+            actualToolCallArgs.add(eventContext.toolArgs.toString())
         }
     }
 
     val actualToolCalls = mutableListOf<String>()
+    val actualToolCallArgs = mutableListOf<String>()
 
     @AfterEach
     fun teardown() {
         actualToolCalls.clear()
+        actualToolCallArgs.clear()
     }
 
     @Retry
     @Test
     fun ollama_simpleTest() = runTest(timeout = 600.seconds) {
+        val giveMeWordTool = GiveMeWordTool("give_me_word_tool")
         val toolRegistry = ToolRegistry.Companion {
-            tool(SayToUser)
+            tool(giveMeWordTool)
         }
 
-        val bookwormPrompt = """
-            You're top librarian, helping user to find books.
-            ALWAYS communicate to user via tools!!!
-            ALWAYS use tools you've been provided.
-            ALWAYS generate valid JSON responses.
-            ALWAYS call tool correctly, with valid arguments.
-            NEVER provide tool call in result body.
-            
-            Example tool call:
-            {
-                "id":"ollama_tool_call_3743609160",
-                "tool":"say_to_user",
-                "content":{"message":"The top 10 books of all time are:\n 1. Don Quixote by Miguel de Cervantes\n 2. A Tale of Two Cities by Charles Dickens\n 3. The Lord of the Rings by J.R.R. Tolkien\n 4. Pride and Prejudice by Jane Austen\n 5. To Kill a Mockingbird by Harper Lee\n 6. The Catcher in the Rye by J.D. Salinger\n 7. 1984 by George Orwell\n 8. The Great Gatsby by F. Scott Fitzgerald\n 9. War and Peace by Leo Tolstoy\n 10. Alice’s Adventures in Wonderland by Lewis Carroll"})
-            }
-        """.trimIndent()
-
-        AIAgent(
+        val result = AIAgent(
             promptExecutor = ollamaSimpleExecutor,
-            systemPrompt = bookwormPrompt,
-            llmModel = ollamaModel,
-            temperature = 0.0,
+            agentConfig = AIAgentConfig(
+                prompt = prompt(
+                    id = "ollama-simple-agent",
+                    params = LLMParams(
+                        temperature = 0.0,
+                        toolChoice = ToolChoice.Named(giveMeWordTool.name)
+                    )
+                ) {},
+                model = ollamaModel,
+                maxAgentIterations = 10,
+            ),
             toolRegistry = toolRegistry,
-            maxIterations = 10,
             installFeatures = { install(EventHandler.Feature, eventHandlerConfig) }
-        ).run("Give me top 10 books of the all time.")
+        ).run(
+            "Give me any word."
+        )
 
-        actualToolCalls.shouldNotBeEmpty().shouldContain(SayToUser.name)
+        actualToolCalls.shouldNotBeEmpty().shouldContain(giveMeWordTool.name)
+        actualToolCallArgs.shouldNotBeEmpty()
+        result.shouldNotBeBlank().shouldContain(WORD)
     }
 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/OllamaExecutorIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/OllamaExecutorIntegrationTest.kt
@@ -12,7 +12,6 @@ import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.clients.LLMClient
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.executor.ollama.client.findByNameOrNull
-import ai.koog.prompt.llm.LLMCapability.Completion
 import ai.koog.prompt.llm.LLMCapability.Schema
 import ai.koog.prompt.llm.LLMCapability.Temperature
 import ai.koog.prompt.llm.LLMCapability.Tools
@@ -23,8 +22,10 @@ import ai.koog.prompt.streaming.StreamFrame
 import io.kotest.assertions.withClue
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.booleans.shouldNotBeTrue
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -256,20 +257,13 @@ class OllamaExecutorIntegrationTest : ExecutorIntegrationTestBase() {
     fun `ollama_test get model`() = runTest(timeout = 600.seconds) {
         client.getModelOrNull(model.id) shouldNotBeNull {
             name shouldBe model.id
-            family shouldBe "llama"
-            families shouldBe listOf("llama")
-            size shouldBe 2019393189
-            parameterCount shouldBe 3212749888
-            contextLength shouldBe 131072
-            embeddingLength shouldBe 3072
-            quantizationLevel shouldBe "Q4_K_M"
-            capabilities shouldBe listOf(
-                Completion,
-                Tools,
-                Temperature,
-                Schema.JSON.Basic,
-                Schema.JSON.Standard
-            )
+            size shouldBeGreaterThan 0
+            contextLength.shouldNotBeNull {
+                this shouldBeGreaterThan 0L
+            }
+            capabilities shouldContain Schema.JSON.Basic
+            capabilities shouldContain Temperature
+            capabilities shouldContain Tools
         }
     }
 


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

Update Ollama integration tests, switch the default model to `QWEN 3.5-9B`
