### PR TITLE
build: set up `isBeta` extra property for all gradle subprojects

### DIFF
--- a/a2a/a2a-client/build.gradle.kts
+++ b/a2a/a2a-client/build.gradle.kts
@@ -1,7 +1,6 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
+val isBeta by extra(true)
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/a2a/a2a-core/build.gradle.kts
+++ b/a2a/a2a-core/build.gradle.kts
@@ -1,7 +1,6 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
+val isBeta by extra(true)
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/a2a/a2a-server/build.gradle.kts
+++ b/a2a/a2a-server/build.gradle.kts
@@ -1,7 +1,6 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
+val isBeta by extra(true)
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/a2a/a2a-transport/a2a-transport-client-jsonrpc-http/build.gradle.kts
+++ b/a2a/a2a-transport/a2a-transport-client-jsonrpc-http/build.gradle.kts
@@ -1,7 +1,6 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
+val isBeta by extra(true)
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/a2a/a2a-transport/a2a-transport-core-jsonrpc/build.gradle.kts
+++ b/a2a/a2a-transport/a2a-transport-core-jsonrpc/build.gradle.kts
@@ -1,7 +1,6 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
+val isBeta by extra(true)
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/a2a/a2a-transport/a2a-transport-server-jsonrpc-http/build.gradle.kts
+++ b/a2a/a2a-transport/a2a-transport-server-jsonrpc-http/build.gradle.kts
@@ -1,7 +1,6 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
+val isBeta by extra(true)
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-core/build.gradle.kts
+++ b/agents/agents-core/build.gradle.kts
@@ -2,8 +2,6 @@ import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 import org.gradle.kotlin.dsl.implementation
 import org.gradle.kotlin.dsl.project
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-ext/build.gradle.kts
+++ b/agents/agents-ext/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-features/agents-features-a2a-client/build.gradle.kts
+++ b/agents/agents-features/agents-features-a2a-client/build.gradle.kts
@@ -1,7 +1,6 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
+val isBeta by extra(true)
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-features/agents-features-a2a-core/build.gradle.kts
+++ b/agents/agents-features/agents-features-a2a-core/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-features/agents-features-a2a-server/build.gradle.kts
+++ b/agents/agents-features/agents-features-a2a-server/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-features/agents-features-acp/build.gradle.kts
+++ b/agents/agents-features/agents-features-acp/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-features/agents-features-chat-history-aws/build.gradle.kts
+++ b/agents/agents-features/agents-features-chat-history-aws/build.gradle.kts
@@ -1,8 +1,6 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 import org.gradle.api.tasks.testing.Test
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-features/agents-features-chat-history-jdbc/build.gradle.kts
+++ b/agents/agents-features/agents-features-chat-history-jdbc/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.jvm")

--- a/agents/agents-features/agents-features-chat-memory-sql/build.gradle.kts
+++ b/agents/agents-features/agents-features-chat-memory-sql/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-features/agents-features-event-handler/build.gradle.kts
+++ b/agents/agents-features/agents-features-event-handler/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-features/agents-features-longterm-memory-aws/build.gradle.kts
+++ b/agents/agents-features/agents-features-longterm-memory-aws/build.gradle.kts
@@ -1,8 +1,6 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 import org.gradle.api.tasks.testing.Test
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-features/agents-features-longterm-memory/build.gradle.kts
+++ b/agents/agents-features/agents-features-longterm-memory/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-features/agents-features-memory/build.gradle.kts
+++ b/agents/agents-features/agents-features-memory/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-features/agents-features-opentelemetry/build.gradle.kts
+++ b/agents/agents-features/agents-features-opentelemetry/build.gradle.kts
@@ -1,8 +1,6 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 import com.android.build.api.variant.LibraryAndroidComponentsExtension
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-features/agents-features-persistence-jdbc/build.gradle.kts
+++ b/agents/agents-features/agents-features-persistence-jdbc/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.jvm")

--- a/agents/agents-features/agents-features-snapshot/build.gradle.kts
+++ b/agents/agents-features/agents-features-snapshot/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-features/agents-features-sql/build.gradle.kts
+++ b/agents/agents-features/agents-features-sql/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-features/agents-features-tokenizer/build.gradle.kts
+++ b/agents/agents-features/agents-features-tokenizer/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-features/agents-features-trace/build.gradle.kts
+++ b/agents/agents-features/agents-features-trace/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-mcp-metadata/build.gradle.kts
+++ b/agents/agents-mcp-metadata/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-mcp-server/build.gradle.kts
+++ b/agents/agents-mcp-server/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform.server")

--- a/agents/agents-mcp/build.gradle.kts
+++ b/agents/agents-mcp/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-test/build.gradle.kts
+++ b/agents/agents-test/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-tools/build.gradle.kts
+++ b/agents/agents-tools/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/agents/agents-utils/build.gradle.kts
+++ b/agents/agents-utils/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,6 +76,26 @@ version = run {
 
 fun isCustomReleaseBranch(branchName: String): Boolean = branchName.matches(Regex("""^(release\/)?\d+\.\d+\.\d+$"""))
 
+/*
+ * Tracks isBeta extra property, which defaults to false.
+ * Subprojects can set it to true to indicate that the published module
+ * should not be considered stable. Unstable modules get a "-beta" suffix
+ * in their version.
+ */
+subprojects {
+    extra["isBeta"] = false
+
+    afterEvaluate {
+        group = rootProject.group
+        // Append "-beta" to version for modules that are "isBeta=true"
+        version = if (extra["isBeta"] as Boolean) {
+            "${rootProject.version}-beta"
+        } else {
+            rootProject.version
+        }
+    }
+}
+
 buildscript {
     dependencies {
         classpath(platform(libs.okhttp.bom))

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -1,8 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.util.Properties
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.jvm")

--- a/embeddings/embeddings-base/build.gradle.kts
+++ b/embeddings/embeddings-base/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/embeddings/embeddings-llm/build.gradle.kts
+++ b/embeddings/embeddings-llm/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/http-client/http-client-core/build.gradle.kts
+++ b/http-client/http-client-core/build.gradle.kts
@@ -5,9 +5,6 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-group = rootProject.group
-version = rootProject.version
-
 kotlin {
     sourceSets {
         commonMain {

--- a/http-client/http-client-java/build.gradle.kts
+++ b/http-client/http-client-java/build.gradle.kts
@@ -6,9 +6,6 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-group = rootProject.group
-version = rootProject.version
-
 dependencies {
     api(project(":http-client:http-client-core"))
     implementation(project(":utils"))

--- a/http-client/http-client-ktor/build.gradle.kts
+++ b/http-client/http-client-ktor/build.gradle.kts
@@ -5,9 +5,6 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-group = rootProject.group
-version = rootProject.version
-
 kotlin {
     sourceSets {
         commonMain {

--- a/http-client/http-client-okhttp/build.gradle.kts
+++ b/http-client/http-client-okhttp/build.gradle.kts
@@ -6,9 +6,6 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-group = rootProject.group
-version = rootProject.version
-
 dependencies {
     api(project(":http-client:http-client-core"))
     implementation(project(":utils"))

--- a/http-client/http-client-test/build.gradle.kts
+++ b/http-client/http-client-test/build.gradle.kts
@@ -3,9 +3,6 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-group = rootProject.group
-version = rootProject.version
-
 dependencies {
     api(project(":http-client:http-client-core"))
     api(libs.ktor.server.cio)

--- a/koog-agents/build.gradle.kts
+++ b/koog-agents/build.gradle.kts
@@ -1,8 +1,6 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 import ai.koog.gradle.xcframework.XCFrameworkConfig.configureFrameworkExportsIfRequested
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/koog-ktor/build.gradle.kts
+++ b/koog-ktor/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/koog-spring-ai/koog-spring-ai-common/build.gradle.kts
+++ b/koog-spring-ai/koog-spring-ai-common/build.gradle.kts
@@ -1,8 +1,6 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
-group = rootProject.group
-version = rootProject.version
 plugins {
     id("ai.kotlin.jvm")
     id("ai.kotlin.jvm.publish")

--- a/koog-spring-ai/koog-spring-ai-starter-chat-memory/build.gradle.kts
+++ b/koog-spring-ai/koog-spring-ai-starter-chat-memory/build.gradle.kts
@@ -1,8 +1,6 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
-group = rootProject.group
-version = rootProject.version
 plugins {
     id("ai.kotlin.jvm")
     id("ai.kotlin.jvm.publish")

--- a/koog-spring-ai/koog-spring-ai-starter-model-chat/build.gradle.kts
+++ b/koog-spring-ai/koog-spring-ai-starter-model-chat/build.gradle.kts
@@ -1,8 +1,6 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
-group = rootProject.group
-version = rootProject.version
 plugins {
     id("ai.kotlin.jvm")
     id("ai.kotlin.jvm.publish")

--- a/koog-spring-ai/koog-spring-ai-starter-model-embedding/build.gradle.kts
+++ b/koog-spring-ai/koog-spring-ai-starter-model-embedding/build.gradle.kts
@@ -1,8 +1,6 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
-group = rootProject.group
-version = rootProject.version
 plugins {
     id("ai.kotlin.jvm")
     id("ai.kotlin.jvm.publish")

--- a/koog-spring-ai/koog-spring-ai-starter-vector-store/build.gradle.kts
+++ b/koog-spring-ai/koog-spring-ai-starter-vector-store/build.gradle.kts
@@ -2,8 +2,6 @@ import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.jvm")

--- a/koog-spring-boot-starter/build.gradle.kts
+++ b/koog-spring-boot-starter/build.gradle.kts
@@ -2,8 +2,6 @@ import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.jvm")

--- a/prompt/prompt-cache/prompt-cache-files/build.gradle.kts
+++ b/prompt/prompt-cache/prompt-cache-files/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-cache/prompt-cache-model/build.gradle.kts
+++ b/prompt/prompt-cache/prompt-cache-model/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-cache/prompt-cache-redis/build.gradle.kts
+++ b/prompt/prompt-cache/prompt-cache-redis/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-executor/prompt-executor-cached/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-cached/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-executor/prompt-executor-clients/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-mistralai-client/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/build.gradle.kts
@@ -5,9 +5,6 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-group = rootProject.group
-version = rootProject.version
-
 kotlin {
     sourceSets {
         commonMain {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-executor/prompt-executor-llms-all/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-llms-all/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-executor/prompt-executor-model/build.gradle.kts
+++ b/prompt/prompt-executor/prompt-executor-model/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-llm/build.gradle.kts
+++ b/prompt/prompt-llm/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-markdown/build.gradle.kts
+++ b/prompt/prompt-markdown/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-model/build.gradle.kts
+++ b/prompt/prompt-model/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-processor/build.gradle.kts
+++ b/prompt/prompt-processor/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-structure/build.gradle.kts
+++ b/prompt/prompt-structure/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-tokenizer/build.gradle.kts
+++ b/prompt/prompt-tokenizer/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/prompt/prompt-xml/build.gradle.kts
+++ b/prompt/prompt-xml/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/rag/rag-base/build.gradle.kts
+++ b/rag/rag-base/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/rag/rag-vector/build.gradle.kts
+++ b/rag/rag-vector/build.gradle.kts
@@ -1,7 +1,5 @@
 import ai.koog.gradle.publish.maven.Publishing.publishToMaven
 
-group = rootProject.group
-version = rootProject.version
 
 plugins {
     id("ai.kotlin.multiplatform")

--- a/serialization/serialization-core/build.gradle.kts
+++ b/serialization/serialization-core/build.gradle.kts
@@ -5,9 +5,6 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-group = rootProject.group
-version = rootProject.version
-
 kotlin {
     sourceSets {
         commonMain {

--- a/serialization/serialization-jackson/build.gradle.kts
+++ b/serialization/serialization-jackson/build.gradle.kts
@@ -5,9 +5,6 @@ plugins {
     id("ai.kotlin.jvm.publish")
 }
 
-group = rootProject.group
-version = rootProject.version
-
 kotlin {
     explicitApi()
 }

--- a/serialization/serialization-test/build.gradle.kts
+++ b/serialization/serialization-test/build.gradle.kts
@@ -3,9 +3,6 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-group = rootProject.group
-version = rootProject.version
-
 kotlin {
     sourceSets {
         commonMain {

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -3,9 +3,6 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-group = rootProject.group
-version = rootProject.version
-
 kotlin {
     sourceSets {
         commonMain {

--- a/utils/build.gradle.kts
+++ b/utils/build.gradle.kts
@@ -5,9 +5,6 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
-group = rootProject.group
-version = rootProject.version
-
 kotlin {
     sourceSets {
         commonMain {


### PR DESCRIPTION
We've agreed on the new versioning scheme that will separate between "stable" and "beta" modules. "beta" modules will contain experimental APIs, and to distinguish between "stable" and "beta", "beta" modules will get a "-beta" postfix in their version, e.g. "1.0-beta".

To simplify maintenance, `isBeta` extra property is introduced for all Koog modules. Now, there's no need to configure `group` and `version` manually in each module, these are controlled centrally. To mark a module as experimental, one can simply set the following somewhere in the root of a module's `build.gradle.kts`:
```
val isBeta by extra(true)
```