### PR TITLE
fix(agents)!: Roll back old nodes names, update new nodes API

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentSimpleStrategies.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentSimpleStrategies.kt
@@ -4,9 +4,9 @@ package ai.koog.agents.core.agent
 
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
+import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
 import ai.koog.agents.core.dsl.extension.onTextMessage
 import ai.koog.agents.core.dsl.extension.onToolCalls
 import kotlin.jvm.JvmName
@@ -27,11 +27,14 @@ import kotlin.jvm.JvmOverloads
  */
 @JvmOverloads
 public fun singleRunStrategy(parallelTools: Boolean = false): AIAgentGraphStrategy<String, String> = strategy<String, String>("single_run") {
-    val nodeLLMRequest by nodeLLMRequest()
-    val nodeExecuteTool by nodeExecuteTools(parallel = parallelTools)
+    val nodeCallLLM by nodeLLMRequest()
+    val nodeExecuteTool by nodeExecuteTools()
+    val nodeSendToolResult by nodeLLMSendToolResults()
 
-    edge(nodeStart forwardTo nodeLLMRequest asUserMessage { it })
-    edge(nodeLLMRequest forwardTo nodeExecuteTool onToolCalls { true })
-    edge(nodeLLMRequest forwardTo nodeFinish onTextMessage { true })
-    edge(nodeExecuteTool forwardTo nodeLLMRequest)
+    edge(nodeStart forwardTo nodeCallLLM)
+    edge(nodeCallLLM forwardTo nodeExecuteTool onToolCalls { true })
+    edge(nodeCallLLM forwardTo nodeFinish onTextMessage { true })
+    edge(nodeExecuteTool forwardTo nodeSendToolResult)
+    edge(nodeSendToolResult forwardTo nodeFinish onTextMessage { true })
+    edge(nodeSendToolResult forwardTo nodeExecuteTool onToolCalls { true })
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBaseCommon.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/context/AIAgentFunctionalContextBaseCommon.kt
@@ -247,69 +247,6 @@ public open class AIAgentFunctionalContextBaseCommon<Pipeline : AIAgentPipeline>
         }
     }
 
-    // ================
-    // LLM Request User nodes
-    // ================
-
-    //region LLMRequest
-
-    /**
-     * Sends a [Message.User] to the LLM and returns the response.
-     * Corresponds to [nodeLLMRequest].
-     */
-    @JvmSynthetic
-    public suspend fun requestLLM(message: Message.User): Message.Assistant {
-        return llm.writeSession {
-            appendPrompt { message(message) }
-            requestLLM()
-        }
-    }
-
-    /**
-     * Sends a [Message.User] to the LLM, restricting it to only calling tools.
-     * Corresponds to [nodeLLMRequestOnlyCallingTools].
-     */
-    @JvmSynthetic
-    public suspend fun requestLLMOnlyCallingTools(message: Message.User): Message.Assistant {
-        return llm.writeSession {
-            appendPrompt { message(message) }
-            requestLLMOnlyCallingTools()
-        }
-    }
-
-    /**
-     * Sends a [Message.User] to the LLM without allowing tool calls.
-     * Corresponds to [nodeLLMRequestWithoutTools].
-     */
-    @JvmSynthetic
-    public suspend fun requestLLMWithoutTools(message: Message.User): Message.Assistant {
-        return llm.writeSession {
-            appendPrompt { message(message) }
-            requestLLMWithoutTools()
-        }
-    }
-
-    /**
-     * Sends a [Message.User] to the LLM and forces it to use a specific tool.
-     * Corresponds to [nodeLLMRequestForceOneTool].
-     */
-    @JvmSynthetic
-    public suspend fun requestLLMForceOneTool(message: Message.User, tool: ToolDescriptor): Message.Assistant {
-        return llm.writeSession {
-            appendPrompt { message(message) }
-            requestLLMForceOneTool(tool)
-        }
-    }
-
-    /**
-     * Sends a [Message.User] to the LLM and forces it to use a specific tool.
-     * Corresponds to [nodeLLMRequestForceOneTool].
-     */
-    @JvmSynthetic
-    public suspend fun requestLLMForceOneTool(message: Message.User, tool: Tool<*, *>): Message.Assistant {
-        return requestLLMForceOneTool(message, tool.descriptor)
-    }
-
     /**
      * Sends a string message to the LLM and returns multiple response choices.
      * Corresponds to [nodeLLMRequestMultipleChoicesWithUserText].
@@ -319,61 +256,6 @@ public open class AIAgentFunctionalContextBaseCommon<Pipeline : AIAgentPipeline>
         return llm.writeSession {
             appendPrompt { user(message) }
             requestLLMMultipleChoices()
-        }
-    }
-
-    /**
-     * Sends a [Message.User] to the LLM and returns multiple response choices.
-     * Corresponds to [nodeLLMRequestMultipleChoices].
-     */
-    @JvmSynthetic
-    public suspend fun requestLLMMultipleChoices(message: Message.User): LLMChoice {
-        return llm.writeSession {
-            appendPrompt { message(message) }
-            requestLLMMultipleChoices()
-        }
-    }
-
-    // Region Streaming
-
-    /**
-     * Sends a [Message.User] to the LLM and streams the response.
-     * Corresponds to [nodeLLMRequestStreaming].
-     */
-    @JvmSynthetic
-    public suspend fun requestLLMStreaming(
-        message: Message.User,
-        structureDefinition: StructureDefinition? = null
-    ): Flow<StreamFrame> {
-        return llm.writeSession {
-            appendPrompt { message(message) }
-            requestLLMStreaming(structureDefinition)
-        }
-    }
-
-    // Region Structured
-
-    /**
-     * Sends a [Message.User] to the LLM and returns a structured response.
-     * Corresponds to [nodeLLMRequestStructured].
-     */
-    @JvmSynthetic
-    public suspend inline fun <reified T> requestLLMStructured(
-        message: Message.User,
-        examples: List<T> = emptyList(),
-        fixingParser: StructureFixingParser? = null
-    ): Result<StructuredResponse<T>> = requestLLMStructured(message, serializer<T>(), examples, fixingParser)
-
-    @PublishedApi
-    internal suspend fun <T> requestLLMStructured(
-        message: Message.User,
-        serializer: KSerializer<T>,
-        examples: List<T> = emptyList(),
-        fixingParser: StructureFixingParser? = null
-    ): Result<StructuredResponse<T>> {
-        return llm.writeSession {
-            appendPrompt { message(message) }
-            requestLLMStructured(serializer, examples, fixingParser)
         }
     }
 
@@ -389,22 +271,6 @@ public open class AIAgentFunctionalContextBaseCommon<Pipeline : AIAgentPipeline>
     ): Result<StructuredResponse<T>> {
         return llm.writeSession {
             appendPrompt { user(message) }
-            requestLLMStructured(config, fixingParser)
-        }
-    }
-
-    /**
-     * Sends a [Message.User] to the LLM and returns a structured response using a [StructuredRequestConfig].
-     * Corresponds to [nodeLLMRequestStructured].
-     */
-    @JvmSynthetic
-    public suspend fun <T> requestLLMStructured(
-        message: Message.User,
-        config: StructuredRequestConfig<T>,
-        fixingParser: StructureFixingParser? = null
-    ): Result<StructuredResponse<T>> {
-        return llm.writeSession {
-            appendPrompt { message(message) }
             requestLLMStructured(config, fixingParser)
         }
     }
@@ -651,28 +517,6 @@ public open class AIAgentFunctionalContextBaseCommon<Pipeline : AIAgentPipeline>
     // ================
     // Conditions
     // ================
-
-    /**
-     * Creates a [Message.User] with the provided text.
-     * @param text Text of the user message.
-     */
-    @JvmSynthetic
-    public suspend fun asUserMessage(text: String): Message.User {
-        return llm.writeSession {
-            userMessage(text)
-        }
-    }
-
-    /**
-     * Creates a [Message.User] with the provided tool results.
-     * @param results List of the tool results of the user message.
-     */
-    @JvmSynthetic
-    public suspend fun asUserMessage(results: List<ReceivedToolResult>): Message.User {
-        return llm.writeSession {
-            userMessage(results.map { it.toMessagePart() })
-        }
-    }
 
     /**
      * Executes the provided action if the given response is of type [Message.Assistant].

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionCommon.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/session/AIAgentLLMWriteSessionCommon.kt
@@ -103,10 +103,10 @@ public abstract class AIAgentLLMWriteSessionCommon internal constructor(
         return SafeTool(tool, environment, clock)
     }
 
-    public fun userMessage(parts: List<MessagePart.RequestPart>): Message.User =
+    internal fun userMessage(parts: List<MessagePart.RequestPart>): Message.User =
         Message.User(parts = parts, metaInfo = RequestMetaInfo.create(clock))
 
-    public fun userMessage(text: String): Message.User =
+    internal fun userMessage(text: String): Message.User =
         Message.User(parts = listOf(MessagePart.Text(text)), metaInfo = RequestMetaInfo.create(clock))
 
     /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentEdges.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentEdges.kt
@@ -80,23 +80,6 @@ public infix fun <IncomingOutput, IntermediateOutput, OutgoingInput> AIAgentEdge
 }
 
 /**
- * Creates an edge that filters assistant messages containing tool calls, based on a custom condition.
- *
- * @param block A function that evaluates whether to accept the assistant message
- */
-@EdgeTransformationDslMarker
-public infix fun <IncomingOutput, IntermediateOutput, OutgoingInput> AIAgentEdgeBuilderIntermediate<IncomingOutput, IntermediateOutput, OutgoingInput>.onToolResults(
-    block: suspend (MessagePart.Tool.Result) -> Boolean
-): AIAgentEdgeBuilderIntermediate<IncomingOutput, ToolResults, OutgoingInput> {
-    return onMessageParts(MessagePart.Tool.Result::class)
-        .onCondition { toolResults ->
-            toolResults.any { block(it) }
-        }.transformed { toolResults ->
-            ToolResults(toolResults.filter { block(it) })
-        }
-}
-
-/**
  * Creates an edge that filters tool call messages for a specific tool and arguments condition.
  *
  * @param tool The tool to match against

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentEdges.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentEdges.kt
@@ -2,6 +2,7 @@ package ai.koog.agents.core.dsl.extension
 
 import ai.koog.agents.core.dsl.builder.AIAgentEdgeBuilderIntermediate
 import ai.koog.agents.core.dsl.builder.EdgeTransformationDslMarker
+import ai.koog.agents.core.environment.ReceivedToolResult
 import ai.koog.agents.core.environment.SafeTool
 import ai.koog.agents.core.tools.Tool
 import ai.koog.prompt.message.Message
@@ -180,4 +181,40 @@ public inline infix fun <IncomingOutput, OutgoingInput, reified TResult> AIAgent
     onIsInstance(SafeTool.Result.Failure::class).transformed { it as SafeTool.Result.Failure<TResult> }
         .onCondition {
             condition(it.message)
+        }
+
+/**
+ * Creates an edge that transforms an intermediate output into a [Message.User] using the provided transform.
+ *
+ * @param transform A function that converts the intermediate output to a String for the user message.
+ */
+@EdgeTransformationDslMarker
+public infix fun <IncomingOutput, IntermediateOutput, OutgoingInput> AIAgentEdgeBuilderIntermediate<IncomingOutput, IntermediateOutput, OutgoingInput>.asUserMessage(
+    transform: suspend (IntermediateOutput) -> String
+): AIAgentEdgeBuilderIntermediate<IncomingOutput, Message.User, OutgoingInput> {
+    return transformed { llm.writeSession { userMessage(transform(it)) } }
+}
+
+/**
+ * Applies a transformation to the intermediate output of the edge builder and filters the received tool results
+ * based on the provided condition. This function is used to handle tool results as a part of the AI agent's edge flow
+ * within the DSL.
+ *
+ * @param filter A suspending lambda function that determines whether a given [ReceivedToolResult] should be included
+ *               in the transformation process. The function takes a [ReceivedToolResult] as input and returns a Boolean
+ *               indicating whether the result satisfies the filter condition.
+ * @return A new instance of [AIAgentEdgeBuilderIntermediate] with the intermediate output type set to
+ *         [ReceivedToolResults], representing a collection of filtered tool results.
+ */
+@EdgeTransformationDslMarker
+public infix fun <IncomingOutput, IntermediateOutput, OutgoingInput> AIAgentEdgeBuilderIntermediate<IncomingOutput, IntermediateOutput, OutgoingInput>.asToolResultMessage(
+    filter: suspend (ReceivedToolResult) -> Boolean
+): AIAgentEdgeBuilderIntermediate<IncomingOutput, Message.User, OutgoingInput> =
+    onIsInstance(ReceivedToolResults::class)
+        .transformed { results ->
+            llm.writeSession {
+                userMessage(
+                    results.toolResults.filter { filter(it) }.map { it.toMessagePart() }
+                )
+            }
         }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentEdges.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentEdges.kt
@@ -30,18 +30,6 @@ public inline infix fun <IncomingOutput, IntermediateOutput, OutgoingInput, reif
 }
 
 /**
- * Creates an edge that transforms an intermediate output into a [Message.User] using the provided transform.
- *
- * @param transform A function that converts the intermediate output to a String for the user message.
- */
-@EdgeTransformationDslMarker
-public infix fun <IncomingOutput, IntermediateOutput, OutgoingInput> AIAgentEdgeBuilderIntermediate<IncomingOutput, IntermediateOutput, OutgoingInput>.asUserMessage(
-    transform: suspend (IntermediateOutput) -> String
-): AIAgentEdgeBuilderIntermediate<IncomingOutput, Message.User, OutgoingInput> {
-    return transformed { llm.writeSession { userMessage(transform(it)) } }
-}
-
-/**
  * Creates an edge that filters outputs based on their MessagePart subtype.
  *
  * @param klass The MessagePart subclass to filter against

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
@@ -93,7 +93,7 @@ public suspend fun <T> AIAgentGraphContextBase.appendPromptImpl(
  * @param name Optional node name, defaults to delegate's property name.
  */
 @AIAgentBuilderDslMarker
-public fun nodeLLMRequestWithUserText(
+public fun nodeLLMRequest(
     name: String? = null,
 ): AIAgentNodeDelegate<String, Message.Assistant> =
     node(name) { message ->
@@ -112,7 +112,7 @@ public fun nodeLLMRequestWithUserText(
  * @param name Optional node name, defaults to delegate's property name.
  */
 @AIAgentBuilderDslMarker
-public fun nodeLLMRequestOnlyCallingToolsWithUserText(
+public fun nodeLLMRequestOnlyCallingTools(
     name: String? = null,
 ): AIAgentNodeDelegate<String, Message.Assistant> =
     node(name) { message ->
@@ -131,7 +131,7 @@ public fun nodeLLMRequestOnlyCallingToolsWithUserText(
  * @param name Optional node name, defaults to delegate's property name.
  */
 @AIAgentBuilderDslMarker
-public fun nodeLLMRequestWithoutToolsWithUserText(
+public fun nodeLLMRequestWithoutTools(
     name: String? = null,
 ): AIAgentNodeDelegate<String, Message.Assistant> =
     node(name) { message ->
@@ -151,7 +151,7 @@ public fun nodeLLMRequestWithoutToolsWithUserText(
  * @param tool The descriptor of the tool the LLM must call.
  */
 @AIAgentBuilderDslMarker
-public fun nodeLLMRequestForceOneToolWithUserText(
+public fun nodeLLMRequestForceOneTool(
     name: String? = null,
     tool: ToolDescriptor
 ): AIAgentNodeDelegate<String, Message.Assistant> =
@@ -171,7 +171,7 @@ public fun nodeLLMRequestForceOneToolWithUserText(
  * @param name Optional node name, defaults to delegate's property name.
  */
 @AIAgentBuilderDslMarker
-public fun nodeLLMRequestMultipleChoicesWithUserText(
+public fun nodeLLMRequestMultipleChoices(
     name: String? = null,
 ): AIAgentNodeDelegate<String, LLMChoice> =
     node(name) { message ->
@@ -194,7 +194,7 @@ public fun nodeLLMRequestMultipleChoicesWithUserText(
  * @param transformStreamData A suspend function that transforms the [StreamFrame] flow into a [Flow] of [T].
  */
 @AIAgentBuilderDslMarker
-public fun <T> nodeLLMRequestStreamingWithUserText(
+public fun <T> nodeLLMRequestStreaming(
     name: String? = null,
     structureDefinition: StructureDefinition? = null,
     transformStreamData: suspend (Flow<StreamFrame>) -> Flow<T>
@@ -216,11 +216,11 @@ public fun <T> nodeLLMRequestStreamingWithUserText(
  * @param structureDefinition An optional structure definition to guide the streaming response format.
  */
 @AIAgentBuilderDslMarker
-public fun nodeLLMRequestStreamingWithUserText(
+public fun nodeLLMRequestStreaming(
     name: String? = null,
     structureDefinition: StructureDefinition? = null,
 ): AIAgentNodeDelegate<String, Flow<StreamFrame>> =
-    nodeLLMRequestStreamingWithUserText(name, structureDefinition) { it }
+    nodeLLMRequestStreaming(name, structureDefinition) { it }
 
 // Region Structured
 
@@ -233,7 +233,7 @@ public fun nodeLLMRequestStreamingWithUserText(
  * @param fixingParser An optional parser used to attempt recovery if the LLM returns malformed structured output.
  */
 @AIAgentBuilderDslMarker
-public fun <T> nodeLLMRequestStructuredWithUserText(
+public fun <T> nodeLLMRequestStructured(
     name: String? = null,
     config: StructuredRequestConfig<T>,
     fixingParser: StructureFixingParser? = null
@@ -257,7 +257,7 @@ public fun <T> nodeLLMRequestStructuredWithUserText(
  * @param fixingParser An optional parser used to attempt recovery if the LLM returns malformed structured output.
  */
 @AIAgentBuilderDslMarker
-public inline fun <reified T> nodeLLMRequestStructuredWithUserText(
+public inline fun <reified T> nodeLLMRequestStructured(
     name: String? = null,
     examples: List<T> = emptyList(),
     fixingParser: StructureFixingParser? = null
@@ -274,112 +274,9 @@ public inline fun <reified T> nodeLLMRequestStructuredWithUserText(
     }
 }
 
-// ================
-// LLM Request message nodes
-// ================
-
-//region LLMRequest
-
 /**
- * A node that appends a [Message.User] to the prompt and requests a response from the LLM.
- *
- * @param name Optional node name, defaults to delegate's property name.
- */
-@AIAgentBuilderDslMarker
-public fun nodeLLMRequest(
-    name: String? = null,
-): AIAgentNodeDelegate<Message.User, Message.Assistant> =
-    node(name) { message ->
-        llm.writeSession {
-            appendPrompt {
-                message(message)
-            }
-            requestLLM()
-        }
-    }
-
-/**
- * A node that appends a [Message.User] to the prompt and requests a response from the LLM,
- * forcing it to call one of the available tools (no plain-text replies allowed).
- *
- * @param name Optional node name, defaults to delegate's property name.
- */
-@AIAgentBuilderDslMarker
-public fun nodeLLMRequestOnlyCallingTools(
-    name: String? = null,
-): AIAgentNodeDelegate<Message.User, Message.Assistant> =
-    node(name) { message ->
-        llm.writeSession {
-            appendPrompt {
-                message(message)
-            }
-            requestLLMOnlyCallingTools()
-        }
-    }
-
-/**
- * A node that appends a [Message.User] to the prompt and requests a response from the LLM,
- * without exposing any tools (pure text response only).
- *
- * @param name Optional node name, defaults to delegate's property name.
- */
-@AIAgentBuilderDslMarker
-public fun nodeLLMRequestWithoutTools(
-    name: String? = null,
-): AIAgentNodeDelegate<Message.User, Message.Assistant> =
-    node(name) { message ->
-        llm.writeSession {
-            appendPrompt {
-                message(message)
-            }
-            requestLLMWithoutTools()
-        }
-    }
-
-/**
- * A node that appends a [Message.User] to the prompt and requests a response from the LLM,
- * forcing it to call exactly the specified tool.
- *
- * @param name Optional node name, defaults to delegate's property name.
- * @param tool The descriptor of the tool the LLM must call.
- */
-@AIAgentBuilderDslMarker
-public fun nodeLLMRequestForceOneTool(
-    name: String? = null,
-    tool: ToolDescriptor
-): AIAgentNodeDelegate<Message.User, Message.Assistant> =
-    node(name) { message ->
-        llm.writeSession {
-            appendPrompt {
-                message(message)
-            }
-            requestLLMForceOneTool(tool)
-        }
-    }
-
-/**
- * A node that appends a [Message.User] to the prompt and requests multiple completion choices
- * from the LLM, returning them as an [LLMChoice].
- *
- * @param name Optional node name, defaults to delegate's property name.
- */
-@AIAgentBuilderDslMarker
-public fun nodeLLMRequestMultipleChoices(
-    name: String? = null,
-): AIAgentNodeDelegate<Message.User, LLMChoice> =
-    node(name) { message ->
-        llm.writeSession {
-            appendPrompt {
-                message(message)
-            }
-            requestLLMMultipleChoices()
-        }
-    }
-
-// Region Streaming
-
-/**
- * [InternalAgentsApi] method. Appends a [Message.User] to the prompt and requests a streaming response from the LLM.
+ * [InternalAgentsApi] method. Appends a [Message.User] with given text to the prompt
+ * and requests a streaming response from the LLM.
  *
  * @param input The user message to append to the prompt.
  * @param structureDefinition An optional structure definition to customize the streaming response.
@@ -388,103 +285,13 @@ public fun nodeLLMRequestMultipleChoices(
  */
 @InternalAgentsApi
 public suspend fun <T> AIAgentGraphContextBase.requestStreamingImpl(
-    input: Message.User,
+    input: String,
     structureDefinition: StructureDefinition? = null,
     transformStreamData: suspend (Flow<StreamFrame>) -> Flow<T>
 ): Flow<T> = llm.writeSession {
-    appendPrompt { message(input) }
+    appendPrompt { user(input) }
     requestStreaming(structureDefinition, transformStreamData)
 }
-
-/**
- * A node that appends a [Message.User] to the prompt and requests a streaming response from the LLM,
- * applying [transformStreamData] to convert the raw [StreamFrame] flow into a flow of [T].
- *
- * @param name Optional node name, defaults to delegate's property name.
- * @param structureDefinition An optional structure definition to guide the streaming response format.
- * @param transformStreamData A suspend function that transforms the [StreamFrame] flow into a [Flow] of [T].
- */
-@AIAgentBuilderDslMarker
-public fun <T> nodeLLMRequestStreaming(
-    name: String? = null,
-    structureDefinition: StructureDefinition? = null,
-    transformStreamData: suspend (Flow<StreamFrame>) -> Flow<T>
-): AIAgentNodeDelegate<Message.User, Flow<T>> =
-    node(name) { message ->
-        llm.writeSession {
-            appendPrompt {
-                message(message)
-            }
-            requestStreaming(structureDefinition, transformStreamData)
-        }
-    }
-
-/**
- * A node that appends a [Message.User] to the prompt and requests a streaming response from the LLM,
- * returning raw [StreamFrame] elements.
- *
- * @param name Optional node name, defaults to delegate's property name.
- * @param structureDefinition An optional structure definition to guide the streaming response format.
- */
-@AIAgentBuilderDslMarker
-public fun nodeLLMRequestStreaming(
-    name: String? = null,
-    structureDefinition: StructureDefinition? = null,
-): AIAgentNodeDelegate<Message.User, Flow<StreamFrame>> = nodeLLMRequestStreaming(name, structureDefinition) { it }
-
-// Region Structured
-
-/**
- * A node that appends a [Message.User] to the prompt and requests a structured response from the LLM
- * using the provided [config].
- *
- * @param name Optional node name, defaults to delegate's property name.
- * @param config Configuration describing the expected structured output format.
- * @param fixingParser An optional parser used to attempt recovery if the LLM returns malformed structured output.
- */
-@AIAgentBuilderDslMarker
-public fun <T> nodeLLMRequestStructured(
-    name: String? = null,
-    config: StructuredRequestConfig<T>,
-    fixingParser: StructureFixingParser? = null
-): AIAgentNodeDelegate<Message.User, Result<StructuredResponse<T>>> =
-    node(name) { message ->
-        llm.writeSession {
-            appendPrompt {
-                message(message)
-            }
-
-            requestLLMStructured(config, fixingParser)
-        }
-    }
-
-/**
- * A node that appends a [Message.User] to the prompt and requests a structured response from the LLM,
- * inferring the output schema from the reified type [T].
- *
- * @param name Optional node name, defaults to delegate's property name.
- * @param examples Optional list of example values of type [T] to guide the LLM's output.
- * @param fixingParser An optional parser used to attempt recovery if the LLM returns malformed structured output.
- */
-@AIAgentBuilderDslMarker
-public inline fun <reified T> nodeLLMRequestStructured(
-    name: String? = null,
-    examples: List<T> = emptyList(),
-    fixingParser: StructureFixingParser? = null
-): AIAgentNodeDelegate<Message.User, Result<StructuredResponse<T>>> = node(name) { message ->
-    llm.writeSession {
-        appendPrompt {
-            message(message)
-        }
-
-        requestLLMStructured<T>(
-            examples = examples,
-            fixingParser = fixingParser
-        )
-    }
-}
-
-// Region Moderate
 
 /**
  * Represents a message that has undergone moderation and the result of the moderation.
@@ -520,6 +327,36 @@ public fun nodeLLMModerateMessage(
         val moderationResult = llm.promptExecutor.moderate(moderationPrompt, moderatingModel ?: llm.model)
 
         ModeratedMessage(message, moderationResult)
+    }
+
+/**
+ * A node that runs content moderation on an incoming text using the LLM.
+ *
+ * @param name Optional node name, defaults to delegate's property name.
+ * @param moderatingModel An optional [LLModel] to use for moderation; defaults to the agent's current model.
+ * @param includeCurrentPrompt If `true`, the full current prompt context is included alongside the message
+ *   when running moderation; otherwise only the single message is sent.
+ */
+@OptIn(DetachedPromptExecutorAPI::class)
+@AIAgentBuilderDslMarker
+public fun nodeLLMModerateText(
+    name: String? = null,
+    moderatingModel: LLModel? = null,
+    includeCurrentPrompt: Boolean = false,
+): AIAgentNodeDelegate<String, ModeratedMessage> =
+    node<String, ModeratedMessage>(name) { text ->
+        val userMessage = llm.writeSession {
+            userMessage(text)
+        }
+        val moderationPrompt = if (includeCurrentPrompt) {
+            prompt(llm.prompt) { message(userMessage) }
+        } else {
+            prompt("single-text-moderation") { message(userMessage) }
+        }
+
+        val moderationResult = llm.promptExecutor.moderate(moderationPrompt, moderatingModel ?: llm.model)
+
+        ModeratedMessage(userMessage, moderationResult)
     }
 
 // ================
@@ -614,25 +451,6 @@ public data class ReceivedToolResults(
     val toolResults: List<ReceivedToolResult>
 )
 
-/**
- * A node that executes the tool calls contained in a [ToolCalls] input, writes the results into the
- * LLM session as a user message, and returns that [Message.User].
- *
- * @param name Optional node name, defaults to delegate's property name.
- * @param parallel If `true`, all tool calls are executed concurrently; otherwise they run sequentially.
- */
-@AIAgentBuilderDslMarker
-public fun nodeExecuteTools(
-    name: String? = null,
-    parallel: Boolean = false,
-): AIAgentNodeDelegate<ToolCalls, Message.User> =
-    node(name) {
-        val parts = executeTools(environment, it.toolCalls, parallel)
-        llm.writeSession {
-            userMessage(parts.map { toolResult -> toolResult.toMessagePart() })
-        }
-    }
-
 // Region ReceivedToolResult
 
 /**
@@ -643,7 +461,7 @@ public fun nodeExecuteTools(
  * @param parallel If `true`, all tool calls are executed concurrently; otherwise they run sequentially.
  */
 @AIAgentBuilderDslMarker
-public fun nodeExecuteToolsAndGetResults(
+public fun nodeExecuteTools(
     name: String? = null,
     parallel: Boolean = false,
 ): AIAgentNodeDelegate<ToolCalls, ReceivedToolResults> =

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
@@ -713,3 +713,195 @@ public suspend fun <T, TInput> AIAgentGraphContextBase.setStructuredOutputImpl(
     prompt = config.updatePrompt(model, prompt)
     message
 }
+
+// ================
+// LLM Request Message nodes
+// ================
+
+//region LLMRequest
+
+/**
+ * A node that appends a [Message.User] to the prompt and requests a response from the LLM.
+ *
+ * @param name Optional node name, defaults to delegate's property name.
+ */
+@AIAgentBuilderDslMarker
+public fun nodeLLMSendMessage(
+    name: String? = null,
+): AIAgentNodeDelegate<Message.User, Message.Assistant> =
+    node(name) { message ->
+        llm.writeSession {
+            appendPrompt {
+                message(message)
+            }
+            requestLLM()
+        }
+    }
+
+/**
+ * A node that appends a [Message.User] to the prompt and requests a response from the LLM,
+ * forcing it to call one of the available tools (no plain-text replies allowed).
+ *
+ * @param name Optional node name, defaults to delegate's property name.
+ */
+@AIAgentBuilderDslMarker
+public fun nodeLLMSendMessageOnlyCallingTools(
+    name: String? = null,
+): AIAgentNodeDelegate<Message.User, Message.Assistant> =
+    node(name) { message ->
+        llm.writeSession {
+            appendPrompt {
+                message(message)
+            }
+            requestLLMOnlyCallingTools()
+        }
+    }
+
+/**
+ * A node that appends a [Message.User] to the prompt and requests a response from the LLM,
+ * without exposing any tools (pure text response only).
+ *
+ * @param name Optional node name, defaults to delegate's property name.
+ */
+@AIAgentBuilderDslMarker
+public fun nodeLLMSendMessageWithoutTools(
+    name: String? = null,
+): AIAgentNodeDelegate<Message.User, Message.Assistant> =
+    node(name) { message ->
+        llm.writeSession {
+            appendPrompt {
+                message(message)
+            }
+            requestLLMWithoutTools()
+        }
+    }
+
+/**
+ * A node that appends a [Message.User] to the prompt and requests a response from the LLM,
+ * forcing it to call exactly the specified tool.
+ *
+ * @param name Optional node name, defaults to delegate's property name.
+ * @param tool The descriptor of the tool the LLM must call.
+ */
+@AIAgentBuilderDslMarker
+public fun nodeLLMSendMessageForceOneTool(
+    name: String? = null,
+    tool: ToolDescriptor
+): AIAgentNodeDelegate<Message.User, Message.Assistant> =
+    node(name) { message ->
+        llm.writeSession {
+            appendPrompt {
+                message(message)
+            }
+            requestLLMForceOneTool(tool)
+        }
+    }
+
+/**
+ * A node that appends a [Message.User] to the prompt and requests multiple completion choices
+ * from the LLM, returning them as an [LLMChoice].
+ *
+ * @param name Optional node name, defaults to delegate's property name.
+ */
+@AIAgentBuilderDslMarker
+public fun nodeLLMSendMessageMultipleChoices(
+    name: String? = null,
+): AIAgentNodeDelegate<Message.User, LLMChoice> =
+    node(name) { message ->
+        llm.writeSession {
+            appendPrompt {
+                message(message)
+            }
+            requestLLMMultipleChoices()
+        }
+    }
+
+// Region Streaming
+
+/**
+ * A node that appends a [Message.User] to the prompt and requests a streaming response from the LLM,
+ * applying [transformStreamData] to convert the raw [StreamFrame] flow into a flow of [T].
+ *
+ * @param name Optional node name, defaults to delegate's property name.
+ * @param structureDefinition An optional structure definition to guide the streaming response format.
+ * @param transformStreamData A suspend function that transforms the [StreamFrame] flow into a [Flow] of [T].
+ */
+@AIAgentBuilderDslMarker
+public fun <T> nodeLLMSendMessageStreaming(
+    name: String? = null,
+    structureDefinition: StructureDefinition? = null,
+    transformStreamData: suspend (Flow<StreamFrame>) -> Flow<T>
+): AIAgentNodeDelegate<Message.User, Flow<T>> =
+    node(name) { message ->
+        llm.writeSession {
+            appendPrompt {
+                message(message)
+            }
+            requestStreaming(structureDefinition, transformStreamData)
+        }
+    }
+
+/**
+ * A node that appends a [Message.User] to the prompt and requests a streaming response from the LLM,
+ * returning raw [StreamFrame] elements.
+ *
+ * @param name Optional node name, defaults to delegate's property name.
+ * @param structureDefinition An optional structure definition to guide the streaming response format.
+ */
+@AIAgentBuilderDslMarker
+public fun nodeLLMSendMessageStreaming(
+    name: String? = null,
+    structureDefinition: StructureDefinition? = null,
+): AIAgentNodeDelegate<Message.User, Flow<StreamFrame>> = nodeLLMSendMessageStreaming(name, structureDefinition) { it }
+
+// Region Structured
+
+/**
+ * A node that appends a [Message.User] to the prompt and requests a structured response from the LLM
+ * using the provided [config].
+ *
+ * @param name Optional node name, defaults to delegate's property name.
+ * @param config Configuration describing the expected structured output format.
+ * @param fixingParser An optional parser used to attempt recovery if the LLM returns malformed structured output.
+ */
+@AIAgentBuilderDslMarker
+public fun <T> nodeLLMSendMessageStructured(
+    name: String? = null,
+    config: StructuredRequestConfig<T>,
+    fixingParser: StructureFixingParser? = null
+): AIAgentNodeDelegate<Message.User, Result<StructuredResponse<T>>> =
+    node(name) { message ->
+        llm.writeSession {
+            appendPrompt {
+                message(message)
+            }
+
+            requestLLMStructured(config, fixingParser)
+        }
+    }
+
+/**
+ * A node that appends a [Message.User] to the prompt and requests a structured response from the LLM,
+ * inferring the output schema from the reified type [T].
+ *
+ * @param name Optional node name, defaults to delegate's property name.
+ * @param examples Optional list of example values of type [T] to guide the LLM's output.
+ * @param fixingParser An optional parser used to attempt recovery if the LLM returns malformed structured output.
+ */
+@AIAgentBuilderDslMarker
+public inline fun <reified T> nodeLLMSendMessageStructured(
+    name: String? = null,
+    examples: List<T> = emptyList(),
+    fixingParser: StructureFixingParser? = null
+): AIAgentNodeDelegate<Message.User, Result<StructuredResponse<T>>> = node(name) { message ->
+    llm.writeSession {
+        appendPrompt {
+            message(message)
+        }
+
+        requestLLMStructured<T>(
+            examples = examples,
+            fixingParser = fixingParser
+        )
+    }
+}

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodes.kt
@@ -578,6 +578,28 @@ public fun nodeLLMSendToolResultsMultipleChoices(
     }
 
 /**
+ * A node that appends tool results to the prompt and requests a streaming response from the LLM,
+ * returning raw [StreamFrame] elements.
+ *
+ * @param name Optional node name, defaults to delegate's property name.
+ * @param structureDefinition An optional structure definition to guide the streaming response format.
+ */
+public fun nodeLLMSendToolResultsStreaming(
+    name: String? = null,
+    structureDefinition: StructureDefinition? = null,
+): AIAgentNodeDelegate<ReceivedToolResults, Flow<StreamFrame>> =
+    node(name) { toolResults ->
+        llm.writeSession {
+            appendPrompt {
+                user {
+                    toolResults.toolResults.forEach { toolResult -> toolResult(toolResult.toMessagePart()) }
+                }
+            }
+            requestStreaming(structureDefinition, { it })
+        }
+    }
+
+/**
  * A node that executes a single [MessagePart.Tool.Call] and returns the [ReceivedToolResult]
  * without writing anything into the LLM session.
  *

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentStrategies.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentStrategies.kt
@@ -6,15 +6,13 @@ import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.agent.entity.createStorageKey
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
+import ai.koog.agents.core.dsl.extension.ReceivedToolResults
 import ai.koog.agents.core.dsl.extension.nodeExecuteTools
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
 import ai.koog.agents.core.dsl.extension.nodeSetStructuredOutput
 import ai.koog.agents.core.dsl.extension.onTextMessage
 import ai.koog.agents.core.dsl.extension.onToolCalls
-import ai.koog.agents.core.dsl.extension.onToolResults
 import ai.koog.prompt.executor.model.StructureFixingParser
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.MessagePart
@@ -31,30 +29,42 @@ import kotlin.jvm.JvmOverloads
  * Allows the agent to interact with the user in a chat-like manner.
  */
 public fun chatAgentStrategy(): AIAgentGraphStrategy<String, String> = strategy("chat") {
-    val nodeLLMRequest by nodeLLMRequest("sendInput")
-    val nodeExecuteTools by nodeExecuteTools("nodeExecuteTool")
+    val nodeCallLLM by nodeLLMRequest("sendInput")
+    val nodeExecuteTool by nodeExecuteTools("nodeExecuteTool")
+    val nodeSendToolResult by nodeLLMSendToolResults("nodeSendToolResult")
 
-    val giveFeedbackToCallTools by node<String, String> { input ->
+    val giveFeedbackToCallTools by node<String, Message.Assistant> { input ->
         llm.writeSession {
-            "Don't chat with plain text! Call one of the available tools, instead: ${
-                tools.joinToString(", ") {
-                    it.name
-                }
-            }"
+            appendPrompt {
+                user(
+                    "Don't chat with plain text! Call one of the available tools, instead: ${
+                        tools.joinToString(", ") {
+                            it.name
+                        }
+                    }"
+                )
+            }
+
+            requestLLM()
         }
     }
 
-    edge(nodeStart forwardTo nodeLLMRequest asUserMessage { it })
+    edge(nodeStart forwardTo nodeCallLLM)
 
-    edge(nodeLLMRequest forwardTo nodeExecuteTools onToolCalls { true })
-    edge(nodeLLMRequest forwardTo giveFeedbackToCallTools onTextMessage { true })
+    edge(nodeCallLLM forwardTo nodeExecuteTool onToolCalls { true })
+    edge(nodeCallLLM forwardTo giveFeedbackToCallTools onTextMessage { true })
+
+    edge(giveFeedbackToCallTools forwardTo giveFeedbackToCallTools onTextMessage { true })
+    edge(giveFeedbackToCallTools forwardTo nodeExecuteTool onToolCalls { true })
+
+    edge(nodeExecuteTool forwardTo nodeSendToolResult)
+
+    edge(nodeSendToolResult forwardTo nodeFinish onTextMessage { true })
     edge(
-        nodeExecuteTools forwardTo nodeFinish
-            onToolResults { it.tool == "__exit__" }
-            transformed { "Chat finished" }
+        nodeSendToolResult forwardTo nodeFinish onToolCalls { tc -> tc.tool == "__exit__" } transformed
+            { "Chat finished" }
     )
-    edge(nodeExecuteTools forwardTo nodeLLMRequest)
-    edge(giveFeedbackToCallTools forwardTo nodeLLMRequest asUserMessage { it })
+    edge(nodeSendToolResult forwardTo nodeExecuteTool onToolCalls { true })
 }
 
 /**
@@ -120,19 +130,32 @@ public fun reActStrategy(
         storage.set(reasoningStepKey, 0)
         it
     }
-    val nodeRequestLLMWithTools by node<Unit, Message.Assistant> {
+    val nodeCallLLM by node<Unit, Message.Assistant> {
         llm.writeSession {
             requestLLM()
         }
     }
-
     val nodeExecuteTools by nodeExecuteTools()
 
-    val nodeRequestLLMReason by node<Message.User, Unit> { result ->
+    val nodeCallLLMReasonInput by node<String, Unit> { stageInput ->
+        llm.writeSession {
+            appendPrompt {
+                user(stageInput)
+                user(reasoningPrompt)
+            }
+
+            requestLLMWithoutTools()
+        }
+    }
+    val nodeCallLLMReason by node<ReceivedToolResults, Unit> { results ->
         val reasoningStep = storage.getValue(reasoningStepKey)
         llm.writeSession {
             appendPrompt {
-                message(result)
+                user {
+                    results.toolResults.forEach {
+                        toolResult(it.toMessagePart())
+                    }
+                }
             }
 
             if (reasoningStep % reasoningInterval == 0) {
@@ -146,11 +169,12 @@ public fun reActStrategy(
     }
 
     edge(nodeStart forwardTo nodeSetup)
-    edge(nodeSetup forwardTo nodeRequestLLMReason asUserMessage { "$it\n$reasoningPrompt" })
-    edge(nodeRequestLLMReason forwardTo nodeRequestLLMWithTools)
-    edge(nodeRequestLLMWithTools forwardTo nodeExecuteTools onToolCalls { true })
-    edge(nodeRequestLLMWithTools forwardTo nodeFinish onTextMessage { true })
-    edge(nodeExecuteTools forwardTo nodeRequestLLMReason)
+    edge(nodeSetup forwardTo nodeCallLLMReasonInput)
+    edge(nodeCallLLMReasonInput forwardTo nodeCallLLM)
+    edge(nodeCallLLM forwardTo nodeExecuteTools onToolCalls { true })
+    edge(nodeCallLLM forwardTo nodeFinish onTextMessage { true })
+    edge(nodeExecuteTools forwardTo nodeCallLLMReason)
+    edge(nodeCallLLMReason forwardTo nodeCallLLM)
 }
 
 /**
@@ -195,7 +219,7 @@ public inline fun <reified Input, reified Output> structuredOutputWithToolsStrat
     val setStructuredOutput by nodeSetStructuredOutput<Input, Output>(config = config)
     val transformInput by node<Input, String> { transform(it) }
     val callLLM by nodeLLMRequest()
-    val executeTools by nodeExecuteToolsAndGetResults(parallel = parallelTools)
+    val executeTools by nodeExecuteTools(parallel = parallelTools)
     val sendToolResult by nodeLLMSendToolResults()
     val transformToStructuredOutput by node<Message.Assistant, Output> { response ->
         llm.writeSession {
@@ -205,7 +229,7 @@ public inline fun <reified Input, reified Output> structuredOutputWithToolsStrat
 
     // Set the structured output, transform the input to a String, then call the LLM as a user message
     nodeStart then setStructuredOutput then transformInput
-    edge(transformInput forwardTo callLLM asUserMessage { it })
+    edge(transformInput forwardTo callLLM)
 
     // If the LLM responded with tool calls, execute them and feed the results back
     edge(callLLM forwardTo executeTools onToolCalls { true })

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
@@ -13,7 +13,7 @@ import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.subgraph
 import ai.koog.agents.core.dsl.extension.ReceivedToolResults
 import ai.koog.agents.core.dsl.extension.ToolCalls
-import ai.koog.agents.core.dsl.extension.nodeLLMRequestWithUserText
+import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
 import ai.koog.agents.core.dsl.extension.onTextMessage
 import ai.koog.agents.core.dsl.extension.onToolCalls
@@ -682,7 +682,7 @@ public fun <Input, Output, OutputTransformed> AIAgentSubgraphBuilderBase<Input, 
     // Helper node to overcome problems of the current api and repeat less code when writing routing conditions
     val nodeDecide by node<Message.Assistant, Message.Assistant> { it }
 
-    val nodeCallLLM by nodeLLMRequestWithUserText()
+    val nodeCallLLM by nodeLLMRequest()
 
     val callToolsHacked by node<ToolCalls, ReceivedToolResults> { message ->
         val (finishToolCalls, regularToolCalls) = message.toolCalls.partition { it.tool == finishTool.name }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/SingleRunStrategyWithHistoryCompression.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/SingleRunStrategyWithHistoryCompression.kt
@@ -1,12 +1,14 @@
 package ai.koog.agents.ext.agent
 
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
+import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
+import ai.koog.agents.core.dsl.extension.ReceivedToolResults
 import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
+import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
 import ai.koog.agents.core.dsl.extension.onTextMessage
 import ai.koog.agents.core.dsl.extension.onToolCalls
 import ai.koog.prompt.Prompt
@@ -45,17 +47,41 @@ public fun singleRunStrategyWithHistoryCompression(
     config: HistoryCompressionConfig,
     parallelTools: Boolean = false,
 ): AIAgentGraphStrategy<String, String> = strategy<String, String>("single_run_with_history_compression") {
-    val nodeLLMRequest by nodeLLMRequest()
+    val nodeCallLLM by nodeLLMRequest()
     val nodeExecuteTool by nodeExecuteTools(parallel = parallelTools)
-    val compressHistory by nodeLLMCompressHistory<Message.User>(
+    val nodeSendToolResult by nodeLLMSendToolResults()
+    val nodeCompressHistory by nodeLLMCompressHistory<ReceivedToolResults>(
         strategy = config.compressionStrategy,
         retrievalModel = config.retrievalModel
     )
+    val nodeSendCompressedHistory by node<ReceivedToolResults, Message.Assistant> {
+        llm.writeSession {
+            requestLLM()
+        }
+    }
 
-    edge(nodeStart forwardTo nodeLLMRequest asUserMessage { it })
-    edge(nodeExecuteTool forwardTo compressHistory onCondition { llm.readSession { config.isHistoryTooBig(prompt) } })
-    edge(nodeExecuteTool forwardTo nodeLLMRequest onCondition { llm.readSession { !config.isHistoryTooBig(prompt) } })
-    edge(compressHistory forwardTo nodeLLMRequest)
-    edge(nodeLLMRequest forwardTo nodeExecuteTool onToolCalls { true })
-    edge(nodeLLMRequest forwardTo nodeFinish onTextMessage { true })
+    edge(nodeStart forwardTo nodeCallLLM)
+    edge(nodeCallLLM forwardTo nodeExecuteTool onToolCalls { true })
+    edge(
+        nodeCallLLM forwardTo nodeFinish
+            onTextMessage { true }
+    )
+
+    edge(nodeExecuteTool forwardTo nodeCompressHistory onCondition { llm.readSession { config.isHistoryTooBig(prompt) } })
+    edge(nodeExecuteTool forwardTo nodeSendToolResult onCondition { llm.readSession { !config.isHistoryTooBig(prompt) } })
+    edge(nodeCompressHistory forwardTo nodeSendCompressedHistory)
+
+    edge(
+        nodeSendToolResult forwardTo nodeFinish
+            onTextMessage { true }
+    )
+
+    edge(nodeSendToolResult forwardTo nodeExecuteTool onToolCalls { true })
+
+    edge(
+        nodeSendCompressedHistory forwardTo nodeFinish
+            onTextMessage { true }
+    )
+
+    edge(nodeSendCompressedHistory forwardTo nodeExecuteTool onToolCalls { true })
 }

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/AIAgentGenericTypesTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/AIAgentGenericTypesTest.kt
@@ -2,7 +2,6 @@ package ai.koog.agents.core.agent
 
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.testing.tools.getMockExecutor
 import ai.koog.prompt.dsl.prompt
@@ -31,11 +30,16 @@ class AIAgentGenericTypesTest {
 
         val customStrategy = strategy<CustomInput, CustomOutput>("custom-strategy") {
             val processInput = { input: CustomInput -> input.query }
-            val processOutput = { output: Message.Assistant -> CustomOutput(result = output.parts.filterIsInstance<MessagePart.Text>().first().text, confidence = 0.95) }
+            val processOutput = { output: Message.Assistant ->
+                CustomOutput(
+                    result = output.parts.filterIsInstance<MessagePart.Text>().first().text,
+                    confidence = 0.95
+                )
+            }
 
             val callLLM by nodeLLMRequest()
 
-            edge(nodeStart forwardTo callLLM asUserMessage { input -> processInput(input) })
+            edge(nodeStart forwardTo callLLM transformed { processInput(it) })
             edge(callLLM forwardTo nodeFinish transformed { output -> processOutput(output) })
         }
 
@@ -69,7 +73,7 @@ class AIAgentGenericTypesTest {
 
             val callLLM by nodeLLMRequest()
 
-            edge(nodeStart forwardTo callLLM asUserMessage { input -> convertToString(input) })
+            edge(nodeStart forwardTo callLLM transformed { convertToString(it) })
             edge(callLLM forwardTo nodeFinish transformed { output -> parseResponse(output) })
         }
 

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/StreamingConnectionExceptionTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/StreamingConnectionExceptionTest.kt
@@ -2,7 +2,6 @@ package ai.koog.agents.core.agent
 
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreaming
 import ai.koog.agents.core.tools.ToolDescriptor
 import ai.koog.agents.core.tools.ToolRegistry
@@ -338,7 +337,7 @@ class StreamingConnectionExceptionTest {
                 stream.collectText()
             }
 
-            edge(nodeStart forwardTo streamNode asUserMessage { it })
+            edge(nodeStart forwardTo streamNode)
             edge(streamNode forwardTo collectNode)
             edge(collectNode forwardTo nodeFinish)
         }

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodesTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/dsl/extension/AIAgentNodesTest.kt
@@ -244,4 +244,54 @@ class AIAgentNodesTest {
         assertNotNull(capturedPrompt!!.params.schema, "Schema should be set for Native config")
         assertEquals(nativeStructure.schema, capturedPrompt!!.params.schema, "Schema should match structure's schema")
     }
+
+    @Test
+    fun testSend() = runTest {
+        val agentStrategy = strategy<String, String>("test") {
+            val nodeSendMessage by nodeLLMSendMessage()
+            val nodeExecuteTools by nodeExecuteTools()
+
+            edge(nodeStart forwardTo nodeSendMessage asUserMessage { "Hello, $it" })
+            edge(nodeSendMessage forwardTo nodeExecuteTools onToolCalls { true })
+            edge(nodeSendMessage forwardTo nodeFinish onTextMessage { true })
+            edge(nodeExecuteTools forwardTo nodeSendMessage asToolResultMessage { true })
+        }
+
+        val results = mutableListOf<Any?>()
+
+        val agentConfig = AIAgentConfig(
+            prompt = prompt("test-agent") {},
+            model = OllamaModels.Meta.LLAMA_3_2,
+            maxAgentIterations = 10
+        )
+
+        val tool = DummyTool()
+
+        val testExecutor = getMockExecutor(serializer) {
+            mockLLMToolCall(tool = tool, args = DummyTool.Args("test"), toolCallId = "0") onRequestContains "Hello"
+            mockLLMAnswer("Buy!").asDefaultResponse
+        }
+
+        val executedNode = mutableListOf<String>()
+        AIAgent(
+            promptExecutor = testExecutor,
+            strategy = agentStrategy,
+            agentConfig = agentConfig,
+            toolRegistry = ToolRegistry {
+                tool(tool)
+            }
+        ) {
+            install(EventHandler) {
+                onAgentCompleted { eventContext -> results += eventContext.result }
+                onNodeExecutionStarting { executedNode.add(it.node.name) }
+            }
+        }.use { agent ->
+            agent.run("Koog", null)
+        }
+
+        assertEquals(1, results.size)
+        assertEquals("Buy!", results.first())
+        assertEquals(5, executedNode.size)
+        assertEquals(listOf("__start__", "nodeSendMessage", "nodeExecuteTools", "nodeSendMessage", "__finish__"), executedNode)
+    }
 }

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/feature/AIAgentPipelineTest.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/feature/AIAgentPipelineTest.kt
@@ -14,13 +14,11 @@ import ai.koog.agents.core.agent.execution.DEFAULT_AGENT_PATH_SEPARATOR
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.builder.subgraph
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeDoNothing
 import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestWithoutTools
 import ai.koog.agents.core.dsl.extension.onToolCalls
-import ai.koog.agents.core.dsl.extension.onToolResults
 import ai.koog.agents.core.environment.AIAgentEnvironment
 import ai.koog.agents.core.environment.ReceivedToolResult
 import ai.koog.agents.core.feature.config.FeatureConfig
@@ -530,8 +528,8 @@ class AIAgentPipelineTest {
             val llmCallWithoutTools by nodeLLMRequestWithoutTools(nodeLLMCallWithoutToolsName)
             val llmCall by nodeLLMRequest(nodeLLMCall)
 
-            edge(nodeStart forwardTo llmCallWithoutTools asUserMessage { testLLMResponse })
-            edge(llmCallWithoutTools forwardTo llmCall asUserMessage { llmCallWithToolsResponse })
+            edge(nodeStart forwardTo llmCallWithoutTools transformed { testLLMResponse })
+            edge(llmCallWithoutTools forwardTo llmCall transformed { llmCallWithToolsResponse })
             edge(llmCall forwardTo nodeFinish transformed { agentOutput })
         }
 
@@ -605,11 +603,11 @@ class AIAgentPipelineTest {
             val nodeSendInput by nodeLLMRequest()
             val toolCallNode by nodeExecuteTools(nodeToolCallName)
 
-            edge(nodeStart forwardTo nodeSendInput asUserMessage { it })
+            edge(nodeStart forwardTo nodeSendInput)
             edge(nodeSendInput forwardTo toolCallNode onToolCalls { true })
             edge(
-                toolCallNode forwardTo nodeFinish onToolResults { true } transformed { toolResults ->
-                    toolResults.toolCalls.joinToString("\n") { it.output }
+                toolCallNode forwardTo nodeFinish transformed { toolResults ->
+                    toolResults.toolResults.joinToString("\n") { it.output }
                 }
             )
         }
@@ -845,8 +843,8 @@ class AIAgentPipelineTest {
             val llmCallWithoutTools by nodeLLMRequestWithoutTools(nodeLLMCallWithoutToolsName)
             val llmCall by nodeLLMRequest(nodeLLMCallName)
 
-            edge(nodeStart forwardTo llmCallWithoutTools asUserMessage { testLLMResponse })
-            edge(llmCallWithoutTools forwardTo llmCall asUserMessage { llmCallWithToolsResponse })
+            edge(nodeStart forwardTo llmCallWithoutTools transformed { testLLMResponse })
+            edge(llmCallWithoutTools forwardTo llmCall transformed { llmCallWithToolsResponse })
             edge(llmCall forwardTo nodeFinish transformed { agentOutput })
         }
 
@@ -906,11 +904,11 @@ class AIAgentPipelineTest {
             val nodeSendInput by nodeLLMRequest()
             val toolCallNode by nodeExecuteTools(nodeToolCallName)
 
-            edge(nodeStart forwardTo nodeSendInput asUserMessage { it })
+            edge(nodeStart forwardTo nodeSendInput)
             edge(nodeSendInput forwardTo toolCallNode onToolCalls { true })
             edge(
-                toolCallNode forwardTo nodeFinish onToolResults { true } transformed { toolResults ->
-                    toolResults.toolCalls.joinToString("\n") { it.output }
+                toolCallNode forwardTo nodeFinish transformed { toolResults ->
+                    toolResults.toolResults.joinToString("\n") { it.output }
                 }
             )
         }

--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentNode.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentNode.kt
@@ -9,7 +9,6 @@ import ai.koog.agents.core.dsl.extension.ModeratedMessage
 import ai.koog.agents.core.dsl.extension.ReceivedToolResults
 import ai.koog.agents.core.dsl.extension.ToolCalls
 import ai.koog.agents.core.dsl.extension.nodeExecuteTools
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
 import ai.koog.agents.core.dsl.extension.nodeLLMModerateMessage
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestForceOneTool
@@ -86,7 +85,7 @@ public actual open class AIAgentNode<TInput, TOutput> internal actual constructo
         @JvmStatic
         public fun llmRequest(
             name: String? = null,
-        ): AIAgentNodeBase<Message.User, Message.Assistant> {
+        ): AIAgentNodeBase<String, Message.Assistant> {
             val node by nodeLLMRequest(name)
             return node
         }
@@ -102,7 +101,7 @@ public actual open class AIAgentNode<TInput, TOutput> internal actual constructo
         @JvmStatic
         public fun llmRequestOnlyCallingTools(
             name: String? = null,
-        ): AIAgentNodeBase<Message.User, Message.Assistant> {
+        ): AIAgentNodeBase<String, Message.Assistant> {
             val node by nodeLLMRequestOnlyCallingTools(name)
             return node
         }
@@ -118,7 +117,7 @@ public actual open class AIAgentNode<TInput, TOutput> internal actual constructo
         @JvmStatic
         public fun llmRequestWithoutTools(
             name: String? = null,
-        ): AIAgentNodeBase<Message.User, Message.Assistant> {
+        ): AIAgentNodeBase<String, Message.Assistant> {
             val node by nodeLLMRequestWithoutTools(name)
             return node
         }
@@ -136,7 +135,7 @@ public actual open class AIAgentNode<TInput, TOutput> internal actual constructo
         public fun llmRequestForceOneTool(
             name: String? = null,
             tool: ToolDescriptor,
-        ): AIAgentNodeBase<Message.User, Message.Assistant> {
+        ): AIAgentNodeBase<String, Message.Assistant> {
             val node by nodeLLMRequestForceOneTool(name, tool)
             return node
         }
@@ -154,7 +153,7 @@ public actual open class AIAgentNode<TInput, TOutput> internal actual constructo
         public fun llmRequestForceOneTool(
             name: String? = null,
             tool: Tool<*, *>,
-        ): AIAgentNodeBase<Message.User, Message.Assistant> {
+        ): AIAgentNodeBase<String, Message.Assistant> {
             val node by nodeLLMRequestForceOneTool(name, tool.descriptor)
             return node
         }
@@ -196,9 +195,9 @@ public actual open class AIAgentNode<TInput, TOutput> internal actual constructo
             outputClass: Class<T>,
             structureDefinition: StructureDefinition? = null,
             name: String? = null,
-        ): AIAgentNodeBase<Message.User, Publisher<T>> =
+        ): AIAgentNodeBase<String, Publisher<T>> =
             builder(name)
-                .withInput(Message.User::class.java)
+                .withInput(String::class.java)
                 .withOutput<Publisher<T>>(typeToken(Publisher::class, listOf(TypeToken.of(outputClass))))
                 .executeOnLLMDispatcher { input ->
                     requestStreamingImpl(input, structureDefinition) { streamFrameFlow ->
@@ -218,7 +217,7 @@ public actual open class AIAgentNode<TInput, TOutput> internal actual constructo
         public fun llmRequestStreaming(
             name: String? = null,
             structureDefinition: StructureDefinition?,
-        ): AIAgentNodeBase<Message.User, Flow<StreamFrame>> {
+        ): AIAgentNodeBase<String, Flow<StreamFrame>> {
             val node by nodeLLMRequestStreaming(name, structureDefinition)
             return node
         }
@@ -237,7 +236,7 @@ public actual open class AIAgentNode<TInput, TOutput> internal actual constructo
             name: String? = null,
             config: StructuredRequestConfig<T>,
             fixingParser: StructureFixingParser?,
-        ): AIAgentNodeBase<Message.User, Result<StructuredResponse<T>>> {
+        ): AIAgentNodeBase<String, Result<StructuredResponse<T>>> {
             val node by nodeLLMRequestStructured(name, config, fixingParser)
             return node
         }
@@ -252,23 +251,8 @@ public actual open class AIAgentNode<TInput, TOutput> internal actual constructo
         @JvmStatic
         public fun executeTools(
             name: String? = null,
-        ): AIAgentNodeBase<ToolCalls, Message.User> {
-            val node by nodeExecuteTools(name)
-            return node
-        }
-
-        /**
-         * A node that executes all tool calls in the assistant message and appends results as a user message.
-         *
-         * @param name Optional node name, defaults to delegate's property name.
-         */
-        @JavaAPI
-        @JvmOverloads
-        @JvmStatic
-        public fun executeToolsAndGetResults(
-            name: String? = null,
         ): AIAgentNodeBase<ToolCalls, ReceivedToolResults> {
-            val node by nodeExecuteToolsAndGetResults(name)
+            val node by nodeExecuteTools(name)
             return node
         }
 

--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentNode.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentNode.kt
@@ -16,6 +16,13 @@ import ai.koog.agents.core.dsl.extension.nodeLLMRequestOnlyCallingTools
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreaming
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStructured
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestWithoutTools
+import ai.koog.agents.core.dsl.extension.nodeLLMSendMessage
+import ai.koog.agents.core.dsl.extension.nodeLLMSendMessageForceOneTool
+import ai.koog.agents.core.dsl.extension.nodeLLMSendMessageMultipleChoices
+import ai.koog.agents.core.dsl.extension.nodeLLMSendMessageOnlyCallingTools
+import ai.koog.agents.core.dsl.extension.nodeLLMSendMessageStreaming
+import ai.koog.agents.core.dsl.extension.nodeLLMSendMessageStructured
+import ai.koog.agents.core.dsl.extension.nodeLLMSendMessageWithoutTools
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
 import ai.koog.agents.core.dsl.extension.requestStreamingImpl
 import ai.koog.agents.core.tools.Tool
@@ -299,5 +306,172 @@ public actual open class AIAgentNode<TInput, TOutput> internal actual constructo
         @JvmStatic
         public fun llmCompressHistory(name: String? = null): CompressHistoryNodeBuilder =
             CompressHistoryNodeBuilder(name ?: "compress-history-${Random.nextInt()}")
+
+        /**
+         * Creates and returns a node for the AI agent strategy graph that is responsible for sending a message.
+         *
+         * @param name An optional name for the node. If null, a default name is assigned.
+         * @return An instance of [AIAgentNodeBase] that represents the message-sending operation. The node processes
+         * input of type [Message.User] and produces output of type [Message.Assistant].
+         */
+        @JavaAPI
+        @JvmOverloads
+        @JvmStatic
+        public fun llmSendMessage(name: String? = null): AIAgentNodeBase<Message.User, Message.Assistant> {
+            val node by nodeLLMSendMessage(name)
+            return node
+        }
+
+        /**
+         * A node that appends a [Message.User] to the prompt and requests a response from the LLM,
+         * forcing it to call one of the available tools (no plain-text replies allowed).
+         *
+         * @param name Optional node name, defaults to delegate's property name.
+         */
+        @JavaAPI
+        @JvmOverloads
+        @JvmStatic
+        public fun llmSendMessageOnlyCallingTools(
+            name: String? = null,
+        ): AIAgentNodeBase<Message.User, Message.Assistant> {
+            val node by nodeLLMSendMessageOnlyCallingTools(name)
+            return node
+        }
+
+        /**
+         * A node that appends a [Message.User] to the prompt and requests a response from the LLM,
+         * without exposing any tools (pure text response only).
+         *
+         * @param name Optional node name, defaults to delegate's property name.
+         */
+        @JavaAPI
+        @JvmOverloads
+        @JvmStatic
+        public fun llmSendMessageWithoutTools(
+            name: String? = null,
+        ): AIAgentNodeBase<Message.User, Message.Assistant> {
+            val node by nodeLLMSendMessageWithoutTools(name)
+            return node
+        }
+
+        /**
+         * A node that appends a [Message.User] to the prompt and requests a response from the LLM,
+         * forcing it to call exactly the specified tool.
+         *
+         * @param name Optional node name, defaults to delegate's property name.
+         * @param tool The [ToolDescriptor] of the tool the LLM must call.
+         */
+        @JavaAPI
+        @JvmOverloads
+        @JvmStatic
+        public fun llmSendMessageForceOneTool(
+            name: String? = null,
+            tool: ToolDescriptor,
+        ): AIAgentNodeBase<Message.User, Message.Assistant> {
+            val node by nodeLLMSendMessageForceOneTool(name, tool)
+            return node
+        }
+
+        /**
+         * A node that appends a [Message.User] to the prompt and requests a response from the LLM,
+         * forcing it to call exactly the specified tool.
+         *
+         * @param name Optional node name, defaults to delegate's property name.
+         * @param tool The [Tool] the LLM must call.
+         */
+        @JavaAPI
+        @JvmOverloads
+        @JvmStatic
+        public fun llmSendMessageForceOneTool(
+            name: String? = null,
+            tool: Tool<*, *>,
+        ): AIAgentNodeBase<Message.User, Message.Assistant> {
+            val node by nodeLLMSendMessageForceOneTool(name, tool.descriptor)
+            return node
+        }
+
+        /**
+         * A node that appends a [Message.User] to the prompt and requests multiple completion choices
+         * from the LLM, returning them as an [LLMChoice].
+         *
+         * @param name Optional node name, defaults to delegate's property name.
+         */
+        @JavaAPI
+        @JvmOverloads
+        @JvmStatic
+        public fun llmSendMessageMultipleChoices(
+            name: String? = null,
+        ): AIAgentNodeBase<Message.User, LLMChoice> {
+            val node by nodeLLMSendMessageMultipleChoices(name)
+            return node
+        }
+
+        /**
+         * A node that appends a [Message.User] to the prompt and requests a streaming response from the LLM.
+         * This overload transforms the stream via a [Publisher] for Java interoperability.
+         *
+         * @param transformStreamData A function that processes the incoming stream of [StreamFrame] objects and transforms them into a publisher.
+         * @param outputClass The class type of the transformed output data.
+         * @param structureDefinition An optional definition of structured data.
+         * @param name An optional name for the node being created.
+         * @return An instance of [AIAgentNodeBase] with a [Message.User] input and a [Publisher] output.
+         */
+        @JavaAPI
+        @JvmOverloads
+        @JvmStatic
+        public fun <T : Any> llmSendMessageStreaming(
+            transformStreamData: (Publisher<StreamFrame>) -> Publisher<T>,
+            outputClass: Class<T>,
+            structureDefinition: StructureDefinition? = null,
+            name: String? = null,
+        ): AIAgentNodeBase<Message.User, Publisher<T>> =
+            builder(name)
+                .withInput(Message.User::class.java)
+                .withOutput<Publisher<T>>(typeToken(Publisher::class, listOf(TypeToken.of(outputClass))))
+                .executeOnLLMDispatcher { message ->
+                    llm.writeSession {
+                        appendPrompt { message(message) }
+                        requestStreaming(structureDefinition) { streamFrameFlow ->
+                            transformStreamData(streamFrameFlow.asPublisher()).asFlow()
+                        }
+                    }.asPublisher()
+                }
+
+        /**
+         * A node that appends a [Message.User] to the prompt and requests a streaming response from the LLM,
+         * returning raw [StreamFrame] elements.
+         *
+         * @param name Optional node name, defaults to delegate's property name.
+         * @param structureDefinition Optional structure definition to customize the streaming response.
+         */
+        @JavaAPI
+        @JvmOverloads
+        @JvmStatic
+        public fun llmSendMessageStreaming(
+            name: String? = null,
+            structureDefinition: StructureDefinition?,
+        ): AIAgentNodeBase<Message.User, Flow<StreamFrame>> {
+            val node by nodeLLMSendMessageStreaming(name, structureDefinition)
+            return node
+        }
+
+        /**
+         * A node that appends a [Message.User] to the prompt and requests a structured response from the LLM.
+         *
+         * @param name Optional node name, defaults to delegate's property name.
+         * @param config The [StructuredRequestConfig] defining the expected output type.
+         * @param fixingParser Optional [StructureFixingParser] for correcting malformed responses.
+         */
+        @JavaAPI
+        @JvmOverloads
+        @JvmStatic
+        public fun <T> llmSendMessageStructured(
+            name: String? = null,
+            config: StructuredRequestConfig<T>,
+            fixingParser: StructureFixingParser?,
+        ): AIAgentNodeBase<Message.User, Result<StructuredResponse<T>>> {
+            val node by nodeLLMSendMessageStructured(name, config, fixingParser)
+            return node
+        }
     }
 }

--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/entity/AgentEdgeBuilder.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/entity/AgentEdgeBuilder.kt
@@ -268,21 +268,6 @@ public open class FullAgentEdgeBuilder<IncomingOutput, IntermediateOutput, Outgo
     )
 
     /**
-     * Creates an edge that transforms an intermediate output into a [Message.User] using the provided transform.
-     *
-     * @param transformation A function that converts the intermediate output to a String for the user message.
-     */
-    @JvmOverloads
-    public fun asUserMessage(
-        transformation: SimpleTransformation<IntermediateOutput, String> = { it.toString() }
-    ): FullAgentEdgeBuilder<IncomingOutput, Message.User, OutgoingInput> =
-        transformed<Message.User> { output, ctx ->
-            ctx.llm.writeSession { session ->
-                session.userMessage(transformation.invoke(output))
-            }
-        }
-
-    /**
      * Filters the intermediate output to only [Message] instances that contain parts of type [T],
      * and transforms the output to a list of those parts.
      *
@@ -294,6 +279,32 @@ public open class FullAgentEdgeBuilder<IncomingOutput, IntermediateOutput, Outgo
     ): FullAgentEdgeBuilder<IncomingOutput, List<T>, OutgoingInput> =
         onCondition { it is Message && (it as Message).parts.any { part -> clazz.isInstance(part) } }
             .transformed<List<T>> { (it as Message).parts.filter { part -> clazz.isInstance(part) }.map { part -> clazz.cast(part) } }
+
+    /**
+     * Transforms the intermediate output of the edge by applying the given action.
+     * This is an alias for [transformed] providing naming consistency with the node builder API.
+     *
+     * @param action A contextual transformation function that takes an intermediate output
+     *               and an AI agent graph context as input, and produces a compatible output.
+     * @return A builder instance configured to handle the transformed outputs.
+     */
+    @JavaAPI
+    public fun <NewOutput : OutgoingInput> withAction(
+        action: ContextualTransformation<IntermediateOutput, NewOutput>
+    ): CompatibleFullAgentEdgeBuilder<IncomingOutput, NewOutput, OutgoingInput> = transformed(action)
+
+    /**
+     * Transforms the intermediate output of the edge by applying the given action.
+     * This is an alias for [transformed] providing naming consistency with the node builder API.
+     *
+     * @param action A simple transformation function that takes an intermediate output
+     *               and produces a compatible output.
+     * @return A builder instance configured to handle the transformed outputs.
+     */
+    @JavaAPI
+    public fun <NewOutput : OutgoingInput> withAction(
+        action: SimpleTransformation<IntermediateOutput, NewOutput>
+    ): CompatibleFullAgentEdgeBuilder<IncomingOutput, NewOutput, OutgoingInput> = transformed(action)
 
     /**
      * Creates an edge that extracts text content from message parts.

--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/entity/AgentEdgeBuilder.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/entity/AgentEdgeBuilder.kt
@@ -7,7 +7,9 @@ import ai.koog.agents.core.agent.context.AIAgentGraphContextBase
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.dsl.builder.AIAgentEdgeBuilder
 import ai.koog.agents.core.dsl.builder.AIAgentEdgeBuilderIntermediate
+import ai.koog.agents.core.dsl.extension.ReceivedToolResults
 import ai.koog.agents.core.dsl.extension.ToolCalls
+import ai.koog.agents.core.environment.ReceivedToolResult
 import ai.koog.agents.core.utils.Option
 import ai.koog.agents.core.utils.Some
 import ai.koog.prompt.message.Message
@@ -367,6 +369,41 @@ public open class FullAgentEdgeBuilder<IncomingOutput, IntermediateOutput, Outgo
         clazz: Class<CompatibleOutput>
     ): CompatibleFullAgentEdgeBuilder<IncomingOutput, CompatibleOutput, OutgoingInput> =
         onCondition { clazz.isInstance(it) }.transformed { it as CompatibleOutput }
+
+    /**
+     * Creates an edge that transforms an intermediate output into a [Message.User] using the provided transform.
+     *
+     * @param transformation A function that converts the intermediate output to a String for the user message.
+     */
+    @JvmOverloads
+    public fun asUserMessage(
+        transformation: SimpleTransformation<IntermediateOutput, String> = { it.toString() }
+    ): FullAgentEdgeBuilder<IncomingOutput, Message.User, OutgoingInput> =
+        transformed<Message.User> { output, ctx ->
+            ctx.llm.writeSession { session ->
+                session.userMessage(transformation.invoke(output))
+            }
+        }
+
+    /**
+     * Creates an edge that transforms an intermediate output into a [Message.User] using the provided transform.
+     *
+     * @param condition A predicate that filters which [ReceivedToolResult] entries are included in the message.
+     */
+    @JvmOverloads
+    public fun asToolResultMessage(
+        condition: SimpleCondition<ReceivedToolResult> = { true }
+    ): FullAgentEdgeBuilder<IncomingOutput, Message.User, OutgoingInput> =
+        onCondition { ReceivedToolResults::class.java.isInstance(it) }
+            .transformed<Message.User> { output, ctx ->
+                ctx.llm.writeSession { session ->
+                    session.userMessage(
+                        (output as ReceivedToolResults).toolResults
+                            .filter { condition.invoke(it) }
+                            .map { it.toMessagePart() }
+                    )
+                }
+            }
 }
 
 /**

--- a/agents/agents-core/src/jvmTest/java/ai/koog/agents/core/agent/JavaGraphStrategyTest.java
+++ b/agents/agents-core/src/jvmTest/java/ai/koog/agents/core/agent/JavaGraphStrategyTest.java
@@ -12,9 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class JavaGraphStrategyTest {
     private static final JacksonSerializer serializer = new JacksonSerializer();
@@ -146,6 +144,52 @@ public class JavaGraphStrategyTest {
             .build();
 
         assertNotNull(agent);
+    }
+
+    @Test
+    public void testSendMessageNode() {
+        AIAgent<String, String> agent = (AIAgent<String, String>) AIAgent.builder()
+            .promptExecutor(MockPromptExecutor.builder(serializer).mockLLMAnswer("llm-response").asDefaultResponse().build())
+            .llmModel(OpenAIModels.Chat.GPT4o)
+            .graphStrategy("llm", b -> {
+                var graph = b
+                    .withInput(String.class)
+                    .withOutput(String.class);
+
+                var llmNode = AIAgentNode.llmSendMessage("llm");
+                var executeTools = AIAgentNode.executeTools("my_tool");
+
+                graph.edge(AIAgentEdge.builder()
+                    .from(graph.nodeStart)
+                    .to(llmNode)
+                    .asUserMessage()
+                    .build()
+                );
+                graph.edge(AIAgentEdge.builder()
+                    .from(llmNode)
+                    .to(executeTools)
+                    .onToolCalls()
+                    .build()
+                );
+                graph.edge(AIAgentEdge.builder()
+                    .from(llmNode)
+                    .to(graph.nodeFinish)
+                    .onTextMessage()
+                    .build()
+                );
+                graph.edge(AIAgentEdge.builder()
+                    .from(executeTools)
+                    .to(llmNode)
+                    .asToolResultMessage()
+                    .build()
+                );
+
+                return graph.build();
+            })
+            .build();
+
+        String result = agent.run("hello", null);
+        assertEquals("llm-response", result);
     }
 
 }

--- a/agents/agents-core/src/jvmTest/java/ai/koog/agents/core/agent/JavaGraphStrategyTest.java
+++ b/agents/agents-core/src/jvmTest/java/ai/koog/agents/core/agent/JavaGraphStrategyTest.java
@@ -61,9 +61,6 @@ public class JavaGraphStrategyTest {
                 graph.edge(AIAgentEdge.builder()
                     .from(graph.nodeStart)
                     .to(llmNode)
-                    .asUserMessage(input -> {
-                        return input;
-                    })
                     .build()
                 );
                 graph.edge(AIAgentEdge.builder()

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/MermaidDiagramGeneratorTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/agent/MermaidDiagramGeneratorTest.kt
@@ -5,9 +5,8 @@ import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.builder.subgraph
-import ai.koog.agents.core.dsl.extension.asUserMessage
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
-import ai.koog.agents.core.dsl.extension.nodeLLMModerateMessage
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
+import ai.koog.agents.core.dsl.extension.nodeLLMModerateText
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
 import ai.koog.agents.core.dsl.extension.onTextMessage
@@ -15,8 +14,6 @@ import ai.koog.agents.core.dsl.extension.onToolCalls
 import ai.koog.agents.ext.agent.CriticResult
 import ai.koog.agents.ext.agent.subgraphWithVerification
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
-import ai.koog.prompt.message.Message
-import ai.koog.prompt.message.RequestMetaInfo
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
 
@@ -26,10 +23,10 @@ class MermaidDiagramGeneratorTest {
     fun `Should generate a diagram for simple graph`() {
         val myStrategy = strategy<String, String>("my-strategy") {
             val nodeCallLLM by nodeLLMRequest()
-            val executeToolCall by nodeExecuteToolsAndGetResults()
+            val executeToolCall by nodeExecuteTools()
             val sendToolResult by nodeLLMSendToolResults()
 
-            edge(nodeStart forwardTo nodeCallLLM asUserMessage { it })
+            edge(nodeStart forwardTo nodeCallLLM)
             edge(nodeCallLLM forwardTo nodeFinish onTextMessage { true })
             edge(nodeCallLLM forwardTo executeToolCall onToolCalls { true })
             edge(executeToolCall forwardTo sendToolResult)
@@ -49,8 +46,8 @@ class MermaidDiagramGeneratorTest {
                 state "nodeCallLLM" as nodeCallLLM
                 state "executeToolCall" as executeToolCall
                 state "sendToolResult" as sendToolResult
-
-                [*] --> nodeCallLLM : transformed
+            
+                [*] --> nodeCallLLM
                 nodeCallLLM --> [*] : transformed
                 nodeCallLLM --> executeToolCall : transformed
                 executeToolCall --> sendToolResult
@@ -64,23 +61,23 @@ class MermaidDiagramGeneratorTest {
         val strategy = strategy<String, String>(
             name = "test-strategy",
         ) {
-            val moderateInput by nodeLLMModerateMessage(
+            val moderateInput by nodeLLMModerateText(
                 name = "moderate-input",
                 moderatingModel = OpenAIModels.Moderation.Omni,
             )
             val nodeCallLLM by nodeLLMRequest("CallLLM")
 
-            val nodeExecuteTool by nodeExecuteToolsAndGetResults("ExecuteTool")
+            val nodeExecuteTool by nodeExecuteTools("ExecuteTool")
             val nodeSendToolResult by nodeLLMSendToolResults("SendToolResult")
 
             edge(
-                nodeStart forwardTo moderateInput asUserMessage { it },
+                nodeStart forwardTo moderateInput,
             )
 
             edge(
                 moderateInput forwardTo nodeCallLLM
                     onCondition { !it.moderationResult.isHarmful }
-                    transformed { Message.User("", metaInfo = RequestMetaInfo.Empty) },
+                    transformed { "" },
             )
 
             edge(
@@ -110,7 +107,7 @@ class MermaidDiagramGeneratorTest {
                 state "ExecuteTool" as ExecuteTool
                 state "SendToolResult" as SendToolResult
 
-                [*] --> moderate_input : transformed
+                [*] --> moderate_input
                 moderate_input --> CallLLM : transformed
                 moderate_input --> [*] : transformed
                 CallLLM --> [*] : transformed
@@ -224,7 +221,7 @@ class MermaidDiagramGeneratorTest {
     fun `Should generate diagram via MermaidDiagramGenerator object`() {
         val myStrategy = strategy<String, String>("object-test") {
             val nodeCallLLM by nodeLLMRequest()
-            edge(nodeStart forwardTo nodeCallLLM asUserMessage { it })
+            edge(nodeStart forwardTo nodeCallLLM)
             edge(nodeCallLLM forwardTo nodeFinish onTextMessage { true })
         }
 

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/feature/ToolCallFailureEventsTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/feature/ToolCallFailureEventsTest.kt
@@ -7,7 +7,7 @@ import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.ReceivedToolResults
 import ai.koog.agents.core.dsl.extension.ToolCalls
 import ai.koog.agents.core.dsl.extension.nodeExecuteSingleTool
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.environment.ReceivedToolResult
 import ai.koog.agents.core.feature.config.FeatureConfig
 import ai.koog.agents.core.feature.handler.tool.ToolCallFailedContext
@@ -79,7 +79,7 @@ class ToolCallFailureEventsTest {
         var toolValidationFailed: ToolValidationFailedContext? = null
 
         val strategy = strategy<ToolCalls, ReceivedToolResults>("tool_failure_strategy") {
-            val executeTool by nodeExecuteToolsAndGetResults()
+            val executeTool by nodeExecuteTools()
             edge(nodeStart forwardTo executeTool)
             edge(executeTool forwardTo nodeFinish)
         }

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerStreamingTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerStreamingTest.kt
@@ -2,7 +2,6 @@ package ai.koog.agents.core.system.feature
 
 import ai.koog.agents.core.annotation.ExperimentalAgentsApi
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreaming
 import ai.koog.agents.core.feature.AIAgentFeatureTestAPI.testClock
 import ai.koog.agents.core.feature.debugger.Debugger
@@ -115,7 +114,7 @@ class DebuggerStreamingTest {
             val strategy = strategy<String, String>(strategyName) {
                 val streamAndCollect by nodeLLMRequestStreaming(nodeLLMRequestStreamingName)
 
-                edge(nodeStart forwardTo streamAndCollect asUserMessage { it })
+                edge(nodeStart forwardTo streamAndCollect)
                 edge(streamAndCollect forwardTo nodeFinish transformed { it.collectText() })
             }
 
@@ -331,7 +330,7 @@ class DebuggerStreamingTest {
             val strategy = strategy<String, String>(strategyName) {
                 val streamAndCollect by nodeLLMRequestStreaming(nodeLLMRequestStreamingName)
 
-                edge(nodeStart forwardTo streamAndCollect asUserMessage { it })
+                edge(nodeStart forwardTo streamAndCollect)
                 edge(streamAndCollect forwardTo nodeFinish transformed { it.collectText() })
             }
 

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/system/feature/DebuggerTest.kt
@@ -5,8 +5,7 @@ import ai.koog.agents.core.agent.entity.AIAgentSubgraphBase.Companion.START_NODE
 import ai.koog.agents.core.annotation.ExperimentalAgentsApi
 import ai.koog.agents.core.annotation.InternalAgentsApi
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
 import ai.koog.agents.core.dsl.extension.onTextMessage
@@ -144,10 +143,10 @@ class DebuggerTest {
         val serverJob = launch {
             val strategy = strategy<String, String>(strategyName) {
                 val nodeSendInput by nodeLLMRequest(nodeSendLLMCallName)
-                val nodeExecuteTool by nodeExecuteToolsAndGetResults(nodeExecuteToolName)
+                val nodeExecuteTool by nodeExecuteTools(nodeExecuteToolName)
                 val nodeSendToolResult by nodeLLMSendToolResults(nodeSendToolResultName)
 
-                edge(nodeStart forwardTo nodeSendInput asUserMessage { it })
+                edge(nodeStart forwardTo nodeSendInput)
                 edge(nodeSendInput forwardTo nodeExecuteTool onToolCalls { true })
                 edge(nodeSendInput forwardTo nodeFinish onTextMessage { true })
                 edge(nodeExecuteTool forwardTo nodeSendToolResult)

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerTest.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerTest.kt
@@ -7,9 +7,9 @@ import ai.koog.agents.core.dsl.builder.AIAgentNodeDelegate
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.builder.subgraph
+import ai.koog.agents.core.dsl.extension.ReceivedToolResults
 import ai.koog.agents.core.dsl.extension.ToolCalls
-import ai.koog.agents.core.dsl.extension.asUserMessage
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreaming
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
@@ -108,7 +108,7 @@ class EventHandlerTest {
         val strategy = strategy<String, String>(strategyName) {
             val llmCallNode by nodeLLMRequest("test LLM call")
 
-            edge(nodeStart forwardTo llmCallNode asUserMessage { testLLMResponse })
+            edge(nodeStart forwardTo llmCallNode transformed { testLLMResponse })
             edge(llmCallNode forwardTo nodeFinish transformed { agentResult })
         }
 
@@ -144,8 +144,6 @@ class EventHandlerTest {
             .append(", temperature: ").append(temperature)
             .toString()
 
-        val expectedUserMessage =
-            "User(parts=[Text(text=$testLLMResponse, cacheControl=null)], metaInfo=RequestMetaInfo(timestamp=$ts, metadata=null), id=null)"
         val expectedAssistantMessage =
             "Assistant(parts=[Text(text=Default test response, cacheControl=null)], metaInfo=ResponseMetaInfo(timestamp=$ts, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, modelId=null, metadata=null), finishReason=null, rawResponse=null, id=null)"
 
@@ -154,10 +152,10 @@ class EventHandlerTest {
             "OnStrategyStarting (run id: $runId, strategy: $strategyName)",
             "OnNodeExecutionStarting (run id: $runId, node: __start__, input: $agentInput)",
             "OnNodeExecutionCompleted (run id: $runId, node: __start__, input: $agentInput, output: $agentInput)",
-            "OnNodeExecutionStarting (run id: $runId, node: test LLM call, input: $expectedUserMessage)",
+            "OnNodeExecutionStarting (run id: $runId, node: test LLM call, input: $testLLMResponse)",
             "OnLLMCallStarting (run id: $runId, prompt: $expectedPromptString, tools: [])",
             "OnLLMCallCompleted (run id: $runId, prompt: $expectedPromptString, model: ${model.eventString}, tools: [], responses: [${expectedMessage(Message.Role.Assistant, "Default test response").trim('{', '}')}])",
-            "OnNodeExecutionCompleted (run id: $runId, node: test LLM call, input: $expectedUserMessage, output: $expectedAssistantMessage)",
+            "OnNodeExecutionCompleted (run id: $runId, node: test LLM call, input: $testLLMResponse, output: $expectedAssistantMessage)",
             "OnNodeExecutionStarting (run id: $runId, node: __finish__, input: $agentResult)",
             "OnNodeExecutionCompleted (run id: $runId, node: __finish__, input: $agentResult, output: $agentResult)",
             "OnStrategyCompleted (run id: $runId, strategy: $strategyName, result: $agentResult)",
@@ -187,10 +185,10 @@ class EventHandlerTest {
 
         val strategy = strategy(strategyName) {
             val nodeSendInput by nodeLLMRequest("test-llm-call")
-            val nodeExecuteTool by nodeExecuteToolsAndGetResults("test-tool-call")
+            val nodeExecuteTool by nodeExecuteTools("test-tool-call")
             val nodeSendToolResult by nodeLLMSendToolResults("test-node-llm-send-tool-result")
 
-            edge(nodeStart forwardTo nodeSendInput asUserMessage { it })
+            edge(nodeStart forwardTo nodeSendInput)
             edge(nodeSendInput forwardTo nodeExecuteTool onToolCalls { true })
             edge(nodeSendInput forwardTo nodeFinish onTextMessage { true })
             edge(nodeExecuteTool forwardTo nodeSendToolResult)
@@ -270,8 +268,6 @@ class EventHandlerTest {
             .append(", temperature: ").append(temperature)
             .toString()
 
-        val userPromptMessageObj =
-            "User(parts=[Text(text=$userPrompt, cacheControl=null)], metaInfo=RequestMetaInfo(timestamp=$ts, metadata=null), id=null)"
         val toolCallAssistantObj =
             "Assistant(parts=[Call(id=null, tool=$dummyToolName, args=$dummyToolArgsEncoded)], metaInfo=ResponseMetaInfo(timestamp=$ts, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, modelId=null, metadata=null), finishReason=null, rawResponse=null, id=null)"
         val toolCallsInput = "ToolCalls(toolCalls=[Call(id=null, tool=$dummyToolName, args=$dummyToolArgsEncoded)])"
@@ -289,10 +285,10 @@ class EventHandlerTest {
             "OnStrategyStarting (run id: $runId, strategy: $strategyName)",
             "OnNodeExecutionStarting (run id: $runId, node: __start__, input: $userPrompt)",
             "OnNodeExecutionCompleted (run id: $runId, node: __start__, input: $userPrompt, output: $userPrompt)",
-            "OnNodeExecutionStarting (run id: $runId, node: test-llm-call, input: $userPromptMessageObj)",
+            "OnNodeExecutionStarting (run id: $runId, node: test-llm-call, input: $userPrompt)",
             "OnLLMCallStarting (run id: $runId, prompt: $expectedPromptFirstCall, tools: [$dummyToolName])",
             "OnLLMCallCompleted (run id: $runId, prompt: $expectedPromptFirstCall, model: ${model.eventString}, tools: [$dummyToolName], responses: [$toolCallResponseEntry])",
-            "OnNodeExecutionCompleted (run id: $runId, node: test-llm-call, input: $userPromptMessageObj, output: $toolCallAssistantObj)",
+            "OnNodeExecutionCompleted (run id: $runId, node: test-llm-call, input: $userPrompt, output: $toolCallAssistantObj)",
             "OnNodeExecutionStarting (run id: $runId, node: test-tool-call, input: $toolCallsInput)",
             "OnToolCallStarting (run id: $runId, tool: $dummyToolName, args: $dummyToolArgsEncoded)",
             "OnToolCallCompleted (run id: $runId, tool: $dummyToolName, args: $dummyToolArgsEncoded, result: $dummyToolResultEncoded)",
@@ -333,8 +329,8 @@ class EventHandlerTest {
             val llmCallNode by nodeLLMRequest("test LLM call")
             val llmCallWithToolsNode by nodeLLMRequest("test LLM call with tools")
 
-            edge(nodeStart forwardTo llmCallNode asUserMessage { testLLMResponse })
-            edge(llmCallNode forwardTo llmCallWithToolsNode asUserMessage { llmCallWithToolsResponse })
+            edge(nodeStart forwardTo llmCallNode transformed { testLLMResponse })
+            edge(llmCallNode forwardTo llmCallWithToolsNode transformed { llmCallWithToolsResponse })
             edge(llmCallWithToolsNode forwardTo nodeFinish transformed { agentResult })
         }
 
@@ -384,9 +380,6 @@ class EventHandlerTest {
             .append(", temperature: ").append(temperature)
             .toString()
 
-        val expectedUserMessage = { text: String ->
-            "User(parts=[Text(text=$text, cacheControl=null)], metaInfo=RequestMetaInfo(timestamp=$ts, metadata=null), id=null)"
-        }
         val expectedAssistantMessage =
             "Assistant(parts=[Text(text=$defaultResponse, cacheControl=null)], metaInfo=ResponseMetaInfo(timestamp=$ts, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, modelId=null, metadata=null), finishReason=null, rawResponse=null, id=null)"
 
@@ -398,14 +391,14 @@ class EventHandlerTest {
             "OnStrategyStarting (run id: $runId, strategy: $strategyName)",
             "OnNodeExecutionStarting (run id: $runId, node: __start__, input: $agentInput)",
             "OnNodeExecutionCompleted (run id: $runId, node: __start__, input: $agentInput, output: $agentInput)",
-            "OnNodeExecutionStarting (run id: $runId, node: test LLM call, input: ${expectedUserMessage(testLLMResponse)})",
+            "OnNodeExecutionStarting (run id: $runId, node: test LLM call, input: $testLLMResponse)",
             "OnLLMCallStarting (run id: $runId, prompt: $expectedPromptFirstCall, tools: [$expectedTools])",
             "OnLLMCallCompleted (run id: $runId, prompt: $expectedPromptFirstCall, model: ${model.eventString}, tools: [$expectedTools], responses: [$responseEntry])",
-            "OnNodeExecutionCompleted (run id: $runId, node: test LLM call, input: ${expectedUserMessage(testLLMResponse)}, output: $expectedAssistantMessage)",
-            "OnNodeExecutionStarting (run id: $runId, node: test LLM call with tools, input: ${expectedUserMessage(llmCallWithToolsResponse)})",
+            "OnNodeExecutionCompleted (run id: $runId, node: test LLM call, input: $testLLMResponse, output: $expectedAssistantMessage)",
+            "OnNodeExecutionStarting (run id: $runId, node: test LLM call with tools, input: $llmCallWithToolsResponse)",
             "OnLLMCallStarting (run id: $runId, prompt: $expectedPromptSecondCall, tools: [$expectedTools])",
             "OnLLMCallCompleted (run id: $runId, prompt: $expectedPromptSecondCall, model: ${model.eventString}, tools: [$expectedTools], responses: [$responseEntry])",
-            "OnNodeExecutionCompleted (run id: $runId, node: test LLM call with tools, input: ${expectedUserMessage(llmCallWithToolsResponse)}, output: $expectedAssistantMessage)",
+            "OnNodeExecutionCompleted (run id: $runId, node: test LLM call with tools, input: $llmCallWithToolsResponse, output: $expectedAssistantMessage)",
             "OnNodeExecutionStarting (run id: $runId, node: __finish__, input: $agentResult)",
             "OnNodeExecutionCompleted (run id: $runId, node: __finish__, input: $agentResult, output: $agentResult)",
             "OnStrategyCompleted (run id: $runId, strategy: $strategyName, result: $agentResult)",
@@ -528,7 +521,7 @@ class EventHandlerTest {
             val llmCallNode by nodeLLMRequest("test LLM call")
             val llmCallWithToolsNode by nodeException("test LLM call with tools")
 
-            edge(nodeStart forwardTo llmCallNode asUserMessage { "Test LLM call prompt" })
+            edge(nodeStart forwardTo llmCallNode transformed { "Test LLM call prompt" })
             edge(llmCallNode forwardTo llmCallWithToolsNode transformed { "Test LLM call with tools prompt" })
             edge(llmCallWithToolsNode forwardTo nodeFinish transformed { "Done" })
         }
@@ -561,7 +554,7 @@ class EventHandlerTest {
         val strategy = strategy<String, String>(strategyName) {
             val streamAndCollect by nodeLLMRequestStreaming("stream-and-collect")
 
-            edge(nodeStart forwardTo streamAndCollect asUserMessage { it })
+            edge(nodeStart forwardTo streamAndCollect)
             edge(
                 streamAndCollect forwardTo nodeFinish transformed { messages ->
                     messages.collectText()
@@ -637,7 +630,7 @@ class EventHandlerTest {
         val strategy = strategy<String, String>(strategyName) {
             val streamAndCollect by nodeLLMRequestStreaming("stream-and-collect")
 
-            edge(nodeStart forwardTo streamAndCollect asUserMessage { it })
+            edge(nodeStart forwardTo streamAndCollect)
             edge(
                 streamAndCollect forwardTo nodeFinish transformed { messages ->
                     messages.collectText()
@@ -864,9 +857,7 @@ class EventHandlerTest {
                 }
                 onNodeExecutionCompleted { ctx ->
                     if (ctx.node.name == "nodeExecuteTool") {
-                        val toolResult = (ctx.output as Message.User).parts
-                            .filterIsInstance<MessagePart.Tool.Result>()
-                            .single()
+                        val toolResult = (ctx.output as ReceivedToolResults).toolResults.single()
                         events += "finished: nodeExecuteTool(tool=${toolResult.tool}, output=${toolResult.output})"
                     }
                 }

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/NodeLLMRequestStreamingAndSendResultsTest.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/NodeLLMRequestStreamingAndSendResultsTest.kt
@@ -5,7 +5,6 @@ import ai.koog.agents.core.agent.GraphAIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreaming
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.testing.tools.getMockExecutor
@@ -62,7 +61,7 @@ class NodeLLMRequestStreamingAndSendResultsTest {
         val strategy = strategy<String, String>("streaming-collect-strategy") {
             val streamAndCollectNode by nodeLLMRequestStreaming("stream-and-collect")
 
-            edge(nodeStart forwardTo streamAndCollectNode asUserMessage { it })
+            edge(nodeStart forwardTo streamAndCollectNode)
             edge(streamAndCollectNode forwardTo nodeFinish transformed { it.collectText() })
         }
 
@@ -100,7 +99,7 @@ class NodeLLMRequestStreamingAndSendResultsTest {
         val strategy = strategy<String, String>("streaming-response-strategy") {
             val streamNode by nodeLLMRequestStreaming("stream-collect")
 
-            edge(nodeStart forwardTo streamNode asUserMessage { it })
+            edge(nodeStart forwardTo streamNode)
             edge(streamNode forwardTo nodeFinish transformed { it.collectText() })
         }
 
@@ -134,7 +133,7 @@ class NodeLLMRequestStreamingAndSendResultsTest {
         val strategy = strategy<String, String>("empty-streaming-strategy") {
             val streamNode by nodeLLMRequestStreaming("stream-empty")
 
-            edge(nodeStart forwardTo streamNode asUserMessage { it })
+            edge(nodeStart forwardTo streamNode)
             edge(streamNode forwardTo nodeFinish transformed { it.collectText() })
         }
 
@@ -172,8 +171,7 @@ class NodeLLMRequestStreamingAndSendResultsTest {
 
             edge(
                 nodeStart forwardTo streamNode
-                    transformed { inputData }
-                    asUserMessage { it.description }
+                    transformed { inputData.description }
             )
             edge(streamNode forwardTo nodeFinish transformed { it.collectText() })
         }

--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/StreamingEventHandlerTest.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/StreamingEventHandlerTest.kt
@@ -3,7 +3,6 @@ package ai.koog.agents.features.eventHandler.feature
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreaming
 import ai.koog.agents.testing.tools.MockExecutorDSLBuilder
 import ai.koog.agents.testing.tools.getMockExecutor
@@ -103,6 +102,6 @@ private suspend fun mockStreaming(
 private fun streamTextStrategy(strategyName: String) =
     strategy<String, String>(strategyName) {
         val llmNode by nodeLLMRequestStreaming("streaming-llm-node")
-        edge(nodeStart forwardTo llmNode asUserMessage { it })
+        edge(nodeStart forwardTo llmNode)
         edge(llmNode forwardTo nodeFinish transformed { it.collectText() })
     }

--- a/agents/agents-features/agents-features-longterm-memory/src/jvmTest/kotlin/ai/koog/agents/longtermmemory/feature/LongTermMemoryIngestionTest.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/jvmTest/kotlin/ai/koog/agents/longtermmemory/feature/LongTermMemoryIngestionTest.kt
@@ -4,7 +4,6 @@ import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.ToolSelectionStrategy
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreaming
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestWithoutTools
 import ai.koog.agents.core.tools.ToolDescriptor
@@ -48,7 +47,7 @@ class LongTermMemoryIngestionTest {
     private val nonStreamingStrategy =
         strategy<String, String>("ingestion-test", toolSelectionStrategy = ToolSelectionStrategy.NONE) {
             val llmNode by nodeLLMRequestWithoutTools(name = "llm-node")
-            edge(nodeStart forwardTo llmNode asUserMessage { it })
+            edge(nodeStart forwardTo llmNode)
             edge(
                 llmNode forwardTo nodeFinish transformed {
                     it.parts.filterIsInstance<MessagePart.Text>().joinToString(separator = "\n") { it.text }
@@ -68,8 +67,8 @@ class LongTermMemoryIngestionTest {
         strategy<String, String>("ingestion-two-call-test", toolSelectionStrategy = ToolSelectionStrategy.NONE) {
             val firstLlmNode by nodeLLMRequestWithoutTools(name = "llm-node-1")
             val secondLlmNode by nodeLLMRequestWithoutTools(name = "llm-node-2")
-            edge(nodeStart forwardTo firstLlmNode asUserMessage { it })
-            edge(firstLlmNode forwardTo secondLlmNode asUserMessage { "Follow-up question" })
+            edge(nodeStart forwardTo firstLlmNode)
+            edge(firstLlmNode forwardTo secondLlmNode transformed { "Follow-up question" })
             edge(
                 secondLlmNode forwardTo nodeFinish transformed {
                     it.parts.filterIsInstance<MessagePart.Text>().joinToString(separator = "\n") { it.text }
@@ -80,7 +79,7 @@ class LongTermMemoryIngestionTest {
     private val streamingStrategy =
         strategy<String, String>("ingestion-streaming-test", toolSelectionStrategy = ToolSelectionStrategy.NONE) {
             val llmNode by nodeLLMRequestStreaming(name = "llm-node")
-            edge(nodeStart forwardTo llmNode asUserMessage { it })
+            edge(nodeStart forwardTo llmNode)
             edge(
                 llmNode forwardTo nodeFinish transformed { flow ->
                     flow.toList().filterIsInstance<StreamFrame.TextDelta>().joinToString("") { it.text }

--- a/agents/agents-features/agents-features-longterm-memory/src/jvmTest/kotlin/ai/koog/agents/longtermmemory/feature/LongTermMemoryRetrievalTest.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/jvmTest/kotlin/ai/koog/agents/longtermmemory/feature/LongTermMemoryRetrievalTest.kt
@@ -4,7 +4,6 @@ import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.entity.ToolSelectionStrategy
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreaming
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestWithoutTools
 import ai.koog.agents.core.tools.ToolDescriptor
@@ -56,14 +55,14 @@ class LongTermMemoryRetrievalTest {
     private val nonStreamingStrategy =
         strategy<String, String>("retrieval-test", toolSelectionStrategy = ToolSelectionStrategy.NONE) {
             val llmNode by nodeLLMRequestWithoutTools(name = "llm-node")
-            edge(nodeStart forwardTo llmNode asUserMessage { it })
+            edge(nodeStart forwardTo llmNode)
             edge(llmNode forwardTo nodeFinish transformed { it.parts.filterIsInstance<MessagePart.Text>().joinToString("\n") { p -> p.text } })
         }
 
     private val streamingStrategy =
         strategy<String, String>("retrieval-streaming-test", toolSelectionStrategy = ToolSelectionStrategy.NONE) {
             val llmNode by nodeLLMRequestStreaming(name = "llm-node")
-            edge(nodeStart forwardTo llmNode asUserMessage { it })
+            edge(nodeStart forwardTo llmNode)
             edge(
                 llmNode forwardTo nodeFinish transformed { flow ->
                     flow.toList().filterIsInstance<StreamFrame.TextDelta>().joinToString("") { it.text }

--- a/agents/agents-features/agents-features-memory/src/jvmTest/kotlin/ai/koog/agents/chatMemory/ChatMemoryTest.kt
+++ b/agents/agents-features/agents-features-memory/src/jvmTest/kotlin/ai/koog/agents/chatMemory/ChatMemoryTest.kt
@@ -7,6 +7,7 @@ import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.functionalStrategy
 import ai.koog.agents.core.agent.singleRunStrategy
 import ai.koog.agents.core.annotation.InternalAgentsApi
+import ai.koog.agents.core.dsl.extension.ReceivedToolResults
 import ai.koog.agents.core.dsl.extension.ToolCalls
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolRegistry
@@ -1247,9 +1248,7 @@ class ChatMemoryTest {
                 }
                 onNodeExecutionCompleted { ctx ->
                     if (ctx.node.name == "nodeExecuteTool") {
-                        val toolResult = (ctx.output as Message.User).parts
-                            .filterIsInstance<MessagePart.Tool.Result>()
-                            .single()
+                        val toolResult = (ctx.output as ReceivedToolResults).toolResults.single()
                         events += "finished: nodeExecuteTool(tool=${toolResult.tool}, output=${toolResult.output})"
                     }
                 }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestAPI.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestAPI.kt
@@ -8,8 +8,7 @@ import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.agent.entity.AIAgentStrategy
 import ai.koog.agents.core.agent.functionalStrategy
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
 import ai.koog.agents.core.dsl.extension.onTextMessage
@@ -100,7 +99,7 @@ internal object OpenTelemetryTestAPI {
         internal val singleLLMCallGraphStrategy = strategy(Parameter.DEFAULT_STRATEGY_NAME) {
             val nodeSendInput by nodeLLMRequest("test-llm-call")
 
-            edge(nodeStart forwardTo nodeSendInput asUserMessage { it })
+            edge(nodeStart forwardTo nodeSendInput)
             edge(nodeSendInput forwardTo nodeFinish onTextMessage { true })
         }
         internal val singleLLMCallFunctionalStrategy =
@@ -116,10 +115,10 @@ internal object OpenTelemetryTestAPI {
 
         internal val singleToolCallGraphStrategy = strategy(Parameter.DEFAULT_STRATEGY_NAME) {
             val nodeCallLLM by nodeLLMRequest("test-llm-call")
-            val nodeExecuteTool by nodeExecuteToolsAndGetResults("test-tool-call")
+            val nodeExecuteTool by nodeExecuteTools("test-tool-call")
             val nodeSendToolResult by nodeLLMSendToolResults("test-node-llm-send-tool-result")
 
-            edge(nodeStart forwardTo nodeCallLLM asUserMessage { it })
+            edge(nodeStart forwardTo nodeCallLLM)
             edge(nodeCallLLM forwardTo nodeExecuteTool onToolCalls { true })
             edge(nodeCallLLM forwardTo nodeFinish onTextMessage { true })
             edge(nodeExecuteTool forwardTo nodeSendToolResult)

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryExecuteToolSpanTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryExecuteToolSpanTest.kt
@@ -1,8 +1,7 @@
 package ai.koog.agents.features.opentelemetry.feature.span
 
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
 import ai.koog.agents.core.dsl.extension.onTextMessage
@@ -119,10 +118,10 @@ class OpenTelemetryExecuteToolSpanTest : OpenTelemetryTestBase() {
 
         val strategy = strategy("test-tool-calls-strategy") {
             val nodeCallLLM by nodeLLMRequest("test-llm-call")
-            val nodeExecuteTool by nodeExecuteToolsAndGetResults("test-multiple-tool-calls")
+            val nodeExecuteTool by nodeExecuteTools("test-multiple-tool-calls")
             val nodeSendToolResult by nodeLLMSendToolResults("test-node-llm-send-multiple-tool-results")
 
-            edge(nodeStart forwardTo nodeCallLLM asUserMessage { it })
+            edge(nodeStart forwardTo nodeCallLLM)
             edge(nodeCallLLM forwardTo nodeExecuteTool onToolCalls { true })
             edge(
                 nodeCallLLM forwardTo nodeFinish

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryInferenceSpanTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/feature/span/OpenTelemetryInferenceSpanTest.kt
@@ -7,7 +7,6 @@ import ai.koog.agents.core.agent.singleRunStrategy
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.builder.subgraph
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.onTextMessage
 import ai.koog.agents.features.opentelemetry.AgentType
@@ -345,14 +344,14 @@ class OpenTelemetryInferenceSpanTest : OpenTelemetryTestBase() {
             val subgraph by subgraph<String, String>(subgraphName) {
                 val nodeSubgraphLLMCall by nodeLLMRequest(subgraphLLMCallNodeName)
 
-                edge(nodeStart forwardTo nodeSubgraphLLMCall asUserMessage { it })
+                edge(nodeStart forwardTo nodeSubgraphLLMCall)
                 edge(nodeSubgraphLLMCall forwardTo nodeFinish onTextMessage { true })
             }
 
             val nodeLLMCall by nodeLLMRequest(rootNodeCallLLMName)
 
             edge(nodeStart forwardTo subgraph)
-            edge(subgraph forwardTo nodeLLMCall asUserMessage { it })
+            edge(subgraph forwardTo nodeLLMCall)
             edge(nodeLLMCall forwardTo nodeFinish onTextMessage { true })
         }
 
@@ -455,7 +454,7 @@ class OpenTelemetryInferenceSpanTest : OpenTelemetryTestBase() {
         val strategy = strategy<String, String>("test-strategy") {
             val nodeLLMCall by nodeLLMRequest(nodeLLMCallName)
 
-            edge(nodeStart forwardTo nodeLLMCall asUserMessage { it })
+            edge(nodeStart forwardTo nodeLLMCall)
             edge(nodeLLMCall forwardTo nodeFinish onTextMessage { true })
         }
 

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/TraceStructureTestBase.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/TraceStructureTestBase.kt
@@ -4,8 +4,7 @@ import ai.koog.agents.core.agent.context.DetachedPromptExecutorAPI
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStructured
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
@@ -82,7 +81,7 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
             val strategy = strategy("single-llm-call-strategy") {
                 val llmRequest by nodeLLMRequest("llm-call")
 
-                edge(nodeStart forwardTo llmRequest asUserMessage { it })
+                edge(nodeStart forwardTo llmRequest)
                 edge(llmRequest forwardTo nodeFinish onTextMessage { true })
             }
 
@@ -182,10 +181,10 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
         TestSpanProcessor().let { testProcessor ->
             val strategy = strategy("llm-tool-llm-strategy") {
                 val llmRequest by nodeLLMRequest("LLM Request")
-                val executeTool by nodeExecuteToolsAndGetResults("Execute Tool")
+                val executeTool by nodeExecuteTools("Execute Tool")
                 val sendToolResult by nodeLLMSendToolResults("Send Tool Result")
 
-                edge(nodeStart forwardTo llmRequest asUserMessage { it })
+                edge(nodeStart forwardTo llmRequest)
                 edge(llmRequest forwardTo executeTool onToolCalls { true })
                 edge(executeTool forwardTo sendToolResult)
                 edge(sendToolResult forwardTo nodeFinish onTextMessage { true })
@@ -314,12 +313,12 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
         TestSpanProcessor().let { testProcessor ->
             val strategy = strategy("multiple-tool-calls-strategy") {
                 val llmRequest by nodeLLMRequest("Initial LLM Request")
-                val executeTool1 by nodeExecuteToolsAndGetResults("Execute Tool 1")
+                val executeTool1 by nodeExecuteTools("Execute Tool 1")
                 val sendToolResult1 by nodeLLMSendToolResults("Send Tool Result 1")
-                val executeTool2 by nodeExecuteToolsAndGetResults("Execute Tool 2")
+                val executeTool2 by nodeExecuteTools("Execute Tool 2")
                 val sendToolResult2 by nodeLLMSendToolResults("Send Tool Result 2")
 
-                edge(nodeStart forwardTo llmRequest asUserMessage { it })
+                edge(nodeStart forwardTo llmRequest)
                 edge(llmRequest forwardTo executeTool1 onToolCalls { true })
                 edge(executeTool1 forwardTo sendToolResult1)
                 edge(sendToolResult1 forwardTo executeTool2 onToolCalls { true })
@@ -478,7 +477,7 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
 
             val strategy = strategy("test-strategy") {
                 val nodeSendInput by nodeLLMRequest("test-llm-call")
-                edge(nodeStart forwardTo nodeSendInput asUserMessage { it })
+                edge(nodeStart forwardTo nodeSendInput)
                 edge(nodeSendInput forwardTo nodeFinish onTextMessage { true })
             }
 
@@ -562,7 +561,7 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
                     name = "llm-structured",
                 )
 
-                edge(nodeStart forwardTo llmStructured asUserMessage { it })
+                edge(nodeStart forwardTo llmStructured)
                 edge(
                     llmStructured forwardTo nodeFinish transformed { result ->
                         result.getOrThrow().message.parts.filterIsInstance<MessagePart.Text>()
@@ -676,10 +675,10 @@ abstract class TraceStructureTestBase(private val openTelemetryConfigurator: Ope
         TestSpanProcessor().let { testProcessor ->
             val strategy = strategy("llm-tool-llm-strategy") {
                 val llmRequest by nodeLLMRequest("LLM Request")
-                val executeTool by nodeExecuteToolsAndGetResults("Execute Tool")
+                val executeTool by nodeExecuteTools("Execute Tool")
                 val sendToolResult by nodeLLMSendToolResults("Send Tool Result")
 
-                edge(nodeStart forwardTo llmRequest asUserMessage { it })
+                edge(nodeStart forwardTo llmRequest)
                 edge(llmRequest forwardTo executeTool onToolCalls { true })
                 edge(executeTool forwardTo sendToolResult)
                 edge(sendToolResult forwardTo nodeFinish onTextMessage { true })

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/ai/koog/agents/snapshot/CheckpointsTests.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/ai/koog/agents/snapshot/CheckpointsTests.kt
@@ -16,10 +16,8 @@ import ai.koog.agents.core.dsl.builder.AIAgentNodeDelegate
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.ToolCalls
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeDoNothing
 import ai.koog.agents.core.dsl.extension.nodeExecuteTools
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
 import ai.koog.agents.core.dsl.extension.onTextMessage
@@ -655,12 +653,12 @@ class CheckpointsTests {
             },
             strategy = strategy("simple-with-interrupt") {
                 val callLLM by nodeLLMRequest()
-                val executeTool by nodeExecuteToolsAndGetResults()
+                val executeTool by nodeExecuteTools()
                 val sendToolResult by nodeLLMSendToolResults()
 
                 val nodeThrow by node<Any?, String> { throw Exception("TERMINATED AFTER THIRD TOOL CALL") }
 
-                edge(nodeStart forwardTo callLLM asUserMessage { it })
+                edge(nodeStart forwardTo callLLM)
                 edge(callLLM forwardTo executeTool onToolCalls { true })
                 edge(callLLM forwardTo nodeFinish onTextMessage { true })
                 edge(executeTool forwardTo sendToolResult onCondition { !agentInterrupted() })
@@ -885,12 +883,12 @@ class CheckpointsTests {
             },
             strategy = strategy("simple-with-interrupt") {
                 val callLLM by nodeLLMRequest()
-                val executeTool by nodeExecuteToolsAndGetResults()
+                val executeTool by nodeExecuteTools()
                 val sendToolResult by nodeLLMSendToolResults()
 
                 val nodeThrow by node<Any?, String> { throw Exception("TERMINATED AFTER THIRD TOOL CALL") }
 
-                edge(nodeStart forwardTo callLLM asUserMessage { it })
+                edge(nodeStart forwardTo callLLM)
                 edge(callLLM forwardTo executeTool onToolCalls { true })
                 edge(callLLM forwardTo nodeFinish onTextMessage { true })
                 edge(executeTool forwardTo sendToolResult onCondition { !agentInterrupted() })

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/ai/koog/agents/snapshot/PersistencyRunsTwiceTest.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/ai/koog/agents/snapshot/PersistencyRunsTwiceTest.kt
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class PersistenceRunsTwiceTest {
     private val serializer = KotlinxSerializer()
@@ -222,6 +223,8 @@ class PersistenceRunsTwiceTest {
                 onNodeExecutionCompleted { ctx ->
                     if (ctx.node.name == "nodeExecuteTool") {
                         val toolResult = (ctx.output as ReceivedToolResults).toolResults.single()
+                        // resultObject is set in the live result but must NOT survive persistence
+                        assertNotNull(toolResult.resultObject)
                         events += "finished: nodeExecuteTool(tool=${toolResult.tool}, output=${toolResult.output})"
                     }
                 }
@@ -264,16 +267,16 @@ class PersistenceRunsTwiceTest {
         assertEquals("nodeExecuteTool", lastCheckpoint.nodePath.substringAfterLast("/"))
         assertNotNull(lastCheckpoint.lastOutput, lastCheckpoint.nodePath.substringAfterLast("/"))
 
-        val lastOutputValue = KotlinxSerializer().decodeFromJSONElement<Message.User>(
+        val lastOutputValue = KotlinxSerializer().decodeFromJSONElement<ReceivedToolResults>(
             lastCheckpoint.lastOutput,
-            typeToken<Message.User>()
+            typeToken<ReceivedToolResults>()
         )
-        val persistedToolResult = lastOutputValue.parts
-            .filterIsInstance<MessagePart.Tool.Result>()
-            .single()
+        val persistedToolResult = lastOutputValue.toolResults.single()
 
         assertEquals("guesser", persistedToolResult.tool)
         assertEquals("encoded_result(\"Hidden Value\")", persistedToolResult.output)
+        // resultObject is @Transient — it is NOT persisted via the Persistence feature
+        assertNull(persistedToolResult.resultObject)
 
         val expectedEventsFirstRun = listOf(
             "onLLMCallStarting(Tell me the secret!)",

--- a/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/ai/koog/agents/snapshot/PersistencyRunsTwiceTest.kt
+++ b/agents/agents-features/agents-features-snapshot/src/jvmTest/kotlin/ai/koog/agents/snapshot/PersistencyRunsTwiceTest.kt
@@ -5,6 +5,7 @@ import ai.koog.agents.core.agent.GraphAIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.agent.singleRunStrategy
 import ai.koog.agents.core.annotation.InternalAgentsApi
+import ai.koog.agents.core.dsl.extension.ReceivedToolResults
 import ai.koog.agents.core.dsl.extension.ToolCalls
 import ai.koog.agents.core.tools.Tool
 import ai.koog.agents.core.tools.ToolRegistry
@@ -220,9 +221,7 @@ class PersistenceRunsTwiceTest {
                 }
                 onNodeExecutionCompleted { ctx ->
                     if (ctx.node.name == "nodeExecuteTool") {
-                        val toolResult = (ctx.output as Message.User).parts
-                            .filterIsInstance<MessagePart.Tool.Result>()
-                            .single()
+                        val toolResult = (ctx.output as ReceivedToolResults).toolResults.single()
                         events += "finished: nodeExecuteTool(tool=${toolResult.tool}, output=${toolResult.output})"
                     }
                 }

--- a/agents/agents-features/agents-features-tokenizer/src/jvmTest/kotlin/ai/koog/agents/features/tokenizer/feature/MessageTokenizerTest.kt
+++ b/agents/agents-features/agents-features-tokenizer/src/jvmTest/kotlin/ai/koog/agents/features/tokenizer/feature/MessageTokenizerTest.kt
@@ -4,8 +4,7 @@ import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
 import ai.koog.agents.core.dsl.extension.onTextMessage
@@ -90,7 +89,7 @@ class MessageTokenizerTest {
 
         val testStrategy = strategy("test") {
             val callLLM by nodeLLMRequest()
-            val callTool by nodeExecuteToolsAndGetResults()
+            val callTool by nodeExecuteTools()
             val sendToolResul by nodeLLMSendToolResults()
 
             val checkTokens by node<String, String> {
@@ -101,7 +100,7 @@ class MessageTokenizerTest {
                 "Total tokens: $totalTokens"
             }
 
-            edge(nodeStart forwardTo callLLM asUserMessage { it })
+            edge(nodeStart forwardTo callLLM)
             edge(callLLM forwardTo callTool onToolCalls { true })
             edge(callLLM forwardTo checkTokens onTextMessage { true })
             edge(callTool forwardTo sendToolResul)

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageFileWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageFileWriterTest.kt
@@ -3,8 +3,7 @@ package ai.koog.agents.features.tracing.writer
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.ReceivedToolResults
 import ai.koog.agents.core.dsl.extension.ToolCalls
-import ai.koog.agents.core.dsl.extension.asUserMessage
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
 import ai.koog.agents.core.dsl.extension.onTextMessage
@@ -118,10 +117,10 @@ class TraceFeatureMessageFileWriterTest {
 
             val strategy = strategy(strategyName) {
                 val nodeSendInput by nodeLLMRequest("test-llm-call")
-                val nodeExecuteTool by nodeExecuteToolsAndGetResults("test-tool-call")
+                val nodeExecuteTool by nodeExecuteTools("test-tool-call")
                 val nodeSendToolResult by nodeLLMSendToolResults("test-node-llm-send-tool-result")
 
-                edge(nodeStart forwardTo nodeSendInput asUserMessage { it })
+                edge(nodeStart forwardTo nodeSendInput)
                 edge(nodeSendInput forwardTo nodeExecuteTool onToolCalls { true })
                 edge(nodeSendInput forwardTo nodeFinish onTextMessage { true })
                 edge(nodeExecuteTool forwardTo nodeSendToolResult)
@@ -196,10 +195,9 @@ class TraceFeatureMessageFileWriterTest {
             )
 
             // Pre-encoded JSON shapes that match the new node input/output types:
-            // - test-llm-call input/output: Message.User / Message.Assistant
+            // - test-llm-call input/output: String / Message.Assistant
             // - test-tool-call input: ToolCalls; output: ReceivedToolResults
             // - test-node-llm-send-tool-result input: ReceivedToolResults; output: Message.Assistant
-            val userMessageEncoded = serializer.encodeToJSONElement(userPromptMessage, typeToken<Message.User>())
             val toolCallMessageEncoded = serializer.encodeToJSONElement(toolCallAssistant, typeToken<Message.Assistant>())
             val toolCallsEncoded = serializer.encodeToJSONElement(ToolCalls(listOf(toolCallPart)), typeToken<ToolCalls>())
             val toolResultsEncoded = serializer.encodeToJSONElement(toolResultsValue, typeToken<ReceivedToolResults>())
@@ -221,10 +219,10 @@ class TraceFeatureMessageFileWriterTest {
                 "${GraphStrategyStartingEvent::class.simpleName} (run id: $runId, strategy: $strategyName)",
                 "${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: __start__, input: \"$userPrompt\")",
                 "${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: __start__, input: \"$userPrompt\", output: \"$userPrompt\")",
-                "${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: test-llm-call, input: $userMessageEncoded)",
+                "${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: test-llm-call, input: \"$userPrompt\")",
                 "${LLMCallStartingEvent::class.simpleName} (run id: $runId, prompt: $expectedPromptFirstCall, model: ${testModel.toModelInfo().modelIdentifierName}, tools: [$dummyToolName])",
                 "${LLMCallCompletedEvent::class.simpleName} (run id: $runId, prompt: $expectedPromptFirstCall, model: ${testModel.toModelInfo().modelIdentifierName}, response: ${toolCallAssistant.traceString}])",
-                "${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: test-llm-call, input: $userMessageEncoded, output: $toolCallMessageEncoded)",
+                "${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: test-llm-call, input: \"$userPrompt\", output: $toolCallMessageEncoded)",
                 "${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: test-tool-call, input: $toolCallsEncoded)",
                 "${ToolCallStartingEvent::class.simpleName} (run id: $runId, tool: $dummyToolName, tool args: $dummyToolArgsEncoded)",
                 "${ToolCallCompletedEvent::class.simpleName} (run id: $runId, tool: $dummyToolName, tool args: $dummyToolArgsEncoded, description: $dummyToolDescription, result: $dummyToolResultEncoded)",
@@ -331,8 +329,8 @@ class TraceFeatureMessageFileWriterTest {
                 val llmCallNode by nodeLLMRequest("test LLM call")
                 val llmCallWithToolsNode by nodeLLMRequest("test LLM call with tools")
 
-                edge(nodeStart forwardTo llmCallNode asUserMessage { "Test LLM call prompt" })
-                edge(llmCallNode forwardTo llmCallWithToolsNode asUserMessage { "Test LLM call with tools prompt" })
+                edge(nodeStart forwardTo llmCallNode transformed { "Test LLM call prompt" })
+                edge(llmCallNode forwardTo llmCallWithToolsNode transformed { "Test LLM call with tools prompt" })
                 edge(llmCallWithToolsNode forwardTo nodeFinish transformed { "Done" })
             }
 
@@ -362,8 +360,8 @@ class TraceFeatureMessageFileWriterTest {
                 val llmCallNode by nodeLLMRequest("test LLM call")
                 val llmCallWithToolsNode by nodeLLMRequest("test LLM call with tools")
 
-                edge(nodeStart forwardTo llmCallNode asUserMessage { "Test LLM call prompt" })
-                edge(llmCallNode forwardTo llmCallWithToolsNode asUserMessage { "Test LLM call with tools prompt" })
+                edge(nodeStart forwardTo llmCallNode transformed { "Test LLM call prompt" })
+                edge(llmCallNode forwardTo llmCallWithToolsNode transformed { "Test LLM call with tools prompt" })
                 edge(llmCallWithToolsNode forwardTo nodeFinish transformed { "Done" })
             }
 
@@ -429,10 +427,10 @@ class TraceFeatureMessageFileWriterTest {
 
             val strategy = strategy(strategyName) {
                 val nodeSendInput by nodeLLMRequest("test-llm-call")
-                val nodeExecuteTool by nodeExecuteToolsAndGetResults("test-tool-call")
+                val nodeExecuteTool by nodeExecuteTools("test-tool-call")
                 val nodeSendToolResult by nodeLLMSendToolResults("test-node-llm-send-tool-result")
 
-                edge(nodeStart forwardTo nodeSendInput asUserMessage { it })
+                edge(nodeStart forwardTo nodeSendInput)
                 edge(nodeSendInput forwardTo nodeExecuteTool onToolCalls { true })
                 edge(nodeSendInput forwardTo nodeFinish onTextMessage { true })
                 edge(nodeExecuteTool forwardTo nodeSendToolResult)

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageLogWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageLogWriterTest.kt
@@ -3,8 +3,7 @@ package ai.koog.agents.features.tracing.writer
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.ReceivedToolResults
 import ai.koog.agents.core.dsl.extension.ToolCalls
-import ai.koog.agents.core.dsl.extension.asUserMessage
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
 import ai.koog.agents.core.dsl.extension.onTextMessage
@@ -105,10 +104,10 @@ class TraceFeatureMessageLogWriterTest {
 
             val strategy = strategy(strategyName) {
                 val nodeSendInput by nodeLLMRequest("test-llm-call")
-                val nodeExecuteTool by nodeExecuteToolsAndGetResults("test-tool-call")
+                val nodeExecuteTool by nodeExecuteTools("test-tool-call")
                 val nodeSendToolResult by nodeLLMSendToolResults("test-node-llm-send-tool-result")
 
-                edge(nodeStart forwardTo nodeSendInput asUserMessage { it })
+                edge(nodeStart forwardTo nodeSendInput)
                 edge(nodeSendInput forwardTo nodeExecuteTool onToolCalls { true })
                 edge(nodeSendInput forwardTo nodeFinish onTextMessage { true })
                 edge(nodeExecuteTool forwardTo nodeSendToolResult)
@@ -178,7 +177,6 @@ class TraceFeatureMessageLogWriterTest {
                 )
             )
 
-            val userMessageEncoded = serializer.encodeToJSONElement(userPromptMessage, typeToken<Message.User>())
             val toolCallMessageEncoded = serializer.encodeToJSONElement(toolCallAssistant, typeToken<Message.Assistant>())
             val toolCallsEncoded = serializer.encodeToJSONElement(ToolCalls(listOf(toolCallPart)), typeToken<ToolCalls>())
             val toolResultsEncoded = serializer.encodeToJSONElement(toolResultsValue, typeToken<ReceivedToolResults>())
@@ -200,10 +198,10 @@ class TraceFeatureMessageLogWriterTest {
                 "[INFO] Received feature message [event]: ${GraphStrategyStartingEvent::class.simpleName} (run id: $runId, strategy: $strategyName)",
                 "[INFO] Received feature message [event]: ${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: __start__, input: \"$userPrompt\")",
                 "[INFO] Received feature message [event]: ${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: __start__, input: \"$userPrompt\", output: \"$userPrompt\")",
-                "[INFO] Received feature message [event]: ${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: test-llm-call, input: $userMessageEncoded)",
+                "[INFO] Received feature message [event]: ${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: test-llm-call, input: \"$userPrompt\")",
                 "[INFO] Received feature message [event]: ${LLMCallStartingEvent::class.simpleName} (run id: $runId, prompt: $expectedPromptFirstCall, model: ${testModel.toModelInfo().modelIdentifierName}, tools: [$dummyToolName])",
                 "[INFO] Received feature message [event]: ${LLMCallCompletedEvent::class.simpleName} (run id: $runId, prompt: $expectedPromptFirstCall, model: ${testModel.toModelInfo().modelIdentifierName}, response: ${toolCallAssistant.traceString}])",
-                "[INFO] Received feature message [event]: ${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: test-llm-call, input: $userMessageEncoded, output: $toolCallMessageEncoded)",
+                "[INFO] Received feature message [event]: ${NodeExecutionCompletedEvent::class.simpleName} (run id: $runId, node: test-llm-call, input: \"$userPrompt\", output: $toolCallMessageEncoded)",
                 "[INFO] Received feature message [event]: ${NodeExecutionStartingEvent::class.simpleName} (run id: $runId, node: test-tool-call, input: $toolCallsEncoded)",
                 "[INFO] Received feature message [event]: ${ToolCallStartingEvent::class.simpleName} (run id: $runId, tool: $dummyToolName, tool args: $dummyToolArgsEncoded)",
                 "[INFO] Received feature message [event]: ${ToolCallCompletedEvent::class.simpleName} (run id: $runId, tool: $dummyToolName, tool args: $dummyToolArgsEncoded, description: $dummyToolDescription, result: $dummyToolResultEncoded)",
@@ -297,8 +295,8 @@ class TraceFeatureMessageLogWriterTest {
                 val llmCallNode by nodeLLMRequest("test LLM call")
                 val llmCallWithToolsNode by nodeLLMRequest("test LLM call with tools")
 
-                edge(nodeStart forwardTo llmCallNode asUserMessage { "Test LLM call prompt" })
-                edge(llmCallNode forwardTo llmCallWithToolsNode asUserMessage { "Test LLM call with tools prompt" })
+                edge(nodeStart forwardTo llmCallNode transformed { "Test LLM call prompt" })
+                edge(llmCallNode forwardTo llmCallWithToolsNode transformed { "Test LLM call with tools prompt" })
                 edge(llmCallWithToolsNode forwardTo nodeFinish transformed { "Done" })
             }
 
@@ -325,8 +323,8 @@ class TraceFeatureMessageLogWriterTest {
                 val llmCallNode by nodeLLMRequest("test LLM call")
                 val llmCallWithToolsNode by nodeLLMRequest("test LLM call with tools")
 
-                edge(nodeStart forwardTo llmCallNode asUserMessage { "Test LLM call prompt" })
-                edge(llmCallNode forwardTo llmCallWithToolsNode asUserMessage { "Test LLM call with tools prompt" })
+                edge(nodeStart forwardTo llmCallNode transformed { "Test LLM call prompt" })
+                edge(llmCallNode forwardTo llmCallWithToolsNode transformed { "Test LLM call with tools prompt" })
                 edge(llmCallWithToolsNode forwardTo nodeFinish transformed { "Done" })
             }
 
@@ -390,10 +388,10 @@ class TraceFeatureMessageLogWriterTest {
 
             val strategy = strategy(strategyName) {
                 val nodeSendInput by nodeLLMRequest("test-llm-call")
-                val nodeExecuteTool by nodeExecuteToolsAndGetResults("test-tool-call")
+                val nodeExecuteTool by nodeExecuteTools("test-tool-call")
                 val nodeSendToolResult by nodeLLMSendToolResults("test-node-llm-send-tool-result")
 
-                edge(nodeStart forwardTo nodeSendInput asUserMessage { it })
+                edge(nodeStart forwardTo nodeSendInput)
                 edge(nodeSendInput forwardTo nodeExecuteTool onToolCalls { true })
                 edge(nodeSendInput forwardTo nodeFinish onTextMessage { true })
                 edge(nodeExecuteTool forwardTo nodeSendToolResult)

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageRemoteWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageRemoteWriterTest.kt
@@ -3,8 +3,7 @@ package ai.koog.agents.features.tracing.writer
 import ai.koog.agents.core.agent.entity.AIAgentSubgraphBase.Companion.FINISH_NODE_PREFIX
 import ai.koog.agents.core.agent.entity.AIAgentSubgraphBase.Companion.START_NODE_PREFIX
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
 import ai.koog.agents.core.dsl.extension.onTextMessage
@@ -130,8 +129,8 @@ class TraceFeatureMessageRemoteWriterTest {
                     val llmCallNode by nodeLLMRequest("test LLM call")
                     val llmCallWithToolsNode by nodeLLMRequest("test LLM call with tools")
 
-                    edge(nodeStart forwardTo llmCallNode asUserMessage { "Test LLM call prompt" })
-                    edge(llmCallNode forwardTo llmCallWithToolsNode asUserMessage { "Test LLM call with tools prompt" })
+                    edge(nodeStart forwardTo llmCallNode transformed { "Test LLM call prompt" })
+                    edge(llmCallNode forwardTo llmCallWithToolsNode transformed { "Test LLM call with tools prompt" })
                     edge(llmCallWithToolsNode forwardTo nodeFinish transformed { "Done" })
                 }
 
@@ -236,10 +235,10 @@ class TraceFeatureMessageRemoteWriterTest {
             TraceFeatureMessageRemoteWriter(connectionConfig = serverConfig).use { writer ->
                 val strategy = strategy(strategyName) {
                     val nodeSendInput by nodeLLMRequest("test-llm-call")
-                    val nodeExecuteTool by nodeExecuteToolsAndGetResults("test-tool-call")
+                    val nodeExecuteTool by nodeExecuteTools("test-tool-call")
                     val nodeSendToolResult by nodeLLMSendToolResults("test-node-llm-send-tool-result")
 
-                    edge(nodeStart forwardTo nodeSendInput asUserMessage { it })
+                    edge(nodeStart forwardTo nodeSendInput)
                     edge(nodeSendInput forwardTo nodeExecuteTool onToolCalls { true })
                     edge(nodeSendInput forwardTo nodeFinish onTextMessage { true })
                     edge(nodeExecuteTool forwardTo nodeSendToolResult)
@@ -630,9 +629,9 @@ class TraceFeatureMessageRemoteWriterTest {
                         val llmCallNode by nodeLLMRequest("test LLM call")
                         val llmCallWithToolsNode by nodeLLMRequest("test LLM call with tools")
 
-                        edge(nodeStart forwardTo llmCallNode asUserMessage { "Test LLM call prompt" })
+                        edge(nodeStart forwardTo llmCallNode transformed { "Test LLM call prompt" })
                         edge(
-                            llmCallNode forwardTo llmCallWithToolsNode asUserMessage {
+                            llmCallNode forwardTo llmCallWithToolsNode transformed {
                                 "Test LLM call with tools prompt"
                             }
                         )
@@ -773,10 +772,10 @@ class TraceFeatureMessageRemoteWriterTest {
             TraceFeatureMessageRemoteWriter(connectionConfig = serverConfig).use { writer ->
                 val strategy = strategy(strategyName) {
                     val nodeSendInput by nodeLLMRequest(nodeSendInputName)
-                    val nodeExecuteTool by nodeExecuteToolsAndGetResults(nodeExecuteToolName)
+                    val nodeExecuteTool by nodeExecuteTools(nodeExecuteToolName)
                     val nodeSendToolResult by nodeLLMSendToolResults(nodeSendToolResultName)
 
-                    edge(nodeStart forwardTo nodeSendInput asUserMessage { it })
+                    edge(nodeStart forwardTo nodeSendInput)
                     edge(nodeSendInput forwardTo nodeExecuteTool onToolCalls { true })
                     edge(nodeSendInput forwardTo nodeFinish onTextMessage { true })
                     edge(nodeExecuteTool forwardTo nodeSendToolResult)

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
@@ -7,6 +7,7 @@ import ai.koog.agents.core.dsl.builder.subgraph
 import ai.koog.agents.core.dsl.extension.ToolCalls
 import ai.koog.agents.core.dsl.extension.nodeAppendPrompt
 import ai.koog.agents.core.dsl.extension.nodeExecuteTools
+import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreaming
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestWithoutTools
 import ai.koog.agents.core.feature.model.AIAgentError
@@ -632,7 +633,7 @@ class TraceFeatureMessageTestWriterTest {
         val strategy = strategy<String, String>(strategyName) {
             val call by nodeLLMRequest(nodeCallFailedName)
 
-            edge(nodeStart forwardTo call asUserMessage { it })
+            edge(nodeStart forwardTo call)
             edge(
                 call forwardTo nodeFinish transformed { input ->
                     input.parts.filterIsInstance<MessagePart.Text>().joinToString("\n") { it.text }

--- a/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
+++ b/agents/agents-features/agents-features-trace/src/jvmTest/kotlin/ai/koog/agents/features/tracing/writer/TraceFeatureMessageTestWriterTest.kt
@@ -5,10 +5,8 @@ import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.builder.subgraph
 import ai.koog.agents.core.dsl.extension.ToolCalls
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeAppendPrompt
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
-import ai.koog.agents.core.dsl.extension.nodeLLMRequest
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreaming
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestWithoutTools
 import ai.koog.agents.core.feature.model.AIAgentError
@@ -91,9 +89,9 @@ class TraceFeatureMessageTestWriterTest {
             val llmRequest1 by nodeLLMRequestWithoutTools("LLM Request 2")
 
             edge(nodeStart forwardTo setPrompt)
-            edge(setPrompt forwardTo llmRequest0 asUserMessage { it })
+            edge(setPrompt forwardTo llmRequest0)
             edge(llmRequest0 forwardTo appendPrompt transformed { _ -> "" })
-            edge(appendPrompt forwardTo llmRequest1 asUserMessage { "" })
+            edge(appendPrompt forwardTo llmRequest1 transformed { "" })
             edge(
                 llmRequest1 forwardTo nodeFinish transformed { input ->
                     input.parts.filterIsInstance<MessagePart.Text>().joinToString("\n") { it.text }
@@ -137,7 +135,7 @@ class TraceFeatureMessageTestWriterTest {
         val toolName = "there is no tool with this name"
         val rawToolArgs = "{}"
         val strategy = strategy<String, String>("tracing-tool-call-test") {
-            val callTool by nodeExecuteToolsAndGetResults("Tool call")
+            val callTool by nodeExecuteTools("Tool call")
             edge(
                 nodeStart forwardTo callTool transformed { _ ->
                     ToolCalls(
@@ -179,7 +177,7 @@ class TraceFeatureMessageTestWriterTest {
     @Test
     fun `test existing tool call`() = runBlocking {
         val strategy = strategy<String, String>("tracing-tool-call-test") {
-            val callTool by nodeExecuteToolsAndGetResults("Tool call")
+            val callTool by nodeExecuteTools("Tool call")
             edge(
                 nodeStart forwardTo callTool transformed { _ ->
                     ToolCalls(
@@ -218,7 +216,7 @@ class TraceFeatureMessageTestWriterTest {
     @Test
     fun `test recursive tool call`() = runBlocking {
         val strategy = strategy<String, String>("recursive-tool-call-test") {
-            val callTool by nodeExecuteToolsAndGetResults("Tool call")
+            val callTool by nodeExecuteTools("Tool call")
             edge(
                 nodeStart forwardTo callTool transformed { _ ->
                     ToolCalls(
@@ -260,7 +258,7 @@ class TraceFeatureMessageTestWriterTest {
         val dummyTool = DummyTool()
 
         val strategy = strategy<String, String>("llm-tool-call-test") {
-            val callTool by nodeExecuteToolsAndGetResults("Tool call")
+            val callTool by nodeExecuteTools("Tool call")
             edge(
                 nodeStart forwardTo callTool transformed { _ ->
                     ToolCalls(
@@ -382,7 +380,7 @@ class TraceFeatureMessageTestWriterTest {
         val strategy = strategy<String, String>(strategyName) {
             val streamAndCollect by nodeLLMRequestStreaming(nodeLLMRequestStreamingName)
 
-            edge(nodeStart forwardTo streamAndCollect asUserMessage { it })
+            edge(nodeStart forwardTo streamAndCollect)
             edge(streamAndCollect forwardTo nodeFinish transformed { it.collectText() })
         }
 
@@ -499,7 +497,7 @@ class TraceFeatureMessageTestWriterTest {
         val strategy = strategy<String, String>(strategyName) {
             val streamAndCollect by nodeLLMRequestStreaming(nodeStreamingFailedName)
 
-            edge(nodeStart forwardTo streamAndCollect asUserMessage { it })
+            edge(nodeStart forwardTo streamAndCollect)
             edge(streamAndCollect forwardTo nodeFinish transformed { it.collectText() })
         }
 

--- a/agents/agents-test/src/commonTest/kotlin/ai/koog/agents/testing/feature/GraphTestingFeatureTest.kt
+++ b/agents/agents-test/src/commonTest/kotlin/ai/koog/agents/testing/feature/GraphTestingFeatureTest.kt
@@ -6,7 +6,7 @@ import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.builder.subgraph
 import ai.koog.agents.core.dsl.extension.nodeExecuteSingleTool
-import ai.koog.agents.core.dsl.extension.nodeLLMRequestWithUserText
+import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.onToolCalls
 import ai.koog.agents.core.environment.ReceivedToolResult
 import ai.koog.agents.core.tools.ToolRegistry
@@ -33,7 +33,7 @@ class GraphTestingFeatureTest {
                 name = "first",
                 tools = listOf(DummyTool, CreateTool, SolveTool)
             ) {
-                val callLLM by nodeLLMRequestWithUserText(name = "callLLM")
+                val callLLM by nodeLLMRequest(name = "callLLM")
                 val executeTool by nodeExecuteSingleTool(name = "executeTool")
                 val giveFeedback by node<Any?, Any?>("giveFeedback") { input ->
                     llm.writeSession {

--- a/docs/docs/agents/graph-based-agents.md
+++ b/docs/docs/agents/graph-based-agents.md
@@ -87,10 +87,10 @@ provide a unique identifier for the strategy, and define the nodes and edges.
     ```kotlin
     val calculatorAgentStrategy = strategy<String, String>("Simple calculator") {
         val nodeSendInput by nodeLLMRequest()
-        val nodeExecuteTool by nodeExecuteToolsAndGetResults()
+        val nodeExecuteTool by nodeExecuteTools()
         val nodeSendToolResult by nodeLLMSendToolResults()
         
-        edge(nodeStart forwardTo nodeSendInput asUserMessage { it })
+        edge(nodeStart forwardTo nodeSendInput)
         edge(nodeSendInput forwardTo nodeFinish onTextMessage { true })
         edge(nodeSendInput forwardTo nodeExecuteTool onToolCalls { true })
         edge(nodeExecuteTool forwardTo nodeSendToolResult)
@@ -123,12 +123,11 @@ provide a unique identifier for the strategy, and define the nodes and edges.
 
     var nodeSendInput = AIAgentNode.llmRequest("nodeSendInput");
     var nodeExecuteTool = AIAgentNode.executeTools("nodeExecuteTool");
-    var nodeSendToolResult = AIAgentNode.llmRequest("nodeSendToolResult");
+    var nodeSendToolResult = AIAgentNode.llmSendToolResults("nodeSendToolResult");
 
     calculatorAgentStrategy.edge(AIAgentEdge.builder()
         .from(calculatorAgentStrategy.nodeStart)
         .to(nodeSendInput)
-        .asUserMessage(input -> input)
         .build());
     calculatorAgentStrategy.edge(AIAgentEdge.builder()
         .from(nodeSendInput)
@@ -138,7 +137,7 @@ provide a unique identifier for the strategy, and define the nodes and edges.
     calculatorAgentStrategy.edge(AIAgentEdge.builder()
         .from(nodeSendInput)
         .to(nodeExecuteTool)
-        .onToolCalls(call -> true)
+        .onToolCalls()
         .build());
     calculatorAgentStrategy.edge(nodeExecuteTool, nodeSendToolResult);
     calculatorAgentStrategy.edge(AIAgentEdge.builder()
@@ -149,7 +148,7 @@ provide a unique identifier for the strategy, and define the nodes and edges.
     calculatorAgentStrategy.edge(AIAgentEdge.builder()
         .from(nodeSendToolResult)
         .to(nodeExecuteTool)
-        .onToolCalls(call -> true)
+        .onToolCalls()
         .build());
     ```
     <!--- KNIT exampleGraphAgentsJava01.java -->
@@ -212,7 +211,7 @@ Let's create an agent instance with this strategy and run it:
     import ai.koog.agents.core.dsl.builder.forwardTo
     import ai.koog.agents.core.dsl.builder.strategy
     import ai.koog.agents.core.dsl.extension.*
-    import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+    import ai.koog.agents.core.dsl.extension.nodeExecuteTools
     import ai.koog.agents.core.dsl.extension.nodeLLMRequest
     import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
     import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
@@ -222,10 +221,10 @@ Let's create an agent instance with this strategy and run it:
     ```kotlin
     val calculatorAgentStrategy = strategy<String, String>("Simple calculator") {
         val nodeSendInput by nodeLLMRequest()
-        val nodeExecuteTool by nodeExecuteToolsAndGetResults()
+        val nodeExecuteTool by nodeExecuteTools()
         val nodeSendToolResult by nodeLLMSendToolResults()
     
-        edge(nodeStart forwardTo nodeSendInput asUserMessage { it })
+        edge(nodeStart forwardTo nodeSendInput)
         edge(nodeSendInput forwardTo nodeFinish onTextMessage { true })
         edge(nodeSendInput forwardTo nodeExecuteTool onToolCalls { true })
         edge(nodeExecuteTool forwardTo nodeSendToolResult)
@@ -272,12 +271,11 @@ Let's create an agent instance with this strategy and run it:
 
     var nodeSendInput = AIAgentNode.llmRequest("nodeSendInput");
     var nodeExecuteTool = AIAgentNode.executeTools("nodeExecuteTool");
-    var nodeSendToolResult = AIAgentNode.llmRequest("nodeSendToolResult");
+    var nodeSendToolResult = AIAgentNode.llmSendToolResults("nodeSendToolResult");
 
     calculatorAgentStrategy.edge(AIAgentEdge.builder()
         .from(calculatorAgentStrategy.nodeStart)
         .to(nodeSendInput)
-        .asUserMessage(input -> input)
         .build());
     calculatorAgentStrategy.edge(AIAgentEdge.builder()
         .from(nodeSendInput)
@@ -287,7 +285,7 @@ Let's create an agent instance with this strategy and run it:
     calculatorAgentStrategy.edge(AIAgentEdge.builder()
         .from(nodeSendInput)
         .to(nodeExecuteTool)
-        .onToolCalls(call -> true)
+        .onToolCalls()
         .build());
     calculatorAgentStrategy.edge(nodeExecuteTool, nodeSendToolResult);
     calculatorAgentStrategy.edge(AIAgentEdge.builder()
@@ -298,7 +296,7 @@ Let's create an agent instance with this strategy and run it:
     calculatorAgentStrategy.edge(AIAgentEdge.builder()
         .from(nodeSendToolResult)
         .to(nodeExecuteTool)
-        .onToolCalls(call -> true)
+        .onToolCalls()
         .build());
 
     var promptExecutor = PromptExecutor.builder()
@@ -447,7 +445,7 @@ Add the tool registry to the agent configuration:
     import ai.koog.agents.core.dsl.builder.forwardTo
     import ai.koog.agents.core.dsl.builder.strategy
     import ai.koog.agents.core.dsl.extension.*
-    import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+    import ai.koog.agents.core.dsl.extension.nodeExecuteTools
     import ai.koog.agents.core.dsl.extension.nodeLLMRequest
     import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
     import ai.koog.agents.core.tools.ToolRegistry
@@ -482,10 +480,10 @@ Add the tool registry to the agent configuration:
     
     val calculatorAgentStrategy = strategy<String, String>("Simple calculator") {
         val nodeSendInput by nodeLLMRequest()
-        val nodeExecuteTool by nodeExecuteToolsAndGetResults()
+        val nodeExecuteTool by nodeExecuteTools()
         val nodeSendToolResult by nodeLLMSendToolResults()
     
-        edge(nodeStart forwardTo nodeSendInput asUserMessage { it })
+        edge(nodeStart forwardTo nodeSendInput)
         edge(nodeSendInput forwardTo nodeFinish onTextMessage { true })
         edge(nodeSendInput forwardTo nodeExecuteTool onToolCalls { true })
         edge(nodeExecuteTool forwardTo nodeSendToolResult)
@@ -551,11 +549,10 @@ Add the tool registry to the agent configuration:
                 .withOutput(String.class);
             var nodeSendInput = AIAgentNode.llmRequest("nodeSendInput");
             var nodeExecuteTool = AIAgentNode.executeTools("nodeExecuteTool");
-            var nodeSendToolResult = AIAgentNode.llmRequest("nodeSendToolResult");
+            var nodeSendToolResult = AIAgentNode.llmSendToolResults("nodeSendToolResult");
             calculatorAgentStrategy.edge(AIAgentEdge.builder()
                 .from(calculatorAgentStrategy.nodeStart)
                 .to(nodeSendInput)
-                .asUserMessage(input -> input)
                 .build());
             calculatorAgentStrategy.edge(AIAgentEdge.builder()
                 .from(nodeSendInput)
@@ -565,7 +562,7 @@ Add the tool registry to the agent configuration:
             calculatorAgentStrategy.edge(AIAgentEdge.builder()
                 .from(nodeSendInput)
                 .to(nodeExecuteTool)
-                .onToolCalls(call -> true)
+                .onToolCalls()
                 .build());
             calculatorAgentStrategy.edge(nodeExecuteTool, nodeSendToolResult);
             calculatorAgentStrategy.edge(AIAgentEdge.builder()
@@ -576,7 +573,7 @@ Add the tool registry to the agent configuration:
             calculatorAgentStrategy.edge(AIAgentEdge.builder()
                 .from(nodeSendToolResult)
                 .to(nodeExecuteTool)
-                .onToolCalls(call -> true)
+                .onToolCalls()
                 .build());
             var promptExecutor = PromptExecutor.builder()
                 .ollama("http://localhost:11434")
@@ -630,7 +627,7 @@ In our example, it is important to describe how the agent should process complex
     import ai.koog.agents.core.dsl.builder.forwardTo
     import ai.koog.agents.core.dsl.builder.strategy
     import ai.koog.agents.core.dsl.extension.*
-    import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+    import ai.koog.agents.core.dsl.extension.nodeExecuteTools
     import ai.koog.agents.core.dsl.extension.nodeLLMRequest
     import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
     import ai.koog.agents.core.tools.ToolRegistry
@@ -665,10 +662,10 @@ In our example, it is important to describe how the agent should process complex
     
     val calculatorAgentStrategy = strategy<String, String>("Simple calculator") {
         val nodeSendInput by nodeLLMRequest()
-        val nodeExecuteTool by nodeExecuteToolsAndGetResults()
+        val nodeExecuteTool by nodeExecuteTools()
         val nodeSendToolResult by nodeLLMSendToolResults()
     
-        edge(nodeStart forwardTo nodeSendInput asUserMessage { it })
+        edge(nodeStart forwardTo nodeSendInput)
         edge(nodeSendInput forwardTo nodeFinish onTextMessage { true })
         edge(nodeSendInput forwardTo nodeExecuteTool onToolCalls { true })
         edge(nodeExecuteTool forwardTo nodeSendToolResult)
@@ -741,11 +738,10 @@ In our example, it is important to describe how the agent should process complex
                 .withOutput(String.class); 
             var nodeSendInput = AIAgentNode.llmRequest("nodeSendInput");
             var nodeExecuteTool = AIAgentNode.executeTools("nodeExecuteTool");
-            var nodeSendToolResult = AIAgentNode.llmRequest("nodeSendToolResult"); 
+            var nodeSendToolResult = AIAgentNode.llmSendToolResults("nodeSendToolResult"); 
             calculatorAgentStrategy.edge(AIAgentEdge.builder()
                 .from(calculatorAgentStrategy.nodeStart)
                 .to(nodeSendInput)
-                .asUserMessage(input -> input)
                 .build());
             calculatorAgentStrategy.edge(AIAgentEdge.builder()
                 .from(nodeSendInput)
@@ -755,7 +751,7 @@ In our example, it is important to describe how the agent should process complex
             calculatorAgentStrategy.edge(AIAgentEdge.builder()
                 .from(nodeSendInput)
                 .to(nodeExecuteTool)
-                .onToolCalls(call -> true)
+                .onToolCalls()
                 .build());
             calculatorAgentStrategy.edge(nodeExecuteTool, nodeSendToolResult);
             calculatorAgentStrategy.edge(AIAgentEdge.builder()
@@ -766,7 +762,7 @@ In our example, it is important to describe how the agent should process complex
             calculatorAgentStrategy.edge(AIAgentEdge.builder()
                 .from(nodeSendToolResult)
                 .to(nodeExecuteTool)
-                .onToolCalls(call -> true)
+                .onToolCalls()
                 .build());
             var promptExecutor = PromptExecutor.builder()
                 .ollama("http://localhost:11434")

--- a/docs/docs/custom-strategy-graphs.md
+++ b/docs/docs/custom-strategy-graphs.md
@@ -303,8 +303,7 @@ Here is an example of a basic strategy graph:
     import ai.koog.agents.core.dsl.builder.node
     import ai.koog.agents.core.dsl.builder.parallel
     import ai.koog.agents.core.dsl.builder.subgraph
-    import ai.koog.agents.core.dsl.extension.asUserMessage
-    import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+    import ai.koog.agents.core.dsl.extension.nodeExecuteTools
     import ai.koog.agents.core.dsl.extension.nodeLLMRequest
     import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
     import ai.koog.agents.core.dsl.extension.onTextMessage
@@ -313,10 +312,10 @@ Here is an example of a basic strategy graph:
     ```kotlin
     val myStrategy = strategy<String, String>("my-strategy") {
         val nodeCallLLM by nodeLLMRequest()
-        val executeToolCall by nodeExecuteToolsAndGetResults()
+        val executeToolCall by nodeExecuteTools()
         val sendToolResult by nodeLLMSendToolResults()
     
-        edge(nodeStart forwardTo nodeCallLLM asUserMessage { it })
+        edge(nodeStart forwardTo nodeCallLLM)
         edge(nodeCallLLM forwardTo nodeFinish onTextMessage { true })
         edge(nodeCallLLM forwardTo executeToolCall onToolCalls { true })
         edge(executeToolCall forwardTo sendToolResult)
@@ -349,18 +348,17 @@ Here is an example of a basic strategy graph:
 
     var nodeCallLLM = AIAgentNode.llmRequest("sendInput");
     var nodeExecuteTool = AIAgentNode.executeTools("nodeExecuteTool");
-    var nodeSendToolResult = AIAgentNode.llmRequest("nodeSendToolResult");
+    var nodeSendToolResult = AIAgentNode.llmSendToolResults("nodeSendToolResult");
 
     graph.edge(AIAgentEdge.builder()
         .from(graph.nodeStart)
         .to(nodeCallLLM)
-        .asUserMessage(input -> input)
         .build());
 
     graph.edge(AIAgentEdge.builder()
         .from(nodeCallLLM)
         .to(nodeExecuteTool)
-        .onToolCalls(call -> true)
+        .onToolCalls()
         .build());
 
     graph.edge(AIAgentEdge.builder()
@@ -380,7 +378,7 @@ Here is an example of a basic strategy graph:
     graph.edge(AIAgentEdge.builder()
         .from(nodeSendToolResult)
         .to(nodeExecuteTool)
-        .onToolCalls(call -> true)
+        .onToolCalls()
         .build());
 
     var strategy = graph.build();
@@ -402,8 +400,7 @@ For the graph created in the previous example, you can run:
     import ai.koog.agents.core.dsl.builder.node
     import ai.koog.agents.core.dsl.builder.parallel
     import ai.koog.agents.core.dsl.builder.subgraph
-    import ai.koog.agents.core.dsl.extension.asUserMessage
-    import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+    import ai.koog.agents.core.dsl.extension.nodeExecuteTools
     import ai.koog.agents.core.dsl.extension.nodeLLMRequest
     import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
     import ai.koog.agents.core.dsl.extension.onTextMessage
@@ -411,9 +408,9 @@ For the graph created in the previous example, you can run:
     fun main() {
         val myStrategy = strategy<String, String>("my-strategy") {
             val nodeCallLLM by nodeLLMRequest()
-            val executeToolCall by nodeExecuteToolsAndGetResults()
+            val executeToolCall by nodeExecuteTools()
             val sendToolResult by nodeLLMSendToolResults()
-            edge(nodeStart forwardTo nodeCallLLM asUserMessage { it })
+            edge(nodeStart forwardTo nodeCallLLM)
             edge(nodeCallLLM forwardTo nodeFinish onTextMessage { true })
             edge(nodeCallLLM forwardTo executeToolCall onToolCalls { true })
             edge(executeToolCall forwardTo sendToolResult)
@@ -481,7 +478,7 @@ For long-running conversations, the history can grow large and consume a lot of 
 
 ### Parallel tool execution
 
-For workflows that require executing multiple tools in parallel, you can use the `nodeExecuteToolsAndGetResults` node with `parallel = true`:
+For workflows that require executing multiple tools in parallel, you can use the `nodeExecuteTools` node with `parallel = true`:
 
 <!--- INCLUDE
 import ai.koog.agents.core.dsl.builder.forwardTo
@@ -490,7 +487,7 @@ import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.parallel
 import ai.koog.agents.core.dsl.builder.subgraph
 import ai.koog.agents.core.dsl.extension.ToolCalls
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
 
 val strategy = strategy<String, String>("strategy_name") {
@@ -500,7 +497,7 @@ val strategy = strategy<String, String>("strategy_name") {
 }
 -->
 ```kotlin
-val executeMultipleTools by nodeExecuteToolsAndGetResults(parallel = true)
+val executeMultipleTools by nodeExecuteTools(parallel = true)
 val processMultipleResults by nodeLLMSendToolResults()
 
 edge(someNode forwardTo executeMultipleTools)
@@ -624,8 +621,7 @@ import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.parallel
 import ai.koog.agents.core.dsl.builder.subgraph
 import ai.koog.agents.core.dsl.extension.ReceivedToolResults
-import ai.koog.agents.core.dsl.extension.asUserMessage
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
@@ -637,12 +633,12 @@ import ai.koog.agents.core.tools.ToolRegistry
 fun toneStrategy(name: String, toolRegistry: ToolRegistry): AIAgentGraphStrategy<String, String> {
     return strategy(name) {
         val nodeSendInput by nodeLLMRequest()
-        val nodeExecuteTool by nodeExecuteToolsAndGetResults()
+        val nodeExecuteTool by nodeExecuteTools()
         val nodeSendToolResult by nodeLLMSendToolResults()
         val nodeCompressHistory by nodeLLMCompressHistory<ReceivedToolResults>()
 
         // Define the flow of the agent
-        edge(nodeStart forwardTo nodeSendInput asUserMessage { it })
+        edge(nodeStart forwardTo nodeSendInput)
 
         // If the LLM responds with a message, finish
         edge(

--- a/docs/docs/custom-subgraphs.md
+++ b/docs/docs/custom-subgraphs.md
@@ -165,10 +165,10 @@ The following code sample shows an actual implementation of a custom subgraph:
        ) {
             // Define nodes and edges for this subgraph
             val sendInput by nodeLLMRequest()
-            val executeToolCall by nodeExecuteToolsAndGetResults()
+            val executeToolCall by nodeExecuteTools()
             val sendToolResult by nodeLLMSendToolResults()
 
-            edge(nodeStart forwardTo sendInput asUserMessage { it })
+            edge(nodeStart forwardTo sendInput)
             edge(sendInput forwardTo executeToolCall onToolCalls { true })
             edge(executeToolCall forwardTo sendToolResult)
             edge(sendToolResult forwardTo nodeFinish onTextMessage { true })
@@ -206,7 +206,7 @@ The following code sample shows an actual implementation of a custom subgraph:
 
     var sendInput = AIAgentNode.llmRequest(null);
     var executeToolCall = AIAgentNode.executeTools(null);
-    var sendToolResult = AIAgentNode.llmRequest(null);
+    var sendToolResult = AIAgentNode.llmSendToolResults(null);
 
     var mySubgraph = AIAgentSubgraph.builder()
         .limitedTools(List.of(firstTool, secondTool))
@@ -218,13 +218,12 @@ The following code sample shows an actual implementation of a custom subgraph:
                 .edge(AIAgentEdge.builder()
                     .from(subgraph.nodeStart)
                     .to(sendInput)
-                    .asUserMessage(input -> input)
                     .build()
                 )
                 .edge(AIAgentEdge.builder()
                     .from(sendInput)
                     .to(executeToolCall)
-                    .onToolCalls(call -> true)
+                    .onToolCalls()
                     .build()
                 )
                 .edge(executeToolCall, sendToolResult)
@@ -561,8 +560,7 @@ The code sample includes three defined subgraphs, `researchSubgraph`, `planSubgr
     import ai.koog.agents.core.dsl.builder.strategy
     import ai.koog.agents.core.dsl.builder.node
     import ai.koog.agents.core.dsl.builder.subgraph
-    import ai.koog.agents.core.dsl.extension.asUserMessage
-    import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+    import ai.koog.agents.core.dsl.extension.nodeExecuteTools
     import ai.koog.agents.core.dsl.extension.nodeLLMRequest
     import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
     import ai.koog.agents.core.dsl.extension.onTextMessage
@@ -616,10 +614,10 @@ The code sample includes three defined subgraphs, `researchSubgraph`, `planSubgr
             tools = listOf(WebSearchTool())
         ) {
             val nodeCallLLM by nodeLLMRequest("call_llm")
-            val nodeExecuteTool by nodeExecuteToolsAndGetResults()
+            val nodeExecuteTool by nodeExecuteTools()
             val nodeSendToolResult by nodeLLMSendToolResults()
 
-            edge(nodeStart forwardTo nodeCallLLM asUserMessage { it })
+            edge(nodeStart forwardTo nodeCallLLM)
             edge(nodeCallLLM forwardTo nodeExecuteTool onToolCalls { true })
             edge(nodeExecuteTool forwardTo nodeSendToolResult)
             edge(nodeSendToolResult forwardTo nodeExecuteTool onToolCalls { true })
@@ -646,7 +644,7 @@ The code sample includes three defined subgraphs, `researchSubgraph`, `planSubgr
             val nodeCallLLM by nodeLLMRequest("call_llm")
 
             edge(nodeStart forwardTo nodeUpdatePrompt)
-            edge(nodeUpdatePrompt forwardTo nodeCallLLM transformed { "Task: $agentInput" } asUserMessage { it })
+            edge(nodeUpdatePrompt forwardTo nodeCallLLM transformed { "Task: $agentInput" })
             edge(nodeCallLLM forwardTo nodeFinish onTextMessage { true })
         }
 
@@ -669,11 +667,11 @@ The code sample includes three defined subgraphs, `researchSubgraph`, `planSubgr
                 }
             }
             val nodeCallLLM by nodeLLMRequest("call_llm")
-            val nodeExecuteTool by nodeExecuteToolsAndGetResults()
+            val nodeExecuteTool by nodeExecuteTools()
             val nodeSendToolResult by nodeLLMSendToolResults()
 
             edge(nodeStart forwardTo nodeUpdatePrompt)
-            edge(nodeUpdatePrompt forwardTo nodeCallLLM transformed { "Task: $agentInput" } asUserMessage { it })
+            edge(nodeUpdatePrompt forwardTo nodeCallLLM transformed { "Task: $agentInput" })
             edge(nodeCallLLM forwardTo nodeExecuteTool onToolCalls { true })
             edge(nodeExecuteTool forwardTo nodeSendToolResult)
             edge(nodeSendToolResult forwardTo nodeExecuteTool onToolCalls { true })
@@ -735,7 +733,7 @@ The code sample includes three defined subgraphs, `researchSubgraph`, `planSubgr
     // A subgraph that includes a tool call
     var nodeCallLLM = AIAgentNode.llmRequest(null);
     var nodeExecuteTool = AIAgentNode.executeTools(null);
-    var nodeSendToolResult = AIAgentNode.llmRequest(null);
+    var nodeSendToolResult = AIAgentNode.llmSendToolResults(null);
 
     var researchSubgraph = AIAgentSubgraph.builder("research_subgraph")
         .limitedTools(new WebSearchToolSet())
@@ -746,30 +744,25 @@ The code sample includes three defined subgraphs, `researchSubgraph`, `planSubgr
                 .edge(AIAgentEdge.builder()
                     .from(subgraph.nodeStart)
                     .to(nodeCallLLM)
-                    .asUserMessage(s -> s)
                     .build()
                 )
                 .edge(AIAgentEdge.builder()
                     .from(nodeCallLLM)
                     .to(nodeExecuteTool)
-                    .onToolCalls(call -> true)
+                    .onToolCalls()
                     .build()
                 )
                 .edge(nodeExecuteTool, nodeSendToolResult)
                 .edge(AIAgentEdge.builder()
                     .from(nodeSendToolResult)
                     .to(nodeExecuteTool)
-                    .onToolCalls(call -> true)
+                    .onToolCalls()
                     .build()
                 )
                 .edge(AIAgentEdge.builder()
                     .from(nodeCallLLM)
                     .to(subgraph.nodeFinish)
-                    .onIsInstance(Message.Assistant.class)
-                    .transformed(m -> ((Message.Assistant) m).getParts().stream()
-                        .filter(p -> p instanceof MessagePart.Text)
-                        .map(p -> ((MessagePart.Text) p).getText())
-                        .collect(Collectors.joining()))
+                    .onTextMessage()
                     .build()
                 )
                 .build();
@@ -805,17 +798,12 @@ The code sample includes three defined subgraphs, `researchSubgraph`, `planSubgr
                 .edge(AIAgentEdge.builder()
                     .from(nodeUpdatePrompt)
                     .to(nodeCallLLMPlan)
-                    .asUserMessage(s -> s)
                     .build()
                 )
                 .edge(AIAgentEdge.builder()
                     .from(nodeCallLLMPlan)
                     .to(subgraph.nodeFinish)
-                    .onIsInstance(Message.Assistant.class)
-                    .transformed(m -> ((Message.Assistant) m).getParts().stream()
-                        .filter(p -> p instanceof MessagePart.Text)
-                        .map(p -> ((MessagePart.Text) p).getText())
-                        .collect(Collectors.joining()))
+                    .onTextMessage()
                     .build()
                 )
                 .build();
@@ -843,7 +831,7 @@ The code sample includes three defined subgraphs, `researchSubgraph`, `planSubgr
 
     var nodeCallLLMExecute = AIAgentNode.llmRequest(null);
     var nodeExecuteToolExecute = AIAgentNode.executeTools(null);
-    var nodeSendToolResultExecute = AIAgentNode.llmRequest(null);
+    var nodeSendToolResultExecute = AIAgentNode.llmSendToolResults(null);
 
     var executeSubgraph = AIAgentSubgraph.builder("execute_subgraph")
         .limitedTools(new ActionToolSet())
@@ -855,30 +843,26 @@ The code sample includes three defined subgraphs, `researchSubgraph`, `planSubgr
                 .edge(AIAgentEdge.builder()
                     .from(nodeUpdatePromptExecute)
                     .to(nodeCallLLMExecute)
-                    .asUserMessage(s -> s)
                     .build()
                 )
                 .edge(AIAgentEdge.builder()
                     .from(nodeCallLLMExecute)
                     .to(nodeExecuteToolExecute)
-                    .onToolCalls(call -> true)
+                    .onToolCalls()
                     .build()
                 )
                 .edge(nodeExecuteToolExecute, nodeSendToolResultExecute)
                 .edge(AIAgentEdge.builder()
                     .from(nodeSendToolResultExecute)
                     .to(nodeExecuteToolExecute)
-                    .onToolCalls(call -> true)
+                    .onToolCalls()
                     .build()
                 )
                 .edge(AIAgentEdge.builder()
                     .from(nodeCallLLMExecute)
                     .to(subgraph.nodeFinish)
                     .onIsInstance(Message.Assistant.class)
-                    .transformed(m -> ((Message.Assistant) m).getParts().stream()
-                        .filter(p -> p instanceof MessagePart.Text)
-                        .map(p -> ((MessagePart.Text) p).getText())
-                        .collect(Collectors.joining()))
+                    .onTextMessage()
                     .build()
                 )
                 .build();

--- a/docs/docs/history-compression.md
+++ b/docs/docs/history-compression.md
@@ -58,8 +58,7 @@ Depending on which step you decide to perform compression, the following scenari
     import ai.koog.agents.core.dsl.builder.strategy
     import ai.koog.agents.core.dsl.builder.node
     import ai.koog.agents.core.dsl.builder.subgraph
-    import ai.koog.agents.core.dsl.extension.asUserMessage
-    import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+    import ai.koog.agents.core.dsl.extension.nodeExecuteTools
     import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
     import ai.koog.agents.core.dsl.extension.nodeLLMRequest
     import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
@@ -73,13 +72,13 @@ Depending on which step you decide to perform compression, the following scenari
     
     val strategy = strategy<String, String>("execute-with-history-compression") {
         val callLLM by nodeLLMRequest()
-        val executeTool by nodeExecuteToolsAndGetResults()
+        val executeTool by nodeExecuteTools()
         val sendToolResult by nodeLLMSendToolResults()
     
         // Compress the LLM history and keep the current ReceivedToolResults for the next node
         val compressHistory by nodeLLMCompressHistory<ReceivedToolResults>()
     
-        edge(nodeStart forwardTo callLLM asUserMessage { it })
+        edge(nodeStart forwardTo callLLM)
         edge(callLLM forwardTo nodeFinish onTextMessage { true })
         edge(callLLM forwardTo executeTool onToolCalls { true })
     
@@ -116,19 +115,18 @@ Depending on which step you decide to perform compression, the following scenari
 
     var callLLM = AIAgentNode.llmRequest(null);
     var executeTool = AIAgentNode.executeTools(null);
-    var sendToolResult = AIAgentNode.llmRequest("sendToolResult");
+    var sendToolResult = AIAgentNode.llmSendToolResults(null);
 
-    // Compress the LLM history; the carried Message.User flows into the next node.
+    // Compress the LLM history; the carried ReceivedToolResults flows into the next node.
     var compressHistory = AIAgentNode
         .llmCompressHistory("compressHistory")
-        .withInput(Message.User.class)
+        .withInput(ReceivedToolResults.class)
         .build();
 
     // Edge from start to callLLM
     graph.edge(AIAgentEdge.builder()
         .from(graph.nodeStart)
         .to(callLLM)
-        .asUserMessage(s -> s)
         .build());
 
     // Edge from callLLM to finish on text response
@@ -142,7 +140,7 @@ Depending on which step you decide to perform compression, the following scenari
     graph.edge(AIAgentEdge.builder()
         .from(callLLM)
         .to(executeTool)
-        .onToolCalls(call -> true)
+        .onToolCalls()
         .build());
 
     // Compress history after executing any tool if the history is too long
@@ -173,7 +171,7 @@ Depending on which step you decide to perform compression, the following scenari
     graph.edge(AIAgentEdge.builder()
         .from(sendToolResult)
         .to(executeTool)
-        .onToolCalls(call -> true)
+        .onToolCalls()
         .build());
 
     // Edge from sendToolResult to finish on text response

--- a/docs/docs/history-compression.md
+++ b/docs/docs/history-compression.md
@@ -101,6 +101,7 @@ Depending on which step you decide to perform compression, the following scenari
     import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy;
     import ai.koog.agents.core.agent.entity.AIAgentNode;
     import ai.koog.prompt.message.Message;
+    import ai.koog.agents.core.dsl.extension.ReceivedToolResults;
     class exampleHistoryCompressionJava01 {
         public static void main(String[] args) {
     -->

--- a/docs/docs/nodes-and-components.md
+++ b/docs/docs/nodes-and-components.md
@@ -326,7 +326,6 @@ Here is an example:
     import ai.koog.agents.core.dsl.builder.node
     import ai.koog.agents.core.dsl.extension.nodeLLMRequest
     import ai.koog.agents.core.dsl.extension.nodeDoNothing
-    import ai.koog.agents.core.dsl.extension.asUserMessage
     val strategy = strategy<String, String>("strategy_name") {
         val getUserQuestion by nodeDoNothing<String>()
     -->
@@ -335,7 +334,7 @@ Here is an example:
     -->
     ```kotlin
     val requestLLM by nodeLLMRequest("requestLLM")
-    edge(getUserQuestion forwardTo requestLLM asUserMessage { it })
+    edge(getUserQuestion forwardTo requestLLM)
     ```
     <!--- KNIT example-nodes-and-component-04.kt -->
 
@@ -366,7 +365,6 @@ Here is an example:
     strategy.edge(AIAgentEdge.builder()
         .from(getUserQuestion)
         .to(requestLLM)
-        .asUserMessage(s -> s)
         .build());
     ```
     <!--- KNIT exampleNodesAndComponentsJava04.java -->
@@ -444,7 +442,6 @@ Here is an example:
     import ai.koog.agents.core.dsl.builder.node
     import ai.koog.agents.core.dsl.extension.nodeLLMRequest
     import ai.koog.agents.core.dsl.extension.nodeDoNothing
-    import ai.koog.agents.core.dsl.extension.asUserMessage
     val strategy = strategy<String, String>("strategy_name") {
         val getComplexUserQuestion by nodeDoNothing<String>()
     -->
@@ -453,7 +450,7 @@ Here is an example:
     -->
     ```kotlin
     val requestLLMMultipleTools by nodeLLMRequest()
-    edge(getComplexUserQuestion forwardTo requestLLMMultipleTools asUserMessage { it })
+    edge(getComplexUserQuestion forwardTo requestLLMMultipleTools)
     ```
     <!--- KNIT example-nodes-and-component-05.kt -->
 
@@ -484,7 +481,6 @@ Here is an example:
     strategy.edge(AIAgentEdge.builder()
         .from(getComplexUserQuestion)
         .to(requestLLMMultipleTools)
-        .asUserMessage(s -> s)
         .build());
     ```
     <!--- KNIT exampleNodesAndComponentsJava05.java -->
@@ -607,7 +603,7 @@ Here is an example:
     import ai.koog.agents.core.dsl.builder.forwardTo
     import ai.koog.agents.core.dsl.builder.strategy
     import ai.koog.agents.core.dsl.builder.node
-    import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+    import ai.koog.agents.core.dsl.extension.nodeExecuteTools
     import ai.koog.agents.core.dsl.extension.nodeLLMRequest
     import ai.koog.agents.core.dsl.extension.onToolCalls
     val strategy = strategy<String, String>("strategy_name") {
@@ -617,7 +613,7 @@ Here is an example:
     -->
     ```kotlin
     val requestLLM by nodeLLMRequest()
-    val executeTool by nodeExecuteToolsAndGetResults()
+    val executeTool by nodeExecuteTools()
     edge(requestLLM forwardTo executeTool onToolCalls { true })
     ```
     <!--- KNIT example-nodes-and-component-07.kt -->
@@ -647,7 +643,7 @@ Here is an example:
     strategy.edge(AIAgentEdge.builder()
         .from(requestLLM)
         .to(executeTool)
-        .onToolCalls(call -> true)
+        .onToolCalls()
         .build());
     ```
     <!--- KNIT exampleNodesAndComponentsJava07.java -->
@@ -685,7 +681,7 @@ Here is an example:
     import ai.koog.agents.core.dsl.builder.forwardTo
     import ai.koog.agents.core.dsl.builder.strategy
     import ai.koog.agents.core.dsl.builder.node
-    import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+    import ai.koog.agents.core.dsl.extension.nodeExecuteTools
     import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
     val strategy = strategy<String, String>("strategy_name") {
     -->
@@ -693,7 +689,7 @@ Here is an example:
     }
     -->
     ```kotlin
-    val executeTool by nodeExecuteToolsAndGetResults()
+    val executeTool by nodeExecuteTools()
     val sendToolResultToLLM by nodeLLMSendToolResults()
     edge(executeTool forwardTo sendToolResultToLLM)
     ```
@@ -716,7 +712,7 @@ Here is an example:
     -->
     ```java
     var executeTool = AIAgentNode.executeTools("executeTool");
-    var sendToolResultToLLM = AIAgentNode.llmRequest("sendToolResultToLLM");
+    var sendToolResultToLLM = AIAgentNode.llmSendToolResults("sendToolResultToLLM");
 
     strategy.edge(executeTool, sendToolResultToLLM);
     ```
@@ -756,7 +752,7 @@ Here is an example:
     import ai.koog.agents.core.dsl.builder.strategy
     import ai.koog.agents.core.dsl.builder.node
     import ai.koog.agents.core.dsl.extension.nodeLLMRequest
-    import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+    import ai.koog.agents.core.dsl.extension.nodeExecuteTools
     import ai.koog.agents.core.dsl.extension.onToolCalls
     val strategy = strategy<String, String>("strategy_name") {
     -->
@@ -765,7 +761,7 @@ Here is an example:
     -->
     ```kotlin
     val requestLLMMultipleTools by nodeLLMRequest()
-    val executeMultipleTools by nodeExecuteToolsAndGetResults(parallel = true)
+    val executeMultipleTools by nodeExecuteTools(parallel = true)
     edge(requestLLMMultipleTools forwardTo executeMultipleTools onToolCalls { true })
     ```
     <!--- KNIT example-nodes-and-component-09.kt -->
@@ -796,7 +792,7 @@ Here is an example:
     strategy.edge(AIAgentEdge.builder()
         .from(requestLLMMultipleTools)
         .to(executeMultipleTools)
-        .onToolCalls(call -> true)
+        .onToolCalls()
         .build());
     ```
     <!--- KNIT exampleNodesAndComponentsJava09.java -->
@@ -835,16 +831,16 @@ Here is an example:
     import ai.koog.agents.core.dsl.builder.strategy
     import ai.koog.agents.core.dsl.builder.node
     import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
-    import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+    import ai.koog.agents.core.dsl.extension.nodeExecuteTools
     val strategy = strategy<String, String>("strategy_name") {
     -->
     <!--- SUFFIX
     }
     -->
     ```kotlin
-    val executeMultipleTools by nodeExecuteToolsAndGetResults(parallel = true)
-    val sendMultipleToolResultsToLLM by nodeLLMSendToolResults()
-    edge(executeMultipleTools forwardTo sendMultipleToolResultsToLLM)
+    val executeTools by nodeExecuteTools(parallel = true)
+    val sendToolResultsToLLM by nodeLLMSendToolResults()
+    edge(executeTools forwardTo sendToolResultsToLLM)
     ```
     <!--- KNIT example-nodes-and-component-10.kt -->
 
@@ -865,10 +861,10 @@ Here is an example:
     }
     -->
     ```java
-    var executeMultipleTools = AIAgentNode.executeTools("executeMultipleTools");
-    var sendMultipleToolResultsToLLM = AIAgentNode.llmRequest("sendMultipleToolResultsToLLM");
+    var executeTools = AIAgentNode.executeTools("executeTools");
+    var sendToolResultsToLLM = AIAgentNode.llmSendToolResults("sendToolResultsToLLM");
 
-    strategy.edge(executeMultipleTools, sendMultipleToolResultsToLLM);
+    strategy.edge(executeTools, sendToolResultsToLLM);
     ```
     <!--- KNIT exampleNodesAndComponentsJava10.java -->
 
@@ -999,7 +995,6 @@ Transform the output of built-in nodes like `nodeLLMRequest` (Kotlin) or `AIAgen
     import ai.koog.agents.core.dsl.builder.strategy
     import ai.koog.agents.core.dsl.builder.node
     import ai.koog.agents.core.dsl.extension.nodeLLMRequest
-    import ai.koog.agents.core.dsl.extension.asUserMessage
     import ai.koog.prompt.message.MessagePart
     val strategy = strategy<String, Int>("strategy_name") {
     -->
@@ -1011,7 +1006,7 @@ Transform the output of built-in nodes like `nodeLLMRequest` (Kotlin) or `AIAgen
         assistantMessage.parts.filterIsInstance<MessagePart.Text>().joinToString("\n") { it.text }.length
     }
 
-    edge(nodeStart forwardTo lengthNode asUserMessage { it })
+    edge(nodeStart forwardTo lengthNode)
     edge(lengthNode forwardTo nodeFinish)
     ```
     <!--- KNIT example-nodes-and-component-13.kt -->
@@ -1052,7 +1047,6 @@ Transform the output of built-in nodes like `nodeLLMRequest` (Kotlin) or `AIAgen
     strategy.edge(AIAgentEdge.builder()
         .from(strategy.nodeStart)
         .to(llmRequest)
-        .asUserMessage(s -> s)
         .build());
     strategy.edge(llmRequest, lengthNode);
     strategy.edge(lengthNode, strategy.nodeFinish);
@@ -1272,10 +1266,10 @@ You can use this strategy when you need to run straightforward processes that do
     ```kotlin
     public fun singleRunStrategy(): AIAgentGraphStrategy<String, String> = strategy("single_run") {
         val nodeCallLLM by nodeLLMRequest("sendInput")
-        val nodeExecuteTool by nodeExecuteToolsAndGetResults("nodeExecuteTool")
+        val nodeExecuteTool by nodeExecuteTools("nodeExecuteTool")
         val nodeSendToolResult by nodeLLMSendToolResults("nodeSendToolResult")
 
-        edge(nodeStart forwardTo nodeCallLLM asUserMessage { it })
+        edge(nodeStart forwardTo nodeCallLLM)
         edge(nodeCallLLM forwardTo nodeExecuteTool onToolCalls { true })
         edge(nodeCallLLM forwardTo nodeFinish onTextMessage { true })
         edge(nodeExecuteTool forwardTo nodeSendToolResult)
@@ -1309,18 +1303,17 @@ You can use this strategy when you need to run straightforward processes that do
 
         var nodeCallLLM = AIAgentNode.llmRequest("sendInput");
         var nodeExecuteTool = AIAgentNode.executeTools("nodeExecuteTool");
-        var nodeSendToolResult = AIAgentNode.llmRequest("nodeSendToolResult");
+        var nodeSendToolResult = AIAgentNode.llmSendToolResults("nodeSendToolResult");
 
         strategy.edge(AIAgentEdge.builder()
             .from(strategy.nodeStart)
             .to(nodeCallLLM)
-            .asUserMessage(input -> input)
             .build());
 
         strategy.edge(AIAgentEdge.builder()
             .from(nodeCallLLM)
             .to(nodeExecuteTool)
-            .onToolCalls(call -> true)
+            .onToolCalls()
             .build());
 
         strategy.edge(AIAgentEdge.builder()
@@ -1340,7 +1333,7 @@ You can use this strategy when you need to run straightforward processes that do
         strategy.edge(AIAgentEdge.builder()
             .from(nodeSendToolResult)
             .to(nodeExecuteTool)
-            .onToolCalls(call -> true)
+            .onToolCalls()
             .build());
 
         return strategy.build();
@@ -1367,11 +1360,11 @@ It typically executes tools based on the LLM decisions and processes the results
     fun toolBasedStrategy(name: String, toolRegistry: ToolRegistry): AIAgentGraphStrategy<String, String> {
         return strategy(name) {
             val nodeSendInput by nodeLLMRequest()
-            val nodeExecuteTool by nodeExecuteToolsAndGetResults()
+            val nodeExecuteTool by nodeExecuteTools()
             val nodeSendToolResult by nodeLLMSendToolResults()
 
             // Define the flow of the agent
-            edge(nodeStart forwardTo nodeSendInput asUserMessage { it })
+            edge(nodeStart forwardTo nodeSendInput)
 
             // If the LLM responds with a message, finish
             edge(
@@ -1429,13 +1422,12 @@ It typically executes tools based on the LLM decisions and processes the results
 
         var nodeSendInput = AIAgentNode.llmRequest("nodeSendInput");
         var nodeExecuteTool = AIAgentNode.executeTools("nodeExecuteTool");
-        var nodeSendToolResult = AIAgentNode.llmRequest("nodeSendToolResult");
+        var nodeSendToolResult = AIAgentNode.llmSendToolResults("nodeSendToolResult");
 
         // Define the flow of the agent
         strategy.edge(AIAgentEdge.builder()
             .from(strategy.nodeStart)
             .to(nodeSendInput)
-            .asUserMessage(input -> input)
             .build());
 
         // If the LLM responds with a message, finish
@@ -1459,7 +1451,7 @@ It typically executes tools based on the LLM decisions and processes the results
         strategy.edge(AIAgentEdge.builder()
             .from(nodeSendToolResult)
             .to(nodeExecuteTool)
-            .onToolCalls(call -> true)
+            .onToolCalls()
             .build());
 
         // If the LLM responds with a message, finish

--- a/docs/docs/sessions.md
+++ b/docs/docs/sessions.md
@@ -802,7 +802,7 @@ Example:
     ```java
     // Java uses dedicated tool-execution nodes in graph strategies.
     var executeTool = AIAgentNode.executeTools("executeTool");
-    var sendToolResult = AIAgentNode.llmRequest("sendToolResult");
+    var sendToolResult = AIAgentNode.llmSendToolResults("sendToolResult");
     ```
     <!--- KNIT exampleSessionsJava11.java -->
 

--- a/docs/docs/structured-output.md
+++ b/docs/docs/structured-output.md
@@ -324,7 +324,6 @@ You can integrate structured data processing into your agent strategies:
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.builder.node
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.example.exampleStructuredData03.WeatherForecast
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
@@ -351,7 +350,7 @@ val agentStrategy = strategy<String, String>("weather-forecast") {
         """.trimIndent()
     }
 
-    edge(nodeStart forwardTo setup asUserMessage { it })
+    edge(nodeStart forwardTo setup)
     edge(setup forwardTo getStructuredForecast)
     edge(getStructuredForecast forwardTo nodeFinish)
 }
@@ -374,7 +373,6 @@ This creates an agent node that:
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.builder.node
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStructured
 import ai.koog.agents.example.exampleStructuredData03.WeatherForecast
@@ -413,7 +411,7 @@ val agentStrategy = strategy<Unit, String>("weather-forecast") {
     }
 
     edge(nodeStart forwardTo setup)
-    edge(setup forwardTo getWeatherForecast asUserMessage { it })
+    edge(setup forwardTo getWeatherForecast)
     edge(getWeatherForecast forwardTo processResult)
     edge(processResult forwardTo nodeFinish)
 }
@@ -430,7 +428,6 @@ import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.builder.node
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.annotations.LLMDescription
@@ -496,7 +493,7 @@ fun main(): Unit = runBlocking {
             """.trimIndent()
         }
   
-        edge(nodeStart forwardTo setup asUserMessage { it })
+        edge(nodeStart forwardTo setup)
         edge(setup forwardTo getStructuredForecast)
         edge(getStructuredForecast forwardTo nodeFinish)
     }

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -1075,7 +1075,7 @@ For more complex agents with multiple subgraphs, you can also test the graph str
                 tools = listOf(DummyTool, CreateTool, SolveTool)
             ) {
                 val callLLM by nodeLLMRequest(allowToolCalls = false)
-                val executeTool by nodeExecuteToolsAndGetResults()
+                val executeTool by nodeExecuteTools()
                 val sendToolResult by nodeLLMSendToolResults()
                 val giveFeedback by node<String, String> { input ->
                     llm.writeSession {
@@ -1086,7 +1086,7 @@ For more complex agents with multiple subgraphs, you can also test the graph str
                     input
                 }
 
-                edge(nodeStart forwardTo callLLM asUserMessage { it })
+                edge(nodeStart forwardTo callLLM)
                 edge(callLLM forwardTo executeTool onToolCalls { true })
                 edge(callLLM forwardTo giveFeedback onTextMessage { true })
                 edge(giveFeedback forwardTo giveFeedback transformed { it })

--- a/examples/simple-examples-java/src/main/java/ai/koog/agents/example/calculator/Calculator.java
+++ b/examples/simple-examples-java/src/main/java/ai/koog/agents/example/calculator/Calculator.java
@@ -10,6 +10,7 @@ import ai.koog.agents.core.agent.entity.AIAgentNodeBase;
 import ai.koog.agents.core.agent.entity.GraphStrategyBuilder;
 import ai.koog.agents.core.agent.entity.TypedGraphStrategyBuilder;
 import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy;
+import ai.koog.agents.core.dsl.extension.ReceivedToolResults;
 import ai.koog.agents.core.dsl.extension.ToolCalls;
 import ai.koog.agents.core.tools.ToolRegistry;
 import ai.koog.agents.example.ApiKeyService;
@@ -75,18 +76,18 @@ public class Calculator {
                         builder.withInput(String.class).withOutput(String.class);
 
                     // --- Node definitions ---
-                    AIAgentNodeBase<Message.User, Message.Assistant> nodeCallLLM =
+                    AIAgentNodeBase<String, Message.Assistant> nodeCallLLM =
                         AIAgentNode.llmRequest("callLLM");
 
-                    AIAgentNodeBase<ToolCalls, Message.User> nodeExecuteTools =
+                    AIAgentNodeBase<ToolCalls, ReceivedToolResults> nodeExecuteTools =
                         AIAgentNode.executeTools("executeTools");
 
-                    AIAgentNodeBase<Message.User, Message.Assistant> nodeSendResults =
-                        AIAgentNode.llmRequest("sendToolResults");
+                    AIAgentNodeBase<ReceivedToolResults, Message.Assistant> nodeSendResults =
+                        AIAgentNode.llmSendToolResults("sendToolResults");
 
-                    AIAgentNodeBase<Message.User, Message.User> nodeCompress =
+                    AIAgentNodeBase<ReceivedToolResults, ReceivedToolResults> nodeCompress =
                         AIAgentNode.llmCompressHistory("compressHistory")
-                            .withInput(Message.User.class)
+                            .withInput(ReceivedToolResults.class)
                             .compressionStrategy(HistoryCompressionStrategy.WholeHistory)
                             .build();
 

--- a/examples/simple-examples-java/src/main/java/ai/koog/agents/example/calculator/Calculator.java
+++ b/examples/simple-examples-java/src/main/java/ai/koog/agents/example/calculator/Calculator.java
@@ -95,7 +95,6 @@ public class Calculator {
                     // start → callLLM (wrap the agent's String input as a user message)
                     graph.edge(
                         AIAgentEdge.builder().from(graph.nodeStart).to(nodeCallLLM)
-                            .asUserMessage()
                             .build()
                     );
 

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/a2a/advancedjoke/JokeWriterAgentExecutor.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/a2a/advancedjoke/JokeWriterAgentExecutor.kt
@@ -313,13 +313,13 @@ private fun jokeWriterStrategy() = strategy<A2AMessage, Unit>("joke-writer") {
     edge(
         setupTaskContext forwardTo classifyNewRequest
             onCondition { task -> task == null }
-            transformed { llm.writeSession { userMessage(agentInput<A2AMessage>().content()) } }
+            transformed { agentInput<A2AMessage>().content() }
     )
     // If task exists, continue processing the joke request
     edge(
         setupTaskContext forwardTo classifyJokeRequest
             onCondition { task -> task != null }
-            transformed { llm.writeSession { userMessage(agentInput<A2AMessage>().content()) } }
+            transformed { agentInput<A2AMessage>().content() }
     )
 
     // New request classification: If not a joke request, decline politely
@@ -340,7 +340,7 @@ private fun jokeWriterStrategy() = strategy<A2AMessage, Unit>("joke-writer") {
     // After creating task, classify the joke details
     edge(
         createTask forwardTo classifyJokeRequest
-            transformed { llm.writeSession { userMessage(agentInput<A2AMessage>().content()) } }
+            transformed { agentInput<A2AMessage>().content()  }
     )
 
     // Joke classification: Ask for clarification if needed

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/acp/KoogAgentSupport.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/acp/KoogAgentSupport.kt
@@ -4,7 +4,6 @@ import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStructured
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.reflect.asTool
@@ -127,7 +126,7 @@ class KoogAgentSession(
         }
 
         edge(nodeStart forwardTo nodePlanPrompt)
-        edge(nodePlanPrompt forwardTo nodeCreatePlan asUserMessage { it })
+        edge(nodePlanPrompt forwardTo nodeCreatePlan)
         edge(nodeCreatePlan forwardTo nodeSendPlan onCondition { it.isSuccess } transformed { it.getOrThrow().data })
         edge(nodeSendPlan forwardTo executePlan)
         edge(executePlan forwardTo nodeFinish)

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/banking/routing/RoutingViaGraph.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/banking/routing/RoutingViaGraph.kt
@@ -69,7 +69,7 @@ suspend fun main() {
                 callLLM forwardTo callLLM onTextMessage { true }
                     transformed { "Please call `${AskUser.name}` tool instead of chatting" }
             )
-            edge(callAskUserTool forwardTo requestClassification)
+            edge(callAskUserTool forwardTo requestClassification transformed { it.toolResults.first().output })
         }
 
         val transferMoney by subgraphWithTask<ClassifiedBankRequest, String>(

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/banking/routing/RoutingViaGraph.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/banking/routing/RoutingViaGraph.kt
@@ -4,7 +4,6 @@ import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.builder.subgraph
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStructured
@@ -54,7 +53,7 @@ suspend fun main() {
             val callLLM by nodeLLMRequest()
             val callAskUserTool by nodeExecuteTools()
 
-            edge(nodeStart forwardTo requestClassification asUserMessage { it })
+            edge(nodeStart forwardTo requestClassification)
             edge(
                 requestClassification forwardTo nodeFinish
                     onCondition { it.isSuccess }
@@ -63,12 +62,12 @@ suspend fun main() {
             edge(
                 requestClassification forwardTo callLLM
                     onCondition { it.isFailure }
-                    asUserMessage { "Failed to understand the user's intent" }
+                    transformed { "Failed to understand the user's intent" }
             )
             edge(callLLM forwardTo callAskUserTool onToolCalls { true })
             edge(
                 callLLM forwardTo callLLM onTextMessage { true }
-                    asUserMessage { "Please call `${AskUser.name}` tool instead of chatting" }
+                    transformed { "Please call `${AskUser.name}` tool instead of chatting" }
             )
             edge(callAskUserTool forwardTo requestClassification)
         }

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/calculator/CalculatorTools.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/calculator/CalculatorTools.kt
@@ -1,9 +1,8 @@
 package ai.koog.agents.example.calculator
 
-import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.ReceivedToolResults
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/calculator/CalculatorTools.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/calculator/CalculatorTools.kt
@@ -3,7 +3,6 @@ package ai.koog.agents.example.calculator
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.ReceivedToolResults
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
 import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
@@ -72,11 +71,11 @@ object CalculatorStrategy {
 
     val strategy = strategy<String, String>("test") {
         val nodeCallLLM by nodeLLMRequest()
-        val nodeExecuteToolMultiple by nodeExecuteToolsAndGetResults(parallel = true)
+        val nodeExecuteToolMultiple by nodeExecuteTools(parallel = true)
         val nodeSendToolResultMultiple by nodeLLMSendToolResults()
         val nodeCompressHistory by nodeLLMCompressHistory<ReceivedToolResults>()
 
-        edge(nodeStart forwardTo nodeCallLLM asUserMessage { it })
+        edge(nodeStart forwardTo nodeCallLLM)
 
         edge(
             (nodeCallLLM forwardTo nodeFinish)

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/chess/Chess.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/chess/Chess.kt
@@ -2,7 +2,6 @@ package ai.koog.agents.example.chess
 
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.onToolCalls
@@ -28,7 +27,7 @@ suspend fun main() {
         val nodeSendToolResult by nodeLLMSendToolResults("nodeSendToolResult")
         val nodeTrimHistory by nodeTrimHistory<ReceivedToolResults>()
 
-        edge(nodeStart forwardTo nodeCallLLM asUserMessage { it })
+        edge(nodeStart forwardTo nodeCallLLM)
         edge(nodeCallLLM forwardTo nodeExecuteTool onToolCalls { true })
         edge(nodeCallLLM forwardTo nodeFinish onTextMessage { true })
         edge(nodeExecuteTool forwardTo nodeTrimHistory)

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/chess/Chess.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/chess/Chess.kt
@@ -2,11 +2,11 @@ package ai.koog.agents.example.chess
 
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.onToolCalls
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.dsl.extension.ReceivedToolResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
 import ai.koog.agents.core.dsl.extension.onTextMessage
 import ai.koog.agents.core.tools.ToolRegistry
@@ -23,7 +23,7 @@ suspend fun main() {
 
     val strategy = strategy<String, String>("chess_strategy") {
         val nodeCallLLM by nodeLLMRequest("sendInput")
-        val nodeExecuteTool by nodeExecuteToolsAndGetResults("nodeExecuteTool")
+        val nodeExecuteTool by nodeExecuteTools("nodeExecuteTool")
         val nodeSendToolResult by nodeLLMSendToolResults("nodeSendToolResult")
         val nodeTrimHistory by nodeTrimHistory<ReceivedToolResults>()
 

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/chess/choice/ChessChoiceExecutor.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/chess/choice/ChessChoiceExecutor.kt
@@ -5,7 +5,7 @@ import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.ReceivedToolResults
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
 import ai.koog.agents.core.dsl.extension.onTextMessage

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/chess/choice/ChessChoiceExecutor.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/chess/choice/ChessChoiceExecutor.kt
@@ -5,7 +5,6 @@ import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.ReceivedToolResults
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
@@ -34,11 +33,11 @@ fun main(): Unit = runBlocking {
 
     val strategy = strategy<String, String>("chess_strategy") {
         val nodeCallLLM by nodeLLMRequest("sendInput")
-        val nodeExecuteTool by nodeExecuteToolsAndGetResults("nodeExecuteTool")
+        val nodeExecuteTool by nodeExecuteTools("nodeExecuteTool")
         val nodeSendToolResult by nodeLLMSendToolResults("nodeSendToolResult")
         val nodeTrimHistory by nodeTrimHistory<ReceivedToolResults>()
 
-        edge(nodeStart forwardTo nodeCallLLM asUserMessage { it })
+        edge(nodeStart forwardTo nodeCallLLM)
         edge(nodeCallLLM forwardTo nodeExecuteTool onToolCalls { true })
         edge(nodeCallLLM forwardTo nodeFinish onTextMessage { true })
         edge(nodeExecuteTool forwardTo nodeTrimHistory)

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/chess/choice/ChessChoiceNodes.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/chess/choice/ChessChoiceNodes.kt
@@ -5,8 +5,7 @@ import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.ReceivedToolResults
-import ai.koog.agents.core.dsl.extension.asUserMessage
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.onTextMessage
 import ai.koog.agents.core.dsl.extension.onToolCalls
@@ -43,12 +42,12 @@ fun main(): Unit = runBlocking {
 
     val strategy = strategy<String, String>("chess_strategy") {
         val nodeCallLLM by nodeLLMRequest("sendInput")
-        val nodeExecuteTool by nodeExecuteToolsAndGetResults("nodeExecuteTool")
+        val nodeExecuteTool by nodeExecuteTools("nodeExecuteTool")
         val nodeSendToolResult by nodeLLMSendResultsMultipleChoices("nodeSendToolResult")
         val nodeSelectLLMChoice by nodeSelectLLMChoice(askChoiceStrategy, "chooseLLMChoice")
         val nodeTrimHistory by nodeTrimHistory<ReceivedToolResults>()
 
-        edge(nodeStart forwardTo nodeCallLLM asUserMessage { it })
+        edge(nodeStart forwardTo nodeCallLLM)
         edge(nodeCallLLM forwardTo nodeExecuteTool onToolCalls { true })
         edge(nodeCallLLM forwardTo nodeFinish onTextMessage { true })
         edge(nodeExecuteTool forwardTo nodeTrimHistory)

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/mcp/UnityMcpAgent.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/mcp/UnityMcpAgent.kt
@@ -4,7 +4,6 @@ import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestWithoutTools
 import ai.koog.agents.core.dsl.extension.onTextMessage
 import ai.koog.agents.ext.agent.subgraphWithTask
@@ -87,7 +86,7 @@ fun main() {
                 }
 
                 edge(
-                    nodeStart forwardTo nodePlanIngredients asUserMessage { input ->
+                    nodeStart forwardTo nodePlanIngredients transformed { input ->
                         "Create detailed plan for $input" +
                             "unsing next tools: ${toolRegistry.tools.joinToString("\n") {
                                 it.name + "\ndescription:" + it.descriptor

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/moderation/JokesWithModeration.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/moderation/JokesWithModeration.kt
@@ -2,7 +2,6 @@ package ai.koog.agents.example.moderation
 
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeLLMModerateMessage
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.example.ApiKeyService
@@ -34,7 +33,7 @@ fun main() = runBlocking {
         edge(
             moderateInput forwardTo callLLM
                 onCondition { !it.moderationResult.isHarmful }
-                asUserMessage { it.message.textContent() }
+                transformed { it.message.textContent() }
         )
 
         edge(
@@ -55,7 +54,7 @@ fun main() = runBlocking {
         edge(
             moderateJoke forwardTo callLLM
                 onCondition { it.moderationResult.isHarmful }
-                asUserMessage { moderatedMessage ->
+                transformed { moderatedMessage ->
                 markdown {
                     h1("You must re-generate the joke to make it not harmful")
 

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/planner/PlannerAgentExample.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/planner/PlannerAgentExample.kt
@@ -11,7 +11,6 @@ import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestWithoutTools
-import ai.koog.agents.core.dsl.extension.nodeLLMRequestWithoutToolsWithUserText
 import ai.koog.agents.core.dsl.extension.onIsInstance
 import ai.koog.agents.core.dsl.extension.onToolCalls
 import ai.koog.agents.core.tools.ToolRegistry
@@ -22,6 +21,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import ai.koog.agents.core.dsl.builder.node
+import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
 import ai.koog.agents.core.dsl.extension.onTextMessage
 
 interface PlannerNode {
@@ -192,7 +192,7 @@ suspend fun planWork(
 
         val callTool by nodeExecuteTools()
         val askLLM by nodeLLMRequestWithoutTools()
-        val resumeAfterTool by nodeLLMRequestWithoutTools("resumeAfterTool")
+        val resumeAfterTool by nodeLLMSendToolResults("resumeAfterTool")
 
         val buildPlanTree by node<Unit, Unit> {
             val tree = storage.get(currentNodeKey)?.builder?.build()

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/planner/PlannerAgentExample.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/planner/PlannerAgentExample.kt
@@ -8,7 +8,6 @@ import ai.koog.agents.core.agent.entity.createStorageKey
 import ai.koog.agents.core.dsl.builder.AIAgentSubgraphBuilderBase
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestWithoutTools
@@ -192,7 +191,7 @@ suspend fun planWork(
         }
 
         val callTool by nodeExecuteTools()
-        val askLLM by nodeLLMRequestWithoutToolsWithUserText()
+        val askLLM by nodeLLMRequestWithoutTools()
         val resumeAfterTool by nodeLLMRequestWithoutTools("resumeAfterTool")
 
         val buildPlanTree by node<Unit, Unit> {
@@ -201,7 +200,7 @@ suspend fun planWork(
             result.complete(tree)
         }
 
-        edge(nodeStart forwardTo setup asUserMessage { it })
+        edge(nodeStart forwardTo setup)
         edge(setup forwardTo tryFindingSequentialSubtasks transformed { initialTaskDescription })
 
         edge(tryFindingParallelSubtasks forwardTo callTool onToolCalls { true })

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/streaming/StreamingAgentWithTools.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/streaming/StreamingAgentWithTools.kt
@@ -2,10 +2,10 @@ package ai.koog.agents.example.streaming
 
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.GraphAIAgent.FeatureContext
-import ai.koog.agents.core.dsl.builder.forwardTo
-import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.nodeExecuteTools
+import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreaming
+import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResultsStreaming
 import ai.koog.agents.core.dsl.extension.onTextMessage
 import ai.koog.agents.core.dsl.extension.onToolCalls
 import ai.koog.agents.core.tools.ToolRegistry
@@ -22,7 +22,6 @@ import ai.koog.prompt.executor.clients.openai.models.ReasoningConfig
 import ai.koog.prompt.executor.clients.openai.models.ReasoningSummary
 import ai.koog.prompt.executor.llms.all.simpleOpenAIExecutor
 import ai.koog.prompt.executor.model.PromptExecutor
-import ai.koog.prompt.message.Message
 import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.prompt.streaming.toMessageResponse
 import kotlinx.coroutines.flow.toList
@@ -83,13 +82,16 @@ private fun openAiAgent(
 ) = AIAgent.builder()
     .graphStrategy { streamingWithToolsStrategy() }
     .promptExecutor(executor)
-    .prompt(prompt("agent", OpenAIResponsesParams(
-        temperature = 1.0,
-        reasoning = ReasoningConfig(effort = ReasoningEffort.MEDIUM, summary = ReasoningSummary.AUTO)
-    ))
-    {
-        system("You're responsible for running a Switch and perform operations on it by request")
-    })
+    .prompt(
+        prompt(
+            "agent", OpenAIResponsesParams(
+                temperature = 1.0,
+                reasoning = ReasoningConfig(effort = ReasoningEffort.MEDIUM, summary = ReasoningSummary.AUTO)
+            )
+        )
+        {
+            system("You're responsible for running a Switch and perform operations on it by request")
+        })
     .llmModel(OpenAIModels.Chat.GPT5_1)
     .toolRegistry(toolRegistry)
     .install(installFeatures)
@@ -115,16 +117,20 @@ fun streamingWithToolsStrategy() = strategy("streaming_loop") {
     // onLLMStreamingFrameReceived / onLLMStreamingFailed / onLLMStreamingCompleted event handlers
     // fire frame-by-frame), then collapses the stream into a Message.Assistant for downstream
     // tool-call / text-part dispatch.
-    val nodeCallLLM by node<Message.User, Message.Assistant>("callLLMStreaming") { user ->
-        llm.writeSession {
-            appendPrompt { message(user) }
-            requestLLMStreaming().toList().toMessageResponse()
-        }
+    val nodeCallLLM by nodeLLMRequestStreaming().transform {
+        it.toList().toMessageResponse()
     }
-    val executeMultipleTools by nodeExecuteTools(parallel = true)
+
+    val nodeSendToolResults by nodeLLMSendToolResultsStreaming().transform {
+        it.toList().toMessageResponse()
+    }
+
+    val executeTools by nodeExecuteTools(parallel = true)
 
     edge(nodeStart forwardTo nodeCallLLM)
-    edge(nodeCallLLM forwardTo executeMultipleTools onToolCalls { true })
-    edge(executeMultipleTools forwardTo nodeCallLLM)
+    edge(nodeCallLLM forwardTo executeTools onToolCalls { true })
+    edge(executeTools forwardTo nodeSendToolResults)
+    edge(nodeSendToolResults forwardTo executeTools onToolCalls { true })
+    edge(nodeSendToolResults forwardTo nodeFinish onTextMessage { true })
     edge(nodeCallLLM forwardTo nodeFinish onTextMessage { true })
 }

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/streaming/StreamingAgentWithTools.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/streaming/StreamingAgentWithTools.kt
@@ -5,7 +5,6 @@ import ai.koog.agents.core.agent.GraphAIAgent.FeatureContext
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.onTextMessage
 import ai.koog.agents.core.dsl.extension.onToolCalls
@@ -124,7 +123,7 @@ fun streamingWithToolsStrategy() = strategy("streaming_loop") {
     }
     val executeMultipleTools by nodeExecuteTools(parallel = true)
 
-    edge(nodeStart forwardTo nodeCallLLM asUserMessage { it })
+    edge(nodeStart forwardTo nodeCallLLM)
     edge(nodeCallLLM forwardTo executeMultipleTools onToolCalls { true })
     edge(executeMultipleTools forwardTo nodeCallLLM)
     edge(nodeCallLLM forwardTo nodeFinish onTextMessage { true })

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/streaming/StreamingKtorServer.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/streaming/StreamingKtorServer.kt
@@ -7,7 +7,6 @@ import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStreaming
 import ai.koog.agents.example.ApiKeyService
 import ai.koog.prompt.dsl.prompt
@@ -148,6 +147,6 @@ private fun createStrategy(
 
     val requestLLMStream by nodeLLMRequestStreaming()
 
-    edge(nodeStart forwardTo requestLLMStream asUserMessage { it })
+    edge(nodeStart forwardTo requestLLMStream)
     requestLLMStream then processStream then nodeFinish
 }

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/structuredoutput/AdvancedWithBasicSchema.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/structuredoutput/AdvancedWithBasicSchema.kt
@@ -6,7 +6,6 @@ import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStructured
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.example.ApiKeyService
@@ -223,7 +222,7 @@ suspend fun main() {
             )
 
             nodeStart then prepareRequest
-            edge(prepareRequest forwardTo getStructuredForecast asUserMessage { it })
+            edge(prepareRequest forwardTo getStructuredForecast)
             edge(getStructuredForecast forwardTo nodeFinish transformed { it.getOrThrow().data })
         }
 

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/structuredoutput/AdvancedWithStandardSchema.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/structuredoutput/AdvancedWithStandardSchema.kt
@@ -4,7 +4,6 @@ import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStructured
 import ai.koog.agents.example.ApiKeyService
 import ai.koog.agents.example.structuredoutput.models.FullWeatherForecast
@@ -91,7 +90,7 @@ suspend fun main() {
         )
 
         nodeStart then prepareRequest
-        edge(prepareRequest forwardTo getStructuredForecast asUserMessage { it })
+        edge(prepareRequest forwardTo getStructuredForecast)
         edge(getStructuredForecast forwardTo nodeFinish transformed { it.getOrThrow().data })
     }
 

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/structuredoutput/SimpleExample.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/structuredoutput/SimpleExample.kt
@@ -4,7 +4,6 @@ import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestStructured
 import ai.koog.agents.core.tools.annotations.LLMDescription
 import ai.koog.agents.example.ApiKeyService
@@ -201,7 +200,7 @@ suspend fun main() {
         )
 
         nodeStart then prepareRequest
-        edge(prepareRequest forwardTo getStructuredForecast asUserMessage { it })
+        edge(prepareRequest forwardTo getStructuredForecast)
         edge(getStructuredForecast forwardTo nodeFinish transformed { it.getOrThrow().data })
     }
 

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/tone/ToneStrategy.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/tone/ToneStrategy.kt
@@ -1,10 +1,9 @@
 package ai.koog.agents.example.tone
 
 import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
-import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.ReceivedToolResults
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
@@ -17,7 +16,7 @@ import ai.koog.agents.core.dsl.extension.onToolCalls
 fun toneStrategy(name: String): AIAgentGraphStrategy<String, String> {
     return strategy<String, String>(name) {
         val nodeSendInput by nodeLLMRequest()
-        val nodeExecuteTool by nodeExecuteToolsAndGetResults()
+        val nodeExecuteTool by nodeExecuteTools()
         val nodeSendToolResult by nodeLLMSendToolResults()
         val nodeCompressHistory by nodeLLMCompressHistory<ReceivedToolResults>()
 

--- a/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/tone/ToneStrategy.kt
+++ b/examples/simple-examples/src/main/kotlin/ai/koog/agents/example/tone/ToneStrategy.kt
@@ -4,7 +4,6 @@ import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
 import ai.koog.agents.core.dsl.builder.forwardTo
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.extension.ReceivedToolResults
-import ai.koog.agents.core.dsl.extension.asUserMessage
 import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
 import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
@@ -23,7 +22,7 @@ fun toneStrategy(name: String): AIAgentGraphStrategy<String, String> {
         val nodeCompressHistory by nodeLLMCompressHistory<ReceivedToolResults>()
 
         // Define the flow of the agent
-        edge(nodeStart forwardTo nodeSendInput asUserMessage { it })
+        edge(nodeStart forwardTo nodeSendInput)
 
         // If the LLM responds with a message, finish
         edge(

--- a/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentGraphStrategyTest.java
+++ b/integration-tests/src/jvmTest/java/ai/koog/integration/tests/agent/JavaAIAgentGraphStrategyTest.java
@@ -1,18 +1,15 @@
 package ai.koog.integration.tests.agent;
 
 import ai.koog.agents.core.agent.AIAgent;
-import ai.koog.agents.core.agent.context.RollbackStrategy;
 import ai.koog.agents.core.agent.context.AIAgentGraphContextBase;
-import ai.koog.agents.core.agent.entity.AIAgentEdge;
-import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy;
-import ai.koog.agents.core.agent.entity.AIAgentNode;
-import ai.koog.agents.core.agent.entity.AIAgentSubgraph;
-import ai.koog.agents.core.agent.entity.CompressHistoryNodeBuilder;
-import ai.koog.agents.core.tools.Tool;
+import ai.koog.agents.core.agent.context.RollbackStrategy;
+import ai.koog.agents.core.agent.entity.*;
 import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy;
+import ai.koog.agents.core.tools.Tool;
 import ai.koog.agents.core.tools.ToolRegistry;
 import ai.koog.agents.core.tools.annotations.LLMDescription;
 import ai.koog.agents.core.tools.reflect.ToolSet;
+import ai.koog.agents.ext.agent.CriticResult;
 import ai.koog.agents.features.eventHandler.feature.EventHandler;
 import ai.koog.agents.snapshot.feature.AgentCheckpointData;
 import ai.koog.agents.snapshot.feature.Persistence;
@@ -23,19 +20,17 @@ import ai.koog.agents.snapshot.providers.file.JVMFilePersistenceStorageProvider;
 import ai.koog.integration.tests.base.KoogJavaTestBase;
 import ai.koog.integration.tests.utils.Models;
 import ai.koog.integration.tests.utils.annotations.Retry;
-import ai.koog.agents.ext.agent.CriticResult;
 import ai.koog.prompt.executor.clients.openai.OpenAIModels;
 import ai.koog.prompt.llm.LLMCapability;
 import ai.koog.prompt.llm.LLModel;
 import ai.koog.prompt.message.Message;
-import ai.koog.prompt.message.MessagePart;
 import ai.koog.prompt.message.RequestMetaInfo;
 import ai.koog.prompt.message.ResponseMetaInfo;
+import ai.koog.serialization.JSONElementKt;
 import ai.koog.serialization.JSONPrimitive;
 import ai.koog.serialization.TypeToken;
-import ai.koog.serialization.JSONElementKt;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -49,7 +44,6 @@ import java.util.Locale;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 import static ai.koog.utils.concurrency.ReentrantCoroutineUtilsKt.runBlockingReentrant;
 import static org.junit.jupiter.api.Assertions.*;
@@ -69,28 +63,18 @@ public class JavaAIAgentGraphStrategyTest extends KoogJavaTestBase {
             .withInput(String.class)
             .withOutput(String.class);
 
-        var preprocess = AIAgentNode.builder("preprocess")
-            .withInput(String.class)
-            .withOutput(Message.User.class)
-            .withAction((input, ctx) -> new Message.User(
-                "Reply with the single word hello to: " + input,
-                new RequestMetaInfo(kotlin.time.Clock.System.INSTANCE.now(), null)
-            ))
-            .build();
-
         var llm = AIAgentNode.llmRequest("llm");
-        var extractContent = AIAgentNode.builder("extract-content")
-            .withInput(Message.Assistant.class)
-            .withOutput(String.class)
-            .withAction((response, ctx) -> assistantContent(response, ""))
-            .build();
 
-        strategy.edge(strategy.nodeStart, preprocess);
-        strategy.edge(preprocess, llm);
-        strategy.edge(llm, extractContent);
         strategy.edge(AIAgentEdge.builder()
-            .from(extractContent)
+            .from(strategy.nodeStart)
+            .to(llm)
+            .withAction((input, ctx) -> "Reply with the single word hello to: " + input)
+            .build());
+
+        strategy.edge(AIAgentEdge.builder()
+            .from(llm)
             .to(strategy.nodeFinish)
+            .onTextMessage()
             .build());
 
         AIAgent<String, String> agent = AIAgent.builder()
@@ -111,12 +95,12 @@ public class JavaAIAgentGraphStrategyTest extends KoogJavaTestBase {
             () -> assertFalse(result.isBlank(), "Graph result should not be blank"),
             () -> assertTrue(containsIgnoreCase(result, "hello"), "Graph result should contain the expected hello reply, but was: " + result),
             () -> assertEquals(
-                List.of("preprocess", "llm", "extract-content"),
+                List.of("llm"),
                 withoutGraphBoundaryNodes(events.nodeNames),
                 "Expected node execution order for typed-node graph"
             ),
             () -> assertEquals(
-                List.of("preprocess", "llm", "extract-content"),
+                List.of("llm"),
                 withoutGraphBoundaryNodes(events.completedNodeNames),
                 "Expected node completion order for typed-node graph"
             )
@@ -348,36 +332,26 @@ public class JavaAIAgentGraphStrategyTest extends KoogJavaTestBase {
             .withInput(String.class)
             .withOutput(String.class);
 
-        var wrapAsUserFirst = toUserMessageNode("wrap-as-user-first");
         var firstLlm = AIAgentNode.llmRequest("first-llm");
-        var extractFirstResponse = AIAgentNode.builder("extract-first-response")
-            .withInput(Message.Assistant.class)
-            .withOutput(String.class)
-            .withAction((response, ctx) -> assistantContent(response, "No response"))
-            .build();
         var compress = new CompressHistoryNodeBuilder("compress")
             .withInput(String.class)
             .compressionStrategy(HistoryCompressionStrategy.WholeHistory)
             .preserveMemory(true)
             .build();
-        var wrapAsUserFinal = toUserMessageNode("wrap-as-user-final");
         var finalLlm = AIAgentNode.llmRequest("final-llm");
-        var extractFinalResponse = AIAgentNode.builder("extract-final-response")
-            .withInput(Message.Assistant.class)
-            .withOutput(String.class)
-            .withAction((response, ctx) -> assistantContent(response, ""))
-            .build();
 
-        strategy.edge(strategy.nodeStart, wrapAsUserFirst);
-        strategy.edge(wrapAsUserFirst, firstLlm);
-        strategy.edge(firstLlm, extractFirstResponse);
-        strategy.edge(extractFirstResponse, compress);
-        strategy.edge(compress, wrapAsUserFinal);
-        strategy.edge(wrapAsUserFinal, finalLlm);
-        strategy.edge(finalLlm, extractFinalResponse);
+        strategy.edge(strategy.nodeStart, firstLlm);
         strategy.edge(AIAgentEdge.builder()
-            .from(extractFinalResponse)
+            .from(firstLlm)
+            .to(compress)
+            .onTextMessage()
+            .build());
+
+        strategy.edge(compress, finalLlm);
+        strategy.edge(AIAgentEdge.builder()
+            .from(finalLlm)
             .to(strategy.nodeFinish)
+            .onTextMessage()
             .build());
 
         AIAgent<String, String> agent = AIAgent.builder()
@@ -824,25 +798,6 @@ public class JavaAIAgentGraphStrategyTest extends KoogJavaTestBase {
         return nodeNames.stream()
             .filter(nodeName -> !"__start__".equals(nodeName) && !"__finish__".equals(nodeName))
             .toList();
-    }
-
-    private static String assistantContent(Message.Assistant response, String fallback) {
-        String text = response.getParts().stream()
-            .filter(p -> p instanceof MessagePart.Text)
-            .map(p -> ((MessagePart.Text) p).getText())
-            .collect(Collectors.joining("\n"));
-        return text.isEmpty() ? fallback : text;
-    }
-
-    private static AIAgentNode<String, Message.User> toUserMessageNode(String name) {
-        return AIAgentNode.builder(name)
-            .withInput(String.class)
-            .withOutput(Message.User.class)
-            .withAction((input, ctx) -> new Message.User(
-                input,
-                new RequestMetaInfo(kotlin.time.Clock.System.INSTANCE.now(), null)
-            ))
-            .build();
     }
 
     private static boolean containsIgnoreCase(String text, String expected) {

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentIntegrationTest.kt
@@ -16,8 +16,7 @@ import ai.koog.agents.core.dsl.extension.Concept
 import ai.koog.agents.core.dsl.extension.FactType
 import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
 import ai.koog.agents.core.dsl.extension.ReceivedToolResults
-import ai.koog.agents.core.dsl.extension.asUserMessage
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMRequestWithoutTools
@@ -226,7 +225,7 @@ class AIAgentIntegrationTest : AIAgentTestBase() {
         compressBeforeToolResult: Boolean,
     ) = strategy<String, Pair<String, List<Message>>>("history-compression-with-tools-test") {
         val callLLM by nodeLLMRequest(name = "callLLM")
-        val executeTool by nodeExecuteToolsAndGetResults("execute_tool")
+        val executeTool by nodeExecuteTools("execute_tool")
         val compressResponse by nodeLLMCompressHistory<Message.Assistant>(
             name = "compress_history",
             strategy = strategy
@@ -237,7 +236,7 @@ class AIAgentIntegrationTest : AIAgentTestBase() {
         )
         val sendToolResult by nodeLLMSendToolResults("send_tool_result")
 
-        edge(nodeStart forwardTo callLLM asUserMessage { it })
+        edge(nodeStart forwardTo callLLM)
         if (compressBeforeToolResult) {
             edge(callLLM forwardTo executeTool onToolCalls { true })
             executeTool then compressToolResult then sendToolResult
@@ -464,7 +463,7 @@ class AIAgentIntegrationTest : AIAgentTestBase() {
 
         val customStrategy = strategy("test-without-tools") {
             val callLLM by nodeLLMRequestWithoutTools(name = "callLLM")
-            edge(nodeStart forwardTo callLLM asUserMessage { it })
+            edge(nodeStart forwardTo callLLM)
             edge(callLLM forwardTo nodeFinish onTextMessage { true })
         }
 
@@ -1336,7 +1335,7 @@ class AIAgentIntegrationTest : AIAgentTestBase() {
                         strategy = strategy
                     )
 
-                    edge(nodeStart forwardTo callLLM asUserMessage { it })
+                    edge(nodeStart forwardTo callLLM)
                     edge(callLLM forwardTo nodeCompressHistory onTextMessage { true })
                     edge(nodeCompressHistory forwardTo nodeFinish transformed { it to llm.prompt.messages })
                 }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/AIAgentTestBase.kt
@@ -6,8 +6,7 @@ import ai.koog.agents.core.agent.context.agentInput
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.builder.subgraph
-import ai.koog.agents.core.dsl.extension.asUserMessage
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMCompressHistory
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
@@ -299,11 +298,11 @@ open class AIAgentTestBase {
                 }
 
                 val callLLM by nodeLLMRequest()
-                val callTool by nodeExecuteToolsAndGetResults()
+                val callTool by nodeExecuteTools()
                 val sendToolResult by nodeLLMSendToolResults()
 
                 edge(nodeStart forwardTo definePromptAnthropic transformed {})
-                edge(definePromptAnthropic forwardTo callLLM transformed { agentInput<String>() } asUserMessage { it })
+                edge(definePromptAnthropic forwardTo callLLM transformed { agentInput<String>() })
                 edge(callLLM forwardTo callTool onToolCalls { true })
                 edge(callLLM forwardTo nodeFinish onTextMessage { true } transformed {})
                 edge(callTool forwardTo sendToolResult)
@@ -331,11 +330,11 @@ open class AIAgentTestBase {
                 }
 
                 val callLLM by nodeLLMRequest()
-                val callTool by nodeExecuteToolsAndGetResults()
+                val callTool by nodeExecuteTools()
                 val sendToolResult by nodeLLMSendToolResults()
 
                 edge(nodeStart forwardTo definePromptOpenAI)
-                edge(definePromptOpenAI forwardTo callLLM transformed { agentInput<String>() } asUserMessage { it })
+                edge(definePromptOpenAI forwardTo callLLM transformed { agentInput<String>() })
                 edge(callLLM forwardTo callTool onToolCalls { true })
                 edge(callLLM forwardTo nodeFinish onTextMessage { true })
                 edge(callTool forwardTo sendToolResult)

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/OllamaAgentIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/agent/OllamaAgentIntegrationTest.kt
@@ -8,8 +8,7 @@ import ai.koog.agents.core.agent.singleRunStrategy
 import ai.koog.agents.core.dsl.builder.node
 import ai.koog.agents.core.dsl.builder.strategy
 import ai.koog.agents.core.dsl.builder.subgraph
-import ai.koog.agents.core.dsl.extension.asUserMessage
-import ai.koog.agents.core.dsl.extension.nodeExecuteToolsAndGetResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.dsl.extension.nodeLLMRequest
 import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
 import ai.koog.agents.core.dsl.extension.onTextMessage
@@ -105,11 +104,11 @@ class OllamaAgentIntegrationTest : AIAgentTestBase() {
             }
 
             val callLLM by nodeLLMRequest()
-            val callTool by nodeExecuteToolsAndGetResults()
+            val callTool by nodeExecuteTools()
             val sendToolResult by nodeLLMSendToolResults()
 
             edge(nodeStart forwardTo definePrompt transformed {})
-            edge(definePrompt forwardTo callLLM transformed { agentInput<String>() } asUserMessage { it })
+            edge(definePrompt forwardTo callLLM transformed { agentInput<String>() })
             edge(callLLM forwardTo callTool onToolCalls { true })
             edge(callTool forwardTo sendToolResult)
             edge(sendToolResult forwardTo callTool onToolCalls { true })
@@ -144,11 +143,11 @@ class OllamaAgentIntegrationTest : AIAgentTestBase() {
             }
 
             val callLLM by nodeLLMRequest()
-            val callTool by nodeExecuteToolsAndGetResults()
+            val callTool by nodeExecuteTools()
             val sendToolResult by nodeLLMSendToolResults()
 
             edge(nodeStart forwardTo definePrompt transformed {})
-            edge(definePrompt forwardTo callLLM transformed { agentInput<String>() } asUserMessage { it })
+            edge(definePrompt forwardTo callLLM transformed { agentInput<String>() })
             edge(callLLM forwardTo callTool onToolCalls { true })
             edge(callTool forwardTo sendToolResult)
             edge(sendToolResult forwardTo callTool onToolCalls { true })


### PR DESCRIPTION
Refactor nodes API so `executeTools` and `llmRequest` (now `llmSendMessage`) can be connected without having a separate `llmSendResult`

BREAKING:
* Roll back old node names (which accept String as input)
* Changed names for new nodes to `llmSendMessage`
