### PR TITLE
fix(agents): subgraphWithTask & subtask missing tool results in prompt if other tools where requested along with finish tool

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBaseCommon.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBaseCommon.kt
@@ -11,6 +11,7 @@ import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
 import ai.koog.agents.core.environment.AIAgentEnvironment
 import ai.koog.agents.core.environment.ReceivedToolResult
 import ai.koog.agents.core.environment.SafeTool
+import ai.koog.agents.core.environment.ToolResultKind
 import ai.koog.agents.core.environment.result
 import ai.koog.agents.core.environment.toSafeResult
 import ai.koog.agents.core.feature.pipeline.AIAgentPipeline
@@ -648,7 +649,16 @@ public open class AIAgentFunctionalContextBaseCommon<Pipeline : AIAgentPipeline>
                 response is Message.Tool.Call -> {
                     val toolResult = executeToolHacked(response, finishTool)
 
-                    if (toolResult.tool == finishTool.descriptor.name) {
+                    if (toolResult.tool == finishTool.descriptor.name && toolResult.resultKind is ToolResultKind.Success) {
+                        // Prompt must contain tool result
+                        llm.writeSession {
+                            appendPrompt {
+                                tool {
+                                    result(toolResult)
+                                }
+                            }
+                        }
+
                         return toolResult.toSafeResult(finishTool, config.serializer).asSuccessful().result
                     }
 
@@ -722,9 +732,20 @@ public open class AIAgentFunctionalContextBaseCommon<Pipeline : AIAgentPipeline>
                     val toolResults =
                         executeMultipleToolsHacked(toolCalls, finishTool, parallelTools = runMode == ToolCalls.PARALLEL)
 
-                    toolResults.firstOrNull { it.tool == finishTool.descriptor.name }
+                    toolResults.firstOrNull { it.tool == finishTool.descriptor.name && it.resultKind is ToolResultKind.Success }
                         ?.let { finishResult ->
-                            return finishResult.toSafeResult(finishTool, config.serializer).asSuccessful().result
+                            // Prompt must contain all tool results
+                            llm.writeSession {
+                                appendPrompt {
+                                    tool {
+                                        toolResults.forEach { result(it) }
+                                    }
+                                }
+                            }
+
+                            return finishResult
+                                .toSafeResult(finishTool, config.serializer)
+                                .asSuccessful().result
                         }
 
                     responses = sendMultipleToolResults(toolResults)

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
@@ -18,6 +18,7 @@ import ai.koog.agents.core.dsl.extension.nodeLLMSendMultipleToolResults
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResult
 import ai.koog.agents.core.environment.ReceivedToolResult
 import ai.koog.agents.core.environment.ToolResultKind
+import ai.koog.agents.core.environment.result
 import ai.koog.agents.core.environment.toSafeResult
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolDescriptor
@@ -681,16 +682,28 @@ public fun <Input, Output, OutputTransformed> AIAgentSubgraphBuilderBase<Input, 
         defineTask(input)
     }
 
-    val finalizeTask by node<ReceivedToolResult, OutputTransformed>(
+    val finalizeTask by node<List<ReceivedToolResult>, OutputTransformed>(
         inputType = typeToken<ReceivedToolResult>(),
         outputType = outputTransformedType
-    ) { toolResult ->
+    ) { toolResults ->
         llm.writeSession {
+            // Append all tool results to the prompt, otherwise there will be calls without results, which is invalid
+            appendPrompt {
+                tool {
+                    toolResults.forEach { result(it) }
+                }
+            }
+
             // Restore original tools
             tools = storage.get(originalToolsKey)!!
         }
 
-        toolResult.toSafeResult(finishTool, config.serializer).asSuccessful().result
+        // Take the first finish tool and return as a result
+        toolResults
+            .first { it.tool == finishTool.name }
+            .toSafeResult(finishTool, config.serializer)
+            .asSuccessful()
+            .result
     }
 
     // Helper node to overcome problems of the current api and repeat less code when writing routing conditions
@@ -795,10 +808,10 @@ public fun <Input, Output, OutputTransformed> AIAgentSubgraphBuilderBase<Input, 
     edge(
         callToolsHacked forwardTo finalizeTask
             onCondition { toolResults ->
-                toolResults.firstOrNull()
-                    ?.let { it.tool == finishTool.name && it.resultKind is ToolResultKind.Success } == true
+                toolResults
+                    .any { it.tool == finishTool.name && it.resultKind is ToolResultKind.Success }
             }
-            transformed { toolsResults -> toolsResults.first() }
+            transformed { toolsResults -> toolsResults }
     )
 
     if (runMode == ToolCalls.SINGLE_RUN_SEQUENTIAL) {
@@ -870,16 +883,6 @@ internal suspend fun <Output, OutputTransformed> AIAgentContext.executeFinishToo
             resultKind = ToolResultKind.Failure(e),
             result = null,
         )
-    }
-
-    // Append a final tool call result to the prompt for further LLM calls
-    // to see it (otherwise they would fail)
-    llm.writeSession {
-        appendPrompt {
-            tool {
-                result(toolCall.id, toolCall.tool, toolCall.content)
-            }
-        }
     }
 
     return ReceivedToolResult(

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
@@ -683,7 +683,7 @@ public fun <Input, Output, OutputTransformed> AIAgentSubgraphBuilderBase<Input, 
     }
 
     val finalizeTask by node<List<ReceivedToolResult>, OutputTransformed>(
-        inputType = typeToken<ReceivedToolResult>(),
+        inputType = typeToken<List<ReceivedToolResult>>(),
         outputType = outputTransformedType
     ) { toolResults ->
         llm.writeSession {
@@ -700,7 +700,7 @@ public fun <Input, Output, OutputTransformed> AIAgentSubgraphBuilderBase<Input, 
 
         // Take the first finish tool and return as a result
         toolResults
-            .first { it.tool == finishTool.name }
+            .first { it.tool == finishTool.name && it.resultKind is ToolResultKind.Success }
             .toSafeResult(finishTool, config.serializer)
             .asSuccessful()
             .result

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
@@ -352,7 +352,7 @@ public fun <Input : Any, OutputTransformed : Any> subgraphWithTask(
     defineTask: suspend AIAgentGraphContextBase.(input: Input) -> String
 ): AIAgentSubgraphDelegate<Input, OutputTransformed> = subgraph<Input, OutputTransformed>(
     inputType = inputType,
-    outputType = inputType,
+    outputType = finishTool.resultType,
     name = name,
     toolSelectionStrategy = toolSelectionStrategy,
     llmModel = llmModel,

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextTest.kt
@@ -1,0 +1,157 @@
+package ai.koog.agents.core.agent.context
+
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.ToolCalls
+import ai.koog.agents.core.agent.functionalStrategy
+import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.features.eventHandler.feature.EventHandler
+import ai.koog.agents.testing.tools.TestBlankTool
+import ai.koog.agents.testing.tools.TestFinishTool
+import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.prompt.dsl.Prompt
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.message.Message
+import ai.koog.serialization.kotlinx.KotlinxSerializer
+import ai.koog.utils.io.use
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class AIAgentFunctionalContextTest {
+
+    private val serializer = KotlinxSerializer()
+
+    /**
+     * Verifies that `subtaskWithMultiToolMode` (`ToolCalls.SEQUENTIAL`) appends tool results for
+     * ALL tool calls to the prompt when the LLM calls the finish tool together with another tool
+     * in a single response.
+     */
+    @Test
+    fun testSubtaskWithMultiToolModeSequentialAllToolCallsHaveToolResults() = runTest {
+        runAndAssertAllToolCallsHaveResults(ToolCalls.SEQUENTIAL)
+    }
+
+    /**
+     * Verifies that `subtaskWithMultiToolMode` (`ToolCalls.PARALLEL`) appends tool results for
+     * ALL tool calls to the prompt when the LLM calls the finish tool together with another tool
+     * in a single response.
+     */
+    @Test
+    fun testSubtaskWithMultiToolModeParallelAllToolCallsHaveToolResults() = runTest {
+        runAndAssertAllToolCallsHaveResults(ToolCalls.PARALLEL)
+    }
+
+    /**
+     * Verifies that `subtaskWithSingleToolMode` (`ToolCalls.SINGLE_RUN_SEQUENTIAL`) appends tool
+     * results for every tool call to the prompt: a regular tool call followed by the finish tool
+     * call across two LLM round-trips (single-tool mode allows only one tool per LLM response).
+     */
+    @Test
+    fun testSubtaskWithSingleToolModeAllToolCallsHaveToolResults() = runTest {
+        val blankTool = TestBlankTool()
+        val finishTool = TestFinishTool
+
+        val toolRegistry = ToolRegistry { tool(blankTool) }
+
+        val inputRequest = "Test input"
+        val blankToolResult = "Working on it"
+        val finishToolResult = "Finished"
+
+        val mockExecutor = getMockExecutor(serializer) {
+            mockLLMToolCall(blankTool, TestBlankTool.Args(blankToolResult)) onRequestEquals inputRequest
+            mockLLMToolCall(finishTool, TestFinishTool.Args(finishToolResult)) onRequestContains blankToolResult
+        }
+
+        val finalPrompt = runAgentAndCapturePrompt(
+            mockExecutor = mockExecutor,
+            toolRegistry = toolRegistry,
+            inputRequest = inputRequest,
+            blankTool = blankTool,
+            finishTool = finishTool,
+            runMode = ToolCalls.SINGLE_RUN_SEQUENTIAL,
+        )
+
+        assertEqualToolCallAndResultCount(finalPrompt, expectedSize = 2)
+    }
+
+    private suspend fun runAndAssertAllToolCallsHaveResults(runMode: ToolCalls) {
+        val blankTool = TestBlankTool()
+        val finishTool = TestFinishTool
+
+        val toolRegistry = ToolRegistry { tool(blankTool) }
+
+        val inputRequest = "Test input"
+        val blankToolResult = "I'm done"
+        val finishToolResult = "Finished"
+
+        val mockExecutor = getMockExecutor(serializer) {
+            @Suppress("UNCHECKED_CAST")
+            mockLLMToolCall(
+                listOf(
+                    blankTool to TestBlankTool.Args(blankToolResult),
+                    finishTool to TestFinishTool.Args(finishToolResult),
+                ) as List<Pair<Tool<Any?, Any?>, Any?>>
+            ) onRequestEquals inputRequest
+        }
+
+        val finalPrompt = runAgentAndCapturePrompt(
+            mockExecutor = mockExecutor,
+            toolRegistry = toolRegistry,
+            inputRequest = inputRequest,
+            blankTool = blankTool,
+            finishTool = finishTool,
+            runMode = runMode,
+        )
+
+        assertEqualToolCallAndResultCount(finalPrompt, expectedSize = 2)
+    }
+
+    private suspend fun runAgentAndCapturePrompt(
+        mockExecutor: PromptExecutor,
+        toolRegistry: ToolRegistry,
+        inputRequest: String,
+        blankTool: TestBlankTool,
+        finishTool: Tool<TestFinishTool.Args, String>,
+        runMode: ToolCalls,
+    ): Prompt {
+        lateinit var finalPrompt: Prompt
+
+        AIAgent(
+            promptExecutor = mockExecutor,
+            llmModel = OpenAIModels.Chat.GPT4o,
+            toolRegistry = toolRegistry,
+            strategy = functionalStrategy<String, String> { input ->
+                subtask(
+                    taskDescription = input,
+                    tools = listOf(blankTool),
+                    finishTool = finishTool,
+                    runMode = runMode,
+                )
+            },
+            systemPrompt = "You are a test agent.",
+        ) {
+            install(EventHandler) {
+                onAgentCompleted { ctx ->
+                    finalPrompt = ctx.context.llm.prompt
+                }
+            }
+        }.use { agent ->
+            agent.run(inputRequest, null)
+        }
+
+        return finalPrompt
+    }
+
+    private fun assertEqualToolCallAndResultCount(prompt: Prompt, expectedSize: Int) {
+        val toolCalls = prompt.messages.filterIsInstance<Message.Tool.Call>()
+        val toolResults = prompt.messages.filterIsInstance<Message.Tool.Result>()
+
+        withClue("Equal number of tool calls and tool results") {
+            toolCalls.size shouldBe expectedSize
+            toolResults.size shouldBe expectedSize
+        }
+    }
+}

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/SubgraphWithTaskTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/SubgraphWithTaskTest.kt
@@ -27,6 +27,8 @@ import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.serialization.kotlinx.KotlinxSerializer
 import ai.koog.utils.io.use
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.runTest
@@ -793,6 +795,64 @@ class SubgraphWithTaskTest {
     }
 
     //endregion
+
+    /**
+     * If the model called finish tool along with some other tools, all results must be present, not only finish tool result.
+     */
+    @Test
+    fun testAllToolCallsHaveRespectiveToolResults() = runTest {
+        val blankTool = TestBlankTool()
+        val finishTool = TestFinishTool
+
+        val toolRegistry = ToolRegistry {
+            tool(blankTool)
+        }
+
+        val model = OpenAIModels.Chat.GPT4o
+
+        val inputRequest = "Test input"
+        val blankToolResult = "I'm done"
+        val finishToolResult = "Finished"
+
+        val mockExecutor = getMockExecutor(serializer) {
+            @Suppress("UNCHECKED_CAST")
+            mockLLMToolCall(
+                listOf(
+                    blankTool to TestBlankTool.Args(blankToolResult),
+                    finishTool to TestFinishTool.Args(finishToolResult),
+                ) as List<Pair<Tool<Any?, Any?>, Any?>>
+            ) onRequestEquals inputRequest
+        }
+
+        lateinit var finalPrompt: Prompt
+
+        createAgent(
+            model = model,
+            runMode = ToolCalls.SEQUENTIAL,
+            toolRegistry = toolRegistry,
+            executor = mockExecutor,
+            finishTool = finishTool,
+            installFeatures = {
+                install(EventHandler) {
+                    onAgentCompleted { ctx ->
+                        finalPrompt = ctx.context.llm.prompt
+                    }
+                }
+            }
+        ).use { agent ->
+            val agentResult = agent.run(inputRequest, null)
+            logger.info { "Agent is finished with result: $agentResult" }
+        }
+
+        val toolCalls = finalPrompt.messages.filterIsInstance<Message.Tool.Call>()
+        val toolResults = finalPrompt.messages.filterIsInstance<Message.Tool.Result>()
+
+        withClue("Equal number of tool calls and tool results") {
+            val expectedSize = 2
+            toolCalls.size shouldBe expectedSize
+            toolResults.size shouldBe expectedSize
+        }
+    }
 
     //region Private Methods
 


### PR DESCRIPTION
In `subgraphWithTask` models can sometimes request other tools along with the finish tool. Previously, other tool results were ignored and not added to prompt, which led to error, since prompts can't have tool calls without matching tool results. Updated the `subgraphWithTask` logic to append all tool results when the finish tool was called