### PR TITLE
fix(agents): KG-844. Add missing LLMCallFailedEvent agent remote events

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/events/llmCallEvents.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/model/events/llmCallEvents.kt
@@ -1,6 +1,7 @@
 package ai.koog.agents.core.feature.model.events
 
 import ai.koog.agents.core.agent.execution.AgentExecutionInfo
+import ai.koog.agents.core.feature.model.AIAgentError
 import ai.koog.agents.utils.ModelInfo
 import ai.koog.prompt.dsl.ModerationResult
 import ai.koog.prompt.dsl.Prompt
@@ -139,6 +140,32 @@ public data class LLMCallCompletedEvent(
     @Deprecated("Use model.eventString instead", ReplaceWith("model.eventString"))
     public val modelString: String get() = model.eventString
 }
+
+/**
+ * Represents an event that occurs when a call to a large language model (LLM) fails. This event captures
+ * relevant details about the failed call, such as the prompt, model information, tools used, and the
+ * associated error.
+ *
+ * @property eventId A unique identifier for the event.
+ * @property executionInfo Execution context information, including the part name and any parent executions.
+ * @property runId A unique identifier for the specific run of the LLM call that failed.
+ * @property prompt The prompt data associated with the LLM call.
+ * @property model Information about the model used for the LLM call.
+ * @property tools A list of tools (if any) involved in the execution that led to the failure.
+ * @property error The error information providing details about why the call failed.
+ * @property timestamp The time at which the event was recorded, represented as milliseconds since epoch.
+ */
+@Serializable
+public data class LLMCallFailedEvent(
+    override val eventId: String,
+    override val executionInfo: AgentExecutionInfo,
+    val runId: String,
+    val prompt: Prompt,
+    val model: ModelInfo,
+    val tools: List<String>,
+    val error: AIAgentError,
+    override val timestamp: Long = KoogClock.System.now().toEpochMilliseconds(),
+) : DefinedFeatureEvent()
 
 //region Deprecated
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/remote/jsonConfig.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/remote/jsonConfig.kt
@@ -10,6 +10,7 @@ import ai.koog.agents.core.feature.model.events.AgentStartingEvent
 import ai.koog.agents.core.feature.model.events.DefinedFeatureEvent
 import ai.koog.agents.core.feature.model.events.GraphStrategyStartingEvent
 import ai.koog.agents.core.feature.model.events.LLMCallCompletedEvent
+import ai.koog.agents.core.feature.model.events.LLMCallFailedEvent
 import ai.koog.agents.core.feature.model.events.LLMCallStartingEvent
 import ai.koog.agents.core.feature.model.events.LLMStreamingCompletedEvent
 import ai.koog.agents.core.feature.model.events.LLMStreamingFailedEvent
@@ -87,6 +88,7 @@ public val defaultFeatureMessageJsonConfig: Json
  * - [ToolCallCompletedEvent] - Fired when a tool call returns a result
  * - [LLMCallStartingEvent] - Fired before making an LLM call
  * - [LLMCallCompletedEvent] - Fired after completing an LLM call
+ * - [LLMCallFailedEvent] - Fired when an LLM call fails
  *
  * This configuration enables proper handling of the diverse event types encountered in the system by ensuring
  * that the polymorphic serialization framework can correctly serialize and deserialize each subclass.
@@ -115,6 +117,7 @@ public val defaultFeatureMessageSerializersModule: SerializersModule
             subclass(ToolCallCompletedEvent::class, ToolCallCompletedEvent.serializer())
             subclass(LLMCallStartingEvent::class, LLMCallStartingEvent.serializer())
             subclass(LLMCallCompletedEvent::class, LLMCallCompletedEvent.serializer())
+            subclass(LLMCallFailedEvent::class, LLMCallFailedEvent.serializer())
             subclass(LLMStreamingStartingEvent::class, LLMStreamingStartingEvent.serializer())
             subclass(LLMStreamingFrameReceivedEvent::class, LLMStreamingFrameReceivedEvent.serializer())
             subclass(LLMStreamingFailedEvent::class, LLMStreamingFailedEvent.serializer())
@@ -141,6 +144,7 @@ public val defaultFeatureMessageSerializersModule: SerializersModule
             subclass(ToolCallCompletedEvent::class, ToolCallCompletedEvent.serializer())
             subclass(LLMCallStartingEvent::class, LLMCallStartingEvent.serializer())
             subclass(LLMCallCompletedEvent::class, LLMCallCompletedEvent.serializer())
+            subclass(LLMCallFailedEvent::class, LLMCallFailedEvent.serializer())
             subclass(LLMStreamingStartingEvent::class, LLMStreamingStartingEvent.serializer())
             subclass(LLMStreamingFrameReceivedEvent::class, LLMStreamingFrameReceivedEvent.serializer())
             subclass(LLMStreamingFailedEvent::class, LLMStreamingFailedEvent.serializer())
@@ -167,6 +171,7 @@ public val defaultFeatureMessageSerializersModule: SerializersModule
             subclass(ToolCallCompletedEvent::class, ToolCallCompletedEvent.serializer())
             subclass(LLMCallStartingEvent::class, LLMCallStartingEvent.serializer())
             subclass(LLMCallCompletedEvent::class, LLMCallCompletedEvent.serializer())
+            subclass(LLMCallFailedEvent::class, LLMCallFailedEvent.serializer())
             subclass(LLMStreamingStartingEvent::class, LLMStreamingStartingEvent.serializer())
             subclass(LLMStreamingFrameReceivedEvent::class, LLMStreamingFrameReceivedEvent.serializer())
             subclass(LLMStreamingFailedEvent::class, LLMStreamingFailedEvent.serializer())

--- a/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/feature/Tracing.kt
+++ b/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/feature/Tracing.kt
@@ -14,6 +14,7 @@ import ai.koog.agents.core.feature.model.events.AgentExecutionFailedEvent
 import ai.koog.agents.core.feature.model.events.AgentStartingEvent
 import ai.koog.agents.core.feature.model.events.GraphStrategyStartingEvent
 import ai.koog.agents.core.feature.model.events.LLMCallCompletedEvent
+import ai.koog.agents.core.feature.model.events.LLMCallFailedEvent
 import ai.koog.agents.core.feature.model.events.LLMCallStartingEvent
 import ai.koog.agents.core.feature.model.events.LLMStreamingCompletedEvent
 import ai.koog.agents.core.feature.model.events.LLMStreamingFailedEvent
@@ -343,6 +344,20 @@ public class Tracing {
                     model = eventContext.model.toModelInfo(),
                     response = eventContext.response,
                     moderationResponse = eventContext.moderationResponse,
+                    timestamp = pipeline.clock.now().toEpochMilliseconds()
+                )
+                processMessage(config, event)
+            }
+
+            pipeline.interceptLLMCallFailed(this) intercept@{ eventContext ->
+                val event = LLMCallFailedEvent(
+                    eventId = eventContext.eventId,
+                    executionInfo = eventContext.executionInfo,
+                    runId = eventContext.runId,
+                    prompt = eventContext.prompt,
+                    model = eventContext.model.toModelInfo(),
+                    tools = eventContext.tools.map { it.name },
+                    error = eventContext.error.toAgentError(),
                     timestamp = pipeline.clock.now().toEpochMilliseconds()
                 )
                 processMessage(config, event)

--- a/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/writer/traceMessageFormat.kt
+++ b/agents/agents-features/agents-features-trace/src/commonMain/kotlin/ai/koog/agents/features/tracing/writer/traceMessageFormat.kt
@@ -8,12 +8,20 @@ import ai.koog.agents.core.feature.model.events.AgentCompletedEvent
 import ai.koog.agents.core.feature.model.events.AgentExecutionFailedEvent
 import ai.koog.agents.core.feature.model.events.AgentStartingEvent
 import ai.koog.agents.core.feature.model.events.LLMCallCompletedEvent
+import ai.koog.agents.core.feature.model.events.LLMCallFailedEvent
 import ai.koog.agents.core.feature.model.events.LLMCallStartingEvent
+import ai.koog.agents.core.feature.model.events.LLMStreamingCompletedEvent
+import ai.koog.agents.core.feature.model.events.LLMStreamingFailedEvent
+import ai.koog.agents.core.feature.model.events.LLMStreamingFrameReceivedEvent
+import ai.koog.agents.core.feature.model.events.LLMStreamingStartingEvent
 import ai.koog.agents.core.feature.model.events.NodeExecutionCompletedEvent
 import ai.koog.agents.core.feature.model.events.NodeExecutionFailedEvent
 import ai.koog.agents.core.feature.model.events.NodeExecutionStartingEvent
 import ai.koog.agents.core.feature.model.events.StrategyCompletedEvent
 import ai.koog.agents.core.feature.model.events.StrategyStartingEventBase
+import ai.koog.agents.core.feature.model.events.SubgraphExecutionCompletedEvent
+import ai.koog.agents.core.feature.model.events.SubgraphExecutionFailedEvent
+import ai.koog.agents.core.feature.model.events.SubgraphExecutionStartingEvent
 import ai.koog.agents.core.feature.model.events.ToolCallCompletedEvent
 import ai.koog.agents.core.feature.model.events.ToolCallFailedEvent
 import ai.koog.agents.core.feature.model.events.ToolCallStartingEvent
@@ -64,6 +72,30 @@ internal val LLMCallStartingEvent.beforeLLMCallEventFormat
 internal val LLMCallCompletedEvent.afterLLMCallEventFormat
     get() = "${this::class.simpleName} (run id: $runId, prompt: ${prompt.traceString}, model: ${model.modelIdentifierName}, response: ${response?.traceString}])"
 
+internal val LLMCallFailedEvent.llmCallFailedEventFormat
+    get() = "${this::class.simpleName} (run id: $runId, prompt: ${prompt.traceString}, model: ${model.modelIdentifierName}, tools: [${tools.joinToString()}], error: ${error.message})"
+
+internal val LLMStreamingStartingEvent.llmStreamingStartingEventFormat
+    get() = "${this::class.simpleName} (run id: $runId, prompt: ${prompt.traceString}, model: ${model.modelIdentifierName}, tools: [${tools.joinToString()}])"
+
+internal val LLMStreamingFrameReceivedEvent.llmStreamingFrameReceivedEventFormat
+    get() = "${this::class.simpleName} (run id: $runId, model: ${model.modelIdentifierName}, frame: $frame)"
+
+internal val LLMStreamingFailedEvent.llmStreamingFailedEventFormat
+    get() = "${this::class.simpleName} (run id: $runId, prompt: ${prompt.traceString}, model: ${model.modelIdentifierName}, error: ${error.message})"
+
+internal val LLMStreamingCompletedEvent.llmStreamingCompletedEventFormat
+    get() = "${this::class.simpleName} (run id: $runId, prompt: ${prompt.traceString}, model: ${model.modelIdentifierName}, tools: [${tools.joinToString()}])"
+
+internal val SubgraphExecutionStartingEvent.subgraphExecutionStartingEventFormat
+    get() = "${this::class.simpleName} (run id: $runId, subgraph: $subgraphName, input: $input)"
+
+internal val SubgraphExecutionCompletedEvent.subgraphExecutionCompletedEventFormat
+    get() = "${this::class.simpleName} (run id: $runId, subgraph: $subgraphName, input: $input, output: $output)"
+
+internal val SubgraphExecutionFailedEvent.subgraphExecutionFailedEventFormat
+    get() = "${this::class.simpleName} (run id: $runId, subgraph: $subgraphName, input: $input, error: ${error.message})"
+
 internal val ToolCallStartingEvent.toolCallEventFormat
     get() = "${this::class.simpleName} (run id: $runId, tool: $toolName, tool args: $toolArgs)"
 
@@ -88,8 +120,16 @@ internal val FeatureMessage.traceMessage: String
             is NodeExecutionStartingEvent -> this.nodeExecutionStartEventFormat
             is NodeExecutionCompletedEvent -> this.nodeExecutionEndEventFormat
             is NodeExecutionFailedEvent -> this.nodeExecutionErrorEventFormat
+            is SubgraphExecutionStartingEvent -> this.subgraphExecutionStartingEventFormat
+            is SubgraphExecutionCompletedEvent -> this.subgraphExecutionCompletedEventFormat
+            is SubgraphExecutionFailedEvent -> this.subgraphExecutionFailedEventFormat
             is LLMCallStartingEvent -> this.beforeLLMCallEventFormat
             is LLMCallCompletedEvent -> this.afterLLMCallEventFormat
+            is LLMCallFailedEvent -> this.llmCallFailedEventFormat
+            is LLMStreamingStartingEvent -> this.llmStreamingStartingEventFormat
+            is LLMStreamingFrameReceivedEvent -> this.llmStreamingFrameReceivedEventFormat
+            is LLMStreamingFailedEvent -> this.llmStreamingFailedEventFormat
+            is LLMStreamingCompletedEvent -> this.llmStreamingCompletedEventFormat
             is ToolCallStartingEvent -> this.toolCallEventFormat
             is ToolValidationFailedEvent -> this.toolValidationErrorEventFormat
             is ToolCallFailedEvent -> this.toolCallFailureEventFormat

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
@@ -8,9 +8,12 @@ import ai.koog.agents.core.dsl.extension.ToolCalls
 import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeAppendPrompt
 import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreaming
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestWithoutTools
 import ai.koog.agents.core.feature.model.AIAgentError
+import ai.koog.agents.core.feature.model.events.LLMCallCompletedEvent
+import ai.koog.agents.core.feature.model.events.LLMCallFailedEvent
 import ai.koog.agents.core.feature.model.events.LLMCallStartingEvent
 import ai.koog.agents.core.feature.model.events.LLMStreamingCompletedEvent
 import ai.koog.agents.core.feature.model.events.LLMStreamingFailedEvent
@@ -609,6 +612,136 @@ class TraceFeatureMessageTestWriterTest {
                         tools = toolRegistry.tools.map { it.name },
                         timestamp = testClock.now().toEpochMilliseconds()
                     )
+                )
+
+                assertEquals(expectedEvents.size, actualEvents.size)
+                assertContentEquals(expectedEvents, actualEvents)
+            }
+        }
+    }
+
+    @Test
+    fun `test llm call events failure`() = runBlocking {
+        val agentId = "test-agent-id"
+        val userPrompt = "Call the dummy tool with argument: test"
+        val systemPrompt = "Test system prompt"
+        val assistantPrompt = "Test assistant prompt"
+        val promptId = "Test prompt id"
+        val strategyName = "tracing-call-failure"
+        val nodeCallFailedName = "test-node-call-failed"
+        val model = OpenAIModels.Chat.GPT4o
+
+        val strategy = strategy<String, String>(strategyName) {
+            val call by nodeLLMRequest(nodeCallFailedName)
+
+            edge(nodeStart forwardTo call asUserMessage { it })
+            edge(
+                call forwardTo nodeFinish transformed { input ->
+                    input.parts.filterIsInstance<MessagePart.Text>().joinToString("\n") { it.text }
+                }
+            )
+        }
+
+        val toolRegistry = ToolRegistry { tool(DummyTool()) }
+
+        val expectedErrorMessage = "Test LLM call error"
+        var expectedStackTrace = ""
+        var expectedCause: String? = null
+        var expectedType: String? = null
+
+        val testCallExecutor = object : PromptExecutor() {
+            override suspend fun execute(
+                prompt: Prompt,
+                model: LLModel,
+                tools: List<ToolDescriptor>
+            ): Message.Assistant {
+                val testException = IllegalStateException(expectedErrorMessage)
+                expectedStackTrace = testException.stackTraceToString()
+                expectedCause = testException.cause?.toString()
+                expectedType = testException::class.qualifiedName
+                throw testException
+            }
+
+            override fun executeStreaming(
+                prompt: Prompt,
+                model: LLModel,
+                tools: List<ToolDescriptor>
+            ): Flow<StreamFrame> = flow { }
+
+            override suspend fun moderate(
+                prompt: Prompt,
+                model: LLModel
+            ): ai.koog.prompt.dsl.ModerationResult {
+                throw UnsupportedOperationException("Not used in test")
+            }
+
+            override fun close() {}
+        }
+
+        TestFeatureMessageWriter().use { writer ->
+
+            createAgent(
+                agentId = agentId,
+                systemPrompt = systemPrompt,
+                userPrompt = userPrompt,
+                assistantPrompt = assistantPrompt,
+                promptId = promptId,
+                model = model,
+                strategy = strategy,
+                promptExecutor = testCallExecutor,
+                toolRegistry = toolRegistry,
+            ) {
+                install(Tracing) {
+                    addMessageProcessor(writer)
+                }
+            }.use { agent ->
+                val throwable = assertFails {
+                    agent.run("", null)
+                }
+
+                assertEquals(expectedErrorMessage, throwable.message)
+
+                val expectedPrompt = Prompt(
+                    messages = listOf(
+                        systemMessage(systemPrompt),
+                        userMessage(userPrompt),
+                        assistantMessage(assistantPrompt),
+                        userMessage(""),
+                    ),
+                    id = promptId
+                )
+
+                val actualEvents = writer.messages.filterIsInstance<LLMCallStartingEvent>() +
+                    writer.messages.filterIsInstance<LLMCallFailedEvent>() +
+                    writer.messages.filterIsInstance<LLMCallCompletedEvent>()
+
+                val actualCallStartingEvent = writer.messages.singleEvent<LLMCallStartingEvent>()
+
+                val expectedEvents = listOf(
+                    LLMCallStartingEvent(
+                        eventId = actualCallStartingEvent.eventId,
+                        executionInfo = agentExecutionInfo(agentId, strategyName, nodeCallFailedName),
+                        runId = writer.runId,
+                        prompt = expectedPrompt,
+                        model = model.toModelInfo(),
+                        tools = toolRegistry.tools.map { it.name },
+                        timestamp = testClock.now().toEpochMilliseconds()
+                    ),
+                    LLMCallFailedEvent(
+                        eventId = actualCallStartingEvent.eventId,
+                        executionInfo = agentExecutionInfo(agentId, strategyName, nodeCallFailedName),
+                        runId = writer.runId,
+                        prompt = expectedPrompt,
+                        model = model.toModelInfo(),
+                        tools = toolRegistry.tools.map { it.name },
+                        error = AIAgentError(
+                            message = expectedErrorMessage,
+                            stackTrace = expectedStackTrace,
+                            cause = expectedCause,
+                            type = expectedType
+                        ),
+                        timestamp = testClock.now().toEpochMilliseconds()
+                    ),
                 )
 
                 assertEquals(expectedEvents.size, actualEvents.size)

--- a/docs/docs/agent-events.md
+++ b/docs/docs/agent-events.md
@@ -255,6 +255,20 @@ Represents the end of an LLM call. Includes the following fields:
 | `responses`          | List<Message.Response> | Yes      |         | One or more responses returned by the model.                                    |
 | `moderationResponse` | ModerationResult       | No       | null    | The moderation response, if any.                                                |
 
+#### LLMCallFailedEvent
+
+Represents the occurrence of an error during an LLM call. Includes the following fields:
+
+| Name            | Data type           | Required | Default | Description                                                                                             |
+|-----------------|---------------------|----------|---------|---------------------------------------------------------------------------------------------------------|
+| `eventId`       | String              | Yes      |         | A unique identifier for the event or a group of events.                                                 |
+| `executionInfo` | AgentExecutionInfo  | Yes      |         | Provides contextual information about the execution associated with this event.                         |
+| `runId`         | String              | Yes      |         | The unique identifier of the LLM run.                                                                   |
+| `prompt`        | Prompt              | Yes      |         | The prompt that was sent to the model.                                                                  |
+| `model`         | ModelInfo           | Yes      |         | The model information. See [ModelInfo](#modelinfo).                                                     |
+| `tools`         | List<String>        | Yes      |         | The list of tools that the model could call.                                                            |
+| `error`         | AIAgentError        | Yes      |         | The specific error that occurred during the call. For more information, see [AIAgentError](#aiagenterror). |
+
 ### LLM streaming events
 
 #### LLMStreamingStartingEvent

--- a/docs/docs/features/tracing.md
+++ b/docs/docs/features/tracing.md
@@ -260,6 +260,7 @@ Tracing
     ├── SubgraphExecutionFailedEvent
     ├── LLMCallStartingEvent
     ├── LLMCallCompletedEvent
+    ├── LLMCallFailedEvent
     ├── LLMStreamingStartingEvent
     ├── LLMStreamingFrameReceivedEvent
     ├── LLMStreamingFailedEvent


### PR DESCRIPTION
- Add missing LLMCallFailedEvent event. Register in the polymorphic feature-message module;
- Add trace-format branches for missing LLMStreaming and SubgraphExecution events.

closes: [KG-844](https://youtrack.jetbrains.com/issue/KG-844)