### PR TITLE
test: fix Ollama tests run

### DIFF
--- a/.github/workflows/ollama-tests.yml
+++ b/.github/workflows/ollama-tests.yml
@@ -13,7 +13,7 @@ on:
     branches: [ "main", "develop" ]
 
 env:
-  OLLAMA_VERSION: "0.12.6"
+  OLLAMA_VERSION: "0.22.0"
 
 jobs:
   integration-tests:
@@ -104,18 +104,25 @@ jobs:
         run: |
           echo "=== Installing Ollama ==="
           curl -fsSL https://ollama.com/install.sh | sh
+          ollama --version
 
-          echo "=== Starting Ollama in background ==="
-          nohup ollama serve > /tmp/ollama.log 2>&1 &
-          OLLAMA_PID=$!
-          echo "OLLAMA_PID=$OLLAMA_PID" >> $GITHUB_ENV
-          echo "Ollama PID: $OLLAMA_PID"
+          if systemctl is-active --quiet ollama; then
+            echo "=== Ollama systemd service is active ==="
+            echo "OLLAMA_PID=" >> $GITHUB_ENV
+          else
+            echo "=== Starting Ollama in background ==="
+            nohup ollama serve > /tmp/ollama.log 2>&1 &
+            OLLAMA_PID=$!
+            echo "OLLAMA_PID=$OLLAMA_PID" >> $GITHUB_ENV
+            echo "Ollama PID: $OLLAMA_PID"
+          fi
 
           echo "=== Waiting for Ollama to be ready ==="
           timeout 10 bash -c 'until curl -s http://localhost:11434 > /dev/null 2>&1; do echo "Waiting..."; sleep 2; done'
 
           echo "=== Ollama started successfully ==="
           curl -s http://localhost:11434
+          curl -s http://localhost:11434/api/version
 
       - name: JvmOllamaTest with Gradle Wrapper
         env:
@@ -152,7 +159,10 @@ jobs:
         if: always()
         run: |
           echo "=== Stopping Ollama ==="
-          if [ -n "$OLLAMA_PID" ]; then
+          if systemctl is-active --quiet ollama; then
+            sudo systemctl stop ollama || true
+            echo "Ollama systemd service stopped"
+          elif [ -n "$OLLAMA_PID" ]; then
             kill $OLLAMA_PID || true
             echo "Ollama process $OLLAMA_PID stopped"
           else
@@ -161,6 +171,7 @@ jobs:
           fi
 
           echo "=== Ollama logs (last 50 lines) ==="
+          journalctl -u ollama --no-pager -n 50 || true
           tail -50 /tmp/ollama.log || echo "No Ollama logs found"
 
       - name: Collect reports

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -553,10 +553,20 @@ public class OllamaClient @JvmOverloads constructor(
                 setBody(OllamaPullModelRequestDTO(name = name, stream = false))
             }.body<OllamaPullModelResponseDTO>()
 
-            if ("success" !in response.status) throw LLMClientException(clientName, "Failed to pull model: '$name'")
+            response.error?.let { error ->
+                throw LLMClientException(clientName, "Failed to pull model '$name': $error")
+            }
+
+            val status = response.status
+                ?: throw LLMClientException(clientName, "Failed to pull model '$name': Ollama response did not contain status")
+
+            if ("success" !in status) throw LLMClientException(clientName, "Failed to pull model '$name': $status")
 
             logger.info { "Pulled model '$name'" }
         } catch (e: CancellationException) {
+            throw e
+        } catch (e: LLMClientException) {
+            logger.error(e) { e.message }
             throw e
         } catch (e: Exception) {
             val exception = LLMClientException(

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaManagementModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaManagementModels.kt
@@ -87,7 +87,8 @@ internal data class OllamaPullModelRequestDTO(
  */
 @Serializable
 internal data class OllamaPullModelResponseDTO(
-    val status: String,
+    val status: String? = null,
+    val error: String? = null,
     val digest: String? = null,
     val total: Long? = null,
     val completed: Long? = null

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClientTest.kt
@@ -1,16 +1,23 @@
 package ai.koog.prompt.executor.ollama.client
 
 import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.clients.LLMClientException
 import ai.koog.prompt.executor.ollama.client.dto.OllamaChatMessageDTO
 import ai.koog.prompt.executor.ollama.client.dto.OllamaChatResponseDTO
 import ai.koog.prompt.executor.ollama.client.dto.OllamaToolCallDTO
 import ai.koog.prompt.message.Message
 import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class OllamaClientTest {
@@ -60,5 +67,37 @@ class OllamaClientTest {
         val assistantMessage = responses[1]
         assertTrue(assistantMessage is Message.Assistant)
         assertEquals(responseContent, assistantMessage.content)
+    }
+
+    @Test
+    fun testGetModelOrNullReportsPullErrorResponse() = runTest {
+        val errorMessage = "pull model manifest: file does not exist"
+        val mockEngine = MockEngine { request ->
+            when (request.url.encodedPath) {
+                "/api/tags" -> respond(
+                    content = """{"models":[]}""",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType to listOf("application/json")),
+                )
+
+                "/api/pull" -> respond(
+                    content = """{"error":"$errorMessage"}""",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType to listOf("application/json")),
+                )
+
+                else -> error("Unexpected request to ${request.url.encodedPath}")
+            }
+        }
+
+        val ollamaClient = OllamaClient(
+            baseClient = HttpClient(mockEngine)
+        )
+
+        val exception = assertFailsWith<LLMClientException> {
+            ollamaClient.getModelOrNull("missing-model", pullIfMissing = true)
+        }
+
+        assertTrue(exception.message.orEmpty().contains(errorMessage))
     }
 }


### PR DESCRIPTION


<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

Handle null `status` and add `error` field in `OllamaPullModelResponseDTO`; enhance error handling in the CI log; update the Ollama version in tests.

The general purpose is to make Ollama tests green again.