### PR TITLE
build(agents): properly ignore all wasm publsihing tasks for otel module

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/build.gradle.kts
+++ b/agents/agents-features/agents-features-opentelemetry/build.gradle.kts
@@ -123,7 +123,9 @@ extensions.configure<LibraryAndroidComponentsExtension> {
 configurations.matching { it.name.startsWith("wasmJs") }.configureEach {
     exclude(group = "io.opentelemetry.kotlin")
 }
-tasks.matching { it.name.startsWith("wasmJs") || it.name == "compileKotlinWasmJs" || it.name == "compileTestKotlinWasmJs" }.configureEach {
+// Match both camelCase prefixed tasks (wasmJsJar, wasmJsSourcesJar, ...) and PascalCase
+// suffixed ones (compileKotlinWasmJs, generateMetadataFileForWasmJsPublication, ...).
+tasks.matching { it.name.startsWith("wasmJs") || it.name.contains("WasmJs") }.configureEach {
     onlyIf("OTel Kotlin SDK 0.3.0 does not publish wasmJs artifacts") { false }
 }
 


### PR DESCRIPTION
The existing task filter only matched names starting with wasmJs, so publication tasks like generateMetadataFileForWasmJsPublication (where WasmJs appears mid-name) slipped through and failed reading the klib that the disabled compileKotlinWasmJs never produced. Broadened the filter to also match contains("WasmJs")