### PR TITLE
feat(agents): add AIAgentStorage to Persistence feature

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentRunSessionImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentRunSessionImpl.kt
@@ -60,7 +60,7 @@ internal class AIAgentRunSessionImpl<Input, Output, TContext : AIAgentContext>(
 
         when (sessionInputs) {
             is AdditionalInputs.None -> {}
-            is AdditionalInputs.Storage -> context.storage.putAll(sessionInputs.storage.toMap())
+            is AdditionalInputs.Storage -> context.storage.putAll(sessionInputs.storage)
         }
 
         val runResult = try {
@@ -119,7 +119,7 @@ internal class AIAgentRunSessionImpl<Input, Output, TContext : AIAgentContext>(
                 is AdditionalInputs.None -> {}
                 is AdditionalInputs.Storage -> {
                     sessionInputs.storage.clear()
-                    sessionInputs.storage.putAll(context.storage.toMap())
+                    sessionInputs.storage.putAll(context.storage)
                 }
             }
         }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/FunctionalAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/FunctionalAIAgent.kt
@@ -103,7 +103,7 @@ public class FunctionalAIAgent<Input, Output>(
             config = agentConfig,
             llm = initialLLMContext,
             stateManager = AIAgentStateManager(),
-            storage = AIAgentStorage(),
+            storage = AIAgentStorage(agentConfig.serializer),
             strategyName = strategy.name,
             pipeline = pipeline,
             executionInfo = executionInfo,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/GraphAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/GraphAIAgent.kt
@@ -170,7 +170,7 @@ public open class GraphAIAgent<Input, Output>(
 
     override suspend fun prepareContext(agentInput: Input, runId: String, eventId: String): AIAgentGraphContextBase {
         val stateManager = AIAgentStateManager()
-        val storage = AIAgentStorage()
+        val storage = AIAgentStorage(agentConfig.serializer)
 
         val executionInfo = AgentExecutionInfo(parent = null, partName = id)
         val initialEnvironment = prepareAgentEnvironment(eventId = eventId, executionInfo = executionInfo)

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentContext.kt
@@ -4,6 +4,7 @@ import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentStateManager
 import ai.koog.agents.core.agent.entity.AIAgentStorage
 import ai.koog.agents.core.agent.entity.AIAgentStorageKey
+import ai.koog.agents.core.agent.entity.createStorageKey
 import ai.koog.agents.core.agent.execution.AgentExecutionInfo
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.environment.AIAgentEnvironment
@@ -257,7 +258,7 @@ public inline fun <T> AIAgentContext.with(partName: String, block: (executionInf
  */
 @OptIn(InternalAgentsApi::class)
 public val graphAgentContextDataAdditionalKey: AIAgentStorageKey<GraphAgentContextData> =
-    AIAgentStorageKey("graph-agent-context-data-key")
+    createStorageKey<GraphAgentContextData>("graph-agent-context-data-key")
 
 /**
  * A storage key used for associating and retrieving `AgentContextData` within the AI agent's storage system.
@@ -272,7 +273,7 @@ public val graphAgentContextDataAdditionalKey: AIAgentStorageKey<GraphAgentConte
  */
 @OptIn(InternalAgentsApi::class)
 public val plannerAgentContextDataAdditionalKey: AIAgentStorageKey<PlannerAgentContextData> =
-    AIAgentStorageKey("planner-agent-context-data-key")
+    createStorageKey<PlannerAgentContextData>("planner-agent-context-data-key")
 
 /**
  * Stores the given agent context data within the current AI agent context.

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AgentContextData.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AgentContextData.kt
@@ -7,6 +7,7 @@ import ai.koog.agents.planner.PlannerAgentExecutionPoint
 import ai.koog.prompt.message.Message
 import ai.koog.serialization.JSONElement
 import ai.koog.serialization.JSONNull
+import ai.koog.serialization.JSONObject
 
 @InternalAgentsApi
 public sealed class AgentContextData {
@@ -18,6 +19,7 @@ public sealed class AgentContextData {
 @InternalAgentsApi
 public class GraphAgentContextData(
     override val messageHistory: List<Message>,
+    internal val storage: JSONObject,
     internal val nodePath: String,
     @Deprecated("Use lastOutput instead, lastOutput will be removed in future versions")
     internal val lastInput: JSONElement = JSONNull,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentGraphStrategy.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentGraphStrategy.kt
@@ -124,6 +124,9 @@ public open class AIAgentGraphStrategyBase<TInput, TOutput>(
         agentContext.llm.withPrompt {
             this.withMessages { (data.messageHistory) }
         }
+
+        // Restore the storage
+        agentContext.storage.putAllSerialized(data.storage.entries)
     }
 
     private fun setExecutionPointImpl(pathSegments: List<String>, node: AIAgentNodeBase<*, *>, input: Any?) {

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentStorage.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentStorage.kt
@@ -2,29 +2,55 @@
 
 package ai.koog.agents.core.agent.entity
 
+import ai.koog.serialization.JSONElement
+import ai.koog.serialization.JSONSerializer
+import ai.koog.serialization.TypeToken
+import ai.koog.serialization.typeToken
+
 /**
- * Represents a storage key used for identifying and accessing data associated with an AI agent.
+ * Represents a storage key used for [AIAgentStorage].
+ * Equality is based on the [name].
  *
- * The generic type parameter [T] specifies the type of data associated with this key, ensuring
- * type safety when storing and retrieving data in the context of an AI agent.
- *
- * Equality of [AIAgentStorageKey] instances is based on referential identity (default implementation):
- * two different instances created with the same [name] are not equal and will refer to distinct
- * storage entries. The [name] is used only for the string representation of the key.
- *
- * @param name The human-readable name of the storage key, used only for its string representation.
+ * @param name String key.
+ * @param typeToken Type of the value stored under this key.
  */
-public class AIAgentStorageKey<T : Any>(public val name: String) {
+public data class AIAgentStorageKey<T : Any>(
+    public val name: String,
+    public val typeToken: TypeToken,
+) {
     override fun toString(): String = "${super.toString()}(name=$name)"
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is AIAgentStorageKey<*>) return false
+
+        if (name != other.name) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return name.hashCode()
+    }
 }
 
 /**
- * Creates a unique storage key for a specific type, allowing identification and retrieval of values associated with it.
+ * Creates a [AIAgentStorageKey].
  *
- * @param name The name of the storage key used only for its string representation.
- * @return A new instance of [AIAgentStorageKey] for the specified type.
+ * @param name String key.
+ * @param typeToken Type of the value stored under this key.
  */
-public fun <T : Any> createStorageKey(name: String): AIAgentStorageKey<T> = AIAgentStorageKey(name)
+public fun <T : Any> createStorageKey(name: String, typeToken: TypeToken): AIAgentStorageKey<T> =
+    AIAgentStorageKey(name, typeToken)
+
+/**
+ * Creates a [AIAgentStorageKey].
+ *
+ * @param name String key.
+ * @param T Type of the value stored under this key.
+ */
+public inline fun <reified T : Any> createStorageKey(name: String): AIAgentStorageKey<T> =
+    AIAgentStorageKey(name, typeToken<T>())
 
 /**
  * Concurrent-safe key-value storage for an agent.
@@ -34,25 +60,26 @@ public fun <T : Any> createStorageKey(name: String): AIAgentStorageKey<T> = AIAg
 public expect class AIAgentStorage internal constructor(
     delegate: AIAgentStorageImpl,
 ) : AIAgentStorageAPI {
-    public constructor()
-
-    internal val delegate: AIAgentStorageImpl
 
     /**
-     * Creates a copy of this storage.
+     * Creates an instance of [AIAgentStorage].
      *
-     * The key-to-value mapping is copied, but the stored values themselves are not deep-copied:
-     * both the original and the copy share the same value instances.
-     *
-     * @return A new instance of [AIAgentStorage] with the same content as this one.
+     * @param serializer The [JSONSerializer] used to handle serialization and deserialization of stored values.
      */
-    internal suspend fun copy(): AIAgentStorage
+    public constructor(
+        serializer: JSONSerializer,
+    )
+
+    internal val delegate: AIAgentStorageImpl
 
     override suspend fun <T : Any> set(key: AIAgentStorageKey<T>, value: T)
     override suspend fun <T : Any> get(key: AIAgentStorageKey<T>): T?
     override suspend fun <T : Any> getValue(key: AIAgentStorageKey<T>): T
     override suspend fun <T : Any> remove(key: AIAgentStorageKey<T>): T?
-    override suspend fun toMap(): Map<AIAgentStorageKey<*>, Any>
     override suspend fun putAll(map: Map<AIAgentStorageKey<*>, Any>)
+    override suspend fun putAll(other: AIAgentStorage)
     override suspend fun clear()
+    override suspend fun copy(): AIAgentStorage
+    override suspend fun toSerializedMap(): Map<String, JSONElement>
+    override suspend fun putAllSerialized(map: Map<String, JSONElement>)
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentStorageAPI.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentStorageAPI.kt
@@ -1,5 +1,7 @@
 package ai.koog.agents.core.agent.entity
 
+import ai.koog.serialization.JSONElement
+
 /**
  * API for [AIAgentStorage]
  */
@@ -39,14 +41,6 @@ public interface AIAgentStorageAPI {
     public suspend fun <T : Any> remove(key: AIAgentStorageKey<T>): T?
 
     /**
-     * Converts the storage to a map representation.
-     *
-     * @return A map containing all key-value pairs currently stored in the system, where keys are of type [AIAgentStorageKey]
-     * and values are of type [Any].
-     */
-    public suspend fun toMap(): Map<AIAgentStorageKey<*>, Any>
-
-    /**
      * Adds all key-value pairs from the given map to the storage.
      *
      * @param map A map containing keys of type [AIAgentStorageKey] and their associated values of type [Any].
@@ -55,7 +49,38 @@ public interface AIAgentStorageAPI {
     public suspend fun putAll(map: Map<AIAgentStorageKey<*>, Any>)
 
     /**
+     * Puts the contents of the [other] storage instance into the current storage.
+     * This method combines key-value pairs from the specified storage with the current one.
+     * If a key exists in both storages, the value from the given storage will overwrite the existing value.
+     *
+     * @param other The [AIAgentStorage] instance whose key-value pairs should be merged into the current storage.
+     */
+    public suspend fun putAll(other: AIAgentStorage)
+
+    /**
+     * Creates a copy of the current storage.
+     */
+    public suspend fun copy(): AIAgentStorage
+
+    /**
      * Clears all data from the storage.
      */
     public suspend fun clear()
+
+    /**
+     * Returns serialized storage entries keyed by [AIAgentStorageKey.name].
+     *
+     * Entries whose values cannot be serialized are omitted.
+     */
+    public suspend fun toSerializedMap(): Map<String, JSONElement>
+
+    /**
+     * Adds serialized storage entries from the given map.
+     *
+     * Each map key is treated as an [AIAgentStorageKey.name]. Later calls to methods like [get] will match entries
+     * by that key name.
+     *
+     * @param map serialized values keyed by storage key name.
+     */
+    public suspend fun putAllSerialized(map: Map<String, JSONElement>)
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentStorageImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentStorageImpl.kt
@@ -1,46 +1,82 @@
 package ai.koog.agents.core.agent.entity
 
+import ai.koog.serialization.JSONElement
+import ai.koog.serialization.JSONSerializer
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
-internal class AIAgentStorageImpl : AIAgentStorageAPI {
+internal class AIAgentStorageImpl(
+    private val serializer: JSONSerializer,
+    private val storageMap: MutableMap<AIAgentStorageKey<*>, Any> = mutableMapOf(),
+    private val serializedStorageMap: MutableMap<String, JSONElement> = mutableMapOf(),
+) : AIAgentStorageAPI {
     private val mutex = Mutex()
-    private val storage = mutableMapOf<AIAgentStorageKey<*>, Any>()
-
-    internal suspend fun copy(): AIAgentStorageImpl {
-        val newStorage = AIAgentStorageImpl()
-        newStorage.putAll(this.toMap())
-        return newStorage
-    }
 
     @Suppress("UNCHECKED_CAST")
     override suspend fun <T : Any> set(key: AIAgentStorageKey<T>, value: T): Unit = mutex.withLock {
-        storage[key] = value
+        storageMap[key] = value
     }
 
-    @Suppress("UNCHECKED_CAST")
     override suspend fun <T : Any> get(key: AIAgentStorageKey<T>): T? = mutex.withLock {
-        storage[key] as T?
+        doGet(key)
     }
 
     override suspend fun <T : Any> getValue(key: AIAgentStorageKey<T>): T {
-        return get(key) ?: throw NoSuchElementException("Key $key not found in storage")
+        return doGet(key) ?: throw NoSuchElementException("Key $key not found in storage")
     }
 
-    @Suppress("UNCHECKED_CAST")
     override suspend fun <T : Any> remove(key: AIAgentStorageKey<T>): T? = mutex.withLock {
-        storage.remove(key) as T?
-    }
-
-    override suspend fun toMap(): Map<AIAgentStorageKey<*>, Any> = mutex.withLock {
-        storage.toMap()
+        doGet(key)?.also { storageMap -= key }
     }
 
     override suspend fun putAll(map: Map<AIAgentStorageKey<*>, Any>): Unit = mutex.withLock {
-        storage.putAll(map)
+        storageMap.putAll(map)
+    }
+
+    override suspend fun putAll(other: AIAgentStorage): Unit = mutex.withLock {
+        storageMap.putAll(other.delegate.storageMap)
+        serializedStorageMap.putAll(other.delegate.serializedStorageMap)
+    }
+
+    override suspend fun copy(): AIAgentStorage = mutex.withLock {
+        AIAgentStorage(AIAgentStorageImpl(serializer, storageMap.toMutableMap(), serializedStorageMap.toMutableMap()))
     }
 
     override suspend fun clear(): Unit = mutex.withLock {
-        storage.clear()
+        storageMap.clear()
+        serializedStorageMap.clear()
+    }
+
+    override suspend fun putAllSerialized(map: Map<String, JSONElement>) = mutex.withLock {
+        serializedStorageMap.putAll(map)
+    }
+
+    override suspend fun toSerializedMap(): Map<String, JSONElement> = mutex.withLock {
+        val newSerializedStorageMap = storageMap
+            .mapNotNull { (key, value) ->
+                runCatching { serializer.encodeToJSONElement(value, key.typeToken) }
+                    .getOrNull()
+                    ?.let { key.name to it }
+            }
+            .toMap()
+
+        serializedStorageMap.toMap() + newSerializedStorageMap
+    }
+
+    /**
+     * Common get implementation without mutex
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun <T : Any> doGet(key: AIAgentStorageKey<T>): T? {
+        val value = storageMap[key] as T?
+        if (value != null) return value
+
+        val deserializedValue = serializedStorageMap[key.name]
+            ?.let { serializer.decodeFromJSONElement(it, key.typeToken) as T? }
+
+        return deserializedValue?.also {
+            storageMap[key] = it
+            serializedStorageMap -= key.name
+        }
     }
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/debugger/Debugger.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/debugger/Debugger.kt
@@ -5,6 +5,7 @@ import ai.koog.agents.core.agent.context.AIAgentContext
 import ai.koog.agents.core.agent.context.featureOrThrow
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.agent.entity.AIAgentStorageKey
+import ai.koog.agents.core.agent.entity.createStorageKey
 import ai.koog.agents.core.annotation.ExperimentalAgentsApi
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.feature.AIAgentFunctionalFeature
@@ -101,7 +102,7 @@ public class Debugger(public val port: Int, public val awaitInitialConnectionTim
         public const val KOOG_DEBUGGER_WAIT_CONNECTION_TIMEOUT_MS_VM_OPTION: String = "koog.debugger.wait.connection.ms"
 
         override val key: AIAgentStorageKey<Debugger> =
-            AIAgentStorageKey("agents-features-debugger")
+            createStorageKey<Debugger>("agents-features-debugger")
 
         override fun createInitialConfig(
             agentConfig: AIAgentConfig,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
@@ -494,7 +494,7 @@ public fun <Input : Any> subgraphWithVerification(
     inputType = inputType,
     outputType = typeToken<CriticResult<Input>>()
 ) {
-    val inputKey = createStorageKey<Input>("subgraphWithVerification-input-key")
+    val inputKey = createStorageKey<Input>("subgraphWithVerification-input-key", inputType)
 
     val saveInput by node<Input, Input>(inputType = inputType, outputType = inputType) { input ->
         storage.set(inputKey, input)

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/PlannerAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/planner/PlannerAIAgent.kt
@@ -112,7 +112,7 @@ public class PlannerAIAgent<Input, Output>(
             config = agentConfig,
             llm = initialLLMContext,
             stateManager = AIAgentStateManager(),
-            storage = AIAgentStorage(),
+            storage = AIAgentStorage(agentConfig.serializer),
             strategyName = strategy.name,
             pipeline = pipeline,
             executionInfo = executionInfo,

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/context/AIAgentContextTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/context/AIAgentContextTest.kt
@@ -1,6 +1,6 @@
 package ai.koog.agents.core.agent.context
 
-import ai.koog.agents.core.agent.entity.AIAgentStorageKey
+import ai.koog.agents.core.agent.entity.createStorageKey
 import ai.koog.agents.core.agent.execution.AgentExecutionInfo
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -26,7 +26,7 @@ class AIAgentContextTest : AgentTestBase() {
 
     @Test
     fun testFeatureRetrieval() = runTest {
-        val featureKey = AIAgentStorageKey<String>("test-feature")
+        val featureKey = createStorageKey<String>("test-feature")
         val featureValue = "test-feature-value"
 
         val context = createTestContext()
@@ -39,7 +39,7 @@ class AIAgentContextTest : AgentTestBase() {
 
     @Test
     fun testFeatureRetrievalNotFound() = runTest {
-        val featureKey = AIAgentStorageKey<String>("non-existent-feature")
+        val featureKey = createStorageKey<String>("non-existent-feature")
         val context = createTestContext()
 
         val retrievedFromStorage = context.storage.get(featureKey)
@@ -48,7 +48,7 @@ class AIAgentContextTest : AgentTestBase() {
 
     @Test
     fun testFeatureOverwrite() = runTest {
-        val featureKey = AIAgentStorageKey<String>("test-feature")
+        val featureKey = createStorageKey<String>("test-feature")
         val initialValue = "initial-value"
         val updatedValue = "updated-value"
         val context = createTestContext()
@@ -203,7 +203,7 @@ class AIAgentContextTest : AgentTestBase() {
 
     @Test
     fun testContextForkWithIsolatedStorage() = runTest {
-        val storageKey = AIAgentStorageKey<String>("test-key")
+        val storageKey = createStorageKey<String>("test-key")
 
         val originalContext = createTestContext()
         originalContext.storage.set(storageKey, "original-value")

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/context/AgentTestBase.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/context/AgentTestBase.kt
@@ -93,7 +93,7 @@ open class AgentTestBase {
     }
 
     protected fun createTestStorage(): AIAgentStorage {
-        return AIAgentStorage()
+        return AIAgentStorage(KotlinxSerializer())
     }
 
     protected open fun createTestContext(

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/entity/AIAgentStorageTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/entity/AIAgentStorageTest.kt
@@ -1,0 +1,104 @@
+package ai.koog.agents.core.agent.entity
+
+import ai.koog.serialization.kotlinx.KotlinxSerializer
+import ai.koog.serialization.typeToken
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.maps.shouldContainKey
+import io.kotest.matchers.maps.shouldNotContainKey
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+
+class AIAgentStorageTest {
+    @Serializable
+    private data class TestPerson(val name: String, val age: Int)
+
+    @Serializable
+    private data class TestAddress(val city: String, val country: String)
+
+    private class Unserializable(val value: String)
+
+    @Test
+    fun testPutAllSerializedThenGetTwice() = runTest {
+        val serializer = KotlinxSerializer()
+        val storage = AIAgentStorage(serializer)
+
+        val personElement = serializer.encodeToJSONElement(TestPerson("Alice", 30), typeToken<TestPerson>())
+        storage.putAllSerialized(mapOf("person" to personElement))
+
+        val key = createStorageKey<TestPerson>("person")
+
+        // First get — deserializes from serializedStorageMap and caches in storageMap
+        storage.get(key) shouldBe TestPerson("Alice", 30)
+
+        // Second get — served from storageMap
+        storage.get(key) shouldBe TestPerson("Alice", 30)
+    }
+
+    @Test
+    fun testSetThenToSerializedMap() = runTest {
+        val serializer = KotlinxSerializer()
+        val storage = AIAgentStorage(serializer)
+
+        val key = createStorageKey<TestPerson>("person")
+        storage.set(key, TestPerson("Bob", 25))
+
+        val serialized = storage.toSerializedMap()
+        serialized shouldContainKey "person"
+
+        serializer.encodeJSONElementToString(serialized["person"]!!) shouldEqualJson """{"name":"Bob","age":25}"""
+    }
+
+    @Test
+    fun testMixedStatePreservesAllKeys() = runTest {
+        val serializer = KotlinxSerializer()
+        val storage = AIAgentStorage(serializer)
+
+        val personElement = serializer.encodeToJSONElement(TestPerson("Alice", 30), typeToken<TestPerson>())
+        val addressElement = serializer.encodeToJSONElement(TestAddress("London", "UK"), typeToken<TestAddress>())
+        storage.putAllSerialized(mapOf("person" to personElement, "address" to addressElement))
+
+        val personKey = createStorageKey<TestPerson>("person")
+        storage.get(personKey) // moves "person" to storageMap, "address" stays in serializedStorageMap
+
+        val scoreKey = createStorageKey<Int>("score")
+        storage.set(scoreKey, 42)
+
+        val result = storage.toSerializedMap()
+        result shouldContainKey "person" // re-serialized from storageMap
+        result shouldContainKey "address" // passed through from serializedStorageMap
+        result shouldContainKey "score" // newly added
+
+        serializer.encodeJSONElementToString(result["score"]!!) shouldEqualJson "42"
+    }
+
+    @Test
+    fun testGetWithWrongTypeThrows() = runTest {
+        val serializer = KotlinxSerializer()
+        val storage = AIAgentStorage(serializer)
+
+        val personElement = serializer.encodeToJSONElement(TestPerson("Alice", 30), typeToken<TestPerson>())
+        storage.putAllSerialized(mapOf("person" to personElement))
+
+        val wrongKey = createStorageKey<Int>("person")
+        shouldThrow<Exception> { storage.get(wrongKey) }
+    }
+
+    @Test
+    fun testToSerializedMapSkipsUnserializableKeys() = runTest {
+        val serializer = KotlinxSerializer()
+        val storage = AIAgentStorage(serializer)
+
+        val goodKey = createStorageKey<TestPerson>("good")
+        storage.set(goodKey, TestPerson("Carol", 20))
+
+        val badKey = createStorageKey<Unserializable>("bad")
+        storage.set(badKey, Unserializable("x"))
+
+        val result = storage.toSerializedMap()
+        result shouldContainKey "good"
+        result shouldNotContainKey "bad"
+    }
+}

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/dsl/extension/ParallelNodesMergeContextTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/dsl/extension/ParallelNodesMergeContextTest.kt
@@ -3,7 +3,7 @@ package ai.koog.agents.core.dsl.extension
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
-import ai.koog.agents.core.agent.entity.AIAgentStorageKey
+import ai.koog.agents.core.agent.entity.createStorageKey
 import ai.koog.agents.core.dsl.builder.AIAgentGraphStrategyBuilder
 import ai.koog.agents.core.dsl.builder.AIAgentNodeDelegate
 import ai.koog.agents.core.dsl.builder.forwardTo
@@ -24,7 +24,7 @@ import kotlin.test.assertNotNull
 class ParallelNodesMergeContextTest {
     private val serializer = KotlinxSerializer()
 
-    private val testKey = AIAgentStorageKey<String>("testKey")
+    private val testKey = createStorageKey<String>("testKey")
 
     private fun AIAgentGraphStrategyBuilder<String, String>.testNode(
         name: String,

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/dsl/extension/ParallelNodesTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/dsl/extension/ParallelNodesTest.kt
@@ -3,7 +3,7 @@ package ai.koog.agents.core.dsl.extension
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
-import ai.koog.agents.core.agent.entity.AIAgentStorageKey
+import ai.koog.agents.core.agent.entity.createStorageKey
 import ai.koog.agents.core.dsl.builder.ParallelNodeExecutionResult
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.node
@@ -60,9 +60,9 @@ class ParallelNodesTest {
     @Test
     fun testContextIsolation() = runTest {
         val agentStrategy = strategy<String, String>("test-isolation") {
-            val testKey1 = AIAgentStorageKey<String>("testKey1")
-            val testKey2 = AIAgentStorageKey<String>("testKey2")
-            val testKey3 = AIAgentStorageKey<String>("testKey3")
+            val testKey1 = createStorageKey<String>("testKey1")
+            val testKey2 = createStorageKey<String>("testKey2")
+            val testKey3 = createStorageKey<String>("testKey3")
             val val1 = "value1"
             val val2 = "value2"
             val val3 = "value3"

--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentStorage.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentStorage.kt
@@ -1,28 +1,22 @@
-@file:Suppress("MissingKDocForPublicAPI", "EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
-@file:OptIn(InternalKoogUtils::class)
-
 package ai.koog.agents.core.agent.entity
 
 import ai.koog.agents.annotations.JavaAPI
+import ai.koog.serialization.JSONSerializer
+import ai.koog.serialization.TypeToken
 import ai.koog.utils.annotations.InternalKoogUtils
 import ai.koog.utils.concurrency.runBlockingReentrant
 
-/**
- * Represents a storage key used for identifying and accessing data associated with an AI agent.
- *
- * The generic type parameter [T] specifies the type of data associated with this key, ensuring
- * type safety when storing and retrieving data in the context of an AI agent.
- */
+@Suppress("MissingKDocForPublicAPI", "EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+@OptIn(InternalKoogUtils::class)
 public actual class AIAgentStorage internal actual constructor(
     internal actual val delegate: AIAgentStorageImpl,
 ) : AIAgentStorageAPI by delegate {
-    public actual constructor() : this(
-        delegate = AIAgentStorageImpl()
-    )
 
-    internal actual suspend fun copy(): AIAgentStorage {
-        return AIAgentStorage(delegate = delegate.copy())
-    }
+    public actual constructor(
+        serializer: JSONSerializer,
+    ) : this(
+        delegate = AIAgentStorageImpl(serializer)
+    )
 
     @JavaAPI
     @JvmName("set")
@@ -49,12 +43,6 @@ public actual class AIAgentStorage internal actual constructor(
     }
 
     @JavaAPI
-    @JvmName("toMap")
-    public fun toMapBlocking(): Map<AIAgentStorageKey<*>, Any> = runBlockingReentrant {
-        toMap()
-    }
-
-    @JavaAPI
     @JvmName("putAll")
     public fun putAllBlocking(map: Map<AIAgentStorageKey<*>, Any>): Unit = runBlockingReentrant {
         putAll(map)
@@ -71,10 +59,11 @@ public actual class AIAgentStorage internal actual constructor(
          * Creates a storage key for a specific type, allowing identification and retrieval of values associated with it.
          *
          * @param name The name of the storage key, used to uniquely identify it.
-         * @return A new instance of [AIAgentStorageKey] for the specified type.
+         * @param typeToken Type of the value stored under this key.
          */
         @JavaAPI
         @JvmStatic
-        public fun <T : Any> createStorageKey(name: String): AIAgentStorageKey<T> = AIAgentStorageKey(name)
+        public fun <T : Any> createStorageKey(name: String, typeToken: TypeToken): AIAgentStorageKey<T> =
+            AIAgentStorageKey(name, typeToken)
     }
 }

--- a/agents/agents-core/src/jvmTest/java/ai/koog/agents/core/agent/JavaAIAgentStorageTest.java
+++ b/agents/agents-core/src/jvmTest/java/ai/koog/agents/core/agent/JavaAIAgentStorageTest.java
@@ -1,6 +1,8 @@
 package ai.koog.agents.core.agent;
 
 import ai.koog.agents.core.agent.entity.AIAgentStorage;
+import ai.koog.serialization.TypeToken;
+import ai.koog.serialization.jackson.JacksonSerializer;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -9,8 +11,8 @@ public class JavaAIAgentStorageTest {
 
     @Test
     void testUseStorage() {
-        var storage = new AIAgentStorage();
-        var stringKey = AIAgentStorage.<String>createStorageKey("test");
+        var storage = new AIAgentStorage(new JacksonSerializer());
+        var stringKey = AIAgentStorage.createStorageKey("test", TypeToken.of(String.class));
         var value = "test value";
 
         storage.set(stringKey, value);

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/AIAgentStoragePassingTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/AIAgentStoragePassingTest.kt
@@ -3,7 +3,7 @@ package ai.koog.agents.core.agent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.context.AIAgentContext
 import ai.koog.agents.core.agent.entity.AIAgentStorage
-import ai.koog.agents.core.agent.entity.AIAgentStorageKey
+import ai.koog.agents.core.agent.entity.createStorageKey
 import ai.koog.agents.core.agent.session.AdditionalInputs
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
@@ -23,8 +23,8 @@ class AIAgentStoragePassingTest {
     private val serializer = KotlinxSerializer()
 
     companion object {
-        val greetingKey = AIAgentStorageKey<String>("greeting")
-        val counterKey = AIAgentStorageKey<Int>("counter")
+        val greetingKey = createStorageKey<String>("greeting")
+        val counterKey = createStorageKey<Int>("counter")
     }
 
     private val agentConfig = AIAgentConfig(
@@ -132,7 +132,7 @@ class AIAgentStoragePassingTest {
             toolRegistry = ToolRegistry.EMPTY,
         )
 
-        val storage = AIAgentStorage()
+        val storage = AIAgentStorage(KotlinxSerializer())
         storage.set(greetingKey, "hello from outside")
         storage.set(counterKey, 42)
 
@@ -174,7 +174,7 @@ class AIAgentStoragePassingTest {
         val session = agent.createSession("test-session")
         val output = session.run(
             input = "ignored",
-            sessionInputs = AdditionalInputs.Storage(AIAgentStorage()),
+            sessionInputs = AdditionalInputs.Storage(AIAgentStorage(KotlinxSerializer())),
         )
 
         assertEquals("greeting=null, counter=null", output)
@@ -189,7 +189,7 @@ class AIAgentStoragePassingTest {
             toolRegistry = ToolRegistry.EMPTY,
         )
 
-        val storage = AIAgentStorage()
+        val storage = AIAgentStorage(KotlinxSerializer())
         storage.set(greetingKey, "original")
 
         val session = agent.createSession("test-session")
@@ -211,7 +211,7 @@ class AIAgentStoragePassingTest {
             toolRegistry = ToolRegistry.EMPTY,
         )
 
-        val externalStorage = AIAgentStorage()
+        val externalStorage = AIAgentStorage(KotlinxSerializer())
         externalStorage.set(greetingKey, "original")
 
         val session = agent.createSession("test-session")
@@ -232,7 +232,7 @@ class AIAgentStoragePassingTest {
             toolRegistry = ToolRegistry.EMPTY,
         )
 
-        val externalStorage = AIAgentStorage()
+        val externalStorage = AIAgentStorage(KotlinxSerializer())
         externalStorage.set(greetingKey, "keep-me")
 
         val session = agent.createSession("test-session")
@@ -254,7 +254,7 @@ class AIAgentStoragePassingTest {
             toolRegistry = ToolRegistry.EMPTY,
         )
 
-        val externalStorage = AIAgentStorage()
+        val externalStorage = AIAgentStorage(KotlinxSerializer())
         externalStorage.set(greetingKey, "to-be-removed")
         externalStorage.set(counterKey, 7)
 
@@ -277,7 +277,7 @@ class AIAgentStoragePassingTest {
             toolRegistry = ToolRegistry.EMPTY,
         )
 
-        val externalStorage = AIAgentStorage()
+        val externalStorage = AIAgentStorage(KotlinxSerializer())
         externalStorage.set(greetingKey, "original")
 
         val session = agent.createSession("test-session")
@@ -300,7 +300,7 @@ class AIAgentStoragePassingTest {
             toolRegistry = ToolRegistry.EMPTY,
         )
 
-        val firstStorage = AIAgentStorage()
+        val firstStorage = AIAgentStorage(KotlinxSerializer())
         firstStorage.set(greetingKey, "first-run")
         firstStorage.set(counterKey, 1)
 
@@ -325,7 +325,7 @@ class AIAgentStoragePassingTest {
             toolRegistry = ToolRegistry.EMPTY,
         )
 
-        val externalStorage = AIAgentStorage()
+        val externalStorage = AIAgentStorage(KotlinxSerializer())
         externalStorage.set(greetingKey, "hello")
 
         val session = agent.createSession("test-session")

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/feature/ToolCallFailureEventsTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/feature/ToolCallFailureEventsTest.kt
@@ -2,7 +2,7 @@ package ai.koog.agents.core.feature
 
 import ai.koog.agents.core.agent.GraphAIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
-import ai.koog.agents.core.agent.entity.AIAgentStorageKey
+import ai.koog.agents.core.agent.entity.createStorageKey
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.nodeExecuteTool
 import ai.koog.agents.core.environment.ReceivedToolResult
@@ -56,7 +56,7 @@ class ToolCallFailureEventsTest {
     }
 
     private object ToolFailureCaptureFeature : AIAgentGraphFeature<ToolFailureCaptureConfig, Unit> {
-        override val key = AIAgentStorageKey<Unit>("tool_failure_capture")
+        override val key = createStorageKey<Unit>("tool_failure_capture")
 
         override fun createInitialConfig(
             agentConfig: AIAgentConfig,

--- a/agents/agents-core/src/nonJvmCommonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentStorage.kt
+++ b/agents/agents-core/src/nonJvmCommonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentStorage.kt
@@ -1,15 +1,14 @@
-@file:Suppress("MissingKDocForPublicAPI", "EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
-
 package ai.koog.agents.core.agent.entity
 
+import ai.koog.serialization.JSONSerializer
+
+@Suppress("MissingKDocForPublicAPI", "EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 public actual class AIAgentStorage internal actual constructor(
     internal actual val delegate: AIAgentStorageImpl,
 ) : AIAgentStorageAPI by delegate {
-    public actual constructor() : this(
-        delegate = AIAgentStorageImpl()
+    public actual constructor(
+        serializer: JSONSerializer,
+    ) : this(
+        delegate = AIAgentStorageImpl(serializer)
     )
-
-    internal actual suspend fun copy(): AIAgentStorage {
-        return AIAgentStorage(delegate = delegate.copy())
-    }
 }

--- a/agents/agents-features/agents-features-acp/src/jvmMain/kotlin/ai/koog/agents/features/acp/AcpAgent.kt
+++ b/agents/agents-features/agents-features-acp/src/jvmMain/kotlin/ai/koog/agents/features/acp/AcpAgent.kt
@@ -4,6 +4,7 @@ import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.context.AIAgentContext
 import ai.koog.agents.core.agent.context.featureOrThrow
 import ai.koog.agents.core.agent.entity.AIAgentStorageKey
+import ai.koog.agents.core.agent.entity.createStorageKey
 import ai.koog.agents.core.agent.exception.AIAgentMaxNumberOfIterationsReachedException
 import ai.koog.agents.core.feature.AIAgentFunctionalFeature
 import ai.koog.agents.core.feature.AIAgentGraphFeature
@@ -120,7 +121,7 @@ public class AcpAgent(
         AIAgentPlannerFeature<AcpConfig, AcpAgent> {
 
         private val logger = KotlinLogging.logger { }
-        override val key: AIAgentStorageKey<AcpAgent> = AIAgentStorageKey("agents-features-acp")
+        override val key: AIAgentStorageKey<AcpAgent> = createStorageKey<AcpAgent>("agents-features-acp")
 
         override fun createInitialConfig(
             agentConfig: AIAgentConfig,

--- a/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandler.kt
+++ b/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandler.kt
@@ -5,6 +5,7 @@ package ai.koog.agents.features.eventHandler.feature
 import ai.koog.agents.core.agent.GraphAIAgent.FeatureContext
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentStorageKey
+import ai.koog.agents.core.agent.entity.createStorageKey
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.feature.AIAgentFunctionalFeature
 import ai.koog.agents.core.feature.AIAgentGraphFeature
@@ -62,7 +63,7 @@ public class EventHandler {
         private val logger = KotlinLogging.logger { }
 
         override val key: AIAgentStorageKey<EventHandler> =
-            AIAgentStorageKey("agents-features-event-handler")
+            createStorageKey<EventHandler>("agents-features-event-handler")
 
         override fun createInitialConfig(
             agentConfig: AIAgentConfig

--- a/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/chatMemory/feature/ChatMemory.kt
+++ b/agents/agents-features/agents-features-memory/src/commonMain/kotlin/ai/koog/agents/chatMemory/feature/ChatMemory.kt
@@ -2,6 +2,7 @@ package ai.koog.agents.chatMemory.feature
 
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentStorageKey
+import ai.koog.agents.core.agent.entity.createStorageKey
 import ai.koog.agents.core.feature.AIAgentFunctionalFeature
 import ai.koog.agents.core.feature.AIAgentGraphFeature
 import ai.koog.agents.core.feature.AIAgentPlannerFeature
@@ -47,7 +48,7 @@ public class ChatMemory {
         AIAgentPlannerFeature<ChatMemoryConfig, ChatMemory> {
 
         override val key: AIAgentStorageKey<ChatMemory> =
-            AIAgentStorageKey("agents-features-chat-memory")
+            createStorageKey<ChatMemory>("agents-features-chat-memory")
 
         override fun createInitialConfig(
             agentConfig: AIAgentConfig,

--- a/agents/agents-features/agents-features-opentelemetry/src/commonMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/commonMain/kotlin/ai/koog/agents/features/opentelemetry/feature/OpenTelemetry.kt
@@ -2,6 +2,7 @@ package ai.koog.agents.features.opentelemetry.feature
 
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentStorageKey
+import ai.koog.agents.core.agent.entity.createStorageKey
 import ai.koog.agents.core.agent.execution.AgentExecutionInfo
 import ai.koog.agents.core.feature.AIAgentFunctionalFeature
 import ai.koog.agents.core.feature.AIAgentGraphFeature
@@ -70,7 +71,7 @@ public class OpenTelemetry {
 
         private val logger = KotlinLogging.logger { }
 
-        override val key: AIAgentStorageKey<OpenTelemetry> = AIAgentStorageKey("agents-features-opentelemetry")
+        override val key: AIAgentStorageKey<OpenTelemetry> = createStorageKey<OpenTelemetry>("agents-features-opentelemetry")
 
         override fun createInitialConfig(
             agentConfig: AIAgentConfig

--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/AgentCheckpointData.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/AgentCheckpointData.kt
@@ -33,9 +33,13 @@ import kotlin.uuid.Uuid
  * Represents the checkpoint data for an agent's state during a session.
  *
  * @property checkpointId The unique identifier of the checkpoint. This allows tracking and restoring the agent's session to a specific state.
- * @property messageHistory A list of messages exchanged in the session up to the checkpoint. Messages include interactions between the user, system, assistant, and tools.
- * @property properties Additional data associated with the checkpoint. This can be used to store additional information about the agent's state.
  * @property createdAt The timestamp when the checkpoint was created.
+ * @property nodePath The identifier of the node where the checkpoint was created.
+ * @property lastInput Serialized input received for node with [nodePath]
+ * @property lastOutput Serialized output received from node with [nodePath]
+ * @property messageHistory A list of messages exchanged in the session up to the checkpoint. Messages include interactions between the user, system, assistant, and tools.
+ * @property storage Serialized [ai.koog.agents.core.agent.entity.AIAgentStorage]
+ * @property properties Additional data associated with the checkpoint. This can be used to store additional information about the agent's state.
  * @property version The version of the checkpoint data structure
  */
 @OptIn(ExperimentalSerializationApi::class)
@@ -45,6 +49,7 @@ public data class AgentCheckpointData internal constructor(
     val checkpointId: String,
     val createdAt: Instant,
     val messageHistory: List<Message>,
+    val storage: JSONObject? = null,
     val version: Long,
     val graphProperties: GraphCheckpointProperties?,
     val plannerProperties: PlannerCheckpointProperties?,
@@ -65,12 +70,13 @@ public data class AgentCheckpointData internal constructor(
         version: Long,
         properties: JSONObject? = null
     ) : this(
-        checkpointId,
-        createdAt,
-        messageHistory,
-        version,
-        GraphCheckpointProperties(nodePath, lastInput ?: JSONNull, lastOutput ?: JSONNull),
-        JSONObject(
+        checkpointId = checkpointId,
+        createdAt = createdAt,
+        messageHistory = messageHistory,
+        storage = null,
+        version = version,
+        graphProperties = GraphCheckpointProperties(nodePath, lastInput ?: JSONNull, lastOutput ?: JSONNull),
+        properties = JSONObject(
             buildMap {
                 properties?.entries?.let { putAll(it) }
             }
@@ -84,17 +90,19 @@ public data class AgentCheckpointData internal constructor(
         checkpointId: String,
         createdAt: Instant,
         messageHistory: List<Message>,
+        storage: JSONObject? = null,
         version: Long,
         graphProperties: GraphCheckpointProperties,
         properties: JSONObject? = null,
     ) : this(
-        checkpointId,
-        createdAt,
-        messageHistory,
-        version,
-        graphProperties,
-        null,
-        properties
+        checkpointId = checkpointId,
+        createdAt = createdAt,
+        messageHistory = messageHistory,
+        storage = storage,
+        version = version,
+        graphProperties = graphProperties,
+        plannerProperties = null,
+        properties = properties
     )
 
     /**
@@ -104,17 +112,19 @@ public data class AgentCheckpointData internal constructor(
         checkpointId: String,
         createdAt: Instant,
         messageHistory: List<Message>,
+        storage: JSONObject? = null,
         version: Long,
         plannerProperties: PlannerCheckpointProperties,
         properties: JSONObject? = null,
     ) : this(
-        checkpointId,
-        createdAt,
-        messageHistory,
-        version,
-        null,
-        plannerProperties,
-        properties
+        checkpointId = checkpointId,
+        createdAt = createdAt,
+        messageHistory = messageHistory,
+        storage = storage,
+        version = version,
+        graphProperties = null,
+        plannerProperties = plannerProperties,
+        properties = properties
     )
 
     /**
@@ -197,9 +207,10 @@ public fun tombstoneCheckpoint(
         checkpointId = Uuid.random().toString(),
         createdAt = createdAt,
         messageHistory = emptyList(),
+        storage = null,
         version = version,
-        null,
-        null,
+        graphProperties = null,
+        plannerProperties = null,
         properties = JSONObject(
             mapOf(
                 PersistenceUtils.TOMBSTONE_CHECKPOINT_NAME to JSONPrimitive(true)
@@ -247,20 +258,21 @@ public fun AgentCheckpointData.toAgentContextData(
 ): AgentContextData? {
     return when {
         graphProperties != null -> GraphAgentContextData(
-            messageHistory,
-            graphProperties.nodePath,
-            graphProperties.lastInput,
-            graphProperties.lastOutput,
-            rollbackStrategy,
-            additionalRollbackActions
+            messageHistory = messageHistory,
+            storage = storage ?: JSONObject(emptyMap()),
+            nodePath = graphProperties.nodePath,
+            lastInput = graphProperties.lastInput,
+            lastOutput = graphProperties.lastOutput,
+            rollbackStrategy = rollbackStrategy,
+            additionalRollbackActions = additionalRollbackActions
         )
         plannerProperties != null -> PlannerAgentContextData(
-            messageHistory,
-            plannerProperties.state,
-            plannerProperties.plan,
-            plannerProperties.executionPoint,
-            rollbackStrategy,
-            additionalRollbackActions
+            messageHistory = messageHistory,
+            state = plannerProperties.state,
+            plan = plannerProperties.plan,
+            executionPoint = plannerProperties.executionPoint,
+            rollbackStrategy = rollbackStrategy,
+            additionalRollbackActions = additionalRollbackActions
         )
         else -> null
     }

--- a/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/Persistence.kt
+++ b/agents/agents-features/agents-features-snapshot/src/commonMain/kotlin/ai/koog/agents/snapshot/feature/Persistence.kt
@@ -13,6 +13,7 @@ import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.agent.entity.AIAgentStorage
 import ai.koog.agents.core.agent.entity.AIAgentStorageKey
 import ai.koog.agents.core.agent.entity.AIAgentSubgraphBase
+import ai.koog.agents.core.agent.entity.createStorageKey
 import ai.koog.agents.core.agent.execution.DEFAULT_AGENT_PATH_SEPARATOR
 import ai.koog.agents.core.agent.session.AIAgentRunSession
 import ai.koog.agents.core.agent.session.AdditionalInputs
@@ -28,6 +29,8 @@ import ai.koog.agents.planner.PlannerAgentExecutionPoint
 import ai.koog.agents.snapshot.providers.PersistenceStorageProvider
 import ai.koog.prompt.message.Message
 import ai.koog.serialization.JSONElement
+import ai.koog.serialization.JSONObject
+import ai.koog.serialization.JSONSerializer
 import ai.koog.serialization.TypeToken
 import ai.koog.serialization.kotlinx.toKoogJSONElement
 import ai.koog.serialization.kotlinx.toKoogJSONObject
@@ -77,10 +80,13 @@ public typealias Persistency = Persistence
  * using the [PersistenceFeatureConfig.enableAutomaticPersistence] option.
  *
  * @property persistenceStorageProvider The provider responsible for storing and retrieving checkpoints
+ * @property serializer The JSON serializer.
+ * @property clock The clock used for timestamping checkpoints
  */
 @OptIn(ExperimentalUuidApi::class, ExperimentalTime::class, InternalAgentsApi::class)
 public class Persistence(
     private val persistenceStorageProvider: PersistenceStorageProvider<*>,
+    internal val serializer: JSONSerializer,
     internal val clock: KoogClock = KoogClock.System,
 ) {
     /**
@@ -116,7 +122,7 @@ public class Persistence(
 
         private val logger = KotlinLogging.logger { }
 
-        override val key: AIAgentStorageKey<Persistence> = AIAgentStorageKey("agents-features-snapshot")
+        override val key: AIAgentStorageKey<Persistence> = createStorageKey<Persistence>("agents-features-snapshot")
 
         override fun createInitialConfig(
             agentConfig: AIAgentConfig
@@ -126,7 +132,7 @@ public class Persistence(
             config: PersistenceFeatureConfig,
             pipeline: AIAgentGraphPipeline,
         ): Persistence {
-            val persistence = Persistence(config.storage)
+            val persistence = Persistence(config.storage, pipeline.config.serializer)
             persistence.rollbackStrategy = config.rollbackStrategy
             persistence.rollbackToolRegistry = config.rollbackToolRegistry
 
@@ -179,7 +185,7 @@ public class Persistence(
         }
 
         override fun install(config: PersistenceFeatureConfig, pipeline: AIAgentPlannerPipeline): Persistence {
-            val persistence = Persistence(config.storage)
+            val persistence = Persistence(config.storage, pipeline.config.serializer)
             persistence.rollbackStrategy = config.rollbackStrategy
             persistence.rollbackToolRegistry = config.rollbackToolRegistry
 
@@ -262,7 +268,7 @@ public class Persistence(
          * **not** need to be installed on the agent for this to work.
          *
          * @param agent The agent to run.
-         * @param agentInput The input to provide to the agent.
+         * @param input The input to provide to the agent.
          * @param checkpoint The checkpoint data to restore from.
          * @param rollbackStrategy The strategy to use when restoring state. Defaults to [RollbackStrategy.Default].
          * @param sessionId Optional session identifier. A random UUID is generated if not provided.
@@ -270,11 +276,14 @@ public class Persistence(
          */
         public suspend fun <Input, Output> runFromCheckpoint(
             agent: AIAgent<Input, Output>,
-            agentInput: Input,
+            input: Input,
             checkpoint: AgentCheckpointData,
             rollbackStrategy: RollbackStrategy = RollbackStrategy.Default,
             sessionId: String? = null,
-        ): Output = runFromCheckpoint(agent.createSession(sessionId), agentInput, checkpoint, rollbackStrategy)
+        ): Output {
+            val session = agent.createSession(sessionId)
+            return runFromCheckpoint(session, input, checkpoint, rollbackStrategy)
+        }
 
         /**
          * Runs the session from a previously saved checkpoint.
@@ -295,7 +304,8 @@ public class Persistence(
             checkpoint: AgentCheckpointData,
             rollbackStrategy: RollbackStrategy = RollbackStrategy.Default,
         ): Output {
-            val storage = AIAgentStorage()
+            val serializer = session.pipeline()?.config?.serializer ?: throw IllegalStateException("Agent config not found in session pipeline")
+            val storage = AIAgentStorage(serializer)
             storage.set(graphAgentContextDataAdditionalKey, checkpoint.toAgentContextData(rollbackStrategy) as GraphAgentContextData)
             return session.run(input, AdditionalInputs.Storage(storage))
         }
@@ -346,7 +356,7 @@ public class Persistence(
         checkpointId: String? = null,
     ): AgentCheckpointData? {
         val inputJson: JSONElement? = try {
-            agentContext.config.serializer.encodeToJSONElement(lastInput, lastInputType)
+            serializer.encodeToJSONElement(lastInput, lastInputType)
         } catch (_: Exception) {
             null
         }
@@ -361,6 +371,7 @@ public class Persistence(
         val checkpoint = AgentCheckpointData(
             checkpointId = checkpointId ?: Uuid.random().toString(),
             messageHistory = agentContext.getHistory(),
+            storage = JSONObject(agentContext.storage.toSerializedMap()),
             createdAt = clock.now(),
             version = version,
             graphProperties = GraphCheckpointProperties(
@@ -394,7 +405,7 @@ public class Persistence(
         checkpointId: String? = null,
     ): AgentCheckpointData? {
         val outputJson = try {
-            agentContext.config.serializer.encodeToJSONElement(lastOutput, lastOutputType)
+            serializer.encodeToJSONElement(lastOutput, lastOutputType)
         } catch (_: Exception) {
             null
         }
@@ -409,6 +420,7 @@ public class Persistence(
         val checkpoint = AgentCheckpointData(
             checkpointId = checkpointId ?: Uuid.random().toString(),
             messageHistory = agentContext.getHistory(),
+            storage = JSONObject(agentContext.storage.toSerializedMap()),
             createdAt = clock.now(),
             version = version,
             graphProperties = GraphCheckpointProperties(
@@ -458,6 +470,7 @@ public class Persistence(
         val checkpoint = AgentCheckpointData(
             checkpointId = checkpointId ?: Uuid.random().toString(),
             messageHistory = agentContext.getHistory(),
+            storage = JSONObject(agentContext.storage.toSerializedMap()),
             createdAt = clock.now(),
             version = version,
             plannerProperties = PlannerCheckpointProperties(
@@ -544,8 +557,9 @@ public class Persistence(
     ) {
         agentContext.store(
             GraphAgentContextData(
-                messageHistory,
-                agentContext.agentId + DEFAULT_AGENT_PATH_SEPARATOR + nodePath,
+                messageHistory = messageHistory,
+                storage = JSONObject(agentContext.storage.toSerializedMap()),
+                nodePath = agentContext.agentId + DEFAULT_AGENT_PATH_SEPARATOR + nodePath,
                 lastInput = input,
                 rollbackStrategy = rollbackStrategy
             )
@@ -581,8 +595,9 @@ public class Persistence(
     ) {
         agentContext.store(
             GraphAgentContextData(
-                messageHistory,
-                agentContext.agentId + DEFAULT_AGENT_PATH_SEPARATOR + nodePath,
+                messageHistory = messageHistory,
+                storage = JSONObject(agentContext.storage.toSerializedMap()),
+                nodePath = agentContext.agentId + DEFAULT_AGENT_PATH_SEPARATOR + nodePath,
                 lastOutput = output,
                 rollbackStrategy = rollbackStrategy
             )
@@ -622,7 +637,7 @@ public class Persistence(
                             toolCall.contentJsonResult
                                 .getOrNull()
                                 ?.toKoogJSONObject()
-                                ?.let { rollbackTool.decodeArgs(it, agentContext.config.serializer) }
+                                ?.let { rollbackTool.decodeArgs(it, serializer) }
                         } catch (e: CancellationException) {
                             throw e
                         } catch (_: Exception) {

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/java/ai/koog/agents/snapshot/feature/RunFromCheckpointJavaTest.java
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/java/ai/koog/agents/snapshot/feature/RunFromCheckpointJavaTest.java
@@ -12,6 +12,7 @@ import ai.koog.prompt.message.Message;
 import ai.koog.prompt.message.RequestMetaInfo;
 import ai.koog.prompt.message.ResponseMetaInfo;
 import ai.koog.serialization.JSONElementKt;
+import ai.koog.serialization.JSONPrimitive;
 import ai.koog.serialization.kotlinx.KotlinxSerializer;
 import kotlin.time.Clock;
 import kotlin.time.Instant;
@@ -67,7 +68,7 @@ public class RunFromCheckpointJavaTest {
             time,
             nodePath(sessionId, "straight-forward", "Node2"),
             null,
-            JSONElementKt.JSONPrimitive("Node 2 output"),
+            JSONPrimitive.of("Node 2 output"),
             List.of(
                 new Message.User("User message", new RequestMetaInfo(time, null)),
                 new Message.Assistant("Assistant message", new ResponseMetaInfo(time, null, null, null))

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/RunFromCheckpointTest.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/RunFromCheckpointTest.kt
@@ -2,11 +2,16 @@ import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.context.RollbackStrategy
 import ai.koog.agents.core.agent.context.graphAgentContextDataAdditionalKey
+import ai.koog.agents.core.agent.entity.AIAgentStorage
+import ai.koog.agents.core.agent.entity.createStorageKey
 import ai.koog.agents.core.agent.execution.path
 import ai.koog.agents.core.annotation.InternalAgentsApi
+import ai.koog.agents.core.dsl.builder.node
+import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.ext.tool.SayToUser
 import ai.koog.agents.snapshot.feature.AgentCheckpointData
+import ai.koog.agents.snapshot.feature.GraphCheckpointProperties
 import ai.koog.agents.snapshot.feature.Persistence
 import ai.koog.agents.snapshot.straightForwardGraphNoCheckpoint
 import ai.koog.agents.testing.tools.getMockExecutor
@@ -15,6 +20,7 @@ import ai.koog.prompt.executor.ollama.client.OllamaModels
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.serialization.JSONObject
 import ai.koog.serialization.JSONPrimitive
 import ai.koog.serialization.kotlinx.KotlinxSerializer
 import kotlinx.coroutines.test.runTest
@@ -66,7 +72,7 @@ class RunFromCheckpointTest {
 
         val output = Persistence.runFromCheckpoint(
             agent = agent,
-            agentInput = "Start the test",
+            input = "Start the test",
             checkpoint = checkpoint,
             sessionId = sessionId,
         )
@@ -104,9 +110,8 @@ class RunFromCheckpointTest {
             toolRegistry = toolRegistry,
         )
 
-        val session = agent.createSession(sessionId)
         val output = Persistence.runFromCheckpoint(
-            session = session,
+            agent = agent,
             input = "Start the test",
             checkpoint = checkpoint,
         )
@@ -146,7 +151,7 @@ class RunFromCheckpointTest {
 
         val output = Persistence.runFromCheckpoint(
             agent = agent,
-            agentInput = "Start the test",
+            input = "Start the test",
             checkpoint = checkpoint,
             rollbackStrategy = RollbackStrategy.MessageHistoryOnly,
             sessionId = sessionId,
@@ -191,7 +196,7 @@ class RunFromCheckpointTest {
 
         val output = Persistence.runFromCheckpoint(
             agent = agent,
-            agentInput = "Ignored input",
+            input = "Ignored input",
             checkpoint = checkpoint,
             sessionId = sessionId,
         )
@@ -232,7 +237,7 @@ class RunFromCheckpointTest {
 
         val output = Persistence.runFromCheckpoint(
             agent = agent,
-            agentInput = "ignored",
+            input = "ignored",
             checkpoint = checkpoint,
             sessionId = sessionId,
         )
@@ -269,13 +274,62 @@ class RunFromCheckpointTest {
         val error = assertFailsWith<IllegalStateException> {
             Persistence.runFromCheckpoint(
                 agent = agent,
-                agentInput = "ignored",
+                input = "ignored",
                 checkpoint = checkpoint,
                 sessionId = sessionId,
             )
         }
 
         assertEquals("Node straight-forward/MissingNode not found", error.message)
+    }
+
+    @Test
+    fun testRunFromCheckpointRestoresStorage() = runTest {
+        val sessionId = "test-session-storage"
+        val time = Clock.System.now()
+        val greetingKey = createStorageKey<String>("greeting")
+        val greetingText = "hello from checkpoint"
+
+        // Create and serialize a storage
+        val storageJson = AIAgentStorage(serializer)
+            .apply { set(greetingKey, greetingText) }
+            .let { JSONObject(it.toSerializedMap()) }
+
+        val checkpoint = AgentCheckpointData(
+            checkpointId = "checkpoint-storage",
+            createdAt = time,
+            messageHistory = emptyList(),
+            storage = storageJson,
+            version = 0,
+            graphProperties = GraphCheckpointProperties(
+                nodePath = path(sessionId, "storage-reading", "Node1"),
+                lastOutput = JSONPrimitive("Node 1 output"),
+            )
+        )
+
+        val agent = AIAgent(
+            promptExecutor = getMockExecutor(serializer) { },
+            strategy = strategy("storage-reading") {
+                val node1 by node<String, String>("Node1") { it }
+
+                val readNode by node<String, String>("readStorage") {
+                    "greeting=${storage.get(greetingKey)}"
+                }
+
+                nodeStart then node1 then readNode then nodeFinish
+            },
+            agentConfig = agentConfig,
+            toolRegistry = toolRegistry,
+        )
+
+        val output = Persistence.runFromCheckpoint(
+            agent = agent,
+            input = "ignored",
+            checkpoint = checkpoint,
+            sessionId = sessionId,
+        )
+
+        assertEquals("greeting=$greetingText", output)
     }
 
     @Test

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/ai/koog/agents/snapshot/CheckpointsTests.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/ai/koog/agents/snapshot/CheckpointsTests.kt
@@ -7,6 +7,8 @@ import ai.koog.agents.core.agent.AIAgentService
 import ai.koog.agents.core.agent.GraphAIAgentService
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
+import ai.koog.agents.core.agent.entity.AIAgentStorage
+import ai.koog.agents.core.agent.entity.createStorageKey
 import ai.koog.agents.core.agent.execution.path
 import ai.koog.agents.core.agent.session.callTool
 import ai.koog.agents.core.dsl.builder.AIAgentGraphStrategyBuilder
@@ -750,6 +752,53 @@ class CheckpointsTests {
             """.trimIndent(),
             tracer.traceAsString().trimIndent()
         )
+    }
+
+    @Test
+    fun testStorageIsSavedInCheckpoint() = runTest {
+        val storageKey = createStorageKey<String>("test-value")
+        val checkpointProvider = InMemoryPersistenceStorageProvider()
+        val sessionId = "storage-checkpoint-session"
+
+        val agent = AIAgent(
+            promptExecutor = getMockExecutor(serializer) { },
+            strategy = strategy("storage-checkpoint") {
+                // write a key to the storage that will be persisted in the checkpoint
+                val writeNode by node<String, String>("writeNode") {
+                    storage.set(storageKey, "persisted-value")
+                    it
+                }
+
+                val checkpointNode by node<String, String>("checkpointNode") {
+                    withPersistence { ctx ->
+                        createCheckpointAfterNode(
+                            agentContext = ctx,
+                            nodePath = ctx.executionInfo.path(),
+                            lastOutput = it,
+                            lastOutputType = typeToken<String>(),
+                            version = 0L
+                        )
+                    }
+                    it
+                }
+
+                nodeStart then writeNode then checkpointNode then nodeFinish
+            },
+            agentConfig = agentConfig,
+            toolRegistry = toolRegistry
+        ) {
+            install(Persistence) {
+                storage = checkpointProvider
+            }
+        }
+
+        agent.run("start", sessionId = sessionId)
+
+        // get second to last checkpoint because the latest checkpoint is a tombstone checkpoint that doesn't have storage and message history
+        val checkpoint = checkpointProvider.getCheckpoints(sessionId).let { it[it.lastIndex - 1] }
+        val restoredStorage = AIAgentStorage(serializer)
+        restoredStorage.putAllSerialized(checkpoint.storage?.entries ?: emptyMap())
+        assertEquals("persisted-value", restoredStorage.get(storageKey))
     }
 
     /**

--- a/agents/agents-features/agents-features-tokenizer/src/commonMain/kotlin/ai/koog/agents/features/tokenizer/feature/MessageTokenizer.kt
+++ b/agents/agents-features/agents-features-tokenizer/src/commonMain/kotlin/ai/koog/agents/features/tokenizer/feature/MessageTokenizer.kt
@@ -4,6 +4,7 @@ import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.context.AIAgentContext
 import ai.koog.agents.core.agent.context.featureOrThrow
 import ai.koog.agents.core.agent.entity.AIAgentStorageKey
+import ai.koog.agents.core.agent.entity.createStorageKey
 import ai.koog.agents.core.feature.AIAgentFunctionalFeature
 import ai.koog.agents.core.feature.AIAgentGraphFeature
 import ai.koog.agents.core.feature.AIAgentPlannerFeature
@@ -53,7 +54,7 @@ public class MessageTokenizer(public val promptTokenizer: PromptTokenizer) {
         AIAgentPlannerFeature<MessageTokenizerConfig, MessageTokenizer> {
 
         override val key: AIAgentStorageKey<MessageTokenizer> =
-            AIAgentStorageKey("agents-features-tracing")
+            createStorageKey<MessageTokenizer>("agents-features-tracing")
 
         override fun createInitialConfig(
             agentConfig: AIAgentConfig,

--- a/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/feature/Tracing.kt
+++ b/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/feature/Tracing.kt
@@ -3,6 +3,7 @@ package ai.koog.agents.features.tracing.feature
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.agent.entity.AIAgentStorageKey
+import ai.koog.agents.core.agent.entity.createStorageKey
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.feature.AIAgentGraphFeature
 import ai.koog.agents.core.feature.message.FeatureMessage
@@ -102,7 +103,7 @@ public class Tracing {
         private val logger = KotlinLogging.logger { }
 
         override val key: AIAgentStorageKey<Tracing> =
-            AIAgentStorageKey("agents-features-tracing")
+            createStorageKey<Tracing>("agents-features-tracing")
 
         override fun createInitialConfig(
             agentConfig: AIAgentConfig,

--- a/docs/docs/data-transfer-between-nodes.md
+++ b/docs/docs/data-transfer-between-nodes.md
@@ -81,6 +81,7 @@ Create a typed storage key for the defined data structure:
     <!--- INCLUDE
     import ai.koog.agents.core.agent.entity.AIAgentStorage;
     import ai.koog.agents.core.agent.entity.AIAgentStorageKey;
+    import ai.koog.serialization.TypeToken;
     class exampleDataTransferBetweenNodesJava02 {
         record UserData(
             String name,
@@ -93,11 +94,11 @@ Create a typed storage key for the defined data structure:
     }
     -->
     ```java
-    AIAgentStorageKey<UserData> userDataKey = AIAgentStorage.createStorageKey("user-data");
+    AIAgentStorageKey<UserData> userDataKey = AIAgentStorage.createStorageKey("user-data", TypeToken.of(UserData.class));
     ```
     <!--- KNIT exampleDataTransferBetweenNodesJava02.java -->
 
-The `createStorageKey` function takes a single string parameter used for identification and debugging purposes.
+The `createStorageKey` function takes a string parameter used for identification and debugging purposes, and a `TypeToken` representing the value type (in Java; Kotlin uses reified generics automatically).
 
 ### Storing data
 
@@ -128,13 +129,14 @@ To save data using a created storage key, use the `storage.set(key: AIAgentStora
     import ai.koog.agents.core.agent.entity.AIAgentNode;
     import ai.koog.agents.core.agent.entity.AIAgentStorage;
     import ai.koog.agents.core.agent.entity.AIAgentStorageKey;
+    import ai.koog.serialization.TypeToken;
     public class exampleDataTransferBetweenNodesJava03 {
         record UserData(
             String name,
             int age
         ) {}
         public static void main(String[] args) {
-            AIAgentStorageKey<UserData> userDataKey = AIAgentStorage.createStorageKey("user-data");
+            AIAgentStorageKey<UserData> userDataKey = AIAgentStorage.createStorageKey("user-data", TypeToken.of(UserData.class));
     -->
     <!--- SUFFIX
         }
@@ -189,13 +191,14 @@ To retrieve the data, use the `storage.get` method in a node:
     import ai.koog.agents.core.agent.entity.AIAgentNode;
     import ai.koog.agents.core.agent.entity.AIAgentStorage;
     import ai.koog.agents.core.agent.entity.AIAgentStorageKey;
+    import ai.koog.serialization.TypeToken;
     public class exampleDataTransferBetweenNodesJava04 {
         record UserData(
             String name,
             int age
         ) {}
         public static void main(String[] args) {
-            AIAgentStorageKey<UserData> userDataKey = AIAgentStorage.createStorageKey("user-data");
+            AIAgentStorageKey<UserData> userDataKey = AIAgentStorage.createStorageKey("user-data", TypeToken.of(UserData.class));
     -->
     <!--- SUFFIX
         }

--- a/docs/docs/features/agent-persistence.md
+++ b/docs/docs/features/agent-persistence.md
@@ -16,9 +16,24 @@ A checkpoint captures the complete state of an agent at a specific point in its 
 - Message history (all interactions between user, system, assistant, and tools)
 - Current node being executed
 - Input data for the current node
+- `AIAgentStorage` contents (key-value data stored during execution)
 - Timestamp of creation
 
 Checkpoints are identified by unique IDs and are associated with a specific agent.
+
+### `AIAgentStorage` persistence
+
+When a checkpoint is created, the framework serializes all values currently held in `AIAgentStorage` and includes them in the checkpoint.
+On restore, those values are deserialized and made available to the resumed agent exactly as they were at the time of the checkpoint.
+
+**Only serializable values are persisted.**
+The serializer used is the one configured in `AIAgentConfig` via its `serializer` property.
+Values that cannot be encoded by that serializer are silently skipped and will not be present in the restored storage.
+
+Non-serializable values are dropped silently when the checkpoint is written.
+If a value is missing after restoring from a checkpoint, verify that its type is serializable by the configured serializer.
+
+See [Serialization](../serialization.md) for more information.
 
 ## Installation
 

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -46,6 +46,7 @@ kotlin {
                 )
                 implementation(project(":agents:agents-features:agents-features-chat-history-aws"))
                 implementation(project(":agents:agents-features:agents-features-longterm-memory-aws"))
+                implementation(project(":serialization:serialization-jackson"))
 
                 // External libraries
                 implementation(libs.junit.jupiter.params)

--- a/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentGraphStrategyTest.java
+++ b/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentGraphStrategyTest.java
@@ -620,7 +620,6 @@ public class JavaAIAgentGraphStrategyTest extends KoogJavaTestBase {
                 new Message.User("Restored user message", new RequestMetaInfo(now, null)),
                 new Message.Assistant("Restored assistant message", new ResponseMetaInfo(now, null, null, null))
             ),
-            null,
             0L,
             null
         );
@@ -672,7 +671,6 @@ public class JavaAIAgentGraphStrategyTest extends KoogJavaTestBase {
             null,
             JSONPrimitive.of("missing"),
             List.of(),
-            null,
             0L,
             null
         );

--- a/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentGraphStrategyTest.java
+++ b/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentGraphStrategyTest.java
@@ -30,6 +30,7 @@ import ai.koog.prompt.llm.LLModel;
 import ai.koog.prompt.message.Message;
 import ai.koog.prompt.message.RequestMetaInfo;
 import ai.koog.prompt.message.ResponseMetaInfo;
+import ai.koog.serialization.JSONPrimitive;
 import ai.koog.serialization.TypeToken;
 import ai.koog.serialization.JSONElementKt;
 import org.junit.jupiter.api.Test;
@@ -619,6 +620,7 @@ public class JavaAIAgentGraphStrategyTest extends KoogJavaTestBase {
                 new Message.User("Restored user message", new RequestMetaInfo(now, null)),
                 new Message.Assistant("Restored assistant message", new ResponseMetaInfo(now, null, null, null))
             ),
+            null,
             0L,
             null
         );
@@ -668,8 +670,9 @@ public class JavaAIAgentGraphStrategyTest extends KoogJavaTestBase {
             now,
             sessionId + "/" + strategyName + "/MissingNode",
             null,
-            JSONElementKt.JSONPrimitive("missing"),
+            JSONPrimitive.of("missing"),
             List.of(),
+            null,
             0L,
             null
         );

--- a/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentIntegrationTest.java
+++ b/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentIntegrationTest.java
@@ -30,7 +30,9 @@ import ai.koog.prompt.llm.LLModel;
 import ai.koog.prompt.message.AttachmentContent;
 import ai.koog.prompt.message.ContentPart;
 import ai.koog.prompt.message.Message;
+import ai.koog.serialization.TypeToken;
 import ai.koog.serialization.kotlinx.KotlinxSerializer;
+import ai.koog.serialization.jackson.JacksonSerializer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -537,7 +539,7 @@ public class JavaAIAgentIntegrationTest extends KoogJavaTestBase {
     public void integration_ShouldStoreAndRetrieveValueWithStorageKeys(LLModel model) {
         Models.assumeAvailable(model.getProvider());
 
-        AIAgentStorageKey<String> storageKey = new AIAgentStorageKey<>("test-key");
+        AIAgentStorageKey<String> storageKey = new AIAgentStorageKey("test-key", TypeToken.of(String.class));
         String expectedValue = "test-value";
         AtomicReference<String> retrievedValue = new AtomicReference<>();
 
@@ -559,7 +561,7 @@ public class JavaAIAgentIntegrationTest extends KoogJavaTestBase {
     public void integration_ShouldReturnNullForNotExistentKey(LLModel model) {
         Models.assumeAvailable(model.getProvider());
 
-        AIAgentStorageKey<String> nonExistentKey = new AIAgentStorageKey<>("non-existent");
+        AIAgentStorageKey<String> nonExistentKey = new AIAgentStorageKey("non-existent", TypeToken.of(String.class));
         AtomicReference<String> retrievedValue = new AtomicReference<>("not-null");
 
         AIAgent<String, String> agent = javaBuilder(model)
@@ -579,7 +581,7 @@ public class JavaAIAgentIntegrationTest extends KoogJavaTestBase {
     public void integration_ShouldOverwriteValueForSameKey(LLModel model) {
         Models.assumeAvailable(model.getProvider());
 
-        AIAgentStorageKey<String> storageKey = new AIAgentStorageKey<>("overwrite-key");
+        AIAgentStorageKey<String> storageKey = new AIAgentStorageKey<>("overwrite-key", TypeToken.of(String.class));
         AtomicReference<String> firstRead = new AtomicReference<>();
         AtomicReference<String> secondRead = new AtomicReference<>();
 
@@ -604,8 +606,8 @@ public class JavaAIAgentIntegrationTest extends KoogJavaTestBase {
     public void integration_ShouldSupportKeysWithDifferentTypes(LLModel model) {
         Models.assumeAvailable(model.getProvider());
 
-        AIAgentStorageKey<String> stringKey = new AIAgentStorageKey<>("string-key");
-        AIAgentStorageKey<Integer> intKey = new AIAgentStorageKey<>("int-key");
+        AIAgentStorageKey<String> stringKey = new AIAgentStorageKey<>("string-key", TypeToken.of(String.class));
+        AIAgentStorageKey<Integer> intKey = new AIAgentStorageKey<>("int-key", TypeToken.of(Integer.class));
         AtomicReference<String> retrievedString = new AtomicReference<>();
         AtomicReference<Integer> retrievedInt = new AtomicReference<>();
 
@@ -630,7 +632,7 @@ public class JavaAIAgentIntegrationTest extends KoogJavaTestBase {
     public void integration_ShouldIsolateStorageForMultipleRuns(LLModel model) {
         Models.assumeAvailable(model.getProvider());
 
-        AIAgentStorageKey<Integer> runCountKey = new AIAgentStorageKey<>("run-count");
+        AIAgentStorageKey<Integer> runCountKey = new AIAgentStorageKey<>("run-count", TypeToken.of(Integer.class));
         AIAgent<String, String> agent = javaBuilder(model)
             .systemPrompt("You are a helpful assistant.")
             .functionalStrategy((AIAgentFunctionalContext context, String input) -> {
@@ -654,8 +656,8 @@ public class JavaAIAgentIntegrationTest extends KoogJavaTestBase {
     public void integration_ShouldNotLeakSessionStorageBetweenRuns(LLModel model) {
         Models.assumeAvailable(model.getProvider());
 
-        AIAgentStorageKey<String> greetingKey = new AIAgentStorageKey<>("java-session-greeting");
-        AIAgentStorageKey<Integer> counterKey = new AIAgentStorageKey<>("java-session-counter");
+        AIAgentStorageKey<String> greetingKey = new AIAgentStorageKey<>("java-session-greeting", TypeToken.of(String.class));
+        AIAgentStorageKey<Integer> counterKey = new AIAgentStorageKey<>("java-session-counter", TypeToken.of(Integer.class));
 
         AIAgent<String, String> agent = javaBuilder(model)
             .systemPrompt("You are a helpful assistant.")
@@ -666,7 +668,7 @@ public class JavaAIAgentIntegrationTest extends KoogJavaTestBase {
             })
             .build();
 
-        AIAgentStorage initialStorage = new AIAgentStorage();
+        AIAgentStorage initialStorage = new AIAgentStorage(new JacksonSerializer());
         JavaUtils.storageSet(initialStorage, greetingKey, "hello-from-java-session");
         JavaUtils.storageSet(initialStorage, counterKey, 11);
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
@@ -4,7 +4,7 @@ import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.ToolCalls
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentStorage
-import ai.koog.agents.core.agent.entity.AIAgentStorageKey
+import ai.koog.agents.core.agent.entity.createStorageKey
 import ai.koog.agents.core.agent.execution.path
 import ai.koog.agents.core.agent.functionalStrategy
 import ai.koog.agents.core.agent.session.AdditionalInputs
@@ -59,6 +59,7 @@ import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.params.LLMParams.ToolChoice
 import ai.koog.serialization.JSONPrimitive
+import ai.koog.serialization.kotlinx.KotlinxSerializer
 import ai.koog.serialization.typeToken
 import ai.koog.utils.time.KoogClock
 import io.kotest.assertions.withClue
@@ -904,8 +905,8 @@ class AIAgentIntegrationTest : AIAgentTestBase() {
     fun integration_AIAgentSessionStorageDoesNotLeakBetweenRuns(model: LLModel) = runTest(timeout = 180.seconds) {
         Models.assumeAvailable(model.provider)
 
-        val greetingKey = AIAgentStorageKey<String>("integration-session-greeting")
-        val counterKey = AIAgentStorageKey<Int>("integration-session-counter")
+        val greetingKey = createStorageKey<String>("integration-session-greeting")
+        val counterKey = createStorageKey<Int>("integration-session-counter")
 
         val storageStrategy = strategy<String, String>("integration-session-storage-strategy") {
             val readNode by node<String, String>("readStorage") {
@@ -931,7 +932,7 @@ class AIAgentIntegrationTest : AIAgentTestBase() {
             toolRegistry = ToolRegistry {},
         )
 
-        val initialStorage = AIAgentStorage().apply {
+        val initialStorage = AIAgentStorage(KotlinxSerializer()).apply {
             set(greetingKey, "hello-from-session-inputs")
             set(counterKey, 7)
         }
@@ -999,7 +1000,7 @@ class AIAgentIntegrationTest : AIAgentTestBase() {
 
         val result = Persistence.runFromCheckpoint(
             agent = agent,
-            agentInput = "ignored",
+            input = "ignored",
             checkpoint = checkpoint,
             sessionId = sessionId,
         )
@@ -1046,7 +1047,7 @@ class AIAgentIntegrationTest : AIAgentTestBase() {
         val error = assertFailsWith<IllegalStateException> {
             Persistence.runFromCheckpoint(
                 agent = agent,
-                agentInput = "ignored",
+                input = "ignored",
                 checkpoint = checkpoint,
                 sessionId = sessionId,
             )


### PR DESCRIPTION
  Extends agent checkpoints to include AIAgentStorage contents, so custom key-value data is saved and restored when resuming from a checkpoint. Values not serializable by the configured serializer are silently dropped.
  
  Storage refactor to support serialization:
  - AIAgentStorageKey now carries a TypeToken and uses name-based equality. Kotlin callers use the new inline reified createStorageKey<T>(name); Java callers use createStorageKey(name, TypeToken.of(...)).
  - AIAgentStorageImpl maintains a typed map and a serialized map side-by-side — deserialization is lazy (values are decoded on first access).
  - AIAgentStorage now requires a JSONSerializer
  - New API: toSerializedMap(), putAllSerialized(), putAll(other: AIAgentStorage). copy() promoted to public. toMap() removed.

  BREAKING:
  - AIAgentStorageKey equality changed from referential to name-based.
  - AIAgentStorageAPI.toMap() removed — use toSerializedMap() or putAll(other).
  - AIAgentStorage() no-arg constructor replaced by AIAgentStorage(serializer).
  - runFromCheckpoint parameter renamed from agentInput to input.