### PR TITLE
fix: Fix ollama message converter which fix ollama tests

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaConverters.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaConverters.kt
@@ -45,45 +45,24 @@ internal fun Prompt.toOllamaChatMessages(model: LLModel): List<OllamaChatMessage
                 }
 
                 is Message.Assistant -> {
-                    message.parts.forEach { part ->
-                        when (part) {
-                            is MessagePart.Text -> {
-                                add(
-                                    OllamaChatMessageDTO(
-                                        role = "assistant",
-                                        content = part.text
+                    add(
+                        OllamaChatMessageDTO(
+                            role = "assistant",
+                            content = message.textContent(),
+                            thinking = message.parts.filterIsInstance<MessagePart.Reasoning>()
+                                .flatMap { it.content }.takeIf { it.isNotEmpty() }?.joinToString { "\n" },
+                            toolCalls = message.parts.filterIsInstance<MessagePart.Tool.Call>().map { part ->
+                                OllamaToolCallDTO(
+                                    function = OllamaToolCallDTO.Call(
+                                        name = part.tool,
+                                        arguments = part.argsJson
                                     )
+                                    // Note: Ollama doesn't support tool call IDs in requests,
+                                    // so we don't include the message.id here
                                 )
                             }
-
-                            is MessagePart.Attachment -> {
-                                throw NotImplementedError("Attachments in assistant messages are not supported by Ollama")
-                            }
-
-                            is MessagePart.Tool.Call -> {
-                                add(
-                                    OllamaChatMessageDTO(
-                                        role = "assistant",
-                                        content = "",
-                                        toolCalls = listOf(
-                                            OllamaToolCallDTO(
-                                                function = OllamaToolCallDTO.Call(
-                                                    name = part.tool,
-                                                    arguments = part.argsJson
-                                                )
-                                                // Note: Ollama doesn't support tool call IDs in requests,
-                                                // so we don't include the message.id here
-                                            )
-                                        )
-                                    )
-                                )
-                            }
-
-                            is MessagePart.Reasoning -> {
-                                throw NotImplementedError("Reasoning is not supported by Ollama")
-                            }
-                        }
-                    }
+                        )
+                    )
                 }
             }
         }


### PR DESCRIPTION
Rewrite ollama message conversion from creating separate messages for each part of the message (text, thinking, tool calls) to a single one containing all, which reflects the way messages are received from the ollama models