### PR TITLE
fix(prompt): stop double-encoding tool-call arguments in OpenAI-compatible requests

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
@@ -319,7 +319,9 @@ public abstract class AbstractOpenAILLMClient<TResponse : OpenAIBaseLLMResponse,
                                     ?.map {
                                         OpenAIToolCall(
                                             it.id ?: Uuid.random().toString(),
-                                            function = OpenAIFunction(it.tool, Json.encodeToString(it.args))
+                                            // `args` already holds the JSON-encoded arguments; re-encoding here would
+                                            // double-encode it into a quoted string that strict backends (e.g. DashScope) reject.
+                                            function = OpenAIFunction(it.tool, it.args)
                                         )
                                     }
                             )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -64,7 +64,6 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.Json
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.jvm.JvmOverloads
 import kotlin.uuid.ExperimentalUuidApi

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -826,7 +826,9 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                                             Item.FunctionToolCall(
                                                 callId = part.id ?: Uuid.random().toString(),
                                                 name = part.tool,
-                                                arguments = Json.encodeToString(part.args)
+                                                // `args` already holds the JSON-encoded arguments; re-encoding here would
+                                                // double-encode it into a quoted string that strict backends (e.g. DashScope) reject.
+                                                arguments = part.args
                                             )
                                         )
                                     } else {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIChatCompletionLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIChatCompletionLLMClientTest.kt
@@ -2,7 +2,10 @@ package ai.koog.prompt.executor.clients.openai
 
 import ai.koog.http.client.ktor.KtorKoogHttpClient
 import ai.koog.prompt.Prompt
+import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.MessagePart
+import ai.koog.prompt.message.RequestMetaInfo
+import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.utils.time.KoogClock
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -10,13 +13,21 @@ import io.ktor.client.engine.mock.respond
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.TextContent
 import io.ktor.http.headersOf
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.time.Instant
 
 class OpenAIChatCompletionLLMClientTest {
@@ -59,6 +70,24 @@ class OpenAIChatCompletionLLMClientTest {
         }
     """.trimIndent()
 
+    //language=json
+    private val plainResponseBody = """
+        {
+          "id": "chatcmpl-plain",
+          "object": "chat.completion",
+          "created": 1716920005,
+          "model": "gpt-4o",
+          "choices": [
+            {
+              "index": 0,
+              "message": {"role": "assistant", "content": "The weather in Boston is 72F."},
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {"total_tokens": 10, "prompt_tokens": 5, "completion_tokens": 5}
+        }
+    """.trimIndent()
+
     @Test
     fun testExecuteToolCallResponsePreservesReasoningMessage() = runTest {
         val engine = MockEngine.Companion { _ ->
@@ -86,5 +115,64 @@ class OpenAIChatCompletionLLMClientTest {
         assertEquals("call_weather", toolCall.id)
         assertEquals("weather", toolCall.tool)
         assertEquals(buildJsonObject { put("city", JsonPrimitive("Boston")) }, toolCall.argsJson)
+    }
+
+    @Test
+    fun testToolCallArgumentsAreNotDoubleEncodedInRequest() = runTest {
+        var capturedBody: String? = null
+        val engine = MockEngine { req ->
+            capturedBody = (req.body as TextContent).text
+            respond(
+                content = plainResponseBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            )
+        }
+        val http = HttpClient(engine) {}
+        val client = OpenAILLMClient(httpClientFactory = KtorKoogHttpClient.Factory(http), apiKey = key, clock = FixedClock)
+
+        val prompt = Prompt(
+            id = "p-toolcall-args",
+            messages = listOf(
+                Message.User("What is the weather in Boston?", RequestMetaInfo.Empty),
+                Message.Assistant(
+                    parts = listOf(
+                        MessagePart.Tool.Call(
+                            id = "call_weather",
+                            tool = "weather",
+                            args = JsonObject(mapOf("city" to JsonPrimitive("Boston"))),
+                        ),
+                    ),
+                    metaInfo = ResponseMetaInfo.Empty
+                ),
+                Message.User(
+                    parts = listOf(
+                        MessagePart.Tool.Result(
+                            id = "call_weather",
+                            tool = "weather",
+                            output = "{\"temperature\":72}",
+                        )
+                    ),
+                    metaInfo = RequestMetaInfo.Empty
+                ),
+            )
+        )
+
+        client.execute(prompt, OpenAIModels.Chat.GPT4o)
+
+        assertNotNull(capturedBody, "Captured request body should not be null")
+        val messages = Json.parseToJsonElement(capturedBody).jsonObject["messages"]!!.jsonArray
+        val assistantMessage = messages
+            .first { it.jsonObject["role"]?.jsonPrimitive?.contentOrNull == "assistant" }
+            .jsonObject
+        val arguments = assistantMessage["tool_calls"]!!.jsonArray[0]
+            .jsonObject["function"]!!.jsonObject["arguments"]!!.jsonPrimitive.content
+
+        // MessagePart.Tool.Call.args already holds JSON-encoded arguments. The serializer must emit
+        // it verbatim; re-encoding produced a double-encoded (quoted) string that strict
+        // OpenAI-compatible backends (e.g. DashScope) reject. arguments must decode to the object.
+        val decoded = Json.parseToJsonElement(arguments)
+        assertIs<JsonObject>(decoded, "function.arguments must be a JSON object, not a double-encoded JSON string")
+        assertEquals(JsonObject(mapOf("city" to JsonPrimitive("Boston"))), decoded)
     }
 }


### PR DESCRIPTION
## What

`MessagePart.Tool.Call.args` already holds the **JSON-encoded** arguments string (the parse side builds it via the `JsonObject` constructor, and `function.arguments` is read back with `Json.parseToJsonElement(...)`). When rebuilding request history it was passed through `Json.encodeToString()` **again**, producing a **double-encoded** (quoted) JSON string on the wire.

OpenAI tolerates this, but strict OpenAI-compatible backends — notably **DashScope / Qwen** — reject the request:

> `<400> InternalError.Algo.InvalidParameter: The "function.arguments" parameter of the code model must be in JSON format.`

This breaks every tool-calling **agent** loop on DashScope at the follow-up `nodeLLMSendToolResults` call (the first tool call runs; replaying the result 400s).

## Fix

Emit `args` verbatim in both serialization paths:

- `AbstractOpenAILLMClient.createMessages` — Chat Completions
- `OpenAILLMClient.convertPromptToResponsesMessages` — Responses API

### On the wire
```jsonc
// before (double-encoded) — decodes to the STRING "{\"a\":3,\"b\":4}"
"arguments":"\"{\\\"a\\\":3,\\\"b\\\":4}\""
// after — decodes to the OBJECT {"a":3,"b":4}
"arguments":"{\"a\":3,\"b\":4}"
```

## Tests

Adds `testToolCallArgumentsAreNotDoubleEncodedInRequest` to `OpenAIChatCompletionLLMClientTest`: it replays an assistant tool call through the client, captures the outgoing request body, and asserts `function.arguments` decode to a `JsonObject` (not a double-encoded string). The pre-existing round-trip tests only asserted the tool-call **name**, never the **arguments**, which is why this regressed unnoticed.

Also verified end-to-end against the live DashScope `qwen-plus` endpoint: the single-encoded form returns `200`, the double-encoded form returns the `400` above.

> Reproduced against the **China-mainland** endpoint — base URL `https://dashscope.aliyuncs.com/` with the compatible-mode path `compatible-mode/v1/chat/completions` (note `DashscopeClientSettings` defaults to the international host `https://dashscope-intl.aliyuncs.com/`). The defect is in shared serialization, so it is endpoint-independent, but the captured 400 above came from the mainland path.

closes #2095
