### PR TITLE
fix(prompt): Don't start a new tool call on repeated tool call id

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestAPI.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/OpenTelemetryTestAPI.kt
@@ -233,7 +233,12 @@ internal object OpenTelemetryTestAPI {
                 addSpanProcessor { simpleSpanProcessor(mockExporter) }
                 setVerbose(verbose)
             }.use { agent ->
-                agent.run(userPrompt ?: USER_PROMPT_PARIS)
+                try {
+                    agent.run(userPrompt ?: USER_PROMPT_PARIS)
+                } catch (throwable: Throwable) {
+                    waitSpansCollected(mockExporter)
+                    throw throwable
+                }
             }
 
             waitSpansCollected(mockExporter)

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
@@ -197,7 +197,13 @@ public class StreamFrameFlowBuilder(
         tryEmitPendingReasoning()
         val sanitizedId = id?.takeUnless { it.isBlank() }
         val previous: PendingToolCall? = pendingToolCallRef.load()
-        val new: PendingToolCall = if (sanitizedId != null || index != previous?.index) {
+        // `id` and `index` are optional per-chunk signals. A new tool call begins only when a
+        // present signal differs from the pending call, not merely because `id` is non-null:
+        // some OpenAI-compatible providers send the same `id` on every chunk (see #2002).
+        val isNewToolCall =
+            (sanitizedId != null && sanitizedId != previous?.id) ||
+                (index != null && index != previous?.index)
+        val new: PendingToolCall = if (isNewToolCall) {
             tryEmitPendingToolCall()
             PendingToolCall(sanitizedId, name, args, index)
         } else {

--- a/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderTest.kt
+++ b/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderTest.kt
@@ -224,6 +224,63 @@ class StreamFrameFlowBuilderTest {
         )
     }
 
+    /**
+     * Regression test for #2002.
+     *
+     * Some OpenAI-compatible providers include the tool call `id` in every streaming chunk
+     * instead of only the first one. Such repeated ids must be treated as a continuation of
+     * the same tool call, not as the start of a new one.
+     */
+    @Test
+    fun testEmitToolCallDeltaWithRepeatedIdAppendsToExisting() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitToolCallDelta(id = "call_1", name = "readFile", args = "", index = 0)
+            emitToolCallDelta(id = "call_1", name = null, args = "{\"path\":", index = 0)
+            emitToolCallDelta(id = "call_1", name = null, args = " \"/Users\"}", index = 0)
+            emitEnd()
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.ToolCallDelta("call_1", "readFile", "", 0),
+                StreamFrame.ToolCallDelta("call_1", null, "{\"path\":", 0),
+                StreamFrame.ToolCallDelta("call_1", null, " \"/Users\"}", 0),
+                StreamFrame.ToolCallComplete("call_1", "readFile", "{\"path\": \"/Users\"}", 0),
+                StreamFrame.End(null, ResponseMetaInfo.Empty)
+            ),
+            frames
+        )
+    }
+
+    /**
+     * Companion to [testEmitToolCallDeltaWithRepeatedIdAppendsToExisting] for #2002:
+     * even when every chunk repeats an `id`, a change to a different `id` must still
+     * start a separate tool call.
+     */
+    @Test
+    fun testEmitToolCallDeltaWithRepeatedIdSeparatesDistinctToolCalls() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitToolCallDelta(id = "call_1", name = "search", args = "{\"q\":", index = 0)
+            emitToolCallDelta(id = "call_1", name = null, args = " 1}", index = 0)
+            emitToolCallDelta(id = "call_2", name = "calculator", args = "{\"a\":", index = 1)
+            emitToolCallDelta(id = "call_2", name = null, args = " 2}", index = 1)
+            emitEnd()
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.ToolCallDelta("call_1", "search", "{\"q\":", 0),
+                StreamFrame.ToolCallDelta("call_1", null, " 1}", 0),
+                StreamFrame.ToolCallComplete("call_1", "search", "{\"q\": 1}", 0),
+                StreamFrame.ToolCallDelta("call_2", "calculator", "{\"a\":", 1),
+                StreamFrame.ToolCallDelta("call_2", null, " 2}", 1),
+                StreamFrame.ToolCallComplete("call_2", "calculator", "{\"a\": 2}", 1),
+                StreamFrame.End(null, ResponseMetaInfo.Empty)
+            ),
+            frames
+        )
+    }
+
     @Test
     fun testEmitToolCallDeltaWithoutPreviousCallThrowsError() = runTest {
         assertFailsWith<StreamFrameFlowBuilderError.NoPartialToolCallToComplete> {


### PR DESCRIPTION
Closes #2002.

### Summary

`StreamFrameFlowBuilder.emitToolCallDelta()` treated every chunk with a non-null tool-call `id` as a new tool call. This fix treats a repeated `id` as a continuation of the pending tool call, so OpenAI-compatible providers that repeat the same `id` on each streaming chunk no longer fragment one logical tool call into multiple premature `ToolCallComplete` frames.

### Fix

A new tool call now begins only when a present `id` or `index` differs from the pending call, instead of whenever `id` is non-null.

Before:

```kotlin
val new: PendingToolCall = if (sanitizedId != null || index != previous?.index) {
```

After:

```kotlin
val isNewToolCall =
    (sanitizedId != null && sanitizedId != previous?.id) ||
        (index != null && index != previous?.index)
val new: PendingToolCall = if (isNewToolCall) {
```

This follows the same id-change principle as `emitReasoningDelta`; absent or blank ids still continue the pending call (the blank case preserves the #1915 handling). The fix lives in the shared `StreamFrameFlowBuilder` because all streaming clients (OpenAI, OpenRouter, Mistral, Anthropic, DeepSeek, Ollama, Bedrock, Dashscope, Google) emit tool-call deltas through it.

### Tests

Two regression tests in `StreamFrameFlowBuilderTest`: `testEmitToolCallDeltaWithRepeatedIdAppendsToExisting` (three chunks with the same `id` combine into one `ToolCallComplete`) and `testEmitToolCallDeltaWithRepeatedIdSeparatesDistinctToolCalls` (switching to a different `id` still starts a separate tool call). `:prompt:prompt-model:jvmTest` (20 tests, 0 failures), `wasmJsNodeTest`, and `ktlintCheck` all pass locally; the full `./gradlew build` (Android and browser targets) is left to CI, since this contributor environment lacks the Android SDK and a headless browser.
