### PR TITLE
build: decrease Android minSdk from 35 to 23

### DIFF
--- a/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
+++ b/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
@@ -143,9 +143,9 @@ android {
 
     // Without an explicit minSdk, AGP falls back to its default (`1`), which propagates
     // into the published AAR's merged manifest and forces every consumer to override it.
-    // It also breaks transitive deps that require a higher minSdk (e.g. LiteRT requires 24+).
+    // It also breaks transitive deps that require a higher minSdk.
     defaultConfig {
-        minSdk = 35
+        minSdk = 23
     }
 
     compileOptions {


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

Describe what this PR changes and why.


<!-- Include BREAKING section below only if this PR introduces breaking changes. Otherwise, delete it. -->
BREAKING:
*

<!-- Include DEPRECATED section below only if this PR deprecates any public APIs. Otherwise, delete it. -->
DEPRECATED:
*

<!-- Include references to related issues below, e.g., closes #1, closes KG-1. Otherwise, delete it. -->
closes
https://github.com/JetBrains/koog/issues/2059