### PR TITLE
fix(prompt): KG-861 Spurious tool result warnings from OllamaConverters

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaConverters.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaConverters.kt
@@ -111,6 +111,10 @@ private fun Message.User.toOllamaTextChatMessage(model: LLModel): OllamaChatMess
                     }
                 }
 
+                is MessagePart.Tool.Result -> {
+                    // this is handled in the outer loop, so don't log warning
+                }
+
                 else -> {
                     logger.warn { "Skipping unsupported message part: $part" }
                 }


### PR DESCRIPTION
Every tool result for Ollama is spuriously logged as a warning, e.g.:
```WARN  a.k.p.e.o.c.dto.OllamaConverters - Skipping unsupported message part: Result(id=ollama_tool_call_1493001671, tool=...```

The log line is coming from `Message.User.toOllamaTextChatMessage()`, but tool results are to be expected here. In fact, they're handled in `Prompt.toOllamaChatMessages()` right after the call to this function:
```
                is Message.User -> {
                    add(message.toOllamaTextChatMessage(model))
                    message.parts.filterIsInstance<MessagePart.Tool.Result>().forEach { part ->
```
Therefore, there's no need to log these as a warning.

closes KG-861