### PR TITLE
fix: reflected tool with optional parameters

### DIFF
--- a/agents/agents-tools/src/jvmCommonMain/kotlin/ai/koog/agents/core/tools/schema/SchemaGenerator.jvmCommon.kt
+++ b/agents/agents-tools/src/jvmCommonMain/kotlin/ai/koog/agents/core/tools/schema/SchemaGenerator.jvmCommon.kt
@@ -116,8 +116,8 @@ public fun getToolDescriptor(
     val schema = createReflectionFunctionGenerator(jsonSchemaConfig)
         .generateSchema(callable)
 
-    // All parameters for function calling are considered required
-    val requiredParameters = schema.parameters.properties
+    val requiredParameterNames = schema.parameters.required.orEmpty().toSet()
+    val (requiredParameters, optionalParameters) = schema.parameters.properties
         .orEmpty()
         .map { (name, property) ->
             val parameterInfo = property.toToolParameter(defs = null) // no defs in function calling schema
@@ -128,11 +128,13 @@ public fun getToolDescriptor(
                 type = parameterInfo.type
             )
         }
+        .partition { it.name in requiredParameterNames }
 
     return ToolDescriptor(
         name = toolName ?: schema.name,
         description = toolDescription ?: schema.description.orEmpty(),
         requiredParameters = requiredParameters,
+        optionalParameters = optionalParameters,
     )
 }
 

--- a/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/schema/FunctionSchemaGenerationTest.kt
+++ b/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/schema/FunctionSchemaGenerationTest.kt
@@ -76,6 +76,16 @@ class FunctionSchemaGenerationTest {
         return ""
     }
 
+    @LLMDescription("Function with default parameters")
+    fun functionWithDefaultParameters(
+        required: String,
+        nullableWithoutDefault: String?,
+        optionalString: String = "default",
+        optionalNullable: Int? = null,
+    ): String {
+        return ""
+    }
+
     @OptIn(InternalAgentToolsApi::class)
     @Test
     fun testGeneratesToolDescriptorFromFunction() {
@@ -251,15 +261,6 @@ class FunctionSchemaGenerationTest {
                 "doubleProperty",
                 "floatProperty",
                 "booleanNullableProperty",
-                "nullableProperty",
-                "listProperty",
-                "mapProperty",
-                "nestedProperty",
-                "nestedListProperty",
-                "nestedMapProperty",
-                "polymorphicProperty",
-                "enumProperty",
-                "objectProperty",
             ),
             additionalProperties = false,
         )
@@ -273,6 +274,8 @@ class FunctionSchemaGenerationTest {
                     description = "Sample parameter",
                     type = ToolParameterType.String,
                 ),
+            ),
+            optionalParameters = listOf(
                 ToolParameterDescriptor(
                     name = "b",
                     description = "Another sample parameter",
@@ -293,6 +296,25 @@ class FunctionSchemaGenerationTest {
         )
 
         assertEquals(expectedDescriptor, actualDescriptor)
+    }
+
+    @OptIn(InternalAgentToolsApi::class)
+    @Test
+    fun testGeneratesOptionalParametersFromDefaultFunctionArguments() {
+        val actualDescriptor = getToolDescriptor(
+            callable = ::functionWithDefaultParameters,
+            toolName = "test_default_params",
+            toolDescription = "Test default parameters",
+        )
+
+        assertEquals(
+            listOf("required", "nullableWithoutDefault"),
+            actualDescriptor.requiredParameters.map { it.name },
+        )
+        assertEquals(
+            listOf("optionalString", "optionalNullable"),
+            actualDescriptor.optionalParameters.map { it.name },
+        )
     }
 
     @OptIn(InternalAgentToolsApi::class)


### PR DESCRIPTION
Tools created by JVM reflection are having incorrect parameters now. All the parameters are set to required.

This PR fixes this behavior, letting the optional parameters being optional.