### PR TITLE
fix: stream Bedrock reasoning content deltas

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseConverters.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseConverters.kt
@@ -48,6 +48,7 @@ import aws.sdk.kotlin.services.bedrockruntime.model.OutputFormatType
 import aws.sdk.kotlin.services.bedrockruntime.model.PerformanceConfiguration
 import aws.sdk.kotlin.services.bedrockruntime.model.PromptVariableValues
 import aws.sdk.kotlin.services.bedrockruntime.model.ReasoningContentBlock
+import aws.sdk.kotlin.services.bedrockruntime.model.ReasoningContentBlockDelta
 import aws.sdk.kotlin.services.bedrockruntime.model.ReasoningTextBlock
 import aws.sdk.kotlin.services.bedrockruntime.model.S3Location
 import aws.sdk.kotlin.services.bedrockruntime.model.SpecificToolChoice
@@ -478,8 +479,30 @@ internal object BedrockConverseConverters {
                         )
                     }
 
-                    is ContentBlockDelta.Citation, is ContentBlockDelta.ReasoningContent -> {
+                    is ContentBlockDelta.Citation -> {
                         logger.warn { "Unsupported Converse content block delta type: ${delta::class.simpleName}" }
+                    }
+
+                    is ContentBlockDelta.ReasoningContent -> when (val reasoningDelta = delta.value) {
+                        is ReasoningContentBlockDelta.Text -> {
+                            emitReasoningDelta(
+                                text = reasoningDelta.value,
+                                index = chunk.value.contentBlockIndex
+                            )
+                        }
+
+                        is ReasoningContentBlockDelta.RedactedContent,
+                        is ReasoningContentBlockDelta.Signature -> {
+                            logger.debug {
+                                "Skipping Converse reasoning content block delta type: ${reasoningDelta::class.simpleName}"
+                            }
+                        }
+
+                        ReasoningContentBlockDelta.SdkUnknown -> {
+                            logger.warn {
+                                "Unknown Converse reasoning content block delta type: ${reasoningDelta::class.simpleName}"
+                            }
+                        }
                     }
 
                     is ContentBlockDelta.Image, is ContentBlockDelta.ToolResult -> {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/bedrock/BedrockLLMClientTest.kt
@@ -10,6 +10,7 @@ import ai.koog.prompt.executor.clients.LLMClientException
 import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.streaming.StreamFrame
 import ai.koog.utils.time.KoogClock
 import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
 import aws.sdk.kotlin.services.bedrockruntime.BedrockRuntimeClient
@@ -47,6 +48,7 @@ import aws.sdk.kotlin.services.bedrockruntime.model.InvokeModelWithResponseStrea
 import aws.sdk.kotlin.services.bedrockruntime.model.ListAsyncInvokesRequest
 import aws.sdk.kotlin.services.bedrockruntime.model.ListAsyncInvokesResponse
 import aws.sdk.kotlin.services.bedrockruntime.model.MessageStopEvent
+import aws.sdk.kotlin.services.bedrockruntime.model.ReasoningContentBlockDelta
 import aws.sdk.kotlin.services.bedrockruntime.model.StartAsyncInvokeRequest
 import aws.sdk.kotlin.services.bedrockruntime.model.StartAsyncInvokeResponse
 import aws.sdk.kotlin.services.bedrockruntime.model.StopReason
@@ -636,6 +638,53 @@ class BedrockLLMClientTest {
 
             val request = requireNotNull(capturedRequest) { "Request should have been captured" }
             assertEquals(null, request.guardrailConfig, "Guardrail config should be null")
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun `converseStream API emits reasoning content deltas`() = runTest {
+        val reasoningText = "I need to inspect the market context first."
+        val mockClient = createMockBedrockClient(
+            onConverseStream = {
+                ConverseStreamResponse {
+                    stream = kotlinx.coroutines.flow.flow {
+                        emit(
+                            ConverseStreamOutput.ContentBlockDelta(
+                                ContentBlockDeltaEvent {
+                                    delta = ContentBlockDelta.ReasoningContent(
+                                        ReasoningContentBlockDelta.Text(reasoningText)
+                                    )
+                                    contentBlockIndex = 0
+                                }
+                            )
+                        )
+                        emit(
+                            ConverseStreamOutput.MessageStop(
+                                MessageStopEvent { stopReason = StopReason.EndTurn }
+                            )
+                        )
+                    }
+                }
+            },
+        )
+
+        val client = BedrockLLMClient(
+            mockClient,
+            apiMethod = BedrockAPIMethod.Converse,
+        )
+
+        try {
+            val frames = client.executeStreaming(
+                Prompt.build("test") { user("Hello") },
+                BedrockModels.MiniMaxM2_5,
+                emptyList()
+            ).toList()
+
+            val reasoningFrame = frames.filterIsInstance<StreamFrame.ReasoningDelta>().single()
+            reasoningFrame.text shouldBe reasoningText
+            reasoningFrame.index shouldBe 0
         } finally {
             client.close()
         }


### PR DESCRIPTION
Emit reasoning text deltas from Bedrock Converse streaming responses as `StreamFrame.ReasoningDelta`.

Previously, `ContentBlockDelta.ReasoningContent` chunks were treated as unsupported, so providers/models that stream reasoning through Bedrock Converse dropped those deltas. This change maps `ReasoningContentBlockDelta.Text` to Koog reasoning stream frames while continuing to skip redacted content and signatures.

Also adds a regression test covering Converse streaming reasoning deltas.

I’ve verified this on Bedrock’s minimax.minimax-m2.5 model. After the code changes, the reasoning content is now displayed correctly.