### PR TITLE
refactor(agents): rename remaining javaApi... methods to ...Blocking, add missing `@JvmSynthetic` to hide suspendable methods from Java

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/llm/LLMCallEventContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/llm/LLMCallEventContext.kt
@@ -70,7 +70,7 @@ public data class LLMCallFailedContext(
     override val tools: List<ToolDescriptor>,
     public val error: Throwable
 ) : LLMCallEventContext {
-    override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.LLMCallStarting
+    override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.LLMCallFailed
 }
 
 /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipelineAPI.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipelineAPI.kt
@@ -13,6 +13,7 @@ import ai.koog.agents.core.feature.handler.subgraph.SubgraphExecutionCompletedCo
 import ai.koog.agents.core.feature.handler.subgraph.SubgraphExecutionFailedContext
 import ai.koog.agents.core.feature.handler.subgraph.SubgraphExecutionStartingContext
 import ai.koog.serialization.TypeToken
+import kotlin.jvm.JvmSynthetic
 
 /**
  * Public API surface for graph-specific pipeline operations (nodes and subgraphs).
@@ -98,31 +99,37 @@ public interface AIAgentGraphPipelineAPI : AIAgentPipelineAPI {
 
     //region Interceptors
 
+    @JvmSynthetic
     public fun interceptNodeExecutionStarting(
         feature: AIAgentGraphFeature<*, *>,
         handle: suspend (eventContext: NodeExecutionStartingContext) -> Unit
     )
 
+    @JvmSynthetic
     public fun interceptNodeExecutionCompleted(
         feature: AIAgentGraphFeature<*, *>,
         handle: suspend (eventContext: NodeExecutionCompletedContext) -> Unit
     )
 
+    @JvmSynthetic
     public fun interceptNodeExecutionFailed(
         feature: AIAgentGraphFeature<*, *>,
         handle: suspend (eventContext: NodeExecutionFailedContext) -> Unit
     )
 
+    @JvmSynthetic
     public fun interceptSubgraphExecutionStarting(
         feature: AIAgentGraphFeature<*, *>,
         handle: suspend (eventContext: SubgraphExecutionStartingContext) -> Unit
     )
 
+    @JvmSynthetic
     public fun interceptSubgraphExecutionCompleted(
         feature: AIAgentGraphFeature<*, *>,
         handle: suspend (eventContext: SubgraphExecutionCompletedContext) -> Unit
     )
 
+    @JvmSynthetic
     public fun interceptSubgraphExecutionFailed(
         feature: AIAgentGraphFeature<*, *>,
         handle: suspend (eventContext: SubgraphExecutionFailedContext) -> Unit

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineAPI.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineAPI.kt
@@ -39,6 +39,7 @@ import ai.koog.serialization.JSONElement
 import ai.koog.serialization.JSONObject
 import ai.koog.serialization.TypeToken
 import ai.koog.utils.time.KoogClock
+import kotlin.jvm.JvmSynthetic
 import kotlin.reflect.KClass
 
 /**
@@ -299,73 +300,88 @@ public interface AIAgentPipelineAPI {
 
     //region Interceptors
 
+    @JvmSynthetic
     public fun interceptEnvironmentCreated(
         feature: AIAgentFeature<*, *>,
         handle: suspend (eventContext: AgentEnvironmentTransformingContext, environment: AIAgentEnvironment) -> AIAgentEnvironment
     )
 
+    @JvmSynthetic
     public fun interceptAgentStarting(feature: AIAgentFeature<*, *>, handle: suspend (AgentStartingContext) -> Unit)
 
+    @JvmSynthetic
     public fun interceptAgentCompleted(
         feature: AIAgentFeature<*, *>,
         handle: suspend (eventContext: AgentCompletedContext) -> Unit
     )
 
+    @JvmSynthetic
     public fun interceptAgentExecutionFailed(
         feature: AIAgentFeature<*, *>,
         handle: suspend (eventContext: AgentExecutionFailedContext) -> Unit
     )
 
+    @JvmSynthetic
     public fun interceptAgentClosing(
         feature: AIAgentFeature<*, *>,
         handle: suspend (eventContext: AgentClosingContext) -> Unit
     )
 
+    @JvmSynthetic
     public fun interceptStrategyStarting(
         feature: AIAgentFeature<*, *>,
         handle: suspend (StrategyStartingContext) -> Unit
     )
 
+    @JvmSynthetic
     public fun interceptStrategyCompleted(
         feature: AIAgentFeature<*, *>,
         handle: suspend (StrategyCompletedContext) -> Unit
     )
 
+    @JvmSynthetic
     public fun interceptLLMCallStarting(
         feature: AIAgentFeature<*, *>,
         handle: suspend (eventContext: LLMCallStartingContext) -> Unit
     )
 
+    @JvmSynthetic
     public fun interceptLLMCallCompleted(
         feature: AIAgentFeature<*, *>,
         handle: suspend (eventContext: LLMCallCompletedContext) -> Unit
     )
 
+    @JvmSynthetic
     public fun interceptLLMCallFailed(
         feature: AIAgentFeature<*, *>,
         handle: suspend (eventContext: LLMCallFailedContext) -> Unit
     )
 
+    @JvmSynthetic
     public fun interceptLLMStreamingStarting(
         feature: AIAgentFeature<*, *>,
         handle: suspend (eventContext: LLMStreamingStartingContext) -> Unit
     )
 
+    @JvmSynthetic
     public fun interceptLLMStreamingFrameReceived(
         feature: AIAgentFeature<*, *>,
         handle: suspend (eventContext: LLMStreamingFrameReceivedContext) -> Unit
     )
 
+    @JvmSynthetic
     public fun interceptLLMStreamingFailed(
         feature: AIAgentFeature<*, *>,
         handle: suspend (eventContext: LLMStreamingFailedContext) -> Unit
     )
 
+    @JvmSynthetic
     public fun interceptLLMStreamingCompleted(
         feature: AIAgentFeature<*, *>,
         handle: suspend (eventContext: LLMStreamingCompletedContext) -> Unit
     )
 
+    @JvmSynthetic
     public fun interceptToolCallStarting(
         feature: AIAgentFeature<*, *>,
         handle: suspend (eventContext: ToolCallStartingContext) -> Unit
@@ -384,21 +400,25 @@ public interface AIAgentPipelineAPI {
      * Merge precedence (documented in [ai.koog.agents.core.environment.ContextualAgentEnvironment]):
      * caller-supplied metadata wins over feature contributions on key collision.
      */
+    @JvmSynthetic
     public fun provideToolCallMetadata(
         feature: AIAgentFeature<*, *>,
         handle: suspend (eventContext: ToolCallStartingContext) -> Map<String, Any?>
     )
 
+    @JvmSynthetic
     public fun interceptToolValidationFailed(
         feature: AIAgentFeature<*, *>,
         handle: suspend (eventContext: ToolValidationFailedContext) -> Unit
     )
 
+    @JvmSynthetic
     public fun interceptToolCallFailed(
         feature: AIAgentFeature<*, *>,
         handle: suspend (eventContext: ToolCallFailedContext) -> Unit
     )
 
+    @JvmSynthetic
     public fun interceptToolCallCompleted(
         feature: AIAgentFeature<*, *>,
         handle: suspend (eventContext: ToolCallCompletedContext) -> Unit

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipelineAPI.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipelineAPI.kt
@@ -11,6 +11,7 @@ import ai.koog.agents.core.feature.handler.planner.PlanCreationStartingContext
 import ai.koog.agents.core.feature.handler.planner.StepExecutionCompletedContext
 import ai.koog.agents.core.feature.handler.planner.StepExecutionStartingContext
 import ai.koog.serialization.TypeToken
+import kotlin.jvm.JvmSynthetic
 
 /**
  * Platform-agnostic API for planner agent pipelines, extending the base pipeline API
@@ -163,6 +164,7 @@ public interface AIAgentPlannerPipelineAPI : AIAgentPipelineAPI {
      * @param feature The feature associated with this handler;
      * @param handle A suspend function that processes the start of a plan creation.
      */
+    @JvmSynthetic
     public fun interceptPlanCreationStarting(
         feature: AIAgentFeature<*, *>,
         handle: suspend (PlanCreationStartingContext) -> Unit
@@ -174,6 +176,7 @@ public interface AIAgentPlannerPipelineAPI : AIAgentPipelineAPI {
      * @param feature The feature associated with this handler;
      * @param handle A suspend function that processes the completion of a plan creation.
      */
+    @JvmSynthetic
     public fun interceptPlanCreationCompleted(
         feature: AIAgentFeature<*, *>,
         handle: suspend (PlanCreationCompletedContext) -> Unit
@@ -192,6 +195,7 @@ public interface AIAgentPlannerPipelineAPI : AIAgentPipelineAPI {
      * }
      * ```
      */
+    @JvmSynthetic
     public fun interceptStepExecutionStarting(
         feature: AIAgentFeature<*, *>,
         handle: suspend (StepExecutionStartingContext) -> Unit
@@ -210,6 +214,7 @@ public interface AIAgentPlannerPipelineAPI : AIAgentPipelineAPI {
      * }
      * ```
      */
+    @JvmSynthetic
     public fun interceptStepExecutionCompleted(
         feature: AIAgentFeature<*, *>,
         handle: suspend (StepExecutionCompletedContext) -> Unit
@@ -221,6 +226,7 @@ public interface AIAgentPlannerPipelineAPI : AIAgentPipelineAPI {
      * @param feature The feature associated with this handler;
      * @param handle A suspend function that processes the start of a plan completion evaluation.
      */
+    @JvmSynthetic
     public fun interceptPlanCompletionEvaluationStarting(
         feature: AIAgentFeature<*, *>,
         handle: suspend (PlanCompletionEvaluationStartingContext) -> Unit
@@ -239,6 +245,7 @@ public interface AIAgentPlannerPipelineAPI : AIAgentPipelineAPI {
      * }
      * ```
      */
+    @JvmSynthetic
     public fun interceptPlanCompletionEvaluationCompleted(
         feature: AIAgentFeature<*, *>,
         handle: suspend (PlanCompletionEvaluationCompletedContext) -> Unit

--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentGraphPipeline.kt
@@ -52,7 +52,7 @@ public actual open class AIAgentGraphPipeline @JvmOverloads actual constructor(
      */
     @JavaAPI
     @JvmName("interceptNodeExecutionStarting")
-    public fun javaApiInterceptNodeExecutionStarting(
+    public fun interceptNodeExecutionStartingBlocking(
         feature: AIAgentGraphFeature<*, *>,
         handle: Interceptor<NodeExecutionStartingContext>
     ) {
@@ -80,7 +80,7 @@ public actual open class AIAgentGraphPipeline @JvmOverloads actual constructor(
      */
     @JavaAPI
     @JvmName("interceptNodeExecutionCompleted")
-    public fun javaApiInterceptNodeExecutionCompleted(
+    public fun interceptNodeExecutionCompletedBlocking(
         feature: AIAgentGraphFeature<*, *>,
         handle: Interceptor<NodeExecutionCompletedContext>
     ) {
@@ -108,7 +108,7 @@ public actual open class AIAgentGraphPipeline @JvmOverloads actual constructor(
      */
     @JavaAPI
     @JvmName("interceptNodeExecutionFailed")
-    public fun javaApiInterceptNodeExecutionFailed(
+    public fun interceptNodeExecutionFailedBlocking(
         feature: AIAgentGraphFeature<*, *>,
         handle: Interceptor<NodeExecutionFailedContext>
     ) {
@@ -136,7 +136,7 @@ public actual open class AIAgentGraphPipeline @JvmOverloads actual constructor(
      */
     @JavaAPI
     @JvmName("interceptSubgraphExecutionStarting")
-    public fun javaApiInterceptSubgraphExecutionStarting(
+    public fun interceptSubgraphExecutionStartingBlocking(
         feature: AIAgentGraphFeature<*, *>,
         handle: Interceptor<SubgraphExecutionStartingContext>
     ) {
@@ -164,7 +164,7 @@ public actual open class AIAgentGraphPipeline @JvmOverloads actual constructor(
      */
     @JavaAPI
     @JvmName("interceptSubgraphExecutionCompleted")
-    public fun javaApiInterceptSubgraphExecutionCompleted(
+    public fun interceptSubgraphExecutionCompletedBlocking(
         feature: AIAgentGraphFeature<*, *>,
         handle: Interceptor<SubgraphExecutionCompletedContext>
     ) {
@@ -192,7 +192,7 @@ public actual open class AIAgentGraphPipeline @JvmOverloads actual constructor(
      */
     @JavaAPI
     @JvmName("interceptSubgraphExecutionFailed")
-    public fun javaApiInterceptSubgraphExecutionFailed(
+    public fun interceptSubgraphExecutionFailedBlocking(
         feature: AIAgentGraphFeature<*, *>,
         handle: Interceptor<SubgraphExecutionFailedContext>
     ) {

--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
@@ -51,7 +51,7 @@ public actual abstract class AIAgentPipeline actual constructor(
      */
     @JavaAPI
     @JvmName("interceptEnvironmentCreated")
-    public fun javaApiInterceptEnvironmentCreated(
+    public fun interceptEnvironmentCreatedBlocking(
         feature: AIAgentFeature<*, *>,
         transform: TransformInterceptor<AgentEnvironmentTransformingContext, AIAgentEnvironment>
     ) {
@@ -73,7 +73,7 @@ public actual abstract class AIAgentPipeline actual constructor(
      */
     @JavaAPI
     @JvmName("interceptAgentStarting")
-    public fun javaApiInterceptAgentStarting(
+    public fun interceptAgentStartingBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<AgentStartingContext>
     ) {
@@ -98,7 +98,7 @@ public actual abstract class AIAgentPipeline actual constructor(
      */
     @JavaAPI
     @JvmName("interceptAgentCompleted")
-    public fun javaApiInterceptAgentCompleted(
+    public fun interceptAgentCompletedBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<AgentCompletedContext>
     ) {
@@ -123,7 +123,7 @@ public actual abstract class AIAgentPipeline actual constructor(
      */
     @JavaAPI
     @JvmName("interceptAgentExecutionFailed")
-    public fun javaApiInterceptAgentExecutionFailed(
+    public fun interceptAgentExecutionFailedBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<AgentExecutionFailedContext>
     ) {
@@ -148,7 +148,7 @@ public actual abstract class AIAgentPipeline actual constructor(
      */
     @JavaAPI
     @JvmName("interceptAgentClosing")
-    public fun javaApiInterceptAgentClosing(
+    public fun interceptAgentClosingBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<AgentClosingContext>
     ) {
@@ -173,7 +173,7 @@ public actual abstract class AIAgentPipeline actual constructor(
      */
     @JavaAPI
     @JvmName("interceptStrategyStarting")
-    public fun javaApiInterceptStrategyStarting(
+    public fun interceptStrategyStartingBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<StrategyStartingContext>
     ) {
@@ -198,7 +198,7 @@ public actual abstract class AIAgentPipeline actual constructor(
      */
     @JavaAPI
     @JvmName("interceptStrategyCompleted")
-    public fun javaApiInterceptStrategyCompleted(
+    public fun interceptStrategyCompletedBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<StrategyCompletedContext>
     ) {
@@ -223,7 +223,7 @@ public actual abstract class AIAgentPipeline actual constructor(
      */
     @JavaAPI
     @JvmName("interceptLLMCallStarting")
-    public fun javaApiInterceptLLMCallStarting(
+    public fun interceptLLMCallStartingBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<LLMCallStartingContext>
     ) {
@@ -248,7 +248,7 @@ public actual abstract class AIAgentPipeline actual constructor(
      */
     @JavaAPI
     @JvmName("interceptLLMCallCompleted")
-    public fun javaApiInterceptLLMCallCompleted(
+    public fun interceptLLMCallCompletedBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<LLMCallCompletedContext>
     ) {
@@ -274,7 +274,7 @@ public actual abstract class AIAgentPipeline actual constructor(
      */
     @JavaAPI
     @JvmName("interceptLLMCallFailed")
-    public fun javaApiInterceptLLMCallFailed(
+    public fun interceptLLMCallFailedBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<LLMCallFailedContext>
     ) {
@@ -299,7 +299,7 @@ public actual abstract class AIAgentPipeline actual constructor(
      */
     @JavaAPI
     @JvmName("interceptLLMStreamingStarting")
-    public fun javaApiInterceptLLMStreamingStarting(
+    public fun interceptLLMStreamingStartingBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<LLMStreamingStartingContext>
     ) {
@@ -324,7 +324,7 @@ public actual abstract class AIAgentPipeline actual constructor(
      */
     @JavaAPI
     @JvmName("interceptLLMStreamingFrameReceived")
-    public fun javaApiInterceptLLMStreamingFrameReceived(
+    public fun interceptLLMStreamingFrameReceivedBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<LLMStreamingFrameReceivedContext>
     ) {
@@ -349,7 +349,7 @@ public actual abstract class AIAgentPipeline actual constructor(
      */
     @JavaAPI
     @JvmName("interceptLLMStreamingFailed")
-    public fun javaApiInterceptLLMStreamingFailed(
+    public fun interceptLLMStreamingFailedBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<LLMStreamingFailedContext>
     ) {
@@ -374,7 +374,7 @@ public actual abstract class AIAgentPipeline actual constructor(
      */
     @JavaAPI
     @JvmName("interceptLLMStreamingCompleted")
-    public fun javaApiInterceptLLMStreamingCompleted(
+    public fun interceptLLMStreamingCompletedBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<LLMStreamingCompletedContext>
     ) {
@@ -399,7 +399,7 @@ public actual abstract class AIAgentPipeline actual constructor(
      */
     @JavaAPI
     @JvmName("interceptToolCallStarting")
-    public fun javaApiInterceptToolCallStarting(
+    public fun interceptToolCallStartingBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<ToolCallStartingContext>
     ) {
@@ -424,7 +424,7 @@ public actual abstract class AIAgentPipeline actual constructor(
      */
     @JavaAPI
     @JvmName("interceptToolValidationFailed")
-    public fun javaApiInterceptToolValidationFailed(
+    public fun interceptToolValidationFailedBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<ToolValidationFailedContext>
     ) {
@@ -449,7 +449,7 @@ public actual abstract class AIAgentPipeline actual constructor(
      */
     @JavaAPI
     @JvmName("interceptToolCallFailed")
-    public fun javaApiInterceptToolCallFailed(
+    public fun interceptToolCallFailedBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<ToolCallFailedContext>
     ) {
@@ -474,7 +474,7 @@ public actual abstract class AIAgentPipeline actual constructor(
      */
     @JavaAPI
     @JvmName("interceptToolCallCompleted")
-    public fun javaApiInterceptToolCallCompleted(
+    public fun interceptToolCallCompletedBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<ToolCallCompletedContext>
     ) {

--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPlannerPipeline.kt
@@ -53,7 +53,7 @@ public actual open class AIAgentPlannerPipeline @JvmOverloads actual constructor
      */
     @JavaAPI
     @JvmName("interceptPlanCreationStarting")
-    public fun javaApiInterceptPlanCreationStarting(
+    public fun interceptPlanCreationStartingBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<PlanCreationStartingContext>
     ) {
@@ -72,7 +72,7 @@ public actual open class AIAgentPlannerPipeline @JvmOverloads actual constructor
      */
     @JavaAPI
     @JvmName("interceptPlanCreationCompleted")
-    public fun javaApiInterceptPlanCreationCompleted(
+    public fun interceptPlanCreationCompletedBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<PlanCreationCompletedContext>
     ) {
@@ -97,7 +97,7 @@ public actual open class AIAgentPlannerPipeline @JvmOverloads actual constructor
      */
     @JavaAPI
     @JvmName("interceptStepExecutionStarting")
-    public fun javaApiInterceptStepExecutionStarting(
+    public fun interceptStepExecutionStartingBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<StepExecutionStartingContext>
     ) {
@@ -122,7 +122,7 @@ public actual open class AIAgentPlannerPipeline @JvmOverloads actual constructor
      */
     @JavaAPI
     @JvmName("interceptStepExecutionCompleted")
-    public fun javaApiInterceptStepExecutionCompleted(
+    public fun interceptStepExecutionCompletedBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<StepExecutionCompletedContext>
     ) {
@@ -141,7 +141,7 @@ public actual open class AIAgentPlannerPipeline @JvmOverloads actual constructor
      */
     @JavaAPI
     @JvmName("interceptPlanCompletionEvaluationStarting")
-    public fun javaApiInterceptPlanCompletionEvaluationStarting(
+    public fun interceptPlanCompletionEvaluationStartingBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<PlanCompletionEvaluationStartingContext>
     ) {
@@ -166,7 +166,7 @@ public actual open class AIAgentPlannerPipeline @JvmOverloads actual constructor
      */
     @JavaAPI
     @JvmName("interceptPlanCompletionEvaluationCompleted")
-    public fun javaApiInterceptPlanCompletionEvaluationCompleted(
+    public fun interceptPlanCompletionEvaluationCompletedBlocking(
         feature: AIAgentFeature<*, *>,
         handle: Interceptor<PlanCompletionEvaluationCompletedContext>
     ) {

--- a/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerConfigCommon.kt
+++ b/agents/agents-features/agents-features-event-handler/src/commonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerConfigCommon.kt
@@ -23,6 +23,7 @@ import ai.koog.agents.core.feature.handler.tool.ToolCallCompletedContext
 import ai.koog.agents.core.feature.handler.tool.ToolCallFailedContext
 import ai.koog.agents.core.feature.handler.tool.ToolCallStartingContext
 import ai.koog.agents.core.feature.handler.tool.ToolValidationFailedContext
+import kotlin.jvm.JvmSynthetic
 
 /**
  * API for the [EventHandlerConfig]
@@ -109,6 +110,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
     /**
      * Append handler called when an agent is started.
      */
+    @JvmSynthetic
     public fun onAgentStarting(handler: suspend (eventContext: AgentStartingContext) -> Unit) {
         val originalHandler = this._onAgentStarting
         this._onAgentStarting = { eventContext ->
@@ -120,6 +122,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
     /**
      * Append handler called when an agent finishes execution.
      */
+    @JvmSynthetic
     public fun onAgentCompleted(handler: suspend (eventContext: AgentCompletedContext) -> Unit) {
         val originalHandler = this._onAgentCompleted
         this._onAgentCompleted = { eventContext ->
@@ -131,6 +134,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
     /**
      * Append handler called when an error occurs during agent execution.
      */
+    @JvmSynthetic
     public fun onAgentExecutionFailed(handler: suspend (eventContext: AgentExecutionFailedContext) -> Unit) {
         val originalHandler = this._onAgentExecutionFailed
         this._onAgentExecutionFailed = { eventContext ->
@@ -143,6 +147,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
      * Appends a handler called before an agent is closed. This allows for additional behavior
      * to be executed prior to the agent being closed.
      */
+    @JvmSynthetic
     public fun onAgentClosing(handler: suspend (eventContext: AgentClosingContext) -> Unit) {
         val originalHandler = this._onAgentClosing
         this._onAgentClosing = { eventContext ->
@@ -158,6 +163,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
     /**
      * Append handler called when a strategy starts execution.
      */
+    @JvmSynthetic
     public fun onStrategyStarting(handler: suspend (eventContext: StrategyStartingContext) -> Unit) {
         val originalHandler = this._onStrategyStarting
         this._onStrategyStarting = { eventContext ->
@@ -169,6 +175,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
     /**
      * Append handler called when a strategy finishes execution.
      */
+    @JvmSynthetic
     public fun onStrategyCompleted(handler: suspend (eventContext: StrategyCompletedContext) -> Unit) {
         val originalHandler = this._onStrategyCompleted
         this._onStrategyCompleted = { eventContext ->
@@ -184,6 +191,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
     /**
      * Append handler called before a node in the agent's execution graph is processed.
      */
+    @JvmSynthetic
     public fun onNodeExecutionStarting(handler: suspend (eventContext: NodeExecutionStartingContext) -> Unit) {
         val originalHandler = this._onNodeExecutionStarting
         this._onNodeExecutionStarting = { eventContext ->
@@ -195,6 +203,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
     /**
      * Append handler called after a node in the agent's execution graph has been processed.
      */
+    @JvmSynthetic
     public fun onNodeExecutionCompleted(handler: suspend (eventContext: NodeExecutionCompletedContext) -> Unit) {
         val originalHandler = this._onNodeExecutionCompleted
         this._onNodeExecutionCompleted = { eventContext ->
@@ -206,6 +215,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
     /**
      * Append handler called when an error occurs during the execution of a node.
      */
+    @JvmSynthetic
     public fun onNodeExecutionFailed(handler: suspend (eventContext: NodeExecutionFailedContext) -> Unit) {
         val originalHandler = this._onNodeExecutionFailed
         this._onNodeExecutionFailed = { eventContext ->
@@ -221,6 +231,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
     /**
      * Append handler called before a subgraph in the agent's execution graph is processed.
      */
+    @JvmSynthetic
     public fun onSubgraphExecutionStarting(handler: suspend (eventContext: SubgraphExecutionStartingContext) -> Unit) {
         val originalHandler = this._onSubgraphExecutionStarting
         this._onSubgraphExecutionStarting = { eventContext ->
@@ -232,6 +243,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
     /**
      * Append handler called after a subgraph in the agent's execution graph has been processed.
      */
+    @JvmSynthetic
     public fun onSubgraphExecutionCompleted(handler: suspend (eventContext: SubgraphExecutionCompletedContext) -> Unit) {
         val originalHandler = this._onSubgraphExecutionCompleted
         this._onSubgraphExecutionCompleted = { eventContext ->
@@ -243,6 +255,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
     /**
      * Append handler called when an error occurs during the execution of a subgraph.
      */
+    @JvmSynthetic
     public fun onSubgraphExecutionFailed(handler: suspend (eventContext: SubgraphExecutionFailedContext) -> Unit) {
         val originalHandler = this._onSubgraphExecutionFailed
         this._onSubgraphExecutionFailed = { eventContext ->
@@ -258,6 +271,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
     /**
      * Append handler called before a call is made to the language model.
      */
+    @JvmSynthetic
     public fun onLLMCallStarting(handler: suspend (eventContext: LLMCallStartingContext) -> Unit) {
         val originalHandler = this._onLLMCallStarting
         this._onLLMCallStarting = { eventContext ->
@@ -269,6 +283,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
     /**
      * Append handler called after a response is received from the language model.
      */
+    @JvmSynthetic
     public fun onLLMCallCompleted(handler: suspend (eventContext: LLMCallCompletedContext) -> Unit) {
         val originalHandler = this._onLLMCallCompleted
         this._onLLMCallCompleted = { eventContext ->
@@ -284,6 +299,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
     /**
      * Append handler called when a tool is about to be called.
      */
+    @JvmSynthetic
     public fun onToolCallStarting(handler: suspend (eventContext: ToolCallStartingContext) -> Unit) {
         val originalHandler = this._onToolCallStarting
         this._onToolCallStarting = { eventContext ->
@@ -295,6 +311,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
     /**
      * Append handler called when a validation error occurs during a tool call.
      */
+    @JvmSynthetic
     public fun onToolValidationFailed(handler: suspend (eventContext: ToolValidationFailedContext) -> Unit) {
         val originalHandler = this._onToolValidationFailed
         this._onToolValidationFailed = { eventContext ->
@@ -306,6 +323,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
     /**
      * Append handler called when a tool call fails with an exception.
      */
+    @JvmSynthetic
     public fun onToolCallFailed(handler: suspend (eventContext: ToolCallFailedContext) -> Unit) {
         val originalHandler = this._onToolCallFailed
         this._onToolCallFailed = { eventContext ->
@@ -317,6 +335,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
     /**
      * Append handler called when a tool call completes successfully.
      */
+    @JvmSynthetic
     public fun onToolCallCompleted(handler: suspend (eventContext: ToolCallCompletedContext) -> Unit) {
         val originalHandler = this._onToolCallCompleted
         this._onToolCallCompleted = { eventContext ->
@@ -346,6 +365,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
      * }
      * ```
      */
+    @JvmSynthetic
     public fun onLLMStreamingStarting(handler: suspend (eventContext: LLMStreamingStartingContext) -> Unit) {
         val originalHandler = this._onLLMStreamingStarting
         this._onLLMStreamingStarting = { eventContext ->
@@ -373,6 +393,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
      * }
      * ```
      */
+    @JvmSynthetic
     public fun onLLMStreamingFrameReceived(handler: suspend (eventContext: LLMStreamingFrameReceivedContext) -> Unit) {
         val originalHandler = this._onLLMStreamingFrameReceived
         this._onLLMStreamingFrameReceived = { eventContext ->
@@ -397,6 +418,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
      * }
      * ```
      */
+    @JvmSynthetic
     public fun onLLMStreamingFailed(handler: suspend (eventContext: LLMStreamingFailedContext) -> Unit) {
         val originalHandler = this._onLLMStreamingFailed
         this._onLLMStreamingFailed = { eventContext ->
@@ -422,6 +444,7 @@ public open class EventHandlerConfigCommon : FeatureConfig() {
      * }
      * ```
      */
+    @JvmSynthetic
     public fun onLLMStreamingCompleted(handler: suspend (eventContext: LLMStreamingCompletedContext) -> Unit) {
         val originalHandler = this._onLLMStreamingCompleted
         this._onLLMStreamingCompleted = { eventContext ->

--- a/agents/agents-features/agents-features-event-handler/src/jvmCommonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerConfig.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmCommonMain/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerConfig.kt
@@ -46,7 +46,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onSubgraphExecutionStarting")
-    public fun javaApiOnSubgraphExecutionStarting(handler: Interceptor<SubgraphExecutionStartingContext>) {
+    public fun onSubgraphExecutionStartingBlocking(handler: Interceptor<SubgraphExecutionStartingContext>) {
         onSubgraphExecutionStarting { eventContext ->
             withContextReentrant(eventContext.context.config.strategyDispatcher) {
                 handler.intercept(eventContext)
@@ -63,7 +63,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onSubgraphExecutionCompleted")
-    public fun javaApiOnSubgraphExecutionCompleted(handler: Interceptor<SubgraphExecutionCompletedContext>) {
+    public fun onSubgraphExecutionCompletedBlocking(handler: Interceptor<SubgraphExecutionCompletedContext>) {
         onSubgraphExecutionCompleted { eventContext ->
             withContextReentrant(eventContext.context.config.strategyDispatcher) {
                 handler.intercept(eventContext)
@@ -78,7 +78,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onSubgraphExecutionFailed")
-    public fun javaApiOnSubgraphExecutionFailed(handler: Interceptor<SubgraphExecutionFailedContext>) {
+    public fun onSubgraphExecutionFailedBlocking(handler: Interceptor<SubgraphExecutionFailedContext>) {
         onSubgraphExecutionFailed { eventContext ->
             withContextReentrant(eventContext.context.config.strategyDispatcher) {
                 handler.intercept(eventContext)
@@ -91,7 +91,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onAgentStarting")
-    public fun javaApiOnAgentStarting(handler: Interceptor<AgentStartingContext>) {
+    public fun onAgentStartingBlocking(handler: Interceptor<AgentStartingContext>) {
         onAgentStarting { eventContext ->
             withContextReentrant(eventContext.context.config.strategyDispatcher) {
                 handler.intercept(eventContext)
@@ -104,7 +104,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onAgentCompleted")
-    public fun javaApiOnAgentCompleted(handler: Interceptor<AgentCompletedContext>) {
+    public fun onAgentCompletedBlocking(handler: Interceptor<AgentCompletedContext>) {
         onAgentCompleted { eventContext ->
             withContextReentrant(eventContext.context.config.strategyDispatcher) {
                 handler.intercept(eventContext)
@@ -117,7 +117,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onAgentExecutionFailed")
-    public fun javaApiOnAgentExecutionFailed(handler: Interceptor<AgentExecutionFailedContext>) {
+    public fun onAgentExecutionFailedBlocking(handler: Interceptor<AgentExecutionFailedContext>) {
         onAgentExecutionFailed { eventContext ->
             withContextReentrant(eventContext.context.config.strategyDispatcher) {
                 handler.intercept(eventContext)
@@ -131,7 +131,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onAgentClosing")
-    public fun javaApiOnAgentClosing(handler: Interceptor<AgentClosingContext>) {
+    public fun onAgentClosingBlocking(handler: Interceptor<AgentClosingContext>) {
         onAgentClosing { eventContext ->
             withContextReentrant(eventContext.agent.agentConfig.strategyDispatcher) {
                 handler.intercept(eventContext)
@@ -144,7 +144,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onStrategyStarting")
-    public fun javaApiOnStrategyStarting(handler: Interceptor<StrategyStartingContext>) {
+    public fun onStrategyStartingBlocking(handler: Interceptor<StrategyStartingContext>) {
         onStrategyStarting { eventContext ->
             withContextReentrant(eventContext.context.config.strategyDispatcher) {
                 handler.intercept(eventContext)
@@ -157,7 +157,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onStrategyCompleted")
-    public fun javaApiOnStrategyCompleted(handler: Interceptor<StrategyCompletedContext>) {
+    public fun onStrategyCompletedBlocking(handler: Interceptor<StrategyCompletedContext>) {
         onStrategyCompleted { eventContext ->
             withContextReentrant(eventContext.context.config.strategyDispatcher) {
                 handler.intercept(eventContext)
@@ -170,7 +170,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onNodeExecutionStarting")
-    public fun javaApiOnNodeExecutionStarting(handler: Interceptor<NodeExecutionStartingContext>) {
+    public fun onNodeExecutionStartingBlocking(handler: Interceptor<NodeExecutionStartingContext>) {
         onNodeExecutionStarting { eventContext ->
             withContextReentrant(eventContext.context.config.strategyDispatcher) {
                 handler.intercept(eventContext)
@@ -183,7 +183,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onNodeExecutionCompleted")
-    public fun javaApiOnNodeExecutionCompleted(handler: Interceptor<NodeExecutionCompletedContext>) {
+    public fun onNodeExecutionCompletedBlocking(handler: Interceptor<NodeExecutionCompletedContext>) {
         onNodeExecutionCompleted { eventContext ->
             withContextReentrant(eventContext.context.config.strategyDispatcher) {
                 handler.intercept(eventContext)
@@ -196,7 +196,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onNodeExecutionFailed")
-    public fun javaApiOnNodeExecutionFailed(handler: Interceptor<NodeExecutionFailedContext>) {
+    public fun onNodeExecutionFailedBlocking(handler: Interceptor<NodeExecutionFailedContext>) {
         onNodeExecutionFailed { eventContext ->
             withContextReentrant(eventContext.context.config.strategyDispatcher) {
                 handler.intercept(eventContext)
@@ -209,7 +209,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onLLMCallStarting")
-    public fun javaApiOnLLMCallStarting(handler: Interceptor<LLMCallStartingContext>) {
+    public fun onLLMCallStartingBlocking(handler: Interceptor<LLMCallStartingContext>) {
         onLLMCallStarting { eventContext ->
             withContextReentrant(eventContext.context.config.strategyDispatcher) {
                 handler.intercept(eventContext)
@@ -222,7 +222,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onLLMCallCompleted")
-    public fun javaApiOnLLMCallCompleted(handler: Interceptor<LLMCallCompletedContext>) {
+    public fun onLLMCallCompletedBlocking(handler: Interceptor<LLMCallCompletedContext>) {
         onLLMCallCompleted { eventContext ->
             withContextReentrant(eventContext.context.config.strategyDispatcher) {
                 handler.intercept(eventContext)
@@ -235,7 +235,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onToolCallStarting")
-    public fun javaApiOnToolCallStarting(handler: Interceptor<ToolCallStartingContext>) {
+    public fun onToolCallStartingBlocking(handler: Interceptor<ToolCallStartingContext>) {
         onToolCallStarting { eventContext ->
             withContextReentrant(eventContext.context.config.strategyDispatcher) {
                 handler.intercept(eventContext)
@@ -248,7 +248,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onToolValidationFailed")
-    public fun javaApiOnToolValidationFailed(handler: Interceptor<ToolValidationFailedContext>) {
+    public fun onToolValidationFailedBlocking(handler: Interceptor<ToolValidationFailedContext>) {
         onToolValidationFailed { eventContext ->
             withContextReentrant(eventContext.context.config.strategyDispatcher) {
                 handler.intercept(eventContext)
@@ -261,7 +261,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onToolCallFailed")
-    public fun javaApiOnToolCallFailed(handler: Interceptor<ToolCallFailedContext>) {
+    public fun onToolCallFailedBlocking(handler: Interceptor<ToolCallFailedContext>) {
         onToolCallFailed { eventContext ->
             withContextReentrant(eventContext.context.config.strategyDispatcher) {
                 handler.intercept(eventContext)
@@ -274,7 +274,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onToolCallCompleted")
-    public fun javaApiOnToolCallCompleted(handler: Interceptor<ToolCallCompletedContext>) {
+    public fun onToolCallCompletedBlocking(handler: Interceptor<ToolCallCompletedContext>) {
         onToolCallCompleted { eventContext ->
             withContextReentrant(eventContext.context.config.strategyDispatcher) {
                 handler.intercept(eventContext)
@@ -287,7 +287,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onLLMStreamingStarting")
-    public fun javaApiOnLLMStreamingStarting(handler: Interceptor<LLMStreamingStartingContext>) {
+    public fun onLLMStreamingStartingBlocking(handler: Interceptor<LLMStreamingStartingContext>) {
         onLLMStreamingStarting { eventContext ->
             withContextReentrant(eventContext.context.config.strategyDispatcher) {
                 handler.intercept(eventContext)
@@ -300,7 +300,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onLLMStreamingFrameReceived")
-    public fun javaApiOnLLMStreamingFrameReceived(handler: Interceptor<LLMStreamingFrameReceivedContext>) {
+    public fun onLLMStreamingFrameReceivedBlocking(handler: Interceptor<LLMStreamingFrameReceivedContext>) {
         onLLMStreamingFrameReceived { eventContext ->
             withContextReentrant(eventContext.context.config.strategyDispatcher) {
                 handler.intercept(eventContext)
@@ -313,7 +313,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onLLMStreamingFailed")
-    public fun javaApiOnLLMStreamingFailed(handler: Interceptor<LLMStreamingFailedContext>) {
+    public fun onLLMStreamingFailedBlocking(handler: Interceptor<LLMStreamingFailedContext>) {
         onLLMStreamingFailed { eventContext ->
             withContextReentrant(eventContext.context.config.strategyDispatcher) {
                 handler.intercept(eventContext)
@@ -326,7 +326,7 @@ public actual open class EventHandlerConfig actual constructor() : EventHandlerC
      */
     @JavaAPI
     @JvmName("onLLMStreamingCompleted")
-    public fun javaApiOnLLMStreamingCompleted(handler: Interceptor<LLMStreamingCompletedContext>) {
+    public fun onLLMStreamingCompletedBlocking(handler: Interceptor<LLMStreamingCompletedContext>) {
         onLLMStreamingCompleted { eventContext ->
             withContextReentrant(eventContext.context.config.strategyDispatcher) {
                 handler.intercept(eventContext)

--- a/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/ActionBuilderCommon.kt
+++ b/agents/agents-planner/src/commonMain/kotlin/ai/koog/agents/planner/goap/ActionBuilderCommon.kt
@@ -1,5 +1,7 @@
 package ai.koog.agents.planner.goap
 
+import kotlin.jvm.JvmSynthetic
+
 /**
  * Action builder configuration common to all platforms.
  */
@@ -41,6 +43,7 @@ public abstract class ActionBuilderCommon<State, Self : ActionBuilderCommon<Stat
     /**
      * Sets the execute function for the action.
      */
+    @JvmSynthetic
     public fun execute(execute: Execute<State>): Self = self().apply { this.execute = execute }
 
     /**

--- a/agents/agents-planner/src/jvmCommonMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
+++ b/agents/agents-planner/src/jvmCommonMain/kotlin/ai/koog/agents/planner/goap/ActionBuilder.kt
@@ -20,7 +20,7 @@ public actual class ActionBuilder<State> : ActionBuilderCommon<State, ActionBuil
      */
     @JavaAPI
     @JvmName("execute")
-    public fun javaApiExecuteSynchronously(execute: ExecuteSync<State>): ActionBuilder<State> =
+    public fun executeBlocking(execute: ExecuteSync<State>): ActionBuilder<State> =
         execute { context, state ->
             withContextReentrant(context.config.strategyDispatcher) {
                 execute.execute(context, state)


### PR DESCRIPTION
Addressing remaining parts after #2005 