### PR TITLE
test: remove Gemini 3 Pro preview and add new profiles

### DIFF
--- a/examples/koog-js-example/koogelis/src/commonMain/kotlin/ai/koog/koogelis/llm/SupportedGoogleModels.kt
+++ b/examples/koog-js-example/koogelis/src/commonMain/kotlin/ai/koog/koogelis/llm/SupportedGoogleModels.kt
@@ -10,8 +10,11 @@ object SupportedGoogleModels {
         GoogleModels.Gemini2_5Pro,
         GoogleModels.Gemini2_5Flash,
         GoogleModels.Gemini2_5FlashLite,
-        GoogleModels.Gemini3_Pro_Preview,
+        GoogleModels.Gemini3_1Pro_Preview,
         GoogleModels.Gemini3_Flash_Preview,
+        GoogleModels.Gemini3_1FlashLite_Preview,
+        GoogleModels.Gemini3_1FlashLite,
+        GoogleModels.Gemini3_5Flash,
     )
     private val LLM_MODEL_BY_ID: Map<String, LLModel> = GOOGLE_MODELS.associateBy { it.id }
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/ExecutorIntegrationTestBase.kt
@@ -208,7 +208,7 @@ abstract class ExecutorIntegrationTestBase {
     open fun integration_testExecuteStreaming(model: LLModel) = runTest(timeout = 300.seconds) {
         Models.assumeAvailable(model.provider)
         assumeTrue(
-            model != GoogleModels.Gemini3_Pro_Preview,
+            model != GoogleModels.Gemini3_1Pro_Preview,
             "KG-768 GoogleLLMClient.executeStreaming() may hang because the stream never completes with End frame"
         )
 
@@ -1169,7 +1169,7 @@ abstract class ExecutorIntegrationTestBase {
         Models.assumeAvailable(model.provider)
         assumeTrue(model.supports(LLMCapability.Tools), "Model $model does not support tools")
         assumeTrue(
-            model != GoogleModels.Gemini3_Pro_Preview,
+            model != GoogleModels.Gemini3_1Pro_Preview,
             "KG-768 GoogleLLMClient.executeStreaming() may hang because the stream never completes with End frame"
         )
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
@@ -120,7 +120,7 @@ object Models {
             // KG-733 [Java API] OpenAILLMClient error: 'reasoning' is provided without its required following item
             // OpenAIModels.Chat.GPT5_2,
             AnthropicModels.Haiku_4_5,
-            GoogleModels.Gemini3_Pro_Preview,
+            GoogleModels.Gemini3_1Pro_Preview,
         )
     }
 

--- a/koog-ktor/src/commonMain/kotlin/ai/koog/ktor/utils/LLMModelParser.kt
+++ b/koog-ktor/src/commonMain/kotlin/ai/koog/ktor/utils/LLMModelParser.kt
@@ -271,7 +271,10 @@ private val GOOGLE_MODELS_MAP = mapOf(
     "gemini2_5flashlite" to GoogleModels.Gemini2_5FlashLite,
     "gemini2_5pro" to GoogleModels.Gemini2_5Pro,
     "gemini3flashpreview" to GoogleModels.Gemini3_Flash_Preview,
-    "gemini3propreview" to GoogleModels.Gemini3_Pro_Preview,
+    "gemini3_1propreview" to GoogleModels.Gemini3_1Pro_Preview,
+    "gemini3_1flashlitepreview" to GoogleModels.Gemini3_1FlashLite_Preview,
+    "gemini3_1flashlite" to GoogleModels.Gemini3_1FlashLite,
+    "gemini3_5flash" to GoogleModels.Gemini3_5Flash,
     "gemini_embedding001" to GoogleModels.Embeddings.GeminiEmbedding001,
 )
 

--- a/koog-ktor/src/commonTest/kotlin/ai/koog/ktor/ModelIdentifierParsingTest.kt
+++ b/koog-ktor/src/commonTest/kotlin/ai/koog/ktor/ModelIdentifierParsingTest.kt
@@ -245,7 +245,10 @@ class ModelIdentifierParsingTest {
             "google.gemini2_5flashlite" to GoogleModels.Gemini2_5FlashLite,
             "google.gemini2_5pro" to GoogleModels.Gemini2_5Pro,
             "google.gemini3flashpreview" to GoogleModels.Gemini3_Flash_Preview,
-            "google.gemini3propreview" to GoogleModels.Gemini3_Pro_Preview,
+            "google.gemini3_1propreview" to GoogleModels.Gemini3_1Pro_Preview,
+            "google.gemini3_1flashlitepreview" to GoogleModels.Gemini3_1FlashLite_Preview,
+            "google.gemini3_1flashlite" to GoogleModels.Gemini3_1FlashLite,
+            "google.gemini3_5flash" to GoogleModels.Gemini3_5Flash,
             "google.gemini_embedding001" to GoogleModels.Embeddings.GeminiEmbedding001,
         )
     )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleModels.kt
@@ -5,8 +5,11 @@ import ai.koog.prompt.executor.clients.google.GoogleModels.Gemini2_0FlashLite001
 import ai.koog.prompt.executor.clients.google.GoogleModels.Gemini2_5Flash
 import ai.koog.prompt.executor.clients.google.GoogleModels.Gemini2_5FlashLite
 import ai.koog.prompt.executor.clients.google.GoogleModels.Gemini2_5Pro
+import ai.koog.prompt.executor.clients.google.GoogleModels.Gemini3_1FlashLite
+import ai.koog.prompt.executor.clients.google.GoogleModels.Gemini3_1FlashLite_Preview
+import ai.koog.prompt.executor.clients.google.GoogleModels.Gemini3_1Pro_Preview
+import ai.koog.prompt.executor.clients.google.GoogleModels.Gemini3_5Flash
 import ai.koog.prompt.executor.clients.google.GoogleModels.Gemini3_Flash_Preview
-import ai.koog.prompt.executor.clients.google.GoogleModels.Gemini3_Pro_Preview
 import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
@@ -22,8 +25,11 @@ import kotlin.jvm.JvmField
  * | [Gemini2_5Pro]              | Slow      | $1.25-$2.50 / $10.00-$15.00² | Audio, Image, Video, Text, Tools, Document  | Text, Tools         |
  * | [Gemini2_5Flash]            | Medium    | $0.15-$1.00 / $0.60-$3.50³   | Audio, Image, Video, Text, Tools            | Text, Tools         |
  * | [Gemini2_5FlashLite]        | Fast      | $0.10-$0.30 / $0.40          | Audio, Image, Video, Text, Tools, Document  | Text, Tools         |
- * | [Gemini3_Pro_Preview]       | Slow      | $2.00-$4.00 / $12.00-$18.00  | Audio, Image, Video, Text, Tools, Document  | Text, Tools         |
  * | [Gemini3_Flash_Preview]     | Fast      | $0.50 / $3                   | Audio, Image, Video, Text, Tools, Document  | Text, Tools         |
+ * | [Gemini3_1Pro_Preview]      | Slow      | $2.00-$4.00 / $12.00-$18.00  | Audio, Image, Video, Text, Tools, Document  | Text, Tools         |
+ * | [Gemini3_1FlashLite_Preview]| Very fast | $0.25-$0.50 / $1.50          | Audio, Image, Video, Text, Tools, Document  | Text, Tools         |
+ * | [Gemini3_1FlashLite]        | Very fast | $0.25-$0.50 / $1.50          | Audio, Image, Video, Text, Tools, Document  | Text, Tools         |
+ * | [Gemini3_5Flash]            | Fast      | $1.50 / $9.00                | Audio, Image, Video, Text, Tools, Document  | Text, Tools         |
  *
  * @see <a href="modelcards.withgoogle.com/model-cards">
  */
@@ -120,8 +126,7 @@ public object GoogleModels : LLModelDefinitions {
     )
 
     /**
-     * Gemini 3 Flash Preview is the latest 3-series model,
-     * with Pro-level intelligence at the speed and pricing of Flash.
+     * Gemini 3 Flash Preview model with Pro-level intelligence at the speed and pricing of Flash.
      *
      * Context window: 1 million tokens
      * Knowledge cutoff: January 2025
@@ -140,18 +145,59 @@ public object GoogleModels : LLModelDefinitions {
     )
 
     /**
-     * Gemini 3 Pro is the first model in the new series, featuring advanced reasoning capabilities.
+     * Gemini 3.1 Pro Preview model with advanced reasoning capabilities.
      * It uses `thinking_level` instead of `thinking_budget` for reasoning control.
      *
      * Context window: 1 million tokens
-     * Knowledge cutoff: January 2025
      *
-     * @see <a href="ai.google.dev/gemini-api/docs/gemini-3">
+     * @see <a href="https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview">
      */
     @JvmField
-    public val Gemini3_Pro_Preview: LLModel = LLModel(
+    public val Gemini3_1Pro_Preview: LLModel = LLModel(
         provider = LLMProvider.Google,
-        id = "gemini-3-pro-preview",
+        id = "gemini-3.1-pro-preview",
+        capabilities = fullCapabilities + LLMCapability.Thinking,
+        contextLength = 1_048_576,
+        maxOutputTokens = 65_536,
+    )
+
+    /**
+     * Gemini 3.1 Flash-Lite Preview model optimized for low latency.
+     *
+     * @see <a href="https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-lite-preview">
+     */
+    @JvmField
+    public val Gemini3_1FlashLite_Preview: LLModel = LLModel(
+        provider = LLMProvider.Google,
+        id = "gemini-3.1-flash-lite-preview",
+        capabilities = fullCapabilities + LLMCapability.Thinking,
+        contextLength = 1_048_576,
+        maxOutputTokens = 65_536,
+    )
+
+    /**
+     * Gemini 3.1 Flash-Lite model optimized for low latency.
+     *
+     * @see <a href="https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-lite">
+     */
+    @JvmField
+    public val Gemini3_1FlashLite: LLModel = LLModel(
+        provider = LLMProvider.Google,
+        id = "gemini-3.1-flash-lite",
+        capabilities = fullCapabilities + LLMCapability.Thinking,
+        contextLength = 1_048_576,
+        maxOutputTokens = 65_536,
+    )
+
+    /**
+     * Gemini 3.5 Flash model optimized for fast multimodal generation.
+     *
+     * @see <a href="https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash">
+     */
+    @JvmField
+    public val Gemini3_5Flash: LLModel = LLModel(
+        provider = LLMProvider.Google,
+        id = "gemini-3.5-flash",
         capabilities = fullCapabilities + LLMCapability.Thinking,
         contextLength = 1_048_576,
         maxOutputTokens = 65_536,
@@ -185,8 +231,11 @@ public object GoogleModels : LLModelDefinitions {
         Gemini2_5Pro,
         Gemini2_5Flash,
         Gemini2_5FlashLite,
-        Gemini3_Pro_Preview,
         Gemini3_Flash_Preview,
+        Gemini3_1Pro_Preview,
+        Gemini3_1FlashLite_Preview,
+        Gemini3_1FlashLite,
+        Gemini3_5Flash,
         Embeddings.GeminiEmbedding001,
     )
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
@@ -421,7 +421,7 @@ class GoogleLLMClientTest {
                 ),
                 id = "id"
             ),
-            GoogleModels.Gemini3_Pro_Preview,
+            GoogleModels.Gemini3_1Pro_Preview,
             emptyList()
         )
 
@@ -455,7 +455,7 @@ class GoogleLLMClientTest {
                 ),
                 id = "id"
             ),
-            GoogleModels.Gemini3_Pro_Preview,
+            GoogleModels.Gemini3_1Pro_Preview,
             emptyList()
         )
 
@@ -489,7 +489,7 @@ class GoogleLLMClientTest {
                 ),
                 id = "id"
             ),
-            GoogleModels.Gemini3_Pro_Preview,
+            GoogleModels.Gemini3_1Pro_Preview,
             emptyList()
         )
 
@@ -655,7 +655,7 @@ class GoogleLLMClientTest {
                 ),
                 id = "id"
             ),
-            GoogleModels.Gemini3_Pro_Preview,
+            GoogleModels.Gemini3_1Pro_Preview,
             emptyList()
         )
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleModelsTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleModelsTest.kt
@@ -104,7 +104,10 @@ class GoogleModelsTest {
 
     @Test
     fun `Gemini 3 preview models should advertise thinking capability`() {
-        assertNotNull(GoogleModels.Gemini3_Pro_Preview.capabilities) shouldContain LLMCapability.Thinking
         assertNotNull(GoogleModels.Gemini3_Flash_Preview.capabilities) shouldContain LLMCapability.Thinking
+        assertNotNull(GoogleModels.Gemini3_1Pro_Preview.capabilities) shouldContain LLMCapability.Thinking
+        assertNotNull(GoogleModels.Gemini3_1FlashLite_Preview.capabilities) shouldContain LLMCapability.Thinking
+        assertNotNull(GoogleModels.Gemini3_1FlashLite.capabilities) shouldContain LLMCapability.Thinking
+        assertNotNull(GoogleModels.Gemini3_5Flash.capabilities) shouldContain LLMCapability.Thinking
     }
 }


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

Add `Gemini3_1Pro_Preview`, `Gemini3_1FlashLite_Preview`, `Gemini3_1FlashLite`, and `Gemini3_5Flash` profiles.

<!-- Include DEPRECATED section below only if this PR deprecates any public APIs. Otherwise, delete it. -->
DEPRECATED:
* `Gemini 3 Pro Preview` profile is no longer supported. `Gemini3_1Pro_Preview` is recommended instead.