### PR TITLE
fix(serialization): use full JavaType in decodeFromJSONElement to preserve generics

### DIFF
--- a/serialization/serialization-jackson/src/main/kotlin/ai/koog/serialization/jackson/JacksonSerializer.kt
+++ b/serialization/serialization-jackson/src/main/kotlin/ai/koog/serialization/jackson/JacksonSerializer.kt
@@ -55,8 +55,7 @@ public class JacksonSerializer(
     override fun <T> decodeFromJSONElement(value: JSONElement, typeToken: TypeToken): T {
         val jsonNode = value.toJacksonJsonNode()
         val javaType = resolveJavaType(typeToken)
-        @Suppress("UNCHECKED_CAST")
-        return objectMapper.treeToValue(jsonNode, javaType.rawClass) as T
+        return objectMapper.treeToValue(jsonNode, javaType)
     }
 
     @OptIn(InternalKoogSerializationApi::class)

--- a/serialization/serialization-jackson/src/test/kotlin/ai/koog/serialization/jackson/JacksonSerializerTest.kt
+++ b/serialization/serialization-jackson/src/test/kotlin/ai/koog/serialization/jackson/JacksonSerializerTest.kt
@@ -123,10 +123,12 @@ class JacksonSerializerTest {
     fun testDecodeFromJSONElementLosesGenericTypeParameters() {
         data class Person(val name: String, val age: Int)
 
-        val jsonElement = JSONArray(listOf(
-            JSONObject(mapOf("name" to JSONPrimitive("Alice"), "age" to JSONPrimitive(30))),
-            JSONObject(mapOf("name" to JSONPrimitive("Bob"), "age" to JSONPrimitive(25))),
-        ))
+        val jsonElement = JSONArray(
+            listOf(
+                JSONObject(mapOf("name" to JSONPrimitive("Alice"), "age" to JSONPrimitive(30))),
+                JSONObject(mapOf("name" to JSONPrimitive("Bob"), "age" to JSONPrimitive(25))),
+            )
+        )
 
         val fromElement: List<Person> = serializer.decodeFromJSONElement(jsonElement, typeToken<List<Person>>())
         fromElement.first().name shouldBe "Alice"

--- a/serialization/serialization-jackson/src/test/kotlin/ai/koog/serialization/jackson/JacksonSerializerTest.kt
+++ b/serialization/serialization-jackson/src/test/kotlin/ai/koog/serialization/jackson/JacksonSerializerTest.kt
@@ -4,6 +4,7 @@ import ai.koog.serialization.JSONArray
 import ai.koog.serialization.JSONLiteral
 import ai.koog.serialization.JSONNull
 import ai.koog.serialization.JSONObject
+import ai.koog.serialization.JSONPrimitive
 import ai.koog.serialization.typeToken
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.assertions.json.shouldEqualJson
@@ -117,6 +118,25 @@ class JacksonSerializerTest {
     data class Third(
         val baz: String
     )
+
+    @Test
+    fun testDecodeFromJSONElementLosesGenericTypeParameters() {
+        data class Person(val name: String, val age: Int)
+
+        val jsonElement = JSONArray(listOf(
+            JSONObject(mapOf("name" to JSONPrimitive("Alice"), "age" to JSONPrimitive(30))),
+            JSONObject(mapOf("name" to JSONPrimitive("Bob"), "age" to JSONPrimitive(25))),
+        ))
+
+        // decodeFromJSONElement uses rawClass, losing generic type info
+        val fromElement: List<Person> = serializer.decodeFromJSONElement(jsonElement, typeToken<List<Person>>())
+        fromElement.first().name shouldBe "Alice"
+
+        // decodeFromString uses full JavaType and works correctly
+        val json = """[{"name":"Alice","age":30},{"name":"Bob","age":25}]"""
+        val fromString: List<Person> = serializer.decodeFromString(json, typeToken<List<Person>>())
+        fromString.first().name shouldBe "Alice"
+    }
 
     @Test
     fun testSerializeDeserializeGenericClassesWithManuallyConstructedTypeTokens() {

--- a/serialization/serialization-jackson/src/test/kotlin/ai/koog/serialization/jackson/JacksonSerializerTest.kt
+++ b/serialization/serialization-jackson/src/test/kotlin/ai/koog/serialization/jackson/JacksonSerializerTest.kt
@@ -128,11 +128,9 @@ class JacksonSerializerTest {
             JSONObject(mapOf("name" to JSONPrimitive("Bob"), "age" to JSONPrimitive(25))),
         ))
 
-        // decodeFromJSONElement uses rawClass, losing generic type info
         val fromElement: List<Person> = serializer.decodeFromJSONElement(jsonElement, typeToken<List<Person>>())
         fromElement.first().name shouldBe "Alice"
 
-        // decodeFromString uses full JavaType and works correctly
         val json = """[{"name":"Alice","age":30},{"name":"Bob","age":25}]"""
         val fromString: List<Person> = serializer.decodeFromString(json, typeToken<List<Person>>())
         fromString.first().name shouldBe "Alice"


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

`JacksonSerializer.decodeFromJSONElement` was passing `javaType.rawClass` to `objectMapper.treeToValue`, discarding generic type parameters. This causes parameterized types (e.g. `List<Person>`) to deserialize elements as `Map` instead of the expected type.

The fix passes the full `JavaType` to `treeToValue`, consistent with how `decodeFromString` already works. This also removes the now-unnecessary `@Suppress("UNCHECKED_CAST")` and explicit `as T` cast.

<!-- Include BREAKING section below only if this PR introduces breaking changes. Otherwise, delete it. -->

<!-- Include DEPRECATED section below only if this PR deprecates any public APIs. Otherwise, delete it. -->

<!-- Include references to related issues below, e.g., closes #1, closes KG-1. Otherwise, delete it. -->
closes #2115
