### PR TITLE
fix(agents): coerce stringified MCP tool args using descriptor types

### DIFF
--- a/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpArgCoercion.kt
+++ b/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpArgCoercion.kt
@@ -1,0 +1,185 @@
+package ai.koog.agents.mcp
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolParameterDescriptor
+import ai.koog.agents.core.tools.ToolParameterType
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+
+/**
+ * Maximum recursion depth applied when walking nested descriptor structures.
+ *
+ * Any input that would coerce deeper than this guard is left untouched so that adversarial or
+ * accidentally cyclic payloads cannot exhaust the stack.
+ */
+private const val MAX_COERCION_DEPTH: Int = 8
+
+/**
+ * Coerces stringified JSON arguments emitted by an LLM into the shapes declared by the tool's
+ * [ToolDescriptor] before they are forwarded to the MCP server.
+ *
+ * ### Gating
+ * Coercion is intentionally restricted to declared parameter types of
+ * [ToolParameterType.Object], [ToolParameterType.AnyOf] and [ToolParameterType.List].
+ * Primitive parameter types ([ToolParameterType.String], [ToolParameterType.Integer],
+ * [ToolParameterType.Float], [ToolParameterType.Boolean], [ToolParameterType.Enum],
+ * [ToolParameterType.Null]) are never touched: forwarding them unchanged preserves user-intended
+ * strings (e.g. `"{not-json}"`) and lets the MCP server's primitive validation remain authoritative.
+ *
+ * ### Behaviour
+ * For each argument whose declared parameter type is one of the gated types and whose value is a
+ * [JsonPrimitive] with `isString == true`, [Json.parseToJsonElement] is invoked on the string
+ * content. The parsed shape is then checked against the declared type:
+ *  - [ToolParameterType.Object] accepts only a parsed [JsonObject].
+ *  - [ToolParameterType.List] accepts only a parsed [JsonArray].
+ *  - [ToolParameterType.AnyOf] accepts the parsed value when the **first** candidate whose shape
+ *    is compatible with the parsed element is found. If no candidate matches, the value is left
+ *    untouched.
+ *
+ * On parse failure or shape mismatch the **original value is preserved** so the MCP server's
+ * schema validation remains the source of truth. The function never throws for malformed input.
+ *
+ * ### Recursion
+ * Object properties, list items and AnyOf candidates are walked recursively so that deeply nested
+ * stringified payloads (e.g. a stringified object containing another stringified object) are
+ * unwrapped consistently. Recursion is bounded by [MAX_COERCION_DEPTH]; values that would be
+ * coerced past the guard are preserved unchanged. AnyOf direct-match recursion shares the same
+ * depth budget as object/list recursion, so the guard fires uniformly regardless of how a value
+ * was routed.
+ *
+ * ### Additional properties
+ * For [ToolParameterType.Object] parameters, declared `properties` are matched first. Keys that
+ * are not declared are coerced using [ToolParameterType.Object.additionalPropertiesType] only when
+ * [ToolParameterType.Object.additionalProperties] is `true` **and** the additional type is
+ * non-null. Otherwise unmatched keys are passed through unchanged.
+ *
+ * @param args The raw arguments produced by the agent framework.
+ * @param descriptor The descriptor of the MCP tool whose parameter types guide coercion.
+ * @return A [JsonObject] whose values have been coerced where applicable; entries without a
+ *         matching parameter descriptor are preserved as-is.
+ */
+internal fun coerceArgsToDescriptorTypes(
+    args: JsonObject,
+    descriptor: ToolDescriptor,
+): JsonObject {
+    val paramsByName: Map<String, ToolParameterDescriptor> =
+        (descriptor.requiredParameters + descriptor.optionalParameters).associateBy { it.name }
+
+    return buildJsonObject {
+        for ((key, value) in args) {
+            val param = paramsByName[key]
+            if (param == null) {
+                put(key, value)
+            } else {
+                put(key, coerceValue(value, param.type, depth = 1))
+            }
+        }
+    }
+}
+
+/**
+ * Recursively coerces [value] against the declared [type], obeying the gating, shape and depth
+ * rules described on [coerceArgsToDescriptorTypes].
+ */
+private fun coerceValue(value: JsonElement, type: ToolParameterType, depth: Int): JsonElement {
+    if (depth > MAX_COERCION_DEPTH) return value
+
+    return when (type) {
+        is ToolParameterType.Object -> coerceObject(value, type, depth)
+        is ToolParameterType.List -> coerceList(value, type, depth)
+        is ToolParameterType.AnyOf -> coerceAnyOf(value, type, depth)
+        else -> value
+    }
+}
+
+private fun coerceObject(value: JsonElement, type: ToolParameterType.Object, depth: Int): JsonElement {
+    val asObject: JsonObject? = when {
+        value is JsonObject -> value
+        value is JsonPrimitive && value.isString ->
+            tryParseAs<JsonObject>(value.content)
+        else -> null
+    }
+    if (asObject == null) return value
+
+    val declaredByName: Map<String, ToolParameterDescriptor> = type.properties.associateBy { it.name }
+    val additionalAllowed = type.additionalProperties == true && type.additionalPropertiesType != null
+
+    return buildJsonObject {
+        for ((k, v) in asObject) {
+            val declared = declaredByName[k]
+            val coerced = when {
+                declared != null -> coerceValue(v, declared.type, depth + 1)
+                additionalAllowed -> coerceValue(v, type.additionalPropertiesType!!, depth + 1)
+                else -> v
+            }
+            put(k, coerced)
+        }
+    }
+}
+
+private fun coerceList(value: JsonElement, type: ToolParameterType.List, depth: Int): JsonElement {
+    val asArray: JsonArray? = when {
+        value is JsonArray -> value
+        value is JsonPrimitive && value.isString ->
+            tryParseAs<JsonArray>(value.content)
+        else -> null
+    }
+    if (asArray == null) return value
+
+    return buildJsonArray {
+        for (element in asArray) {
+            add(coerceValue(element, type.itemsType, depth + 1))
+        }
+    }
+}
+
+private fun coerceAnyOf(value: JsonElement, type: ToolParameterType.AnyOf, depth: Int): JsonElement {
+    // If the current value already matches some candidate shape, recurse into that candidate so
+    // nested stringified payloads keep being unwrapped.
+    val directMatch = type.types.firstOrNull { isShapeCompatible(value, it.type) }
+    if (directMatch != null) {
+        return coerceValue(value, directMatch.type, depth + 1)
+    }
+
+    if (value is JsonPrimitive && value.isString) {
+        val parsed = tryParse(value.content) ?: return value
+        val candidate = type.types.firstOrNull { isShapeCompatible(parsed, it.type) } ?: return value
+        return coerceValue(parsed, candidate.type, depth + 1)
+    }
+
+    return value
+}
+
+private fun isShapeCompatible(value: JsonElement, type: ToolParameterType): Boolean = when (type) {
+    is ToolParameterType.Object -> value is JsonObject
+    is ToolParameterType.List -> value is JsonArray
+    is ToolParameterType.String -> value is JsonPrimitive && value.isString
+    is ToolParameterType.Integer, is ToolParameterType.Float ->
+        value is JsonPrimitive && !value.isString && value.content.toDoubleOrNull() != null
+    is ToolParameterType.Boolean ->
+        value is JsonPrimitive &&
+            !value.isString &&
+            (value.content == "true" || value.content == "false")
+    is ToolParameterType.Null -> value is JsonPrimitive && !value.isString && value.content == "null"
+    is ToolParameterType.Enum ->
+        value is JsonPrimitive &&
+            value.isString &&
+            type.entries.contains(value.content)
+    is ToolParameterType.AnyOf -> type.types.any { isShapeCompatible(value, it.type) }
+}
+
+private inline fun <reified T : JsonElement> tryParseAs(content: String): T? {
+    val parsed = tryParse(content) ?: return null
+    return parsed as? T
+}
+
+private fun tryParse(content: String): JsonElement? = try {
+    Json.parseToJsonElement(content)
+} catch (_: Throwable) {
+    null
+}

--- a/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpTool.kt
+++ b/agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpTool.kt
@@ -53,13 +53,18 @@ public class McpTool(
      * This method calls the MCP tool through the MCP client and converts the result
      * to a Result object that can be used by the agent framework.
      *
+     * Before forwarding, arguments are passed through [coerceArgsToDescriptorTypes] so that
+     * stringified JSON values emitted by an LLM for declared object / list / anyOf parameters are
+     * unwrapped into their declared shapes. Values that do not parse, do not match the declared
+     * shape or are not gated by the descriptor are forwarded unchanged.
+     *
      * @param args The arguments for the MCP tool call.
      * @return The result of the MCP tool call.
      */
     override suspend fun execute(args: JSONObject): CallToolResult {
         return mcpClient.callTool(
             name = descriptor.name,
-            arguments = args.toKotlinxJsonObject()
+            arguments = coerceArgsToDescriptorTypes(args.toKotlinxJsonObject(), descriptor)
         )
     }
 

--- a/agents/agents-mcp/src/commonTest/kotlin/ai/koog/agents/mcp/McpArgCoercionTest.kt
+++ b/agents/agents-mcp/src/commonTest/kotlin/ai/koog/agents/mcp/McpArgCoercionTest.kt
@@ -1,0 +1,312 @@
+package ai.koog.agents.mcp
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolParameterDescriptor
+import ai.koog.agents.core.tools.ToolParameterType
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class McpArgCoercionTest {
+
+    private fun descriptor(vararg required: ToolParameterDescriptor) = ToolDescriptor(
+        name = "test",
+        description = "test",
+        requiredParameters = required.toList(),
+        optionalParameters = emptyList(),
+    )
+
+    private fun optDescriptor(vararg optional: ToolParameterDescriptor) = ToolDescriptor(
+        name = "test",
+        description = "test",
+        requiredParameters = emptyList(),
+        optionalParameters = optional.toList(),
+    )
+
+    private fun param(name: String, type: ToolParameterType) =
+        ToolParameterDescriptor(name = name, description = "", type = type)
+
+    @Test
+    fun `coerce stringified object to JsonObject when descriptor type is Object`() {
+        val desc = descriptor(
+            param(
+                "payload",
+                ToolParameterType.Object(
+                    properties = listOf(param("k", ToolParameterType.String))
+                )
+            )
+        )
+        val args = buildJsonObject { put("payload", "{\"k\":\"v\"}") }
+
+        val result = coerceArgsToDescriptorTypes(args, desc)
+
+        val expected = buildJsonObject {
+            put("payload", buildJsonObject { put("k", "v") })
+        }
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `coerce stringified array to JsonArray when descriptor type is List`() {
+        val desc = descriptor(
+            param("items", ToolParameterType.List(itemsType = ToolParameterType.String))
+        )
+        val args = buildJsonObject { put("items", "[\"a\",\"b\"]") }
+
+        val result = coerceArgsToDescriptorTypes(args, desc)
+
+        val expected = buildJsonObject {
+            put(
+                "items",
+                buildJsonArray {
+                    add(JsonPrimitive("a"))
+                    add(JsonPrimitive("b"))
+                }
+            )
+        }
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `leave already-object value untouched`() {
+        val desc = descriptor(
+            param(
+                "payload",
+                ToolParameterType.Object(
+                    properties = listOf(param("k", ToolParameterType.String))
+                )
+            )
+        )
+        val inner = buildJsonObject { put("k", "v") }
+        val args = buildJsonObject { put("payload", inner) }
+
+        val result = coerceArgsToDescriptorTypes(args, desc)
+
+        assertEquals(args, result)
+    }
+
+    @Test
+    fun `leave already-string value untouched when descriptor type is String`() {
+        val desc = descriptor(param("name", ToolParameterType.String))
+        val args = buildJsonObject { put("name", "{not-json-but-valid-string}") }
+
+        val result = coerceArgsToDescriptorTypes(args, desc)
+
+        assertEquals(args, result)
+    }
+
+    @Test
+    fun `leave value untouched when JSON parse fails for Object param`() {
+        val desc = descriptor(
+            param("payload", ToolParameterType.Object(properties = emptyList()))
+        )
+        val args = buildJsonObject { put("payload", "not a json") }
+
+        val result = coerceArgsToDescriptorTypes(args, desc)
+
+        assertEquals(args, result)
+    }
+
+    @Test
+    fun `leave value untouched when parsed shape mismatches descriptor - Object expected but array given as string`() {
+        val desc = descriptor(
+            param("payload", ToolParameterType.Object(properties = emptyList()))
+        )
+        val args = buildJsonObject { put("payload", "[1,2,3]") }
+
+        val result = coerceArgsToDescriptorTypes(args, desc)
+
+        assertEquals(args, result)
+    }
+
+    @Test
+    fun `recursively coerce nested stringified object inside Object properties`() {
+        val innerType = ToolParameterType.Object(
+            properties = listOf(param("k", ToolParameterType.String))
+        )
+        val outerType = ToolParameterType.Object(
+            properties = listOf(param("inner", innerType))
+        )
+        val desc = descriptor(param("outer", outerType))
+
+        // outer is a stringified object whose "inner" value is itself a stringified object
+        val args = buildJsonObject { put("outer", "{\"inner\":\"{\\\"k\\\":\\\"v\\\"}\"}") }
+
+        val result = coerceArgsToDescriptorTypes(args, desc)
+
+        val expected = buildJsonObject {
+            put(
+                "outer",
+                buildJsonObject {
+                    put("inner", buildJsonObject { put("k", "v") })
+                }
+            )
+        }
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `AnyOf with Object candidate coerces stringified object via that candidate`() {
+        val desc = descriptor(
+            param(
+                "x",
+                ToolParameterType.AnyOf(
+                    types = arrayOf(
+                        param("", ToolParameterType.Null),
+                        param(
+                            "",
+                            ToolParameterType.Object(
+                                properties = listOf(param("k", ToolParameterType.String))
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        val args = buildJsonObject { put("x", "{\"k\":\"v\"}") }
+
+        val result = coerceArgsToDescriptorTypes(args, desc)
+
+        val expected = buildJsonObject {
+            put("x", buildJsonObject { put("k", "v") })
+        }
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `AnyOf without Object candidate leaves stringified array untouched`() {
+        val desc = descriptor(
+            param(
+                "x",
+                ToolParameterType.AnyOf(
+                    types = arrayOf(
+                        param("", ToolParameterType.Null),
+                        param(
+                            "",
+                            ToolParameterType.Object(
+                                properties = listOf(param("k", ToolParameterType.String))
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        // array is not compatible with any candidate (Null or Object)
+        val args = buildJsonObject { put("x", "[1,2,3]") }
+
+        val result = coerceArgsToDescriptorTypes(args, desc)
+
+        assertEquals(args, result)
+    }
+
+    @Test
+    fun `additionalPropertiesType coerces unmatched keys when configured`() {
+        val additionalType = ToolParameterType.Object(
+            properties = listOf(param("v", ToolParameterType.String))
+        )
+        val desc = descriptor(
+            param(
+                "obj",
+                ToolParameterType.Object(
+                    properties = listOf(param("k1", ToolParameterType.String)),
+                    additionalProperties = true,
+                    additionalPropertiesType = additionalType,
+                )
+            )
+        )
+        val args = buildJsonObject {
+            put(
+                "obj",
+                buildJsonObject {
+                    put("k1", "ok")
+                    put("k2", "{\"v\":\"x\"}")
+                }
+            )
+        }
+
+        val result = coerceArgsToDescriptorTypes(args, desc)
+
+        val expected = buildJsonObject {
+            put(
+                "obj",
+                buildJsonObject {
+                    put("k1", "ok")
+                    put("k2", buildJsonObject { put("v", "x") })
+                }
+            )
+        }
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `additionalProperties == false leaves unmatched keys untouched`() {
+        val desc = descriptor(
+            param(
+                "obj",
+                ToolParameterType.Object(
+                    properties = listOf(param("k1", ToolParameterType.String)),
+                    additionalProperties = false,
+                )
+            )
+        )
+        val args = buildJsonObject {
+            put(
+                "obj",
+                buildJsonObject {
+                    put("k1", "ok")
+                    put("k2", "{\"v\":\"x\"}")
+                }
+            )
+        }
+
+        val result = coerceArgsToDescriptorTypes(args, desc)
+
+        assertEquals(args, result)
+    }
+
+    @Test
+    fun `depth-bounded recursion stops at MAX_DEPTH and preserves original`() {
+        // Build a descriptor that nests Object 9 levels deep (exceeds MAX_COERCION_DEPTH = 8)
+        fun nestedObjectType(depth: Int): ToolParameterType.Object {
+            return if (depth <= 1) {
+                ToolParameterType.Object(properties = listOf(param("leaf", ToolParameterType.String)))
+            } else {
+                ToolParameterType.Object(properties = listOf(param("nested", nestedObjectType(depth - 1))))
+            }
+        }
+
+        val desc = descriptor(param("root", nestedObjectType(9)))
+
+        // Build args: root is a stringified object that is itself 9 levels deep of stringified objects.
+        // Innermost is the real {"leaf":"v"}; each outer level wraps the previous level as a
+        // stringified JSON value.
+        var innerJson = "{\"leaf\":\"v\"}"
+        repeat(8) {
+            innerJson = "{\"nested\":${Json.encodeToString(JsonPrimitive.serializer(), JsonPrimitive(innerJson))}}"
+        }
+        val args = buildJsonObject { put("root", innerJson) }
+
+        // Should not throw; the depth guard must prevent stack overflow.
+        val result = coerceArgsToDescriptorTypes(args, desc)
+
+        // Verify the exact boundary from plan §3.4 / §4.1 case 12:
+        // depths 1..8 must be unwrapped to JsonObject, and the value at depth 9 — which would
+        // require crossing MAX_COERCION_DEPTH — must remain the original string.
+        val rootObj = result["root"] as JsonObject
+        var node: JsonElement = rootObj
+        repeat(7) { node = (node as JsonObject)["nested"]!! }
+        assertTrue(node is JsonObject, "depth 8 should be unwrapped to JsonObject but was $node")
+        val depth9 = (node as JsonObject)["nested"]!!
+        assertTrue(
+            depth9 is JsonPrimitive && depth9.isString,
+            "depth 9 should remain a string but was $depth9"
+        )
+    }
+}

--- a/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/McpToolTest.kt
+++ b/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/McpToolTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.junit.jupiter.api.AfterAll
@@ -87,6 +88,25 @@ class McpToolTest {
                 ToolDescriptor(
                     name = "empty",
                     description = "An empty tool",
+                ),
+                ToolDescriptor(
+                    name = "echoObject",
+                    description = "Echoes the received payload argument as JSON",
+                    requiredParameters = listOf(
+                        ToolParameterDescriptor(
+                            name = "payload",
+                            description = "",
+                            type = ToolParameterType.Object(
+                                properties = listOf(
+                                    ToolParameterDescriptor(
+                                        name = "k",
+                                        description = "",
+                                        type = ToolParameterType.String,
+                                    )
+                                )
+                            )
+                        )
+                    )
                 )
             )
 
@@ -215,6 +235,29 @@ class McpToolTest {
             expected = "Error: Error line 1\nError line 2",
             actual = encodedResult
         )
+    }
+
+    @OptIn(InternalAgentToolsApi::class)
+    @Test
+    fun `execute coerces stringified object arg before forwarding to client`() = runTest(timeout = 30.seconds) {
+        testMcpTools { toolRegistry ->
+            val echoTool = toolRegistry.getTool("echoObject") as McpTool
+
+            // Simulate an LLM emitting a nested object as a stringified JSON primitive — the
+            // failure mode reported in issue #2017. After coercion, payload must arrive on the
+            // wire as a structured JsonObject, not as the original string.
+            val args = buildJsonObject { put("payload", "{\"k\":\"v\"}") }
+
+            val result = withContext(Dispatchers.Default.limitedParallelism(1)) {
+                withTimeout(1.minutes) {
+                    echoTool.execute(args.toKoogJSONObject())
+                }
+            }
+
+            val echoed = (result.content.single() as TextContent).text
+            val parsed = Json.parseToJsonElement(echoed)
+            assertEquals(buildJsonObject { put("k", "v") }, parsed)
+        }
     }
 
     @Test

--- a/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/StreamableHttpMcpToolTest.kt
+++ b/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/StreamableHttpMcpToolTest.kt
@@ -92,6 +92,25 @@ class StreamableHttpMcpToolTest {
                 ToolDescriptor(
                     name = "empty",
                     description = "An empty tool",
+                ),
+                ToolDescriptor(
+                    name = "echoObject",
+                    description = "Echoes the received payload argument as JSON",
+                    requiredParameters = listOf(
+                        ToolParameterDescriptor(
+                            name = "payload",
+                            description = "",
+                            type = ToolParameterType.Object(
+                                properties = listOf(
+                                    ToolParameterDescriptor(
+                                        name = "k",
+                                        description = "",
+                                        type = ToolParameterType.String,
+                                    )
+                                )
+                            )
+                        )
+                    )
                 )
             )
 

--- a/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/TestMcpServer.kt
+++ b/agents/agents-mcp/src/jvmTest/kotlin/ai/koog/agents/mcp/TestMcpServer.kt
@@ -22,6 +22,9 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -118,6 +121,30 @@ class TestMcpServer(
             inputSchema = ToolSchema()
         ) {
             CallToolResult(content = emptyList())
+        }
+
+        // Echoes the received `payload` argument back as JSON text so callers can assert how the
+        // value arrived on the wire (object vs. stringified-object). Used by McpToolTest wiring
+        // case to prove McpTool.execute() coerces stringified JSON args before forwarding.
+        server.addTool(
+            name = "echoObject",
+            description = "Echoes the received payload argument as JSON",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    putJsonObject("payload") {
+                        put("type", "object")
+                        putJsonObject("properties") {
+                            putJsonObject("k") {
+                                put("type", "string")
+                            }
+                        }
+                    }
+                },
+                required = listOf("payload")
+            )
+        ) { request ->
+            val payload = request.arguments?.get("payload") ?: JsonNull
+            CallToolResult(content = listOf(TextContent(Json.encodeToString(JsonElement.serializer(), payload))))
         }
 
         return server


### PR DESCRIPTION
**Summary**

- `McpTool.execute` at `agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpTool.kt:64-69` forwarded `args.toKotlinxJsonObject()` to `mcpClient.callTool` without consulting the tool descriptor, so when an LLM emitted a nested `object`/`array` parameter as a stringified JSON value (the failure mode reported in #2017 against `obsidian-mcp`) the argument reached the server as a `JsonPrimitive(isString = true)` and was rejected by the server's schema validation.
- Add an internal helper `coerceArgsToDescriptorTypes(args, descriptor)` (new file `agents/agents-mcp/src/commonMain/kotlin/ai/koog/agents/mcp/McpArgCoercion.kt`) that walks each argument against its declared `ToolParameterType` and, only for `Object`, `List`, and `AnyOf` parameters, attempts `Json.parseToJsonElement` on string values, replacing the original only when the parsed shape is compatible with the declared type (or with the first compatible candidate for `AnyOf`). Parse failures and shape mismatches preserve the original value so the MCP server's schema validation remains authoritative. `McpTool.execute` calls the helper once on the forwarding path.
- Gating decision: primitive parameter types (`String`, `Integer`, `Float`, `Boolean`, `Enum`, `Null`) are never touched, so an intentional string payload like `"{not-json}"` against a `String` parameter cannot be mis-parsed. Recursion through `Object.properties`, `List.itemsType`, and `AnyOf` candidates is bounded by `MAX_COERCION_DEPTH = 8`; the AnyOf direct-match path shares the same depth budget so the guard fires uniformly. For `Object` parameters, declared `properties` match first; unmatched keys fall through to `additionalPropertiesType` only when `additionalProperties == true` and the additional type is non-null, otherwise they pass through unchanged. All four decisions are documented on the helper's KDoc.

Closes #2017 (runtime side; parser-side `oneOf` + `const` handling is tracked in a separate PR).

**Test plan**

- [x] `gradle :agents:agents-mcp:jvmTest` — adds `McpArgCoercionTest` (new file, 12 server-less unit cases covering happy path, gating, parse failure, shape mismatch, recursive Object, AnyOf positive/negative, `additionalProperties` true/false, and the depth-8 boundary) and one wiring case in `McpToolTest` that pushes a stringified JSON argument through `execute` and asserts the server-side fixture observed a real nested object. The depth-boundary case asserts `JsonObject` at depths 1..8 and a stringified `JsonPrimitive` at depth 9, so the cast chain pinpoints which depth a future regression breaks at.
- [x] `gradle :agents:agents-mcp:ktlintCheck`
- [x] `gradle :agents:agents-mcp:compileKotlinJvm --warning-mode=all` — zero warnings in `agents-mcp`.

**Notes**

- `TestMcpServer.kt` is shared by `McpToolTest` (SSE) and `StreamableHttpMcpToolTest` (Streamable HTTP). The new `echoObject` fixture tool is added once on the shared server, and both transports' existing assertions were updated to include it in the expected tool list. No additional wiring case is added against the Streamable HTTP transport: `McpTool.execute` is transport-neutral, so a duplicate wiring assertion against a second transport would cover the same call site without adding regression value. If a future change introduces transport-specific behaviour on the forwarding path, a transport-specific wiring case can be added at that point.