### PR TITLE
feat(agents): Add a Claude skill to write Java code snippets in mkdocs

### DIFF
--- a/.claude/skills/add-java-code-snippets-in-docs/SKILL.md
+++ b/.claude/skills/add-java-code-snippets-in-docs/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: add-java-code-snippets-in-docs
+description: Use when the user asks to add Java tabs/examples to mkdocs docs that already have Kotlin examples (files under docs/docs/**.md using === "Kotlin" / Knit INCLUDE+SUFFIX blocks). Handles mkdocs-material tabs, Knit directives, @JavaAPI bridge methods, and JVM factory classes.
+allowed-tools: Read, Edit, Write, Bash, Grep, Glob
+---
+
+## When to use
+
+Adding Java code blocks alongside existing Kotlin blocks in mkdocs documentation (`docs/docs/**.md`). Typical triggers: "add Java examples to <file>", "add Java tabs", "complete the Java side of <doc>", "fix the Java block in <doc>".
+
+**Do NOT use this skill for:**
+
+- Writing brand-new Kotlin docs (no precursor Kotlin block to mirror).
+- Splitting source files between JVM and non-JVM source sets — use the **`split-jvm-nonjvm`** skill instead.
+- Java examples outside the mkdocs/Knit pipeline.
+
+## Prerequisites
+
+JDK 17. Gradle 8.x fails cryptically on newer JDKs. If the default JDK is newer, prefix every `./gradlew` command in this workflow with `JAVA_HOME=/path/to/jdk-17`.
+
+## Before starting
+
+Read **one** reference doc to anchor on the established pattern:
+
+- `docs/docs/features/tracing.md` — full Tracing feature (blocks 1–6).
+- `docs/docs/agent-events.md` — custom `FeatureMessageProcessor` subclass (suspend bridge methods `handleMessage` / `handleClose`).
+- `docs/docs/testing.md` — `MockPromptExecutor` builder, tool mocking, comment-only blocks for Kotlin-only DSL.
+- `docs/docs/features/open-telemetry/index.md` — OpenTelemetry examples.
+- `docs/docs/features/open-telemetry/opentelemetry-langfuse-exporter.md` — Langfuse exporter.
+- `docs/docs/features/open-telemetry/opentelemetry-weave-exporter.md` — Weave exporter.
+
+## Workflow
+
+For each Kotlin code block in the target `.md`:
+
+1. **Read** the Kotlin block: INCLUDE, visible code, SUFFIX, KNIT directive.
+2. **Check existing Java tab.** If absent → add one. If it has empty `/** */` placeholder content → replace entirely. If it has real content → update.
+3. **Consider Kotlin-side alignment.** If the Kotlin block uses Kotlin-only APIs (`kotlinx.io`, `MutableStateFlow`, `KLogger`, inline `Duration`), consider whether the Kotlin example should switch to a JVM `create()` factory (e.g., `TraceFeatureMessageFileWriter.create(path)`). This keeps the two examples structurally aligned. See `reference/factory-classes.md`.
+4. **Add `@JavaAPI` bridge methods if missing.** If the Java code needs a bridge that doesn't exist yet (e.g., a builder method on `MockExecutorBuilder`), add it before writing the Java tab. This may pause the doc work for a source-code change — flag it to the user before proceeding.
+5. **Write the Java tab** immediately after the Kotlin tab, using the template below.
+6. **If renaming Knit files** (e.g., hyphenated `example-feature-java-01.java` → camelCase `exampleFeatureJava01.java`), delete the old generated files first.
+7. **Generate and compile** (see Verification at the bottom).
+8. **Read the generated `.java`** to confirm correctness. Fix and repeat 7–8 on failure.
+
+## Mkdocs / Knit tab structure
+
+Java tabs go immediately after the Kotlin tab. All content inside a tab is indented 4 spaces. `<!--- INCLUDE -->`, `<!--- SUFFIX -->`, `<!--- KNIT -->` are Knit directives (HTML comments — invisible when rendered), not mkdocs syntax.
+
+```markdown
+=== "Kotlin"
+
+    <!--- INCLUDE
+    import ...
+    -->
+    ```kotlin
+    // visible code
+    ```
+    <!--- KNIT example-feature-01.kt -->
+
+=== "Java"
+
+    <!--- INCLUDE
+    import ...;
+    public class exampleFeatureJava01 {
+        public static void main(String[] args) {
+    -->
+    <!--- SUFFIX
+        }
+    }
+    -->
+    ```java
+    // visible code
+    ```
+    <!--- KNIT exampleFeatureJava01.java -->
+```
+
+### KNIT naming — capital "Java" matters
+
+`docs/knit.code.include` has the check `<#if !knit.name?contains("Java")>package ...`. Files with capital "Java" in the name skip the `package` declaration; lowercase "java" or hyphenated names emit a `package` line that breaks compilation.
+
+- ✅ `exampleFeatureJava01.java`, `exampleTestingJava13.java`
+- ❌ `example-feature-java-01.java`, `examplefeaturejava01.java`
+
+### Knit rules
+
+- INCLUDE + visible code + SUFFIX must concatenate into a valid Java file.
+- Hidden variables in Kotlin INCLUDE (`outputPath`, `input`, etc.) must also appear in Java INCLUDE.
+- Visible-code indentation in `.md` is 4 spaces (tab content). Knit strips that when generating.
+- Always import in INCLUDE; never use FQNs in visible code.
+- Never use file-level annotations (`@file:Suppress`, `@file:OptIn`) — scope to specific declarations.
+
+## Structural matching (the most important rule)
+
+**The Java visible code must match the Kotlin visible code in scope and structure.**
+
+- If Kotlin shows no `main()`, Java must hide `main()` in INCLUDE/SUFFIX.
+- If Kotlin shows `install(Feature) { ... }`, Java must show `.install(Feature.Feature, config -> { })`.
+- If Kotlin creates a writer before the agent, Java must too.
+- If Kotlin shows `agent.run(input)`, Java must too.
+
+Read both visible blocks side-by-side after writing. They should read as equivalent code in their respective languages.
+
+### When Kotlin uses APIs with no Java bridge
+
+Some Kotlin DSLs (graph testing: `testGraph`, `assertSubgraphByName`, `assertNodes`, `assertEdges`, `verifySubgraph`, `assertReachable`) have no `@JavaAPI` bridges. To check: grep for `@JavaAPI` in the source file — if absent, treat as Kotlin-only.
+
+When the Kotlin block uses an entirely Kotlin-only API:
+
+1. **Do NOT leave the Java tab empty.** Write a compilable Java class with explanatory comments.
+2. The class must have a valid `main` so it compiles.
+3. Comments explain what the Kotlin DSL does and the recommended Java alternative.
+
+```java
+// Graph structure testing (testGraph, assertSubgraphByName, assertEdges,
+// verifySubgraph, assertReachable) is available through the Kotlin testing DSL.
+//
+// In Java, test agent behavior by running and asserting on the result:
+//   String result = agent.run("test input");
+//   assert "expected".equals(result);
+```
+
+## Deep references
+
+Load these only when you need them:
+
+- **`reference/interop-tables.md`** — Kotlin↔Java mapping table, suspend bridges (`@JvmName("run")`, `handleMessage`, `handleClose`), abstract-property rules, key source files to grep for `@JavaAPI`.
+- **`reference/factory-classes.md`** — JVM `create()` factory pattern, two-overload skeleton, type-conversion cheat sheet, when needed vs not, anti-patterns. Cross-references the `split-jvm-nonjvm` skill.
+- **`reference/pitfalls.md`** — `var`-vs-field, brace-counting in SUFFIX, `is`-prefixed property getters, `@JvmOverloads` requirement, docs classpath limits (no JUnit), legacy `/** */` placeholder, `MockExecutorBuilder` API.
+
+## Verification
+
+After each Java block:
+
+```bash
+./gradlew :docs:knit
+./gradlew :docs:compileJava
+```
+
+On failure, read the generated file to diagnose:
+
+```bash
+cat docs/src/main/kotlin/exampleFeatureJavaNN.java
+```

--- a/.claude/skills/add-java-code-snippets-in-docs/reference/factory-classes.md
+++ b/.claude/skills/add-java-code-snippets-in-docs/reference/factory-classes.md
@@ -1,0 +1,81 @@
+# JVM `create()` factory classes
+
+Load this file when the Kotlin block uses types that aren't callable from Java and you need to expose (or audit) a Java-friendly factory.
+
+## When a factory is needed
+
+Kotlin constructors / APIs Java can't call cleanly:
+
+- Uses `kotlinx.io` types (`Sink`, `Path`, `SystemFileSystem`).
+- Uses inline value classes (`Duration`) — the constructor becomes private from Java.
+- Uses `KLogger` (kotlin-logging) instead of SLF4J `Logger`.
+- Has default parameters without `@JvmOverloads` — generates synthetic constructors with `DefaultConstructorMarker`.
+
+If the Kotlin constructor uses only Java-compatible types and has `@JvmOverloads` (or no default params), Java can call it directly with `new`. Example:
+
+```java
+// No factory needed — constructor is Java-accessible
+new TraceFeatureMessageRemoteWriter()
+new TraceFeatureMessageRemoteWriter(connectionConfig)
+```
+
+## Pattern
+
+Add a `companion object` with `create(...)` methods **on the class itself**, in the `jvmCommonMain` source set. The class must already live in `jvmCommonMain` (or have a JVM actual) for this to apply.
+
+> **Prerequisite:** if the class is still in `commonMain`, run the **`split-jvm-nonjvm`** skill first to produce the `expect class` + `jvmCommonMain` actual scaffolding. `split-jvm-nonjvm` requires the class to have no companion object at split time — so the order is: (1) split, then (2) add the companion `create()` on the JVM actual. If the class already has a companion in `commonMain`, raise it with the user before splitting.
+
+Provide two overloads of `create()`:
+
+1. **Kotlin-facing** — accepts the original Kotlin-only types (`kotlinx.io.Path`, `Sink`, `KLogger`, `Duration`). No JVM annotations needed; convenient sugar for Kotlin callers and keeps API symmetry.
+2. **Java-facing** — accepts only Java-compatible types (`java.nio.file.Path`, `java.io.OutputStream`, `org.slf4j.Logger`, primitives, etc.). Annotate with `@JavaAPI` (intent), `@JvmStatic` (static call site), and `@JvmOverloads` (one method per default-parameter combination). Convert to Kotlin-only types inside the body, then delegate to the primary constructor.
+
+## Skeleton
+
+Substitute `Xxx` with the class name, `KotlinT` / `JavaT` with the actual type pair:
+
+```kotlin
+// In: jvmCommonMain/.../Xxx.kt
+public class Xxx(/* primary constructor uses Kotlin-only types */) {
+    public companion object {
+        // (1) Kotlin-facing
+        public fun create(
+            param: KotlinT,
+            // ...defaulted params with Kotlin types
+        ): Xxx = Xxx(/* pass through */)
+
+        // (2) Java-facing
+        @JavaAPI
+        @JvmStatic
+        @JvmOverloads
+        public fun create(
+            param: JavaT,
+            // ...defaulted params with Java-friendly types
+        ): Xxx {
+            val kotlinParam = /* convert JavaT -> KotlinT */
+            return Xxx(/* pass converted values */)
+        }
+    }
+}
+```
+
+Java callers then write `Xxx.create(javaParam)` — no separate class, no `Continuation`, no `DefaultConstructorMarker`.
+
+## Conversion cheat sheet
+
+| Kotlin-only type | Java-facing replacement | Conversion inside `create()` |
+|------------------|-------------------------|------------------------------|
+| `kotlinx.io.files.Path` | `java.nio.file.Path` | `Path.of(javaPath.toString())` or use `SystemFileSystem` |
+| `kotlinx.io.Sink` | `java.io.OutputStream` (via opener lambda) | `outputStream.asSink().buffered()` |
+| `KLogger` (kotlin-logging) | `org.slf4j.Logger` | `KotlinLogging.logger(slf4jLogger)` |
+| `kotlin.time.Duration` | `long millis` / `java.time.Duration` | `millis.milliseconds` / `Duration.ofMillis(...).toKotlinDuration()` |
+| `(T) -> R` with Kotlin types | `Function<T, R>` or SAM with Java types | `{ t -> javaFn.apply(t) }` |
+
+## Reference implementations
+
+- `agents/agents-features/agents-features-trace/src/jvmCommonMain/.../TraceFeatureMessageFileWriter.kt` — `Path` / `Sink` ↔ `java.nio.file.Path` / `OutputStream`.
+- `agents/agents-features/agents-features-trace/src/jvmCommonMain/.../TraceFeatureMessageLogWriter.kt` — `KLogger` ↔ SLF4J `Logger`.
+
+## Anti-pattern: separate `*Jvm` object
+
+Do **not** introduce a separate `public object XxxJvm { ... }` alongside the original class. The convention is to put the Java-facing `create()` on the original class's companion. A `*Jvm` companion class would be redundant and inconsistent with the existing `TraceFeatureMessage*Writer` classes.

--- a/.claude/skills/add-java-code-snippets-in-docs/reference/interop-tables.md
+++ b/.claude/skills/add-java-code-snippets-in-docs/reference/interop-tables.md
@@ -1,0 +1,78 @@
+# Kotlin ↔ Java Interop Reference
+
+Load this file when writing the Java side of a non-trivial Kotlin block: figuring out how a Kotlin construct maps to Java, or whether a `suspend` function has a Java-friendly bridge.
+
+## Quick mapping table
+
+| Kotlin | Java |
+|--------|------|
+| `AIAgent(...) { }` | `AIAgent.builder()...build()` |
+| `install(Feature) { }` | `.install(Feature.Feature, config -> { })` |
+| `install(Testing) { config() }` | `.install(Testing.Feature, config -> { })` (`ConfigureAction<T>` is a `fun interface`) |
+| `simpleOllamaAIExecutor()` | `PromptExecutor.builder().ollama().build()` |
+| `KotlinLogging.logger { }` | `LoggerFactory.getLogger("name")` |
+| `val x = ...` (local) | `var x = ...` |
+| `val x = ...` (field) | `static Type x = ...` (never `static var`) |
+| `runBlocking { }` | not needed (`agent.run` is blocking in Java — see suspend bridges below) |
+| `config.addMessageProcessor(...)` | `config.addMessageProcessor(...)` |
+| `class Foo : Bar()` | `class Foo extends Bar` |
+| `when (x) { is Type -> ... }` | `if (x instanceof Type) { ... } else if ...` |
+| `override suspend fun processMessage(msg)` | `void handleMessage(FeatureMessage msg)` — see suspend bridges |
+| `override suspend fun close()` | `void handleClose()` — see suspend bridges |
+| `TraceFeatureMessageFileWriter(path, sinkOpener)` | `TraceFeatureMessageFileWriter.create(path)` — JVM `create()` overload taking `java.nio.file.Path` |
+| `TraceFeatureMessageLogWriter(klogger)` | `TraceFeatureMessageLogWriter.create(slf4jLogger)` — JVM `create()` overload taking SLF4J `Logger` |
+| `TraceFeatureMessageRemoteWriter(config)` | `new TraceFeatureMessageRemoteWriter()` (direct, no factory needed) |
+| `getMockExecutor(...) { mockLLMAnswer(...) }` | `MockPromptExecutor.builder(serializer).mockLLMAnswer(...).build()` |
+
+## Suspend functions and Java
+
+Kotlin `suspend` functions compile to JVM methods with an extra `Continuation` parameter and `Object` return type. **Java code snippets must NEVER show `Continuation` parameters.** The codebase provides Java-friendly bridges.
+
+### Calling suspend methods from Java
+
+Methods annotated with `@JavaAPI` and `@JvmName` provide blocking wrappers. Use the Java-facing name directly:
+
+| Kotlin (suspend) | Java (blocking) |
+|------------------|-----------------|
+| `agent.run(input)` | `agent.run(input)` (calls `javaNonSuspendRun` via `@JvmName("run")`) |
+| `processor.initialize()` | `processor.initialize()` (calls `javaNonSuspendInitialize` via `@JvmName`) |
+| `processor.onMessage(msg)` | `processor.onMessage(msg)` (calls `javaNonSuspendOnMessage` via `@JvmName`) |
+
+These wrappers use `runBlockingIfRequired()` internally. Java code calls them like normal blocking methods.
+
+### Overriding suspend methods from Java
+
+When a Java class extends a Kotlin class with `suspend` methods to override, look for non-suspend bridge methods annotated with `@JavaAPI`:
+
+| Kotlin override | Java override |
+|-----------------|---------------|
+| `override suspend fun processMessage(msg)` | `void handleMessage(FeatureMessage msg)` |
+| `override suspend fun close()` | `void handleClose()` |
+
+**Why the names differ:** `@JvmName` cannot be used on `open` or `override` methods (Kotlin restriction — it would break polymorphism). So Java-facing override names can diverge from the Kotlin suspend names (`handleMessage` not `processMessage`).
+
+### Abstract properties with Kotlin types
+
+Abstract properties like `val isOpen: StateFlow<Boolean>` leak Kotlin coroutine types to Java. If the base class provides a default `open val` implementation (e.g., via `MutableStateFlow`), Java subclasses don't need to implement it. Check whether the property is `abstract` or `open` before writing the Java example.
+
+### Before writing a Java subclass example
+
+1. Check what `@JavaAPI` bridge methods exist on the class — grep for `@JavaAPI` in the `jvmCommonMain` actual.
+2. Check which members are `abstract` vs `open` — abstract ones MUST be implemented in Java.
+3. Never show `Continuation`, `Object` return types, or `Unit.INSTANCE` in Java — use the bridge methods.
+
+## `is`-prefixed Kotlin properties
+
+Kotlin `val isOpen: StateFlow<Boolean>` generates Java getter `isOpen()` (not `getIsOpen()`). The `is` prefix follows JavaBeans convention for boolean-like property names.
+
+## Key source files to grep
+
+When writing Java examples that use these classes, check the JVM actuals for available `@JavaAPI` bridge methods:
+
+- `agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/AIAgent.kt` — `javaNonSuspendRun` with `@JvmName("run")`.
+- `agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/feature/message/FeatureMessageProcessor.kt` — calling bridges (`javaNonSuspendInitialize`, `javaNonSuspendOnMessage`) and overriding bridges (`handleMessage`, `handleClose`).
+- `agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockExecutorBuilder.kt` — Java builder for mock executor: `mockLLMAnswer()`, `mockLLMToolCall()`, `mockTool()` + inner builder classes.
+- `agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockPromptExecutor.kt` — entry point: `MockPromptExecutor.builder(serializer)` with `@JvmStatic @JavaAPI`.
+- `agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/tools/MockExecutorDSLBuilder.kt` — Kotlin DSL builder (reference for understanding what the Java builder delegates to).
+- `agents/agents-test/src/commonMain/kotlin/ai/koog/agents/testing/feature/TestingFeature.kt` — `Testing.Feature` companion object (used in Java as `Testing.Feature`).
+- `agents/agents-core/src/jvmTest/java/ai/koog/agents/core/agent/JavaAPIAgentBuilderJavaTest.java` — reference Java test using `MockPromptExecutor`, `AIAgent.builder()`, and functional strategies.

--- a/.claude/skills/add-java-code-snippets-in-docs/reference/pitfalls.md
+++ b/.claude/skills/add-java-code-snippets-in-docs/reference/pitfalls.md
@@ -1,0 +1,117 @@
+# Pitfalls, testing API, and docs classpath
+
+Load this file when something fails to compile, or when you're writing a `MockPromptExecutor`-based testing block.
+
+## Common pitfalls
+
+### `var` is only for local variables
+
+Java `var` (type inference) works only for local variables inside methods. For fields, use explicit types:
+
+```java
+// WRONG: static var logger = LoggerFactory.getLogger("x");
+// RIGHT: static Logger logger = LoggerFactory.getLogger("x");
+```
+
+### Inline value classes make constructors private from Java
+
+Kotlin classes with `Duration`, `Duration?`, or other inline value class parameters in their constructors generate synthetic constructors with `DefaultConstructorMarker`. These are not callable from Java. Solution: add a JVM `create()` factory — see `factory-classes.md`.
+
+### Import management
+
+Always add imports to the INCLUDE block. Never use fully-qualified names in visible code:
+
+```java
+// WRONG (in visible code): private static final org.slf4j.Logger logger = ...
+// RIGHT (in INCLUDE):      import org.slf4j.Logger;
+// RIGHT (in visible code): static Logger logger = ...
+```
+
+### `@JvmOverloads` check
+
+Before calling a Kotlin constructor/method with default parameters from Java, verify it has `@JvmOverloads`. Without it, Java only sees the full-parameter version (or synthetic constructors with `DefaultConstructorMarker`).
+
+### SUFFIX brace counting
+
+Count opening braces in INCLUDE carefully. The SUFFIX must have exactly the matching number of closing braces. Off-by-one errors cause `Syntax error: Expecting a top level declaration` at the end of the generated file. After writing SUFFIX, mentally concatenate INCLUDE + visible code + SUFFIX and verify all braces match.
+
+### `is`-prefixed Kotlin properties
+
+Kotlin `val isOpen: StateFlow<Boolean>` generates Java getter `isOpen()` (not `getIsOpen()`). The `is` prefix follows JavaBeans convention.
+
+### Kotlin `expect`/`actual` classes
+
+When an `expect abstract class` in `commonMain` has `abstract` members, Java subclasses must implement them. Check the **JVM actual** (in `jvmCommonMain`), not the `expect` declaration — the actual may provide default implementations or bridge methods not visible in the `expect`.
+
+### Legacy `/** **/` placeholder pattern
+
+Some docs have existing Java tabs that wrap code in `/** */` block comments (making the code a Javadoc comment that trivially compiles). This is a legacy pattern — **always replace with real compilable Java code** or explanatory comments for Kotlin-only APIs.
+
+## Testing API: `MockPromptExecutor.builder`
+
+The testing module (`agents-test`) provides Java-friendly builder APIs via `MockPromptExecutor.builder(serializer)`.
+
+### `MockExecutorBuilder` methods
+
+| Method | Description |
+|--------|-------------|
+| `mockLLMAnswer(text)` | Returns `MockLLMAnswerBuilder` — configure with `.asDefaultResponse()`, `.onRequestContains(pattern)`, `.onRequestEquals(pattern)`, `.onCondition(pred)`. |
+| `mockLLMToolCall(tool, args)` | Returns `MockLLMToolCallBuilder` — configure with `.onRequestEquals(pattern)`, `.onRequestContains(pattern)`, `.onCondition(pred)`. |
+| `mockTool(tool)` | Returns `MockToolBuilder` — configure with `.alwaysReturns(result)`, `.alwaysDoes(action)`, `.returns(result).onArguments(args)`, `.returns(result).onArgumentsMatching(pred)`. |
+| `clock(clock)` | Set custom clock. |
+| `tokenizer(tokenizer)` | Set custom tokenizer. |
+| `handleLastAssistantMessage(bool)` | Configure last-assistant-message handling. |
+| `build()` | Returns `PromptExecutor`. |
+
+All sub-builders return `MockExecutorBuilder` for method chaining.
+
+### Full Java test pattern
+
+```java
+PromptExecutor mockLLMApi = MockPromptExecutor.builder(new JacksonSerializer())
+    .mockLLMToolCall(SayToUser.INSTANCE, new SayToUser.Args(positiveText))
+        .onRequestEquals(positiveText)
+    .mockLLMAnswer(positiveResponse).onRequestContains(positiveResponse)
+    .mockLLMAnswer(defaultText).asDefaultResponse()
+    .mockTool(SayToUser.INSTANCE).alwaysReturns(positiveResponse)
+    .build();
+
+var agent = AIAgent.builder()
+    .promptExecutor(mockLLMApi)
+    .llmModel(OpenAIModels.Chat.GPT4o)
+    .install(Testing.Feature, config -> { })
+    .build();
+
+String result = agent.run(positiveText);
+```
+
+### Importing Kotlin objects in Java INCLUDE
+
+When Java code needs Kotlin objects defined in a Kotlin example's generated package, import from the generated package:
+
+```java
+import ai.koog.agents.example.exampleTesting03.*;
+```
+
+This gives access to tool definitions and other objects declared at the top level of the Kotlin example file.
+
+## Docs compilation environment
+
+### JDK version
+
+The project requires JDK 17. If the default JDK is newer (e.g., 25), compilation fails with cryptic errors. Use:
+
+```bash
+JAVA_HOME=/path/to/jdk-17 ./gradlew :docs:knit
+JAVA_HOME=/path/to/jdk-17 ./gradlew :docs:compileJava
+```
+
+### Docs classpath constraints
+
+The docs module has a limited classpath:
+
+- **JUnit is NOT available.** Do not use `import org.junit.jupiter.api.Assertions.*`. Use Java `assert` statements instead: `assert expected.equals(result) : "message";`
+- **JacksonSerializer IS available:** `import ai.koog.serialization.jackson.JacksonSerializer;`
+- **agents-core, agents-test, agents-ext ARE available:** agent builders, mock executors, `SayToUser` tool, etc.
+
+If compilation fails with "package X does not exist", check `docs/build.gradle.kts` for available dependencies.

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ docs/docs-code-snippets/*.java
 **/.env*
 .venv
 .DS_Store
-/.claude/
+/.claude/*
 !/.claude/skills/
 /.junie/memory
 


### PR DESCRIPTION
- Add a skill to append the Java code snippets in documentation based on existing Kotlin code blocks;
- Fix gitignore to allow committing Claude Code skills in the repo.