### PR TITLE
docs(koog-agents): bump koog-agents version to 0.8.0 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Currently, the framework supports the JVM, JS, WasmJS and iOS targets.
 
     ```
     dependencies {
-        implementation("ai.koog:koog-agents:0.7.3")
+        implementation("ai.koog:koog-agents:0.8.0")
     }
     ```
 2. Make sure that you have `mavenCentral()` in the list of repositories.
@@ -103,7 +103,7 @@ Currently, the framework supports the JVM, JS, WasmJS and iOS targets.
 
     ```
     dependencies {
-        implementation 'ai.koog:koog-agents:0.7.3'
+        implementation 'ai.koog:koog-agents:0.8.0'
     }
     ```
 2. Make sure that you have `mavenCentral()` in the list of repositories.
@@ -115,7 +115,7 @@ Currently, the framework supports the JVM, JS, WasmJS and iOS targets.
     <dependency>
         <groupId>ai.koog</groupId>
         <artifactId>koog-agents-jvm</artifactId>
-        <version>0.7.3</version>
+        <version>0.8.0</version>
     </dependency>
     ```
 2. Make sure that you have `mavenCentral` in the list of repositories.


### PR DESCRIPTION
# Description

Update the `README.md` dependencies examples to refer to the latest stable version of Koog framework, `0.8.0`, instead of the older `0.7.3`.