### PR TITLE
build(agents): KG-836. Drop wasmJs target for open-telemetry feature

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/build.gradle.kts
+++ b/agents/agents-features/agents-features-opentelemetry/build.gradle.kts
@@ -115,16 +115,4 @@ extensions.configure<LibraryAndroidComponentsExtension> {
     }
 }
 
-// OTel Kotlin SDK 0.3.0 doesn't publish wasmJs artifacts, so the wasmJs target can't
-// actually compile against OTel. We keep the target registered (so its KMP publication
-// has the standard `agents-features-opentelemetry-wasm-js` coordinates that KMP consumers
-// expect) but exclude OTel from wasmJs configurations and skip wasmJs tasks so nothing
-// tries to build/publish broken wasmJs artifacts.
-configurations.matching { it.name.startsWith("wasmJs") }.configureEach {
-    exclude(group = "io.opentelemetry.kotlin")
-}
-tasks.matching { it.name.startsWith("wasmJs") || it.name == "compileKotlinWasmJs" || it.name == "compileTestKotlinWasmJs" }.configureEach {
-    onlyIf("OTel Kotlin SDK 0.3.0 does not publish wasmJs artifacts") { false }
-}
-
 publishToMaven()

--- a/agents/agents-features/agents-features-opentelemetry/gradle.properties
+++ b/agents/agents-features/agents-features-opentelemetry/gradle.properties
@@ -1,0 +1,4 @@
+# OTel Kotlin SDK 0.3.0 does not publish wasmJs artifacts. Opt this module out of
+# the wasmJs target, so no `*-wasm-js` publication is produced for it. Remove this
+# file once upstream adds wasmJs support.
+koog.target.wasmJs=false

--- a/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
+++ b/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
@@ -15,6 +15,11 @@ plugins {
     id("signing")
 }
 
+// Per-module opt-out for the wasmJs target. Modules that depend on libraries with no wasmJs publication,
+// for example, the "OTel Kotlin SDK 0.3.0" set `koog.target.wasmJs=false` in their gradle.properties.
+// The target is not registered at all, and no wasm-js publication is produced.
+val isWasmJsIncluded = (findProperty("koog.target.wasmJs") as? String)?.toBoolean() ?: true
+
 kotlin {
     // Tiers are in accordance with <https://kotlinlang.org/docs/native-target-support.html>
     // Tier 1
@@ -45,10 +50,12 @@ kotlin {
         configureTests()
     }
 
-    wasmJs {
-        browser()
-        nodejs()
-        binaries.library()
+    if (isWasmJsIncluded) {
+        wasmJs {
+            browser()
+            nodejs()
+            binaries.library()
+        }
     }
 
     applyDefaultHierarchyTemplate()
@@ -92,12 +99,14 @@ kotlin {
             dependsOn(nonJvmCommonTest)
         }
 
-        wasmJsMain {
-            dependsOn(nonJvmCommonMain)
-        }
+        if (isWasmJsIncluded) {
+            wasmJsMain {
+                dependsOn(nonJvmCommonMain)
+            }
 
-        wasmJsTest {
-            dependsOn(nonJvmCommonTest)
+            wasmJsTest {
+                dependsOn(nonJvmCommonTest)
+            }
         }
 
         jvmMain {

--- a/koog-agents/build.gradle.kts
+++ b/koog-agents/build.gradle.kts
@@ -104,6 +104,14 @@ val included = setOf(
     ":utils",
 )
 
+// Modules that do not publish a wasmJs artifact. They are filtered out of the
+// commonMain api auto-loop and declared on a local `nonWasmJsMain` intermediate
+// source set that all non-wasmJs leaf targets inherit from, so that the
+// koog-agents-wasm-js publication does not reference missing coordinates.
+val wasmJsExcluded = setOf(
+    ":agents:agents-features:agents-features-opentelemetry",
+)
+
 kotlin {
     val projects = rootProject.subprojects
         .filterNot { it.path in excluded }
@@ -143,26 +151,46 @@ kotlin {
                     }
                 }
 
-                projects.forEach {
+                projects.filterNot { it.path in wasmJsExcluded }.forEach {
                     api(project(it.path))
                 }
             }
         }
 
-        androidMain.dependencies {
-            api(libs.ktor.client.okhttp)
+        // Source set holding dependencies that are valid on every target except wasmJs.
+        // 'jvmCommonMain', 'jsMain', and 'appleMain' pick these up.
+        // 'wasmJsMain' keeps its existing parent (nonJvmCommonMain, commonMain) and never sees them.
+        val nonWasmJsMain by creating {
+            dependsOn(commonMain.get())
+            dependencies {
+                wasmJsExcluded.forEach { api(project(it)) }
+            }
+        }
+
+        jvmCommonMain {
+            dependsOn(nonWasmJsMain)
         }
 
         jvmMain.dependencies {
             api(libs.ktor.client.apache5)
         }
 
-        appleMain.dependencies {
-            api(libs.ktor.client.darwin)
+        androidMain.dependencies {
+            api(libs.ktor.client.okhttp)
         }
 
-        jsMain.dependencies {
-            api(libs.ktor.client.js)
+        appleMain {
+            dependsOn(nonWasmJsMain)
+            dependencies {
+                api(libs.ktor.client.darwin)
+            }
+        }
+
+        jsMain {
+            dependsOn(nonWasmJsMain)
+            dependencies {
+                api(libs.ktor.client.js)
+            }
         }
 
         wasmJsMain.dependencies {


### PR DESCRIPTION
- OTel Kotlin SDK 0.3.0 does not publish wasmJs artifacts. Replace the regex-based workaround in the OTel build with a koog.target.wasmJs property gate in the convention plugin, and route OTel through a local nonWasmJsMain intermediate source set in :koog-agents so its wasm-js publication no longer references a missing coordinate.

closes: [KG-836](https://youtrack.jetbrains.com/issue/KG-836)