### PR TITLE
fix(prompt): handle responses api message phases

### DIFF
--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerTest.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerTest.kt
@@ -147,7 +147,7 @@ class EventHandlerTest {
             .toString()
 
         val expectedAssistantMessage =
-            "Assistant(parts=[Text(text=Default test response, cacheControl=null)], metaInfo=ResponseMetaInfo(timestamp=$ts, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, modelId=null, metadata=null), finishReason=null, rawResponse=null, id=null)"
+            "Assistant(parts=[Text(text=Default test response, cacheControl=null, phase=null)], metaInfo=ResponseMetaInfo(timestamp=$ts, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, modelId=null, metadata=null), finishReason=null, rawResponse=null, id=null)"
 
         val expectedEvents = listOf(
             "OnAgentStarting (agent id: $agentId, run id: $runId)",
@@ -275,7 +275,7 @@ class EventHandlerTest {
         val toolCallsInput = "ToolCalls(toolCalls=[Call(id=null, tool=$dummyToolName, args=$dummyToolArgsEncoded)])"
         val receivedToolResults = "ReceivedToolResults(toolResults=[$dummyToolReceivedToolResult])"
         val finalAssistantObj =
-            "Assistant(parts=[Text(text=$mockResponse, cacheControl=null)], metaInfo=ResponseMetaInfo(timestamp=$ts, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, modelId=null, metadata=null), finishReason=null, rawResponse=null, id=null)"
+            "Assistant(parts=[Text(text=$mockResponse, cacheControl=null, phase=null)], metaInfo=ResponseMetaInfo(timestamp=$ts, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, modelId=null, metadata=null), finishReason=null, rawResponse=null, id=null)"
 
         val toolCallResponseEntry =
             "role: ${Message.Role.Assistant}, parts: [$toolCallPart]"
@@ -383,7 +383,7 @@ class EventHandlerTest {
             .toString()
 
         val expectedAssistantMessage =
-            "Assistant(parts=[Text(text=$defaultResponse, cacheControl=null)], metaInfo=ResponseMetaInfo(timestamp=$ts, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, modelId=null, metadata=null), finishReason=null, rawResponse=null, id=null)"
+            "Assistant(parts=[Text(text=$defaultResponse, cacheControl=null, phase=null)], metaInfo=ResponseMetaInfo(timestamp=$ts, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, modelId=null, metadata=null), finishReason=null, rawResponse=null, id=null)"
 
         val expectedTools = toolRegistry.tools.joinToString { it.name }
         val responseEntry = expectedMessage(Message.Role.Assistant, defaultResponse).trim('{', '}')
@@ -605,8 +605,8 @@ class EventHandlerTest {
 
         val expectedEvents = listOf(
             "OnLLMStreamingStarting (run id: $runId, prompt: $expectedPromptString, model: ${model.eventString}, tools: [${toolRegistry.tools.joinToString { it.name }}])",
-            "OnLLMStreamingFrameReceived (run id: $runId, frame: TextDelta(text=$testLLMResponse, index=0))",
-            "OnLLMStreamingFrameReceived (run id: $runId, frame: TextComplete(text=$testLLMResponse, index=0))",
+            "OnLLMStreamingFrameReceived (run id: $runId, frame: TextDelta(text=$testLLMResponse, index=0, phase=null))",
+            "OnLLMStreamingFrameReceived (run id: $runId, frame: TextComplete(text=$testLLMResponse, index=0, phase=null))",
             "OnLLMStreamingFrameReceived (run id: $runId, frame: End(finishReason=null, metaInfo=ResponseMetaInfo(timestamp=$ts, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, modelId=null, metadata=null)))",
             "OnLLMStreamingCompleted (run id: $runId, prompt: $expectedPromptString, model: ${model.eventString}, tools: [${toolRegistry.tools.joinToString { it.name }}])",
         )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -359,6 +359,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
             params = params,
             stream = true
         )
+        val outputMessagePhases = mutableMapOf<Int, MessagePart.Text.Phase?>()
 
         return try {
             httpClient.sse(
@@ -371,7 +372,19 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                 processStreamingChunk = {
                     when (it) {
                         is OpenAIStreamEvent.ResponseOutputTextDelta -> {
-                            StreamFrame.TextDelta(text = it.delta, index = it.outputIndex)
+                            StreamFrame.TextDelta(
+                                text = it.delta,
+                                index = it.outputIndex,
+                                phase = outputMessagePhases[it.outputIndex]
+                            )
+                        }
+
+                        is OpenAIStreamEvent.ResponseOutputTextDone -> {
+                            StreamFrame.TextComplete(
+                                text = it.text,
+                                index = it.outputIndex,
+                                phase = outputMessagePhases[it.outputIndex]
+                            )
                         }
 
                         is OpenAIStreamEvent.ResponseReasoningTextDelta -> {
@@ -396,10 +409,12 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                         is OpenAIStreamEvent.ResponseOutputItemDone -> {
                             when (val item = it.item) {
                                 is Item.Text -> {
-                                    StreamFrame.TextComplete(item.value, it.outputIndex)
+                                    StreamFrame.TextComplete(
+                                        text = item.value,
+                                        index = it.outputIndex,
+                                        phase = outputMessagePhases[it.outputIndex]
+                                    )
                                 }
-
-                                is Item.OutputMessage -> null
 
                                 is Item.Reasoning -> {
                                     // https://developers.openai.com/api/reference/resources/responses/streaming-events#response.reasoning_text.done
@@ -430,7 +445,13 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                             }
                         }
 
-                        is OpenAIStreamEvent.ResponseOutputItemAdded -> null
+                        is OpenAIStreamEvent.ResponseOutputItemAdded -> {
+                            val outputMessage = it.item as? Item.OutputMessage
+                            if (outputMessage != null) {
+                                outputMessagePhases[it.outputIndex] = outputMessage.phase
+                            }
+                            null
+                        }
 
                         is OpenAIStreamEvent.ResponseCompleted -> {
                             StreamFrame.End(
@@ -814,7 +835,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                                                     content = listOf(
                                                         OutputContent.Text(text = part.text, annotations = emptyList())
                                                     ),
-                                                    phase = message.phase,
+                                                    phase = part.phase,
                                                 )
                                             )
                                         }
@@ -930,8 +951,6 @@ public open class OpenAILLMClient @JvmOverloads constructor(
         )
 
         var finishReason: String? = null
-        val outputMessagePhases = mutableSetOf<String>()
-
         val parts = buildList {
             response.output.forEach { output ->
                 when (output) {
@@ -948,15 +967,14 @@ public open class OpenAILLMClient @JvmOverloads constructor(
 
                     is Item.OutputMessage -> {
                         finishReason = output.status?.name
-                        output.phase?.let { outputMessagePhases.add(it) }
                         output.content.forEach { content ->
                             when (content) {
                                 is OutputContent.Text -> {
-                                    add(MessagePart.Text(content.text))
+                                    add(MessagePart.Text(content.text, phase = output.phase))
                                 }
 
                                 is OutputContent.Refusal -> {
-                                    add(MessagePart.Text(content.refusal))
+                                    add(MessagePart.Text(content.refusal, phase = output.phase))
                                 }
                             }
                         }
@@ -984,7 +1002,6 @@ public open class OpenAILLMClient @JvmOverloads constructor(
             parts = parts,
             finishReason = finishReason,
             metaInfo = metaInfo,
-            phase = outputMessagePhases.singleOrNull(),
         )
     }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -260,8 +260,6 @@ public open class OpenAILLMClient @JvmOverloads constructor(
 
     private companion object {
         private const val OPENAI_CLIENT_NAME = "OpenAILLMClient"
-        private const val OPENAI_MESSAGE_PHASE_COMMENTARY = "commentary"
-        private const val OPENAI_MESSAGE_PHASE_FINAL_ANSWER = "final_answer"
         private val staticLogger = KotlinLogging.logger { }
     }
 
@@ -362,8 +360,6 @@ public open class OpenAILLMClient @JvmOverloads constructor(
             stream = true
         )
 
-        val outputMessagePhases = mutableMapOf<Int, String?>()
-
         return try {
             httpClient.sse(
                 path = settings.responsesAPIPath,
@@ -375,11 +371,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                 processStreamingChunk = {
                     when (it) {
                         is OpenAIStreamEvent.ResponseOutputTextDelta -> {
-                            if (outputMessagePhases[it.outputIndex] == OPENAI_MESSAGE_PHASE_COMMENTARY) {
-                                null
-                            } else {
-                                StreamFrame.TextDelta(text = it.delta, index = it.outputIndex)
-                            }
+                            StreamFrame.TextDelta(text = it.delta, index = it.outputIndex)
                         }
 
                         is OpenAIStreamEvent.ResponseReasoningTextDelta -> {
@@ -407,10 +399,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                                     StreamFrame.TextComplete(item.value, it.outputIndex)
                                 }
 
-                                is Item.OutputMessage -> {
-                                    outputMessagePhases[it.outputIndex] = item.phase
-                                    null
-                                }
+                                is Item.OutputMessage -> null
 
                                 is Item.Reasoning -> {
                                     // https://developers.openai.com/api/reference/resources/responses/streaming-events#response.reasoning_text.done
@@ -441,12 +430,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                             }
                         }
 
-                        is OpenAIStreamEvent.ResponseOutputItemAdded -> {
-                            if (it.item is Item.OutputMessage) {
-                                outputMessagePhases[it.outputIndex] = it.item.phase
-                            }
-                            null
-                        }
+                        is OpenAIStreamEvent.ResponseOutputItemAdded -> null
 
                         is OpenAIStreamEvent.ResponseCompleted -> {
                             StreamFrame.End(

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -260,6 +260,8 @@ public open class OpenAILLMClient @JvmOverloads constructor(
 
     private companion object {
         private const val OPENAI_CLIENT_NAME = "OpenAILLMClient"
+        private const val OPENAI_MESSAGE_PHASE_COMMENTARY = "commentary"
+        private const val OPENAI_MESSAGE_PHASE_FINAL_ANSWER = "final_answer"
         private val staticLogger = KotlinLogging.logger { }
     }
 
@@ -360,6 +362,8 @@ public open class OpenAILLMClient @JvmOverloads constructor(
             stream = true
         )
 
+        val outputMessagePhases = mutableMapOf<Int, String?>()
+
         return try {
             httpClient.sse(
                 path = settings.responsesAPIPath,
@@ -371,7 +375,11 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                 processStreamingChunk = {
                     when (it) {
                         is OpenAIStreamEvent.ResponseOutputTextDelta -> {
-                            StreamFrame.TextDelta(text = it.delta, index = it.outputIndex)
+                            if (outputMessagePhases[it.outputIndex] == OPENAI_MESSAGE_PHASE_COMMENTARY) {
+                                null
+                            } else {
+                                StreamFrame.TextDelta(text = it.delta, index = it.outputIndex)
+                            }
                         }
 
                         is OpenAIStreamEvent.ResponseReasoningTextDelta -> {
@@ -397,6 +405,11 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                             when (val item = it.item) {
                                 is Item.Text -> {
                                     StreamFrame.TextComplete(item.value, it.outputIndex)
+                                }
+
+                                is Item.OutputMessage -> {
+                                    outputMessagePhases[it.outputIndex] = item.phase
+                                    null
                                 }
 
                                 is Item.Reasoning -> {
@@ -426,6 +439,13 @@ public open class OpenAILLMClient @JvmOverloads constructor(
 
                                 else -> null
                             }
+                        }
+
+                        is OpenAIStreamEvent.ResponseOutputItemAdded -> {
+                            if (it.item is Item.OutputMessage) {
+                                outputMessagePhases[it.outputIndex] = it.item.phase
+                            }
+                            null
                         }
 
                         is OpenAIStreamEvent.ResponseCompleted -> {
@@ -810,6 +830,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                                                     content = listOf(
                                                         OutputContent.Text(text = part.text, annotations = emptyList())
                                                     ),
+                                                    phase = message.phase,
                                                 )
                                             )
                                         }
@@ -925,6 +946,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
         )
 
         var finishReason: String? = null
+        val outputMessagePhases = mutableSetOf<String>()
 
         val parts = buildList {
             response.output.forEach { output ->
@@ -942,6 +964,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
 
                     is Item.OutputMessage -> {
                         finishReason = output.status?.name
+                        output.phase?.let { outputMessagePhases.add(it) }
                         output.content.forEach { content ->
                             when (content) {
                                 is OutputContent.Text -> {
@@ -976,7 +999,8 @@ public open class OpenAILLMClient @JvmOverloads constructor(
         return Message.Assistant(
             parts = parts,
             finishReason = finishReason,
-            metaInfo = metaInfo
+            metaInfo = metaInfo,
+            phase = outputMessagePhases.singleOrNull(),
         )
     }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPI.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPI.kt
@@ -6,6 +6,7 @@ import ai.koog.prompt.executor.clients.openai.base.models.OpenAIChoiceLogProbs
 import ai.koog.prompt.executor.clients.openai.base.models.ReasoningEffort
 import ai.koog.prompt.executor.clients.openai.base.models.ServiceTier
 import ai.koog.prompt.executor.clients.serialization.AdditionalPropertiesFlatteningSerializer
+import ai.koog.prompt.message.MessagePart
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.KSerializer
@@ -225,7 +226,7 @@ internal sealed interface Item {
         val id: String? = null,
         val role: String = "assistant",
         val status: OpenAIInputStatus? = null,
-        val phase: String? = null
+        val phase: MessagePart.Text.Phase? = null
     ) : Item {
         val type: String = "message"
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPI.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPI.kt
@@ -217,13 +217,15 @@ internal sealed interface Item {
      * @property role The role of the output message. Always `assistant`.
      * @property status The status of the message input. One of `in_progress`, `completed`, or `incomplete`.
      * Populated when input items are returned via API.
+     * @property phase Labels an assistant message as intermediate commentary or the final answer.
      */
     @Serializable
     class OutputMessage(
         val content: List<OutputContent>,
         val id: String? = null,
         val role: String = "assistant",
-        val status: OpenAIInputStatus? = null
+        val status: OpenAIInputStatus? = null,
+        val phase: String? = null
     ) : Item {
         val type: String = "message"
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIPrimaryConstructorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIPrimaryConstructorTest.kt
@@ -77,7 +77,7 @@ class OpenAIPrimaryConstructorTest {
     }
 
     @Test
-    fun `responses API should preserve assistant phase and suppress commentary output messages`() = runTest {
+    fun testResponsesAPIPreservesAssistantPhaseForReplayAndKeepsCommentaryOutput() = runTest {
         val transport = CapturingKoogHttpClient(clientName = "CapturingOpenAIResponsesClient") { responseType ->
             when (responseType) {
                 OpenAIResponsesAPIResponse::class -> OpenAIResponsesAPIResponse(
@@ -127,11 +127,14 @@ class OpenAIPrimaryConstructorTest {
 
         assertEquals("v1/responses", transport.lastPath)
         assertEquals(true, transport.lastRequest.toString().contains("\"phase\":\"final_answer\""))
-        assertEquals(1, responses.size)
+        assertEquals(2, responses.parts.size)
+        assertEquals(null, responses.phase)
 
-        val message = assertIs<Message.Assistant>(responses.single())
-        assertEquals("Final answer", message.content)
-        assertEquals("final_answer", message.phase)
+        val commentary = assertIs<MessagePart.Text>(responses.parts[0])
+        assertEquals("Working through it", commentary.text)
+
+        val finalAnswer = assertIs<MessagePart.Text>(responses.parts[1])
+        assertEquals("Final answer", finalAnswer.text)
     }
 
     @Test
@@ -282,7 +285,7 @@ class OpenAIPrimaryConstructorTest {
     }
 
     @Test
-    fun `responses streaming should suppress commentary text deltas`() = runTest {
+    fun testResponsesStreamingEmitsCommentaryTextDeltas() = runTest {
         val responsesPath = "v1/responses"
 
         val transport = object : KoogHttpClient {
@@ -292,24 +295,27 @@ class OpenAIPrimaryConstructorTest {
                 path: String,
                 responseType: KClass<R>,
                 parameters: Map<String, String>,
+                headers: Map<String, String>,
             ): R = error("GET is not expected in this test")
 
             override suspend fun <T : Any, R : Any> post(
                 path: String,
-                request: T,
+                requestBody: T,
                 requestBodyType: KClass<T>,
                 responseType: KClass<R>,
                 parameters: Map<String, String>,
+                headers: Map<String, String>,
             ): R = error("POST is not expected in this test")
 
             override fun <T : Any, R : Any, O : Any> sse(
                 path: String,
-                request: T,
+                requestBody: T,
                 requestBodyType: KClass<T>,
                 dataFilter: (String?) -> Boolean,
                 decodeStreamingResponse: (String) -> R,
                 processStreamingChunk: (R) -> O?,
                 parameters: Map<String, String>,
+                headers: Map<String, String>,
             ): Flow<O> {
                 assertEquals(responsesPath, path)
 
@@ -375,6 +381,14 @@ class OpenAIPrimaryConstructorTest {
                 }
             }
 
+            override fun <T : Any> lines(
+                path: String,
+                requestBody: T,
+                requestBodyType: KClass<T>,
+                parameters: Map<String, String>,
+                headers: Map<String, String>,
+            ): Flow<String> = error("lines is not expected in this test")
+
             override fun close(): Unit = Unit
         }
         val client = OpenAILLMClient(
@@ -391,8 +405,9 @@ class OpenAIPrimaryConstructorTest {
             model = OpenAIModels.Chat.GPT4o
         ).toList()
 
-        assertEquals(2, frames.size)
-        assertEquals(StreamFrame.TextDelta(text = "Final", index = 1), frames[0])
-        assertIs<StreamFrame.End>(frames[1])
+        assertEquals(3, frames.size)
+        assertEquals(StreamFrame.TextDelta(text = "Working", index = 0), frames[0])
+        assertEquals(StreamFrame.TextDelta(text = "Final", index = 1), frames[1])
+        assertIs<StreamFrame.End>(frames[2])
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIPrimaryConstructorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIPrimaryConstructorTest.kt
@@ -12,6 +12,7 @@ import ai.koog.prompt.executor.clients.openai.models.OutputContent
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.MessagePart
+import ai.koog.prompt.message.MessagePart.Text.Phase
 import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.streaming.StreamFrame
@@ -21,6 +22,10 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlin.reflect.KClass
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -88,13 +93,13 @@ class OpenAIPrimaryConstructorTest {
                         Item.OutputMessage(
                             content = listOf(OutputContent.Text(annotations = emptyList(), text = "Working through it")),
                             id = "msg_commentary",
-                            phase = "commentary",
+                            phase = Phase.COMMENTARY,
                             status = OpenAIInputStatus.COMPLETED
                         ),
                         Item.OutputMessage(
                             content = listOf(OutputContent.Text(annotations = emptyList(), text = "Final answer")),
                             id = "msg_final",
-                            phase = "final_answer",
+                            phase = Phase.FINAL_ANSWER,
                             status = OpenAIInputStatus.COMPLETED
                         )
                     ),
@@ -114,9 +119,11 @@ class OpenAIPrimaryConstructorTest {
             prompt = Prompt(
                 messages = listOf(
                     Message.Assistant(
-                        content = "Earlier final answer",
+                        part = MessagePart.Text(
+                            text = "Earlier final answer",
+                            phase = Phase.FINAL_ANSWER
+                        ),
                         metaInfo = ResponseMetaInfo.Empty,
-                        phase = "final_answer"
                     )
                 ),
                 id = "test",
@@ -125,16 +132,19 @@ class OpenAIPrimaryConstructorTest {
             model = OpenAIModels.Chat.GPT4o
         )
 
-        assertEquals("v1/responses", transport.lastPath)
-        assertEquals(true, transport.lastRequest.toString().contains("\"phase\":\"final_answer\""))
+        val request = Json.parseToJsonElement(transport.lastRequest.toString()).jsonObject
+        val replayedAssistant = request.getValue("input").jsonArray.single().jsonObject
+        assertEquals("final_answer", replayedAssistant.getValue("phase").jsonPrimitive.content)
+
         assertEquals(2, responses.parts.size)
-        assertEquals(null, responses.phase)
 
         val commentary = assertIs<MessagePart.Text>(responses.parts[0])
         assertEquals("Working through it", commentary.text)
+        assertEquals(Phase.COMMENTARY, commentary.phase)
 
         val finalAnswer = assertIs<MessagePart.Text>(responses.parts[1])
         assertEquals("Final answer", finalAnswer.text)
+        assertEquals(Phase.FINAL_ANSWER, finalAnswer.phase)
     }
 
     @Test
@@ -325,7 +335,7 @@ class OpenAIPrimaryConstructorTest {
                             item = Item.OutputMessage(
                                 content = emptyList(),
                                 id = "msg_commentary",
-                                phase = "commentary"
+                                phase = Phase.COMMENTARY
                             ),
                             outputIndex = 0,
                             sequenceNumber = 1
@@ -341,14 +351,23 @@ class OpenAIPrimaryConstructorTest {
                         ) as R
                     ),
                     processStreamingChunk(
+                        OpenAIStreamEvent.ResponseOutputTextDone(
+                            itemId = "msg_commentary",
+                            outputIndex = 0,
+                            contentIndex = 0,
+                            text = "Working",
+                            sequenceNumber = 3
+                        ) as R
+                    ),
+                    processStreamingChunk(
                         OpenAIStreamEvent.ResponseOutputItemAdded(
                             item = Item.OutputMessage(
                                 content = emptyList(),
                                 id = "msg_final",
-                                phase = "final_answer"
+                                phase = Phase.FINAL_ANSWER
                             ),
                             outputIndex = 1,
-                            sequenceNumber = 3
+                            sequenceNumber = 4
                         ) as R
                     ),
                     processStreamingChunk(
@@ -357,7 +376,16 @@ class OpenAIPrimaryConstructorTest {
                             outputIndex = 1,
                             contentIndex = 0,
                             delta = "Final",
-                            sequenceNumber = 4
+                            sequenceNumber = 5
+                        ) as R
+                    ),
+                    processStreamingChunk(
+                        OpenAIStreamEvent.ResponseOutputTextDone(
+                            itemId = "msg_final",
+                            outputIndex = 1,
+                            contentIndex = 0,
+                            text = "Final",
+                            sequenceNumber = 6
                         ) as R
                     ),
                     processStreamingChunk(
@@ -371,7 +399,7 @@ class OpenAIPrimaryConstructorTest {
                                 status = OpenAIInputStatus.COMPLETED,
                                 text = OpenAITextConfig()
                             ),
-                            sequenceNumber = 5
+                            sequenceNumber = 7
                         ) as R
                     )
                 )
@@ -405,9 +433,11 @@ class OpenAIPrimaryConstructorTest {
             model = OpenAIModels.Chat.GPT4o
         ).toList()
 
-        assertEquals(3, frames.size)
-        assertEquals(StreamFrame.TextDelta(text = "Working", index = 0), frames[0])
-        assertEquals(StreamFrame.TextDelta(text = "Final", index = 1), frames[1])
-        assertIs<StreamFrame.End>(frames[2])
+        assertEquals(5, frames.size)
+        assertEquals(StreamFrame.TextDelta(text = "Working", index = 0, phase = Phase.COMMENTARY), frames[0])
+        assertEquals(StreamFrame.TextComplete(text = "Working", index = 0, phase = Phase.COMMENTARY), frames[1])
+        assertEquals(StreamFrame.TextDelta(text = "Final", index = 1, phase = Phase.FINAL_ANSWER), frames[2])
+        assertEquals(StreamFrame.TextComplete(text = "Final", index = 1, phase = Phase.FINAL_ANSWER), frames[3])
+        assertIs<StreamFrame.End>(frames[4])
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIPrimaryConstructorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIPrimaryConstructorTest.kt
@@ -8,10 +8,12 @@ import ai.koog.prompt.executor.clients.openai.models.OpenAIInputStatus
 import ai.koog.prompt.executor.clients.openai.models.OpenAIResponsesAPIResponse
 import ai.koog.prompt.executor.clients.openai.models.OpenAIStreamEvent
 import ai.koog.prompt.executor.clients.openai.models.OpenAITextConfig
+import ai.koog.prompt.executor.clients.openai.models.OutputContent
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.MessagePart
 import ai.koog.prompt.message.RequestMetaInfo
+import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.test.utils.CapturingKoogHttpClient
 import kotlinx.coroutines.flow.Flow
@@ -72,6 +74,64 @@ class OpenAIPrimaryConstructorTest {
         assertEquals(1, responses.parts.size)
         val textPart = assertIs<MessagePart.Text>(responses.parts.single())
         assertEquals("Hello from KoogHttpClient", textPart.text)
+    }
+
+    @Test
+    fun `responses API should preserve assistant phase and suppress commentary output messages`() = runTest {
+        val transport = CapturingKoogHttpClient(clientName = "CapturingOpenAIResponsesClient") { responseType ->
+            when (responseType) {
+                OpenAIResponsesAPIResponse::class -> OpenAIResponsesAPIResponse(
+                    created = 1716920005,
+                    id = "resp_123",
+                    model = "gpt-5.4",
+                    output = listOf(
+                        Item.OutputMessage(
+                            content = listOf(OutputContent.Text(annotations = emptyList(), text = "Working through it")),
+                            id = "msg_commentary",
+                            phase = "commentary",
+                            status = OpenAIInputStatus.COMPLETED
+                        ),
+                        Item.OutputMessage(
+                            content = listOf(OutputContent.Text(annotations = emptyList(), text = "Final answer")),
+                            id = "msg_final",
+                            phase = "final_answer",
+                            status = OpenAIInputStatus.COMPLETED
+                        )
+                    ),
+                    parallelToolCalls = false,
+                    status = OpenAIInputStatus.COMPLETED,
+                    text = OpenAITextConfig()
+                )
+                else -> error("Unexpected response type: $responseType")
+            }
+        }
+        val client = OpenAILLMClient(
+            settings = OpenAIClientSettings(baseUrl = "https://unused.test"),
+            httpClient = transport
+        )
+
+        val responses = client.execute(
+            prompt = Prompt(
+                messages = listOf(
+                    Message.Assistant(
+                        content = "Earlier final answer",
+                        metaInfo = ResponseMetaInfo.Empty,
+                        phase = "final_answer"
+                    )
+                ),
+                id = "test",
+                params = OpenAIResponsesParams()
+            ),
+            model = OpenAIModels.Chat.GPT4o
+        )
+
+        assertEquals("v1/responses", transport.lastPath)
+        assertEquals(true, transport.lastRequest.toString().contains("\"phase\":\"final_answer\""))
+        assertEquals(1, responses.size)
+
+        val message = assertIs<Message.Assistant>(responses.single())
+        assertEquals("Final answer", message.content)
+        assertEquals("final_answer", message.phase)
     }
 
     @Test
@@ -219,5 +279,120 @@ class OpenAIPrimaryConstructorTest {
         assertEquals(totalTokens, end.metaInfo.totalTokensCount)
         assertEquals(inputTokens, end.metaInfo.inputTokensCount)
         assertEquals(outputTokens, end.metaInfo.outputTokensCount)
+    }
+
+    @Test
+    fun `responses streaming should suppress commentary text deltas`() = runTest {
+        val responsesPath = "v1/responses"
+
+        val transport = object : KoogHttpClient {
+            override val clientName: String = "StreamingOpenAIClient"
+
+            override suspend fun <R : Any> get(
+                path: String,
+                responseType: KClass<R>,
+                parameters: Map<String, String>,
+            ): R = error("GET is not expected in this test")
+
+            override suspend fun <T : Any, R : Any> post(
+                path: String,
+                request: T,
+                requestBodyType: KClass<T>,
+                responseType: KClass<R>,
+                parameters: Map<String, String>,
+            ): R = error("POST is not expected in this test")
+
+            override fun <T : Any, R : Any, O : Any> sse(
+                path: String,
+                request: T,
+                requestBodyType: KClass<T>,
+                dataFilter: (String?) -> Boolean,
+                decodeStreamingResponse: (String) -> R,
+                processStreamingChunk: (R) -> O?,
+                parameters: Map<String, String>,
+            ): Flow<O> {
+                assertEquals(responsesPath, path)
+
+                val events = listOfNotNull(
+                    processStreamingChunk(
+                        OpenAIStreamEvent.ResponseOutputItemAdded(
+                            item = Item.OutputMessage(
+                                content = emptyList(),
+                                id = "msg_commentary",
+                                phase = "commentary"
+                            ),
+                            outputIndex = 0,
+                            sequenceNumber = 1
+                        ) as R
+                    ),
+                    processStreamingChunk(
+                        OpenAIStreamEvent.ResponseOutputTextDelta(
+                            itemId = "msg_commentary",
+                            outputIndex = 0,
+                            contentIndex = 0,
+                            delta = "Working",
+                            sequenceNumber = 2
+                        ) as R
+                    ),
+                    processStreamingChunk(
+                        OpenAIStreamEvent.ResponseOutputItemAdded(
+                            item = Item.OutputMessage(
+                                content = emptyList(),
+                                id = "msg_final",
+                                phase = "final_answer"
+                            ),
+                            outputIndex = 1,
+                            sequenceNumber = 3
+                        ) as R
+                    ),
+                    processStreamingChunk(
+                        OpenAIStreamEvent.ResponseOutputTextDelta(
+                            itemId = "msg_final",
+                            outputIndex = 1,
+                            contentIndex = 0,
+                            delta = "Final",
+                            sequenceNumber = 4
+                        ) as R
+                    ),
+                    processStreamingChunk(
+                        OpenAIStreamEvent.ResponseCompleted(
+                            response = OpenAIResponsesAPIResponse(
+                                created = 1716920005,
+                                id = "resp_123",
+                                model = "gpt-5.4",
+                                output = emptyList(),
+                                parallelToolCalls = false,
+                                status = OpenAIInputStatus.COMPLETED,
+                                text = OpenAITextConfig()
+                            ),
+                            sequenceNumber = 5
+                        ) as R
+                    )
+                )
+
+                return flow {
+                    events.forEach { emit(it) }
+                }
+            }
+
+            override fun close(): Unit = Unit
+        }
+        val client = OpenAILLMClient(
+            settings = OpenAIClientSettings(baseUrl = "https://unused.test"),
+            httpClient = transport
+        )
+
+        val frames = client.executeStreaming(
+            prompt = Prompt(
+                messages = listOf(Message.User("Hello?", RequestMetaInfo.Empty)),
+                id = "test",
+                params = OpenAIResponsesParams()
+            ),
+            model = OpenAIModels.Chat.GPT4o
+        ).toList()
+
+        assertEquals(2, frames.size)
+        assertEquals(StreamFrame.TextDelta(text = "Final", index = 1), frames[0])
+        assertIs<StreamFrame.End>(frames[1])
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPIItemsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPIItemsTest.kt
@@ -89,7 +89,8 @@ class OpenAIResponsesAPIItemsTest {
                     ),
                     id = "msg-123",
                     role = "assistant",
-                    status = OpenAIInputStatus.COMPLETED
+                    status = OpenAIInputStatus.COMPLETED,
+                    phase = "final_answer"
                 )
             ) shouldEqualJson """
             {
@@ -97,7 +98,8 @@ class OpenAIResponsesAPIItemsTest {
                 "content": [{"type": "output_text", "annotations": [], "text": "Response text"}],
                 "id": "msg-123",
                 "role": "assistant",
-                "status": "completed"
+                "status": "completed",
+                "phase": "final_answer"
             }
             """.trimIndent()
         }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPIItemsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPIItemsTest.kt
@@ -1,5 +1,6 @@
 package ai.koog.prompt.executor.clients.openai.models
 
+import ai.koog.prompt.message.MessagePart
 import ai.koog.test.utils.runWithBothJsonConfigurations
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.matchers.collections.shouldHaveSize
@@ -90,7 +91,7 @@ class OpenAIResponsesAPIItemsTest {
                     id = "msg-123",
                     role = "assistant",
                     status = OpenAIInputStatus.COMPLETED,
-                    phase = "final_answer"
+                    phase = MessagePart.Text.Phase.FINAL_ANSWER
                 )
             ) shouldEqualJson """
             {

--- a/prompt/prompt-model/api/android/prompt-model.api
+++ b/prompt/prompt-model/api/android/prompt-model.api
@@ -661,30 +661,35 @@ public final class ai/koog/prompt/message/Message$Assistant : ai/koog/prompt/mes
 	public fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;)V
 	public fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
 	public fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)V
-	public synthetic fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;)V
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;)V
 	public fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;)V
 	public fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
 	public fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Lai/koog/prompt/message/ResponseMetaInfo;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Lkotlinx/serialization/json/JsonObject;
 	public final fun component5 ()Ljava/lang/String;
-	public final fun copy (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)Lai/koog/prompt/message/Message$Assistant;
-	public static synthetic fun copy$default (Lai/koog/prompt/message/Message$Assistant;Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILjava/lang/Object;)Lai/koog/prompt/message/Message$Assistant;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/message/Message$Assistant;
+	public static synthetic fun copy$default (Lai/koog/prompt/message/Message$Assistant;Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lai/koog/prompt/message/Message$Assistant;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFinishReason ()Ljava/lang/String;
 	public fun getId ()Ljava/lang/String;
 	public synthetic fun getMetaInfo ()Lai/koog/prompt/message/MessageMetaInfo;
 	public fun getMetaInfo ()Lai/koog/prompt/message/ResponseMetaInfo;
 	public fun getParts ()Ljava/util/List;
+	public final fun getPhase ()Ljava/lang/String;
 	public final fun getRawResponse ()Lkotlinx/serialization/json/JsonObject;
 	public fun getRole ()Lai/koog/prompt/message/Message$Role;
 	public fun hashCode ()I

--- a/prompt/prompt-model/api/android/prompt-model.api
+++ b/prompt/prompt-model/api/android/prompt-model.api
@@ -661,35 +661,30 @@ public final class ai/koog/prompt/message/Message$Assistant : ai/koog/prompt/mes
 	public fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;)V
 	public fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
 	public fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)V
-	public fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;)V
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)V
-	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;)V
 	public fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;)V
 	public fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
 	public fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)V
-	public fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Lai/koog/prompt/message/ResponseMetaInfo;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Lkotlinx/serialization/json/JsonObject;
 	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/message/Message$Assistant;
-	public static synthetic fun copy$default (Lai/koog/prompt/message/Message$Assistant;Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lai/koog/prompt/message/Message$Assistant;
+	public final fun copy (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)Lai/koog/prompt/message/Message$Assistant;
+	public static synthetic fun copy$default (Lai/koog/prompt/message/Message$Assistant;Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILjava/lang/Object;)Lai/koog/prompt/message/Message$Assistant;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFinishReason ()Ljava/lang/String;
 	public fun getId ()Ljava/lang/String;
 	public synthetic fun getMetaInfo ()Lai/koog/prompt/message/MessageMetaInfo;
 	public fun getMetaInfo ()Lai/koog/prompt/message/ResponseMetaInfo;
 	public fun getParts ()Ljava/util/List;
-	public final fun getPhase ()Ljava/lang/String;
 	public final fun getRawResponse ()Lkotlinx/serialization/json/JsonObject;
 	public fun getRole ()Lai/koog/prompt/message/Message$Role;
 	public fun hashCode ()I
@@ -944,13 +939,16 @@ public final class ai/koog/prompt/message/MessagePart$Text : ai/koog/prompt/mess
 	public static final field Companion Lai/koog/prompt/message/MessagePart$Text$Companion;
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
-	public synthetic fun <init> (Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/CacheControl;Lai/koog/prompt/message/MessagePart$Text$Phase;)V
+	public synthetic fun <init> (Ljava/lang/String;Lai/koog/prompt/message/CacheControl;Lai/koog/prompt/message/MessagePart$Text$Phase;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lai/koog/prompt/message/CacheControl;
-	public final fun copy (Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)Lai/koog/prompt/message/MessagePart$Text;
-	public static synthetic fun copy$default (Lai/koog/prompt/message/MessagePart$Text;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)Lai/koog/prompt/message/MessagePart$Text;
+	public final fun component3 ()Lai/koog/prompt/message/MessagePart$Text$Phase;
+	public final fun copy (Ljava/lang/String;Lai/koog/prompt/message/CacheControl;Lai/koog/prompt/message/MessagePart$Text$Phase;)Lai/koog/prompt/message/MessagePart$Text;
+	public static synthetic fun copy$default (Lai/koog/prompt/message/MessagePart$Text;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;Lai/koog/prompt/message/MessagePart$Text$Phase;ILjava/lang/Object;)Lai/koog/prompt/message/MessagePart$Text;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getCacheControl ()Lai/koog/prompt/message/CacheControl;
+	public final fun getPhase ()Lai/koog/prompt/message/MessagePart$Text$Phase;
 	public final fun getText ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -968,6 +966,19 @@ public final synthetic class ai/koog/prompt/message/MessagePart$Text$$serializer
 }
 
 public final class ai/koog/prompt/message/MessagePart$Text$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ai/koog/prompt/message/MessagePart$Text$Phase : java/lang/Enum {
+	public static final field COMMENTARY Lai/koog/prompt/message/MessagePart$Text$Phase;
+	public static final field Companion Lai/koog/prompt/message/MessagePart$Text$Phase$Companion;
+	public static final field FINAL_ANSWER Lai/koog/prompt/message/MessagePart$Text$Phase;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lai/koog/prompt/message/MessagePart$Text$Phase;
+	public static fun values ()[Lai/koog/prompt/message/MessagePart$Text$Phase;
+}
+
+public final class ai/koog/prompt/message/MessagePart$Text$Phase$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -1445,14 +1456,16 @@ public final class ai/koog/prompt/streaming/StreamFrame$ReasoningDelta$Companion
 
 public final class ai/koog/prompt/streaming/StreamFrame$TextComplete : ai/koog/prompt/streaming/StreamFrame, ai/koog/prompt/streaming/StreamFrame$CompleteFrame {
 	public static final field Companion Lai/koog/prompt/streaming/StreamFrame$TextComplete$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/Integer;
-	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;)Lai/koog/prompt/streaming/StreamFrame$TextComplete;
-	public static synthetic fun copy$default (Lai/koog/prompt/streaming/StreamFrame$TextComplete;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lai/koog/prompt/streaming/StreamFrame$TextComplete;
+	public final fun component3 ()Lai/koog/prompt/message/MessagePart$Text$Phase;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;)Lai/koog/prompt/streaming/StreamFrame$TextComplete;
+	public static synthetic fun copy$default (Lai/koog/prompt/streaming/StreamFrame$TextComplete;Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;ILjava/lang/Object;)Lai/koog/prompt/streaming/StreamFrame$TextComplete;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getIndex ()Ljava/lang/Integer;
+	public final fun getPhase ()Lai/koog/prompt/message/MessagePart$Text$Phase;
 	public final fun getText ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1475,14 +1488,16 @@ public final class ai/koog/prompt/streaming/StreamFrame$TextComplete$Companion {
 
 public final class ai/koog/prompt/streaming/StreamFrame$TextDelta : ai/koog/prompt/streaming/StreamFrame, ai/koog/prompt/streaming/StreamFrame$DeltaFrame {
 	public static final field Companion Lai/koog/prompt/streaming/StreamFrame$TextDelta$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/Integer;
-	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;)Lai/koog/prompt/streaming/StreamFrame$TextDelta;
-	public static synthetic fun copy$default (Lai/koog/prompt/streaming/StreamFrame$TextDelta;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lai/koog/prompt/streaming/StreamFrame$TextDelta;
+	public final fun component3 ()Lai/koog/prompt/message/MessagePart$Text$Phase;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;)Lai/koog/prompt/streaming/StreamFrame$TextDelta;
+	public static synthetic fun copy$default (Lai/koog/prompt/streaming/StreamFrame$TextDelta;Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;ILjava/lang/Object;)Lai/koog/prompt/streaming/StreamFrame$TextDelta;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getIndex ()Ljava/lang/Integer;
+	public final fun getPhase ()Lai/koog/prompt/message/MessagePart$Text$Phase;
 	public final fun getText ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1584,8 +1599,8 @@ public final class ai/koog/prompt/streaming/StreamFrameFlowBuilder {
 	public static synthetic fun emitEnd$default (Lai/koog/prompt/streaming/StreamFrameFlowBuilder;Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun emitReasoningDelta (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun emitReasoningDelta$default (Lai/koog/prompt/streaming/StreamFrameFlowBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun emitTextDelta (Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun emitTextDelta$default (Lai/koog/prompt/streaming/StreamFrameFlowBuilder;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun emitTextDelta (Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun emitTextDelta$default (Lai/koog/prompt/streaming/StreamFrameFlowBuilder;Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun emitToolCallDelta (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun emitToolCallDelta$default (Lai/koog/prompt/streaming/StreamFrameFlowBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun tryEmitPendingReasoning (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1615,10 +1630,10 @@ public final class ai/koog/prompt/streaming/StreamFrameFlowBuilderKt {
 	public static synthetic fun emitReasoningComplete$default (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun emitReasoningDelta (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun emitReasoningDelta$default (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun emitTextComplete (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun emitTextComplete$default (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun emitTextDelta (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun emitTextDelta$default (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun emitTextComplete (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun emitTextComplete$default (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun emitTextDelta (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun emitTextDelta$default (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun emitToolCallComplete (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun emitToolCallComplete$default (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun emitToolCallDelta (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/prompt/prompt-model/api/jvm/prompt-model.api
+++ b/prompt/prompt-model/api/jvm/prompt-model.api
@@ -673,35 +673,30 @@ public final class ai/koog/prompt/message/Message$Assistant : ai/koog/prompt/mes
 	public fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;)V
 	public fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
 	public fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)V
-	public fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;)V
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)V
-	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;)V
 	public fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;)V
 	public fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
 	public fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)V
-	public fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Lai/koog/prompt/message/ResponseMetaInfo;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Lkotlinx/serialization/json/JsonObject;
 	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/message/Message$Assistant;
-	public static synthetic fun copy$default (Lai/koog/prompt/message/Message$Assistant;Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lai/koog/prompt/message/Message$Assistant;
+	public final fun copy (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)Lai/koog/prompt/message/Message$Assistant;
+	public static synthetic fun copy$default (Lai/koog/prompt/message/Message$Assistant;Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILjava/lang/Object;)Lai/koog/prompt/message/Message$Assistant;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFinishReason ()Ljava/lang/String;
 	public fun getId ()Ljava/lang/String;
 	public synthetic fun getMetaInfo ()Lai/koog/prompt/message/MessageMetaInfo;
 	public fun getMetaInfo ()Lai/koog/prompt/message/ResponseMetaInfo;
 	public fun getParts ()Ljava/util/List;
-	public final fun getPhase ()Ljava/lang/String;
 	public final fun getRawResponse ()Lkotlinx/serialization/json/JsonObject;
 	public fun getRole ()Lai/koog/prompt/message/Message$Role;
 	public fun hashCode ()I
@@ -963,13 +958,16 @@ public final class ai/koog/prompt/message/MessagePart$Text : ai/koog/prompt/mess
 	public static final field Companion Lai/koog/prompt/message/MessagePart$Text$Companion;
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
-	public synthetic fun <init> (Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/CacheControl;Lai/koog/prompt/message/MessagePart$Text$Phase;)V
+	public synthetic fun <init> (Ljava/lang/String;Lai/koog/prompt/message/CacheControl;Lai/koog/prompt/message/MessagePart$Text$Phase;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lai/koog/prompt/message/CacheControl;
-	public final fun copy (Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)Lai/koog/prompt/message/MessagePart$Text;
-	public static synthetic fun copy$default (Lai/koog/prompt/message/MessagePart$Text;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)Lai/koog/prompt/message/MessagePart$Text;
+	public final fun component3 ()Lai/koog/prompt/message/MessagePart$Text$Phase;
+	public final fun copy (Ljava/lang/String;Lai/koog/prompt/message/CacheControl;Lai/koog/prompt/message/MessagePart$Text$Phase;)Lai/koog/prompt/message/MessagePart$Text;
+	public static synthetic fun copy$default (Lai/koog/prompt/message/MessagePart$Text;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;Lai/koog/prompt/message/MessagePart$Text$Phase;ILjava/lang/Object;)Lai/koog/prompt/message/MessagePart$Text;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getCacheControl ()Lai/koog/prompt/message/CacheControl;
+	public final fun getPhase ()Lai/koog/prompt/message/MessagePart$Text$Phase;
 	public final fun getText ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -987,6 +985,19 @@ public final synthetic class ai/koog/prompt/message/MessagePart$Text$$serializer
 }
 
 public final class ai/koog/prompt/message/MessagePart$Text$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ai/koog/prompt/message/MessagePart$Text$Phase : java/lang/Enum {
+	public static final field COMMENTARY Lai/koog/prompt/message/MessagePart$Text$Phase;
+	public static final field Companion Lai/koog/prompt/message/MessagePart$Text$Phase$Companion;
+	public static final field FINAL_ANSWER Lai/koog/prompt/message/MessagePart$Text$Phase;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lai/koog/prompt/message/MessagePart$Text$Phase;
+	public static fun values ()[Lai/koog/prompt/message/MessagePart$Text$Phase;
+}
+
+public final class ai/koog/prompt/message/MessagePart$Text$Phase$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -1547,14 +1558,16 @@ public final class ai/koog/prompt/streaming/StreamFrame$ReasoningDelta$Companion
 
 public final class ai/koog/prompt/streaming/StreamFrame$TextComplete : ai/koog/prompt/streaming/StreamFrame, ai/koog/prompt/streaming/StreamFrame$CompleteFrame {
 	public static final field Companion Lai/koog/prompt/streaming/StreamFrame$TextComplete$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/Integer;
-	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;)Lai/koog/prompt/streaming/StreamFrame$TextComplete;
-	public static synthetic fun copy$default (Lai/koog/prompt/streaming/StreamFrame$TextComplete;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lai/koog/prompt/streaming/StreamFrame$TextComplete;
+	public final fun component3 ()Lai/koog/prompt/message/MessagePart$Text$Phase;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;)Lai/koog/prompt/streaming/StreamFrame$TextComplete;
+	public static synthetic fun copy$default (Lai/koog/prompt/streaming/StreamFrame$TextComplete;Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;ILjava/lang/Object;)Lai/koog/prompt/streaming/StreamFrame$TextComplete;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getIndex ()Ljava/lang/Integer;
+	public final fun getPhase ()Lai/koog/prompt/message/MessagePart$Text$Phase;
 	public final fun getText ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1577,14 +1590,16 @@ public final class ai/koog/prompt/streaming/StreamFrame$TextComplete$Companion {
 
 public final class ai/koog/prompt/streaming/StreamFrame$TextDelta : ai/koog/prompt/streaming/StreamFrame, ai/koog/prompt/streaming/StreamFrame$DeltaFrame {
 	public static final field Companion Lai/koog/prompt/streaming/StreamFrame$TextDelta$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/Integer;
-	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;)Lai/koog/prompt/streaming/StreamFrame$TextDelta;
-	public static synthetic fun copy$default (Lai/koog/prompt/streaming/StreamFrame$TextDelta;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lai/koog/prompt/streaming/StreamFrame$TextDelta;
+	public final fun component3 ()Lai/koog/prompt/message/MessagePart$Text$Phase;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;)Lai/koog/prompt/streaming/StreamFrame$TextDelta;
+	public static synthetic fun copy$default (Lai/koog/prompt/streaming/StreamFrame$TextDelta;Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;ILjava/lang/Object;)Lai/koog/prompt/streaming/StreamFrame$TextDelta;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getIndex ()Ljava/lang/Integer;
+	public final fun getPhase ()Lai/koog/prompt/message/MessagePart$Text$Phase;
 	public final fun getText ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1686,8 +1701,8 @@ public final class ai/koog/prompt/streaming/StreamFrameFlowBuilder {
 	public static synthetic fun emitEnd$default (Lai/koog/prompt/streaming/StreamFrameFlowBuilder;Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun emitReasoningDelta (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun emitReasoningDelta$default (Lai/koog/prompt/streaming/StreamFrameFlowBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun emitTextDelta (Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun emitTextDelta$default (Lai/koog/prompt/streaming/StreamFrameFlowBuilder;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun emitTextDelta (Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun emitTextDelta$default (Lai/koog/prompt/streaming/StreamFrameFlowBuilder;Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun emitToolCallDelta (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun emitToolCallDelta$default (Lai/koog/prompt/streaming/StreamFrameFlowBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun tryEmitPendingReasoning (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1717,10 +1732,10 @@ public final class ai/koog/prompt/streaming/StreamFrameFlowBuilderKt {
 	public static synthetic fun emitReasoningComplete$default (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun emitReasoningDelta (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun emitReasoningDelta$default (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun emitTextComplete (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun emitTextComplete$default (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun emitTextDelta (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun emitTextDelta$default (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun emitTextComplete (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun emitTextComplete$default (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun emitTextDelta (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun emitTextDelta$default (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/Integer;Lai/koog/prompt/message/MessagePart$Text$Phase;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun emitToolCallComplete (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun emitToolCallComplete$default (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun emitToolCallDelta (Lkotlinx/coroutines/flow/FlowCollector;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/prompt/prompt-model/api/jvm/prompt-model.api
+++ b/prompt/prompt-model/api/jvm/prompt-model.api
@@ -673,30 +673,35 @@ public final class ai/koog/prompt/message/Message$Assistant : ai/koog/prompt/mes
 	public fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;)V
 	public fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
 	public fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)V
-	public synthetic fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lai/koog/prompt/message/MessagePart$ResponsePart;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;)V
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;)V
 	public fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;)V
 	public fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
 	public fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Lai/koog/prompt/message/ResponseMetaInfo;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Lkotlinx/serialization/json/JsonObject;
 	public final fun component5 ()Ljava/lang/String;
-	public final fun copy (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)Lai/koog/prompt/message/Message$Assistant;
-	public static synthetic fun copy$default (Lai/koog/prompt/message/Message$Assistant;Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILjava/lang/Object;)Lai/koog/prompt/message/Message$Assistant;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/message/Message$Assistant;
+	public static synthetic fun copy$default (Lai/koog/prompt/message/Message$Assistant;Ljava/util/List;Lai/koog/prompt/message/ResponseMetaInfo;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lai/koog/prompt/message/Message$Assistant;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFinishReason ()Ljava/lang/String;
 	public fun getId ()Ljava/lang/String;
 	public synthetic fun getMetaInfo ()Lai/koog/prompt/message/MessageMetaInfo;
 	public fun getMetaInfo ()Lai/koog/prompt/message/ResponseMetaInfo;
 	public fun getParts ()Ljava/util/List;
+	public final fun getPhase ()Ljava/lang/String;
 	public final fun getRawResponse ()Lkotlinx/serialization/json/JsonObject;
 	public fun getRole ()Lai/koog/prompt/message/Message$Role;
 	public fun hashCode ()I

--- a/prompt/prompt-model/api/prompt-model.klib.api
+++ b/prompt/prompt-model/api/prompt-model.klib.api
@@ -338,9 +338,9 @@ sealed interface ai.koog.prompt.message/Message { // ai.koog.prompt.message/Mess
     }
 
     final class Assistant : ai.koog.prompt.message/Message { // ai.koog.prompt.message/Message.Assistant|null[0]
-        constructor <init>(ai.koog.prompt.message/MessagePart.ResponsePart, ai.koog.prompt.message/ResponseMetaInfo, kotlin/String? = ..., kotlinx.serialization.json/JsonObject? = ..., kotlin/String? = ...) // ai.koog.prompt.message/Message.Assistant.<init>|<init>(ai.koog.prompt.message.MessagePart.ResponsePart;ai.koog.prompt.message.ResponseMetaInfo;kotlin.String?;kotlinx.serialization.json.JsonObject?;kotlin.String?){}[0]
-        constructor <init>(kotlin.collections/List<ai.koog.prompt.message/MessagePart.ResponsePart>, ai.koog.prompt.message/ResponseMetaInfo, kotlin/String? = ..., kotlinx.serialization.json/JsonObject? = ..., kotlin/String? = ...) // ai.koog.prompt.message/Message.Assistant.<init>|<init>(kotlin.collections.List<ai.koog.prompt.message.MessagePart.ResponsePart>;ai.koog.prompt.message.ResponseMetaInfo;kotlin.String?;kotlinx.serialization.json.JsonObject?;kotlin.String?){}[0]
-        constructor <init>(kotlin/String, ai.koog.prompt.message/ResponseMetaInfo, kotlin/String? = ..., kotlinx.serialization.json/JsonObject? = ..., kotlin/String? = ...) // ai.koog.prompt.message/Message.Assistant.<init>|<init>(kotlin.String;ai.koog.prompt.message.ResponseMetaInfo;kotlin.String?;kotlinx.serialization.json.JsonObject?;kotlin.String?){}[0]
+        constructor <init>(ai.koog.prompt.message/MessagePart.ResponsePart, ai.koog.prompt.message/ResponseMetaInfo, kotlin/String? = ..., kotlinx.serialization.json/JsonObject? = ..., kotlin/String? = ..., kotlin/String? = ...) // ai.koog.prompt.message/Message.Assistant.<init>|<init>(ai.koog.prompt.message.MessagePart.ResponsePart;ai.koog.prompt.message.ResponseMetaInfo;kotlin.String?;kotlinx.serialization.json.JsonObject?;kotlin.String?;kotlin.String?){}[0]
+        constructor <init>(kotlin.collections/List<ai.koog.prompt.message/MessagePart.ResponsePart>, ai.koog.prompt.message/ResponseMetaInfo, kotlin/String? = ..., kotlinx.serialization.json/JsonObject? = ..., kotlin/String? = ..., kotlin/String? = ...) // ai.koog.prompt.message/Message.Assistant.<init>|<init>(kotlin.collections.List<ai.koog.prompt.message.MessagePart.ResponsePart>;ai.koog.prompt.message.ResponseMetaInfo;kotlin.String?;kotlinx.serialization.json.JsonObject?;kotlin.String?;kotlin.String?){}[0]
+        constructor <init>(kotlin/String, ai.koog.prompt.message/ResponseMetaInfo, kotlin/String? = ..., kotlinx.serialization.json/JsonObject? = ..., kotlin/String? = ..., kotlin/String? = ...) // ai.koog.prompt.message/Message.Assistant.<init>|<init>(kotlin.String;ai.koog.prompt.message.ResponseMetaInfo;kotlin.String?;kotlinx.serialization.json.JsonObject?;kotlin.String?;kotlin.String?){}[0]
 
         final val finishReason // ai.koog.prompt.message/Message.Assistant.finishReason|{}finishReason[0]
             final fun <get-finishReason>(): kotlin/String? // ai.koog.prompt.message/Message.Assistant.finishReason.<get-finishReason>|<get-finishReason>(){}[0]
@@ -350,6 +350,8 @@ sealed interface ai.koog.prompt.message/Message { // ai.koog.prompt.message/Mess
             final fun <get-metaInfo>(): ai.koog.prompt.message/ResponseMetaInfo // ai.koog.prompt.message/Message.Assistant.metaInfo.<get-metaInfo>|<get-metaInfo>(){}[0]
         final val parts // ai.koog.prompt.message/Message.Assistant.parts|{}parts[0]
             final fun <get-parts>(): kotlin.collections/List<ai.koog.prompt.message/MessagePart.ResponsePart> // ai.koog.prompt.message/Message.Assistant.parts.<get-parts>|<get-parts>(){}[0]
+        final val phase // ai.koog.prompt.message/Message.Assistant.phase|{}phase[0]
+            final fun <get-phase>(): kotlin/String? // ai.koog.prompt.message/Message.Assistant.phase.<get-phase>|<get-phase>(){}[0]
         final val rawResponse // ai.koog.prompt.message/Message.Assistant.rawResponse|{}rawResponse[0]
             final fun <get-rawResponse>(): kotlinx.serialization.json/JsonObject? // ai.koog.prompt.message/Message.Assistant.rawResponse.<get-rawResponse>|<get-rawResponse>(){}[0]
         final val role // ai.koog.prompt.message/Message.Assistant.role|{}role[0]
@@ -360,7 +362,8 @@ sealed interface ai.koog.prompt.message/Message { // ai.koog.prompt.message/Mess
         final fun component3(): kotlin/String? // ai.koog.prompt.message/Message.Assistant.component3|component3(){}[0]
         final fun component4(): kotlinx.serialization.json/JsonObject? // ai.koog.prompt.message/Message.Assistant.component4|component4(){}[0]
         final fun component5(): kotlin/String? // ai.koog.prompt.message/Message.Assistant.component5|component5(){}[0]
-        final fun copy(kotlin.collections/List<ai.koog.prompt.message/MessagePart.ResponsePart> = ..., ai.koog.prompt.message/ResponseMetaInfo = ..., kotlin/String? = ..., kotlinx.serialization.json/JsonObject? = ..., kotlin/String? = ...): ai.koog.prompt.message/Message.Assistant // ai.koog.prompt.message/Message.Assistant.copy|copy(kotlin.collections.List<ai.koog.prompt.message.MessagePart.ResponsePart>;ai.koog.prompt.message.ResponseMetaInfo;kotlin.String?;kotlinx.serialization.json.JsonObject?;kotlin.String?){}[0]
+        final fun component6(): kotlin/String? // ai.koog.prompt.message/Message.Assistant.component6|component6(){}[0]
+        final fun copy(kotlin.collections/List<ai.koog.prompt.message/MessagePart.ResponsePart> = ..., ai.koog.prompt.message/ResponseMetaInfo = ..., kotlin/String? = ..., kotlinx.serialization.json/JsonObject? = ..., kotlin/String? = ..., kotlin/String? = ...): ai.koog.prompt.message/Message.Assistant // ai.koog.prompt.message/Message.Assistant.copy|copy(kotlin.collections.List<ai.koog.prompt.message.MessagePart.ResponsePart>;ai.koog.prompt.message.ResponseMetaInfo;kotlin.String?;kotlinx.serialization.json.JsonObject?;kotlin.String?;kotlin.String?){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // ai.koog.prompt.message/Message.Assistant.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // ai.koog.prompt.message/Message.Assistant.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // ai.koog.prompt.message/Message.Assistant.toString|toString(){}[0]

--- a/prompt/prompt-model/api/prompt-model.klib.api
+++ b/prompt/prompt-model/api/prompt-model.klib.api
@@ -338,9 +338,9 @@ sealed interface ai.koog.prompt.message/Message { // ai.koog.prompt.message/Mess
     }
 
     final class Assistant : ai.koog.prompt.message/Message { // ai.koog.prompt.message/Message.Assistant|null[0]
-        constructor <init>(ai.koog.prompt.message/MessagePart.ResponsePart, ai.koog.prompt.message/ResponseMetaInfo, kotlin/String? = ..., kotlinx.serialization.json/JsonObject? = ..., kotlin/String? = ..., kotlin/String? = ...) // ai.koog.prompt.message/Message.Assistant.<init>|<init>(ai.koog.prompt.message.MessagePart.ResponsePart;ai.koog.prompt.message.ResponseMetaInfo;kotlin.String?;kotlinx.serialization.json.JsonObject?;kotlin.String?;kotlin.String?){}[0]
-        constructor <init>(kotlin.collections/List<ai.koog.prompt.message/MessagePart.ResponsePart>, ai.koog.prompt.message/ResponseMetaInfo, kotlin/String? = ..., kotlinx.serialization.json/JsonObject? = ..., kotlin/String? = ..., kotlin/String? = ...) // ai.koog.prompt.message/Message.Assistant.<init>|<init>(kotlin.collections.List<ai.koog.prompt.message.MessagePart.ResponsePart>;ai.koog.prompt.message.ResponseMetaInfo;kotlin.String?;kotlinx.serialization.json.JsonObject?;kotlin.String?;kotlin.String?){}[0]
-        constructor <init>(kotlin/String, ai.koog.prompt.message/ResponseMetaInfo, kotlin/String? = ..., kotlinx.serialization.json/JsonObject? = ..., kotlin/String? = ..., kotlin/String? = ...) // ai.koog.prompt.message/Message.Assistant.<init>|<init>(kotlin.String;ai.koog.prompt.message.ResponseMetaInfo;kotlin.String?;kotlinx.serialization.json.JsonObject?;kotlin.String?;kotlin.String?){}[0]
+        constructor <init>(ai.koog.prompt.message/MessagePart.ResponsePart, ai.koog.prompt.message/ResponseMetaInfo, kotlin/String? = ..., kotlinx.serialization.json/JsonObject? = ..., kotlin/String? = ...) // ai.koog.prompt.message/Message.Assistant.<init>|<init>(ai.koog.prompt.message.MessagePart.ResponsePart;ai.koog.prompt.message.ResponseMetaInfo;kotlin.String?;kotlinx.serialization.json.JsonObject?;kotlin.String?){}[0]
+        constructor <init>(kotlin.collections/List<ai.koog.prompt.message/MessagePart.ResponsePart>, ai.koog.prompt.message/ResponseMetaInfo, kotlin/String? = ..., kotlinx.serialization.json/JsonObject? = ..., kotlin/String? = ...) // ai.koog.prompt.message/Message.Assistant.<init>|<init>(kotlin.collections.List<ai.koog.prompt.message.MessagePart.ResponsePart>;ai.koog.prompt.message.ResponseMetaInfo;kotlin.String?;kotlinx.serialization.json.JsonObject?;kotlin.String?){}[0]
+        constructor <init>(kotlin/String, ai.koog.prompt.message/ResponseMetaInfo, kotlin/String? = ..., kotlinx.serialization.json/JsonObject? = ..., kotlin/String? = ...) // ai.koog.prompt.message/Message.Assistant.<init>|<init>(kotlin.String;ai.koog.prompt.message.ResponseMetaInfo;kotlin.String?;kotlinx.serialization.json.JsonObject?;kotlin.String?){}[0]
 
         final val finishReason // ai.koog.prompt.message/Message.Assistant.finishReason|{}finishReason[0]
             final fun <get-finishReason>(): kotlin/String? // ai.koog.prompt.message/Message.Assistant.finishReason.<get-finishReason>|<get-finishReason>(){}[0]
@@ -350,8 +350,6 @@ sealed interface ai.koog.prompt.message/Message { // ai.koog.prompt.message/Mess
             final fun <get-metaInfo>(): ai.koog.prompt.message/ResponseMetaInfo // ai.koog.prompt.message/Message.Assistant.metaInfo.<get-metaInfo>|<get-metaInfo>(){}[0]
         final val parts // ai.koog.prompt.message/Message.Assistant.parts|{}parts[0]
             final fun <get-parts>(): kotlin.collections/List<ai.koog.prompt.message/MessagePart.ResponsePart> // ai.koog.prompt.message/Message.Assistant.parts.<get-parts>|<get-parts>(){}[0]
-        final val phase // ai.koog.prompt.message/Message.Assistant.phase|{}phase[0]
-            final fun <get-phase>(): kotlin/String? // ai.koog.prompt.message/Message.Assistant.phase.<get-phase>|<get-phase>(){}[0]
         final val rawResponse // ai.koog.prompt.message/Message.Assistant.rawResponse|{}rawResponse[0]
             final fun <get-rawResponse>(): kotlinx.serialization.json/JsonObject? // ai.koog.prompt.message/Message.Assistant.rawResponse.<get-rawResponse>|<get-rawResponse>(){}[0]
         final val role // ai.koog.prompt.message/Message.Assistant.role|{}role[0]
@@ -362,8 +360,7 @@ sealed interface ai.koog.prompt.message/Message { // ai.koog.prompt.message/Mess
         final fun component3(): kotlin/String? // ai.koog.prompt.message/Message.Assistant.component3|component3(){}[0]
         final fun component4(): kotlinx.serialization.json/JsonObject? // ai.koog.prompt.message/Message.Assistant.component4|component4(){}[0]
         final fun component5(): kotlin/String? // ai.koog.prompt.message/Message.Assistant.component5|component5(){}[0]
-        final fun component6(): kotlin/String? // ai.koog.prompt.message/Message.Assistant.component6|component6(){}[0]
-        final fun copy(kotlin.collections/List<ai.koog.prompt.message/MessagePart.ResponsePart> = ..., ai.koog.prompt.message/ResponseMetaInfo = ..., kotlin/String? = ..., kotlinx.serialization.json/JsonObject? = ..., kotlin/String? = ..., kotlin/String? = ...): ai.koog.prompt.message/Message.Assistant // ai.koog.prompt.message/Message.Assistant.copy|copy(kotlin.collections.List<ai.koog.prompt.message.MessagePart.ResponsePart>;ai.koog.prompt.message.ResponseMetaInfo;kotlin.String?;kotlinx.serialization.json.JsonObject?;kotlin.String?;kotlin.String?){}[0]
+        final fun copy(kotlin.collections/List<ai.koog.prompt.message/MessagePart.ResponsePart> = ..., ai.koog.prompt.message/ResponseMetaInfo = ..., kotlin/String? = ..., kotlinx.serialization.json/JsonObject? = ..., kotlin/String? = ...): ai.koog.prompt.message/Message.Assistant // ai.koog.prompt.message/Message.Assistant.copy|copy(kotlin.collections.List<ai.koog.prompt.message.MessagePart.ResponsePart>;ai.koog.prompt.message.ResponseMetaInfo;kotlin.String?;kotlinx.serialization.json.JsonObject?;kotlin.String?){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // ai.koog.prompt.message/Message.Assistant.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // ai.koog.prompt.message/Message.Assistant.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // ai.koog.prompt.message/Message.Assistant.toString|toString(){}[0]
@@ -657,19 +654,38 @@ sealed interface ai.koog.prompt.message/MessagePart { // ai.koog.prompt.message/
     }
 
     final class Text : ai.koog.prompt.message/MessagePart.ContentPart { // ai.koog.prompt.message/MessagePart.Text|null[0]
-        constructor <init>(kotlin/String, ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.message/MessagePart.Text.<init>|<init>(kotlin.String;ai.koog.prompt.message.CacheControl?){}[0]
+        constructor <init>(kotlin/String, ai.koog.prompt.message/CacheControl? = ..., ai.koog.prompt.message/MessagePart.Text.Phase? = ...) // ai.koog.prompt.message/MessagePart.Text.<init>|<init>(kotlin.String;ai.koog.prompt.message.CacheControl?;ai.koog.prompt.message.MessagePart.Text.Phase?){}[0]
 
         final val cacheControl // ai.koog.prompt.message/MessagePart.Text.cacheControl|{}cacheControl[0]
             final fun <get-cacheControl>(): ai.koog.prompt.message/CacheControl? // ai.koog.prompt.message/MessagePart.Text.cacheControl.<get-cacheControl>|<get-cacheControl>(){}[0]
+        final val phase // ai.koog.prompt.message/MessagePart.Text.phase|{}phase[0]
+            final fun <get-phase>(): ai.koog.prompt.message/MessagePart.Text.Phase? // ai.koog.prompt.message/MessagePart.Text.phase.<get-phase>|<get-phase>(){}[0]
         final val text // ai.koog.prompt.message/MessagePart.Text.text|{}text[0]
             final fun <get-text>(): kotlin/String // ai.koog.prompt.message/MessagePart.Text.text.<get-text>|<get-text>(){}[0]
 
         final fun component1(): kotlin/String // ai.koog.prompt.message/MessagePart.Text.component1|component1(){}[0]
         final fun component2(): ai.koog.prompt.message/CacheControl? // ai.koog.prompt.message/MessagePart.Text.component2|component2(){}[0]
-        final fun copy(kotlin/String = ..., ai.koog.prompt.message/CacheControl? = ...): ai.koog.prompt.message/MessagePart.Text // ai.koog.prompt.message/MessagePart.Text.copy|copy(kotlin.String;ai.koog.prompt.message.CacheControl?){}[0]
+        final fun component3(): ai.koog.prompt.message/MessagePart.Text.Phase? // ai.koog.prompt.message/MessagePart.Text.component3|component3(){}[0]
+        final fun copy(kotlin/String = ..., ai.koog.prompt.message/CacheControl? = ..., ai.koog.prompt.message/MessagePart.Text.Phase? = ...): ai.koog.prompt.message/MessagePart.Text // ai.koog.prompt.message/MessagePart.Text.copy|copy(kotlin.String;ai.koog.prompt.message.CacheControl?;ai.koog.prompt.message.MessagePart.Text.Phase?){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // ai.koog.prompt.message/MessagePart.Text.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // ai.koog.prompt.message/MessagePart.Text.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // ai.koog.prompt.message/MessagePart.Text.toString|toString(){}[0]
+
+        final enum class Phase : kotlin/Enum<ai.koog.prompt.message/MessagePart.Text.Phase> { // ai.koog.prompt.message/MessagePart.Text.Phase|null[0]
+            enum entry COMMENTARY // ai.koog.prompt.message/MessagePart.Text.Phase.COMMENTARY|null[0]
+            enum entry FINAL_ANSWER // ai.koog.prompt.message/MessagePart.Text.Phase.FINAL_ANSWER|null[0]
+
+            final val entries // ai.koog.prompt.message/MessagePart.Text.Phase.entries|#static{}entries[0]
+                final fun <get-entries>(): kotlin.enums/EnumEntries<ai.koog.prompt.message/MessagePart.Text.Phase> // ai.koog.prompt.message/MessagePart.Text.Phase.entries.<get-entries>|<get-entries>#static(){}[0]
+
+            final fun valueOf(kotlin/String): ai.koog.prompt.message/MessagePart.Text.Phase // ai.koog.prompt.message/MessagePart.Text.Phase.valueOf|valueOf#static(kotlin.String){}[0]
+            final fun values(): kotlin/Array<ai.koog.prompt.message/MessagePart.Text.Phase> // ai.koog.prompt.message/MessagePart.Text.Phase.values|values#static(){}[0]
+
+            final object Companion : kotlinx.serialization.internal/SerializerFactory { // ai.koog.prompt.message/MessagePart.Text.Phase.Companion|null[0]
+                final fun serializer(): kotlinx.serialization/KSerializer<ai.koog.prompt.message/MessagePart.Text.Phase> // ai.koog.prompt.message/MessagePart.Text.Phase.Companion.serializer|serializer(){}[0]
+                final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // ai.koog.prompt.message/MessagePart.Text.Phase.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+            }
+        }
 
         final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<ai.koog.prompt.message/MessagePart.Text> { // ai.koog.prompt.message/MessagePart.Text.$serializer|null[0]
             final val descriptor // ai.koog.prompt.message/MessagePart.Text.$serializer.descriptor|{}descriptor[0]
@@ -809,16 +825,19 @@ sealed interface ai.koog.prompt.streaming/StreamFrame { // ai.koog.prompt.stream
     }
 
     final class TextComplete : ai.koog.prompt.streaming/StreamFrame, ai.koog.prompt.streaming/StreamFrame.CompleteFrame { // ai.koog.prompt.streaming/StreamFrame.TextComplete|null[0]
-        constructor <init>(kotlin/String, kotlin/Int? = ...) // ai.koog.prompt.streaming/StreamFrame.TextComplete.<init>|<init>(kotlin.String;kotlin.Int?){}[0]
+        constructor <init>(kotlin/String, kotlin/Int? = ..., ai.koog.prompt.message/MessagePart.Text.Phase? = ...) // ai.koog.prompt.streaming/StreamFrame.TextComplete.<init>|<init>(kotlin.String;kotlin.Int?;ai.koog.prompt.message.MessagePart.Text.Phase?){}[0]
 
         final val index // ai.koog.prompt.streaming/StreamFrame.TextComplete.index|{}index[0]
             final fun <get-index>(): kotlin/Int? // ai.koog.prompt.streaming/StreamFrame.TextComplete.index.<get-index>|<get-index>(){}[0]
+        final val phase // ai.koog.prompt.streaming/StreamFrame.TextComplete.phase|{}phase[0]
+            final fun <get-phase>(): ai.koog.prompt.message/MessagePart.Text.Phase? // ai.koog.prompt.streaming/StreamFrame.TextComplete.phase.<get-phase>|<get-phase>(){}[0]
         final val text // ai.koog.prompt.streaming/StreamFrame.TextComplete.text|{}text[0]
             final fun <get-text>(): kotlin/String // ai.koog.prompt.streaming/StreamFrame.TextComplete.text.<get-text>|<get-text>(){}[0]
 
         final fun component1(): kotlin/String // ai.koog.prompt.streaming/StreamFrame.TextComplete.component1|component1(){}[0]
         final fun component2(): kotlin/Int? // ai.koog.prompt.streaming/StreamFrame.TextComplete.component2|component2(){}[0]
-        final fun copy(kotlin/String = ..., kotlin/Int? = ...): ai.koog.prompt.streaming/StreamFrame.TextComplete // ai.koog.prompt.streaming/StreamFrame.TextComplete.copy|copy(kotlin.String;kotlin.Int?){}[0]
+        final fun component3(): ai.koog.prompt.message/MessagePart.Text.Phase? // ai.koog.prompt.streaming/StreamFrame.TextComplete.component3|component3(){}[0]
+        final fun copy(kotlin/String = ..., kotlin/Int? = ..., ai.koog.prompt.message/MessagePart.Text.Phase? = ...): ai.koog.prompt.streaming/StreamFrame.TextComplete // ai.koog.prompt.streaming/StreamFrame.TextComplete.copy|copy(kotlin.String;kotlin.Int?;ai.koog.prompt.message.MessagePart.Text.Phase?){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // ai.koog.prompt.streaming/StreamFrame.TextComplete.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // ai.koog.prompt.streaming/StreamFrame.TextComplete.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // ai.koog.prompt.streaming/StreamFrame.TextComplete.toString|toString(){}[0]
@@ -833,21 +852,26 @@ sealed interface ai.koog.prompt.streaming/StreamFrame { // ai.koog.prompt.stream
         }
 
         final object Companion { // ai.koog.prompt.streaming/StreamFrame.TextComplete.Companion|null[0]
+            final val $childSerializers // ai.koog.prompt.streaming/StreamFrame.TextComplete.Companion.$childSerializers|{}$childSerializers[0]
+
             final fun serializer(): kotlinx.serialization/KSerializer<ai.koog.prompt.streaming/StreamFrame.TextComplete> // ai.koog.prompt.streaming/StreamFrame.TextComplete.Companion.serializer|serializer(){}[0]
         }
     }
 
     final class TextDelta : ai.koog.prompt.streaming/StreamFrame, ai.koog.prompt.streaming/StreamFrame.DeltaFrame { // ai.koog.prompt.streaming/StreamFrame.TextDelta|null[0]
-        constructor <init>(kotlin/String, kotlin/Int? = ...) // ai.koog.prompt.streaming/StreamFrame.TextDelta.<init>|<init>(kotlin.String;kotlin.Int?){}[0]
+        constructor <init>(kotlin/String, kotlin/Int? = ..., ai.koog.prompt.message/MessagePart.Text.Phase? = ...) // ai.koog.prompt.streaming/StreamFrame.TextDelta.<init>|<init>(kotlin.String;kotlin.Int?;ai.koog.prompt.message.MessagePart.Text.Phase?){}[0]
 
         final val index // ai.koog.prompt.streaming/StreamFrame.TextDelta.index|{}index[0]
             final fun <get-index>(): kotlin/Int? // ai.koog.prompt.streaming/StreamFrame.TextDelta.index.<get-index>|<get-index>(){}[0]
+        final val phase // ai.koog.prompt.streaming/StreamFrame.TextDelta.phase|{}phase[0]
+            final fun <get-phase>(): ai.koog.prompt.message/MessagePart.Text.Phase? // ai.koog.prompt.streaming/StreamFrame.TextDelta.phase.<get-phase>|<get-phase>(){}[0]
         final val text // ai.koog.prompt.streaming/StreamFrame.TextDelta.text|{}text[0]
             final fun <get-text>(): kotlin/String // ai.koog.prompt.streaming/StreamFrame.TextDelta.text.<get-text>|<get-text>(){}[0]
 
         final fun component1(): kotlin/String // ai.koog.prompt.streaming/StreamFrame.TextDelta.component1|component1(){}[0]
         final fun component2(): kotlin/Int? // ai.koog.prompt.streaming/StreamFrame.TextDelta.component2|component2(){}[0]
-        final fun copy(kotlin/String = ..., kotlin/Int? = ...): ai.koog.prompt.streaming/StreamFrame.TextDelta // ai.koog.prompt.streaming/StreamFrame.TextDelta.copy|copy(kotlin.String;kotlin.Int?){}[0]
+        final fun component3(): ai.koog.prompt.message/MessagePart.Text.Phase? // ai.koog.prompt.streaming/StreamFrame.TextDelta.component3|component3(){}[0]
+        final fun copy(kotlin/String = ..., kotlin/Int? = ..., ai.koog.prompt.message/MessagePart.Text.Phase? = ...): ai.koog.prompt.streaming/StreamFrame.TextDelta // ai.koog.prompt.streaming/StreamFrame.TextDelta.copy|copy(kotlin.String;kotlin.Int?;ai.koog.prompt.message.MessagePart.Text.Phase?){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // ai.koog.prompt.streaming/StreamFrame.TextDelta.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // ai.koog.prompt.streaming/StreamFrame.TextDelta.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // ai.koog.prompt.streaming/StreamFrame.TextDelta.toString|toString(){}[0]
@@ -862,6 +886,8 @@ sealed interface ai.koog.prompt.streaming/StreamFrame { // ai.koog.prompt.stream
         }
 
         final object Companion { // ai.koog.prompt.streaming/StreamFrame.TextDelta.Companion|null[0]
+            final val $childSerializers // ai.koog.prompt.streaming/StreamFrame.TextDelta.Companion.$childSerializers|{}$childSerializers[0]
+
             final fun serializer(): kotlinx.serialization/KSerializer<ai.koog.prompt.streaming/StreamFrame.TextDelta> // ai.koog.prompt.streaming/StreamFrame.TextDelta.Companion.serializer|serializer(){}[0]
         }
     }
@@ -1226,7 +1252,7 @@ final class ai.koog.prompt.streaming/StreamFrameFlowBuilder { // ai.koog.prompt.
 
     final suspend fun emitEnd(kotlin/String? = ..., ai.koog.prompt.message/ResponseMetaInfo? = ...) // ai.koog.prompt.streaming/StreamFrameFlowBuilder.emitEnd|emitEnd(kotlin.String?;ai.koog.prompt.message.ResponseMetaInfo?){}[0]
     final suspend fun emitReasoningDelta(kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/Int? = ...) // ai.koog.prompt.streaming/StreamFrameFlowBuilder.emitReasoningDelta|emitReasoningDelta(kotlin.String?;kotlin.String?;kotlin.String?;kotlin.Int?){}[0]
-    final suspend fun emitTextDelta(kotlin/String, kotlin/Int? = ...) // ai.koog.prompt.streaming/StreamFrameFlowBuilder.emitTextDelta|emitTextDelta(kotlin.String;kotlin.Int?){}[0]
+    final suspend fun emitTextDelta(kotlin/String, kotlin/Int? = ..., ai.koog.prompt.message/MessagePart.Text.Phase? = ...) // ai.koog.prompt.streaming/StreamFrameFlowBuilder.emitTextDelta|emitTextDelta(kotlin.String;kotlin.Int?;ai.koog.prompt.message.MessagePart.Text.Phase?){}[0]
     final suspend fun emitToolCallDelta(kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/Int? = ...) // ai.koog.prompt.streaming/StreamFrameFlowBuilder.emitToolCallDelta|emitToolCallDelta(kotlin.String?;kotlin.String?;kotlin.String?;kotlin.Int?){}[0]
     final suspend fun tryEmitPendingReasoning() // ai.koog.prompt.streaming/StreamFrameFlowBuilder.tryEmitPendingReasoning|tryEmitPendingReasoning(){}[0]
     final suspend fun tryEmitPendingText() // ai.koog.prompt.streaming/StreamFrameFlowBuilder.tryEmitPendingText|tryEmitPendingText(){}[0]
@@ -1592,7 +1618,7 @@ final suspend fun (kotlinx.coroutines.flow/FlowCollector<ai.koog.prompt.streamin
 final suspend fun (kotlinx.coroutines.flow/FlowCollector<ai.koog.prompt.streaming/StreamFrame>).ai.koog.prompt.streaming/emitReasoningComplete(kotlin/String? = ..., kotlin.collections/List<kotlin/String>, kotlin.collections/List<kotlin/String>? = ..., kotlin/String? = ..., kotlin/Int? = ...) // ai.koog.prompt.streaming/emitReasoningComplete|emitReasoningComplete@kotlinx.coroutines.flow.FlowCollector<ai.koog.prompt.streaming.StreamFrame>(kotlin.String?;kotlin.collections.List<kotlin.String>;kotlin.collections.List<kotlin.String>?;kotlin.String?;kotlin.Int?){}[0]
 final suspend fun (kotlinx.coroutines.flow/FlowCollector<ai.koog.prompt.streaming/StreamFrame>).ai.koog.prompt.streaming/emitReasoningComplete(kotlin/String? = ..., kotlin/String, kotlin/String? = ..., kotlin/String? = ..., kotlin/Int? = ...) // ai.koog.prompt.streaming/emitReasoningComplete|emitReasoningComplete@kotlinx.coroutines.flow.FlowCollector<ai.koog.prompt.streaming.StreamFrame>(kotlin.String?;kotlin.String;kotlin.String?;kotlin.String?;kotlin.Int?){}[0]
 final suspend fun (kotlinx.coroutines.flow/FlowCollector<ai.koog.prompt.streaming/StreamFrame>).ai.koog.prompt.streaming/emitReasoningDelta(kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/Int? = ...) // ai.koog.prompt.streaming/emitReasoningDelta|emitReasoningDelta@kotlinx.coroutines.flow.FlowCollector<ai.koog.prompt.streaming.StreamFrame>(kotlin.String?;kotlin.String?;kotlin.String?;kotlin.Int?){}[0]
-final suspend fun (kotlinx.coroutines.flow/FlowCollector<ai.koog.prompt.streaming/StreamFrame>).ai.koog.prompt.streaming/emitTextComplete(kotlin/String, kotlin/Int? = ...) // ai.koog.prompt.streaming/emitTextComplete|emitTextComplete@kotlinx.coroutines.flow.FlowCollector<ai.koog.prompt.streaming.StreamFrame>(kotlin.String;kotlin.Int?){}[0]
-final suspend fun (kotlinx.coroutines.flow/FlowCollector<ai.koog.prompt.streaming/StreamFrame>).ai.koog.prompt.streaming/emitTextDelta(kotlin/String, kotlin/Int? = ...) // ai.koog.prompt.streaming/emitTextDelta|emitTextDelta@kotlinx.coroutines.flow.FlowCollector<ai.koog.prompt.streaming.StreamFrame>(kotlin.String;kotlin.Int?){}[0]
+final suspend fun (kotlinx.coroutines.flow/FlowCollector<ai.koog.prompt.streaming/StreamFrame>).ai.koog.prompt.streaming/emitTextComplete(kotlin/String, kotlin/Int? = ..., ai.koog.prompt.message/MessagePart.Text.Phase? = ...) // ai.koog.prompt.streaming/emitTextComplete|emitTextComplete@kotlinx.coroutines.flow.FlowCollector<ai.koog.prompt.streaming.StreamFrame>(kotlin.String;kotlin.Int?;ai.koog.prompt.message.MessagePart.Text.Phase?){}[0]
+final suspend fun (kotlinx.coroutines.flow/FlowCollector<ai.koog.prompt.streaming/StreamFrame>).ai.koog.prompt.streaming/emitTextDelta(kotlin/String, kotlin/Int? = ..., ai.koog.prompt.message/MessagePart.Text.Phase? = ...) // ai.koog.prompt.streaming/emitTextDelta|emitTextDelta@kotlinx.coroutines.flow.FlowCollector<ai.koog.prompt.streaming.StreamFrame>(kotlin.String;kotlin.Int?;ai.koog.prompt.message.MessagePart.Text.Phase?){}[0]
 final suspend fun (kotlinx.coroutines.flow/FlowCollector<ai.koog.prompt.streaming/StreamFrame>).ai.koog.prompt.streaming/emitToolCallComplete(kotlin/String?, kotlin/String, kotlin/String, kotlin/Int? = ...) // ai.koog.prompt.streaming/emitToolCallComplete|emitToolCallComplete@kotlinx.coroutines.flow.FlowCollector<ai.koog.prompt.streaming.StreamFrame>(kotlin.String?;kotlin.String;kotlin.String;kotlin.Int?){}[0]
 final suspend fun (kotlinx.coroutines.flow/FlowCollector<ai.koog.prompt.streaming/StreamFrame>).ai.koog.prompt.streaming/emitToolCallDelta(kotlin/String?, kotlin/String?, kotlin/String?, kotlin/Int? = ...) // ai.koog.prompt.streaming/emitToolCallDelta|emitToolCallDelta@kotlinx.coroutines.flow.FlowCollector<ai.koog.prompt.streaming.StreamFrame>(kotlin.String?;kotlin.String?;kotlin.String?;kotlin.Int?){}[0]

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
@@ -164,6 +164,7 @@ public sealed interface Message {
      * @property finishReason The reason the LLM stopped generating (e.g. `"stop"`, `"tool_calls"`), or null if unknown.
      * @property rawResponse The raw JSON response body from the provider, or null if not captured.
      * @property id Optional unique identifier for the message.
+     * @property phase An optional provider-specific phase label for assistant messages.
      */
     @Serializable
     public data class Assistant @JvmOverloads constructor(
@@ -173,6 +174,7 @@ public sealed interface Message {
         // TODO: replace with JSONObject?
         public val rawResponse: JsonObject? = null,
         override val id: String? = null,
+        public val phase: String? = null,
     ) : Message {
         override val role: Role = Role.Assistant
 
@@ -186,12 +188,14 @@ public sealed interface Message {
             finishReason: String? = null,
             rawResponse: JsonObject? = null,
             id: String? = null,
+            phase: String? = null,
         ) : this(
             listOf(part),
             metaInfo,
             finishReason,
             rawResponse,
-            id
+            id,
+            phase,
         )
 
         /**
@@ -206,12 +210,14 @@ public sealed interface Message {
             finishReason: String? = null,
             rawResponse: JsonObject? = null,
             id: String? = null,
+            phase: String? = null,
         ) : this(
             MessagePart.Text(content),
             metaInfo,
             finishReason,
             rawResponse,
-            id
+            id,
+            phase,
         )
     }
 

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
@@ -1,6 +1,7 @@
 package ai.koog.prompt.message
 
 import ai.koog.utils.time.KoogClock
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -164,7 +165,6 @@ public sealed interface Message {
      * @property finishReason The reason the LLM stopped generating (e.g. `"stop"`, `"tool_calls"`), or null if unknown.
      * @property rawResponse The raw JSON response body from the provider, or null if not captured.
      * @property id Optional unique identifier for the message.
-     * @property phase An optional provider-specific phase label for assistant messages.
      */
     @Serializable
     public data class Assistant @JvmOverloads constructor(
@@ -174,7 +174,6 @@ public sealed interface Message {
         // TODO: replace with JSONObject?
         public val rawResponse: JsonObject? = null,
         override val id: String? = null,
-        public val phase: String? = null,
     ) : Message {
         override val role: Role = Role.Assistant
 
@@ -188,14 +187,12 @@ public sealed interface Message {
             finishReason: String? = null,
             rawResponse: JsonObject? = null,
             id: String? = null,
-            phase: String? = null,
         ) : this(
             listOf(part),
             metaInfo,
             finishReason,
             rawResponse,
             id,
-            phase,
         )
 
         /**
@@ -210,14 +207,12 @@ public sealed interface Message {
             finishReason: String? = null,
             rawResponse: JsonObject? = null,
             id: String? = null,
-            phase: String? = null,
         ) : this(
             MessagePart.Text(content),
             metaInfo,
             finishReason,
             rawResponse,
             id,
-            phase,
         )
     }
 
@@ -279,12 +274,30 @@ public sealed interface MessagePart {
      * Text content part of the message.
      *
      * @property text The text content.
+     * @property phase Optional assistant text phase, used by providers that distinguish intermediate commentary
+     * from the final answer.
      */
     @Serializable
     public data class Text @JvmOverloads constructor(
         public val text: String,
         override val cacheControl: CacheControl? = null,
-    ) : ContentPart
+        public val phase: Phase? = null,
+    ) : ContentPart {
+
+        /**
+         * Labels assistant text as intermediate commentary or the final answer.
+         */
+        @Serializable
+        public enum class Phase {
+            /** Intermediate assistant commentary, such as preambles or progress updates. */
+            @SerialName("commentary")
+            COMMENTARY,
+
+            /** The completed assistant answer intended for the user. */
+            @SerialName("final_answer")
+            FINAL_ANSWER,
+        }
+    }
 
     /**
      * Attachment content part of the message.

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrame.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrame.kt
@@ -1,5 +1,6 @@
 package ai.koog.prompt.streaming
 
+import ai.koog.prompt.message.MessagePart
 import ai.koog.prompt.message.ResponseMetaInfo
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -30,22 +31,26 @@ public sealed interface StreamFrame {
      * Represents a frame of a streaming response from a LLM with text delta.
      *
      * @property text The text to append to the response.
+     * @property phase Optional assistant text phase for this streamed text.
      */
     @Serializable
     public data class TextDelta(
         val text: String,
-        override val index: Int? = null
+        override val index: Int? = null,
+        val phase: MessagePart.Text.Phase? = null,
     ) : DeltaFrame, StreamFrame
 
     /**
      * Represents a completion of a streaming response text part.
      *
      * @property text The complete text of the response.
+     * @property phase Optional assistant text phase for this completed text.
      */
     @Serializable
     public data class TextComplete(
         val text: String,
-        override val index: Int? = null
+        override val index: Int? = null,
+        val phase: MessagePart.Text.Phase? = null,
     ) : CompleteFrame, StreamFrame
 
     /**

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameExt.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameExt.kt
@@ -55,8 +55,8 @@ public fun Message.Assistant.toStreamFrames(): List<StreamFrame> {
                 }
 
                 is MessagePart.Text -> {
-                    add(StreamFrame.TextDelta(part.text, index))
-                    add(StreamFrame.TextComplete(part.text, index))
+                    add(StreamFrame.TextDelta(part.text, index, part.phase))
+                    add(StreamFrame.TextComplete(part.text, index, part.phase))
                 }
 
                 is MessagePart.Tool.Call -> {
@@ -99,7 +99,7 @@ public fun Iterable<StreamFrame>.toMessageResponse(): Message.Assistant {
             )
 
             is StreamFrame.TextComplete ->
-                MessagePart.Text(frame.text)
+                MessagePart.Text(frame.text, phase = frame.phase)
 
             is StreamFrame.ToolCallComplete ->
                 MessagePart.Tool.Call(

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
@@ -1,5 +1,6 @@
 package ai.koog.prompt.streaming
 
+import ai.koog.prompt.message.MessagePart
 import ai.koog.prompt.message.ResponseMetaInfo
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
@@ -36,14 +37,22 @@ public fun streamFrameFlow(@BuilderInference block: suspend FlowCollector<Stream
 /**
  * Emits a [StreamFrame.TextDelta] with the given [text].
  */
-public suspend fun FlowCollector<StreamFrame>.emitTextDelta(text: String, index: Int? = null): Unit =
-    emit(StreamFrame.TextDelta(text, index))
+public suspend fun FlowCollector<StreamFrame>.emitTextDelta(
+    text: String,
+    index: Int? = null,
+    phase: MessagePart.Text.Phase? = null,
+): Unit =
+    emit(StreamFrame.TextDelta(text, index, phase))
 
 /**
  * Emits a [StreamFrame.TextComplete] with the given [text].
  */
-public suspend fun FlowCollector<StreamFrame>.emitTextComplete(text: String, index: Int? = null): Unit =
-    emit(StreamFrame.TextComplete(text, index))
+public suspend fun FlowCollector<StreamFrame>.emitTextComplete(
+    text: String,
+    index: Int? = null,
+    phase: MessagePart.Text.Phase? = null,
+): Unit =
+    emit(StreamFrame.TextComplete(text, index, phase))
 
 /**
  * Emits a [StreamFrame.ReasoningDelta] with the given [text] and [summary].
@@ -141,16 +150,20 @@ public class StreamFrameFlowBuilder(
     /**
      * Emits a [StreamFrame.TextDelta] with the given [text].
      */
-    public suspend fun emitTextDelta(text: String, index: Int? = null) {
+    public suspend fun emitTextDelta(
+        text: String,
+        index: Int? = null,
+        phase: MessagePart.Text.Phase? = null,
+    ) {
         tryEmitPendingToolCall()
         tryEmitPendingReasoning()
         val previous: PendingText? = pendingTextRef.load()
         if (previous == null) {
-            pendingTextRef.store(PendingText(textDelta = text, index = index))
+            pendingTextRef.store(PendingText(textDelta = text, index = index, phase = phase))
         } else {
-            pendingTextRef.store(previous.appendTextDelta(text, index))
+            pendingTextRef.store(previous.appendTextDelta(text, index, phase))
         }
-        flowCollector.emitTextDelta(text, index)
+        flowCollector.emitTextDelta(text, index, phase)
     }
 
     /**
@@ -230,7 +243,8 @@ public class StreamFrameFlowBuilder(
         if (pendingText != null) {
             flowCollector.emitTextComplete(
                 text = pendingText.textDelta ?: "",
-                index = pendingText.index
+                index = pendingText.index,
+                phase = pendingText.phase,
             )
         }
     }
@@ -282,9 +296,15 @@ public class StreamFrameFlowBuilder(
     private data class PendingText(
         val textDelta: String?,
         val index: Int?,
+        val phase: MessagePart.Text.Phase?,
     ) {
-        fun appendTextDelta(textDelta: String?, index: Int?): PendingText {
+        fun appendTextDelta(
+            textDelta: String?,
+            index: Int?,
+            phase: MessagePart.Text.Phase?,
+        ): PendingText {
             require(this.index == index)
+            require(this.phase == phase)
             val newText = if (textDelta == null) this.textDelta else (this.textDelta ?: "") + textDelta
             return copy(textDelta = newText)
         }


### PR DESCRIPTION
## Summary

- Add OpenAI Responses API `phase` support to assistant messages and output message items.
- Preserve assistant phases when replaying prior Responses API output messages.
- Suppress `commentary` output when a `final_answer` message is present, including streaming text deltas.

## Root cause

OpenAI GPT-5.4+ Responses API output can include multiple assistant messages for different phases. Koog treated all output messages as visible assistant responses and did not retain the phase metadata, so intermediate commentary could surface as a duplicate agent message.

## Validation

- `env GRADLE_USER_HOME=/private/tmp/koog-gradle-home ./gradlew :prompt:prompt-model:jvmTest :prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client:jvmTest`

Note: affected module `build` tasks were attempted locally, but this environment does not have Android SDK configured (`ANDROID_HOME`/`local.properties`), so Gradle stops at Android annotation extraction before running the full build.

Closes #1961
