### PR TITLE
build: Update min Java version from 11 to 17

### DIFF
--- a/convention-plugin-ai/src/main/kotlin/ai.kotlin.configuration.gradle.kts
+++ b/convention-plugin-ai/src/main/kotlin/ai.kotlin.configuration.gradle.kts
@@ -57,7 +57,7 @@ tasks.withType<KotlinCompilationTask<*>>().configureEach {
 
 tasks.withType<KotlinJvmCompile>().configureEach {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_11)
+        jvmTarget.set(JvmTarget.JVM_17)
         jvmDefault = JvmDefaultMode.ENABLE
         javaParameters = true
         freeCompilerArgs.addAll(
@@ -71,8 +71,8 @@ tasks.withType<KotlinJvmCompile>().configureEach {
 
 tasks.withType<JavaCompile>().configureEach {
     this.options.compilerArgs.addAll(listOf("-parameters", "-g"))
-    sourceCompatibility = JavaVersion.VERSION_11.toString()
-    targetCompatibility = JavaVersion.VERSION_11.toString()
+    sourceCompatibility = JavaVersion.VERSION_17.toString()
+    targetCompatibility = JavaVersion.VERSION_17.toString()
 }
 
 configurations.all {


### PR DESCRIPTION

JDK 17 is already a minimal required version in the documentation and in the README.

<!-- Include BREAKING section below only if this PR introduces breaking changes. Otherwise, delete it. -->
BREAKING:
* Update min Java version from 11 to 17.

<!-- Include DEPRECATED section below only if this PR deprecates any public APIs. Otherwise, delete it. -->
DEPRECATED:
*

<!-- Include references to related issues below, e.g., closes #1, closes KG-1. Otherwise, delete it. -->
closes
