### PR TITLE
fix(prompt): forward Anthropic thinking signature through streaming

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
@@ -262,6 +262,7 @@ public open class AnthropicLLMClient @JvmOverloads constructor(
                                 is AnthropicContent.Thinking -> {
                                     emitReasoningDelta(
                                         text = contentBlock.thinking,
+                                        encrypted = contentBlock.signature.takeUnless { it.isEmpty() },
                                         index = response.index
                                             ?: throw LLMClientException(clientName, "Thinking index is missing")
                                     )
@@ -300,6 +301,15 @@ public open class AnthropicLLMClient @JvmOverloads constructor(
                                         emitReasoningDelta(
                                             text = delta.thinking
                                                 ?: throw LLMClientException(clientName, "Reasoning delta is missing"),
+                                            index = response.index
+                                                ?: throw LLMClientException(clientName, "Reasoning index is missing")
+                                        )
+                                    }
+
+                                    AnthropicStreamDeltaContentType.SIGNATURE_DELTA.value -> {
+                                        emitReasoningDelta(
+                                            encrypted = delta.signature
+                                                ?: throw LLMClientException(clientName, "Signature delta is missing"),
                                             index = response.index
                                                 ?: throw LLMClientException(clientName, "Reasoning index is missing")
                                         )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/models/AnthropicChatMessages.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/models/AnthropicChatMessages.kt
@@ -620,6 +620,9 @@ public data class AnthropicStreamResponse(
  * @property text Optional text content associated with the delta update.
  * @property partialJson Optional partial JSON content for tool use streaming.
  * @property stopReason Optional reason why the generation process was stopped, if applicable.
+ * @property thinking Optional thinking text for `thinking_delta` updates inside a thinking content block.
+ * @property signature Optional signature for `signature_delta` updates that seal a thinking content block.
+ *   This signature must be sent back as `encrypted` on subsequent requests for the thinking to validate.
  * @property toolUse Optional tool usage data associated with the delta update (deprecated).
  */
 @InternalLLMClientApi
@@ -630,6 +633,7 @@ public data class AnthropicStreamDelta(
     val partialJson: String? = null,
     val stopReason: String? = null,
     val thinking: String? = null,
+    val signature: String? = null,
     val toolUse: AnthropicContent.ToolUse? = null
 )
 
@@ -662,6 +666,7 @@ public enum class AnthropicStreamDeltaContentType(public val value: String) {
     TEXT_DELTA("text_delta"),
     INPUT_JSON_DELTA("input_json_delta"),
     THINKING_DELTA("thinking_delta"),
+    SIGNATURE_DELTA("signature_delta"),
 }
 
 /**

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
@@ -155,18 +155,31 @@ public class StreamFrameFlowBuilder(
 
     /**
      * Emits a [StreamFrame.ReasoningDelta] with the given [text].
+     *
+     * [encrypted] is buffered into the pending reasoning so it is carried over to the eventual
+     * [StreamFrame.ReasoningComplete]; [StreamFrame.ReasoningDelta] itself does not expose it.
      */
-    public suspend fun emitReasoningDelta(id: String? = null, text: String? = null, summary: String? = null, index: Int? = null) {
+    public suspend fun emitReasoningDelta(
+        id: String? = null,
+        text: String? = null,
+        summary: String? = null,
+        encrypted: String? = null,
+        index: Int? = null
+    ) {
         tryEmitPendingToolCall()
         tryEmitPendingText()
         val previous: PendingReasoning? = pendingReasoningRef.load()
         if (previous == null) {
-            pendingReasoningRef.store(PendingReasoning(id = id, textDelta = text, summaryDelta = summary, index = index))
+            pendingReasoningRef.store(
+                PendingReasoning(id = id, textDelta = text, summaryDelta = summary, encrypted = encrypted, index = index)
+            )
         } else if (id != previous.id) {
             tryEmitPendingReasoning()
-            pendingReasoningRef.store(PendingReasoning(id = id, textDelta = text, summaryDelta = summary, index = index))
+            pendingReasoningRef.store(
+                PendingReasoning(id = id, textDelta = text, summaryDelta = summary, encrypted = encrypted, index = index)
+            )
         } else {
-            pendingReasoningRef.store(previous.appendDelta(id, text, summary, index))
+            pendingReasoningRef.store(previous.appendDelta(id, text, summary, encrypted, index))
         }
         flowCollector.emitReasoningDelta(id, text, summary, index)
     }
@@ -239,6 +252,7 @@ public class StreamFrameFlowBuilder(
                 id = pendingReasoning.id,
                 text = pendingReasoning.textDelta?.let { listOf(pendingReasoning.textDelta) } ?: emptyList(),
                 summary = pendingReasoning.summaryDelta?.let { listOf(pendingReasoning.summaryDelta) },
+                encrypted = pendingReasoning.encrypted,
                 index = pendingReasoning.index
             )
         }
@@ -288,14 +302,25 @@ public class StreamFrameFlowBuilder(
         val id: String?,
         val textDelta: String?,
         val summaryDelta: String?,
+        val encrypted: String?,
         val index: Int?
     ) {
-        fun appendDelta(id: String?, textDelta: String?, summaryDelta: String?, index: Int?): PendingReasoning {
+        fun appendDelta(
+            id: String?,
+            textDelta: String?,
+            summaryDelta: String?,
+            encrypted: String?,
+            index: Int?
+        ): PendingReasoning {
             require(this.index == index)
             require(this.id == id)
             val newTextDelta = if (textDelta == null) this.textDelta else (this.textDelta ?: "") + textDelta
             val newSummaryDelta = if (summaryDelta == null) this.summaryDelta else (this.summaryDelta ?: "") + summaryDelta
-            return copy(textDelta = newTextDelta, summaryDelta = newSummaryDelta)
+            return copy(
+                textDelta = newTextDelta,
+                summaryDelta = newSummaryDelta,
+                encrypted = encrypted ?: this.encrypted
+            )
         }
     }
 }

--- a/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderTest.kt
+++ b/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderTest.kt
@@ -131,6 +131,57 @@ class StreamFrameFlowBuilderTest {
     }
 
     @Test
+    fun testEmitReasoningDeltaWithEncrypted() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitReasoningDelta(text = "Thinking...", index = 0)
+            emitReasoningDelta(text = " step 2", index = 0)
+            emitReasoningDelta(encrypted = "sig-abc123", index = 0)
+            emitEnd()
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.ReasoningDelta(text = "Thinking...", index = 0),
+                StreamFrame.ReasoningDelta(text = " step 2", index = 0),
+                StreamFrame.ReasoningDelta(index = 0),
+                StreamFrame.ReasoningComplete(
+                    id = null,
+                    text = listOf("Thinking... step 2"),
+                    encrypted = "sig-abc123",
+                    index = 0
+                ),
+                StreamFrame.End(null, ResponseMetaInfo.Empty)
+            ),
+            frames
+        )
+    }
+
+    @Test
+    fun testEmitReasoningDeltaEncryptedSurvivesTransition() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitReasoningDelta(text = "Thinking...", encrypted = "sig-xyz", index = 0)
+            emitTextDelta("Answer", 1)
+            emitEnd()
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.ReasoningDelta(text = "Thinking...", index = 0),
+                StreamFrame.ReasoningComplete(
+                    id = null,
+                    text = listOf("Thinking..."),
+                    encrypted = "sig-xyz",
+                    index = 0
+                ),
+                StreamFrame.TextDelta("Answer", 1),
+                StreamFrame.TextComplete("Answer", 1),
+                StreamFrame.End(null, ResponseMetaInfo.Empty)
+            ),
+            frames
+        )
+    }
+
+    @Test
     fun testEmitToolCallDelta() = runTest {
         val frames = buildStreamFrameFlow {
             emitToolCallDelta(id = "call_1", name = "calculator", args = "{\"a\":", 0)


### PR DESCRIPTION
## Summary
Fixes #1959: Anthropic's extended thinking signature was lost during streaming, so the next request in a multi-turn conversation failed with:

> Encrypted signature is required for reasoning messages but was null

The signature was being dropped in three places:
1. `AnthropicLLMClient.executeStreaming` ignored `AnthropicContent.Thinking.signature` on `CONTENT_BLOCK_START`.
2. `CONTENT_BLOCK_DELTA` had no branch for `signature_delta` events.
3. `StreamFrameFlowBuilder.PendingReasoning` carried no `encrypted` field, so `ReasoningComplete.encrypted` was always `null`.

### Changes
- Add `signature` to `AnthropicStreamDelta` and `SIGNATURE_DELTA` to `AnthropicStreamDeltaContentType`.
- Forward the signature on both `content_block_start` and `signature_delta` events in `executeStreaming`.
- Add `encrypted` to `PendingReasoning` and propagate it through `tryEmitPendingReasoning` to `ReasoningComplete`.

## Test plan
- [x] `./gradlew :prompt:prompt-model:jvmTest` (adds `testEmitReasoningDeltaWithEncrypted` and `testEmitReasoningDeltaEncryptedSurvivesTransition` for the new plumbing).
- [x] `./gradlew :prompt:prompt-executor:prompt-executor-clients:prompt-executor-anthropic-client:jvmTest`
- [x] `./gradlew :prompt:prompt-executor:prompt-executor-clients:prompt-executor-google-client:jvmTest :prompt:prompt-executor:prompt-executor-clients:prompt-executor-openrouter-client:jvmTest :prompt:prompt-executor:prompt-executor-clients:prompt-executor-ollama-client:jvmTest` (sister clients that call `emitReasoningDelta` still pass with the new optional `encrypted` parameter).
- [x] `compileKotlinJs` for `prompt-model` and the Anthropic client to confirm common-source compatibility.

Fixes #1959