### PR TITLE
fix(agents): tool schema generation for nested nullable objects

### DIFF
--- a/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/schema/SchemaGenerator.kt
+++ b/agents/agents-tools/src/commonMain/kotlin/ai/koog/agents/core/tools/schema/SchemaGenerator.kt
@@ -127,6 +127,9 @@ public fun PropertyDefinition.toToolParameter(
                 val const = (this.constValue as? JsonPrimitive)?.contentOrNull
 
                 when {
+                    // Null represented as "type": ["null"]
+                    type == JsonSchemaConstants.Types.NULL_TYPE -> ToolParameterType.Null
+
                     // Normal enum
                     enum != null -> ToolParameterType.Enum(enum.toTypedArray())
 
@@ -180,8 +183,8 @@ public fun PropertyDefinition.toToolParameter(
                 throw IllegalArgumentException("Unsupported value property definition type: $this")
         }
 
-        val effectiveParameterType = if (isNullableType) {
-            // emulate type union
+        // If the type is nullable, except the null itself, wrap it in an AnyOf with the null type to simulate type union
+        val effectiveParameterType = if (isNullableType && parameterType !is ToolParameterType.Null) {
             ToolParameterType.AnyOf(
                 types = arrayOf(
                     ToolParameterDescriptor(type = ToolParameterType.Null, name = "", description = ""),

--- a/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/schema/SerializableSchemaGeneratorTest.kt
+++ b/agents/agents-tools/src/commonTest/kotlin/ai/koog/agents/core/tools/schema/SerializableSchemaGeneratorTest.kt
@@ -24,6 +24,7 @@ class SerializableSchemaGeneratorTest {
         val floatProperty: Float,
         val booleanNullableProperty: Boolean?,
         val nullableProperty: String? = null,
+        val nullableNestedObject: NestedProperty? = null,
         val listProperty: List<String> = emptyList(),
         val mapProperty: Map<String, Int> = emptyMap(),
         @property:LLMDescription("A custom nested property")
@@ -149,6 +150,16 @@ class SerializableSchemaGeneratorTest {
                         types = arrayOf(
                             ToolParameterDescriptor(type = ToolParameterType.Null, name = "", description = ""),
                             ToolParameterDescriptor(type = ToolParameterType.String, name = "", description = ""),
+                        )
+                    )
+                ),
+                ToolParameterDescriptor(
+                    name = "nullableNestedObject",
+                    description = "",
+                    type = ToolParameterType.AnyOf(
+                        types = arrayOf(
+                            ToolParameterDescriptor(type = ToolParameterType.Null, name = "", description = ""),
+                            ToolParameterDescriptor(type = nestedObject, name = "", description = "Nested property class"),
                         )
                     )
                 ),

--- a/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/schema/FunctionSchemaGenerationTest.kt
+++ b/agents/agents-tools/src/jvmTest/kotlin/ai/koog/agents/schema/FunctionSchemaGenerationTest.kt
@@ -23,6 +23,7 @@ class FunctionSchemaGenerationTest {
         val floatProperty: Float,
         val booleanNullableProperty: Boolean?,
         val nullableProperty: String? = null,
+        val nullableNestedObject: NestedProperty? = null,
         val listProperty: List<String> = emptyList(),
         val mapProperty: Map<String, Int> = emptyMap(),
         @property:LLMDescription("A custom nested property")
@@ -147,6 +148,16 @@ class FunctionSchemaGenerationTest {
                     )
                 ),
                 ToolParameterDescriptor(
+                    name = "nullableNestedObject",
+                    description = "Nested property class",
+                    type = ToolParameterType.AnyOf(
+                        types = arrayOf(
+                            ToolParameterDescriptor(type = ToolParameterType.Null, name = "", description = ""),
+                            ToolParameterDescriptor(type = nestedObject, name = "", description = ""),
+                        )
+                    )
+                ),
+                ToolParameterDescriptor(
                     name = "listProperty",
                     description = "",
                     type = ToolParameterType.List(ToolParameterType.String),
@@ -252,6 +263,7 @@ class FunctionSchemaGenerationTest {
                 "floatProperty",
                 "booleanNullableProperty",
                 "nullableProperty",
+                "nullableNestedObject",
                 "listProperty",
                 "mapProperty",
                 "nestedProperty",


### PR DESCRIPTION
Nested nullable objects cause improper schema to be generated that looks something like this: `AnyOf(AnyOf(Null, String), Object)` - there's additional nested `AnyOf` with `String` that shouldn't be there. Now, proper schemas are generated that look like this: `AnyOf(Null, Object)`