### PR TITLE
fix(agents): Rewrite prompt message parts in PromptAugmenter implementations

### DIFF
--- a/agents/agents-features/agents-features-longterm-memory-aws/Module.md
+++ b/agents/agents-features/agents-features-longterm-memory-aws/Module.md
@@ -39,16 +39,16 @@ textual content, optional unique identifier, key-value metadata, and the
 An enum that classifies AgentCore memory strategy kinds and drives the augmentation pathway
 used by `AgentcorePromptAugmenter`: `SEMANTIC` and `PREFERENCE` records are folded into the
 system message; `EPISODES` and `REFLECTIONS` records are placed under dedicated labelled
-sections in the system message; `SUMMARY` records rewrite the last user message to prepend
-retrieved context.
+sections in the system message; `SUMMARY` records are appended to the last user message as
+an additional text part.
 
 ### AgentcorePromptAugmenter
 
 A `PromptAugmenter` that routes each retrieved `AgentcoreMemoryRecord` to the correct
 injection point based on its `AgentcoreMemoryStrategy`. SEMANTIC and PREFERENCE content is
 appended to the system message; EPISODES and REFLECTIONS are rendered as distinct labelled
-sections in the system message; SUMMARY content rewrites the last user message. A system
-message is created automatically when none is present.
+sections in the system message; SUMMARY content is appended as an extra text part at the
+end of the last user message. A system message is created automatically when none is present.
 
 ### AgentcoreNamespaceScope
 

--- a/agents/agents-features/agents-features-longterm-memory-aws/src/jvmMain/kotlin/ai/koog/agents/features/longtermmemory/aws/augmentation/AgentcorePromptAugmenter.kt
+++ b/agents/agents-features/agents-features-longterm-memory-aws/src/jvmMain/kotlin/ai/koog/agents/features/longtermmemory/aws/augmentation/AgentcorePromptAugmenter.kt
@@ -19,8 +19,8 @@ import ai.koog.rag.base.storage.search.SearchResult
  *   dedicated "[SECTION_EPISODES]" section.
  * - [AgentcoreMemoryStrategy.REFLECTIONS] — content is appended to the system message under a
  *   dedicated "[SECTION_REFLECTIONS]" section.
- * - [AgentcoreMemoryStrategy.SUMMARY] — the last user message is rewritten to prepend the
- *   retrieved summaries as query context.
+ * - [AgentcoreMemoryStrategy.SUMMARY] — the retrieved summaries (rendered via [userTemplate])
+ *   are appended to the last user message as an additional [MessagePart.Text] part.
  *
  * If no system message exists in the prompt, one is created. If no user message exists when
  * handling [AgentcoreMemoryStrategy.SUMMARY] records, the summaries fall back to system-message
@@ -30,13 +30,18 @@ import ai.koog.rag.base.storage.search.SearchResult
  *   Defaults to [PromptAugmenter.DEFAULT_CONTEXT_PREFIX].
  * @param sectionEpisodes Section header for EPISODES records. Defaults to [SECTION_EPISODES].
  * @param sectionReflections Section header for REFLECTIONS records. Defaults to [SECTION_REFLECTIONS].
- * @param sectionSeparator Separator string between sections. Defaults to [SECTION_SEPARATOR].
+ * @param sectionSeparator Separator string between sections. Defaults to
+ *   [PromptAugmenter.SECTION_SEPARATOR].
+ * @param userTemplate Template used to render SUMMARY context appended to the last user message.
+ *   Must contain the [PromptAugmenter.RELEVANT_CONTEXT_PLACEHOLDER] placeholder. Defaults to
+ *   [DEFAULT_USER_TEMPLATE].
  */
 public class AgentcorePromptAugmenter @JvmOverloads constructor(
     private val contextPrefix: String = PromptAugmenter.DEFAULT_CONTEXT_PREFIX,
     private val sectionEpisodes: String = SECTION_EPISODES,
     private val sectionReflections: String = SECTION_REFLECTIONS,
-    private val sectionSeparator: String = SECTION_SEPARATOR,
+    private val sectionSeparator: String = PromptAugmenter.SECTION_SEPARATOR,
+    private val userTemplate: String = DEFAULT_USER_TEMPLATE,
 ) : PromptAugmenter {
 
     public companion object {
@@ -46,8 +51,17 @@ public class AgentcorePromptAugmenter @JvmOverloads constructor(
         /** Default section header for EPISODIC reflections (actor-scoped lessons learned). */
         public const val SECTION_REFLECTIONS: String = "Lessons learned"
 
-        /** Trailing newline separator between sections. */
-        public const val SECTION_SEPARATOR: String = "\n\n"
+        /**
+         * Default template used to wrap SUMMARY context appended to the last user message.
+         * Use [PromptAugmenter.RELEVANT_CONTEXT_PLACEHOLDER] as the placeholder for the rendered
+         * context block.
+         */
+        public val DEFAULT_USER_TEMPLATE: String =
+            """
+            |Here is a relevant conversation summary for the question above:
+            |
+            |${PromptAugmenter.RELEVANT_CONTEXT_PLACEHOLDER}
+            """.trimMargin().trim()
     }
 
     override fun augment(
@@ -111,13 +125,12 @@ public class AgentcorePromptAugmenter @JvmOverloads constructor(
         return prompt.withMessages { messages ->
             if (systemIndex >= 0) {
                 val existing = messages[systemIndex] as Message.System
-                val merged = Message.System(
+                val merged = existing.copy(
                     parts = buildList {
                         addAll(existing.parts)
                         add(MessagePart.Text(sectionSeparator))
                         add(MessagePart.Text(contextText))
-                    },
-                    existing.metaInfo
+                    }
                 )
                 messages.toMutableList().also { it[systemIndex] = merged }
             } else {
@@ -139,15 +152,12 @@ public class AgentcorePromptAugmenter @JvmOverloads constructor(
         }
         val contextText = formatPlain(context)
         if (contextText.isBlank()) return prompt
+        val rendered = PromptAugmenter.formatTemplate(userTemplate, contextText)
+        if (rendered.isBlank()) return prompt
         return prompt.withMessages { messages ->
             val original = messages[userIndex] as Message.User
-            val rewritten = Message.User(
-                parts = buildList {
-                    add(MessagePart.Text(contextText))
-                    add(MessagePart.Text("\nUser question:"))
-                    addAll(original.parts)
-                },
-                metaInfo = original.metaInfo,
+            val rewritten = original.copy(
+                parts = original.parts + MessagePart.Text(rendered)
             )
             messages.toMutableList().also { it[userIndex] = rewritten }
         }

--- a/agents/agents-features/agents-features-longterm-memory-aws/src/jvmTest/kotlin/ai/koog/agents/features/longtermmemory/aws/augmentation/AgentcorePromptAugmenterTest.kt
+++ b/agents/agents-features/agents-features-longterm-memory-aws/src/jvmTest/kotlin/ai/koog/agents/features/longtermmemory/aws/augmentation/AgentcorePromptAugmenterTest.kt
@@ -1,0 +1,111 @@
+package ai.koog.agents.features.longtermmemory.aws.augmentation
+
+import ai.koog.agents.features.longtermmemory.aws.AgentcoreMemoryRecord
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.MessagePart
+import ai.koog.rag.base.TextDocument
+import ai.koog.rag.base.storage.search.Score
+import ai.koog.rag.base.storage.search.ScoreMetric
+import ai.koog.rag.base.storage.search.SearchResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AgentcorePromptAugmenterTest {
+
+    private fun result(content: String, strategy: AgentcoreMemoryStrategy): SearchResult<TextDocument> =
+        SearchResult(
+            document = AgentcoreMemoryRecord(content = content, strategy = strategy),
+            score = Score(1.0, ScoreMetric.COSINE_SIMILARITY)
+        )
+
+    @Test
+    fun testSummaryIsAppendedToLastUserMessage() {
+        val originalPrompt = prompt("test") {
+            system("You are a helpful assistant")
+            user("What is Kotlin?")
+        }
+
+        val augmented = AgentcorePromptAugmenter().augment(
+            originalPrompt = originalPrompt,
+            relevantContext = listOf(
+                result(
+                    "Previously discussed: Kotlin is a JVM language",
+                    AgentcoreMemoryStrategy.SUMMARY
+                )
+            )
+        )
+
+        // The existing user message is augmented in place by appending an extra MessagePart.Text;
+        // no new user message is added.
+        val userMessages = augmented.messages.filter { it is Message.User }
+        assertEquals(1, userMessages.size)
+        val textParts = userMessages[0].parts.filterIsInstance<MessagePart.Text>()
+        // The original user text is preserved as a preceding part
+        assertTrue(textParts.any { it.text == "What is Kotlin?" })
+        // The retrieved summary is in the last text part
+        assertTrue(textParts.last().text.contains("Previously discussed: Kotlin is a JVM language"))
+        // Original user content appears before the appended summary
+        assertTrue(
+            textParts.indexOfFirst { it.text == "What is Kotlin?" } < textParts.lastIndex ||
+                textParts.size == 1
+        )
+    }
+
+    @Test
+    fun testSummaryNoOpWhenNoUserMessage() {
+        val originalPrompt = prompt("test") {
+            system("You are a helpful assistant")
+        }
+
+        val augmented = AgentcorePromptAugmenter().augment(
+            originalPrompt = originalPrompt,
+            relevantContext = listOf(result("some summary", AgentcoreMemoryStrategy.SUMMARY))
+        )
+
+        // No user message exists; summaries are ignored on the user-side branch.
+        assertEquals(originalPrompt.messages.size, augmented.messages.size)
+        assertTrue(augmented.messages.none { it is Message.User })
+    }
+
+    @Test
+    fun testSemanticIsAppendedToSystemMessage() {
+        val originalPrompt = prompt("test") {
+            system("You are a helpful assistant")
+            user("What is Kotlin?")
+        }
+
+        val augmented = AgentcorePromptAugmenter().augment(
+            originalPrompt = originalPrompt,
+            relevantContext = listOf(result("Kotlin was developed by JetBrains", AgentcoreMemoryStrategy.SEMANTIC))
+        )
+
+        val systemMessages = augmented.messages.filter { it is Message.System }
+        assertEquals(1, systemMessages.size)
+        val systemText = systemMessages[0].parts.filterIsInstance<MessagePart.Text>()
+            .joinToString("\n") { it.text }
+        assertTrue(systemText.contains("You are a helpful assistant"))
+        assertTrue(systemText.contains("Kotlin was developed by JetBrains"))
+
+        // User message is left untouched when only SEMANTIC context is provided.
+        val userParts = augmented.messages.filterIsInstance<Message.User>()
+            .single().parts.filterIsInstance<MessagePart.Text>()
+        assertEquals(listOf("What is Kotlin?"), userParts.map { it.text })
+    }
+
+    @Test
+    fun testEmptyContextReturnsOriginalPrompt() {
+        val originalPrompt = prompt("test") {
+            system("You are a helpful assistant")
+            user("What is Kotlin?")
+        }
+
+        val augmented = AgentcorePromptAugmenter().augment(
+            originalPrompt = originalPrompt,
+            relevantContext = emptyList()
+        )
+
+        assertEquals(originalPrompt.messages, augmented.messages)
+    }
+}

--- a/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/augmentation/PromptAugmenter.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/augmentation/PromptAugmenter.kt
@@ -65,6 +65,14 @@ public fun interface PromptAugmenter {
         public const val DEFAULT_CONTEXT_PREFIX: String = "Relevant information:\n"
 
         /**
+         * Separator inserted between logical sections of a message (e.g. between the
+         * original system content and an appended retrieved-context section, or between
+         * multiple retrieved-context sections). Shared by all built-in [PromptAugmenter]
+         * implementations to keep the rendered layout consistent.
+         */
+        public const val SECTION_SEPARATOR: String = "\n\n"
+
+        /**
          * Formats a list of search results into a numbered text block with the given prefix.
          */
         public fun formatContext(

--- a/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/augmentation/SystemPromptAugmenter.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/augmentation/SystemPromptAugmenter.kt
@@ -2,15 +2,22 @@ package ai.koog.agents.longtermmemory.retrieval.augmentation
 
 import ai.koog.prompt.Prompt
 import ai.koog.prompt.message.Message
-import ai.koog.prompt.message.RequestMetaInfo
+import ai.koog.prompt.message.MessagePart
 import ai.koog.rag.base.TextDocument
 import ai.koog.rag.base.storage.search.SearchResult
 
 /**
- * A [PromptAugmenter] that inserts retrieved context as a system message at the beginning of the prompt.
+ * A [PromptAugmenter] that injects retrieved context into the first [Message.System] of the prompt.
  *
- * The new context system message is prepended before all existing messages.
- * If there is no system message in the prompt, the prompt is returned unchanged.
+ * The retrieved context is rendered through [template] and added as an additional
+ * [MessagePart.Text] **appended** to the existing parts of the first system message, separated
+ * by [PromptAugmenter.SECTION_SEPARATOR]. The original system message is replaced with a copy that:
+ * - preserves its [Message.metaInfo] and [Message.id],
+ * - preserves all existing parts (text, attachments, etc.),
+ * - gains two extra [MessagePart.Text] entries at the end: a separator and the formatted context.
+ *
+ * If the prompt contains no [Message.System], or the formatted context is blank, or the relevant
+ * context list is empty, the original prompt is returned unchanged.
  *
  * @param template The template for the system message. Use [PromptAugmenter.RELEVANT_CONTEXT_PLACEHOLDER] placeholder.
  * @param contextPrefix The prefix to add before relevant context.
@@ -80,8 +87,16 @@ public class SystemPromptAugmenter(
         if (contextMessage.isBlank()) return originalPrompt
 
         return originalPrompt.withMessages { messages ->
-            val systemMessage = Message.System(contextMessage, RequestMetaInfo.Empty)
-            listOf<Message>(systemMessage) + messages
+            val systemIndex = messages.indexOfFirst { it is Message.System }
+            if (systemIndex < 0) return@withMessages messages
+
+            val original = messages[systemIndex] as Message.System
+            val updated = original.copy(
+                parts = original.parts +
+                    MessagePart.Text(PromptAugmenter.SECTION_SEPARATOR) +
+                    MessagePart.Text(contextMessage)
+            )
+            messages.toMutableList().also { it[systemIndex] = updated }
         }
     }
 }

--- a/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/augmentation/UserPromptAugmenter.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/commonMain/kotlin/ai/koog/agents/longtermmemory/retrieval/augmentation/UserPromptAugmenter.kt
@@ -2,14 +2,22 @@ package ai.koog.agents.longtermmemory.retrieval.augmentation
 
 import ai.koog.prompt.Prompt
 import ai.koog.prompt.message.Message
-import ai.koog.prompt.message.RequestMetaInfo
+import ai.koog.prompt.message.MessagePart
 import ai.koog.rag.base.TextDocument
 import ai.koog.rag.base.storage.search.SearchResult
 
 /**
- * A [PromptAugmenter] that inserts retrieved context as a user message before the last user message.
+ * A [PromptAugmenter] that injects retrieved context into the last [Message.User] of the prompt.
  *
- * If the prompt contains no user messages, the original prompt is returned unchanged.
+ * The retrieved context is rendered through [template] and added as an additional
+ * [MessagePart.Text] **appended** to the existing parts of the last user message. The original
+ * user message is replaced with a copy that:
+ * - preserves its [Message.metaInfo] and [Message.id],
+ * - preserves all existing parts (text, attachments, tool results, etc.),
+ * - gains one extra [MessagePart.Text] at the end carrying the formatted context.
+ *
+ * If the prompt contains no [Message.User], or the formatted context is blank, or the relevant
+ * context list is empty, the original prompt is returned unchanged.
  *
  * @param template The template for user context insertion. Use [PromptAugmenter.RELEVANT_CONTEXT_PLACEHOLDER] placeholder.
  * @param contextPrefix The prefix to add before relevant context.
@@ -30,11 +38,11 @@ public class UserPromptAugmenter(
          */
         public val DEFAULT_USER_PROMPT_TEMPLATE: String =
             """
-            |Here is some relevant context:
+            |Here is some relevant context to help answer the question above:
             |
             |${PromptAugmenter.RELEVANT_CONTEXT_PLACEHOLDER}
             |
-            |Based on the above context, please answer the following question:
+            |Please answer the question above based on this context.
             """.trimMargin().trim()
     }
 
@@ -80,13 +88,13 @@ public class UserPromptAugmenter(
 
         return originalPrompt.withMessages { messages ->
             val lastUserIndex = messages.indexOfLast { it is Message.User }
-            if (lastUserIndex >= 0) {
-                messages.toMutableList().apply {
-                    add(lastUserIndex, Message.User(formattedContext, RequestMetaInfo.Empty))
-                }
-            } else {
-                messages
-            }
+            if (lastUserIndex < 0) return@withMessages messages
+
+            val original = messages[lastUserIndex] as Message.User
+            val updated = original.copy(
+                parts = original.parts + MessagePart.Text(formattedContext)
+            )
+            messages.toMutableList().also { it[lastUserIndex] = updated }
         }
     }
 }

--- a/agents/agents-features/agents-features-longterm-memory/src/jvmTest/kotlin/ai/koog/agents/longtermmemory/retrieval/augmentation/PromptAugmenterTest.kt
+++ b/agents/agents-features/agents-features-longterm-memory/src/jvmTest/kotlin/ai/koog/agents/longtermmemory/retrieval/augmentation/PromptAugmenterTest.kt
@@ -38,27 +38,18 @@ class PromptAugmenterTest {
             relevantContext = relevantContext
         )
 
-        // Verify a new system message with context was prepended, keeping the original intact
+        // The existing system message is augmented in place by appending extra MessagePart.Text
+        // entries; no new system message is added.
         val systemMessages = augmentedPrompt.messages.filter { it is Message.System }
-        assertEquals(2, systemMessages.size)
-        // First system message should contain the context
-        assertTrue(
-            systemMessages[0].parts.filterIsInstance<MessagePart.Text>().joinToString(separator = "\n") { it.text }
-                .contains("Kotlin was developed by JetBrains")
-        )
-        assertTrue(
-            systemMessages[0].parts.filterIsInstance<MessagePart.Text>().joinToString(separator = "\n") { it.text }
-                .contains("Kotlin is 100% interoperable with Java")
-        )
-        assertTrue(
-            systemMessages[0].parts.filterIsInstance<MessagePart.Text>().joinToString(separator = "\n") { it.text }
-                .contains("Relevant information")
-        )
-        // Second system message should be the original
-        assertEquals(
-            "You are a helpful assistant",
-            systemMessages[1].parts.filterIsInstance<MessagePart.Text>().joinToString(separator = "\n") { it.text }
-        )
+        assertEquals(1, systemMessages.size)
+        val systemText = systemMessages[0].parts.filterIsInstance<MessagePart.Text>()
+            .joinToString(separator = "\n") { it.text }
+        // Original system content is preserved
+        assertTrue(systemText.contains("You are a helpful assistant"))
+        // And the appended retrieved-context section is present
+        assertTrue(systemText.contains("Kotlin was developed by JetBrains"))
+        assertTrue(systemText.contains("Kotlin is 100% interoperable with Java"))
+        assertTrue(systemText.contains("Relevant information"))
     }
 
     @Test
@@ -76,20 +67,17 @@ class PromptAugmenterTest {
             relevantContext = relevantContext
         )
 
-        // Verify a new user message was inserted before the last user message
+        // The existing user message is augmented in place by appending an extra MessagePart.Text;
+        // no new user message is added.
         val userMessages = augmentedPrompt.messages.filter { it is Message.User }
-        assertEquals(2, userMessages.size)
-
-        // First user message should contain the context
-        assertTrue(
-            userMessages[0].parts.filterIsInstance<MessagePart.Text>().joinToString(separator = "\n") { it.text }
-                .contains("Kotlin was developed by JetBrains")
-        )
-        // Second user message should be the original
-        assertEquals(
-            "What is Kotlin?",
-            userMessages[1].parts.filterIsInstance<MessagePart.Text>().joinToString(separator = "\n") { it.text }
-        )
+        assertEquals(1, userMessages.size)
+        val textParts = userMessages[0].parts.filterIsInstance<MessagePart.Text>()
+        // Last part carries the retrieved context
+        assertTrue(textParts.last().text.contains("Kotlin was developed by JetBrains"))
+        // Original user content is preserved as a preceding part
+        assertTrue(textParts.any { it.text == "What is Kotlin?" })
+        // Original user content appears before the appended context
+        assertTrue(textParts.indexOfFirst { it.text == "What is Kotlin?" } < textParts.lastIndex || textParts.size == 1)
     }
 
     @Test
@@ -144,22 +132,14 @@ class PromptAugmenterTest {
             relevantContext = relevantContext
         )
 
-        // Verify a new system message with the custom template was prepended
+        // Verify the existing system message was augmented in place with the custom template
         val systemMessages = augmentedPrompt.messages.filter { it is Message.System }
-        assertEquals(2, systemMessages.size)
-        assertTrue(
-            systemMessages[0].parts.filterIsInstance<MessagePart.Text>().joinToString(separator = "\n") { it.text }
-                .contains("CUSTOM CONTEXT:")
-        )
-        assertTrue(
-            systemMessages[0].parts.filterIsInstance<MessagePart.Text>().joinToString(separator = "\n") { it.text }
-                .contains("Kotlin was developed by JetBrains")
-        )
-        // Original system message should remain unchanged
-        assertEquals(
-            "You are a helpful assistant",
-            systemMessages[1].parts.filterIsInstance<MessagePart.Text>().joinToString(separator = "\n") { it.text }
-        )
+        assertEquals(1, systemMessages.size)
+        val systemText = systemMessages[0].parts.filterIsInstance<MessagePart.Text>()
+            .joinToString(separator = "\n") { it.text }
+        assertTrue(systemText.contains("You are a helpful assistant"))
+        assertTrue(systemText.contains("CUSTOM CONTEXT:"))
+        assertTrue(systemText.contains("Kotlin was developed by JetBrains"))
     }
 
     @Test
@@ -201,24 +181,13 @@ class PromptAugmenterTest {
         )
 
         val systemMessages = augmentedPrompt.messages.filter { it is Message.System }
-        assertEquals(2, systemMessages.size)
-        assertTrue(
-            systemMessages[0].parts.filterIsInstance<MessagePart.Text>().joinToString(separator = "\n") { it.text }
-                .contains("[1] First context item")
-        )
-        assertTrue(
-            systemMessages[0].parts.filterIsInstance<MessagePart.Text>().joinToString(separator = "\n") { it.text }
-                .contains("[2] Second context item")
-        )
-        assertTrue(
-            systemMessages[0].parts.filterIsInstance<MessagePart.Text>().joinToString(separator = "\n") { it.text }
-                .contains("[3] Third context item")
-        )
-        // Original system message should remain unchanged
-        assertEquals(
-            "You are a helpful assistant",
-            systemMessages[1].parts.filterIsInstance<MessagePart.Text>().joinToString(separator = "\n") { it.text }
-        )
+        assertEquals(1, systemMessages.size)
+        val systemText = systemMessages[0].parts.filterIsInstance<MessagePart.Text>()
+            .joinToString(separator = "\n") { it.text }
+        assertTrue(systemText.contains("You are a helpful assistant"))
+        assertTrue(systemText.contains("[1] First context item"))
+        assertTrue(systemText.contains("[2] Second context item"))
+        assertTrue(systemText.contains("[3] Third context item"))
     }
 
     @Test

--- a/docs/docs/features/long-term-memory.md
+++ b/docs/docs/features/long-term-memory.md
@@ -87,7 +87,7 @@ Use retrieval without ingestion when you have a pre-populated knowledge base:
 | Augmenter | Behavior |
 |---|---|
 | `SystemPromptAugmenter()` | Inserts context as a system message at the start of the prompt (no-op if there is no system message) |
-| `UserPromptAugmenter()` | Inserts context as a separate user message before the last user message |
+| `UserPromptAugmenter()` | Appends the retrieved context as an extra text part at the end of the last user message (no-op if there is no user message) |
 | `PromptAugmenter { prompt, context -> ... }` | Custom augmentation via lambda |
 
 ### Search Query Providers


### PR DESCRIPTION
Update and consolidate `PromptAugmenter` implementations after `Message` refactoring. Now all of them append a new `MessagePart` to an existing `Message`.

<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

Describe what this PR changes and why.


<!-- Include BREAKING section below only if this PR introduces breaking changes. Otherwise, delete it. -->
BREAKING:
*

<!-- Include DEPRECATED section below only if this PR deprecates any public APIs. Otherwise, delete it. -->
DEPRECATED:
*

<!-- Include references to related issues below, e.g., closes #1, closes KG-1. Otherwise, delete it. -->
closes
