### PR TITLE
fix(agents): persist and restore AIAgentContext.storage in checkpoints

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AgentContextData.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AgentContextData.kt
@@ -2,6 +2,7 @@
 
 package ai.koog.agents.core.agent.context
 
+import ai.koog.agents.core.agent.entity.AIAgentStorageKey
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.prompt.message.Message
 import ai.koog.serialization.JSONElement
@@ -14,7 +15,8 @@ public class AgentContextData(
     internal val lastInput: JSONElement? = null,
     internal val lastOutput: JSONElement? = null,
     internal val rollbackStrategy: RollbackStrategy,
-    internal val additionalRollbackActions: suspend (AIAgentContext) -> Unit = {}
+    internal val additionalRollbackActions: suspend (AIAgentContext) -> Unit = {},
+    internal val storageEntries: Map<AIAgentStorageKey<*>, Any> = emptyMap(),
 ) {
     init {
         require(lastInput == null || lastOutput == null) { "`lastInput` and `lastOutput` cannot be both set" }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentGraphStrategy.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentGraphStrategy.kt
@@ -123,6 +123,13 @@ public open class AIAgentGraphStrategyBase<TInput, TOutput>(
         agentContext.llm.withPrompt {
             this.withMessages { (data.messageHistory) }
         }
+
+        // Restore user-defined storage entries (intermediate state, retry counters, cached data, etc.).
+        // Identity-based key equality means entries are written under the original key instances supplied
+        // by the caller, so existing reads via those keys keep working after resume.
+        if (data.storageEntries.isNotEmpty()) {
+            agentContext.storage.putAll(data.storageEntries)
+        }
     }
 
     private fun setExecutionPointImpl(pathSegments: List<String>, node: AIAgentNodeBase<*, *>, input: Any?) {

--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/AgentCheckpointData.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/AgentCheckpointData.kt
@@ -5,6 +5,7 @@ package ai.koog.agents.snapshot.feature
 import ai.koog.agents.core.agent.context.AIAgentContext
 import ai.koog.agents.core.agent.context.AgentContextData
 import ai.koog.agents.core.agent.context.RollbackStrategy
+import ai.koog.agents.core.agent.entity.AIAgentStorageKey
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.snapshot.providers.PersistenceUtils
 import ai.koog.prompt.message.Message
@@ -14,12 +15,17 @@ import ai.koog.serialization.JSONObject
 import ai.koog.serialization.JSONPrimitive
 import ai.koog.serialization.kotlinx.toKoogJSONElement
 import ai.koog.serialization.kotlinx.toKoogJSONObject
+import ai.koog.serialization.kotlinx.toKotlinxJsonElement
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlin.jvm.JvmOverloads
 import kotlin.time.Instant
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
+
+private val logger = KotlinLogging.logger { }
 
 /**
  * Represents the checkpoint data for an agent's state during a session.
@@ -31,10 +37,15 @@ import kotlin.uuid.Uuid
  * @property lastOutput Serialized output received from node with [nodePath]
  * @property properties Additional data associated with the checkpoint. This can be used to store additional information about the agent's state.
  * @property createdAt The timestamp when the checkpoint was created.
- * @property version The version of the checkpoint data structure
+ * @property version The version of the checkpoint data structure.
+ * @property storage Encoded `AIAgentContext.storage` entries opted in via
+ *  [PersistenceFeatureConfig.persistedKeys]. Keys are the storage key names and values are the
+ *  serialized form produced with the registered [kotlinx.serialization.KSerializer]. `null` (the
+ *  default) means no storage was captured, which is what older checkpoints look like - they keep
+ *  deserializing without a structure version bump.
  */
 @Serializable
-public data class AgentCheckpointData(
+public data class AgentCheckpointData @JvmOverloads constructor(
     val checkpointId: String,
     val createdAt: Instant,
     val nodePath: String,
@@ -43,7 +54,8 @@ public data class AgentCheckpointData(
     val lastOutput: JSONElement? = null,
     val messageHistory: List<Message>,
     val version: Long,
-    val properties: JSONObject? = null
+    val properties: JSONObject? = null,
+    val storage: JSONObject? = null,
 ) {
     /**
      * Constructs an instance of the class with the specified parameters.
@@ -70,14 +82,15 @@ public data class AgentCheckpointData(
         version: Long,
         properties: JsonObject? = null
     ) : this(
-        checkpointId,
-        createdAt,
-        nodePath,
-        lastInput?.toKoogJSONElement(),
-        lastOutput?.toKoogJSONElement(),
-        messageHistory,
-        version,
-        properties?.toKoogJSONObject()
+        checkpointId = checkpointId,
+        createdAt = createdAt,
+        nodePath = nodePath,
+        lastInput = lastInput?.toKoogJSONElement(),
+        lastOutput = lastOutput?.toKoogJSONElement(),
+        messageHistory = messageHistory,
+        version = version,
+        properties = properties?.toKoogJSONObject(),
+        storage = null,
     )
 
     init {
@@ -100,7 +113,8 @@ public data class AgentCheckpointData(
             eq(lastOutput, other.lastOutput) &&
             messageHistory == other.messageHistory &&
             version == other.version &&
-            properties == other.properties
+            properties == other.properties &&
+            storage == other.storage
     }
 }
 
@@ -131,15 +145,26 @@ public fun tombstoneCheckpoint(time: Instant, version: Long): AgentCheckpointDat
 /**
  * Converts an instance of [AgentCheckpointData] to [AgentContextData].
  *
- * The conversion maps the `messageHistory`, `nodeId`, and `lastOutput` properties of
- * [AgentCheckpointData] directly to a new [AgentContextData] instance.
+ * In addition to the execution-position fields (`messageHistory`, `nodePath`, `lastInput`/`lastOutput`),
+ * any [storage] entries whose key name matches an entry in [persistedKeys] are decoded with the
+ * registered [kotlinx.serialization.KSerializer] and surfaced through [AgentContextData.storageEntries],
+ * so the strategy can write them back into the agent's storage under the original key instances.
  *
- * @return A new [AgentContextData] instance containing the message history, node ID,
- * and last input from the [AgentCheckpointData].
+ * Entries in [storage] without a matching registration are dropped with a warning - that case usually
+ * means the user removed a key from [PersistenceFeatureConfig.persistedKeys] but still has older
+ * checkpoints around. Decoding errors are also dropped per-entry rather than failing the whole resume,
+ * because losing one piece of intermediate state is usually preferable to losing the whole session.
+ *
+ * @param rollbackStrategy How execution state should be rolled back when restoring.
+ * @param additionalRollbackAction Optional extra cleanup (for example, side-effecting tool rollbacks).
+ * @param persistedKeys Storage keys to restore. Defaults to empty for callers that don't use storage
+ *  persistence; pass the same list registered with [PersistenceFeatureConfig.persistedKeys] when
+ *  resuming an agent that captured storage entries.
  */
 public fun AgentCheckpointData.toAgentContextData(
     rollbackStrategy: RollbackStrategy,
-    additionalRollbackAction: suspend (AIAgentContext) -> Unit = {}
+    additionalRollbackAction: suspend (AIAgentContext) -> Unit = {},
+    persistedKeys: List<PersistableStorageKey<*>> = emptyList(),
 ): AgentContextData {
     @Suppress("DEPRECATION")
     return AgentContextData(
@@ -147,9 +172,78 @@ public fun AgentCheckpointData.toAgentContextData(
         nodePath = nodePath,
         lastInput = lastInput,
         lastOutput = lastOutput,
-        rollbackStrategy,
-        additionalRollbackAction
+        rollbackStrategy = rollbackStrategy,
+        additionalRollbackActions = additionalRollbackAction,
+        storageEntries = decodeStorageEntries(storage, persistedKeys),
     )
+}
+
+/**
+ * Decodes [encodedStorage] into a typed map keyed by the original [AIAgentStorageKey] instances
+ * supplied through [persistedKeys]. Returns an empty map if there is nothing to decode.
+ */
+private fun decodeStorageEntries(
+    encodedStorage: JSONObject?,
+    persistedKeys: List<PersistableStorageKey<*>>,
+): Map<AIAgentStorageKey<*>, Any> {
+    if (encodedStorage == null || encodedStorage.entries.isEmpty()) return emptyMap()
+    if (persistedKeys.isEmpty()) {
+        logger.warn {
+            "Checkpoint contains ${encodedStorage.entries.size} persisted storage entr" +
+                "${if (encodedStorage.entries.size == 1) "y" else "ies"} but no PersistableStorageKey is " +
+                "registered for restore - storage will not be restored."
+        }
+        return emptyMap()
+    }
+    val keysByName = persistedKeys.associateBy { it.key.name }
+    val json = PersistenceUtils.defaultCheckpointJson
+    val result = mutableMapOf<AIAgentStorageKey<*>, Any>()
+    for ((name, encoded) in encodedStorage.entries) {
+        val persistable = keysByName[name]
+        if (persistable == null) {
+            logger.warn {
+                "Checkpoint contains storage entry '$name' with no matching PersistableStorageKey - skipping."
+            }
+            continue
+        }
+        val decoded = try {
+            json.decodeFromJsonElement(persistable.serializer, encoded.toKotlinxJsonElement())
+        } catch (e: Exception) {
+            logger.warn(e) { "Failed to decode persisted storage entry '$name', skipping." }
+            null
+        }
+        if (decoded != null) {
+            result[persistable.key] = decoded
+        }
+    }
+    return result
+}
+
+/**
+ * Encodes the storage entries that match [persistedKeys] into a [JSONObject] suitable for
+ * [AgentCheckpointData.storage]. Entries whose key is not in [storageMap] are omitted; encoding
+ * failures are logged and skipped per-entry rather than failing the whole snapshot.
+ *
+ * Returns `null` when no entries were encoded so the field is omitted from the serialized form.
+ */
+internal fun encodeStorageEntries(
+    storageMap: Map<AIAgentStorageKey<*>, Any>,
+    persistedKeys: List<PersistableStorageKey<*>>,
+): JSONObject? {
+    if (persistedKeys.isEmpty() || storageMap.isEmpty()) return null
+    val json = PersistenceUtils.defaultCheckpointJson
+    val encoded = mutableMapOf<String, JSONElement>()
+    for (persistable in persistedKeys) {
+        val value = storageMap[persistable.key] ?: continue
+        try {
+            @Suppress("UNCHECKED_CAST")
+            val serializer = persistable.serializer as kotlinx.serialization.KSerializer<Any>
+            encoded[persistable.key.name] = json.encodeToJsonElement(serializer, value).toKoogJSONElement()
+        } catch (e: Exception) {
+            logger.warn(e) { "Failed to encode persisted storage entry '${persistable.key.name}', skipping." }
+        }
+    }
+    return if (encoded.isEmpty()) null else JSONObject(encoded)
 }
 
 /**

--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/PersistableStorageKey.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/PersistableStorageKey.kt
@@ -1,0 +1,35 @@
+package ai.koog.agents.snapshot.feature
+
+import ai.koog.agents.core.agent.entity.AIAgentStorageKey
+import kotlinx.serialization.KSerializer
+
+/**
+ * Pairs an [AIAgentStorageKey] with a [KSerializer] so the persistence feature
+ * can round-trip its value through a checkpoint.
+ *
+ * Storage holds `Any` values; without an explicit serializer per key there is no portable way
+ * to encode and decode them. Equality of [AIAgentStorageKey] is identity-based, so the same
+ * instance must also be used at restore time, which is why registration carries the key itself
+ * and not just its name.
+ *
+ * Construct via [persisted] and pass the result to [PersistenceFeatureConfig.persistedKeys] (for the
+ * automatic snapshot path) or to [Persistence.runFromCheckpoint] (when resuming an agent that did
+ * not have the feature installed).
+ *
+ * @param T The type of the value stored under [key].
+ * @property key The storage key whose value should be included in checkpoints.
+ * @property serializer The kotlinx serializer used to encode and decode the value.
+ */
+public class PersistableStorageKey<T : Any> internal constructor(
+    public val key: AIAgentStorageKey<T>,
+    public val serializer: KSerializer<T>,
+)
+
+/**
+ * Registers [key] for persistence with the given [serializer]. The returned wrapper is intended
+ * for [PersistenceFeatureConfig.persistedKeys] or [Persistence.runFromCheckpoint].
+ */
+public fun <T : Any> persisted(
+    key: AIAgentStorageKey<T>,
+    serializer: KSerializer<T>,
+): PersistableStorageKey<T> = PersistableStorageKey(key, serializer)

--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/Persistence.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/Persistence.kt
@@ -8,6 +8,7 @@ import ai.koog.agents.core.agent.context.AgentContextData
 import ai.koog.agents.core.agent.context.RollbackStrategy
 import ai.koog.agents.core.agent.context.agentContextDataAdditionalKey
 import ai.koog.agents.core.agent.context.featureOrThrow
+import ai.koog.agents.core.agent.context.rootContext
 import ai.koog.agents.core.agent.context.store
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.agent.entity.AIAgentStorage
@@ -104,6 +105,14 @@ public class Persistence(
     public var rollbackToolRegistry: RollbackToolRegistry = RollbackToolRegistry {}
 
     /**
+     * Storage keys included in checkpoints. Mirrors [PersistenceFeatureConfig.persistedKeys] and is
+     * threaded through every snapshot/restore call site so that values stored under these keys survive
+     * resume. Empty by default - callers that don't opt in keep the pre-existing behavior of not
+     * persisting storage at all.
+     */
+    public var persistedKeys: List<PersistableStorageKey<*>> = emptyList()
+
+    /**
      * Companion object implementing agent feature, handling [Persistence] creation and installation.
      */
     public companion object Feature : AIAgentGraphFeature<PersistenceFeatureConfig, Persistence> {
@@ -122,6 +131,7 @@ public class Persistence(
             val persistence = Persistence(config.storage)
             persistence.rollbackStrategy = config.rollbackStrategy
             persistence.rollbackToolRegistry = config.rollbackToolRegistry
+            persistence.persistedKeys = config.persistedKeys
 
             pipeline.interceptStrategyStarting(this) { ctx ->
                 val strategy = ctx.strategy as AIAgentGraphStrategy<*, *>
@@ -182,6 +192,9 @@ public class Persistence(
          * @param checkpoint The checkpoint data to restore from.
          * @param rollbackStrategy The strategy to use when restoring state. Defaults to [RollbackStrategy.Default].
          * @param sessionId Optional session identifier. A random UUID is generated if not provided.
+         * @param persistedKeys Storage keys to restore from [AgentCheckpointData.storage]. Must use the same
+         *  [AIAgentStorageKey] instances as the live agent code so identity-based key lookups keep working.
+         *  Defaults to empty, matching the original behavior of not restoring storage.
          * @return The output produced by the agent after resuming from the checkpoint.
          */
         public suspend fun <Input, Output> runFromCheckpoint(
@@ -190,7 +203,14 @@ public class Persistence(
             checkpoint: AgentCheckpointData,
             rollbackStrategy: RollbackStrategy = RollbackStrategy.Default,
             sessionId: String? = null,
-        ): Output = runFromCheckpoint(agent.createSession(sessionId), agentInput, checkpoint, rollbackStrategy)
+            persistedKeys: List<PersistableStorageKey<*>> = emptyList(),
+        ): Output = runFromCheckpoint(
+            session = agent.createSession(sessionId),
+            input = agentInput,
+            checkpoint = checkpoint,
+            rollbackStrategy = rollbackStrategy,
+            persistedKeys = persistedKeys,
+        )
 
         /**
          * Runs the session from a previously saved checkpoint.
@@ -203,6 +223,9 @@ public class Persistence(
          * @param input The input to provide to the session.
          * @param checkpoint The checkpoint data to restore from.
          * @param rollbackStrategy The strategy to use when restoring state. Defaults to [RollbackStrategy.Default].
+         * @param persistedKeys Storage keys to restore from [AgentCheckpointData.storage]. Must use the same
+         *  [AIAgentStorageKey] instances as the live agent code so identity-based key lookups keep working.
+         *  Defaults to empty, matching the original behavior of not restoring storage.
          * @return The output produced by the session after resuming from the checkpoint.
          */
         public suspend fun <Input, Output, TContext : AIAgentContext> runFromCheckpoint(
@@ -210,9 +233,13 @@ public class Persistence(
             input: Input,
             checkpoint: AgentCheckpointData,
             rollbackStrategy: RollbackStrategy = RollbackStrategy.Default,
+            persistedKeys: List<PersistableStorageKey<*>> = emptyList(),
         ): Output {
             val storage = AIAgentStorage()
-            storage.set(agentContextDataAdditionalKey, checkpoint.toAgentContextData(rollbackStrategy))
+            storage.set(
+                agentContextDataAdditionalKey,
+                checkpoint.toAgentContextData(rollbackStrategy, persistedKeys = persistedKeys),
+            )
             return session.run(input, AdditionalInputs.Storage(storage))
         }
 
@@ -231,8 +258,9 @@ public class Persistence(
             checkpoint: AgentCheckpointData,
             rollbackStrategy: RollbackStrategy = RollbackStrategy.Default,
             sessionId: String? = null,
+            persistedKeys: List<PersistableStorageKey<*>> = emptyList(),
         ): Output = runBlockingOnStrategy(agent.agentConfig) {
-            runFromCheckpoint(agent, agentInput, checkpoint, rollbackStrategy, sessionId)
+            runFromCheckpoint(agent, agentInput, checkpoint, rollbackStrategy, sessionId, persistedKeys)
         }
     }
 
@@ -322,6 +350,8 @@ public class Persistence(
             return null
         }
 
+        val storageJson = encodeStorageEntries(agentContext.rootContext().storage.toMap(), persistedKeys)
+
         val checkpoint = agentContext.llm.readSession {
             return@readSession AgentCheckpointData(
                 checkpointId = checkpointId ?: Uuid.random().toString(),
@@ -330,6 +360,7 @@ public class Persistence(
                 lastOutput = outputJson,
                 createdAt = Clock.System.now(),
                 version = version,
+                storage = storageJson,
             )
         }
 
@@ -476,29 +507,33 @@ public class Persistence(
         val checkpoint: AgentCheckpointData? = getCheckpointById(agentContext.runId, checkpointId)
         if (checkpoint != null) {
             agentContext.store(
-                checkpoint.toAgentContextData(rollbackStrategy) { context ->
-                    messageHistoryDiff(
-                        currentMessages = context.llm.prompt.messages,
-                        checkpointMessages = checkpoint.messageHistory
-                    )
-                        .filterIsInstance<Message.Tool.Call>()
-                        .reversed()
-                        .forEach { toolCall ->
-                            rollbackToolRegistry.getRollbackTool(toolCall.tool)?.let { rollbackTool ->
-                                val toolArgs = try {
-                                    toolCall.contentJsonResult
-                                        .getOrNull()
-                                        ?.toKoogJSONObject()
-                                        ?.let { rollbackTool.decodeArgs(it, agentContext.config.serializer) }
-                                } catch (e: CancellationException) {
-                                    throw e
-                                } catch (_: Exception) {
-                                    null
+                checkpoint.toAgentContextData(
+                    rollbackStrategy,
+                    additionalRollbackAction = { context ->
+                        messageHistoryDiff(
+                            currentMessages = context.llm.prompt.messages,
+                            checkpointMessages = checkpoint.messageHistory
+                        )
+                            .filterIsInstance<Message.Tool.Call>()
+                            .reversed()
+                            .forEach { toolCall ->
+                                rollbackToolRegistry.getRollbackTool(toolCall.tool)?.let { rollbackTool ->
+                                    val toolArgs = try {
+                                        toolCall.contentJsonResult
+                                            .getOrNull()
+                                            ?.toKoogJSONObject()
+                                            ?.let { rollbackTool.decodeArgs(it, agentContext.config.serializer) }
+                                    } catch (e: CancellationException) {
+                                        throw e
+                                    } catch (_: Exception) {
+                                        null
+                                    }
+                                    rollbackTool.executeUnsafe(toolArgs)
                                 }
-                                rollbackTool.executeUnsafe(toolArgs)
                             }
-                        }
-                }
+                    },
+                    persistedKeys = persistedKeys,
+                )
             )
         }
 
@@ -543,7 +578,7 @@ public class Persistence(
             return null
         }
 
-        agentContext.store(checkpoint.toAgentContextData(rollbackStrategy))
+        agentContext.store(checkpoint.toAgentContextData(rollbackStrategy, persistedKeys = persistedKeys))
         return checkpoint
     }
 }

--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/PersistenceFeatureConfig.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/PersistenceFeatureConfig.kt
@@ -51,4 +51,26 @@ public class PersistenceFeatureConfig : FeatureConfig() {
      * Configure it during Persistence installation. Do not mutate later in withPersistence.
      */
     public var rollbackToolRegistry: RollbackToolRegistry = RollbackToolRegistry.EMPTY
+
+    /**
+     * Storage keys whose values should be captured in checkpoints and restored on resume.
+     *
+     * Each entry pairs an [ai.koog.agents.core.agent.entity.AIAgentStorageKey] with a kotlinx
+     * [kotlinx.serialization.KSerializer] for its value type; build them with the [persisted] helper.
+     * Only registered keys participate in persistence; everything else (including framework-internal
+     * storage entries such as the per-feature state) is left untouched, so existing storage usage
+     * keeps working without change.
+     *
+     * Example:
+     * ```kotlin
+     * install(Persistence) {
+     *     storage = InMemoryPersistenceStorageProvider()
+     *     persistedKeys = listOf(
+     *         persisted(RetryCounterKey, Int.serializer()),
+     *         persisted(PendingHumanInputKey, PendingHumanInput.serializer()),
+     *     )
+     * }
+     * ```
+     */
+    public var persistedKeys: List<PersistableStorageKey<*>> = emptyList()
 }

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/StoragePersistenceTest.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/StoragePersistenceTest.kt
@@ -1,0 +1,279 @@
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.agent.context.AIAgentContext
+import ai.koog.agents.core.agent.context.rootContext
+import ai.koog.agents.core.agent.entity.AIAgentStorageKey
+import ai.koog.agents.core.agent.entity.createStorageKey
+import ai.koog.agents.core.agent.execution.path
+import ai.koog.agents.core.dsl.builder.AIAgentNodeDelegate
+import ai.koog.agents.core.dsl.builder.forwardTo
+import ai.koog.agents.core.dsl.builder.node
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.ext.tool.SayToUser
+import ai.koog.agents.snapshot.feature.AgentCheckpointData
+import ai.koog.agents.snapshot.feature.Persistence
+import ai.koog.agents.snapshot.feature.persisted
+import ai.koog.agents.snapshot.providers.InMemoryPersistenceStorageProvider
+import ai.koog.agents.snapshot.providers.PersistenceUtils
+import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.ollama.client.OllamaModels
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.RequestMetaInfo
+import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.serialization.JSONObject
+import ai.koog.serialization.JSONPrimitive
+import ai.koog.serialization.kotlinx.KotlinxSerializer
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.serializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+
+@Serializable
+private data class RetryStats(val attempts: Int, val lastReason: String)
+
+private val RetryCounterKey: AIAgentStorageKey<Int> = createStorageKey("retry_counter")
+private val RetryStatsKey: AIAgentStorageKey<RetryStats> = createStorageKey("retry_stats")
+private val SecretKey: AIAgentStorageKey<String> = createStorageKey("secret_unregistered")
+
+class StoragePersistenceTest {
+    private val systemPrompt = "You are a test agent."
+    private val agentConfig = AIAgentConfig(
+        prompt = prompt("test") { system(systemPrompt) },
+        model = OllamaModels.Meta.LLAMA_3_2,
+        maxAgentIterations = 20,
+    )
+    private val toolRegistry = ToolRegistry { tool(SayToUser) }
+    private val serializer = KotlinxSerializer()
+
+    @Test
+    fun checkpointSerializationRoundTripsStorageField() {
+        val now = Clock.System.now()
+        val checkpoint = AgentCheckpointData(
+            checkpointId = "cp-storage",
+            createdAt = now,
+            nodePath = "NodeA",
+            lastOutput = JSONPrimitive("done"),
+            messageHistory = listOf(
+                Message.User("hi", metaInfo = RequestMetaInfo(now)),
+                Message.Assistant("hello", metaInfo = ResponseMetaInfo(now)),
+            ),
+            version = 0L,
+            storage = JSONObject(
+                mapOf(
+                    "retry_counter" to JSONPrimitive(3),
+                    "retry_stats" to JSONObject(
+                        mapOf(
+                            "attempts" to JSONPrimitive(2),
+                            "lastReason" to JSONPrimitive("rate-limit"),
+                        )
+                    ),
+                )
+            ),
+        )
+
+        val json = PersistenceUtils.defaultCheckpointJson
+        val serialized = json.encodeToString(AgentCheckpointData.serializer(), checkpoint)
+        val restored = json.decodeFromString(AgentCheckpointData.serializer(), serialized)
+
+        assertEquals(checkpoint, restored)
+        assertEquals(checkpoint.storage, restored.storage)
+    }
+
+    @Test
+    fun storageFieldOmittedWhenNull() {
+        val now = Clock.System.now()
+        val checkpoint = AgentCheckpointData(
+            checkpointId = "cp-no-storage",
+            createdAt = now,
+            nodePath = "NodeA",
+            lastOutput = JSONPrimitive("done"),
+            messageHistory = emptyList(),
+            version = 0L,
+        )
+
+        val serialized = PersistenceUtils.defaultCheckpointJson
+            .encodeToString(AgentCheckpointData.serializer(), checkpoint)
+
+        // Older checkpoints (before the storage field) must still encode without an empty `storage` member.
+        assertTrue("\"storage\"" !in serialized, "Serialized JSON should omit storage when null")
+        assertNull(checkpoint.storage)
+    }
+
+    @Test
+    fun runFromCheckpointRestoresRegisteredStorageEntries() = runTest {
+        val sessionId = "test-session-storage"
+        val now = Clock.System.now()
+
+        val checkpoint = AgentCheckpointData(
+            checkpointId = "cp-with-storage",
+            createdAt = now,
+            nodePath = path(sessionId, "storage-strategy", "Node1"),
+            lastOutput = JSONPrimitive("Node 1 output"),
+            messageHistory = listOf(
+                Message.User("ignored", metaInfo = RequestMetaInfo(now)),
+            ),
+            version = 0L,
+            storage = JSONObject(
+                mapOf(
+                    "retry_counter" to JSONPrimitive(7),
+                    "retry_stats" to JSONObject(
+                        mapOf(
+                            "attempts" to JSONPrimitive(2),
+                            "lastReason" to JSONPrimitive("timeout"),
+                        )
+                    ),
+                )
+            ),
+        )
+
+        val agent = AIAgent(
+            promptExecutor = getMockExecutor(serializer) { },
+            strategy = storageReadingGraph(),
+            agentConfig = agentConfig,
+            toolRegistry = toolRegistry,
+        )
+
+        val output = Persistence.runFromCheckpoint(
+            agent = agent,
+            agentInput = "ignored",
+            checkpoint = checkpoint,
+            sessionId = sessionId,
+            persistedKeys = listOf(
+                persisted(RetryCounterKey, Int.serializer()),
+                persisted(RetryStatsKey, RetryStats.serializer()),
+            ),
+        )
+
+        // The `storageReader` node, which runs after restore at Node2, observes the restored values
+        // through the same key instances declared at file scope - this is what proves identity-keyed
+        // restoration works.
+        assertEquals("retry=7 attempts=2 reason=timeout", output)
+    }
+
+    @Test
+    fun runFromCheckpointSkipsUnregisteredStorageEntries() = runTest {
+        val sessionId = "test-session-unreg"
+        val now = Clock.System.now()
+
+        val checkpoint = AgentCheckpointData(
+            checkpointId = "cp-unreg",
+            createdAt = now,
+            nodePath = path(sessionId, "storage-strategy", "Node1"),
+            lastOutput = JSONPrimitive("Node 1 output"),
+            messageHistory = emptyList(),
+            version = 0L,
+            storage = JSONObject(
+                mapOf(
+                    "retry_counter" to JSONPrimitive(4),
+                    "secret_unregistered" to JSONPrimitive("should-not-restore"),
+                )
+            ),
+        )
+
+        val agent = AIAgent(
+            promptExecutor = getMockExecutor(serializer) { },
+            strategy = storageReadingGraph { ctx ->
+                val retry = ctx.rootContext().storage.get(RetryCounterKey)
+                val secret = ctx.rootContext().storage.get(SecretKey)
+                "retry=$retry secret=$secret"
+            },
+            agentConfig = agentConfig,
+            toolRegistry = toolRegistry,
+        )
+
+        val output = Persistence.runFromCheckpoint(
+            agent = agent,
+            agentInput = "ignored",
+            checkpoint = checkpoint,
+            sessionId = sessionId,
+            // Only the retry counter is registered; the unrelated entry must NOT leak into storage.
+            persistedKeys = listOf(persisted(RetryCounterKey, Int.serializer())),
+        )
+
+        assertEquals("retry=4 secret=null", output)
+    }
+
+    @Test
+    fun automaticPersistenceCapturesStorageAndRunFromCheckpointRestoresIt() = runTest {
+        val storageProvider = InMemoryPersistenceStorageProvider()
+        val sessionId = "auto-storage-run"
+
+        // Run an agent whose first node writes to storage. Auto-persistence captures a checkpoint
+        // after each user node, so the post-writer checkpoint must encode the storage entry under
+        // the registered key.
+        val firstAgent = AIAgent(
+            promptExecutor = getMockExecutor(serializer) { },
+            strategy = writerThenReaderGraph(),
+            agentConfig = agentConfig,
+            toolRegistry = toolRegistry,
+        ) {
+            install(Persistence) {
+                storage = storageProvider
+                persistedKeys = listOf(persisted(RetryCounterKey, Int.serializer()))
+            }
+        }
+        firstAgent.run("seed", sessionId)
+
+        val checkpoints = storageProvider.getCheckpoints(sessionId).filter { it.storage != null }
+        val afterWriter = checkpoints.first { it.nodePath.endsWith("/writer") }
+        assertEquals(JSONPrimitive(5), afterWriter.storage?.entries?.get("retry_counter"))
+
+        // Resume into a fresh agent with the same strategy but no installed persistence. The
+        // restored storage is what the reader observes when it executes after the resumed
+        // execution point. This is the human-in-the-loop pattern from issue #1944: stash a
+        // checkpoint when waiting for input, then resume later from it.
+        val resumed = Persistence.runFromCheckpoint(
+            agent = AIAgent(
+                promptExecutor = getMockExecutor(serializer) { },
+                strategy = writerThenReaderGraph(),
+                agentConfig = agentConfig,
+                toolRegistry = toolRegistry,
+            ),
+            agentInput = "ignored",
+            checkpoint = afterWriter,
+            sessionId = "resume-session",
+            persistedKeys = listOf(persisted(RetryCounterKey, Int.serializer())),
+        )
+
+        assertEquals("restored=5", resumed)
+    }
+}
+
+private fun storageReadingGraph(
+    reader: suspend (AIAgentContext) -> String = { ctx ->
+        val retry = ctx.rootContext().storage.get(RetryCounterKey)
+        val stats = ctx.rootContext().storage.get(RetryStatsKey)
+        "retry=$retry attempts=${stats?.attempts} reason=${stats?.lastReason}"
+    },
+) = strategy("storage-strategy") {
+    val node1 by passthroughNode("Node1")
+    val node2 by passthroughNode("Node2")
+    val storageReader by node<String, String>("storageReader") { reader(this) }
+
+    edge(nodeStart forwardTo node1)
+    edge(node1 forwardTo node2)
+    edge(node2 forwardTo storageReader)
+    edge(storageReader forwardTo nodeFinish)
+}
+
+private fun writerThenReaderGraph() = strategy("auto-storage") {
+    val writer by node<String, String>("writer") { input ->
+        rootContext().storage.set(RetryCounterKey, 5)
+        input
+    }
+    val reader by node<String, String>("reader") { _ ->
+        "restored=${rootContext().storage.get(RetryCounterKey)}"
+    }
+
+    edge(nodeStart forwardTo writer)
+    edge(writer forwardTo reader)
+    edge(reader forwardTo nodeFinish)
+}
+
+private fun passthroughNode(name: String): AIAgentNodeDelegate<String, String> = node(name) { it }


### PR DESCRIPTION
Closes #1944.

Persistence checkpoints currently capture `messageHistory`, `nodePath`, `lastInput/lastOutput`, `version`, and `properties` but never the entries held in `AIAgentContext.storage`. Workflows that stash retry counters, cached tool data, or pending human-input markers in storage see those values disappear on resume, leading to incorrect control flow and broken human-in-the-loop graphs.

This PR threads storage through the snapshot/restore round-trip via opt-in registration:

```kotlin
install(Persistence) {
    storage = InMemoryPersistenceStorageProvider()
    persistedKeys = listOf(
        persisted(RetryCounterKey, Int.serializer()),
        persisted(PendingHumanInputKey, PendingHumanInput.serializer()),
    )
}
```

`Persistence.runFromCheckpoint` accepts the same list, for callers resuming an agent without the feature installed.

### Why opt-in registration over polymorphic / reflective serialization

- `AIAgentStorageKey` equality is referential, so the original key instance must be reused at restore. Even if storage values were uniformly serializable, callers would still need a way to map persisted key names back to live key instances. Registration covers both concerns at once.
- Reflective `KSerializer` lookup is not portable to Kotlin/JS or Wasm.
- Backward compatibility is automatic: unregistered keys are not persisted, so existing storage usage is unchanged unless callers opt in.

### Wire-up

- `PersistenceFeatureConfig.persistedKeys` carries the registration list for the auto-snapshot path.
- `AgentCheckpointData.storage: JSONObject?` holds the encoded entries. Default `null` plus `explicitNulls = false` means old checkpoints decode unchanged, so no structure-version bump is needed.
- `@JvmOverloads` is added to `AgentCheckpointData`'s primary constructor so Java callers binding to the 8-arg form still resolve to the typed `JSONElement` constructor instead of the deprecated `kotlinx.JsonElement` one.
- Encoding and decoding go through `PersistenceUtils.defaultCheckpointJson` with the user-supplied `KSerializer`, not the agent's `JSONSerializer`, so this code path doesn't break under non-kotlinx providers (e.g. Jackson).
- Per-entry encode/decode failures are logged and skipped: losing one piece of intermediate state on resume beats failing the whole session.

### Tests

`StoragePersistenceTest` (jvmTest) covers five scenarios:

- `checkpointSerializationRoundTripsStorageField` (encode/decode equality)
- `storageFieldOmittedWhenNull` (backward compatibility with old checkpoints)
- `runFromCheckpointRestoresRegisteredStorageEntries` (identity-keyed restore via the static API)
- `runFromCheckpointSkipsUnregisteredStorageEntries` (opt-in invariant: stale entries don't leak)
- `automaticPersistenceCapturesStorageAndRunFromCheckpointRestoresIt` (end-to-end through the installed feature)

## Test plan

- [x] `./gradlew :agents:agents-features:agents-features-snapshot:jvmTest` (54 tests, 0 failures)
- [x] `./gradlew :agents:agents-features:agents-features-snapshot:build` (JVM, JS, Wasm)
- [x] `./gradlew jvmTest` (whole tree)
- [x] `./gradlew :agents:agents-features:agents-features-snapshot:wasmJsTest`