### PR TITLE
feat(prompt): add Google service tier support

### DIFF
--- a/docs/docs/llm-parameters.md
+++ b/docs/docs/llm-parameters.md
@@ -453,7 +453,7 @@ Here is the complete reference of provider-specific parameters in Koog:
     llm-parameters-snippets.md:promptCacheKey
     llm-parameters-snippets.md:reasoningEffort
     llm-parameters-snippets.md:safetyIdentifier
-    llm-parameters-snippets.md:openAIServiceTier
+    llm-parameters-snippets.md:serviceTier
     llm-parameters-snippets.md:stop
     llm-parameters-snippets.md:store
     llm-parameters-snippets.md:topLogprobs
@@ -473,7 +473,7 @@ Here is the complete reference of provider-specific parameters in Koog:
     llm-parameters-snippets.md:promptCacheKey
     llm-parameters-snippets.md:reasoning
     llm-parameters-snippets.md:safetyIdentifier
-    llm-parameters-snippets.md:openAIServiceTier
+    llm-parameters-snippets.md:serviceTier
     llm-parameters-snippets.md:store
     llm-parameters-snippets.md:topLogprobs
     llm-parameters-snippets.md:topP

--- a/docs/docs/llm-parameters.md
+++ b/docs/docs/llm-parameters.md
@@ -453,7 +453,7 @@ Here is the complete reference of provider-specific parameters in Koog:
     llm-parameters-snippets.md:promptCacheKey
     llm-parameters-snippets.md:reasoningEffort
     llm-parameters-snippets.md:safetyIdentifier
-    llm-parameters-snippets.md:serviceTier
+    llm-parameters-snippets.md:openAIServiceTier
     llm-parameters-snippets.md:stop
     llm-parameters-snippets.md:store
     llm-parameters-snippets.md:topLogprobs
@@ -473,7 +473,7 @@ Here is the complete reference of provider-specific parameters in Koog:
     llm-parameters-snippets.md:promptCacheKey
     llm-parameters-snippets.md:reasoning
     llm-parameters-snippets.md:safetyIdentifier
-    llm-parameters-snippets.md:serviceTier
+    llm-parameters-snippets.md:openAIServiceTier
     llm-parameters-snippets.md:store
     llm-parameters-snippets.md:topLogprobs
     llm-parameters-snippets.md:topP
@@ -484,6 +484,7 @@ Here is the complete reference of provider-specific parameters in Koog:
 
     --8<--
     llm-parameters-snippets.md:heading
+    llm-parameters-snippets.md:googleServiceTier
     llm-parameters-snippets.md:thinkingConfig
     llm-parameters-snippets.md:topK
     llm-parameters-snippets.md:topP
@@ -495,7 +496,7 @@ Here is the complete reference of provider-specific parameters in Koog:
     llm-parameters-snippets.md:heading
     llm-parameters-snippets.md:container
     llm-parameters-snippets.md:mcpServers
-    llm-parameters-snippets.md:serviceTier
+    llm-parameters-snippets.md:anthropicServiceTier
     llm-parameters-snippets.md:stopSequences
     llm-parameters-snippets.md:thinking
     llm-parameters-snippets.md:topK

--- a/docs/docs/snippets/llm-parameters-snippets.md
+++ b/docs/docs/snippets/llm-parameters-snippets.md
@@ -44,9 +44,9 @@ search:
 | `safetyIdentifier` | String | A stable and unique user identifier that may be used to detect users who violate OpenAI policies. |
 # --8<-- [end:safetyIdentifier]
 
-# --8<-- [start:serviceTier]
+# --8<-- [start:openAIServiceTier]
 | `serviceTier` | ServiceTier | OpenAI processing tier selection that lets you prioritize performance over cost or vice versa. For more information, see the API documentation for [ServiceTier](api:prompt-executor-openai-client-base::ai.koog.prompt.executor.clients.openai.base.models.ServiceTier). |
-# --8<-- [end:serviceTier]
+# --8<-- [end:openAIServiceTier]
 
 # --8<-- [start:store]
 | `store` | Boolean | If `true`, the provider may store outputs for later retrieval. |
@@ -128,9 +128,9 @@ search:
 | `mcpServers` | List&lt;AnthropicMCPServerURLDefinition&gt; | Definitions of MCP servers to be used in the request. Supports at most 20 servers. For more information, see the API reference for [AnthropicMCPServerURLDefinition](api:prompt-executor-anthropic-client::ai.koog.prompt.executor.clients.anthropic.models.AnthropicMCPServerURLDefinition). |
 # --8<-- [end:mcpServers]
 
-# --8<-- [start:serviceTier]
+# --8<-- [start:anthropicServiceTier]
 | `serviceTier` | AnthropicServiceTier | Determines whether to use priority capacity (if available) or standard capacity for the request. For more information, see the API reference for [AnthropicServiceTier](api:prompt-executor-anthropic-client::ai.koog.prompt.executor.clients.anthropic.models.AnthropicServiceTier) and Anthropic's [Service tiers](https://platform.claude.com/docs/en/api/service-tiers) documentation. |
-# --8<-- [end:serviceTier]
+# --8<-- [end:anthropicServiceTier]
 
 # --8<-- [start:thinking]
 | `thinking` | AnthropicThinking | Configuration for activating Claude's extended thinking. When activated, responses also include thinking content blocks. For more information, see the API reference for [AnthropicThinking](api:prompt-executor-anthropic-client::ai.koog.prompt.executor.clients.anthropic.models.AnthropicThinking). |
@@ -139,6 +139,10 @@ search:
 # --8<-- [start:thinkingConfig]
 | `thinkingConfig` | GoogleThinkingConfig | Controls whether the model should expose its chain-of-thought and how many tokens it may spend on it. For more information, see the API reference for [GoogleThinkingConfig](api:prompt-executor-google-client::ai.koog.prompt.executor.clients.google.models.GoogleThinkingConfig). |
 # --8<-- [end:thinkingConfig]
+
+# --8<-- [start:googleServiceTier]
+| `serviceTier` | GoogleServiceTier | Google processing tier selection that lets you balance cost and reliability for synchronous GenerateContent requests. For more information, see the API reference for [GoogleServiceTier](api:prompt-executor-google-client::ai.koog.prompt.executor.clients.google.models.GoogleServiceTier) and Google's [Gemini API optimization and inference](https://ai.google.dev/gemini-api/docs/optimization) documentation. |
+# --8<-- [end:googleServiceTier]
 
 # --8<-- [start:enableSearch]
 | `enableSearch` | Boolean | Specifies whether to enable web search functionality. For more information, see Alibaba's [Web search](https://www.alibabacloud.com/help/en/model-studio/web-search?spm=a2c63.p38356.0.i14) documentation. |

--- a/docs/docs/snippets/llm-parameters-snippets.md
+++ b/docs/docs/snippets/llm-parameters-snippets.md
@@ -44,9 +44,9 @@ search:
 | `safetyIdentifier` | String | A stable and unique user identifier that may be used to detect users who violate OpenAI policies. |
 # --8<-- [end:safetyIdentifier]
 
-# --8<-- [start:openAIServiceTier]
+# --8<-- [start:serviceTier]
 | `serviceTier` | ServiceTier | OpenAI processing tier selection that lets you prioritize performance over cost or vice versa. For more information, see the API documentation for [ServiceTier](api:prompt-executor-openai-client-base::ai.koog.prompt.executor.clients.openai.base.models.ServiceTier). |
-# --8<-- [end:openAIServiceTier]
+# --8<-- [end:serviceTier]
 
 # --8<-- [start:store]
 | `store` | Boolean | If `true`, the provider may store outputs for later retrieval. |

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -382,7 +382,6 @@ public open class GoogleLLMClient @JvmOverloads constructor(
             candidateCount = if (model.supports(LLMCapability.MultipleChoices)) googleParams.numberOfChoices else null,
             topP = googleParams.topP,
             topK = googleParams.topK,
-            serviceTier = googleParams.serviceTier,
             thinkingConfig = googleParams.thinkingConfig,
             additionalProperties = googleParams.additionalProperties
         )
@@ -410,6 +409,7 @@ public open class GoogleLLMClient @JvmOverloads constructor(
             tools = googleTools,
             generationConfig = generationConfig,
             toolConfig = GoogleToolConfig(functionCallingConfig),
+            serviceTier = googleParams.serviceTier,
         )
     }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -382,6 +382,7 @@ public open class GoogleLLMClient @JvmOverloads constructor(
             candidateCount = if (model.supports(LLMCapability.MultipleChoices)) googleParams.numberOfChoices else null,
             topP = googleParams.topP,
             topK = googleParams.topK,
+            serviceTier = googleParams.serviceTier,
             thinkingConfig = googleParams.thinkingConfig,
             additionalProperties = googleParams.additionalProperties
         )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleParams.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleParams.kt
@@ -1,6 +1,7 @@
 package ai.koog.prompt.executor.clients.google
 
 import ai.koog.prompt.executor.clients.google.models.GoogleThinkingConfig
+import ai.koog.prompt.executor.clients.google.models.GoogleServiceTier
 import ai.koog.prompt.params.LLMParams
 import kotlinx.serialization.json.JsonElement
 
@@ -33,6 +34,7 @@ internal fun LLMParams.toGoogleParams(): GoogleParams {
  * @property additionalProperties Additional properties that can be used to store custom parameters.
  * @property topP The maximum cumulative probability of tokens to consider when sampling.
  * @property topK The maximum number of tokens to consider when sampling.
+ * @property serviceTier Processing tier selection for cost/reliability trade-offs.
  * @property thinkingConfig Controls whether the model should expose its chain-of-thought
  * and how many tokens it may spend on it (see [GoogleThinkingConfig]).
  */
@@ -48,6 +50,7 @@ public class GoogleParams(
     additionalProperties: Map<String, JsonElement>? = null,
     public val topP: Double? = null,
     public val topK: Int? = null,
+    public val serviceTier: GoogleServiceTier? = null,
     public val thinkingConfig: GoogleThinkingConfig? = null,
 ) : LLMParams(
     temperature,
@@ -91,6 +94,7 @@ public class GoogleParams(
         additionalProperties = additionalProperties,
         topP = topP,
         topK = topK,
+        serviceTier = serviceTier,
         thinkingConfig = thinkingConfig,
     )
 
@@ -108,6 +112,7 @@ public class GoogleParams(
         additionalProperties: Map<String, JsonElement>? = this.additionalProperties,
         topP: Double? = this.topP,
         topK: Int? = this.topK,
+        serviceTier: GoogleServiceTier? = this.serviceTier,
         thinkingConfig: GoogleThinkingConfig? = this.thinkingConfig,
     ): GoogleParams = GoogleParams(
         temperature = temperature,
@@ -120,6 +125,7 @@ public class GoogleParams(
         additionalProperties = additionalProperties,
         topP = topP,
         topK = topK,
+        serviceTier = serviceTier,
         thinkingConfig = thinkingConfig,
     )
 
@@ -137,13 +143,14 @@ public class GoogleParams(
                 additionalProperties == other.additionalProperties &&
                 topP == other.topP &&
                 topK == other.topK &&
+                serviceTier == other.serviceTier &&
                 thinkingConfig == other.thinkingConfig
     }
 
     override fun hashCode(): Int = listOf(
         temperature, maxTokens, numberOfChoices,
         speculation, schema, toolChoice, user,
-        additionalProperties, topP, topK, thinkingConfig
+        additionalProperties, topP, topK, serviceTier, thinkingConfig
     ).fold(0) { acc, element ->
         31 * acc + (element?.hashCode() ?: 0)
     }
@@ -160,6 +167,7 @@ public class GoogleParams(
         append(", additionalProperties=$additionalProperties")
         append(", topP=$topP")
         append(", topK=$topK")
+        append(", serviceTier=$serviceTier")
         append(", thinkingConfig=$thinkingConfig")
         append(")")
     }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/models/GoogleGenerateContent.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/models/GoogleGenerateContent.kt
@@ -24,6 +24,7 @@ import kotlinx.serialization.json.jsonObject
  * Supported `Tools` are `Function` and `codeExecution`.
  * @property systemInstruction Developer set system instruction(s). Text only.
  * @property generationConfig Configuration options for model generation and outputs.
+ * @property serviceTier Processing tier selection for cost/reliability trade-offs.
  */
 @Serializable
 internal class GoogleRequest(
@@ -33,6 +34,7 @@ internal class GoogleRequest(
     @Serializable(with = GoogleGenerationConfigSerializer::class)
     val generationConfig: GoogleGenerationConfig? = null,
     val toolConfig: GoogleToolConfig? = null,
+    val serviceTier: GoogleServiceTier? = null,
 )
 
 /**
@@ -305,7 +307,6 @@ internal class GoogleFunctionDeclaration(
  * @property candidateCount The number of reply choices to generate.
  * @property topP The maximum cumulative probability of tokens to consider when sampling.
  * @property topK The maximum number of tokens to consider when sampling.
- * @property serviceTier Processing tier selection for cost/reliability trade-offs.
  * @property thinkingConfig Controls whether the model should expose its chain-of-thought
  * and how many tokens it may spend on it (see [GoogleThinkingConfig]).
  */
@@ -320,8 +321,6 @@ internal class GoogleGenerationConfig(
     val candidateCount: Int? = null,
     val topP: Double? = null,
     val topK: Int? = null,
-    @SerialName("service_tier")
-    val serviceTier: GoogleServiceTier? = null,
     val thinkingConfig: GoogleThinkingConfig? = null,
     val additionalProperties: Map<String, JsonElement>? = null,
 )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/models/GoogleGenerateContent.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/models/GoogleGenerateContent.kt
@@ -305,6 +305,7 @@ internal class GoogleFunctionDeclaration(
  * @property candidateCount The number of reply choices to generate.
  * @property topP The maximum cumulative probability of tokens to consider when sampling.
  * @property topK The maximum number of tokens to consider when sampling.
+ * @property serviceTier Processing tier selection for cost/reliability trade-offs.
  * @property thinkingConfig Controls whether the model should expose its chain-of-thought
  * and how many tokens it may spend on it (see [GoogleThinkingConfig]).
  */
@@ -319,9 +320,39 @@ internal class GoogleGenerationConfig(
     val candidateCount: Int? = null,
     val topP: Double? = null,
     val topK: Int? = null,
+    @SerialName("service_tier")
+    val serviceTier: GoogleServiceTier? = null,
     val thinkingConfig: GoogleThinkingConfig? = null,
     val additionalProperties: Map<String, JsonElement>? = null,
 )
+
+/**
+ * Service tier used to process a Google GenerateContent request.
+ *
+ * - [STANDARD]: Standard pricing and reliability.
+ * - [FLEX]: Cost-optimized best-effort processing for latency-tolerant workloads.
+ * - [PRIORITY]: Reliability-optimized processing for critical workloads.
+ */
+@Serializable
+public enum class GoogleServiceTier {
+    /**
+     * Standard synchronous processing. Serialized as `"standard"`.
+     */
+    @SerialName("standard")
+    STANDARD,
+
+    /**
+     * Cost-optimized best-effort processing. Serialized as `"flex"`.
+     */
+    @SerialName("flex")
+    FLEX,
+
+    /**
+     * Reliability-optimized processing. Serialized as `"priority"`.
+     */
+    @SerialName("priority")
+    PRIORITY,
+}
 
 /**
  * Configuration for tool calling

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
@@ -264,7 +264,7 @@ class GoogleLLMClientTest {
         gen.candidateCount shouldBe 2
         gen.topP shouldBe 0.8
         gen.topK shouldBe 10
-        gen.serviceTier shouldBe GoogleServiceTier.FLEX
+        request.serviceTier shouldBe GoogleServiceTier.FLEX
         gen.thinkingConfig?.includeThoughts shouldBe true
         gen.thinkingConfig?.thinkingBudget shouldBe 99
         gen.additionalProperties shouldNotBe null

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
@@ -13,6 +13,7 @@ import ai.koog.prompt.executor.clients.google.models.GoogleFunctionCallingMode
 import ai.koog.prompt.executor.clients.google.models.GooglePart
 import ai.koog.prompt.executor.clients.google.models.GoogleRequest
 import ai.koog.prompt.executor.clients.google.models.GoogleResponse
+import ai.koog.prompt.executor.clients.google.models.GoogleServiceTier
 import ai.koog.prompt.executor.clients.google.models.GoogleThinkingConfig
 import ai.koog.prompt.message.AttachmentContent
 import ai.koog.prompt.message.AttachmentSource
@@ -243,6 +244,7 @@ class GoogleLLMClientTest {
             numberOfChoices = 2,
             topP = 0.8,
             topK = 10,
+            serviceTier = GoogleServiceTier.FLEX,
             thinkingConfig = GoogleThinkingConfig(
                 includeThoughts = true,
                 thinkingBudget = 99
@@ -262,6 +264,7 @@ class GoogleLLMClientTest {
         gen.candidateCount shouldBe 2
         gen.topP shouldBe 0.8
         gen.topK shouldBe 10
+        gen.serviceTier shouldBe GoogleServiceTier.FLEX
         gen.thinkingConfig?.includeThoughts shouldBe true
         gen.thinkingConfig?.thinkingBudget shouldBe 99
         gen.additionalProperties shouldNotBe null

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleSerializationTest.kt
@@ -2,6 +2,7 @@ package ai.koog.prompt.executor.clients.google
 
 import ai.koog.prompt.executor.clients.google.models.GoogleGenerationConfig
 import ai.koog.prompt.executor.clients.google.models.GoogleRequest
+import ai.koog.prompt.executor.clients.google.models.GoogleServiceTier
 import ai.koog.prompt.executor.clients.google.models.GoogleThinkingConfig
 import ai.koog.test.utils.runWithBothJsonConfigurations
 import ai.koog.test.utils.verifyDeserialization
@@ -30,7 +31,8 @@ class GoogleSerializationTest {
                 temperature = 0.7,
                 candidateCount = 1,
                 topP = 0.9,
-                topK = 40
+                topK = 40,
+                serviceTier = GoogleServiceTier.PRIORITY
             )
 
             val jsonElement = json.encodeToJsonElement(request)
@@ -42,6 +44,7 @@ class GoogleSerializationTest {
             jsonObject["candidateCount"]?.jsonPrimitive?.intOrNull shouldBe 1
             jsonObject["topP"]?.jsonPrimitive?.doubleOrNull shouldBe 0.9
             jsonObject["topK"]?.jsonPrimitive?.intOrNull shouldBe 40
+            jsonObject["service_tier"]?.jsonPrimitive?.contentOrNull shouldBe "priority"
             jsonObject["additionalProperties"] shouldBe null
         }
 
@@ -91,7 +94,8 @@ class GoogleSerializationTest {
                 "temperature": 0.7,
                 "candidateCount": 1,
                 "topP": 0.9,
-                "topK": 40
+                "topK": 40,
+                "service_tier": "flex"
             }
                 """.trimIndent()
 
@@ -106,6 +110,7 @@ class GoogleSerializationTest {
             request.candidateCount shouldBe 1
             request.topP shouldBe 0.9
             request.topK shouldBe 40
+            request.serviceTier shouldBe GoogleServiceTier.FLEX
             request.additionalProperties shouldBe null
         }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleSerializationTest.kt
@@ -31,8 +31,7 @@ class GoogleSerializationTest {
                 temperature = 0.7,
                 candidateCount = 1,
                 topP = 0.9,
-                topK = 40,
-                serviceTier = GoogleServiceTier.PRIORITY
+                topK = 40
             )
 
             val jsonElement = json.encodeToJsonElement(request)
@@ -44,8 +43,26 @@ class GoogleSerializationTest {
             jsonObject["candidateCount"]?.jsonPrimitive?.intOrNull shouldBe 1
             jsonObject["topP"]?.jsonPrimitive?.doubleOrNull shouldBe 0.9
             jsonObject["topK"]?.jsonPrimitive?.intOrNull shouldBe 40
-            jsonObject["service_tier"]?.jsonPrimitive?.contentOrNull shouldBe "priority"
+            jsonObject["serviceTier"] shouldBe null
             jsonObject["additionalProperties"] shouldBe null
+        }
+
+    @Test
+    fun `test request serialization with serviceTier`() =
+        runWithBothJsonConfigurations("request serialization with serviceTier") { json ->
+            val request = GoogleRequest(
+                contents = emptyList(),
+                serviceTier = GoogleServiceTier.PRIORITY
+            )
+
+            json.encodeToString(GoogleRequest.serializer(), request) shouldEqualJson
+                // language=json
+                """
+            {
+                "contents": [],
+                "serviceTier": "priority"
+            }
+                """.trimIndent()
         }
 
     @Test
@@ -94,8 +111,7 @@ class GoogleSerializationTest {
                 "temperature": 0.7,
                 "candidateCount": 1,
                 "topP": 0.9,
-                "topK": 40,
-                "service_tier": "flex"
+                "topK": 40
             }
                 """.trimIndent()
 
@@ -110,8 +126,27 @@ class GoogleSerializationTest {
             request.candidateCount shouldBe 1
             request.topP shouldBe 0.9
             request.topK shouldBe 40
-            request.serviceTier shouldBe GoogleServiceTier.FLEX
             request.additionalProperties shouldBe null
+        }
+
+    @Test
+    fun `test request deserialization with serviceTier`() =
+        runWithBothJsonConfigurations("request deserialization with serviceTier") { json ->
+            val jsonString =
+                // language=json
+                """
+            {
+                "contents": [],
+                "serviceTier": "flex"
+            }
+                """.trimIndent()
+
+            val request: GoogleRequest = verifyDeserialization(
+                payload = jsonString,
+                json = json
+            )
+
+            request.serviceTier shouldBe GoogleServiceTier.FLEX
         }
 
     @Test


### PR DESCRIPTION
Google recently added new service tiers, similar to the tiers that anthropic and openai have.

Blog post https://blog.google/innovation-and-ai/technology/developers-tools/introducing-flex-and-priority-inference/
Documentation https://ai.google.dev/gemini-api/docs/flex-inference

I tested this by running
```
val params = GoogleParams(
    serviceTier = GoogleServiceTier.FLEX
)

val agent = AIAgent(
    promptExecutor = MultiLLMPromptExecutor(GoogleLLMClient(apiKey)),
    agentConfig = AIAgentConfig(
        prompt = Prompt.build("google-service-tier-agent", params) {
            system("Answer with one short sentence.")
        },
        model = GoogleModels.Gemini3_Flash_Preview,
        maxAgentIterations = 5,
    )
)

val result = agent.run("Hello! How can you help me?")
println("AGENT_RESULT: $result")

```