### PR TITLE
fix(prompt): preserve Google assistant text alongside tool calls

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -315,14 +315,19 @@ public open class GoogleLLMClient @JvmOverloads constructor(
     internal fun createGoogleRequest(prompt: Prompt, model: LLModel, tools: List<ToolDescriptor>): GoogleRequest {
         val systemMessageParts = mutableListOf<GooglePart.Text>()
         val contents = mutableListOf<GoogleContent>()
+        val pendingTextParts = mutableListOf<GooglePart.Text>()
         val pendingCalls = mutableListOf<GooglePart.FunctionCall>()
         val pendingResults = mutableListOf<GooglePart.FunctionResponse>()
         var lastSignature: String? = null
         val isThinkingModel = model.supports(LLMCapability.Thinking)
 
-        fun flushCalls() {
-            if (pendingCalls.isNotEmpty()) {
-                contents += GoogleContent(role = "model", parts = pendingCalls.toList())
+        fun flushModel() {
+            if (pendingTextParts.isNotEmpty() || pendingCalls.isNotEmpty()) {
+                contents += GoogleContent(
+                    role = "model",
+                    parts = pendingTextParts.toList() + pendingCalls.toList()
+                )
+                pendingTextParts.clear()
                 pendingCalls.clear()
             }
         }
@@ -335,7 +340,7 @@ public open class GoogleLLMClient @JvmOverloads constructor(
         }
 
         fun flushAll() {
-            flushCalls()
+            flushModel()
             flushResults()
         }
 
@@ -352,21 +357,16 @@ public open class GoogleLLMClient @JvmOverloads constructor(
                 }
 
                 is Message.Assistant -> {
-                    flushAll()
-                    contents.add(
-                        GoogleContent(
-                            role = "model",
-                            parts = listOf(GooglePart.Text(message.content))
-                        )
-                    )
+                    // A new model turn starts here, so close any pending user turn (tool results) first.
+                    flushResults()
+                    // Buffer assistant text so it merges with any following Tool.Calls in the same model turn.
+                    pendingTextParts.add(GooglePart.Text(message.content))
                 }
 
                 is Message.Reasoning -> {
-                    // Reasoning indicates a new step - flush previous step
-                    flushAll()
-
                     if (message.content.isNotBlank()) {
-                        // If content is present, it's a "Thought Summary" -> Convert to Text part with thought=true
+                        // Thought summaries become their own model turn — close any pending model + user turns.
+                        flushAll()
                         contents.add(
                             GoogleContent(
                                 role = "model",
@@ -380,13 +380,17 @@ public open class GoogleLLMClient @JvmOverloads constructor(
                             )
                         )
                     } else {
-                        // If content is empty/blank, it's strictly a signature carrier for the next Tool.Call
+                        // Empty content: strictly a signature carrier for the next Tool.Call.
+                        // It belongs to the same logical model turn as the upcoming Tool.Call,
+                        // so do NOT close pendingTextParts/pendingCalls — only close any pending user turn.
+                        flushResults()
                         lastSignature = message.encrypted
                     }
                 }
 
                 is Message.Tool.Result -> {
-                    // Just buffer results. We only flush when we know the current tool turn is complete.
+                    // Tool results start a user turn; close any pending model turn first.
+                    flushModel()
                     pendingResults.add(
                         GooglePart.FunctionResponse(
                             functionResponse = GoogleData.FunctionResponse(
@@ -745,21 +749,15 @@ public open class GoogleLLMClient @JvmOverloads constructor(
             }
         }
 
-        return when {
-            // When the model calls tools, keep Reasoning (for signature) and Tool.Call, filter out Assistant text
-            responses.any { it is Message.Tool.Call } -> responses.filter { it is Message.Reasoning || it is Message.Tool.Call }
-
-            // If no messages where returned, return an empty message and check finishReason
-            responses.isEmpty() -> listOf(
+        return responses.ifEmpty {
+            // If no messages were returned, return an empty message and check finishReason
+            listOf(
                 Message.Assistant(
                     content = "",
                     finishReason = candidate.finishReason,
                     metaInfo = metaInfo
                 )
             )
-
-            // Just return responses
-            else -> responses
         }
     }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
@@ -504,6 +504,157 @@ class GoogleLLMClientTest {
     }
 
     @Test
+    fun `processGoogleCandidate keeps Assistant text alongside Tool Call`() {
+        val client = GoogleLLMClient(apiKey = "test")
+        val candidate = GoogleCandidate(
+            content = GoogleContent(
+                role = "model",
+                parts = listOf(
+                    GooglePart.Text("Let me check the weather"),
+                    GooglePart.FunctionCall(
+                        functionCall = GoogleData.FunctionCall(
+                            name = "getWeather",
+                            args = buildJsonObject { }
+                        )
+                    )
+                )
+            ),
+            finishReason = "STOP"
+        )
+
+        val responses = client.processGoogleCandidate(candidate, ResponseMetaInfo.Empty)
+
+        responses shouldHaveSize 2
+        responses[0].shouldBeInstanceOf<Message.Assistant>()
+        (responses[0] as Message.Assistant).content shouldBe "Let me check the weather"
+        responses[1].shouldBeInstanceOf<Message.Tool.Call>()
+        (responses[1] as Message.Tool.Call).tool shouldBe "getWeather"
+    }
+
+    @Test
+    fun `processGoogleCandidate keeps Reasoning, Assistant text, and Tool Call together`() {
+        val client = GoogleLLMClient(apiKey = "test")
+        val candidate = GoogleCandidate(
+            content = GoogleContent(
+                role = "model",
+                parts = listOf(
+                    GooglePart.Text(
+                        text = "Thinking step",
+                        thought = true,
+                        thoughtSignature = "sig-1"
+                    ),
+                    GooglePart.Text("Calling weather tool"),
+                    GooglePart.FunctionCall(
+                        functionCall = GoogleData.FunctionCall(
+                            name = "getWeather",
+                            args = buildJsonObject { }
+                        )
+                    )
+                )
+            ),
+            finishReason = "STOP"
+        )
+
+        val responses = client.processGoogleCandidate(candidate, ResponseMetaInfo.Empty)
+
+        responses shouldHaveSize 3
+        responses[0].shouldBeInstanceOf<Message.Reasoning>()
+        (responses[0] as Message.Reasoning).content shouldBe "Thinking step"
+        responses[1].shouldBeInstanceOf<Message.Assistant>()
+        (responses[1] as Message.Assistant).content shouldBe "Calling weather tool"
+        responses[2].shouldBeInstanceOf<Message.Tool.Call>()
+    }
+
+    @Test
+    fun `createGoogleRequest merges Assistant text with following Tool Call into single model content`() {
+        val client = GoogleLLMClient(apiKey = "test")
+        val request = client.createGoogleRequest(
+            Prompt(
+                messages = listOf(
+                    Message.User("query", RequestMetaInfo.Empty),
+                    Message.Assistant("Let me check the weather", ResponseMetaInfo.Empty),
+                    Message.Tool.Call(id = "1", tool = "getWeather", content = "{}", metaInfo = ResponseMetaInfo.Empty),
+                ),
+                id = "id"
+            ),
+            GoogleModels.Gemini2_5Flash,
+            emptyList()
+        )
+
+        request.contents shouldHaveSize 2
+        request.contents[0].role shouldBe "user"
+        request.contents[1].role shouldBe "model"
+        val modelParts = request.contents[1].parts!!
+        modelParts shouldHaveSize 2
+        (modelParts[0] as GooglePart.Text).text shouldBe "Let me check the weather"
+        (modelParts[1] as GooglePart.FunctionCall).functionCall.name shouldBe "getWeather"
+    }
+
+    @Test
+    fun `createGoogleRequest preserves model-user-model order across tool round-trip`() {
+        val client = GoogleLLMClient(apiKey = "test")
+        val request = client.createGoogleRequest(
+            Prompt(
+                messages = listOf(
+                    Message.User("what's the weather?", RequestMetaInfo.Empty),
+                    Message.Assistant("Let me check", ResponseMetaInfo.Empty),
+                    Message.Tool.Call(id = "1", tool = "getWeather", content = "{}", metaInfo = ResponseMetaInfo.Empty),
+                    Message.Tool.Result(id = "1", tool = "getWeather", content = "sunny", metaInfo = RequestMetaInfo.Empty),
+                    Message.Assistant("It's sunny.", ResponseMetaInfo.Empty),
+                ),
+                id = "id"
+            ),
+            GoogleModels.Gemini2_5Flash,
+            emptyList()
+        )
+
+        request.contents shouldHaveSize 4
+        request.contents[0].role shouldBe "user"
+        request.contents[1].role shouldBe "model"
+        request.contents[2].role shouldBe "user"
+        request.contents[3].role shouldBe "model"
+
+        val firstModelParts = request.contents[1].parts!!
+        firstModelParts shouldHaveSize 2
+        (firstModelParts[0] as GooglePart.Text).text shouldBe "Let me check"
+        (firstModelParts[1] as GooglePart.FunctionCall).functionCall.name shouldBe "getWeather"
+
+        val toolResultParts = request.contents[2].parts!!
+        toolResultParts shouldHaveSize 1
+        toolResultParts[0].shouldBeInstanceOf<GooglePart.FunctionResponse>()
+
+        val secondModelParts = request.contents[3].parts!!
+        secondModelParts shouldHaveSize 1
+        (secondModelParts[0] as GooglePart.Text).text shouldBe "It's sunny."
+    }
+
+    @Test
+    fun `createGoogleRequest carries thought signature from Reasoning between Assistant text and Tool Call`() {
+        val client = GoogleLLMClient(apiKey = "test")
+        val request = client.createGoogleRequest(
+            Prompt(
+                messages = listOf(
+                    Message.User("query", RequestMetaInfo.Empty),
+                    Message.Assistant("Let me check", ResponseMetaInfo.Empty),
+                    Message.Reasoning(encrypted = "carried-sig", content = "", metaInfo = ResponseMetaInfo.Empty),
+                    Message.Tool.Call(id = "1", tool = "t1", content = "{}", metaInfo = ResponseMetaInfo.Empty),
+                ),
+                id = "id"
+            ),
+            GoogleModels.Gemini3_Pro_Preview,
+            emptyList()
+        )
+
+        request.contents shouldHaveSize 2
+        val modelParts = request.contents[1].parts!!
+        modelParts shouldHaveSize 2
+        (modelParts[0] as GooglePart.Text).text shouldBe "Let me check"
+        val call = modelParts[1] as GooglePart.FunctionCall
+        call.functionCall.name shouldBe "t1"
+        call.thoughtSignature shouldBe "carried-sig"
+    }
+
+    @Test
     fun `processGoogleCandidate creates Reasoning from Text with thought=true`() {
         val client = GoogleLLMClient(apiKey = "test")
         val candidate = GoogleCandidate(


### PR DESCRIPTION
## Summary

Fixes #1152.

`GoogleLLMClient` was filtering out `Message.Assistant` whenever the same response contained any `Tool.Call`, silently discarding model-generated text the user had already paid for. The encoder also wrote that assistant text and the tool call as two separate `"model"` turns, which is not how Gemini emitted them.

This change:

- Removes the `responses.filter { ... }` in `processGoogleCandidate` that dropped assistant text when tool calls were present.
- Adds a `pendingTextParts` buffer in `createGoogleRequest` so assistant text is sent in the **same** `GoogleContent` as the following `Tool.Call`(s).
- Tightens the turn-boundary logic so that `Tool.Result` closes any pending model turn and a following `Assistant` closes any pending user (results) turn. This keeps `user`/`model` alternation correct across tool round-trips.

Existing tests around parallel tool calls and thought signatures continue to pass; the helper rename from `flushCalls` to `flushModel` does not change observable behavior for those cases.

## Test plan

- [x] `./gradlew :prompt:prompt-executor:prompt-executor-clients:prompt-executor-google-client:jvmTest` (43 tests, 0 failures)
- [x] New tests:
  - `processGoogleCandidate keeps Assistant text alongside Tool Call`
  - `processGoogleCandidate keeps Reasoning, Assistant text, and Tool Call together`
  - `createGoogleRequest merges Assistant text with following Tool Call into single model content`
  - `createGoogleRequest preserves model-user-model order across tool round-trip`
  - `createGoogleRequest carries thought signature from Reasoning between Assistant text and Tool Call`