### PR TITLE
build: add macosArm64 target (Apple Silicon)

### DIFF
--- a/agents/agents-core/api/agents-core.klib.api
+++ b/agents/agents-core/api/agents-core.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/agents/agents-features/agents-features-chat-memory-sql/api/agents-features-chat-memory-sql.klib.api
+++ b/agents/agents-features/agents-features-chat-memory-sql/api/agents-features-chat-memory-sql.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/agents/agents-features/agents-features-event-handler/api/agents-features-event-handler.klib.api
+++ b/agents/agents-features/agents-features-event-handler/api/agents-features-event-handler.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/agents/agents-features/agents-features-memory/api/agents-features-memory.klib.api
+++ b/agents/agents-features/agents-features-memory/api/agents-features-memory.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/agents/agents-features/agents-features-opentelemetry/gradle.properties
+++ b/agents/agents-features/agents-features-opentelemetry/gradle.properties
@@ -2,3 +2,5 @@
 # the wasmJs target, so no `*-wasm-js` publication is produced for it. Remove this
 # file once upstream adds wasmJs support.
 koog.target.wasmJs=false
+# OTel Kotlin SDK 0.3.0 also publishes no macosArm64 artifact — opt out of macos too.
+koog.target.macos=false

--- a/agents/agents-features/agents-features-snapshot/api/agents-features-snapshot.klib.api
+++ b/agents/agents-features/agents-features-snapshot/api/agents-features-snapshot.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/agents/agents-features/agents-features-sql/api/agents-features-sql.klib.api
+++ b/agents/agents-features/agents-features-sql/api/agents-features-sql.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/agents/agents-features/agents-features-tokenizer/api/agents-features-tokenizer.klib.api
+++ b/agents/agents-features/agents-features-tokenizer/api/agents-features-tokenizer.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/agents/agents-features/agents-features-trace/api/agents-features-trace.klib.api
+++ b/agents/agents-features/agents-features-trace/api/agents-features-trace.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/agents/agents-mcp-metadata/api/agents-mcp-metadata.klib.api
+++ b/agents/agents-mcp-metadata/api/agents-mcp-metadata.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/agents/agents-test/api/agents-test.klib.api
+++ b/agents/agents-test/api/agents-test.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/agents/agents-tools/api/agents-tools.klib.api
+++ b/agents/agents-tools/api/agents-tools.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/agents/agents-utils/api/agents-utils.klib.api
+++ b/agents/agents-utils/api/agents-utils.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
+++ b/convention-plugin-ai/src/main/kotlin/ai.kotlin.multiplatform.gradle.kts
@@ -20,6 +20,11 @@ plugins {
 // for example, the "OTel Kotlin SDK 0.3.0" set `koog.target.wasmJs=false` in their gradle.properties.
 // The target is not registered at all, and no wasm-js publication is produced.
 val isWasmJsIncluded = (findProperty("koog.target.wasmJs") as? String)?.toBoolean() ?: true
+
+// Per-module opt-out for the macosArm64 target, mirroring the wasmJs flag above. Modules whose deps
+// have no macosArm64 publication (e.g. io.opentelemetry.kotlin 0.3.0) set `koog.target.macos=false`.
+val isMacosIncluded = (findProperty("koog.target.macos") as? String)?.toBoolean() ?: true
+
 kotlin {
     @OptIn(ExperimentalAbiValidation::class)
     abiValidation {
@@ -42,6 +47,7 @@ kotlin {
     // Tier 1
     iosSimulatorArm64()
     iosArm64()
+    if (isMacosIncluded) macosArm64()
 
     // Tier 2
 

--- a/embeddings/embeddings-base/api/embeddings-base.klib.api
+++ b/embeddings/embeddings-base/api/embeddings-base.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/embeddings/embeddings-llm/api/embeddings-llm.klib.api
+++ b/embeddings/embeddings-llm/api/embeddings-llm.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/http-client/http-client-core/api/http-client-core.klib.api
+++ b/http-client/http-client-core/api/http-client-core.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/http-client/http-client-ktor/api/http-client-ktor.klib.api
+++ b/http-client/http-client-ktor/api/http-client-ktor.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/koog-agents-additions/build.gradle.kts
+++ b/koog-agents-additions/build.gradle.kts
@@ -189,10 +189,17 @@ kotlin {
         }
 
         appleMain {
-            dependsOn(nonWasmJsMain)
+            // NOTE: not dependsOn(nonWasmJsMain) — that holds the OpenTelemetry feature, whose dep
+            // (io.opentelemetry.kotlin) has no macosArm64. Keep Darwin here (both iOS + macOS need it)
+            // and attach the nonWasmJs modules at the iOS level only (below).
             dependencies {
                 api(libs.ktor.client.darwin)
             }
+        }
+
+        // OpenTelemetry et al. (nonWasmJsMain) are available on iOS but not macOS.
+        iosMain {
+            dependsOn(nonWasmJsMain)
         }
 
         jsMain {

--- a/koog-agents/api/koog-agents.klib.api
+++ b/koog-agents/api/koog-agents.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/koog-agents/build.gradle.kts
+++ b/koog-agents/build.gradle.kts
@@ -188,10 +188,17 @@ kotlin {
         }
 
         appleMain {
-            dependsOn(nonWasmJsMain)
+            // NOTE: not dependsOn(nonWasmJsMain) — that holds the OpenTelemetry feature, whose dep
+            // (io.opentelemetry.kotlin) has no macosArm64. Keep Darwin here (both iOS + macOS need it)
+            // and attach the nonWasmJs modules at the iOS level only (below).
             dependencies {
                 api(libs.ktor.client.darwin)
             }
+        }
+
+        // OpenTelemetry et al. (nonWasmJsMain) are available on iOS but not macOS.
+        iosMain {
+            dependsOn(nonWasmJsMain)
         }
 
         jsMain {

--- a/prompt/prompt-cache/prompt-cache-files/api/prompt-cache-files.klib.api
+++ b/prompt/prompt-cache/prompt-cache-files/api/prompt-cache-files.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/prompt/prompt-cache/prompt-cache-model/api/prompt-cache-model.klib.api
+++ b/prompt/prompt-cache/prompt-cache-model/api/prompt-cache-model.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/prompt/prompt-executor/prompt-executor-cached/api/prompt-executor-cached.klib.api
+++ b/prompt/prompt-executor/prompt-executor-cached/api/prompt-executor-cached.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/prompt/prompt-executor/prompt-executor-clients/api/prompt-executor-clients.klib.api
+++ b/prompt/prompt-executor/prompt-executor-clients/api/prompt-executor-clients.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/api/prompt-executor-anthropic-client.klib.api
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/api/prompt-executor-anthropic-client.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/api/prompt-executor-bedrock-client.klib.api
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/api/prompt-executor-bedrock-client.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/api/prompt-executor-ollama-client.klib.api
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/api/prompt-executor-ollama-client.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/prompt-executor-openai-client-base.klib.api
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/prompt-executor-openai-client-base.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/api/prompt-executor-openai-client.klib.api
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/api/prompt-executor-openai-client.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/api/prompt-executor-openrouter-client.klib.api
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openrouter-client/api/prompt-executor-openrouter-client.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/prompt/prompt-executor/prompt-executor-model/api/prompt-executor-model.klib.api
+++ b/prompt/prompt-executor/prompt-executor-model/api/prompt-executor-model.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/prompt/prompt-llm/api/prompt-llm.klib.api
+++ b/prompt/prompt-llm/api/prompt-llm.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/prompt/prompt-markdown/api/prompt-markdown.klib.api
+++ b/prompt/prompt-markdown/api/prompt-markdown.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/prompt/prompt-model/api/prompt-model.klib.api
+++ b/prompt/prompt-model/api/prompt-model.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/prompt/prompt-processor/api/prompt-processor.klib.api
+++ b/prompt/prompt-processor/api/prompt-processor.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/prompt/prompt-structure/api/prompt-structure.klib.api
+++ b/prompt/prompt-structure/api/prompt-structure.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/prompt/prompt-tokenizer/api/prompt-tokenizer.klib.api
+++ b/prompt/prompt-tokenizer/api/prompt-tokenizer.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/prompt/prompt-xml/api/prompt-xml.klib.api
+++ b/prompt/prompt-xml/api/prompt-xml.klib.api
@@ -1,6 +1,6 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
-// Alias: ios => [iosArm64, iosSimulatorArm64, iosX64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
+// Alias: apple => [iosArm64, iosSimulatorArm64, iosX64, macosArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true
@@ -17,10 +17,10 @@ final class ai.koog.prompt.xml/XmlContentBuilder : ai.koog.prompt.text/TextConte
     final fun processingInstruction(kotlin/String, kotlin/String) // ai.koog.prompt.xml/XmlContentBuilder.processingInstruction|processingInstruction(kotlin.String;kotlin.String){}[0]
     final fun xmlDeclaration(kotlin/String = ..., kotlin/String = ..., kotlin/Boolean? = ...) // ai.koog.prompt.xml/XmlContentBuilder.xmlDeclaration|xmlDeclaration(kotlin.String;kotlin.String;kotlin.Boolean?){}[0]
 
-    // Targets: [ios, wasmJs]
+    // Targets: [apple, wasmJs]
     final fun selfClosingTag(kotlin/String, kotlin.collections/HashMap<kotlin/String, kotlin/String> = ...) // ai.koog.prompt.xml/XmlContentBuilder.selfClosingTag|selfClosingTag(kotlin.String;kotlin.collections.HashMap<kotlin.String,kotlin.String>){}[0]
 
-    // Targets: [ios, wasmJs]
+    // Targets: [apple, wasmJs]
     final fun tag(kotlin/String, kotlin.collections/HashMap<kotlin/String, kotlin/String> = ..., kotlin/Function1<ai.koog.prompt.xml/XmlContentBuilder, kotlin/Unit> = ...) // ai.koog.prompt.xml/XmlContentBuilder.tag|tag(kotlin.String;kotlin.collections.HashMap<kotlin.String,kotlin.String>;kotlin.Function1<ai.koog.prompt.xml.XmlContentBuilder,kotlin.Unit>){}[0]
 
     // Targets: [js]

--- a/rag/rag-base/api/rag-base.klib.api
+++ b/rag/rag-base/api/rag-base.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/serialization/serialization-core/api/serialization-core.klib.api
+++ b/serialization/serialization-core/api/serialization-core.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/serialization/serialization-test/api/serialization-test.klib.api
+++ b/serialization/serialization-test/api/serialization-test.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/test-utils/api/test-utils.klib.api
+++ b/test-utils/api/test-utils.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/utils/api/utils.klib.api
+++ b/utils/api/utils.klib.api
@@ -1,6 +1,6 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, wasmJs]
-// Alias: ios => [iosArm64, iosSimulatorArm64, iosX64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
+// Alias: apple => [iosArm64, iosSimulatorArm64, iosX64, macosArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true
@@ -50,7 +50,7 @@ final fun ai.koog.utils.system/systemConfigReader(): ai.koog.utils.system/System
 final fun ai.koog.utils.system/systemSecretsReader(): ai.koog.utils.system/SystemSecretsReader // ai.koog.utils.system/systemSecretsReader|systemSecretsReader(){}[0]
 final suspend inline fun <#A: ai.koog.utils.io/Closeable, #B: kotlin/Any?> (#A).ai.koog.utils.io/use(kotlin.coroutines/SuspendFunction1<#A, #B>): #B // ai.koog.utils.io/use|use@0:0(kotlin.coroutines.SuspendFunction1<0:0,0:1>){0§<ai.koog.utils.io.Closeable>;1§<kotlin.Any?>}[0]
 
-// Targets: [ios]
+// Targets: [apple]
 final class ai.koog.utils.system/UserDefaultsSystemConfigReader : ai.koog.utils.system/SystemConfigReader { // ai.koog.utils.system/UserDefaultsSystemConfigReader|null[0]
     constructor <init>(platform.Foundation/NSUserDefaults) // ai.koog.utils.system/UserDefaultsSystemConfigReader.<init>|<init>(platform.Foundation.NSUserDefaults){}[0]
 


### PR DESCRIPTION
Enable the Kotlin/Native **macosArm64** target across the library modules so Koog can be consumed by native macOS apps (e.g. a SwiftUI Mac app sharing KMP logic), not just iOS. `macosArm64` is Tier 1 in Kotlin/Native. Purely additive — no public API or behavioural changes.

## What this does
- **convention-plugin-ai**: register `macosArm64()`, gated by a per-module `koog.target.macos` flag (mirrors the existing `koog.target.wasmJs` opt-out).
- **agents-features-opentelemetry**: opt out of macos — its dependency `io.opentelemetry.kotlin:0.3.0` publishes no macosArm64 artifact (the same reason it already opts out of wasmJs).
- **koog-agents** and **koog-agents-additions**: route the `nonWasmJsMain` modules (which hold the OTel feature) to the iOS source set only, keeping the Darwin engine on `appleMain` so macOS still gets HTTP. macOS therefore aggregates everything except the OTel feature.

## Public API / ABI
Adding a target rewrites the `// Targets:` header of every stable module's `api/*.klib.api` dump (gains `macosArm64`; the `ios` alias widens to `apple`). Regenerated via `./gradlew updateLegacyAbi` (40 dumps) and committed — the diff is header metadata only, no API-surface changes. `./gradlew checkLegacyAbi` is green.

## Verification
- `./gradlew updateLegacyAbi` — succeeds; all klibs (incl. macosArm64) compile.
- `./gradlew checkLegacyAbi` — green.
- Not run here: full `./gradlew build` test suite (integration tests need API keys) and confirmation the publish matrix emits `macosArm64` artifacts.

## Note on the missing test
The one functional fix (macos source-set routing in `koog-agents-additions`) is a build-graph dependency-resolution issue; it is exercised by `:koog-agents-additions:compileKotlinMacosArm64` resolving and building, which is impractical to assert via a unit test.
