### PR TITLE
refactor(http-client)!: make Ollama use KoogHttpClient instead of Ktor one

### DIFF
--- a/.github/workflows/conventional-prs.yml
+++ b/.github/workflows/conventional-prs.yml
@@ -36,6 +36,7 @@ jobs:
             a2a
             agents
             embeddings
+            http-client
             integration-tests
             koog-agents
             koog-ktor

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,7 @@ The following scopes are supported:
 - `a2a`
 - `agents`
 - `embeddings`
+- `http-client`
 - `integration-tests`
 - `koog-agents`
 - `koog-ktor`

--- a/http-client/http-client-core/build.gradle.kts
+++ b/http-client/http-client-core/build.gradle.kts
@@ -14,6 +14,18 @@ kotlin {
                 api(libs.jetbrains.annotations)
             }
         }
+
+        commonTest {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
+
+        jvmTest {
+            dependencies {
+                implementation(kotlin("test-junit5"))
+            }
+        }
     }
 
     explicitApi()

--- a/http-client/http-client-core/src/commonMain/kotlin/ai/koog/http/client/KoogHttpClient.kt
+++ b/http-client/http-client-core/src/commonMain/kotlin/ai/koog/http/client/KoogHttpClient.kt
@@ -90,6 +90,23 @@ public interface KoogHttpClient : AutoCloseable {
         parameters: Map<String, String> = emptyMap(),
     ): Flow<O>
 
+    /**
+     * Sends an HTTP POST request and emits each non-blank UTF-8 line of the response body as it arrives.
+     *
+     * @param path The endpoint path to which the HTTP POST request is sent.
+     * @param request The request payload to be sent in the POST request.
+     * @param requestBodyType The Kotlin class reference representing the type of the request body.
+     * @param parameters Optional query parameters to include in the request.
+     * @return A [Flow] emitting each non-blank line of the response body as it arrives.
+     * @throws KoogHttpClientException if the server returns a non-success status.
+     */
+    public fun <T : Any> lines(
+        path: String,
+        request: T,
+        requestBodyType: KClass<T>,
+        parameters: Map<String, String> = emptyMap(),
+    ): Flow<String>
+
     public interface Factory {
         /**
          * Creates a configured [KoogHttpClient].
@@ -183,3 +200,18 @@ public inline fun <reified T : Any, reified R : Any, O : Any> KoogHttpClient.sse
     noinline processStreamingChunk: (R) -> O?,
     parameters: Map<String, String> = emptyMap(),
 ): Flow<O> = sse(path, request, T::class, dataFilter, decodeStreamingResponse, processStreamingChunk, parameters)
+
+/**
+ * Sends an HTTP POST request and emits each non-blank UTF-8 line of the response body as it arrives.
+ *
+ * @param path The endpoint path to which the HTTP POST request is sent.
+ * @param request The request payload to be sent in the POST request.
+ * @param parameters Optional query parameters to include in the request.
+ * @return A [Flow] emitting each non-blank line of the response body as it arrives.
+ * @throws KoogHttpClientException if the server returns a non-success status.
+ */
+public inline fun <reified T : Any> KoogHttpClient.lines(
+    path: String,
+    request: T,
+    parameters: Map<String, String> = emptyMap(),
+): Flow<String> = lines(path, request, T::class, parameters)

--- a/http-client/http-client-core/src/commonMain/kotlin/ai/koog/http/client/KoogHttpClient.kt
+++ b/http-client/http-client-core/src/commonMain/kotlin/ai/koog/http/client/KoogHttpClient.kt
@@ -23,13 +23,14 @@ public interface KoogHttpClient : AutoCloseable {
     public val clientName: String
 
     /**
-     * Sends an HTTP GET request to the specified `path` with the provided `request` payload.
-     * The type of the request body and the expected response must be explicitly specified
-     * using `requestBodyType` and `responseType`, respectively.
+     * Sends an HTTP GET request to the specified `path`.
+     * The expected response type must be explicitly specified using `responseType`.
      *
-     * @param path The endpoint path to which the HTTP POST request is sent.
+     * @param path The endpoint path to which the HTTP GET request is sent.
      * @param responseType The Kotlin class reference representing the expected type of the response.
-     * @param parameters Optional query parameters to include in the request.
+     * @param parameters Optional query parameters merged with default query parameters configured on the client.
+     * @param headers Optional request headers merged with headers configured on the client. Headers with the same
+     * name replace configured or inferred header values; other configured headers are preserved.
      *
      * @return The response payload, deserialized into the specified type.
      * @throws Exception if the request fails or the response cannot be deserialized.
@@ -38,6 +39,7 @@ public interface KoogHttpClient : AutoCloseable {
         path: String,
         responseType: KClass<R>,
         parameters: Map<String, String> = emptyMap(),
+        headers: Map<String, String> = emptyMap(),
     ): R
 
     /**
@@ -49,7 +51,9 @@ public interface KoogHttpClient : AutoCloseable {
      * @param request The request payload to be sent in the POST request.
      * @param requestBodyType The Kotlin class reference representing the type of the request body.
      * @param responseType The Kotlin class reference representing the expected type of the response.
-     * @param parameters Optional query parameters to include in the request.
+     * @param parameters Optional query parameters merged with default query parameters configured on the client.
+     * @param headers Optional request headers merged with headers configured on the client. Headers with the same
+     * name replace configured or inferred header values; other configured headers are preserved.
      * @return The response payload, deserialized into the specified type.
      * @throws Exception if the request fails or the response cannot be deserialized.
      */
@@ -59,6 +63,7 @@ public interface KoogHttpClient : AutoCloseable {
         requestBodyType: KClass<T>,
         responseType: KClass<R>,
         parameters: Map<String, String> = emptyMap(),
+        headers: Map<String, String> = emptyMap(),
     ): R
 
     /**
@@ -76,7 +81,9 @@ public interface KoogHttpClient : AutoCloseable {
      * @param decodeStreamingResponse A lambda function used to decode the raw streaming response data
      * into the target type. It takes a raw string and converts it into an object of type `R`.
      * @param processStreamingChunk A lambda function that processes the decoded streaming chunk and returns
-     * @param parameters Optional query parameters to include in the request.
+     * @param parameters Optional query parameters merged with default query parameters configured on the client.
+     * @param headers Optional request headers merged with headers configured on the client. Headers with the same
+     * name replace configured or inferred header values; other configured headers are preserved.
      * a string result. If the returned value is `null`, the chunk will not be emitted to the resulting flow.
      * @return A [Flow] emitting processed strings derived from the streamed chunks of data.
      */
@@ -88,6 +95,7 @@ public interface KoogHttpClient : AutoCloseable {
         decodeStreamingResponse: (String) -> R,
         processStreamingChunk: (R) -> O?,
         parameters: Map<String, String> = emptyMap(),
+        headers: Map<String, String> = emptyMap(),
     ): Flow<O>
 
     /**
@@ -96,7 +104,9 @@ public interface KoogHttpClient : AutoCloseable {
      * @param path The endpoint path to which the HTTP POST request is sent.
      * @param request The request payload to be sent in the POST request.
      * @param requestBodyType The Kotlin class reference representing the type of the request body.
-     * @param parameters Optional query parameters to include in the request.
+     * @param parameters Optional query parameters merged with default query parameters configured on the client.
+     * @param headers Optional request headers merged with headers configured on the client. Headers with the same
+     * name replace configured or inferred header values; other configured headers are preserved.
      * @return A [Flow] emitting each non-blank line of the response body as it arrives.
      * @throws KoogHttpClientException if the server returns a non-success status.
      */
@@ -105,6 +115,7 @@ public interface KoogHttpClient : AutoCloseable {
         request: T,
         requestBodyType: KClass<T>,
         parameters: Map<String, String> = emptyMap(),
+        headers: Map<String, String> = emptyMap(),
     ): Flow<String>
 
     public interface Factory {
@@ -151,7 +162,9 @@ public interface KoogHttpClient : AutoCloseable {
  *
  * @param path The endpoint path to which the HTTP POST request is sent.
  * @param request The request payload to be sent in the POST request.
- * @param parameters Optional query parameters to include in the request.
+ * @param parameters Optional query parameters merged with default query parameters configured on the client.
+ * @param headers Optional request headers merged with headers configured on the client. Headers with the same
+ * name replace configured or inferred header values; other configured headers are preserved.
  * @return The response payload, deserialized into the specified type.
  * @throws Exception if the request fails or the response cannot be deserialized.
  */
@@ -159,20 +172,24 @@ public suspend inline fun <reified T : Any, reified R : Any> KoogHttpClient.post
     path: String,
     request: T,
     parameters: Map<String, String> = emptyMap(),
-): R = post(path, request, T::class, R::class, parameters)
+    headers: Map<String, String> = emptyMap(),
+): R = post(path, request, T::class, R::class, parameters, headers)
 
 /**
  * Sends an HTTP GET request to the specified `path` with the provided parameters.
  *
  * @param path The endpoint path to which the HTTP GET request is sent.
- * @param parameters Optional query parameters to include in the request.
+ * @param parameters Optional query parameters merged with default query parameters configured on the client.
+ * @param headers Optional request headers merged with headers configured on the client. Headers with the same
+ * name replace configured or inferred header values; other configured headers are preserved.
  * @return The response payload, deserialized into the specified type.
  * @throws Exception if the request fails or the response cannot be deserialized.
  */
 public suspend inline fun <reified R : Any> KoogHttpClient.get(
     path: String,
     parameters: Map<String, String> = emptyMap(),
-): R = get(path, R::class, parameters)
+    headers: Map<String, String> = emptyMap(),
+): R = get(path, R::class, parameters, headers)
 
 /**
  * Initiates a Server-Sent Events (SSE) streaming operation over an HTTP POST request.
@@ -188,7 +205,9 @@ public suspend inline fun <reified R : Any> KoogHttpClient.get(
  * @param decodeStreamingResponse A lambda function used to decode the raw streaming response data
  * into the target type. It takes a raw string and converts it into an object of type `R`.
  * @param processStreamingChunk A lambda function that processes the decoded streaming chunk and returns
- * @param parameters Optional query parameters to include in the request.
+ * @param parameters Optional query parameters merged with default query parameters configured on the client.
+ * @param headers Optional request headers merged with headers configured on the client. Headers with the same
+ * name replace configured or inferred header values; other configured headers are preserved.
  * a string result. If the returned value is `null`, the chunk will not be emitted to the resulting flow.
  * @return A [Flow] emitting processed strings derived from the streamed chunks of data.
  */
@@ -199,14 +218,26 @@ public inline fun <reified T : Any, reified R : Any, O : Any> KoogHttpClient.sse
     noinline decodeStreamingResponse: (String) -> R,
     noinline processStreamingChunk: (R) -> O?,
     parameters: Map<String, String> = emptyMap(),
-): Flow<O> = sse(path, request, T::class, dataFilter, decodeStreamingResponse, processStreamingChunk, parameters)
+    headers: Map<String, String> = emptyMap(),
+): Flow<O> = sse(
+    path = path,
+    request = request,
+    requestBodyType = T::class,
+    dataFilter = dataFilter,
+    decodeStreamingResponse = decodeStreamingResponse,
+    processStreamingChunk = processStreamingChunk,
+    parameters = parameters,
+    headers = headers,
+)
 
 /**
  * Sends an HTTP POST request and emits each non-blank UTF-8 line of the response body as it arrives.
  *
  * @param path The endpoint path to which the HTTP POST request is sent.
  * @param request The request payload to be sent in the POST request.
- * @param parameters Optional query parameters to include in the request.
+ * @param parameters Optional query parameters merged with default query parameters configured on the client.
+ * @param headers Optional request headers merged with headers configured on the client. Headers with the same
+ * name replace configured or inferred header values; other configured headers are preserved.
  * @return A [Flow] emitting each non-blank line of the response body as it arrives.
  * @throws KoogHttpClientException if the server returns a non-success status.
  */
@@ -214,4 +245,5 @@ public inline fun <reified T : Any> KoogHttpClient.lines(
     path: String,
     request: T,
     parameters: Map<String, String> = emptyMap(),
-): Flow<String> = lines(path, request, T::class, parameters)
+    headers: Map<String, String> = emptyMap(),
+): Flow<String> = lines(path, request, T::class, parameters, headers)

--- a/http-client/http-client-core/src/commonMain/kotlin/ai/koog/http/client/utils.kt
+++ b/http-client/http-client-core/src/commonMain/kotlin/ai/koog/http/client/utils.kt
@@ -1,0 +1,27 @@
+package ai.koog.http.client
+
+/**
+ * Merges header groups into a single map.
+ *
+ * Header names are matched case-insensitively. If the same header name appears more than once,
+ * the value from the later group replaces the earlier one while unrelated headers are preserved.
+ *
+ * Pass groups in ascending precedence order, for example:
+ * `mergeHeaders(defaultHeaders, inferredHeaders, requestHeaders)`.
+ *
+ * @param headerGroups Header maps ordered from lowest to highest precedence.
+ */
+public fun mergeHeaders(vararg headerGroups: Map<String, String>): Map<String, String> {
+    return headerGroups.fold(mutableMapOf()) { finalHeaders, currentHeaders ->
+        currentHeaders.forEach { (key, value) -> finalHeaders.putIgnoringCase(key, value) }
+        finalHeaders
+    }
+}
+
+private fun MutableMap<String, String>.putIgnoringCase(key: String, value: String) {
+    val existingKey = keys.firstOrNull { it.equals(key, ignoreCase = true) }
+    if (existingKey != null) {
+        remove(existingKey)
+    }
+    put(key, value)
+}

--- a/http-client/http-client-core/src/commonMain/kotlin/ai/koog/http/client/utils.kt
+++ b/http-client/http-client-core/src/commonMain/kotlin/ai/koog/http/client/utils.kt
@@ -1,4 +1,8 @@
+@file:JvmName("Utils")
+
 package ai.koog.http.client
+
+import kotlin.jvm.JvmName
 
 /**
  * Merges header groups into a single map.

--- a/http-client/http-client-core/src/commonTest/kotlin/UtilsTest.kt
+++ b/http-client/http-client-core/src/commonTest/kotlin/UtilsTest.kt
@@ -1,0 +1,49 @@
+package ai.koog.http.client
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UtilsTest {
+    @Test
+    fun testMergeHeadersPreservesUnrelatedHeaders() {
+        val result = mergeHeaders(
+            mapOf("Authorization" to "Bearer token"),
+            mapOf("Content-Type" to "application/json")
+        )
+
+        assertEquals(
+            mapOf(
+                "Authorization" to "Bearer token",
+                "Content-Type" to "application/json"
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun testMergeHeadersUsesLaterGroupsForSameHeaderIgnoringCase() {
+        val result = mergeHeaders(
+            mapOf("Content-Type" to "text/plain"),
+            mapOf("content-type" to "application/json")
+        )
+
+        assertEquals(mapOf("content-type" to "application/json"), result)
+    }
+
+    @Test
+    fun testMergeHeadersUsesArgumentOrderAsPrecedence() {
+        val result = mergeHeaders(
+            mapOf("X-Request-Id" to "default", "Authorization" to "Bearer default"),
+            mapOf("x-request-id" to "inferred"),
+            mapOf("X-REQUEST-ID" to "request")
+        )
+
+        assertEquals(
+            mapOf(
+                "Authorization" to "Bearer default",
+                "X-REQUEST-ID" to "request"
+            ),
+            result
+        )
+    }
+}

--- a/http-client/http-client-java/src/main/kotlin/ai/koog/http/client/java/JavaKoogHttpClient.kt
+++ b/http-client/http-client-java/src/main/kotlin/ai/koog/http/client/java/JavaKoogHttpClient.kt
@@ -239,6 +239,64 @@ public class JavaKoogHttpClient internal constructor(
         }
     }
 
+    override fun <T : Any> lines(
+        path: String,
+        request: T,
+        requestBodyType: KClass<T>,
+        parameters: Map<String, String>
+    ): Flow<String> = callbackFlow {
+        val requestBody = prepareRequestBody(request, requestBodyType)
+
+        val httpRequest = HttpRequest.newBuilder()
+            .uri(buildUri(path, parameters))
+            .defaultHeaders()
+            .defaultTimeout()
+            .POST(HttpRequest.BodyPublishers.ofString(requestBody.body))
+            .header("Content-Type", requestBody.contentType)
+            .build()
+
+        try {
+            val response = withContext(Dispatchers.SuitableForIO) {
+                httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofLines())
+            }
+
+            if (response.statusCode() !in 200..299) {
+                close(
+                    KoogHttpClientException(
+                        clientName = clientName,
+                        statusCode = response.statusCode(),
+                    )
+                )
+                return@callbackFlow
+            }
+
+            logger.debug { "Lines flow opened for $clientName" }
+
+            response.body().forEach { line ->
+                if (line.isNotBlank()) {
+                    trySend(line)
+                }
+            }
+
+            logger.debug { "Lines flow closed for $clientName" }
+            close()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            close(
+                KoogHttpClientException(
+                    clientName = clientName,
+                    message = "Exception during streaming: ${e.message}",
+                    cause = e
+                )
+            )
+        }
+
+        awaitClose {
+            // Cleanup if needed
+        }
+    }
+
     /**
      * Common logic of preparing the request body.
      */

--- a/http-client/http-client-java/src/main/kotlin/ai/koog/http/client/java/JavaKoogHttpClient.kt
+++ b/http-client/http-client-java/src/main/kotlin/ai/koog/http/client/java/JavaKoogHttpClient.kt
@@ -2,6 +2,7 @@ package ai.koog.http.client.java
 
 import ai.koog.http.client.KoogHttpClient
 import ai.koog.http.client.KoogHttpClientException
+import ai.koog.http.client.mergeHeaders
 import ai.koog.utils.io.SuitableForIO
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -10,6 +11,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
@@ -104,7 +106,7 @@ public class JavaKoogHttpClient internal constructor(
         return "${baseUrl.trimEnd('/')}/${path.trimStart('/')}"
     }
 
-    private fun HttpRequest.Builder.defaultHeaders(): HttpRequest.Builder = apply {
+    private fun HttpRequest.Builder.headers(headers: Map<String, String>): HttpRequest.Builder = apply {
         headers.forEach { (name, value) -> header(name, value) }
     }
 
@@ -115,11 +117,12 @@ public class JavaKoogHttpClient internal constructor(
     override suspend fun <R : Any> get(
         path: String,
         responseType: KClass<R>,
-        parameters: Map<String, String>
+        parameters: Map<String, String>,
+        headers: Map<String, String>
     ): R = withContext(Dispatchers.SuitableForIO) {
         val httpRequest = HttpRequest.newBuilder()
             .uri(buildUri(path, parameters))
-            .defaultHeaders()
+            .headers(mergeHeaders(this@JavaKoogHttpClient.headers, headers))
             .defaultTimeout()
             .GET()
             .build()
@@ -134,16 +137,22 @@ public class JavaKoogHttpClient internal constructor(
         request: T,
         requestBodyType: KClass<T>,
         responseType: KClass<R>,
-        parameters: Map<String, String>
+        parameters: Map<String, String>,
+        headers: Map<String, String>
     ): R = withContext(Dispatchers.SuitableForIO) {
         val requestBody = prepareRequestBody(request, requestBodyType)
 
         val httpRequest = HttpRequest.newBuilder()
             .uri(buildUri(path, parameters))
-            .defaultHeaders()
+            .headers(
+                mergeHeaders(
+                    this@JavaKoogHttpClient.headers,
+                    mapOf("Content-Type" to requestBody.contentType),
+                    headers,
+                )
+            )
             .defaultTimeout()
             .POST(HttpRequest.BodyPublishers.ofString(requestBody.body))
-            .header("Content-Type", requestBody.contentType)
             .build()
 
         val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString())
@@ -158,18 +167,26 @@ public class JavaKoogHttpClient internal constructor(
         dataFilter: (String?) -> Boolean,
         decodeStreamingResponse: (String) -> R,
         processStreamingChunk: (R) -> O?,
-        parameters: Map<String, String>
+        parameters: Map<String, String>,
+        headers: Map<String, String>
     ): Flow<O> = callbackFlow {
         val requestBody = prepareRequestBody(request, requestBodyType)
 
         val httpRequest = HttpRequest.newBuilder()
             .uri(buildUri(path, parameters))
-            .defaultHeaders()
+            .headers(
+                mergeHeaders(
+                    this@JavaKoogHttpClient.headers,
+                    mapOf(
+                        "Content-Type" to requestBody.contentType,
+                        "Accept" to "text/event-stream",
+                        "Cache-Control" to "no-cache",
+                    ),
+                    headers,
+                )
+            )
             .defaultTimeout()
             .POST(HttpRequest.BodyPublishers.ofString(requestBody.body))
-            .header("Content-Type", requestBody.contentType)
-            .header("Accept", "text/event-stream")
-            .header("Cache-Control", "no-cache")
             // Note: "Connection" header is restricted in Java HttpClient and managed automatically
             .build()
 
@@ -243,57 +260,69 @@ public class JavaKoogHttpClient internal constructor(
         path: String,
         request: T,
         requestBodyType: KClass<T>,
-        parameters: Map<String, String>
+        parameters: Map<String, String>,
+        headers: Map<String, String>
     ): Flow<String> = callbackFlow {
         val requestBody = prepareRequestBody(request, requestBodyType)
 
         val httpRequest = HttpRequest.newBuilder()
             .uri(buildUri(path, parameters))
-            .defaultHeaders()
+            .headers(
+                mergeHeaders(
+                    this@JavaKoogHttpClient.headers,
+                    mapOf("Content-Type" to requestBody.contentType),
+                    headers,
+                )
+            )
             .defaultTimeout()
             .POST(HttpRequest.BodyPublishers.ofString(requestBody.body))
-            .header("Content-Type", requestBody.contentType)
             .build()
 
-        try {
-            val response = withContext(Dispatchers.SuitableForIO) {
-                httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofLines())
-            }
+        val responseFuture = httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofLines())
+        val readerJob = launch(Dispatchers.SuitableForIO) {
+            try {
+                val response = responseFuture.get()
+                if (response.statusCode() !in 200..299) {
+                    close(
+                        KoogHttpClientException(
+                            clientName = clientName,
+                            statusCode = response.statusCode(),
+                        )
+                    )
+                    return@launch
+                }
 
-            if (response.statusCode() !in 200..299) {
+                logger.debug { "Lines flow opened for $clientName" }
+                response.body().use { lines ->
+                    val iterator = lines.iterator()
+                    while (iterator.hasNext()) {
+                        val line = iterator.next()
+                        if (line.isBlank()) continue
+                        if (trySend(line).isClosed) {
+                            responseFuture.cancel(true)
+                            return@launch
+                        }
+                    }
+                }
+
+                logger.debug { "Lines flow closed for $clientName" }
+                close()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
                 close(
                     KoogHttpClientException(
                         clientName = clientName,
-                        statusCode = response.statusCode(),
+                        message = "Exception during streaming: ${e.message}",
+                        cause = e
                     )
                 )
-                return@callbackFlow
             }
-
-            logger.debug { "Lines flow opened for $clientName" }
-
-            response.body().forEach { line ->
-                if (line.isNotBlank()) {
-                    trySend(line)
-                }
-            }
-
-            logger.debug { "Lines flow closed for $clientName" }
-            close()
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            close(
-                KoogHttpClientException(
-                    clientName = clientName,
-                    message = "Exception during streaming: ${e.message}",
-                    cause = e
-                )
-            )
         }
 
         awaitClose {
-            // Cleanup if needed
+            responseFuture.cancel(true)
+            readerJob.cancel()
         }
     }
 

--- a/http-client/http-client-java/src/test/kotlin/ai/koog/http/client/java/JavaKoogHttpClientTestBase.kt
+++ b/http-client/http-client-java/src/test/kotlin/ai/koog/http/client/java/JavaKoogHttpClientTestBase.kt
@@ -47,6 +47,26 @@ abstract class JavaKoogHttpClientTestBase : BaseKoogHttpClientTest() {
     }
 
     @Test
+    override fun `test lines emits non-blank lines`() =
+        super.`test lines emits non-blank lines`()
+
+    @Test
+    override fun `test lines skips blank lines`() =
+        super.`test lines skips blank lines`()
+
+    @Test
+    override fun `test lines emits nothing for empty body`() =
+        super.`test lines emits nothing for empty body`()
+
+    @Test
+    override fun `test lines surfaces non-2xx as KoogHttpClientException`() =
+        super.`test lines surfaces non-2xx as KoogHttpClientException`()
+
+    @Test
+    override fun `test lines propagates cancellation`() =
+        super.`test lines propagates cancellation`()
+
+    @Test
     fun testJavaFactoryAppliesBaseUrlAndDefaultQueryParameters() = runTest {
         val mockServer = MockWebServer()
         try {

--- a/http-client/http-client-java/src/test/kotlin/ai/koog/http/client/java/JavaKoogHttpClientTestBase.kt
+++ b/http-client/http-client-java/src/test/kotlin/ai/koog/http/client/java/JavaKoogHttpClientTestBase.kt
@@ -21,6 +21,10 @@ abstract class JavaKoogHttpClientTestBase : BaseKoogHttpClientTest() {
         super.`test return success string response on post`()
 
     @Test
+    override fun `test post request headers override inferred string content type`() =
+        super.`test post request headers override inferred string content type`()
+
+    @Test
     override fun `test post JSON request and get JSON response`() =
         super.`test post JSON request and get JSON response`()
 
@@ -49,6 +53,10 @@ abstract class JavaKoogHttpClientTestBase : BaseKoogHttpClientTest() {
     @Test
     override fun `test lines emits non-blank lines`() =
         super.`test lines emits non-blank lines`()
+
+    @Test
+    override fun `test lines request headers override inferred string content type`() =
+        super.`test lines request headers override inferred string content type`()
 
     @Test
     override fun `test lines skips blank lines`() =

--- a/http-client/http-client-ktor/src/commonMain/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClient.kt
+++ b/http-client/http-client-ktor/src/commonMain/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClient.kt
@@ -20,8 +20,10 @@ import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
+import io.ktor.client.request.preparePost
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsChannel
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
@@ -35,6 +37,7 @@ import io.ktor.http.takeFrom
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.util.reflect.TypeInfo
 import io.ktor.utils.io.CancellationException
+import io.ktor.utils.io.readUTF8Line
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -187,6 +190,54 @@ public class KtorKoogHttpClient internal constructor(
                 message = e.message,
                 cause = e
             )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            throw KoogHttpClientException(
+                clientName = clientName,
+                message = "Exception during streaming: ${e.message}",
+                cause = e,
+            )
+        }
+    }
+
+    override fun <T : Any> lines(
+        path: String,
+        request: T,
+        requestBodyType: KClass<T>,
+        parameters: Map<String, String>,
+    ): Flow<String> = flow {
+        logger.debug { "Opening lines flow for $clientName" }
+
+        try {
+            ktorClient.preparePost(path) {
+                parameters.forEach { (key, value) ->
+                    parameter(key, value)
+                }
+                if (requestBodyType == String::class) {
+                    @Suppress("UNCHECKED_CAST")
+                    setBody(request as String)
+                } else {
+                    setBody(request, TypeInfo(requestBodyType))
+                }
+            }.execute { response: HttpResponse ->
+                if (!response.status.isSuccess()) {
+                    throw KoogHttpClientException(
+                        clientName = clientName,
+                        statusCode = response.status.value,
+                        errorBody = response.bodyAsText(),
+                    )
+                }
+
+                val channel = response.bodyAsChannel()
+                while (!channel.isClosedForRead) {
+                    val line = channel.readUTF8Line() ?: break
+                    if (line.isBlank()) continue
+                    emit(line)
+                }
+            }
+        } catch (e: KoogHttpClientException) {
+            throw e
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/http-client/http-client-ktor/src/commonMain/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClient.kt
+++ b/http-client/http-client-ktor/src/commonMain/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClient.kt
@@ -2,6 +2,7 @@ package ai.koog.http.client.ktor
 
 import ai.koog.http.client.KoogHttpClient
 import ai.koog.http.client.KoogHttpClientException
+import ai.koog.http.client.mergeHeaders
 import ai.koog.utils.io.SuitableForIO
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -15,7 +16,7 @@ import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.sse.SSE
 import io.ktor.client.plugins.sse.SSEClientException
 import io.ktor.client.plugins.sse.sse
-import io.ktor.client.request.accept
+import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
@@ -99,15 +100,30 @@ public class KtorKoogHttpClient internal constructor(
         )
     }
 
+    private fun HttpRequestBuilder.applyRequestHeaders(headers: Map<String, String>) {
+        headers.forEach { (name, value) ->
+            if (name.equals(HttpHeaders.ContentType, ignoreCase = true)) {
+                contentType(ContentType.parse(value))
+            } else {
+                headers {
+                    remove(name)
+                    append(name, value)
+                }
+            }
+        }
+    }
+
     override suspend fun <R : Any> get(
         path: String,
         responseType: KClass<R>,
-        parameters: Map<String, String>
+        parameters: Map<String, String>,
+        headers: Map<String, String>
     ): R = withContext(Dispatchers.SuitableForIO) {
         val response = ktorClient.get(path) {
             parameters.forEach { (key, value) ->
                 parameter(key, value)
             }
+            applyRequestHeaders(headers)
         }
         processResponse(response, responseType)
     }
@@ -117,7 +133,8 @@ public class KtorKoogHttpClient internal constructor(
         request: T,
         requestBodyType: KClass<T>,
         responseType: KClass<R>,
-        parameters: Map<String, String>
+        parameters: Map<String, String>,
+        headers: Map<String, String>
     ): R = withContext(Dispatchers.SuitableForIO) {
         val response = ktorClient.post(path) {
             if (requestBodyType == String::class) {
@@ -129,6 +146,7 @@ public class KtorKoogHttpClient internal constructor(
             parameters.forEach { (key, value) ->
                 parameter(key, value)
             }
+            applyRequestHeaders(headers)
         }
 
         processResponse(response, responseType)
@@ -142,6 +160,7 @@ public class KtorKoogHttpClient internal constructor(
         decodeStreamingResponse: (String) -> R,
         processStreamingChunk: (R) -> O?,
         parameters: Map<String, String>,
+        headers: Map<String, String>,
     ): Flow<O> = flow {
         logger.debug { "Opening sse connection for $clientName" }
 
@@ -154,11 +173,16 @@ public class KtorKoogHttpClient internal constructor(
                     parameters.forEach { (key, value) ->
                         parameter(key, value)
                     }
-                    accept(ContentType.Text.EventStream)
-                    headers {
-                        append(HttpHeaders.CacheControl, "no-cache")
-                        append(HttpHeaders.Connection, "keep-alive")
-                    }
+                    applyRequestHeaders(
+                        mergeHeaders(
+                            mapOf(
+                                HttpHeaders.Accept to ContentType.Text.EventStream.toString(),
+                                HttpHeaders.CacheControl to "no-cache",
+                                HttpHeaders.Connection to "keep-alive",
+                            ),
+                            headers,
+                        )
+                    )
                     if (requestBodyType == String::class) {
                         @Suppress("UNCHECKED_CAST")
                         setBody(request as String)
@@ -206,6 +230,7 @@ public class KtorKoogHttpClient internal constructor(
         request: T,
         requestBodyType: KClass<T>,
         parameters: Map<String, String>,
+        headers: Map<String, String>,
     ): Flow<String> = flow {
         logger.debug { "Opening lines flow for $clientName" }
 
@@ -214,6 +239,7 @@ public class KtorKoogHttpClient internal constructor(
                 parameters.forEach { (key, value) ->
                     parameter(key, value)
                 }
+                applyRequestHeaders(headers)
                 if (requestBodyType == String::class) {
                     @Suppress("UNCHECKED_CAST")
                     setBody(request as String)

--- a/http-client/http-client-ktor/src/jvmTest/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClientTestBase.kt
+++ b/http-client/http-client-ktor/src/jvmTest/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClientTestBase.kt
@@ -35,6 +35,10 @@ abstract class KtorKoogHttpClientTestBase : BaseKoogHttpClientTest() {
         super.`test return success string response on post`()
 
     @Test
+    override fun `test post request headers override inferred string content type`() =
+        super.`test post request headers override inferred string content type`()
+
+    @Test
     override fun `test post JSON request and get JSON response`() =
         super.`test post JSON request and get JSON response`()
 
@@ -63,6 +67,10 @@ abstract class KtorKoogHttpClientTestBase : BaseKoogHttpClientTest() {
     @Test
     override fun `test lines emits non-blank lines`() =
         super.`test lines emits non-blank lines`()
+
+    @Test
+    override fun `test lines request headers override inferred string content type`() =
+        super.`test lines request headers override inferred string content type`()
 
     @Test
     override fun `test lines skips blank lines`() =

--- a/http-client/http-client-ktor/src/jvmTest/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClientTestBase.kt
+++ b/http-client/http-client-ktor/src/jvmTest/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClientTestBase.kt
@@ -60,6 +60,26 @@ abstract class KtorKoogHttpClientTestBase : BaseKoogHttpClientTest() {
         super.`test return success string response on post with parameters`()
     }
 
+    @Test
+    override fun `test lines emits non-blank lines`() =
+        super.`test lines emits non-blank lines`()
+
+    @Test
+    override fun `test lines skips blank lines`() =
+        super.`test lines skips blank lines`()
+
+    @Test
+    override fun `test lines emits nothing for empty body`() =
+        super.`test lines emits nothing for empty body`()
+
+    @Test
+    override fun `test lines surfaces non-2xx as KoogHttpClientException`() =
+        super.`test lines surfaces non-2xx as KoogHttpClientException`()
+
+    @Test
+    override fun `test lines propagates cancellation`() =
+        super.`test lines propagates cancellation`()
+
     abstract fun ktorClient(
         baseClient: HttpClient,
         baseUrl: String = "",

--- a/http-client/http-client-okhttp/src/main/kotlin/ai/koog/http/client/okhttp/OkHttpKoogHttpClient.kt
+++ b/http-client/http-client-okhttp/src/main/kotlin/ai/koog/http/client/okhttp/OkHttpKoogHttpClient.kt
@@ -2,6 +2,7 @@ package ai.koog.http.client.okhttp
 
 import ai.koog.http.client.KoogHttpClient
 import ai.koog.http.client.KoogHttpClientException
+import ai.koog.http.client.mergeHeaders
 import ai.koog.utils.io.SuitableForIO
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -10,10 +11,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
-import okhttp3.Headers
 import okhttp3.Headers.Companion.toHeaders
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -52,7 +53,10 @@ public class OkHttpKoogHttpClient internal constructor(
     private val queryParameters: Map<String, String> = emptyMap(),
 ) : KoogHttpClient {
 
-    private val defaultHeaders: Headers = headers.toHeaders()
+    private val defaultHeaders: Map<String, String> = headers
+
+    private fun Map<String, String>.headerValue(name: String): String? =
+        entries.firstOrNull { (key, _) -> key.equals(name, ignoreCase = true) }?.value
 
     private fun <R : Any> processResponse(response: Response, responseType: KClass<R>): R {
         if (response.isSuccessful) {
@@ -99,11 +103,12 @@ public class OkHttpKoogHttpClient internal constructor(
     override suspend fun <R : Any> get(
         path: String,
         responseType: KClass<R>,
-        parameters: Map<String, String>
+        parameters: Map<String, String>,
+        headers: Map<String, String>
     ): R = withContext(Dispatchers.SuitableForIO) {
         val httpRequest = Request.Builder()
             .url(buildUrl(path, parameters))
-            .headers(defaultHeaders)
+            .headers(mergeHeaders(defaultHeaders, headers).toHeaders())
             .get()
             .build()
 
@@ -118,13 +123,20 @@ public class OkHttpKoogHttpClient internal constructor(
         request: T,
         requestBodyType: KClass<T>,
         responseType: KClass<R>,
-        parameters: Map<String, String>
+        parameters: Map<String, String>,
+        headers: Map<String, String>
     ): R = withContext(Dispatchers.SuitableForIO) {
-        val requestBody = prepareRequestBody(request, requestBodyType)
+        val requestBody = prepareRequestBody(request, requestBodyType, headers.headerValue("Content-Type"))
 
         val httpRequest = Request.Builder()
             .url(buildUrl(path, parameters))
-            .headers(defaultHeaders)
+            .headers(
+                mergeHeaders(
+                    defaultHeaders,
+                    mapOf("Content-Type" to requestBody.contentType().toString()),
+                    headers,
+                ).toHeaders()
+            )
             .post(requestBody)
             .build()
 
@@ -142,17 +154,27 @@ public class OkHttpKoogHttpClient internal constructor(
         dataFilter: (String?) -> Boolean,
         decodeStreamingResponse: (String) -> R,
         processStreamingChunk: (R) -> O?,
-        parameters: Map<String, String>
+        parameters: Map<String, String>,
+        headers: Map<String, String>
     ): Flow<O> = callbackFlow {
-        val requestBody = prepareRequestBody(request, requestBodyType)
+        val requestBody = prepareRequestBody(request, requestBodyType, headers.headerValue("Content-Type"))
 
         val httpRequest = Request.Builder()
             .url(buildUrl(path, parameters))
-            .headers(defaultHeaders)
+            .headers(
+                mergeHeaders(
+                    defaultHeaders,
+                    mapOf(
+                        "Content-Type" to requestBody.contentType().toString(),
+                        "Accept" to "text/event-stream",
+                        "Cache-Control" to "no-cache",
+                        "Connection" to "keep-alive",
+                    ),
+                    headers,
+                )
+                    .toHeaders()
+            )
             .post(requestBody)
-            .header("Accept", "text/event-stream")
-            .header("Cache-Control", "no-cache")
-            .header("Connection", "keep-alive")
             .build()
 
         val eventSourceListener = object : EventSourceListener() {
@@ -208,20 +230,27 @@ public class OkHttpKoogHttpClient internal constructor(
         path: String,
         request: T,
         requestBodyType: KClass<T>,
-        parameters: Map<String, String>
+        parameters: Map<String, String>,
+        headers: Map<String, String>
     ): Flow<String> = callbackFlow {
-        val requestBody = prepareRequestBody(request, requestBodyType)
+        val requestBody = prepareRequestBody(request, requestBodyType, headers.headerValue("Content-Type"))
 
         val httpRequest = Request.Builder()
             .url(buildUrl(path, parameters))
-            .headers(defaultHeaders)
+            .headers(
+                mergeHeaders(
+                    defaultHeaders,
+                    mapOf("Content-Type" to requestBody.contentType().toString()),
+                    headers,
+                ).toHeaders()
+            )
             .post(requestBody)
             .build()
 
         val call = okHttpClient.newCall(httpRequest)
 
-        try {
-            withContext(Dispatchers.SuitableForIO) {
+        val readerJob = launch(Dispatchers.SuitableForIO) {
+            try {
                 val response: Response = call.execute()
 
                 if (!response.isSuccessful) {
@@ -234,7 +263,7 @@ public class OkHttpKoogHttpClient internal constructor(
                             errorBody = errorBody,
                         )
                     )
-                    return@withContext
+                    return@launch
                 }
 
                 logger.debug { "Lines flow opened for $clientName" }
@@ -243,26 +272,30 @@ public class OkHttpKoogHttpClient internal constructor(
                     while (!source.exhausted()) {
                         val line = source.readUtf8Line() ?: break
                         if (line.isBlank()) continue
-                        trySend(line)
+                        if (trySend(line).isClosed) {
+                            call.cancel()
+                            return@launch
+                        }
                     }
                 }
                 logger.debug { "Lines flow closed for $clientName" }
                 close()
-            }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            close(
-                KoogHttpClientException(
-                    clientName = clientName,
-                    message = "Exception during streaming: ${e.message}",
-                    cause = e
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                close(
+                    KoogHttpClientException(
+                        clientName = clientName,
+                        message = "Exception during streaming: ${e.message}",
+                        cause = e
+                    )
                 )
-            )
+            }
         }
 
         awaitClose {
             call.cancel()
+            readerJob.cancel()
         }
     }
 
@@ -272,14 +305,15 @@ public class OkHttpKoogHttpClient internal constructor(
     private fun <T : Any> prepareRequestBody(
         request: T,
         requestBodyType: KClass<T>,
+        contentType: String? = null,
     ): RequestBody {
         return if (requestBodyType == String::class) {
             @Suppress("UNCHECKED_CAST")
-            (request as String).toRequestBody("text/plain".toMediaType())
+            (request as String).toRequestBody((contentType ?: "text/plain").toMediaType())
         } else {
             val serializer = serializer(requestBodyType.java)
             val jsonString = json.encodeToString(serializer, request)
-            jsonString.toRequestBody("application/json".toMediaType())
+            jsonString.toRequestBody((contentType ?: "application/json").toMediaType())
         }
     }
 

--- a/http-client/http-client-okhttp/src/main/kotlin/ai/koog/http/client/okhttp/OkHttpKoogHttpClient.kt
+++ b/http-client/http-client-okhttp/src/main/kotlin/ai/koog/http/client/okhttp/OkHttpKoogHttpClient.kt
@@ -5,6 +5,7 @@ import ai.koog.http.client.KoogHttpClientException
 import ai.koog.utils.io.SuitableForIO
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -200,6 +201,68 @@ public class OkHttpKoogHttpClient internal constructor(
 
         awaitClose {
             eventSource.cancel()
+        }
+    }
+
+    override fun <T : Any> lines(
+        path: String,
+        request: T,
+        requestBodyType: KClass<T>,
+        parameters: Map<String, String>
+    ): Flow<String> = callbackFlow {
+        val requestBody = prepareRequestBody(request, requestBodyType)
+
+        val httpRequest = Request.Builder()
+            .url(buildUrl(path, parameters))
+            .headers(defaultHeaders)
+            .post(requestBody)
+            .build()
+
+        val call = okHttpClient.newCall(httpRequest)
+
+        try {
+            withContext(Dispatchers.SuitableForIO) {
+                val response: Response = call.execute()
+
+                if (!response.isSuccessful) {
+                    val errorBody = response.body.string()
+                    response.close()
+                    close(
+                        KoogHttpClientException(
+                            clientName = clientName,
+                            statusCode = response.code,
+                            errorBody = errorBody,
+                        )
+                    )
+                    return@withContext
+                }
+
+                logger.debug { "Lines flow opened for $clientName" }
+                response.use {
+                    val source = response.body.source()
+                    while (!source.exhausted()) {
+                        val line = source.readUtf8Line() ?: break
+                        if (line.isBlank()) continue
+                        trySend(line)
+                    }
+                }
+                logger.debug { "Lines flow closed for $clientName" }
+                close()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            close(
+                KoogHttpClientException(
+                    clientName = clientName,
+                    message = "Exception during streaming: ${e.message}",
+                    cause = e
+                )
+            )
+        }
+
+        awaitClose {
+            call.cancel()
         }
     }
 

--- a/http-client/http-client-okhttp/src/test/kotlin/ai/koog/http/client/okhttp/OkHttpKoogHttpClientTestBase.kt
+++ b/http-client/http-client-okhttp/src/test/kotlin/ai/koog/http/client/okhttp/OkHttpKoogHttpClientTestBase.kt
@@ -47,6 +47,26 @@ abstract class OkHttpKoogHttpClientTestBase : BaseKoogHttpClientTest() {
     }
 
     @Test
+    override fun `test lines emits non-blank lines`() =
+        super.`test lines emits non-blank lines`()
+
+    @Test
+    override fun `test lines skips blank lines`() =
+        super.`test lines skips blank lines`()
+
+    @Test
+    override fun `test lines emits nothing for empty body`() =
+        super.`test lines emits nothing for empty body`()
+
+    @Test
+    override fun `test lines surfaces non-2xx as KoogHttpClientException`() =
+        super.`test lines surfaces non-2xx as KoogHttpClientException`()
+
+    @Test
+    override fun `test lines propagates cancellation`() =
+        super.`test lines propagates cancellation`()
+
+    @Test
     fun testOkHttpFactoryAppliesBaseUrlAndDefaultQueryParameters() = runTest {
         val mockServer = MockWebServer()
         try {

--- a/http-client/http-client-okhttp/src/test/kotlin/ai/koog/http/client/okhttp/OkHttpKoogHttpClientTestBase.kt
+++ b/http-client/http-client-okhttp/src/test/kotlin/ai/koog/http/client/okhttp/OkHttpKoogHttpClientTestBase.kt
@@ -17,6 +17,10 @@ abstract class OkHttpKoogHttpClientTestBase : BaseKoogHttpClientTest() {
         super.`test return success string response on post`()
 
     @Test
+    override fun `test post request headers override inferred string content type`() =
+        super.`test post request headers override inferred string content type`()
+
+    @Test
     override fun `test return success string response on get`() =
         super.`test return success string response on get`()
 
@@ -49,6 +53,10 @@ abstract class OkHttpKoogHttpClientTestBase : BaseKoogHttpClientTest() {
     @Test
     override fun `test lines emits non-blank lines`() =
         super.`test lines emits non-blank lines`()
+
+    @Test
+    override fun `test lines request headers override inferred string content type`() =
+        super.`test lines request headers override inferred string content type`()
 
     @Test
     override fun `test lines skips blank lines`() =

--- a/http-client/http-client-test/src/main/kotlin/ai/koog/http/client/test/BaseKoogHttpClientTest.kt
+++ b/http-client/http-client-test/src/main/kotlin/ai/koog/http/client/test/BaseKoogHttpClientTest.kt
@@ -6,13 +6,20 @@ import ai.koog.http.client.get
 import ai.koog.http.client.lines
 import ai.koog.http.client.post
 import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.Serializable
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.assertThrows
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.test.fail
@@ -68,6 +75,33 @@ abstract class BaseKoogHttpClientTest {
         val result: String = client.post(
             path = mockServer.url("/echo"),
             request = "PAYLOAD"
+        )
+
+        assertEquals(responseBody, result)
+    }
+
+    @Suppress("FunctionName")
+    open fun `test post request headers override inferred string content type`(): Unit = runTest {
+        val responseBody = "RESPONSE_OK"
+
+        mockServer.start(
+            postEndpoints = listOf(
+                MockWebServer.PostEndpointConfig(
+                    path = "/echo",
+                    responseBody = responseBody,
+                    statusCode = HttpStatusCode.OK,
+                    contentType = ContentType.Text.Plain,
+                    expectedHeaders = mapOf(HttpHeaders.ContentType to ContentType.Application.Json.toString())
+                )
+            )
+        )
+
+        val client = createClient()
+
+        val result: String = client.post(
+            path = mockServer.url("/echo"),
+            request = "{}",
+            headers = mapOf(HttpHeaders.ContentType to ContentType.Application.Json.toString())
         )
 
         assertEquals(responseBody, result)
@@ -244,8 +278,8 @@ abstract class BaseKoogHttpClientTest {
         val lines = listOf("""{"i":1}""", """{"i":2}""", """{"i":3}""")
 
         mockServer.start(
-            streamEndpoints = listOf(
-                MockWebServer.StreamEndpointConfig(
+            linesEndpoints = listOf(
+                MockWebServer.LinesEndpointConfig(
                     path = "/stream",
                     lines = lines
                 )
@@ -263,12 +297,37 @@ abstract class BaseKoogHttpClientTest {
     }
 
     @Suppress("FunctionName")
+    open fun `test lines request headers override inferred string content type`(): Unit = runTest {
+        val lines = listOf("""{"i":1}""")
+
+        mockServer.start(
+            linesEndpoints = listOf(
+                MockWebServer.LinesEndpointConfig(
+                    path = "/stream",
+                    lines = lines,
+                    expectedHeaders = mapOf(HttpHeaders.ContentType to ContentType.Application.Json.toString())
+                )
+            )
+        )
+
+        val client = createClient()
+
+        val collected = client.lines(
+            path = mockServer.url("/stream"),
+            request = "{}",
+            headers = mapOf(HttpHeaders.ContentType to ContentType.Application.Json.toString())
+        ).toList()
+
+        assertEquals(lines, collected)
+    }
+
+    @Suppress("FunctionName")
     open fun `test lines skips blank lines`(): Unit = runTest {
         val lines = listOf("""{"i":1}""", "", "   ", """{"i":2}""")
 
         mockServer.start(
-            streamEndpoints = listOf(
-                MockWebServer.StreamEndpointConfig(
+            linesEndpoints = listOf(
+                MockWebServer.LinesEndpointConfig(
                     path = "/stream",
                     lines = lines
                 )
@@ -288,8 +347,8 @@ abstract class BaseKoogHttpClientTest {
     @Suppress("FunctionName")
     open fun `test lines emits nothing for empty body`(): Unit = runTest {
         mockServer.start(
-            streamEndpoints = listOf(
-                MockWebServer.StreamEndpointConfig(
+            linesEndpoints = listOf(
+                MockWebServer.LinesEndpointConfig(
                     path = "/stream",
                     lines = emptyList()
                 )
@@ -309,8 +368,8 @@ abstract class BaseKoogHttpClientTest {
     @Suppress("FunctionName")
     open fun `test lines surfaces non-2xx as KoogHttpClientException`(): Unit = runTest {
         mockServer.start(
-            streamEndpoints = listOf(
-                MockWebServer.StreamEndpointConfig(
+            linesEndpoints = listOf(
+                MockWebServer.LinesEndpointConfig(
                     path = "/stream",
                     lines = listOf("ignored"),
                     statusCode = HttpStatusCode.BadRequest,
@@ -321,40 +380,56 @@ abstract class BaseKoogHttpClientTest {
 
         val client = createClient()
 
-        try {
+        val failure = assertThrows<KoogHttpClientException> {
             client.lines(
                 path = mockServer.url("/stream"),
                 request = "{}"
             ).toList()
-            fail("Expected KoogHttpClientException for non-2xx response")
-        } catch (e: KoogHttpClientException) {
-            assertEquals("TestClient", e.clientName)
-            assertEquals(400, e.statusCode)
         }
+        assertEquals(client.clientName, failure.clientName)
+        assertEquals(400, failure.statusCode)
     }
 
     @Suppress("FunctionName")
     open fun `test lines propagates cancellation`(): Unit = runTest {
-        val lines = List(100) { """{"i":$it}""" }
+        // Given: server that emits up to 1000 lines
+        val totalLines = 1_000
+        val lines = List(totalLines) { """{"i":$it}""" }
+        val writtenLines = AtomicInteger(0)
+        val streamClosed = CompletableDeferred<Unit>()
 
         mockServer.start(
-            streamEndpoints = listOf(
-                MockWebServer.StreamEndpointConfig(
+            linesEndpoints = listOf(
+                MockWebServer.LinesEndpointConfig(
                     path = "/stream",
-                    lines = lines
+                    lines = lines,
+                    lineDelayMillis = 20,
+                    onLineWritten = { writtenLines.incrementAndGet() },
+                    onStreamClosed = { streamClosed.complete(Unit) }
                 )
             )
         )
 
+        // And: client
         val client = createClient()
 
+        // When: client collects only the first 3 lines, causing upstream cancellation
         val collected = client.lines(
             path = mockServer.url("/stream"),
             request = "{}"
         ).take(3).toList()
 
+        // Then: client received correct lines
         assertEquals(3, collected.size)
         assertEquals(lines.take(3), collected)
+
+        // And: server observes stream closure before writing all lines
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            withTimeout(2_000) {
+                streamClosed.await()
+            }
+        }
+        assertTrue(writtenLines.get() < totalLines)
     }
 
     @Suppress("FunctionName")

--- a/http-client/http-client-test/src/main/kotlin/ai/koog/http/client/test/BaseKoogHttpClientTest.kt
+++ b/http-client/http-client-test/src/main/kotlin/ai/koog/http/client/test/BaseKoogHttpClientTest.kt
@@ -3,15 +3,18 @@ package ai.koog.http.client.test
 import ai.koog.http.client.KoogHttpClient
 import ai.koog.http.client.KoogHttpClientException
 import ai.koog.http.client.get
+import ai.koog.http.client.lines
 import ai.koog.http.client.post
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlin.test.fail
 
 /**
@@ -234,6 +237,124 @@ abstract class BaseKoogHttpClientTest {
         )
 
         assertEquals(responseBody, result)
+    }
+
+    @Suppress("FunctionName")
+    open fun `test lines emits non-blank lines`(): Unit = runTest {
+        val lines = listOf("""{"i":1}""", """{"i":2}""", """{"i":3}""")
+
+        mockServer.start(
+            streamEndpoints = listOf(
+                MockWebServer.StreamEndpointConfig(
+                    path = "/stream",
+                    lines = lines
+                )
+            )
+        )
+
+        val client = createClient()
+
+        val collected = client.lines(
+            path = mockServer.url("/stream"),
+            request = "{}"
+        ).toList()
+
+        assertEquals(lines, collected)
+    }
+
+    @Suppress("FunctionName")
+    open fun `test lines skips blank lines`(): Unit = runTest {
+        val lines = listOf("""{"i":1}""", "", "   ", """{"i":2}""")
+
+        mockServer.start(
+            streamEndpoints = listOf(
+                MockWebServer.StreamEndpointConfig(
+                    path = "/stream",
+                    lines = lines
+                )
+            )
+        )
+
+        val client = createClient()
+
+        val collected = client.lines(
+            path = mockServer.url("/stream"),
+            request = "{}"
+        ).toList()
+
+        assertEquals(listOf("""{"i":1}""", """{"i":2}"""), collected)
+    }
+
+    @Suppress("FunctionName")
+    open fun `test lines emits nothing for empty body`(): Unit = runTest {
+        mockServer.start(
+            streamEndpoints = listOf(
+                MockWebServer.StreamEndpointConfig(
+                    path = "/stream",
+                    lines = emptyList()
+                )
+            )
+        )
+
+        val client = createClient()
+
+        val collected = client.lines(
+            path = mockServer.url("/stream"),
+            request = "{}"
+        ).toList()
+
+        assertTrue(collected.isEmpty())
+    }
+
+    @Suppress("FunctionName")
+    open fun `test lines surfaces non-2xx as KoogHttpClientException`(): Unit = runTest {
+        mockServer.start(
+            streamEndpoints = listOf(
+                MockWebServer.StreamEndpointConfig(
+                    path = "/stream",
+                    lines = listOf("ignored"),
+                    statusCode = HttpStatusCode.BadRequest,
+                    contentType = ContentType.Text.Plain
+                )
+            )
+        )
+
+        val client = createClient()
+
+        try {
+            client.lines(
+                path = mockServer.url("/stream"),
+                request = "{}"
+            ).toList()
+            fail("Expected KoogHttpClientException for non-2xx response")
+        } catch (e: KoogHttpClientException) {
+            assertEquals("TestClient", e.clientName)
+            assertEquals(400, e.statusCode)
+        }
+    }
+
+    @Suppress("FunctionName")
+    open fun `test lines propagates cancellation`(): Unit = runTest {
+        val lines = List(100) { """{"i":$it}""" }
+
+        mockServer.start(
+            streamEndpoints = listOf(
+                MockWebServer.StreamEndpointConfig(
+                    path = "/stream",
+                    lines = lines
+                )
+            )
+        )
+
+        val client = createClient()
+
+        val collected = client.lines(
+            path = mockServer.url("/stream"),
+            request = "{}"
+        ).take(3).toList()
+
+        assertEquals(3, collected.size)
+        assertEquals(lines.take(3), collected)
     }
 
     @Suppress("FunctionName")

--- a/http-client/http-client-test/src/main/kotlin/ai/koog/http/client/test/MockWebServer.kt
+++ b/http-client/http-client-test/src/main/kotlin/ai/koog/http/client/test/MockWebServer.kt
@@ -12,6 +12,7 @@ import io.ktor.server.request.receiveText
 import io.ktor.server.response.header
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
+import io.ktor.server.response.respondTextWriter
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
@@ -63,12 +64,24 @@ class MockWebServer {
     )
 
     /**
+     * Configuration for a mock chunked-stream endpoint that emits newline-delimited lines over plain POST.
+     */
+    data class StreamEndpointConfig(
+        val path: String,
+        val lines: List<String>,
+        val statusCode: HttpStatusCode = HttpStatusCode.OK,
+        val contentType: ContentType = ContentType.Application.Json,
+        val expectedParameters: Map<String, String> = emptyMap()
+    )
+
+    /**
      * Starts the server with the specified endpoint configurations
      */
     fun start(
         getEndpoints: List<GetEndpointConfig> = emptyList(),
         postEndpoints: List<PostEndpointConfig> = emptyList(),
         sseEndpoints: List<SSEEndpointConfig> = emptyList(),
+        streamEndpoints: List<StreamEndpointConfig> = emptyList(),
         port: Int = 0
     ) {
         require(
@@ -129,6 +142,34 @@ class MockWebServer {
                             contentType = config.contentType,
                             status = config.statusCode
                         )
+                    }
+                }
+
+                // Configure chunked-stream endpoints for POST requests (newline-delimited body)
+                streamEndpoints.forEach { config ->
+                    post(config.path) {
+                        call.receiveText()
+                        val actualParameters = call.request.queryParameters
+
+                        config.expectedParameters.forEach { (key, expectedValue) ->
+                            val actualValue = actualParameters[key]
+                            if (actualValue != expectedValue) {
+                                call.respondText(
+                                    text = "Parameter mismatch: expected $key=$expectedValue, got $key=$actualValue",
+                                    status = HttpStatusCode.BadRequest
+                                )
+                                return@post
+                            }
+                        }
+
+                        call.respondTextWriter(contentType = config.contentType, status = config.statusCode) {
+                            config.lines.forEach { line ->
+                                write(line)
+                                write("\n")
+                                flush()
+                                delay(10)
+                            }
+                        }
                     }
                 }
 

--- a/http-client/http-client-test/src/main/kotlin/ai/koog/http/client/test/MockWebServer.kt
+++ b/http-client/http-client-test/src/main/kotlin/ai/koog/http/client/test/MockWebServer.kt
@@ -52,7 +52,8 @@ class MockWebServer {
         val responseBody: String,
         val statusCode: HttpStatusCode = HttpStatusCode.OK,
         val contentType: ContentType = ContentType.Text.Plain,
-        val expectedParameters: Map<String, String> = emptyMap()
+        val expectedParameters: Map<String, String> = emptyMap(),
+        val expectedHeaders: Map<String, String> = emptyMap()
     )
 
     /**
@@ -66,12 +67,16 @@ class MockWebServer {
     /**
      * Configuration for a mock chunked-stream endpoint that emits newline-delimited lines over plain POST.
      */
-    data class StreamEndpointConfig(
+    data class LinesEndpointConfig(
         val path: String,
         val lines: List<String>,
         val statusCode: HttpStatusCode = HttpStatusCode.OK,
         val contentType: ContentType = ContentType.Application.Json,
-        val expectedParameters: Map<String, String> = emptyMap()
+        val expectedParameters: Map<String, String> = emptyMap(),
+        val expectedHeaders: Map<String, String> = emptyMap(),
+        val lineDelayMillis: Long = 10,
+        val onLineWritten: (Int) -> Unit = {},
+        val onStreamClosed: () -> Unit = {},
     )
 
     /**
@@ -81,7 +86,7 @@ class MockWebServer {
         getEndpoints: List<GetEndpointConfig> = emptyList(),
         postEndpoints: List<PostEndpointConfig> = emptyList(),
         sseEndpoints: List<SSEEndpointConfig> = emptyList(),
-        streamEndpoints: List<StreamEndpointConfig> = emptyList(),
+        linesEndpoints: List<LinesEndpointConfig> = emptyList(),
         port: Int = 0
     ) {
         require(
@@ -137,6 +142,17 @@ class MockWebServer {
                             }
                         }
 
+                        config.expectedHeaders.forEach { (key, expectedValue) ->
+                            val actualValue = call.request.headers[key]
+                            if (actualValue?.startsWith(expectedValue, ignoreCase = true) != true) {
+                                call.respondText(
+                                    text = "Header mismatch: expected $key=$expectedValue, got $key=$actualValue",
+                                    status = HttpStatusCode.BadRequest
+                                )
+                                return@post
+                            }
+                        }
+
                         call.respondText(
                             text = config.responseBody,
                             contentType = config.contentType,
@@ -145,8 +161,8 @@ class MockWebServer {
                     }
                 }
 
-                // Configure chunked-stream endpoints for POST requests (newline-delimited body)
-                streamEndpoints.forEach { config ->
+                // Configure line stream endpoints for POST requests (newline-delimited body)
+                linesEndpoints.forEach { config ->
                     post(config.path) {
                         call.receiveText()
                         val actualParameters = call.request.queryParameters
@@ -162,12 +178,28 @@ class MockWebServer {
                             }
                         }
 
+                        config.expectedHeaders.forEach { (key, expectedValue) ->
+                            val actualValue = call.request.headers[key]
+                            if (actualValue?.startsWith(expectedValue, ignoreCase = true) != true) {
+                                call.respondText(
+                                    text = "Header mismatch: expected $key=$expectedValue, got $key=$actualValue",
+                                    status = HttpStatusCode.BadRequest
+                                )
+                                return@post
+                            }
+                        }
+
                         call.respondTextWriter(contentType = config.contentType, status = config.statusCode) {
-                            config.lines.forEach { line ->
-                                write(line)
-                                write("\n")
-                                flush()
-                                delay(10)
+                            try {
+                                config.lines.forEachIndexed { index, line ->
+                                    write(line)
+                                    write("\n")
+                                    flush()
+                                    config.onLineWritten(index)
+                                    delay(config.lineDelayMillis)
+                                }
+                            } finally {
+                                config.onStreamClosed()
                             }
                         }
                     }

--- a/koog-ktor/src/commonMain/kotlin/ai/koog/ktor/KoogAgentsConfig.kt
+++ b/koog-ktor/src/commonMain/kotlin/ai/koog/ktor/KoogAgentsConfig.kt
@@ -870,7 +870,7 @@ public class KoogAgentsConfig(private val scope: CoroutineScope) {
     public class OllamaConfig {
         /**
          * The base URL for the Ollama API, used as the endpoint for all HTTP requests made
-         * by the Ollama client. By default, it is set to `[OllamaClient.baseUrl]`.
+         * by the Ollama client. By default, it is set to `[OllamaClient.DEFAULT_BASE_URL]`.
          *
          * This property can be configured to point to a custom server or different instance
          * of the Ollama service, depending on the deployment or development needs.
@@ -1071,10 +1071,9 @@ public class KoogAgentsConfig(private val scope: CoroutineScope) {
     internal fun ollama(configure: OllamaConfig.() -> Unit) {
         val client = with(OllamaConfig()) {
             configure()
-            val defaults = OllamaClient()
 
             OllamaClient(
-                baseUrl = baseUrl ?: defaults.baseUrl,
+                baseUrl = baseUrl ?: OllamaClient.DEFAULT_BASE_URL,
                 baseClient = httpClient,
                 timeoutConfig = timeoutConfig ?: ConnectionTimeoutConfig()
             )

--- a/koog-spring-boot-starter/src/test/kotlin/ai/koog/spring/KoogAutoConfigurationTest.kt
+++ b/koog-spring-boot-starter/src/test/kotlin/ai/koog/spring/KoogAutoConfigurationTest.kt
@@ -17,6 +17,7 @@ import ai.koog.prompt.executor.clients.retry.RetryingLLMClient
 import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
 import ai.koog.prompt.executor.ollama.client.OllamaClient
+import ai.koog.prompt.executor.ollama.client.OllamaModels
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.spring.prompt.executor.MultiLLMAutoConfiguration
 import ai.koog.spring.prompt.executor.clients.anthropic.AnthropicLLMAutoConfiguration
@@ -609,21 +610,58 @@ class KoogAutoConfigurationTest {
     }
 
     @Test
-    fun `should supply Ollama executor bean with provided baseUrl`() {
-        val configBaseUrl = "https://some-url.com"
-        createApplicationContextRunner().withPropertyValues(
-            "ai.koog.ollama.enabled=true",
-            "ai.koog.ollama.base-url=$configBaseUrl"
-        )
-            .run { context ->
-                val executor = context.getBean<MultiLLMPromptExecutor>()
-                val llmClient = getLlmClient(executor, "ollama")
-                assertInstanceOf<OllamaClient>(llmClient)
+    fun `should send Ollama request with configured baseUrl`() {
+        val requestPath = AtomicReference<String>()
+        val requestBody = AtomicReference<String>()
+        val server = HttpServer.create(InetSocketAddress(0), 0).apply {
+            createContext("/api/chat") { exchange ->
+                requestPath.set(exchange.requestURI.toString())
+                requestBody.set(exchange.requestBody.reader().readText())
 
-                val baseUrl = getPrivateFieldValue(llmClient, "baseUrl")
+                val response = """
+                    {
+                      "model": "llama3.2:latest",
+                      "message": {
+                        "role": "assistant",
+                        "content": "Ollama says hi"
+                      },
+                      "done": true,
+                      "prompt_eval_count": 4,
+                      "eval_count": 5
+                    }
+                """.trimIndent().toByteArray()
 
-                assertEquals(configBaseUrl, baseUrl)
+                exchange.responseHeaders.add("Content-Type", "application/json")
+                exchange.sendResponseHeaders(200, response.size.toLong())
+                exchange.responseBody.use { it.write(response) }
             }
+            start()
+        }
+
+        try {
+            createApplicationContextRunner().withPropertyValues(
+                "ai.koog.ollama.enabled=true",
+                "ai.koog.ollama.base-url=http://localhost:${server.address.port}",
+            )
+                .run { context ->
+                    val executor = context.getBean<MultiLLMPromptExecutor>()
+                    val llmClient = getLlmClient(executor, "ollama")
+                    assertInstanceOf<OllamaClient>(llmClient)
+
+                    val responses = runBlocking {
+                        executor.execute(
+                            prompt = prompt("spring-ollama-test") { user("Hello from Spring?") },
+                            model = OllamaModels.Meta.LLAMA_3_2,
+                        )
+                    }
+
+                    assertEquals("/api/chat", requestPath.get())
+                    assertTrue(requestBody.get().contains("Hello from Spring?"))
+                    assertEquals("Ollama says hi", responses.single().content)
+                }
+        } finally {
+            server.stop(0)
+        }
     }
 
     @Test

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
@@ -590,6 +590,13 @@ class GoogleLLMClientTest {
                 return if (chunk != null) flowOf(chunk) else emptyFlow()
             }
 
+            override fun <T : Any> lines(
+                path: String,
+                request: T,
+                requestBodyType: KClass<T>,
+                parameters: Map<String, String>,
+            ): Flow<String> = error("lines is not expected in this test")
+
             override fun close(): Unit = Unit
         }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
@@ -544,6 +544,7 @@ class GoogleLLMClientTest {
                 path: String,
                 responseType: KClass<R>,
                 parameters: Map<String, String>,
+                headers: Map<String, String>,
             ): R = error("GET is not expected in this test")
 
             override suspend fun <T : Any, R : Any> post(
@@ -552,6 +553,7 @@ class GoogleLLMClientTest {
                 requestBodyType: KClass<T>,
                 responseType: KClass<R>,
                 parameters: Map<String, String>,
+                headers: Map<String, String>,
             ): R = error("POST is not expected in this test")
 
             override fun <T : Any, R : Any, O : Any> sse(
@@ -562,6 +564,7 @@ class GoogleLLMClientTest {
                 decodeStreamingResponse: (String) -> R,
                 processStreamingChunk: (R) -> O?,
                 parameters: Map<String, String>,
+                headers: Map<String, String>,
             ): Flow<O> {
                 path shouldBe "v1beta/models/${model.id}:streamGenerateContent"
                 request.shouldBeInstanceOf<GoogleRequest>()
@@ -595,6 +598,7 @@ class GoogleLLMClientTest {
                 request: T,
                 requestBodyType: KClass<T>,
                 parameters: Map<String, String>,
+                headers: Map<String, String>,
             ): Flow<String> = error("lines is not expected in this test")
 
             override fun close(): Unit = Unit

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
             dependencies {
                 api(project(":agents:agents-tools"))
                 api(project(":http-client:http-client-core"))
+                api(project(":http-client:http-client-ktor"))
                 api(project(":prompt:prompt-llm"))
                 api(project(":prompt:prompt-model"))
                 api(project(":prompt:prompt-tokenizer"))
@@ -18,10 +19,8 @@ kotlin {
                 api(project(":prompt:prompt-executor:prompt-executor-clients"))
                 api(project(":embeddings:embeddings-base"))
 
-                api(libs.ktor.client.logging)
                 api(libs.kotlinx.coroutines.core)
-                api(libs.ktor.client.content.negotiation)
-                api(libs.ktor.serialization.kotlinx.json)
+                api(libs.ktor.client.core)
                 implementation(libs.oshai.kotlin.logging)
             }
         }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -2,7 +2,12 @@ package ai.koog.prompt.executor.ollama.client
 
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.serialization.ToolDescriptorSchemaGenerator
+import ai.koog.http.client.KoogHttpClient
 import ai.koog.http.client.KoogHttpClientException
+import ai.koog.http.client.get
+import ai.koog.http.client.ktor.KtorKoogHttpClient
+import ai.koog.http.client.lines
+import ai.koog.http.client.post
 import ai.koog.prompt.dsl.ModerationCategory
 import ai.koog.prompt.dsl.ModerationCategoryResult
 import ai.koog.prompt.dsl.ModerationResult
@@ -41,23 +46,6 @@ import ai.koog.prompt.streaming.buildStreamFrameFlow
 import ai.koog.utils.time.KoogClock
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.plugins.HttpTimeout
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.request.get
-import io.ktor.client.request.post
-import io.ktor.client.request.preparePost
-import io.ktor.client.request.setBody
-import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.bodyAsChannel
-import io.ktor.client.statement.bodyAsText
-import io.ktor.http.ContentType
-import io.ktor.http.contentType
-import io.ktor.http.isSuccess
-import io.ktor.serialization.kotlinx.json.json
-import io.ktor.utils.io.ByteReadChannel
-import io.ktor.utils.io.readUTF8Line
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.json.Json
@@ -70,23 +58,26 @@ import kotlin.jvm.JvmOverloads
  * - [LLMClient] for executing prompts and streaming responses.
  * - [LLMEmbeddingProvider] for generating embeddings from input text.
  *
- * @param baseUrl The base URL of the Ollama server. Defaults to "http://localhost:11434".
- * @param baseClient The underlying HTTP client used for making requests.
- * @param timeoutConfig Configuration for connection, request, and socket timeouts.
+ * @param httpClient A preconfigured Koog HTTP client used for API calls. Must have the Ollama base URL
+ *   and timeouts already embedded. To create a client with standard defaults, use the secondary
+ *   constructor that accepts a base URL and a [KoogHttpClient.Factory].
  * @param clock Clock instance used for tracking response metadata timestamps.
  * @param contextWindowStrategy The [ContextWindowStrategy] to use for computing context window lengths.
  *   Defaults to [ContextWindowStrategy.None].
+ * @param toolDescriptorConverter Generates JSON schemas for tool descriptors sent to the model.
  */
 public class OllamaClient @JvmOverloads constructor(
-    public val baseUrl: String = "http://localhost:11434",
-    baseClient: HttpClient = HttpClient(),
-    timeoutConfig: ConnectionTimeoutConfig = ConnectionTimeoutConfig(),
+    private val httpClient: KoogHttpClient,
     private val clock: KoogClock = KoogClock.System,
     private val contextWindowStrategy: ContextWindowStrategy = ContextWindowStrategy.Companion.None,
     private val toolDescriptorConverter: ToolDescriptorSchemaGenerator = OllamaToolDescriptorSchemaGenerator()
 ) : LLMClient() {
 
-    private companion object {
+    public companion object {
+        public const val DEFAULT_BASE_URL: String = "http://localhost:11434"
+
+        private const val CLIENT_NAME = "OllamaClient"
+
         private val logger = KotlinLogging.logger { }
 
         private const val DEFAULT_MESSAGE_PATH = "api/chat"
@@ -94,6 +85,11 @@ public class OllamaClient @JvmOverloads constructor(
         private const val DEFAULT_LIST_MODELS_PATH = "api/tags"
         private const val DEFAULT_SHOW_MODEL_PATH = "api/show"
         private const val DEFAULT_PULL_MODEL_PATH = "api/pull"
+
+        private val ollamaJson = Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+        }
 
         private val moderationCategoriesMapping: Map<String, List<ModerationCategory>> = mapOf(
             // Violent crimes: unlawful violence towards people and animals
@@ -139,29 +135,52 @@ public class OllamaClient @JvmOverloads constructor(
         private val possibleModerationCategories = moderationCategoriesMapping.values.flatten().distinct()
     }
 
-    private val ollamaJson = Json {
-        ignoreUnknownKeys = true
-        isLenient = true
-    }
+    /**
+     * Secondary constructor that builds the underlying [KoogHttpClient] from a [KoogHttpClient.Factory].
+     */
+    @JvmOverloads
+    public constructor(
+        baseUrl: String = DEFAULT_BASE_URL,
+        httpClientFactory: KoogHttpClient.Factory,
+        timeoutConfig: ConnectionTimeoutConfig = ConnectionTimeoutConfig(),
+        clock: KoogClock = KoogClock.System,
+        contextWindowStrategy: ContextWindowStrategy = ContextWindowStrategy.Companion.None,
+        toolDescriptorConverter: ToolDescriptorSchemaGenerator = OllamaToolDescriptorSchemaGenerator()
+    ) : this(
+        httpClient = httpClientFactory.create(
+            clientName = CLIENT_NAME,
+            baseUrl = baseUrl,
+            headers = emptyMap(),
+            queryParameters = emptyMap(),
+            requestTimeoutMillis = timeoutConfig.requestTimeoutMillis,
+            connectTimeoutMillis = timeoutConfig.connectTimeoutMillis,
+            socketTimeoutMillis = timeoutConfig.socketTimeoutMillis,
+            json = ollamaJson,
+        ),
+        clock = clock,
+        contextWindowStrategy = contextWindowStrategy,
+        toolDescriptorConverter = toolDescriptorConverter,
+    )
 
-    private val client = baseClient.config {
-        defaultRequest {
-            url(baseUrl)
-            contentType(ContentType.Application.Json)
-        }
-        install(ContentNegotiation) {
-            json(ollamaJson)
-            // Ollama sometimes returns non-streaming responses with `Content-Type: text/plain`
-            // (see https://github.com/JetBrains/koog/issues/1237). Register the same JSON
-            // deserializer for that content type so the body is still parsed correctly.
-            json(ollamaJson, ContentType.Text.Plain)
-        }
-        install(HttpTimeout) {
-            requestTimeoutMillis = timeoutConfig.requestTimeoutMillis
-            connectTimeoutMillis = timeoutConfig.connectTimeoutMillis
-            socketTimeoutMillis = timeoutConfig.socketTimeoutMillis
-        }
-    }
+    /**
+     * Secondary constructor for creating an [OllamaClient] backed by a Ktor [HttpClient].
+     */
+    @JvmOverloads
+    public constructor(
+        baseUrl: String = DEFAULT_BASE_URL,
+        baseClient: HttpClient = HttpClient(),
+        timeoutConfig: ConnectionTimeoutConfig = ConnectionTimeoutConfig(),
+        clock: KoogClock = KoogClock.System,
+        contextWindowStrategy: ContextWindowStrategy = ContextWindowStrategy.Companion.None,
+        toolDescriptorConverter: ToolDescriptorSchemaGenerator = OllamaToolDescriptorSchemaGenerator()
+    ) : this(
+        baseUrl = baseUrl,
+        httpClientFactory = KtorKoogHttpClient.Factory(baseClient),
+        timeoutConfig = timeoutConfig,
+        clock = clock,
+        contextWindowStrategy = contextWindowStrategy,
+        toolDescriptorConverter = toolDescriptorConverter,
+    )
 
     internal fun LLMParams.toOllamaChatParams(): OllamaParams {
         if (this is OllamaParams) return this
@@ -222,27 +241,21 @@ public class OllamaClient @JvmOverloads constructor(
             )
         )
 
-        val response = client.post(DEFAULT_MESSAGE_PATH) {
-            setBody(request)
-        }
-
-        if (response.status.isSuccess()) {
-            return parseResponse(response.body<OllamaChatResponseDTO>())
-        } else {
-            // TODO: after the update to the KoogHttpClient, delegate this logic to the http client
-
-            val httpClientException = KoogHttpClientException(
-                statusCode = response.status.value,
-                errorBody = response.bodyAsText(),
-            )
+        val responseBody = try {
+            httpClient.post<String, String>(path = DEFAULT_MESSAGE_PATH, request = request)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
             val exception = LLMClientException(
                 clientName = clientName,
-                message = httpClientException.message,
-                cause = httpClientException,
+                message = e.message,
+                cause = e
             )
             logger.error(exception) { exception.message }
             throw exception
         }
+
+        return parseResponse(ollamaJson.decodeFromString<OllamaChatResponseDTO>(responseBody))
     }
 
     private fun parseResponse(response: OllamaChatResponseDTO): List<Message.Response> {
@@ -315,40 +328,30 @@ public class OllamaClient @JvmOverloads constructor(
             )
         )
 
-        client.preparePost(DEFAULT_MESSAGE_PATH) {
-            contentType(ContentType.Application.Json)
-            setBody(request)
-        }.execute { response: HttpResponse ->
-            val channel: ByteReadChannel = response.bodyAsChannel()
-
-            while (!channel.isClosedForRead) {
-                val line = channel.readUTF8Line() ?: break
-                if (line.isBlank()) continue
-                try {
-                    val chunk = ollamaJson.decodeFromString<OllamaChatResponseDTO>(line)
-                    chunk.message?.let { message ->
-                        if (message.content.isNotEmpty()) {
-                            emitTextDelta(text = message.content)
-                        }
-                        if (message.thinking.isNullOrEmpty().not()) {
-                            emitReasoningDelta(text = message.thinking)
-                        }
-                        message.toolCalls?.forEachIndexed { index, toolCall ->
-                            val name = toolCall.function.name
-                            val args = toolCall.function.arguments.toString()
-                            emitToolCallDelta(
-                                id = generateToolCallId(name, args, index),
-                                name = toolCall.function.name,
-                                args = args,
-                                index = index
-                            )
-                            tryEmitPendingToolCall()
-                        }
+        httpClient.lines(path = DEFAULT_MESSAGE_PATH, request = request).collect { line ->
+            try {
+                val chunk = ollamaJson.decodeFromString<OllamaChatResponseDTO>(line)
+                chunk.message?.let { message ->
+                    if (message.content.isNotEmpty()) {
+                        emitTextDelta(text = message.content)
                     }
-                } catch (_: Exception) {
-                    // Skip malformed JSON lines
-                    continue
+                    if (message.thinking.isNullOrEmpty().not()) {
+                        emitReasoningDelta(text = message.thinking)
+                    }
+                    message.toolCalls?.forEachIndexed { index, toolCall ->
+                        val name = toolCall.function.name
+                        val args = toolCall.function.arguments.toString()
+                        emitToolCallDelta(
+                            id = generateToolCallId(name, args, index),
+                            name = toolCall.function.name,
+                            args = args,
+                            index = index
+                        )
+                        tryEmitPendingToolCall()
+                    }
                 }
+            } catch (_: Exception) {
+                // Skip malformed JSON lines
             }
         }
     }
@@ -378,19 +381,20 @@ public class OllamaClient @JvmOverloads constructor(
             throw LLMClientException(clientName, "Model ${model.id} does not have the Embed capability")
         }
 
-        val response = client.post(DEFAULT_EMBEDDINGS_PATH) {
-            setBody(EmbeddingRequestDTO(model = model.id, input = text))
-        }
-
-        if (!response.status.isSuccess()) {
-            val errorBody = response.bodyAsText()
+        val responseBody = try {
+            httpClient.post<EmbeddingRequestDTO, String>(
+                path = DEFAULT_EMBEDDINGS_PATH,
+                request = EmbeddingRequestDTO(model = model.id, input = text)
+            )
+        } catch (e: KoogHttpClientException) {
             throw LLMClientException(
                 clientName,
-                "Embedding request failed (HTTP ${response.status.value}): $errorBody"
+                "Embedding request failed (HTTP ${e.statusCode}): ${e.errorBody}",
+                cause = e
             )
         }
 
-        val embeddingResponse = response.body<EmbeddingBatchResponseDTO>()
+        val embeddingResponse = ollamaJson.decodeFromString<EmbeddingBatchResponseDTO>(responseBody)
         return embeddingResponse.normalizedEmbeddings().firstOrNull() ?: emptyList()
     }
 
@@ -413,11 +417,12 @@ public class OllamaClient @JvmOverloads constructor(
             throw LLMClientException(clientName, "Model ${model.id} does not have the Embed capability")
         }
 
-        val response = client.post(DEFAULT_EMBEDDINGS_PATH) {
-            setBody(EmbeddingBatchRequestDTO(model = model.id, input = inputs))
-        }
+        val responseBody = httpClient.post<EmbeddingBatchRequestDTO, String>(
+            path = DEFAULT_EMBEDDINGS_PATH,
+            request = EmbeddingBatchRequestDTO(model = model.id, input = inputs)
+        )
 
-        val embeddingResponse = response.body<EmbeddingBatchResponseDTO>()
+        val embeddingResponse = ollamaJson.decodeFromString<EmbeddingBatchResponseDTO>(responseBody)
         return embeddingResponse.normalizedEmbeddings()
     }
 
@@ -538,20 +543,25 @@ public class OllamaClient @JvmOverloads constructor(
     }
 
     private suspend fun listModels(): OllamaModelsListResponseDTO {
-        return client.get(DEFAULT_LIST_MODELS_PATH).body<OllamaModelsListResponseDTO>()
+        val responseBody = httpClient.get<String>(path = DEFAULT_LIST_MODELS_PATH)
+        return ollamaJson.decodeFromString(responseBody)
     }
 
     private suspend fun showModel(name: String): OllamaShowModelResponseDTO {
-        return client.post(DEFAULT_SHOW_MODEL_PATH) {
-            setBody(OllamaShowModelRequestDTO(name = name))
-        }.body<OllamaShowModelResponseDTO>()
+        val responseBody = httpClient.post<OllamaShowModelRequestDTO, String>(
+            path = DEFAULT_SHOW_MODEL_PATH,
+            request = OllamaShowModelRequestDTO(name = name)
+        )
+        return ollamaJson.decodeFromString(responseBody)
     }
 
     private suspend fun pullModel(name: String) {
         try {
-            val response = client.post(DEFAULT_PULL_MODEL_PATH) {
-                setBody(OllamaPullModelRequestDTO(name = name, stream = false))
-            }.body<OllamaPullModelResponseDTO>()
+            val responseBody = httpClient.post<OllamaPullModelRequestDTO, String>(
+                path = DEFAULT_PULL_MODEL_PATH,
+                request = OllamaPullModelRequestDTO(name = name, stream = false)
+            )
+            val response = ollamaJson.decodeFromString<OllamaPullModelResponseDTO>(responseBody)
 
             response.error?.let { error ->
                 throw LLMClientException(clientName, "Failed to pull model '$name': $error")
@@ -580,6 +590,6 @@ public class OllamaClient @JvmOverloads constructor(
     }
 
     override fun close() {
-        client.close()
+        httpClient.close()
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -86,6 +86,8 @@ public class OllamaClient @JvmOverloads constructor(
         private const val DEFAULT_SHOW_MODEL_PATH = "api/show"
         private const val DEFAULT_PULL_MODEL_PATH = "api/pull"
 
+        private val jsonContentHeaders = mapOf("Content-Type" to "application/json")
+
         private val ollamaJson = Json {
             ignoreUnknownKeys = true
             isLenient = true
@@ -242,7 +244,11 @@ public class OllamaClient @JvmOverloads constructor(
         )
 
         val responseBody = try {
-            httpClient.post<String, String>(path = DEFAULT_MESSAGE_PATH, request = request)
+            httpClient.post<String, String>(
+                path = DEFAULT_MESSAGE_PATH,
+                request = request,
+                headers = jsonContentHeaders
+            )
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -328,7 +334,11 @@ public class OllamaClient @JvmOverloads constructor(
             )
         )
 
-        httpClient.lines(path = DEFAULT_MESSAGE_PATH, request = request).collect { line ->
+        httpClient.lines(
+            path = DEFAULT_MESSAGE_PATH,
+            request = request,
+            headers = jsonContentHeaders
+        ).collect { line ->
             try {
                 val chunk = ollamaJson.decodeFromString<OllamaChatResponseDTO>(line)
                 chunk.message?.let { message ->

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/OllamaClient.kt
@@ -142,8 +142,10 @@ public class OllamaClient @JvmOverloads constructor(
      */
     @JvmOverloads
     public constructor(
-        baseUrl: String = DEFAULT_BASE_URL,
         httpClientFactory: KoogHttpClient.Factory,
+        baseUrl: String = DEFAULT_BASE_URL,
+        headers: Map<String, String> = emptyMap(),
+        queryParameters: Map<String, String> = emptyMap(),
         timeoutConfig: ConnectionTimeoutConfig = ConnectionTimeoutConfig(),
         clock: KoogClock = KoogClock.System,
         contextWindowStrategy: ContextWindowStrategy = ContextWindowStrategy.Companion.None,
@@ -152,8 +154,8 @@ public class OllamaClient @JvmOverloads constructor(
         httpClient = httpClientFactory.create(
             clientName = CLIENT_NAME,
             baseUrl = baseUrl,
-            headers = emptyMap(),
-            queryParameters = emptyMap(),
+            headers = headers,
+            queryParameters = queryParameters,
             requestTimeoutMillis = timeoutConfig.requestTimeoutMillis,
             connectTimeoutMillis = timeoutConfig.connectTimeoutMillis,
             socketTimeoutMillis = timeoutConfig.socketTimeoutMillis,
@@ -171,13 +173,17 @@ public class OllamaClient @JvmOverloads constructor(
     public constructor(
         baseUrl: String = DEFAULT_BASE_URL,
         baseClient: HttpClient = HttpClient(),
+        headers: Map<String, String> = emptyMap(),
+        queryParameters: Map<String, String> = emptyMap(),
         timeoutConfig: ConnectionTimeoutConfig = ConnectionTimeoutConfig(),
         clock: KoogClock = KoogClock.System,
         contextWindowStrategy: ContextWindowStrategy = ContextWindowStrategy.Companion.None,
         toolDescriptorConverter: ToolDescriptorSchemaGenerator = OllamaToolDescriptorSchemaGenerator()
     ) : this(
-        baseUrl = baseUrl,
         httpClientFactory = KtorKoogHttpClient.Factory(baseClient),
+        baseUrl = baseUrl,
+        headers = headers,
+        queryParameters = queryParameters,
         timeoutConfig = timeoutConfig,
         clock = clock,
         contextWindowStrategy = contextWindowStrategy,
@@ -396,12 +402,24 @@ public class OllamaClient @JvmOverloads constructor(
                 path = DEFAULT_EMBEDDINGS_PATH,
                 request = EmbeddingRequestDTO(model = model.id, input = text)
             )
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: KoogHttpClientException) {
-            throw LLMClientException(
+            val exception = LLMClientException(
                 clientName,
                 "Embedding request failed (HTTP ${e.statusCode}): ${e.errorBody}",
                 cause = e
             )
+            logger.error(exception) { exception.message }
+            throw exception
+        } catch (e: Exception) {
+            val exception = LLMClientException(
+                clientName = clientName,
+                message = e.message,
+                cause = e
+            )
+            logger.error(exception) { exception.message }
+            throw exception
         }
 
         val embeddingResponse = ollamaJson.decodeFromString<EmbeddingBatchResponseDTO>(responseBody)

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIPrimaryConstructorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIPrimaryConstructorTest.kt
@@ -94,6 +94,7 @@ class OpenAIPrimaryConstructorTest {
                 path: String,
                 responseType: KClass<R>,
                 parameters: Map<String, String>,
+                headers: Map<String, String>,
             ): R = error("GET is not expected in this test")
 
             override suspend fun <T : Any, R : Any> post(
@@ -102,6 +103,7 @@ class OpenAIPrimaryConstructorTest {
                 requestBodyType: KClass<T>,
                 responseType: KClass<R>,
                 parameters: Map<String, String>,
+                headers: Map<String, String>,
             ): R = error("POST is not expected in this test")
 
             override fun <T : Any, R : Any, O : Any> sse(
@@ -112,6 +114,7 @@ class OpenAIPrimaryConstructorTest {
                 decodeStreamingResponse: (String) -> R,
                 processStreamingChunk: (R) -> O?,
                 parameters: Map<String, String>,
+                headers: Map<String, String>,
             ): Flow<O> {
                 assertEquals(responsesPath, path)
 
@@ -176,6 +179,7 @@ class OpenAIPrimaryConstructorTest {
                 request: T,
                 requestBodyType: KClass<T>,
                 parameters: Map<String, String>,
+                headers: Map<String, String>,
             ): Flow<String> = error("lines is not expected in this test")
 
             override fun close(): Unit = Unit

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIPrimaryConstructorTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIPrimaryConstructorTest.kt
@@ -171,6 +171,13 @@ class OpenAIPrimaryConstructorTest {
                 }
             }
 
+            override fun <T : Any> lines(
+                path: String,
+                request: T,
+                requestBodyType: KClass<T>,
+                parameters: Map<String, String>,
+            ): Flow<String> = error("lines is not expected in this test")
+
             override fun close(): Unit = Unit
         }
         val client = OpenAILLMClient(

--- a/prompt/prompt-executor/prompt-executor-model/src/jvmMain/kotlin/ai/koog/prompt/executor/model/PromptExecutorBuilder.kt
+++ b/prompt/prompt-executor/prompt-executor-model/src/jvmMain/kotlin/ai/koog/prompt/executor/model/PromptExecutorBuilder.kt
@@ -223,12 +223,12 @@ public class PromptExecutorBuilder {
     ): PromptExecutorBuilder = apply {
         addClient(
             OllamaClient(
-                baseUrl,
-                baseClient,
-                timeoutConfig,
-                clock,
-                contextWindowStrategy,
-                toolDescriptorConverter
+                baseUrl = baseUrl,
+                baseClient = baseClient,
+                timeoutConfig = timeoutConfig,
+                clock = clock,
+                contextWindowStrategy = contextWindowStrategy,
+                toolDescriptorConverter = toolDescriptorConverter,
             )
         )
     }

--- a/test-utils/src/commonMain/kotlin/ai/koog/test/utils/CapturingKoogHttpClient.kt
+++ b/test-utils/src/commonMain/kotlin/ai/koog/test/utils/CapturingKoogHttpClient.kt
@@ -56,5 +56,12 @@ public class CapturingKoogHttpClient(
         parameters: Map<String, String>,
     ): Flow<O> = emptyFlow()
 
+    override fun <T : Any> lines(
+        path: String,
+        request: T,
+        requestBodyType: KClass<T>,
+        parameters: Map<String, String>,
+    ): Flow<String> = emptyFlow()
+
     override fun close(): Unit = Unit
 }

--- a/test-utils/src/commonMain/kotlin/ai/koog/test/utils/CapturingKoogHttpClient.kt
+++ b/test-utils/src/commonMain/kotlin/ai/koog/test/utils/CapturingKoogHttpClient.kt
@@ -29,7 +29,12 @@ public class CapturingKoogHttpClient(
     /** Captured request body from the most recent POST request. */
     public var lastRequest: Any? = null
 
-    override suspend fun <R : Any> get(path: String, responseType: KClass<R>, parameters: Map<String, String>): R {
+    override suspend fun <R : Any> get(
+        path: String,
+        responseType: KClass<R>,
+        parameters: Map<String, String>,
+        headers: Map<String, String>,
+    ): R {
         error("GET is not expected in this test")
     }
 
@@ -39,6 +44,7 @@ public class CapturingKoogHttpClient(
         requestBodyType: KClass<T>,
         responseType: KClass<R>,
         parameters: Map<String, String>,
+        headers: Map<String, String>,
     ): R {
         lastPath = path
         lastRequest = request
@@ -54,6 +60,7 @@ public class CapturingKoogHttpClient(
         decodeStreamingResponse: (String) -> R,
         processStreamingChunk: (R) -> O?,
         parameters: Map<String, String>,
+        headers: Map<String, String>,
     ): Flow<O> = emptyFlow()
 
     override fun <T : Any> lines(
@@ -61,6 +68,7 @@ public class CapturingKoogHttpClient(
         request: T,
         requestBodyType: KClass<T>,
         parameters: Map<String, String>,
+        headers: Map<String, String>,
     ): Flow<String> = emptyFlow()
 
     override fun close(): Unit = Unit


### PR DESCRIPTION
What’s changed:
- Decoupled `OllamaClient` from direct Ktor usage by making it work through the abstract `KoogHttpClient` contract.
- Added `lines()` to `KoogHttpClient` so Ollama streaming (NOT sse!) can use whichever HTTP client implementation is supplied.
- Added per-request `headers` parameters and a shared utility for merging configured, inferred, and request-specific HTTP headers.
- Aligned and extended tests for header precedence, line streaming, cancellation, and Spring Boot Ollama configuration.

BREAKING:
- `KoogHttpClient` implementations must now implement the new `lines()` method.
- `KoogHttpClient` methods now accept `headers` parameters for per-request headers, allowing clients like Ollama to specify request-specific `Content-Type`.
- `OllamaClient` no longer exposes the `baseUrl` property because it now delegates endpoint configuration to the supplied `KoogHttpClient`.

closes KG-833