### PR TITLE
fix(prompt): update OpenAI JSON schema generation for serialization of nullable collections

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/structure/OpenAIStandardJsonSchemaGenerator.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/structure/OpenAIStandardJsonSchemaGenerator.kt
@@ -74,6 +74,41 @@ public open class OpenAIStandardJsonSchemaGenerator : StandardJsonSchemaGenerato
         throw UnsupportedOperationException("OpenAI JSON schema doesn't support maps")
     }
 
+    /*
+     OpenAI strict-mode validators (notably the GPT-5 family) reject nullable arrays encoded as
+     a type union `{"type": ["array", "null"], "items": {...}}`. Emit `anyOf` instead, which is
+     accepted by all current OpenAI strict validators. Non-nullable lists are unchanged.
+     */
+    override fun processList(context: GenerationContext): JsonObject {
+        if (!context.descriptor.isNullable) {
+            return super.processList(context)
+        }
+
+        val itemDescriptor = context.descriptor.getElementDescriptor(0)
+        return buildJsonObject {
+            put(
+                JsonSchemaConsts.Keys.ANY_OF,
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put(JsonSchemaConsts.Keys.TYPE, JsonSchemaConsts.Types.ARRAY)
+                            put(
+                                JsonSchemaConsts.Keys.ITEMS,
+                                process(context.copy(descriptor = itemDescriptor, currentDescription = null))
+                            )
+                        }
+                    )
+                    add(
+                        buildJsonObject {
+                            put(JsonSchemaConsts.Keys.TYPE, JsonSchemaConsts.Types.NULL)
+                        }
+                    )
+                }
+            )
+            context.currentDescription?.let { put(JsonSchemaConsts.Keys.DESCRIPTION, it) }
+        }
+    }
+
     override fun processObject(context: GenerationContext): JsonObject {
         val refObject = super.processObject(context).toMutableMap()
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/structure/OpenAIStandardJsonSchemaGeneratorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/structure/OpenAIStandardJsonSchemaGeneratorTest.kt
@@ -117,6 +117,137 @@ class OpenAIStandardJsonSchemaGeneratorTest {
         }
     }
 
+    @Serializable
+    @SerialName("Tag")
+    data class Tag(
+        val name: String
+    )
+
+    @Serializable
+    @SerialName("NullableListContainer")
+    data class NullableListContainer(
+        val name: String,
+        @property:LLMDescription("Optional list of tags")
+        val tags: List<String>? = null,
+        @property:LLMDescription("Optional list of complex tags")
+        val complexTags: List<Tag>? = null
+    )
+
+    @Test
+    fun testGenerateOpenAIStandardJsonSchemaForNullableLists() {
+        val result = fullGenerator.generate(
+            json,
+            "NullableListContainer",
+            serializer<NullableListContainer>(),
+            emptyMap()
+        )
+        val schema = json.encodeToString(result.schema)
+
+        val expectedSchema = """
+            {
+              "${"$"}id": "NullableListContainer",
+              "${"$"}defs": {
+                "Tag": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "additionalProperties": false
+                },
+                "NullableListContainer": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "tags": {
+                      "anyOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Optional list of tags"
+                    },
+                    "complexTags": {
+                      "anyOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "${"$"}ref": "#/${"$"}defs/Tag"
+                          }
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Optional list of complex tags"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "tags",
+                    "complexTags"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "tags": {
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Optional list of tags"
+                },
+                "complexTags": {
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "${"$"}ref": "#/${"$"}defs/Tag"
+                      }
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Optional list of complex tags"
+                }
+              },
+              "required": [
+                "name",
+                "tags",
+                "complexTags"
+              ],
+              "additionalProperties": false
+            }
+        """.trimIndent()
+
+        assertEquals(expectedSchema, schema)
+    }
+
     @Test
     fun testGenerateOpenAIStandardJsonSchemaWeatherForecast() {
         val result = fullGenerator.generate(json, "WeatherForecast", serializer<WeatherForecast>(), emptyMap())


### PR DESCRIPTION
## Summary                                             

- Nullable `List<X>?` fields produced `{"type": ["array", "null"], "items": {...}}`, which OpenAI's                                                                                   
    GPT-5-family strict-mode validator rejects (surfaces as `'Invalid schema for response_format ...                                                                                    
    got "type": "None"'`). Switch `OpenAIStandardJsonSchemaGenerator.processList` to emit                                                                                               
    `{"anyOf": [{"type": "array", "items": ...}, {"type": "null"}]}` for nullable lists, mirroring                                                                                      
    the shape already used for nullable objects.                                                                                                                                        
- Non-nullable lists, nullable primitives, and the LLM-agnostic `StandardJsonSchemaGenerator` are                                                                                     
    unchanged. Only the OpenAI-specific generator is touched, so other providers keep their existing                                                                                    
    type-union encoding.                                                                                                                                                                
- Adds a regression test (`testGenerateOpenAIStandardJsonSchemaForNullableLists`) covering both                                                                                       
    primitive (`List<String>?`) and `$ref` (`List<Tag>?`) item types.

## Out of scope (could follow up)

- `OpenAIBasicJsonSchemaGenerator` still emits the OpenAPI-3.0-style `nullable: true` keyword, which
    OpenAI strict mode silently ignores. Same root cause family, different generator — happy to file
    a follow-up if useful.                                                                                                         
                                                                                                                                                                                        
closes #1930



