### PR TITLE
fix(prompt): enrich OpenRouter models from API metadata

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClient.kt
@@ -21,6 +21,7 @@ import ai.koog.prompt.executor.clients.openrouter.models.OpenRouterChatCompletio
 import ai.koog.prompt.executor.clients.openrouter.models.OpenRouterChatCompletionStreamResponse
 import ai.koog.prompt.executor.clients.openrouter.models.OpenRouterEmbeddingRequest
 import ai.koog.prompt.executor.clients.openrouter.models.OpenRouterEmbeddingResponse
+import ai.koog.prompt.executor.clients.openrouter.models.OpenRouterModel
 import ai.koog.prompt.executor.clients.openrouter.models.OpenRouterModelsResponse
 import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLMProvider
@@ -215,7 +216,7 @@ public class OpenRouterLLMClient @JvmOverloads constructor(
      * Fetches the list of available models from the OpenRouter service.
      * https://openrouter.ai/docs/api/api-reference/models/get-models
      *
-     * @return A list of model IDs available from OpenRouter.
+     * @return A list of model definitions available from OpenRouter, enriched with API metadata when present.
      */
     override suspend fun models(): List<LLModel> {
         logger.debug { "Fetching available models from OpenRouter" }
@@ -225,7 +226,70 @@ public class OpenRouterLLMClient @JvmOverloads constructor(
         )
 
         val modelsById = OpenRouterModels.modelsById()
-        return models.data.map { modelsById[it.id] ?: LLModel(provider = llmProvider(), id = it.id) }
+        return models.data.map { it.toLLModel(modelsById[it.id]) }
+    }
+
+    /**
+     * Converts an OpenRouter model response into [LLModel].
+     *
+     * Runtime metadata returned by OpenRouter takes precedence because it reflects the selected endpoint/provider.
+     * Static model definitions are used only as a fallback when the API omits optional metadata.
+     *
+     * @param fallback Static model definition with the same ID, if one is known locally.
+     * @return A model definition enriched with capabilities, context length, and output token limit.
+     */
+    private fun OpenRouterModel.toLLModel(fallback: LLModel?): LLModel = LLModel(
+        provider = llmProvider(),
+        id = id,
+        capabilities = capabilitiesFromResponse(fallback?.capabilities),
+        contextLength = contextLength ?: topProvider.contextLength ?: fallback?.contextLength,
+        maxOutputTokens = topProvider.maxCompletionTokens
+            ?: perRequestLimits?.completionTokens
+            ?: fallback?.maxOutputTokens,
+    )
+
+    /**
+     * Infers Koog capabilities from OpenRouter model metadata.
+     *
+     * OpenRouter exposes supported inputs and provider parameters instead of Koog capability names.
+     * This method maps those response fields to [LLMCapability] values and falls back to the local model definition
+     * when the response does not include enough metadata to infer capabilities.
+     *
+     * @param fallback Capabilities from the static model definition, if available.
+     * @return Inferred capabilities, fallback capabilities, or `null` when neither source provides them.
+     */
+    private fun OpenRouterModel.capabilitiesFromResponse(fallback: List<LLMCapability>?): List<LLMCapability>? {
+        val inputModalities = architecture.inputModalities?.map { it.lowercase() }?.toSet()
+        val outputModalities = architecture.outputModalities?.map { it.lowercase() }?.toSet()
+        val supportedParameters = supportedParameters?.map { it.lowercase() }?.toSet()
+
+        if (inputModalities == null && outputModalities == null && supportedParameters == null) {
+            return fallback
+        }
+
+        val capabilities = buildList {
+            if (outputModalities == null || "text" in outputModalities) add(LLMCapability.Completion)
+            if (outputModalities?.any { it == "embedding" || it == "embeddings" } == true) add(LLMCapability.Embed)
+
+            if ("image" in inputModalities.orEmpty()) add(LLMCapability.Vision.Image)
+            if ("video" in inputModalities.orEmpty()) add(LLMCapability.Vision.Video)
+            if ("audio" in inputModalities.orEmpty()) add(LLMCapability.Audio)
+            if ("file" in inputModalities.orEmpty()) add(LLMCapability.Document)
+
+            if ("temperature" in supportedParameters.orEmpty()) add(LLMCapability.Temperature)
+            if ("tools" in supportedParameters.orEmpty()) add(LLMCapability.Tools)
+            if ("tool_choice" in supportedParameters.orEmpty()) add(LLMCapability.ToolChoice)
+            if ("response_format" in supportedParameters.orEmpty()) add(LLMCapability.Schema.JSON.Basic)
+            if ("structured_outputs" in supportedParameters.orEmpty()) add(LLMCapability.Schema.JSON.Standard)
+            if ("reasoning" in supportedParameters.orEmpty() || "include_reasoning" in supportedParameters.orEmpty()) {
+                add(LLMCapability.Thinking)
+            }
+            if ("prediction" in supportedParameters.orEmpty()) add(LLMCapability.Speculation)
+            if ("n" in supportedParameters.orEmpty()) add(LLMCapability.MultipleChoices)
+            if (pricing.inputCacheRead != null || pricing.inputCacheWrite != null) add(LLMCapability.PromptCaching)
+        }.distinct()
+
+        return capabilities.ifEmpty { fallback.orEmpty() }.takeIf { it.isNotEmpty() }
     }
 
     /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openrouter/OpenRouterLLMClientTest.kt
@@ -2,6 +2,7 @@ package ai.koog.prompt.executor.clients.openrouter
 
 import ai.koog.http.client.ktor.KtorKoogHttpClient
 import ai.koog.prompt.Prompt
+import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.message.MessagePart
 import ai.koog.utils.time.KoogClock
 import io.ktor.client.HttpClient
@@ -17,6 +18,8 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 import kotlin.time.Instant
 
 class OpenRouterLLMClientTest {
@@ -59,6 +62,89 @@ class OpenRouterLLMClientTest {
         }
     """.trimIndent()
 
+    //language=json
+    private val modelsBody = """
+        {
+          "data": [
+            {
+              "id": "google/gemini-3.5-flash",
+              "canonical_slug": "google/gemini-3.5-flash-20260519",
+              "hugging_face_id": null,
+              "name": "Google: Gemini 3.5 Flash",
+              "created": 1779193800,
+              "description": "Gemini 3.5 Flash",
+              "context_length": 1048576,
+              "architecture": {
+                "modality": "text+image+file+audio+video->text",
+                "input_modalities": ["text", "image", "video", "file", "audio"],
+                "output_modalities": ["text"],
+                "tokenizer": "Gemini",
+                "instruct_type": null
+              },
+              "pricing": {
+                "prompt": "0.0000015",
+                "completion": "0.000009",
+                "image": "0.0000015",
+                "audio": "0.000003",
+                "internal_reasoning": "0.000009",
+                "input_cache_read": "0.00000015",
+                "input_cache_write": "0.00000008333333333333334"
+              },
+              "top_provider": {
+                "context_length": 1048576,
+                "max_completion_tokens": 65536,
+                "is_moderated": false
+              },
+              "per_request_limits": null,
+              "supported_parameters": [
+                "include_reasoning",
+                "max_tokens",
+                "reasoning",
+                "response_format",
+                "structured_outputs",
+                "temperature",
+                "tool_choice",
+                "tools"
+              ],
+              "default_parameters": {
+                "temperature": null,
+                "top_p": null,
+                "top_k": null
+              },
+              "knowledge_cutoff": "2025-01-01"
+            },
+            {
+              "id": "openrouter/context-fallback",
+              "canonical_slug": "openrouter/context-fallback",
+              "hugging_face_id": null,
+              "name": "Context fallback",
+              "created": 1779193800,
+              "description": "Model with limits from nested fields",
+              "context_length": null,
+              "architecture": {
+                "input_modalities": ["text"],
+                "output_modalities": ["text"],
+                "tokenizer": "Unknown"
+              },
+              "pricing": {
+                "prompt": "0.000001",
+                "completion": "0.000002"
+              },
+              "top_provider": {
+                "context_length": 8192,
+                "max_completion_tokens": null,
+                "is_moderated": false
+              },
+              "per_request_limits": {
+                "prompt_tokens": 4096,
+                "completion_tokens": 2048
+              },
+              "supported_parameters": null
+            }
+          ]
+        }
+    """.trimIndent()
+
     @Test
     fun testExecuteToolCallResponsePreservesReasoningMessage() = runTest {
         val engine = MockEngine.Companion { _ ->
@@ -86,5 +172,47 @@ class OpenRouterLLMClientTest {
         assertEquals("call_weather", toolCall.id)
         assertEquals("weather", toolCall.tool)
         assertEquals(buildJsonObject { put("city", JsonPrimitive("Boston")) }, toolCall.argsJson)
+    }
+
+    @Test
+    fun testModelsUsesOpenRouterResponseMetadata() = runTest {
+        val engine = MockEngine.Companion { _ ->
+            respond(
+                content = modelsBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val http = HttpClient(engine) {}
+        val client = OpenRouterLLMClient(httpClientFactory = KtorKoogHttpClient.Factory(http), apiKey = apiKey)
+
+        val models = client.models()
+
+        val gemini = models.single { it.id == "google/gemini-3.5-flash" }
+        assertEquals(1_048_576, gemini.contextLength)
+        assertEquals(65_536, gemini.maxOutputTokens)
+
+        val capabilities = assertNotNull(gemini.capabilities)
+        listOf(
+            LLMCapability.Completion,
+            LLMCapability.Temperature,
+            LLMCapability.Tools,
+            LLMCapability.ToolChoice,
+            LLMCapability.Schema.JSON.Basic,
+            LLMCapability.Schema.JSON.Standard,
+            LLMCapability.Thinking,
+            LLMCapability.PromptCaching,
+            LLMCapability.Vision.Image,
+            LLMCapability.Vision.Video,
+            LLMCapability.Audio,
+            LLMCapability.Document,
+        ).forEach { capability ->
+            assertTrue(capability in capabilities, "Expected ${gemini.id} to support ${capability.id}")
+        }
+
+        val fallback = models.single { it.id == "openrouter/context-fallback" }
+        assertEquals(8_192, fallback.contextLength)
+        assertEquals(2_048, fallback.maxOutputTokens)
+        assertEquals(listOf(LLMCapability.Completion), fallback.capabilities)
     }
 }


### PR DESCRIPTION
Enrich OpenRouter model definitions returned by `OpenRouterLLMClient.models()` with metadata from the OpenRouter models API response.

The client now maps response fields into `LLModel` values for:
- capabilities inferred from modalities and supported parameters
- context length from `context_length` or `top_provider.context_length`
- max output tokens from `top_provider.max_completion_tokens` or per-request limits

Static OpenRouter model definitions remain as fallback metadata when the API response omits optional fields.

Tests:
- Added `testModelsUsesOpenRouterResponseMetadata`
- Ran `./gradlew :prompt:prompt-executor:prompt-executor-clients:prompt-executor-openrouter-client:jvmTest`
- Ran `./gradlew :prompt:prompt-executor:prompt-executor-clients:prompt-executor-openrouter-client:build`