### PR TITLE
feat(prompt): add simpleDeepSeekExecutor helper

### DIFF
--- a/docs/docs/prompts/prompt-executors.md
+++ b/docs/docs/prompts/prompt-executors.md
@@ -178,6 +178,7 @@ the predefined executors will return a PromptExecutor instance configured with a
 | Amazon Bedrock | [simpleBedrockExecutorWithBearerToken](api:prompt-executor-llms-all::ai.koog.prompt.executor.llms.all.simpleBedrockExecutorWithBearerToken) | Wraps `BedrockLLMClient` and uses the provided Bedrock API key to send requests. |
 | Mistral        | [simpleMistralAIExecutor](api:prompt-executor-llms-all::ai.koog.prompt.executor.llms.all.simpleMistralAIExecutor)                            | Wraps `MistralAILLMClient` that runs prompts with Mistral models.                |
 | Ollama         | [simpleOllamaAIExecutor](api:prompt-executor-llms-all::ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor)                              | Wraps `OllamaClient` that runs prompts with Ollama.                              |
+| DeepSeek       | [simpleDeepSeekExecutor](api:prompt-executor-llms-all::ai.koog.prompt.executor.llms.all.simpleDeepSeekExecutor)                              | Wraps `DeepSeekLLMClient` that runs prompts with DeepSeek models.                |
 
 Here is an example of creating a pre-defined executor:
 

--- a/prompt/prompt-executor/prompt-executor-llms-all/src/commonMain/kotlin/ai/koog/prompt/executor/llms/all/SimplePromptExecutors.kt
+++ b/prompt/prompt-executor/prompt-executor-llms-all/src/commonMain/kotlin/ai/koog/prompt/executor/llms/all/SimplePromptExecutors.kt
@@ -5,6 +5,7 @@ package ai.koog.prompt.executor.llms.all
 
 import ai.koog.http.client.KoogHttpClient
 import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
+import ai.koog.prompt.executor.clients.deepseek.DeepSeekLLMClient
 import ai.koog.prompt.executor.clients.google.GoogleLLMClient
 import ai.koog.prompt.executor.clients.mistralai.MistralAILLMClient
 import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
@@ -137,3 +138,16 @@ public fun simpleOllamaAIExecutor(
  */
 public fun simpleMistralAIExecutor(apiKey: String, httpClientFactory: KoogHttpClient.Factory): MultiLLMPromptExecutor =
     MultiLLMPromptExecutor(LLMProvider.MistralAI to MistralAILLMClient(apiKey = apiKey, httpClientFactory = httpClientFactory))
+
+/**
+ * Creates an instance of `MultiLLMPromptExecutor` with a `DeepSeekLLMClient`.
+ *
+ * @param apiKey The API token used for authentication with the DeepSeek API.
+ * @param httpClientFactory Factory used to create the underlying HTTP client.
+ */
+public fun simpleDeepSeekExecutor(
+    apiKey: String,
+    httpClientFactory: KoogHttpClient.Factory,
+): MultiLLMPromptExecutor = MultiLLMPromptExecutor(
+    LLMProvider.DeepSeek to DeepSeekLLMClient(apiKey = apiKey, httpClientFactory = httpClientFactory)
+)

--- a/prompt/prompt-executor/prompt-executor-llms-all/src/jvmCommonMain/kotlin/ai/koog/prompt/executor/llms/all/SimplePromptExecutors.jvmCommon.kt
+++ b/prompt/prompt-executor/prompt-executor-llms-all/src/jvmCommonMain/kotlin/ai/koog/prompt/executor/llms/all/SimplePromptExecutors.jvmCommon.kt
@@ -4,6 +4,7 @@
 package ai.koog.prompt.executor.llms.all
 
 import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
+import ai.koog.prompt.executor.clients.deepseek.DeepSeekLLMClient
 import ai.koog.prompt.executor.clients.google.GoogleLLMClient
 import ai.koog.prompt.executor.clients.mistralai.MistralAILLMClient
 import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
@@ -105,3 +106,12 @@ public fun simpleOllamaAIExecutor(
  */
 public fun simpleMistralAIExecutor(apiKey: String): MultiLLMPromptExecutor =
     MultiLLMPromptExecutor(LLMProvider.MistralAI to MistralAILLMClient(apiKey))
+
+/**
+ * Convenience overload that constructs the underlying client via its JVM no-factory entry point
+ * (resolves the default [ai.koog.http.client.KoogHttpClient.Factory] at call time). JVM and Android only.
+ *
+ * @see simpleDeepSeekExecutor
+ */
+public fun simpleDeepSeekExecutor(apiKey: String): MultiLLMPromptExecutor =
+    MultiLLMPromptExecutor(LLMProvider.DeepSeek to DeepSeekLLMClient(apiKey))


### PR DESCRIPTION
## Summary

- Add `simpleDeepSeekExecutor` to `prompt-executor-llms-all` for the common and JVM/Android source sets, matching the shape of the existing `simple*Executor` helpers.
- Document DeepSeek in the pre-defined prompt executors table in `docs/docs/prompts/prompt-executors.md`.

## Notes

- Based on the feedback in #1974, the helper wraps `DeepSeekLLMClient` in `MultiLLMPromptExecutor` rather than the deprecated `SingleLLMPromptExecutor`.
- Streaming works without additional code: `MultiLLMPromptExecutor.executeStreaming` delegates to `DeepSeekLLMClient`, so DeepSeek can use the same executor-based streaming flow with a DeepSeek model.
- No module dependency changes — `prompt-executor-llms-all` already has an API dependency on `prompt-executor-deepseek-client`.

## Local verification

- `gradle :prompt:prompt-executor:prompt-executor-llms-all:jvmTest` — passed.
- `gradle :prompt:prompt-executor:prompt-executor-llms-all:ktlintCheck` — passed.
- A full `gradle build` was not exercised locally (no Android SDK / headless browsers in this environment); CI is expected to cover the remaining targets.

Closes #1974