### PR TITLE
Fix double JSON encoding of function.arguments in AbstractOpenAILLMClient

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
@@ -319,7 +319,7 @@ public abstract class AbstractOpenAILLMClient<TResponse : OpenAIBaseLLMResponse,
                                     ?.map {
                                         OpenAIToolCall(
                                             it.id ?: Uuid.random().toString(),
-                                            function = OpenAIFunction(it.tool, Json.encodeToString(it.args))
+                                            function = OpenAIFunction(it.tool, it.args)
                                         )
                                     }
                             )


### PR DESCRIPTION
  ## Problem
  `MessagePart.Tool.Call.args` is already a JSON string (encoded in its constructor via `Json.encodeToString(args)`). However, `AbstractOpenAILLMClient.convertPromptToMessages` calls `Json.encodeToString(it.args)` again, causing double encoding.
  
  ## Impact
  - **Dashscope (Qwen)**: Strict API validation rejects the double-encoded string with `"The \"function.arguments\" parameter ... must be in JSON format."`
  - **DeepSeek**: Works by accident due to lenient parsing.
  
  ## Fix
  Remove the redundant `Json.encodeToString` call.
  
  ```diff
  - function = OpenAIFunction(it.tool, Json.encodeToString(it.args))
  + function = OpenAIFunction(it.tool, it.args)