### PR TITLE
fix: filter empty text complete frames in stream responses

### DIFF
--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameExt.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameExt.kt
@@ -102,7 +102,7 @@ public fun Iterable<StreamFrame>.toMessageResponses(): List<Message.Response> {
                 )
             )
         }
-        textMessagesCompleteFrames.forEach {
+        textMessagesCompleteFrames.filterNot { it.text.isEmpty() }.forEach {
             add(
                 Message.Assistant(
                     content = it.text,

--- a/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameExtTest.kt
+++ b/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameExtTest.kt
@@ -357,6 +357,56 @@ internal class StreamFrameExtTest {
     }
 
     @Test
+    fun testToMessageResponsesSkipsEmptyTextCompleteFrames() {
+        val frames = listOf(
+            StreamFrame.TextComplete("Hello", index = 0),
+            StreamFrame.ToolCallComplete("call_1", "tool", "{}", index = 1),
+            StreamFrame.TextDelta("", index = 2),
+            StreamFrame.TextComplete("", index = 2),
+            StreamFrame.ToolCallComplete("call_2", "otherTool", """{"query":"test"}""", index = 3),
+            StreamFrame.End("tool_calls", ResponseMetaInfo.Empty)
+        )
+
+        val messages = frames.toMessageResponses()
+
+        assertEquals(
+            listOf(
+                Message.Assistant(
+                    parts = listOf(ContentPart.Text("Hello")),
+                    finishReason = "tool_calls",
+                    metaInfo = ResponseMetaInfo.Empty
+                ),
+                Message.Tool.Call(
+                    id = "call_1",
+                    tool = "tool",
+                    content = "{}",
+                    metaInfo = ResponseMetaInfo.Empty
+                ),
+                Message.Tool.Call(
+                    id = "call_2",
+                    tool = "otherTool",
+                    content = """{"query":"test"}""",
+                    metaInfo = ResponseMetaInfo.Empty
+                )
+            ),
+            messages
+        )
+    }
+
+    @Test
+    fun testToMessageResponsesSkipsEmptyOnlyTextCompleteFrames() {
+        val frames = listOf(
+            StreamFrame.TextDelta(""),
+            StreamFrame.TextComplete(""),
+            StreamFrame.End("stop", ResponseMetaInfo.Empty)
+        )
+
+        val messages = frames.toMessageResponses()
+
+        assertEquals(emptyList(), messages)
+    }
+
+    @Test
     fun testToMessageResponsesWithEmptyFrames() {
         val frames = emptyList<StreamFrame>()
 


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

Filter out empty text complete frames in `toMessageResponses` conversion and add corresponding tests.

<!-- Include references to related issues below, e.g., closes #1, closes KG-1. Otherwise, delete it. -->
closes #1923 
