### PR TITLE
Add AI agent CLI delegation tool

### DIFF
--- a/agents/agents-ext/Module.md
+++ b/agents/agents-ext/Module.md
@@ -2,4 +2,29 @@
 
 Extends `agents-core` module with tools, as well as utilities for building graphs and strategies.
 
-<!-- TODO -->
+## AI agent CLI delegation
+
+`AIAgentCliTool` lets a Koog agent delegate a bounded task to an installed AI coding CLI.
+The integration is profile based: the host application owns the trusted command shape, while
+tool calls provide only the task, optional context, working directory, and timeout.
+
+Preset profiles are available for:
+
+- OpenAI Codex CLI: `AIAgentCliProfiles.codex()`
+- Anthropic Claude Code CLI: `AIAgentCliProfiles.claudeCode()`
+- GitHub Copilot CLI: `AIAgentCliProfiles.githubCopilot()`
+
+Custom CLI integrations can be added with `AIAgentCliProfiles.custom(...)`.
+
+```kotlin
+val tool = AIAgentCliTool(
+    profile = AIAgentCliProfiles.codex(extraArguments = listOf("--full-auto")),
+    executor = ShellAIAgentCliExecutor(shellCommandExecutor),
+    confirmationHandler = PrintAIAgentCliConfirmationHandler()
+)
+```
+
+`ShellAIAgentCliExecutor` is implemented in `commonMain` and adapts CLI profiles to Koog's
+`ShellCommandExecutor` abstraction. JVM applications can pass `JvmShellCommandExecutor`; other
+targets can supply their own shell executor implementation.
+Use a confirmation handler unless the application already runs the CLI inside an appropriate sandbox.

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/cli/AIAgentCliConfirmation.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/cli/AIAgentCliConfirmation.kt
@@ -1,0 +1,69 @@
+package ai.koog.agents.ext.tool.cli
+
+/**
+ * User decision on whether to delegate work to an external AI agent CLI.
+ */
+public sealed class AIAgentCliConfirmation {
+    /**
+     * CLI delegation approved.
+     */
+    public data object Approved : AIAgentCliConfirmation()
+
+    /**
+     * CLI delegation denied.
+     *
+     * @property userResponse Free-form explanation or denial text.
+     */
+    public data class Denied(val userResponse: String) : AIAgentCliConfirmation()
+}
+
+/**
+ * Strategy for approving external AI agent CLI delegation.
+ */
+public fun interface AIAgentCliConfirmationHandler {
+    /**
+     * Requests approval before starting the external CLI process.
+     *
+     * @param request Fully built process invocation.
+     * @param args Tool arguments supplied by the agent.
+     * @return Approval or denial decision.
+     */
+    public suspend fun requestConfirmation(
+        request: AIAgentCliExecutionRequest,
+        args: AIAgentCliTool.Args,
+    ): AIAgentCliConfirmation
+}
+
+/**
+ * Confirmation handler that always approves CLI delegation.
+ *
+ * Use only when the host application already provides an appropriate sandbox or trust boundary.
+ */
+public class BraveModeAIAgentCliConfirmationHandler : AIAgentCliConfirmationHandler {
+    override suspend fun requestConfirmation(
+        request: AIAgentCliExecutionRequest,
+        args: AIAgentCliTool.Args,
+    ): AIAgentCliConfirmation = AIAgentCliConfirmation.Approved
+}
+
+/**
+ * Console confirmation handler for interactive applications.
+ */
+public class PrintAIAgentCliConfirmationHandler : AIAgentCliConfirmationHandler {
+    override suspend fun requestConfirmation(
+        request: AIAgentCliExecutionRequest,
+        args: AIAgentCliTool.Args,
+    ): AIAgentCliConfirmation {
+        println("Agent wants to delegate to ${request.profileId}: ${request.command.joinToString(" ")}")
+        request.workingDirectory?.let { println("In: $it") }
+        println("Timeout: ${request.timeoutSeconds}s")
+        println("Task: ${args.task}")
+        print("Confirm (y / n / reason-for-denying): ")
+
+        val userResponse = readln().trim()
+        return when (userResponse.lowercase()) {
+            "y", "yes" -> AIAgentCliConfirmation.Approved
+            else -> AIAgentCliConfirmation.Denied(userResponse)
+        }
+    }
+}

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/cli/AIAgentCliExecutor.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/cli/AIAgentCliExecutor.kt
@@ -1,0 +1,58 @@
+package ai.koog.agents.ext.tool.cli
+
+/**
+ * Executes an external AI agent CLI process.
+ *
+ * @see ShellAIAgentCliExecutor
+ */
+public interface AIAgentCliExecutor {
+    /**
+     * Runs the CLI process described by [request].
+     *
+     * @param request Fully built process invocation.
+     * @return Captured process output and completion status.
+     */
+    public suspend fun execute(request: AIAgentCliExecutionRequest): AIAgentCliExecutionResult
+}
+
+/**
+ * Fully expanded invocation for an external AI agent CLI.
+ *
+ * The command is represented as an executable plus argument vector rather than a shell string.
+ * Implementations should pass it directly to process APIs to avoid shell interpolation.
+ *
+ * @property profileId Stable profile identifier, for diagnostics.
+ * @property executable Executable name or absolute path.
+ * @property arguments Command arguments in order.
+ * @property stdin Optional text to write to the process standard input.
+ * @property workingDirectory Optional directory where the process should run.
+ * @property environment Additional environment variables for the process.
+ * @property timeoutSeconds Maximum time to wait before terminating the process.
+ */
+public data class AIAgentCliExecutionRequest(
+    val profileId: String,
+    val executable: String,
+    val arguments: List<String>,
+    val stdin: String? = null,
+    val workingDirectory: String? = null,
+    val environment: Map<String, String> = emptyMap(),
+    val timeoutSeconds: Int,
+) {
+    /**
+     * The process command as an argument vector.
+     */
+    public val command: List<String> = listOf(executable) + arguments
+}
+
+/**
+ * Result returned by an external AI agent CLI process.
+ *
+ * @property output Combined process output.
+ * @property exitCode Process exit code, or null when the process did not complete normally.
+ * @property timedOut True when the process was terminated because [AIAgentCliExecutionRequest.timeoutSeconds] was reached.
+ */
+public data class AIAgentCliExecutionResult(
+    val output: String,
+    val exitCode: Int?,
+    val timedOut: Boolean = false,
+)

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/cli/AIAgentCliProfile.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/cli/AIAgentCliProfile.kt
@@ -1,0 +1,102 @@
+package ai.koog.agents.ext.tool.cli
+
+/**
+ * Builds an executable invocation for an external AI agent CLI.
+ */
+public fun interface AIAgentCliArgumentBuilder {
+    /**
+     * Creates process arguments and stdin for [task].
+     *
+     * @param task Rendered task text to delegate.
+     * @param args Original tool arguments supplied by the agent.
+     * @return Process invocation details, excluding executable and timeout.
+     */
+    public fun build(task: String, args: AIAgentCliTool.Args): AIAgentCliInvocation
+}
+
+/**
+ * Process invocation details produced by [AIAgentCliArgumentBuilder].
+ *
+ * @property arguments Command arguments in order.
+ * @property stdin Optional text to write to standard input.
+ * @property workingDirectory Optional working directory override.
+ * @property environment Additional environment variables.
+ */
+public data class AIAgentCliInvocation(
+    val arguments: List<String>,
+    val stdin: String? = null,
+    val workingDirectory: String? = null,
+    val environment: Map<String, String> = emptyMap(),
+)
+
+/**
+ * Extracts the assistant-facing text from a CLI execution result.
+ */
+public fun interface AIAgentCliOutputExtractor {
+    /**
+     * Converts raw process output to the tool result output.
+     *
+     * @param result Raw CLI process result.
+     * @return Output exposed to the Koog agent.
+     */
+    public fun extract(result: AIAgentCliExecutionResult): String
+}
+
+/**
+ * Describes how Koog delegates a task to an external AI agent CLI.
+ *
+ * A profile owns the command shape for one CLI family. It keeps command construction in trusted application code,
+ * while tool calls only provide the task text, working directory, and timeout.
+ *
+ * @property id Stable profile identifier.
+ * @property displayName Human-readable CLI name.
+ * @property executable Executable name or absolute path.
+ * @property defaultTimeoutSeconds Default maximum process lifetime.
+ * @property argumentBuilder Builds process arguments and stdin for each task.
+ * @property outputExtractor Extracts assistant-facing output from the process result.
+ */
+public data class AIAgentCliProfile(
+    val id: String,
+    val displayName: String,
+    val executable: String,
+    val defaultTimeoutSeconds: Int = DEFAULT_TIMEOUT_SECONDS,
+    val argumentBuilder: AIAgentCliArgumentBuilder,
+    val outputExtractor: AIAgentCliOutputExtractor = AIAgentCliOutputExtractor { it.output },
+) {
+    init {
+        require(id.isNotBlank()) { "Profile id must not be blank" }
+        require(displayName.isNotBlank()) { "Profile displayName must not be blank" }
+        require(executable.isNotBlank()) { "Profile executable must not be blank" }
+        require(defaultTimeoutSeconds > 0) { "Profile defaultTimeoutSeconds must be positive" }
+    }
+
+    /**
+     * Builds a full execution request for [args].
+     *
+     * @param task Rendered task text.
+     * @param args Tool arguments supplied by the agent.
+     * @return Full process execution request.
+     */
+    public fun buildRequest(task: String, args: AIAgentCliTool.Args): AIAgentCliExecutionRequest {
+        val invocation = argumentBuilder.build(task, args)
+        val timeoutSeconds = args.timeoutSeconds ?: defaultTimeoutSeconds
+        require(timeoutSeconds > 0) { "timeoutSeconds must be positive" }
+
+        return AIAgentCliExecutionRequest(
+            profileId = id,
+            executable = executable,
+            arguments = invocation.arguments,
+            stdin = invocation.stdin,
+            workingDirectory = args.workingDirectory ?: invocation.workingDirectory,
+            environment = invocation.environment,
+            timeoutSeconds = timeoutSeconds,
+        )
+    }
+
+    public companion object {
+        /**
+         * Default timeout for delegated CLI tasks.
+         */
+        public const val DEFAULT_TIMEOUT_SECONDS: Int = 900
+    }
+}

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/cli/AIAgentCliProfiles.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/cli/AIAgentCliProfiles.kt
@@ -1,0 +1,114 @@
+package ai.koog.agents.ext.tool.cli
+
+/**
+ * Preset profiles for popular AI agent command-line tools.
+ */
+public object AIAgentCliProfiles {
+    /**
+     * Creates a profile for OpenAI Codex CLI non-interactive execution.
+     *
+     * The generated command shape is:
+     * `codex exec --color never --ephemeral EXTRA_ARGUMENTS TASK`.
+     *
+     * @param executable Codex executable name or absolute path.
+     * @param extraArguments Additional trusted arguments inserted before the task.
+     * @param defaultTimeoutSeconds Default maximum process lifetime.
+     * @return Codex CLI profile.
+     */
+    public fun codex(
+        executable: String = "codex",
+        extraArguments: List<String> = emptyList(),
+        defaultTimeoutSeconds: Int = AIAgentCliProfile.DEFAULT_TIMEOUT_SECONDS,
+    ): AIAgentCliProfile = AIAgentCliProfile(
+        id = "codex",
+        displayName = "Codex CLI",
+        executable = executable,
+        defaultTimeoutSeconds = defaultTimeoutSeconds,
+        argumentBuilder = AIAgentCliArgumentBuilder { task, _ ->
+            AIAgentCliInvocation(
+                arguments = listOf("exec", "--color", "never", "--ephemeral") + extraArguments + task
+            )
+        }
+    )
+
+    /**
+     * Creates a profile for Anthropic Claude Code CLI print mode.
+     *
+     * The generated command shape is:
+     * `claude -p --output-format text EXTRA_ARGUMENTS TASK`.
+     *
+     * @param executable Claude executable name or absolute path.
+     * @param extraArguments Additional trusted arguments inserted before the task.
+     * @param defaultTimeoutSeconds Default maximum process lifetime.
+     * @return Claude Code CLI profile.
+     */
+    public fun claudeCode(
+        executable: String = "claude",
+        extraArguments: List<String> = emptyList(),
+        defaultTimeoutSeconds: Int = AIAgentCliProfile.DEFAULT_TIMEOUT_SECONDS,
+    ): AIAgentCliProfile = AIAgentCliProfile(
+        id = "claude-code",
+        displayName = "Claude Code CLI",
+        executable = executable,
+        defaultTimeoutSeconds = defaultTimeoutSeconds,
+        argumentBuilder = AIAgentCliArgumentBuilder { task, _ ->
+            AIAgentCliInvocation(
+                arguments = listOf("-p", "--output-format", "text") + extraArguments + task
+            )
+        }
+    )
+
+    /**
+     * Creates a profile for GitHub Copilot CLI programmatic prompt mode.
+     *
+     * The generated command shape is:
+     * `copilot -s -p TASK EXTRA_ARGUMENTS`.
+     *
+     * @param executable Copilot executable name or absolute path.
+     * @param extraArguments Additional trusted arguments appended after the prompt.
+     * @param defaultTimeoutSeconds Default maximum process lifetime.
+     * @return GitHub Copilot CLI profile.
+     */
+    public fun githubCopilot(
+        executable: String = "copilot",
+        extraArguments: List<String> = emptyList(),
+        defaultTimeoutSeconds: Int = AIAgentCliProfile.DEFAULT_TIMEOUT_SECONDS,
+    ): AIAgentCliProfile = AIAgentCliProfile(
+        id = "github-copilot",
+        displayName = "GitHub Copilot CLI",
+        executable = executable,
+        defaultTimeoutSeconds = defaultTimeoutSeconds,
+        argumentBuilder = AIAgentCliArgumentBuilder { task, _ ->
+            AIAgentCliInvocation(
+                arguments = listOf("-s", "-p", task) + extraArguments
+            )
+        }
+    )
+
+    /**
+     * Creates a custom profile for any AI agent CLI.
+     *
+     * @param id Stable profile identifier.
+     * @param displayName Human-readable CLI name.
+     * @param executable Executable name or absolute path.
+     * @param defaultTimeoutSeconds Default maximum process lifetime.
+     * @param argumentBuilder Trusted command builder for this CLI.
+     * @param outputExtractor Optional raw-output extractor.
+     * @return Custom AI agent CLI profile.
+     */
+    public fun custom(
+        id: String,
+        displayName: String,
+        executable: String,
+        defaultTimeoutSeconds: Int = AIAgentCliProfile.DEFAULT_TIMEOUT_SECONDS,
+        argumentBuilder: AIAgentCliArgumentBuilder,
+        outputExtractor: AIAgentCliOutputExtractor = AIAgentCliOutputExtractor { it.output },
+    ): AIAgentCliProfile = AIAgentCliProfile(
+        id = id,
+        displayName = displayName,
+        executable = executable,
+        defaultTimeoutSeconds = defaultTimeoutSeconds,
+        argumentBuilder = argumentBuilder,
+        outputExtractor = outputExtractor,
+    )
+}

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/cli/AIAgentCliTool.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/cli/AIAgentCliTool.kt
@@ -1,0 +1,163 @@
+package ai.koog.agents.ext.tool.cli
+
+import ai.koog.agents.core.tools.Tool
+import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.serialization.JSONSerializer
+import ai.koog.serialization.typeToken
+import kotlinx.serialization.Serializable
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Delegates a bounded task to an external AI agent CLI such as Codex CLI, Claude Code CLI, or GitHub Copilot CLI.
+ *
+ * The tool intentionally accepts task-level inputs only. Command flags and process shape are owned by
+ * [AIAgentCliProfile] so host applications can review and lock down each supported CLI integration.
+ *
+ * @property profile CLI profile used for process construction.
+ * @property executor Platform-specific process executor.
+ * @property confirmationHandler Approval strategy applied before the process starts.
+ */
+public class AIAgentCliTool(
+    private val profile: AIAgentCliProfile,
+    private val executor: AIAgentCliExecutor,
+    private val confirmationHandler: AIAgentCliConfirmationHandler,
+) : Tool<AIAgentCliTool.Args, AIAgentCliTool.Result>(
+    argsType = typeToken<Args>(),
+    resultType = typeToken<Result>(),
+    name = "__delegate_to_${profile.id.toToolNameSegment()}_cli__",
+    description = """
+        Delegates a well-scoped software engineering task to ${profile.displayName}.
+        Use this when another installed AI coding CLI is better suited to inspect or modify the local workspace.
+        Provide a concrete task, optional context, optional absolute working directory, and a timeout.
+    """.trimIndent()
+) {
+    /**
+     * Arguments for delegating a task to an external AI agent CLI.
+     *
+     * @property task Concrete task for the delegated CLI agent.
+     * @property context Optional supporting context appended to the delegated prompt.
+     * @property workingDirectory Optional absolute filesystem path where the CLI should run.
+     * @property timeoutSeconds Optional timeout override for this task.
+     */
+    @Serializable
+    public data class Args(
+        @property:LLMDescription(
+            "Concrete task to delegate to the external AI coding CLI. Include expected files, behavior, and verification."
+        )
+        val task: String,
+        @property:LLMDescription(
+            "Optional supporting context that should be appended to the delegated task."
+        )
+        val context: String? = null,
+        @property:LLMDescription(
+            "Optional absolute filesystem path where the CLI should run. If omitted, the profile or process default is used."
+        )
+        val workingDirectory: String? = null,
+        @property:LLMDescription(
+            "Optional timeout in seconds. Must be positive when provided."
+        )
+        val timeoutSeconds: Int? = null,
+    )
+
+    /**
+     * Result of a delegated CLI task.
+     *
+     * @property profileId CLI profile identifier.
+     * @property command Executed command as an argument vector.
+     * @property exitCode Process exit code, or null if the process did not complete normally.
+     * @property timedOut True when the process was terminated after reaching its timeout.
+     * @property output Output extracted from the CLI process result.
+     */
+    @Serializable
+    public data class Result(
+        val profileId: String,
+        val command: List<String>,
+        val exitCode: Int?,
+        val timedOut: Boolean,
+        val output: String,
+    )
+
+    override suspend fun execute(args: Args): Result {
+        val task = renderTask(args)
+        val request = profile.buildRequest(task, args)
+
+        return when (val confirmation = confirmationHandler.requestConfirmation(request, args)) {
+            is AIAgentCliConfirmation.Approved -> executeApproved(request)
+            is AIAgentCliConfirmation.Denied -> Result(
+                profileId = profile.id,
+                command = request.command,
+                exitCode = null,
+                timedOut = false,
+                output = "CLI delegation denied with user response: ${confirmation.userResponse}"
+            )
+        }
+    }
+
+    private suspend fun executeApproved(request: AIAgentCliExecutionRequest): Result {
+        return try {
+            val processResult = executor.execute(request)
+            Result(
+                profileId = profile.id,
+                command = request.command,
+                exitCode = processResult.exitCode,
+                timedOut = processResult.timedOut,
+                output = profile.outputExtractor.extract(processResult)
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Result(
+                profileId = profile.id,
+                command = request.command,
+                exitCode = null,
+                timedOut = false,
+                output = "Failed to execute ${profile.displayName}: ${e.message}"
+            )
+        }
+    }
+
+    override fun encodeResultToString(result: Result, serializer: JSONSerializer): String = with(result) {
+        buildString {
+            appendLine("CLI profile: $profileId")
+            appendLine("Command: ${command.joinToString(" ")}")
+            if (output.isNotBlank()) {
+                appendLine(output.trimEnd())
+            } else if (exitCode != null) {
+                appendLine("(no output)")
+            }
+            if (timedOut) {
+                appendLine("Timed out")
+            }
+            exitCode?.let { appendLine("Exit code: $it") }
+        }.trimEnd()
+    }
+
+    private fun renderTask(args: Args): String {
+        require(args.task.isNotBlank()) { "task must not be blank" }
+        args.timeoutSeconds?.let { require(it > 0) { "timeoutSeconds must be positive" } }
+
+        return buildString {
+            append(args.task.trim())
+            val context = args.context?.trim()
+            if (!context.isNullOrEmpty()) {
+                appendLine()
+                appendLine()
+                appendLine("Additional context:")
+                append(context)
+            }
+        }
+    }
+
+    private companion object {
+        fun String.toToolNameSegment(): String {
+            val sanitized = map { char ->
+                when (char) {
+                    in 'A'..'Z', in 'a'..'z', in '0'..'9', '_' -> char
+                    else -> '_'
+                }
+            }.joinToString("")
+
+            return sanitized.trim('_').ifBlank { "agent" }
+        }
+    }
+}

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/cli/ShellAIAgentCliExecutor.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/cli/ShellAIAgentCliExecutor.kt
@@ -1,0 +1,86 @@
+package ai.koog.agents.ext.tool.cli
+
+import ai.koog.agents.ext.tool.shell.ShellCommandExecutor
+
+/**
+ * CommonMain implementation of [AIAgentCliExecutor] backed by Koog's shell executor abstraction.
+ *
+ * This class contains the CLI-specific execution implementation in common code: it renders the trusted
+ * executable/argument vector from [AIAgentCliExecutionRequest] into a shell command, delegates the platform process
+ * boundary to [ShellCommandExecutor], and maps the result back to [AIAgentCliExecutionResult].
+ *
+ * @property shellCommandExecutor Platform shell executor supplied by the host application.
+ * @property commandLineRenderer Renderer that converts an argument vector into a shell command line.
+ */
+public class ShellAIAgentCliExecutor(
+    private val shellCommandExecutor: ShellCommandExecutor,
+    private val commandLineRenderer: AIAgentCliShellCommandLineRenderer = PosixAIAgentCliShellCommandLineRenderer,
+) : AIAgentCliExecutor {
+    override suspend fun execute(request: AIAgentCliExecutionRequest): AIAgentCliExecutionResult {
+        val shellResult = shellCommandExecutor.execute(
+            command = commandLineRenderer.render(request),
+            workingDirectory = request.workingDirectory,
+            timeoutSeconds = request.timeoutSeconds
+        )
+
+        return AIAgentCliExecutionResult(
+            output = shellResult.output,
+            exitCode = shellResult.exitCode,
+            timedOut = shellResult.timedOut,
+        )
+    }
+}
+
+/**
+ * Renders an AI agent CLI request into a command line accepted by [ShellCommandExecutor].
+ */
+public fun interface AIAgentCliShellCommandLineRenderer {
+    /**
+     * Converts [request] into a shell command line.
+     *
+     * @param request Fully built CLI execution request.
+     * @return Shell command line to pass to [ShellCommandExecutor].
+     */
+    public fun render(request: AIAgentCliExecutionRequest): String
+}
+
+/**
+ * POSIX shell renderer for AI agent CLI requests.
+ *
+ * Every executable and argument is single-quoted, single quotes inside values are escaped, environment variable names
+ * are validated, and optional standard input is provided through `printf`.
+ */
+public object PosixAIAgentCliShellCommandLineRenderer : AIAgentCliShellCommandLineRenderer {
+    override fun render(request: AIAgentCliExecutionRequest): String {
+        val command = buildString {
+            if (request.environment.isNotEmpty()) {
+                append(renderEnvironment(request.environment))
+                append(' ')
+            }
+            append(request.command.joinToString(" ") { it.posixQuote() })
+        }
+
+        val stdin = request.stdin
+        return if (stdin == null) {
+            command
+        } else {
+            "printf %s ${stdin.posixQuote()} | $command"
+        }
+    }
+
+    private fun renderEnvironment(environment: Map<String, String>): String {
+        return environment.entries.joinToString(" ") { (name, value) ->
+            require(name.isValidEnvironmentName()) { "Invalid environment variable name: $name" }
+            "$name=${value.posixQuote()}"
+        }
+    }
+
+    private fun String.isValidEnvironmentName(): Boolean {
+        if (isEmpty()) return false
+        val first = first()
+        if (first != '_' && first !in 'A'..'Z' && first !in 'a'..'z') return false
+        return drop(1).all { it == '_' || it in 'A'..'Z' || it in 'a'..'z' || it in '0'..'9' }
+    }
+
+    private fun String.posixQuote(): String = "'${replace("'", "'\"'\"'")}'"
+}

--- a/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/shell/ShellCommandExecutor.kt
+++ b/agents/agents-ext/src/commonMain/kotlin/ai/koog/agents/ext/tool/shell/ShellCommandExecutor.kt
@@ -19,9 +19,11 @@ public interface ShellCommandExecutor {
      *
      * @property output All text printed by the command (both success and error messages)
      * @property exitCode Process exit code (0 = success), or null if the process was interrupted or timed out
+     * @property timedOut True when the process was terminated because the timeout was reached
      */
     public data class ExecutionResult(
         val output: String,
-        val exitCode: Int?
+        val exitCode: Int?,
+        val timedOut: Boolean = false,
     )
 }

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/cli/AIAgentCliProfilesTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/cli/AIAgentCliProfilesTest.kt
@@ -1,0 +1,88 @@
+package ai.koog.agents.ext.tool.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class AIAgentCliProfilesTest {
+    @Test
+    fun testCodexProfileBuildsExecCommand() {
+        val profile = AIAgentCliProfiles.codex(
+            extraArguments = listOf("--full-auto"),
+            defaultTimeoutSeconds = 42
+        )
+
+        val request = profile.buildRequest("fix failing tests", AIAgentCliTool.Args(task = "fix failing tests"))
+
+        assertEquals("codex", profile.id)
+        assertEquals(42, request.timeoutSeconds)
+        assertEquals(
+            listOf("codex", "exec", "--color", "never", "--ephemeral", "--full-auto", "fix failing tests"),
+            request.command
+        )
+    }
+
+    @Test
+    fun testClaudeCodeProfileBuildsPrintCommand() {
+        val profile = AIAgentCliProfiles.claudeCode(extraArguments = listOf("--model", "sonnet"))
+
+        val request = profile.buildRequest("summarize the module", AIAgentCliTool.Args(task = "summarize the module"))
+
+        assertEquals("claude-code", profile.id)
+        assertEquals(
+            listOf("claude", "-p", "--output-format", "text", "--model", "sonnet", "summarize the module"),
+            request.command
+        )
+    }
+
+    @Test
+    fun testGithubCopilotProfileBuildsProgrammaticPromptCommand() {
+        val profile = AIAgentCliProfiles.githubCopilot(extraArguments = listOf("--allow-all-tools"))
+
+        val request = profile.buildRequest("write unit tests", AIAgentCliTool.Args(task = "write unit tests"))
+
+        assertEquals("github-copilot", profile.id)
+        assertEquals(
+            listOf("copilot", "-s", "-p", "write unit tests", "--allow-all-tools"),
+            request.command
+        )
+    }
+
+    @Test
+    fun testCustomProfileSupportsStdinAndEnvironment() {
+        val profile = AIAgentCliProfiles.custom(
+            id = "custom-cli",
+            displayName = "Custom CLI",
+            executable = "agent",
+            argumentBuilder = AIAgentCliArgumentBuilder { task, _ ->
+                AIAgentCliInvocation(
+                    arguments = listOf("run", "--stdin"),
+                    stdin = task,
+                    environment = mapOf("AGENT_MODE" to "test")
+                )
+            }
+        )
+
+        val request = profile.buildRequest("inspect code", AIAgentCliTool.Args(task = "inspect code"))
+
+        assertEquals(listOf("agent", "run", "--stdin"), request.command)
+        assertEquals("inspect code", request.stdin)
+        assertEquals(mapOf("AGENT_MODE" to "test"), request.environment)
+    }
+
+    @Test
+    fun testProfileRejectsInvalidConfiguration() {
+        assertFailsWith<IllegalArgumentException> {
+            AIAgentCliProfiles.custom(
+                id = "",
+                displayName = "Custom CLI",
+                executable = "agent",
+                argumentBuilder = AIAgentCliArgumentBuilder { _, _ -> AIAgentCliInvocation(emptyList()) }
+            )
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            AIAgentCliProfiles.codex(defaultTimeoutSeconds = 0)
+        }
+    }
+}

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/cli/AIAgentCliToolTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/cli/AIAgentCliToolTest.kt
@@ -1,0 +1,167 @@
+package ai.koog.agents.ext.tool.cli
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class AIAgentCliToolTest {
+    @Test
+    fun testToolDelegatesTaskWithContext() = runTest {
+        val executor = RecordingExecutor(
+            AIAgentCliExecutionResult(output = "raw output", exitCode = 0)
+        )
+        val confirmationHandler = RecordingConfirmationHandler(AIAgentCliConfirmation.Approved)
+        val profile = AIAgentCliProfiles.custom(
+            id = "test-cli",
+            displayName = "Test CLI",
+            executable = "agent",
+            defaultTimeoutSeconds = 30,
+            argumentBuilder = AIAgentCliArgumentBuilder { task, _ ->
+                AIAgentCliInvocation(
+                    arguments = listOf("--task", task),
+                    workingDirectory = "/profile",
+                    environment = mapOf("MODE" to "test")
+                )
+            },
+            outputExtractor = AIAgentCliOutputExtractor { "extracted: ${it.output}" }
+        )
+        val tool = AIAgentCliTool(profile, executor, confirmationHandler)
+
+        val result = tool.execute(
+            AIAgentCliTool.Args(
+                task = "Fix the parser",
+                context = "Prefer small changes.",
+                workingDirectory = "/repo",
+                timeoutSeconds = 12
+            )
+        )
+
+        val expectedTask = """
+            Fix the parser
+
+            Additional context:
+            Prefer small changes.
+        """.trimIndent()
+
+        assertEquals(1, executor.calls)
+        assertEquals(listOf("agent", "--task", expectedTask), executor.lastRequest.command)
+        assertEquals("/repo", executor.lastRequest.workingDirectory)
+        assertEquals(mapOf("MODE" to "test"), executor.lastRequest.environment)
+        assertEquals(12, executor.lastRequest.timeoutSeconds)
+        assertEquals(expectedTask, confirmationHandler.lastArgs.taskWithContext)
+        assertEquals("extracted: raw output", result.output)
+        assertEquals(0, result.exitCode)
+    }
+
+    @Test
+    fun testToolDoesNotExecuteWhenDenied() = runTest {
+        val executor = RecordingExecutor(AIAgentCliExecutionResult(output = "should not run", exitCode = 0))
+        val tool = AIAgentCliTool(
+            profile = AIAgentCliProfiles.codex(),
+            executor = executor,
+            confirmationHandler = RecordingConfirmationHandler(AIAgentCliConfirmation.Denied("not now"))
+        )
+
+        val result = tool.execute(AIAgentCliTool.Args(task = "Change production code"))
+
+        assertEquals(0, executor.calls)
+        assertEquals(null, result.exitCode)
+        assertEquals("CLI delegation denied with user response: not now", result.output)
+    }
+
+    @Test
+    fun testToolReturnsFailureResultWhenExecutorThrows() = runTest {
+        val executor = ThrowingExecutor(IllegalStateException("missing binary"))
+        val profile = AIAgentCliProfiles.claudeCode()
+        val tool = AIAgentCliTool(profile, executor, BraveModeAIAgentCliConfirmationHandler())
+
+        val result = tool.execute(AIAgentCliTool.Args(task = "Explain this repository"))
+
+        assertEquals(null, result.exitCode)
+        assertEquals("Failed to execute Claude Code CLI: missing binary", result.output)
+    }
+
+    @Test
+    fun testToolNameUsesSanitizedProfileId() {
+        val profile = AIAgentCliProfiles.custom(
+            id = "codex/dev.1",
+            displayName = "Custom CLI",
+            executable = "agent",
+            argumentBuilder = AIAgentCliArgumentBuilder { task, _ -> AIAgentCliInvocation(listOf(task)) }
+        )
+        val tool = AIAgentCliTool(
+            profile = profile,
+            executor = RecordingExecutor(AIAgentCliExecutionResult(output = "", exitCode = 0)),
+            confirmationHandler = BraveModeAIAgentCliConfirmationHandler()
+        )
+
+        assertEquals("__delegate_to_codex_dev_1_cli__", tool.name)
+    }
+
+    @Test
+    fun testToolRejectsBlankTaskAndInvalidTimeout() = runTest {
+        val tool = AIAgentCliTool(
+            profile = AIAgentCliProfiles.codex(),
+            executor = RecordingExecutor(AIAgentCliExecutionResult(output = "", exitCode = 0)),
+            confirmationHandler = BraveModeAIAgentCliConfirmationHandler()
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            tool.execute(AIAgentCliTool.Args(task = " "))
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            tool.execute(AIAgentCliTool.Args(task = "Inspect", timeoutSeconds = -1))
+        }
+    }
+
+    private val AIAgentCliTool.Args.taskWithContext: String
+        get() = buildString {
+            append(task.trim())
+            val context = context?.trim()
+            if (!context.isNullOrEmpty()) {
+                appendLine()
+                appendLine()
+                appendLine("Additional context:")
+                append(context)
+            }
+        }
+
+    private class RecordingExecutor(
+        private val result: AIAgentCliExecutionResult,
+    ) : AIAgentCliExecutor {
+        var calls: Int = 0
+        lateinit var lastRequest: AIAgentCliExecutionRequest
+
+        override suspend fun execute(request: AIAgentCliExecutionRequest): AIAgentCliExecutionResult {
+            calls++
+            lastRequest = request
+            return result
+        }
+    }
+
+    private class ThrowingExecutor(
+        private val exception: Exception,
+    ) : AIAgentCliExecutor {
+        override suspend fun execute(request: AIAgentCliExecutionRequest): AIAgentCliExecutionResult {
+            throw exception
+        }
+    }
+
+    private class RecordingConfirmationHandler(
+        private val confirmation: AIAgentCliConfirmation,
+    ) : AIAgentCliConfirmationHandler {
+        lateinit var lastRequest: AIAgentCliExecutionRequest
+        lateinit var lastArgs: AIAgentCliTool.Args
+
+        override suspend fun requestConfirmation(
+            request: AIAgentCliExecutionRequest,
+            args: AIAgentCliTool.Args,
+        ): AIAgentCliConfirmation {
+            lastRequest = request
+            lastArgs = args
+            return confirmation
+        }
+    }
+}

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/cli/ShellAIAgentCliExecutorTest.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/tool/cli/ShellAIAgentCliExecutorTest.kt
@@ -1,0 +1,84 @@
+package ai.koog.agents.ext.tool.cli
+
+import ai.koog.agents.ext.tool.shell.ShellCommandExecutor
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ShellAIAgentCliExecutorTest {
+    @Test
+    fun testExecutesRenderedCommandThroughShellExecutor() = runTest {
+        val shellExecutor = RecordingShellCommandExecutor(
+            ShellCommandExecutor.ExecutionResult(output = "done", exitCode = null, timedOut = true)
+        )
+        val executor = ShellAIAgentCliExecutor(shellExecutor)
+        val request = AIAgentCliExecutionRequest(
+            profileId = "test",
+            executable = "agent",
+            arguments = listOf("run", "can't ; rm -rf /"),
+            workingDirectory = "/repo",
+            timeoutSeconds = 17
+        )
+
+        val result = executor.execute(request)
+
+        assertEquals("""'agent' 'run' 'can'"'"'t ; rm -rf /'""", shellExecutor.lastCommand)
+        assertEquals("/repo", shellExecutor.lastWorkingDirectory)
+        assertEquals(17, shellExecutor.lastTimeoutSeconds)
+        assertEquals("done", result.output)
+        assertEquals(null, result.exitCode)
+        assertTrue(result.timedOut)
+    }
+
+    @Test
+    fun testRendersEnvironmentAndStdin() {
+        val request = AIAgentCliExecutionRequest(
+            profileId = "test",
+            executable = "agent",
+            arguments = listOf("run"),
+            stdin = "line1\nline2",
+            environment = mapOf("AGENT_MODE" to "test value"),
+            timeoutSeconds = 5
+        )
+
+        val command = PosixAIAgentCliShellCommandLineRenderer.render(request)
+
+        assertEquals("printf %s 'line1\nline2' | AGENT_MODE='test value' 'agent' 'run'", command)
+    }
+
+    @Test
+    fun testRejectsInvalidEnvironmentName() {
+        val request = AIAgentCliExecutionRequest(
+            profileId = "test",
+            executable = "agent",
+            arguments = listOf("run"),
+            environment = mapOf("INVALID-NAME" to "value"),
+            timeoutSeconds = 5
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            PosixAIAgentCliShellCommandLineRenderer.render(request)
+        }
+    }
+
+    private class RecordingShellCommandExecutor(
+        private val result: ShellCommandExecutor.ExecutionResult,
+    ) : ShellCommandExecutor {
+        lateinit var lastCommand: String
+        var lastWorkingDirectory: String? = null
+        var lastTimeoutSeconds: Int = 0
+
+        override suspend fun execute(
+            command: String,
+            workingDirectory: String?,
+            timeoutSeconds: Int,
+        ): ShellCommandExecutor.ExecutionResult {
+            lastCommand = command
+            lastWorkingDirectory = workingDirectory
+            lastTimeoutSeconds = timeoutSeconds
+            return result
+        }
+    }
+}

--- a/agents/agents-ext/src/jvmMain/kotlin/ai/koog/agents/ext/tool/cli/JvmAIAgentCliExecutor.kt
+++ b/agents/agents-ext/src/jvmMain/kotlin/ai/koog/agents/ext/tool/cli/JvmAIAgentCliExecutor.kt
@@ -1,0 +1,99 @@
+package ai.koog.agents.ext.tool.cli
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import java.io.File
+import java.io.IOException
+
+/**
+ * JVM process executor for [AIAgentCliTool].
+ */
+public class JvmAIAgentCliExecutor : AIAgentCliExecutor {
+    override suspend fun execute(request: AIAgentCliExecutionRequest): AIAgentCliExecutionResult = withContext(Dispatchers.IO) {
+        val stdoutBuilder = StringBuilder()
+        val stderrBuilder = StringBuilder()
+
+        val process = ProcessBuilder(request.command)
+            .apply {
+                request.workingDirectory?.let { directory(File(it)) }
+                environment().putAll(request.environment)
+            }
+            .start()
+
+        try {
+            val stdoutJob = launch {
+                process.inputStream.bufferedReader().useLines { lines ->
+                    try {
+                        lines.forEach { stdoutBuilder.appendLine(it) }
+                    } catch (_: IOException) {
+                        // The process may close its stream while it is being collected.
+                    }
+                }
+            }
+
+            val stderrJob = launch {
+                process.errorStream.bufferedReader().useLines { lines ->
+                    try {
+                        lines.forEach { stderrBuilder.appendLine(it) }
+                    } catch (_: IOException) {
+                        // The process may close its stream while it is being collected.
+                    }
+                }
+            }
+
+            val stdinJob = launch {
+                try {
+                    process.outputStream.bufferedWriter().use { writer ->
+                        request.stdin?.let {
+                            writer.write(it)
+                            writer.flush()
+                        }
+                    }
+                } catch (_: IOException) {
+                    // The process may exit or be terminated before stdin is written.
+                }
+            }
+
+            val isCompleted = withTimeoutOrNull(request.timeoutSeconds * 1000L) {
+                process.onExit().await()
+            } != null
+
+            if (!isCompleted) {
+                process.descendants().forEach { it.destroyForcibly() }
+                process.destroyForcibly()
+            }
+
+            stdinJob.join()
+            stdoutJob.join()
+            stderrJob.join()
+
+            val output = buildCombinedOutput(
+                stdoutBuilder.toString().trimEnd(),
+                stderrBuilder.toString().trimEnd(),
+                if (isCompleted) null else "CLI process timed out after ${request.timeoutSeconds} seconds"
+            )
+
+            AIAgentCliExecutionResult(
+                output = output,
+                exitCode = if (isCompleted) process.exitValue() else null,
+                timedOut = !isCompleted,
+            )
+        } finally {
+            if (process.isAlive) {
+                process.descendants().forEach { it.destroyForcibly() }
+                process.destroyForcibly()
+            }
+        }
+    }
+
+    private fun buildCombinedOutput(stdout: String, stderr: String, message: String? = null): String {
+        return buildString {
+            if (stdout.isNotEmpty()) appendLine(stdout)
+            if (stderr.isNotEmpty()) appendLine(stderr)
+            message?.let { appendLine(it) }
+        }.trimEnd()
+    }
+}

--- a/agents/agents-ext/src/jvmMain/kotlin/ai/koog/agents/ext/tool/shell/JvmShellCommandExecutor.kt
+++ b/agents/agents-ext/src/jvmMain/kotlin/ai/koog/agents/ext/tool/shell/JvmShellCommandExecutor.kt
@@ -101,8 +101,7 @@ public class JvmShellCommandExecutor : ShellCommandExecutor {
                     stderrBuilder.toString().trimEnd(),
                     "Command timed out after $timeoutSeconds seconds"
                 )
-
-                ExecutionResult(output = combinedPartialOutput, exitCode = null)
+                ExecutionResult(output = combinedPartialOutput, exitCode = null, timedOut = true)
             } else {
                 val combinedOutput = buildCombinedOutput(
                     stdoutBuilder.toString().trimEnd(),

--- a/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/cli/JvmAIAgentCliExecutorTest.kt
+++ b/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/cli/JvmAIAgentCliExecutorTest.kt
@@ -1,0 +1,56 @@
+package ai.koog.agents.ext.tool.cli
+
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.createFile
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class JvmAIAgentCliExecutorTest {
+    private val executor = JvmAIAgentCliExecutor()
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    @EnabledOnOs(OS.LINUX, OS.MAC)
+    fun testExecutesCommandWithWorkingDirectoryAndStdin() = runBlocking {
+        tempDir.resolve("marker.txt").createFile()
+        val request = AIAgentCliExecutionRequest(
+            profileId = "test",
+            executable = "/bin/sh",
+            arguments = listOf("-c", "read line; printf '%s:' \"${'$'}line\"; pwd; ls marker.txt"),
+            stdin = "hello\n",
+            workingDirectory = tempDir.toString(),
+            timeoutSeconds = 5
+        )
+
+        val result = executor.execute(request)
+
+        assertEquals(0, result.exitCode)
+        assertTrue(result.output.contains("hello:"))
+        assertTrue(result.output.contains("marker.txt"))
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX, OS.MAC)
+    fun testReportsTimeout() = runBlocking {
+        val request = AIAgentCliExecutionRequest(
+            profileId = "test",
+            executable = "/bin/sh",
+            arguments = listOf("-c", "sleep 2"),
+            timeoutSeconds = 1
+        )
+
+        val result = executor.execute(request)
+
+        assertNull(result.exitCode)
+        assertTrue(result.timedOut)
+        assertTrue(result.output.contains("CLI process timed out after 1 seconds"))
+    }
+}

--- a/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/shell/ExecuteShellCommandToolJvmTest.kt
+++ b/agents/agents-ext/src/jvmTest/kotlin/ai/koog/agents/ext/tool/shell/ExecuteShellCommandToolJvmTest.kt
@@ -392,6 +392,15 @@ class ExecuteShellCommandToolJvmTest {
         assertTrue(executionTimeMs < 4000, "Should timeout at 1s, but took ${executionTimeMs}ms")
     }
 
+    @Test
+    @EnabledOnOs(OS.LINUX, OS.MAC)
+    fun testExecutorResultMarksTimeout() = runBlocking {
+        val result = executor.execute("sleep 2", workingDirectory = null, timeoutSeconds = 1)
+
+        assertNull(result.exitCode)
+        assertTrue(result.timedOut)
+    }
+
     // CANCELLATION TESTS
 
     @RepeatedTest(10)


### PR DESCRIPTION
## Summary

Adds an `agents-ext` tool layer for delegating bounded tasks to external AI coding CLIs while keeping command construction in trusted host code.

- Introduces `AIAgentCliTool`, profile/confirmation/executor abstractions, and preset profiles for Codex CLI, Claude Code CLI, and GitHub Copilot CLI.
- Adds `ShellAIAgentCliExecutor` in `commonMain` so the CLI delegation implementation is available from common code through Koog's existing `ShellCommandExecutor` abstraction.
- Keeps a JVM exact-argv `ProcessBuilder` executor available for JVM hosts that want to avoid shell rendering.
- Documents the delegation pattern in `agents-ext/Module.md` and adds common/JVM tests for command construction, validation, confirmation, failure handling, common shell execution, timeout propagation, and JVM process execution.

## Why

Codex CLI, Claude Code CLI, and GitHub Copilot CLI are agent processes rather than ordinary LLM providers. Exposing them as a Koog tool keeps the Koog agent in control of when delegation happens, while profiles let applications audit and lock down the exact command shape and permissions.

The commonMain executor contains the reusable CLI execution path. Platform-specific process details remain behind `ShellCommandExecutor`, matching the existing `agents-ext` shell-tool pattern and allowing non-JVM targets to supply their own executor.

## Validation

Passed:

- `env GRADLE_USER_HOME=/private/tmp/koog-gradle-home ./gradlew :agents:agents-ext:jvmTest`
- `env GRADLE_USER_HOME=/private/tmp/koog-gradle-home ./gradlew :agents:agents-ext:jsTest`
- `env GRADLE_USER_HOME=/private/tmp/koog-gradle-home ./gradlew :agents:agents-ext:jvmTest :agents:agents-ext:jsTest`
- `env ANDROID_HOME=/Users/openclaw/Library/Android/sdk GRADLE_USER_HOME=/private/tmp/koog-gradle-home ./gradlew :agents:agents-ext:ktlintCheck`
- `env ANDROID_HOME=/Users/openclaw/Library/Android/sdk GRADLE_USER_HOME=/private/tmp/koog-gradle-home ./gradlew :agents:agents-ext:build`
- `env ANDROID_HOME=/Users/openclaw/Library/Android/sdk GRADLE_USER_HOME=/private/tmp/koog-gradle-home ./gradlew :docs:knit`
- `git diff --check`
- `git diff --cached --check`

Attempted:

- `env ANDROID_HOME=/Users/openclaw/Library/Android/sdk GRADLE_USER_HOME=/private/tmp/koog-gradle-home ./gradlew build`

The root build progressed past `:docs:knitCheck` after generating ignored knit sources, but failed in `:integration-tests:allTests` because this local environment lacks required external integration-test settings: `OPEN_AI_API_TEST_KEY`, `ANTHROPIC_API_TEST_KEY`, `GEMINI_API_TEST_KEY`, and `OLLAMA_IMAGE_URL`.
