### PR TITLE
fix(agents): support oneOf and const schemas in MCP tool parser

### DIFF
--- a/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpToolDefinitionParser.kt
+++ b/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpToolDefinitionParser.kt
@@ -107,6 +107,54 @@ public object DefaultMcpToolDescriptorParser : McpToolDescriptorParser {
             }
 
             /**
+             * oneOf with multiple types.
+             *
+             * JSON Schema semantically distinguishes oneOf (exactly one) from anyOf (one or more),
+             * but our internal [ToolParameterType] only models a union (AnyOf). For tool-argument
+             * descriptors this is sound: argument values are validated by the MCP server, and the
+             * koog-side descriptor only enumerates the legal shapes for the LLM to choose from.
+             *
+             * Schema example:
+             * {
+             *   "oneOfParam": {
+             *     "oneOf": [
+             *       { "type": "string" },
+             *       { "type": "number" }
+             *     ],
+             *     "title": "string or number parameter"
+             *   }
+             * }
+             */
+            val oneOf = element["oneOf"]?.jsonArray
+            if (oneOf != null) {
+                return ToolParameterType.AnyOf(
+                    types = oneOf.map { it.jsonObject }.map {
+                        ToolParameterDescriptor(
+                            name = "",
+                            description = it["description"]?.jsonPrimitive?.content.orEmpty(),
+                            type = parseParameterType(it.jsonObject, defs)
+                        )
+                    }.toTypedArray()
+                )
+            }
+
+            /**
+             * const: a single permitted value. JSON Schema defines `const: X` as equivalent to
+             * `enum: [X]`, so we map it onto a singleton [ToolParameterType.Enum]. This commonly
+             * appears as a discriminator inside oneOf-of-objects (e.g. obsidian_write_note.target),
+             * which previously failed at the "must have type property" throw site below.
+             *
+             * Schema example:
+             * {
+             *   "kind": { "const": "path" }
+             * }
+             */
+            val const = element["const"]
+            if (const != null) {
+                return ToolParameterType.Enum(arrayOf(enumEntryToString(const)))
+            }
+
+            /**
              * Special case for enum string types.
              * Schema example:
              * {

--- a/agents/agents-mcp/src/commonTest/kotlin/ai/koog/agents/mcp/DefaultMcpToolDescriptorParserTest.kt
+++ b/agents/agents-mcp/src/commonTest/kotlin/ai/koog/agents/mcp/DefaultMcpToolDescriptorParserTest.kt
@@ -1236,6 +1236,273 @@ class DefaultMcpToolDescriptorParserTest {
         }
     }
 
+    // ====== oneOf tests ======
+
+    @Test
+    fun `test parsing simple oneOf parameter type`() {
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "A test tool with oneOf parameter",
+            properties = buildJsonObject {
+                putJsonObject("oneOfParam") {
+                    put("description", "String or number parameter")
+                    putJsonArray("oneOf") {
+                        addJsonObject {
+                            put("type", "string")
+                            put("description", "String option")
+                        }
+                        addJsonObject {
+                            put("type", "number")
+                            put("description", "Number option")
+                        }
+                    }
+                }
+            },
+            required = emptyList()
+        )
+
+        val toolDescriptor = parser.parse(sdkTool)
+
+        val expectedToolDescriptor = ToolDescriptor(
+            name = "test-tool",
+            description = "A test tool with oneOf parameter",
+            requiredParameters = emptyList(),
+            optionalParameters = listOf(
+                ToolParameterDescriptor(
+                    name = "oneOfParam",
+                    description = "String or number parameter",
+                    type = ToolParameterType.AnyOf(
+                        types = arrayOf(
+                            ToolParameterDescriptor(
+                                name = "",
+                                description = "String option",
+                                type = ToolParameterType.String
+                            ),
+                            ToolParameterDescriptor(
+                                name = "",
+                                description = "Number option",
+                                type = ToolParameterType.Float
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        assertEquals(expectedToolDescriptor, toolDescriptor)
+    }
+
+    @Test
+    fun `test parsing oneOf with refs`() {
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "A test tool with oneOf ${'$'}ref parameter",
+            properties = buildJsonObject {
+                putJsonObject("shape") {
+                    putJsonArray("oneOf") {
+                        addJsonObject {
+                            put("\$ref", "#/\$defs/Circle")
+                        }
+                        addJsonObject {
+                            put("\$ref", "#/\$defs/Square")
+                        }
+                    }
+                }
+            },
+            required = listOf("shape"),
+            defs = buildJsonObject {
+                putJsonObject("Circle") {
+                    put("type", "object")
+                    putJsonObject("properties") {
+                        putJsonObject("radius") {
+                            put("type", "number")
+                            put("description", "Circle radius")
+                        }
+                    }
+                }
+                putJsonObject("Square") {
+                    put("type", "object")
+                    putJsonObject("properties") {
+                        putJsonObject("side") {
+                            put("type", "number")
+                            put("description", "Square side length")
+                        }
+                    }
+                }
+            }
+        )
+
+        val toolDescriptor = parser.parse(sdkTool)
+
+        assertEquals(1, toolDescriptor.requiredParameters.size)
+        val param = toolDescriptor.requiredParameters.single()
+        assertEquals("shape", param.name)
+        assertTrue(param.type is ToolParameterType.AnyOf)
+        val anyOf = param.type as ToolParameterType.AnyOf
+        assertEquals(2, anyOf.types.size)
+
+        val circleType = anyOf.types[0].type as ToolParameterType.Object
+        assertEquals(1, circleType.properties.size)
+        assertEquals("radius", circleType.properties[0].name)
+        assertEquals(ToolParameterType.Float, circleType.properties[0].type)
+
+        val squareType = anyOf.types[1].type as ToolParameterType.Object
+        assertEquals(1, squareType.properties.size)
+        assertEquals("side", squareType.properties[0].name)
+        assertEquals(ToolParameterType.Float, squareType.properties[0].type)
+    }
+
+    @Test
+    fun `test parsing oneOf nested in array items`() {
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "A test tool with array of oneOf items",
+            properties = buildJsonObject {
+                putJsonObject("values") {
+                    put("type", "array")
+                    put("description", "Array of string or integer values")
+                    putJsonObject("items") {
+                        putJsonArray("oneOf") {
+                            addJsonObject {
+                                put("type", "string")
+                            }
+                            addJsonObject {
+                                put("type", "integer")
+                            }
+                        }
+                    }
+                }
+            },
+            required = listOf("values")
+        )
+
+        val toolDescriptor = parser.parse(sdkTool)
+
+        val param = toolDescriptor.requiredParameters.single()
+        assertEquals("values", param.name)
+        assertTrue(param.type is ToolParameterType.List)
+        val listType = param.type as ToolParameterType.List
+        assertTrue(listType.itemsType is ToolParameterType.AnyOf)
+        val anyOf = listType.itemsType as ToolParameterType.AnyOf
+        assertEquals(2, anyOf.types.size)
+        assertEquals(ToolParameterType.String, anyOf.types[0].type)
+        assertEquals(ToolParameterType.Integer, anyOf.types[1].type)
+    }
+
+    @Test
+    fun `test parsing const as singleton enum`() {
+        val sdkTool = createSdkTool(
+            name = "test-tool",
+            description = "A test tool with const parameters",
+            properties = buildJsonObject {
+                putJsonObject("kindString") {
+                    put("const", "path")
+                }
+                putJsonObject("kindNumber") {
+                    put("const", 42)
+                }
+                putJsonObject("kindNull") {
+                    put("const", JsonNull)
+                }
+            },
+            required = listOf("kindString", "kindNumber", "kindNull")
+        )
+
+        val toolDescriptor = parser.parse(sdkTool)
+
+        assertEquals(3, toolDescriptor.requiredParameters.size)
+
+        val stringConst = toolDescriptor.requiredParameters[0].type as ToolParameterType.Enum
+        assertEquals(listOf("path"), stringConst.entries.toList())
+
+        val numberConst = toolDescriptor.requiredParameters[1].type as ToolParameterType.Enum
+        assertEquals(listOf("42"), numberConst.entries.toList())
+
+        val nullConst = toolDescriptor.requiredParameters[2].type as ToolParameterType.Enum
+        assertEquals(listOf("null"), nullConst.entries.toList())
+    }
+
+    @Test
+    fun `test parsing oneOf of objects with const discriminator like issue 2017`() {
+        // Reproduces the obsidian_write_note.target schema from issue #2017.
+        // Previously threw IllegalArgumentException("Parameter  must have type property")
+        // at the {const: "path"|"active"|"periodic"} properties inside the oneOf candidates.
+        val sdkTool = createSdkTool(
+            name = "obsidian_write_note",
+            description = "Write a note to Obsidian",
+            properties = buildJsonObject {
+                putJsonObject("target") {
+                    put("description", "Where the note lives.")
+                    putJsonArray("oneOf") {
+                        addJsonObject {
+                            put("type", "object")
+                            putJsonObject("properties") {
+                                putJsonObject("type") {
+                                    put("const", "path")
+                                }
+                                putJsonObject("path") {
+                                    put("type", "string")
+                                    put("description", "Vault-relative path to the note")
+                                }
+                            }
+                            putJsonArray("required") {
+                                add("type")
+                                add("path")
+                            }
+                        }
+                        addJsonObject {
+                            put("type", "object")
+                            putJsonObject("properties") {
+                                putJsonObject("type") {
+                                    put("const", "active")
+                                }
+                            }
+                            putJsonArray("required") {
+                                add("type")
+                            }
+                        }
+                        addJsonObject {
+                            put("type", "object")
+                            putJsonObject("properties") {
+                                putJsonObject("type") {
+                                    put("const", "periodic")
+                                }
+                                putJsonObject("period") {
+                                    put("type", "string")
+                                    put("description", "Period identifier")
+                                }
+                            }
+                            putJsonArray("required") {
+                                add("type")
+                            }
+                        }
+                    }
+                }
+            },
+            required = listOf("target")
+        )
+
+        val toolDescriptor = parser.parse(sdkTool)
+
+        val param = toolDescriptor.requiredParameters.single()
+        assertEquals("target", param.name)
+        assertTrue(param.type is ToolParameterType.AnyOf)
+        val anyOf = param.type as ToolParameterType.AnyOf
+        assertEquals(3, anyOf.types.size)
+
+        // Each candidate is an object whose "type" property is a singleton Enum (const discriminator)
+        val pathObj = anyOf.types[0].type as ToolParameterType.Object
+        val pathTypeProp = pathObj.properties.first { it.name == "type" }
+        assertEquals(ToolParameterType.Enum(arrayOf("path")), pathTypeProp.type)
+
+        val activeObj = anyOf.types[1].type as ToolParameterType.Object
+        val activeTypeProp = activeObj.properties.first { it.name == "type" }
+        assertEquals(ToolParameterType.Enum(arrayOf("active")), activeTypeProp.type)
+
+        val periodicObj = anyOf.types[2].type as ToolParameterType.Object
+        val periodicTypeProp = periodicObj.properties.first { it.name == "type" }
+        assertEquals(ToolParameterType.Enum(arrayOf("periodic")), periodicTypeProp.type)
+    }
+
     // Helper function to create an SDK Tool for testing
     private fun createSdkTool(
         name: String,


### PR DESCRIPTION
**Summary**

- `DefaultMcpToolDescriptorParser.parseParameterType` only inspected `$ref → type → anyOf → enum`, so MCP server schemas using top-level `oneOf` (no `type`) fell through to `throw IllegalArgumentException("Parameter ${title} must have type property")` at `agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpToolDefinitionParser.kt:127-129`, and `buildToolRegistry` then logged the parse failure and silently skipped registering the tool. The example from the issue (`obsidian_write_note.target`) is `oneOf` of objects whose discriminator property is `{"const": "path"|"active"|"periodic"}`, so a `oneOf`-only fix would still re-hit the same throw site inside the candidate objects' properties.
- Add two sibling branches inside the `typeStr == null` block: `oneOf → ToolParameterType.AnyOf(...)` (mirrors the existing `anyOf` handling; koog only models a union, and the MCP server enforces exact-one semantics on the wire), and `const → ToolParameterType.Enum(arrayOf(enumEntryToString(const)))` (JSON Schema 7.1.1 defines `const: X` as equivalent to `enum: [X]`, and the existing `enum` path already stringifies entry values). Both decisions are documented in KDoc on the new branches. Branch ordering becomes `anyOf → oneOf → const → enum → throw`.

Refs #2017 (parser side; runtime-side coercion is tracked in a separate PR).

**Test plan**

- [x] `gradle :agents:agents-mcp:jvmTest --tests "ai.koog.agents.mcp.DefaultMcpToolDescriptorParserTest"`
- [x] `gradle :agents:agents-mcp:ktlintCheck`
- [x] `gradle :agents:agents-mcp:compileKotlinJvm --warning-mode=all` — zero warnings in `agents-mcp`.
