### PR TITLE
fix(prompt): Handle Gemini safety behavior

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -22,6 +22,7 @@ import ai.koog.prompt.executor.clients.google.models.GoogleFunctionDeclaration
 import ai.koog.prompt.executor.clients.google.models.GoogleGenerationConfig
 import ai.koog.prompt.executor.clients.google.models.GoogleModelsResponse
 import ai.koog.prompt.executor.clients.google.models.GooglePart
+import ai.koog.prompt.executor.clients.google.models.GooglePromptFeedback
 import ai.koog.prompt.executor.clients.google.models.GoogleRequest
 import ai.koog.prompt.executor.clients.google.models.GoogleResponse
 import ai.koog.prompt.executor.clients.google.models.GoogleTool
@@ -747,8 +748,7 @@ public open class GoogleLLMClient @JvmOverloads constructor(
      */
     private fun processGoogleResponse(response: GoogleResponse): List<Message.Assistant> {
         if (response.candidates.isEmpty()) {
-            logger.error { "Empty candidates in Google API response" }
-            throw LLMClientException(clientName, "Empty candidates in Google API response")
+            throw noCandidatesException(response)
         }
 
         // Extract token count from the response
@@ -766,6 +766,25 @@ public open class GoogleLLMClient @JvmOverloads constructor(
         return response.candidates.map { candidate ->
             processGoogleCandidate(candidate, metaInfo)
         }
+    }
+
+    /**
+     * Builds an exception for a Google response that carries no candidates.
+     *
+     * Google omits the `candidates` field entirely when the prompt itself is rejected by the safety
+     * filters, returning only [GoogleResponse.promptFeedback]. When that happens we surface the
+     * [GooglePromptFeedback.blockReason] so the caller can tell a content-policy block apart from a
+     * genuine framework error.
+     */
+    private fun noCandidatesException(response: GoogleResponse): LLMClientException {
+        val blockReason = response.promptFeedback?.blockReason
+        val message = if (blockReason != null) {
+            "Google API returned no candidates: the prompt was blocked (reason: $blockReason)"
+        } else {
+            "Google API returned no candidates"
+        }
+        logger.error { message }
+        return LLMClientException(clientName, message)
     }
 
     /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/models/GoogleGenerateContent.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/models/GoogleGenerateContent.kt
@@ -399,13 +399,15 @@ internal enum class GoogleFunctionCallingMode {
  * Represents the response from the Google AI.
  *
  * @property candidates Candidate responses from the model.
+ * Defaults to an empty list because the field is omitted entirely when the prompt is blocked
+ * by Google's safety filters (only [promptFeedback] is returned in that case).
  * @property promptFeedback Returns the prompt's feedback related to the content filters.
  * @property usageMetadata Metadata on the generation requests' token usage.
  * @property modelVersion The model version used to generate the response.
  */
 @Serializable
 internal class GoogleResponse(
-    val candidates: List<GoogleCandidate>,
+    val candidates: List<GoogleCandidate> = emptyList(),
     val promptFeedback: GooglePromptFeedback? = null,
     val usageMetadata: GoogleUsageMetadata? = null,
     val modelVersion: String? = null,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
@@ -6,11 +6,13 @@ import ai.koog.agents.core.tools.ToolParameterType
 import ai.koog.http.client.KoogHttpClient
 import ai.koog.http.client.ktor.KtorKoogHttpClient
 import ai.koog.prompt.Prompt
+import ai.koog.prompt.executor.clients.LLMClientException
 import ai.koog.prompt.executor.clients.google.models.GoogleCandidate
 import ai.koog.prompt.executor.clients.google.models.GoogleContent
 import ai.koog.prompt.executor.clients.google.models.GoogleData
 import ai.koog.prompt.executor.clients.google.models.GoogleFunctionCallingMode
 import ai.koog.prompt.executor.clients.google.models.GooglePart
+import ai.koog.prompt.executor.clients.google.models.GooglePromptFeedback
 import ai.koog.prompt.executor.clients.google.models.GoogleRequest
 import ai.koog.prompt.executor.clients.google.models.GoogleResponse
 import ai.koog.prompt.executor.clients.google.models.GoogleThinkingConfig
@@ -22,16 +24,19 @@ import ai.koog.prompt.message.RequestMetaInfo
 import ai.koog.prompt.message.ResponseMetaInfo
 import ai.koog.prompt.params.LLMParams
 import ai.koog.prompt.streaming.StreamFrame
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -40,6 +45,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlin.reflect.KClass
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 
 class GoogleLLMClientTest {
 
@@ -694,5 +700,90 @@ class GoogleLLMClientTest {
         response.parts[1].shouldBeInstanceOf<MessagePart.Attachment>()
         val filePart = (response.parts[1] as MessagePart.Attachment).source as AttachmentSource.Image
         filePart.format shouldBe "png"
+    }
+
+    @Test
+    fun `GoogleResponse deserializes when candidates field is missing`() {
+        // When a prompt is blocked by safety filters, Google returns 200 with only promptFeedback
+        // and omits the candidates field entirely. Deserialization must tolerate that.
+        val json = Json { ignoreUnknownKeys = true; isLenient = true }
+        val payload = """
+            {
+              "promptFeedback": { "blockReason": "SAFETY" },
+              "usageMetadata": { "promptTokenCount": 7, "totalTokenCount": 7 },
+              "modelVersion": "gemini-2.5-pro"
+            }
+        """.trimIndent()
+
+        val response = json.decodeFromString<GoogleResponse>(payload)
+
+        response.candidates.shouldBeEmpty()
+        response.promptFeedback?.blockReason shouldBe "SAFETY"
+    }
+
+    @Test
+    fun `execute surfaces block reason when prompt is blocked and no candidates returned`() = runTest {
+        val model = GoogleModels.Gemini2_5Pro
+
+        val transport = object : KoogHttpClient {
+            override val clientName: String = "GoogleBlockedTestClient"
+
+            override suspend fun <R : Any> get(
+                path: String,
+                responseType: KClass<R>,
+                parameters: Map<String, String>,
+                headers: Map<String, String>,
+            ): R = error("GET is not expected in this test")
+
+            @Suppress("UNCHECKED_CAST")
+            override suspend fun <T : Any, R : Any> post(
+                path: String,
+                requestBody: T,
+                requestBodyType: KClass<T>,
+                responseType: KClass<R>,
+                parameters: Map<String, String>,
+                headers: Map<String, String>,
+            ): R {
+                path shouldBe "v1beta/models/${model.id}:generateContent"
+                requestBody.shouldBeInstanceOf<GoogleRequest>()
+                return GoogleResponse(
+                    candidates = emptyList(),
+                    promptFeedback = GooglePromptFeedback(blockReason = "SAFETY"),
+                ) as R
+            }
+
+            override fun <T : Any, R : Any, O : Any> sse(
+                path: String,
+                requestBody: T,
+                requestBodyType: KClass<T>,
+                dataFilter: (String?) -> Boolean,
+                decodeStreamingResponse: (String) -> R,
+                processStreamingChunk: (R) -> O?,
+                parameters: Map<String, String>,
+                headers: Map<String, String>,
+            ): Flow<O> = error("sse is not expected in this test")
+
+            override fun <T : Any> lines(
+                path: String,
+                requestBody: T,
+                requestBodyType: KClass<T>,
+                parameters: Map<String, String>,
+                headers: Map<String, String>,
+            ): Flow<String> = error("lines is not expected in this test")
+
+            override fun close(): Unit = Unit
+        }
+
+        val client = GoogleLLMClient(httpClient = transport)
+
+        val exception = assertFailsWith<LLMClientException> {
+            client.execute(
+                prompt = Prompt(messages = listOf(Message.User("spicy question", RequestMetaInfo.Empty)), id = "id"),
+                model = model,
+                tools = emptyList(),
+            )
+        }
+
+        exception.message shouldContain "SAFETY"
     }
 }


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

ISSUE: [KG-858](https://youtrack.jetbrains.com/issue/KG-858/Intermittent-candidates-field-missing-errors)

Occasionally I get error like this when using Gemini: Field 'candidates' is required for type with serial name 'ai.koog.prompt.executor.clients.google.models.GoogleResponse', but it was missing at path: $

Google seems to omit **candidates** field for some prompts, this is not handled correctly. This PR fixes the problem. 

<!-- Include references to related issues below, e.g., closes #1, closes KG-1. Otherwise, delete it. -->
closes: [KG-858](https://youtrack.jetbrains.com/issue/KG-858/Intermittent-candidates-field-missing-errors)
