### PR TITLE
fix(agents): let hosts sanitize tool-failure messages before they reach the model

### DIFF
--- a/agents/agents-cli/src/commonMain/kotlin/ai/koog/agents/cli/CliAIAgent.kt
+++ b/agents/agents-cli/src/commonMain/kotlin/ai/koog/agents/cli/CliAIAgent.kt
@@ -187,6 +187,7 @@ public class CliAIAgent<Input, Output> internal constructor(
             logger = logger,
             toolRegistry = toolRegistry,
             serializer = agentConfig.serializer,
+            toolFailurePresenter = agentConfig.toolFailurePresenter,
         )
 
         return baseEnvironment

--- a/agents/agents-core/api/agents-core.klib.api
+++ b/agents/agents-core/api/agents-core.klib.api
@@ -53,6 +53,18 @@ final enum class ai.koog.agents.core.dsl.extension/FactType : kotlin/Enum<ai.koo
     }
 }
 
+final enum class ai.koog.agents.core.environment/ToolFailureStage : kotlin/Enum<ai.koog.agents.core.environment/ToolFailureStage> { // ai.koog.agents.core.environment/ToolFailureStage|null[0]
+    enum entry ArgumentParsing // ai.koog.agents.core.environment/ToolFailureStage.ArgumentParsing|null[0]
+    enum entry Execution // ai.koog.agents.core.environment/ToolFailureStage.Execution|null[0]
+    enum entry ResultSerialization // ai.koog.agents.core.environment/ToolFailureStage.ResultSerialization|null[0]
+
+    final val entries // ai.koog.agents.core.environment/ToolFailureStage.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<ai.koog.agents.core.environment/ToolFailureStage> // ai.koog.agents.core.environment/ToolFailureStage.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): ai.koog.agents.core.environment/ToolFailureStage // ai.koog.agents.core.environment/ToolFailureStage.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<ai.koog.agents.core.environment/ToolFailureStage> // ai.koog.agents.core.environment/ToolFailureStage.values|values#static(){}[0]
+}
+
 final enum class ai.koog.agents.core.model/AgentServiceErrorType : kotlin/Enum<ai.koog.agents.core.model/AgentServiceErrorType> { // ai.koog.agents.core.model/AgentServiceErrorType|null[0]
     enum entry AGENT_NOT_FOUND // ai.koog.agents.core.model/AgentServiceErrorType.AGENT_NOT_FOUND|null[0]
     enum entry MALFORMED_MESSAGE // ai.koog.agents.core.model/AgentServiceErrorType.MALFORMED_MESSAGE|null[0]
@@ -85,6 +97,15 @@ abstract fun interface <#A: kotlin/Any?, #B: kotlin/Any?> ai.koog.agents.core.ut
 
 abstract fun interface <#A: kotlin/Any?> ai.koog.agents.core.utils/ConfigureAction { // ai.koog.agents.core.utils/ConfigureAction|null[0]
     abstract fun configure(#A) // ai.koog.agents.core.utils/ConfigureAction.configure|configure(1:0){}[0]
+}
+
+abstract fun interface ai.koog.agents.core.environment/ToolFailurePresenter { // ai.koog.agents.core.environment/ToolFailurePresenter|null[0]
+    abstract fun present(ai.koog.agents.core.environment/ToolFailure): kotlin/String // ai.koog.agents.core.environment/ToolFailurePresenter.present|present(ai.koog.agents.core.environment.ToolFailure){}[0]
+
+    final object Companion { // ai.koog.agents.core.environment/ToolFailurePresenter.Companion|null[0]
+        final val Default // ai.koog.agents.core.environment/ToolFailurePresenter.Companion.Default|{}Default[0]
+            final fun <get-Default>(): ai.koog.agents.core.environment/ToolFailurePresenter // ai.koog.agents.core.environment/ToolFailurePresenter.Companion.Default.<get-Default>|<get-Default>(){}[0]
+    }
 }
 
 abstract interface <#A: ai.koog.agents.core.feature.config/FeatureConfig, #B: kotlin/Any> ai.koog.agents.core.feature/AIAgentFeature { // ai.koog.agents.core.feature/AIAgentFeature|null[0]
@@ -1616,7 +1637,7 @@ final class <#A: kotlin/Any?> ai.koog.agents.ext.agent/RetrySubgraphResult { // 
 }
 
 final class ai.koog.agents.core.agent.config/AIAgentConfig : ai.koog.agents.core.agent.config/AIAgentConfigBase { // ai.koog.agents.core.agent.config/AIAgentConfig|null[0]
-    constructor <init>(ai.koog.prompt/Prompt, ai.koog.prompt.llm/LLModel, kotlin/Int, ai.koog.agents.core.agent.config/MissingToolsConversionStrategy = ..., ai.koog.prompt.processor/ResponseProcessor? = ..., ai.koog.serialization/JSONSerializer = ...) // ai.koog.agents.core.agent.config/AIAgentConfig.<init>|<init>(ai.koog.prompt.Prompt;ai.koog.prompt.llm.LLModel;kotlin.Int;ai.koog.agents.core.agent.config.MissingToolsConversionStrategy;ai.koog.prompt.processor.ResponseProcessor?;ai.koog.serialization.JSONSerializer){}[0]
+    constructor <init>(ai.koog.prompt/Prompt, ai.koog.prompt.llm/LLModel, kotlin/Int, ai.koog.agents.core.agent.config/MissingToolsConversionStrategy = ..., ai.koog.prompt.processor/ResponseProcessor? = ..., ai.koog.serialization/JSONSerializer = ..., ai.koog.agents.core.environment/ToolFailurePresenter = ...) // ai.koog.agents.core.agent.config/AIAgentConfig.<init>|<init>(ai.koog.prompt.Prompt;ai.koog.prompt.llm.LLModel;kotlin.Int;ai.koog.agents.core.agent.config.MissingToolsConversionStrategy;ai.koog.prompt.processor.ResponseProcessor?;ai.koog.serialization.JSONSerializer;ai.koog.agents.core.environment.ToolFailurePresenter){}[0]
 
     final val maxAgentIterations // ai.koog.agents.core.agent.config/AIAgentConfig.maxAgentIterations|{}maxAgentIterations[0]
         final fun <get-maxAgentIterations>(): kotlin/Int // ai.koog.agents.core.agent.config/AIAgentConfig.maxAgentIterations.<get-maxAgentIterations>|<get-maxAgentIterations>(){}[0]
@@ -1630,6 +1651,8 @@ final class ai.koog.agents.core.agent.config/AIAgentConfig : ai.koog.agents.core
         final fun <get-responseProcessor>(): ai.koog.prompt.processor/ResponseProcessor? // ai.koog.agents.core.agent.config/AIAgentConfig.responseProcessor.<get-responseProcessor>|<get-responseProcessor>(){}[0]
     final val serializer // ai.koog.agents.core.agent.config/AIAgentConfig.serializer|{}serializer[0]
         final fun <get-serializer>(): ai.koog.serialization/JSONSerializer // ai.koog.agents.core.agent.config/AIAgentConfig.serializer.<get-serializer>|<get-serializer>(){}[0]
+    final val toolFailurePresenter // ai.koog.agents.core.agent.config/AIAgentConfig.toolFailurePresenter|{}toolFailurePresenter[0]
+        final fun <get-toolFailurePresenter>(): ai.koog.agents.core.environment/ToolFailurePresenter // ai.koog.agents.core.agent.config/AIAgentConfig.toolFailurePresenter.<get-toolFailurePresenter>|<get-toolFailurePresenter>(){}[0]
 
     final object Companion { // ai.koog.agents.core.agent.config/AIAgentConfig.Companion|null[0]
         final fun withSystemPrompt(kotlin/String, ai.koog.prompt.llm/LLModel = ..., kotlin/String = ..., kotlin/Int = ...): ai.koog.agents.core.agent.config/AIAgentConfig // ai.koog.agents.core.agent.config/AIAgentConfig.Companion.withSystemPrompt|withSystemPrompt(kotlin.String;ai.koog.prompt.llm.LLModel;kotlin.String;kotlin.Int){}[0]
@@ -2072,7 +2095,7 @@ final class ai.koog.agents.core.dsl.extension/ToolResults { // ai.koog.agents.co
 }
 
 final class ai.koog.agents.core.environment/GenericAgentEnvironment : ai.koog.agents.core.environment/AIAgentEnvironment { // ai.koog.agents.core.environment/GenericAgentEnvironment|null[0]
-    constructor <init>(kotlin/String, io.github.oshai.kotlinlogging/KLogger, ai.koog.agents.core.tools/ToolRegistry, ai.koog.serialization/JSONSerializer) // ai.koog.agents.core.environment/GenericAgentEnvironment.<init>|<init>(kotlin.String;io.github.oshai.kotlinlogging.KLogger;ai.koog.agents.core.tools.ToolRegistry;ai.koog.serialization.JSONSerializer){}[0]
+    constructor <init>(kotlin/String, io.github.oshai.kotlinlogging/KLogger, ai.koog.agents.core.tools/ToolRegistry, ai.koog.serialization/JSONSerializer, ai.koog.agents.core.environment/ToolFailurePresenter = ...) // ai.koog.agents.core.environment/GenericAgentEnvironment.<init>|<init>(kotlin.String;io.github.oshai.kotlinlogging.KLogger;ai.koog.agents.core.tools.ToolRegistry;ai.koog.serialization.JSONSerializer;ai.koog.agents.core.environment.ToolFailurePresenter){}[0]
 
     final suspend fun executeTool(ai.koog.prompt.message/MessagePart.Tool.Call): ai.koog.agents.core.environment/ReceivedToolResult // ai.koog.agents.core.environment/GenericAgentEnvironment.executeTool|executeTool(ai.koog.prompt.message.MessagePart.Tool.Call){}[0]
     final suspend fun executeTool(ai.koog.prompt.message/MessagePart.Tool.Call, ai.koog.agents.core.tools/ToolCallMetadata): ai.koog.agents.core.environment/ReceivedToolResult // ai.koog.agents.core.environment/GenericAgentEnvironment.executeTool|executeTool(ai.koog.prompt.message.MessagePart.Tool.Call;ai.koog.agents.core.tools.ToolCallMetadata){}[0]
@@ -2128,6 +2151,17 @@ final class ai.koog.agents.core.environment/ReceivedToolResult { // ai.koog.agen
 
         final fun serializer(): kotlinx.serialization/KSerializer<ai.koog.agents.core.environment/ReceivedToolResult> // ai.koog.agents.core.environment/ReceivedToolResult.Companion.serializer|serializer(){}[0]
     }
+}
+
+final class ai.koog.agents.core.environment/ToolFailure { // ai.koog.agents.core.environment/ToolFailure|null[0]
+    final val defaultMessage // ai.koog.agents.core.environment/ToolFailure.defaultMessage|{}defaultMessage[0]
+        final fun <get-defaultMessage>(): kotlin/String // ai.koog.agents.core.environment/ToolFailure.defaultMessage.<get-defaultMessage>|<get-defaultMessage>(){}[0]
+    final val error // ai.koog.agents.core.environment/ToolFailure.error|{}error[0]
+        final fun <get-error>(): kotlin/Throwable // ai.koog.agents.core.environment/ToolFailure.error.<get-error>|<get-error>(){}[0]
+    final val stage // ai.koog.agents.core.environment/ToolFailure.stage|{}stage[0]
+        final fun <get-stage>(): ai.koog.agents.core.environment/ToolFailureStage // ai.koog.agents.core.environment/ToolFailure.stage.<get-stage>|<get-stage>(){}[0]
+    final val toolName // ai.koog.agents.core.environment/ToolFailure.toolName|{}toolName[0]
+        final fun <get-toolName>(): kotlin/String // ai.koog.agents.core.environment/ToolFailure.toolName.<get-toolName>|<get-toolName>(){}[0]
 }
 
 final class ai.koog.agents.core.exception/AgentNotFoundException : ai.koog.agents.core.exception/AgentEngineException { // ai.koog.agents.core.exception/AgentNotFoundException|null[0]

--- a/agents/agents-core/api/android/agents-core.api
+++ b/agents/agents-core/api/android/agents-core.api
@@ -419,14 +419,15 @@ public final class ai/koog/agents/core/agent/PlannerAgentBuilder : ai/koog/agent
 
 public final class ai/koog/agents/core/agent/config/AIAgentConfig : ai/koog/agents/core/agent/config/AIAgentConfigBase {
 	public static final field Companion Lai/koog/agents/core/agent/config/AIAgentConfig$Companion;
-	public fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Lai/koog/serialization/JSONSerializer;)V
-	public synthetic fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Lai/koog/serialization/JSONSerializer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Lai/koog/serialization/JSONSerializer;Lai/koog/agents/core/environment/ToolFailurePresenter;)V
+	public synthetic fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Lai/koog/serialization/JSONSerializer;Lai/koog/agents/core/environment/ToolFailurePresenter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILjava/util/concurrent/Executor;)V
 	public fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILjava/util/concurrent/Executor;Ljava/util/concurrent/Executor;)V
 	public fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILjava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;)V
 	public fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILjava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;)V
 	public fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILjava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Lai/koog/serialization/JSONSerializer;)V
-	public synthetic fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILjava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Lai/koog/serialization/JSONSerializer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILjava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Lai/koog/serialization/JSONSerializer;Lai/koog/agents/core/environment/ToolFailurePresenter;)V
+	public synthetic fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILjava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Lai/koog/serialization/JSONSerializer;Lai/koog/agents/core/environment/ToolFailurePresenter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun builder ()Lai/koog/agents/core/agent/config/AIAgentConfig$Companion$InitialAIAgentBuilder;
 	public final fun getMaxAgentIterations ()I
 	public final fun getMissingToolsConversionStrategy ()Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;
@@ -434,6 +435,7 @@ public final class ai/koog/agents/core/agent/config/AIAgentConfig : ai/koog/agen
 	public fun getPrompt ()Lai/koog/prompt/Prompt;
 	public final fun getResponseProcessor ()Lai/koog/prompt/processor/ResponseProcessor;
 	public final fun getSerializer ()Lai/koog/serialization/JSONSerializer;
+	public final fun getToolFailurePresenter ()Lai/koog/agents/core/environment/ToolFailurePresenter;
 }
 
 public final class ai/koog/agents/core/agent/config/AIAgentConfig$Companion {
@@ -443,8 +445,8 @@ public final class ai/koog/agents/core/agent/config/AIAgentConfig$Companion {
 }
 
 public final class ai/koog/agents/core/agent/config/AIAgentConfig$Companion$AIAgentConfigBuilder {
-	public fun <init> (Lai/koog/prompt/llm/LLModel;Lai/koog/prompt/Prompt;Ljava/lang/Integer;Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Lai/koog/serialization/JSONSerializer;)V
-	public synthetic fun <init> (Lai/koog/prompt/llm/LLModel;Lai/koog/prompt/Prompt;Ljava/lang/Integer;Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Lai/koog/serialization/JSONSerializer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lai/koog/prompt/llm/LLModel;Lai/koog/prompt/Prompt;Ljava/lang/Integer;Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Lai/koog/serialization/JSONSerializer;Lai/koog/agents/core/environment/ToolFailurePresenter;)V
+	public synthetic fun <init> (Lai/koog/prompt/llm/LLModel;Lai/koog/prompt/Prompt;Ljava/lang/Integer;Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Lai/koog/serialization/JSONSerializer;Lai/koog/agents/core/environment/ToolFailurePresenter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun build ()Lai/koog/agents/core/agent/config/AIAgentConfig;
 	public final fun getMaxAgentIterations ()Ljava/lang/Integer;
 	public final fun getMissingToolsConversionStrategy ()Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;
@@ -462,6 +464,7 @@ public final class ai/koog/agents/core/agent/config/AIAgentConfig$Companion$AIAg
 	public final fun setPrompt (Lai/koog/prompt/Prompt;)V
 	public final fun setResponseProcessor (Lai/koog/prompt/processor/ResponseProcessor;)V
 	public final fun strategyExecutor (Ljava/util/concurrent/Executor;)Lai/koog/agents/core/agent/config/AIAgentConfig$Companion$AIAgentConfigBuilder;
+	public final fun toolFailurePresenter (Lai/koog/agents/core/environment/ToolFailurePresenter;)Lai/koog/agents/core/agent/config/AIAgentConfig$Companion$AIAgentConfigBuilder;
 }
 
 public final class ai/koog/agents/core/agent/config/AIAgentConfig$Companion$InitialAIAgentBuilder {
@@ -2171,7 +2174,8 @@ public final class ai/koog/agents/core/environment/AIAgentEnvironment$DefaultImp
 }
 
 public final class ai/koog/agents/core/environment/GenericAgentEnvironment : ai/koog/agents/core/environment/AIAgentEnvironment {
-	public fun <init> (Ljava/lang/String;Lio/github/oshai/kotlinlogging/KLogger;Lai/koog/agents/core/tools/ToolRegistry;Lai/koog/serialization/JSONSerializer;)V
+	public fun <init> (Ljava/lang/String;Lio/github/oshai/kotlinlogging/KLogger;Lai/koog/agents/core/tools/ToolRegistry;Lai/koog/serialization/JSONSerializer;Lai/koog/agents/core/environment/ToolFailurePresenter;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/oshai/kotlinlogging/KLogger;Lai/koog/agents/core/tools/ToolRegistry;Lai/koog/serialization/JSONSerializer;Lai/koog/agents/core/environment/ToolFailurePresenter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun executeTool (Lai/koog/prompt/message/MessagePart$Tool$Call;Lai/koog/agents/core/tools/ToolCallMetadata;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun executeTool (Lai/koog/prompt/message/MessagePart$Tool$Call;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun executeTools (Ljava/util/List;Lai/koog/agents/core/tools/ToolCallMetadata;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2296,6 +2300,31 @@ public final class ai/koog/agents/core/environment/TerminationTool {
 	public static final field ARG Ljava/lang/String;
 	public static final field INSTANCE Lai/koog/agents/core/environment/TerminationTool;
 	public static final field NAME Ljava/lang/String;
+}
+
+public final class ai/koog/agents/core/environment/ToolFailure {
+	public final fun getDefaultMessage ()Ljava/lang/String;
+	public final fun getError ()Ljava/lang/Throwable;
+	public final fun getStage ()Lai/koog/agents/core/environment/ToolFailureStage;
+	public final fun getToolName ()Ljava/lang/String;
+}
+
+public abstract interface class ai/koog/agents/core/environment/ToolFailurePresenter {
+	public static final field Companion Lai/koog/agents/core/environment/ToolFailurePresenter$Companion;
+	public abstract fun present (Lai/koog/agents/core/environment/ToolFailure;)Ljava/lang/String;
+}
+
+public final class ai/koog/agents/core/environment/ToolFailurePresenter$Companion {
+	public final fun getDefault ()Lai/koog/agents/core/environment/ToolFailurePresenter;
+}
+
+public final class ai/koog/agents/core/environment/ToolFailureStage : java/lang/Enum {
+	public static final field ArgumentParsing Lai/koog/agents/core/environment/ToolFailureStage;
+	public static final field Execution Lai/koog/agents/core/environment/ToolFailureStage;
+	public static final field ResultSerialization Lai/koog/agents/core/environment/ToolFailureStage;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lai/koog/agents/core/environment/ToolFailureStage;
+	public static fun values ()[Lai/koog/agents/core/environment/ToolFailureStage;
 }
 
 public abstract class ai/koog/agents/core/environment/ToolResultKind {

--- a/agents/agents-core/api/jvm/agents-core.api
+++ b/agents/agents-core/api/jvm/agents-core.api
@@ -419,14 +419,15 @@ public final class ai/koog/agents/core/agent/PlannerAgentBuilder : ai/koog/agent
 
 public final class ai/koog/agents/core/agent/config/AIAgentConfig : ai/koog/agents/core/agent/config/AIAgentConfigBase {
 	public static final field Companion Lai/koog/agents/core/agent/config/AIAgentConfig$Companion;
-	public fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Lai/koog/serialization/JSONSerializer;)V
-	public synthetic fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Lai/koog/serialization/JSONSerializer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Lai/koog/serialization/JSONSerializer;Lai/koog/agents/core/environment/ToolFailurePresenter;)V
+	public synthetic fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Lai/koog/serialization/JSONSerializer;Lai/koog/agents/core/environment/ToolFailurePresenter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILjava/util/concurrent/Executor;)V
 	public fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILjava/util/concurrent/Executor;Ljava/util/concurrent/Executor;)V
 	public fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILjava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;)V
 	public fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILjava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;)V
 	public fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILjava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Lai/koog/serialization/JSONSerializer;)V
-	public synthetic fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILjava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Lai/koog/serialization/JSONSerializer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILjava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Lai/koog/serialization/JSONSerializer;Lai/koog/agents/core/environment/ToolFailurePresenter;)V
+	public synthetic fun <init> (Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;ILjava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Lai/koog/serialization/JSONSerializer;Lai/koog/agents/core/environment/ToolFailurePresenter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun builder ()Lai/koog/agents/core/agent/config/AIAgentConfig$Companion$InitialAIAgentBuilder;
 	public final fun getMaxAgentIterations ()I
 	public final fun getMissingToolsConversionStrategy ()Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;
@@ -434,6 +435,7 @@ public final class ai/koog/agents/core/agent/config/AIAgentConfig : ai/koog/agen
 	public fun getPrompt ()Lai/koog/prompt/Prompt;
 	public final fun getResponseProcessor ()Lai/koog/prompt/processor/ResponseProcessor;
 	public final fun getSerializer ()Lai/koog/serialization/JSONSerializer;
+	public final fun getToolFailurePresenter ()Lai/koog/agents/core/environment/ToolFailurePresenter;
 }
 
 public final class ai/koog/agents/core/agent/config/AIAgentConfig$Companion {
@@ -443,8 +445,8 @@ public final class ai/koog/agents/core/agent/config/AIAgentConfig$Companion {
 }
 
 public final class ai/koog/agents/core/agent/config/AIAgentConfig$Companion$AIAgentConfigBuilder {
-	public fun <init> (Lai/koog/prompt/llm/LLModel;Lai/koog/prompt/Prompt;Ljava/lang/Integer;Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Lai/koog/serialization/JSONSerializer;)V
-	public synthetic fun <init> (Lai/koog/prompt/llm/LLModel;Lai/koog/prompt/Prompt;Ljava/lang/Integer;Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Lai/koog/serialization/JSONSerializer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lai/koog/prompt/llm/LLModel;Lai/koog/prompt/Prompt;Ljava/lang/Integer;Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Lai/koog/serialization/JSONSerializer;Lai/koog/agents/core/environment/ToolFailurePresenter;)V
+	public synthetic fun <init> (Lai/koog/prompt/llm/LLModel;Lai/koog/prompt/Prompt;Ljava/lang/Integer;Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;Lai/koog/prompt/processor/ResponseProcessor;Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Lai/koog/serialization/JSONSerializer;Lai/koog/agents/core/environment/ToolFailurePresenter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun build ()Lai/koog/agents/core/agent/config/AIAgentConfig;
 	public final fun getMaxAgentIterations ()Ljava/lang/Integer;
 	public final fun getMissingToolsConversionStrategy ()Lai/koog/agents/core/agent/config/MissingToolsConversionStrategy;
@@ -462,6 +464,7 @@ public final class ai/koog/agents/core/agent/config/AIAgentConfig$Companion$AIAg
 	public final fun setPrompt (Lai/koog/prompt/Prompt;)V
 	public final fun setResponseProcessor (Lai/koog/prompt/processor/ResponseProcessor;)V
 	public final fun strategyExecutor (Ljava/util/concurrent/Executor;)Lai/koog/agents/core/agent/config/AIAgentConfig$Companion$AIAgentConfigBuilder;
+	public final fun toolFailurePresenter (Lai/koog/agents/core/environment/ToolFailurePresenter;)Lai/koog/agents/core/agent/config/AIAgentConfig$Companion$AIAgentConfigBuilder;
 }
 
 public final class ai/koog/agents/core/agent/config/AIAgentConfig$Companion$InitialAIAgentBuilder {
@@ -2171,7 +2174,8 @@ public final class ai/koog/agents/core/environment/AIAgentEnvironment$DefaultImp
 }
 
 public final class ai/koog/agents/core/environment/GenericAgentEnvironment : ai/koog/agents/core/environment/AIAgentEnvironment {
-	public fun <init> (Ljava/lang/String;Lio/github/oshai/kotlinlogging/KLogger;Lai/koog/agents/core/tools/ToolRegistry;Lai/koog/serialization/JSONSerializer;)V
+	public fun <init> (Ljava/lang/String;Lio/github/oshai/kotlinlogging/KLogger;Lai/koog/agents/core/tools/ToolRegistry;Lai/koog/serialization/JSONSerializer;Lai/koog/agents/core/environment/ToolFailurePresenter;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/github/oshai/kotlinlogging/KLogger;Lai/koog/agents/core/tools/ToolRegistry;Lai/koog/serialization/JSONSerializer;Lai/koog/agents/core/environment/ToolFailurePresenter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun executeTool (Lai/koog/prompt/message/MessagePart$Tool$Call;Lai/koog/agents/core/tools/ToolCallMetadata;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun executeTool (Lai/koog/prompt/message/MessagePart$Tool$Call;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun executeTools (Ljava/util/List;Lai/koog/agents/core/tools/ToolCallMetadata;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2296,6 +2300,31 @@ public final class ai/koog/agents/core/environment/TerminationTool {
 	public static final field ARG Ljava/lang/String;
 	public static final field INSTANCE Lai/koog/agents/core/environment/TerminationTool;
 	public static final field NAME Ljava/lang/String;
+}
+
+public final class ai/koog/agents/core/environment/ToolFailure {
+	public final fun getDefaultMessage ()Ljava/lang/String;
+	public final fun getError ()Ljava/lang/Throwable;
+	public final fun getStage ()Lai/koog/agents/core/environment/ToolFailureStage;
+	public final fun getToolName ()Ljava/lang/String;
+}
+
+public abstract interface class ai/koog/agents/core/environment/ToolFailurePresenter {
+	public static final field Companion Lai/koog/agents/core/environment/ToolFailurePresenter$Companion;
+	public abstract fun present (Lai/koog/agents/core/environment/ToolFailure;)Ljava/lang/String;
+}
+
+public final class ai/koog/agents/core/environment/ToolFailurePresenter$Companion {
+	public final fun getDefault ()Lai/koog/agents/core/environment/ToolFailurePresenter;
+}
+
+public final class ai/koog/agents/core/environment/ToolFailureStage : java/lang/Enum {
+	public static final field ArgumentParsing Lai/koog/agents/core/environment/ToolFailureStage;
+	public static final field Execution Lai/koog/agents/core/environment/ToolFailureStage;
+	public static final field ResultSerialization Lai/koog/agents/core/environment/ToolFailureStage;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lai/koog/agents/core/environment/ToolFailureStage;
+	public static fun values ()[Lai/koog/agents/core/environment/ToolFailureStage;
 }
 
 public abstract class ai/koog/agents/core/environment/ToolResultKind {

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/FunctionalAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/FunctionalAIAgent.kt
@@ -143,6 +143,7 @@ public class FunctionalAIAgent<Input, Output>(
             logger = logger,
             toolRegistry = toolRegistry,
             serializer = agentConfig.serializer,
+            toolFailurePresenter = agentConfig.toolFailurePresenter,
         )
 
         return baseEnvironment

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/GraphAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/GraphAIAgent.kt
@@ -182,6 +182,7 @@ public open class GraphAIAgent<Input, Output>(
             logger = logger,
             toolRegistry = toolRegistry,
             serializer = agentConfig.serializer,
+            toolFailurePresenter = agentConfig.toolFailurePresenter,
         )
 
         val preparedEnvironment = pipeline.onAgentEnvironmentTransforming(

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/config/AIAgentConfig.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/config/AIAgentConfig.kt
@@ -2,6 +2,7 @@
 
 package ai.koog.agents.core.agent.config
 
+import ai.koog.agents.core.environment.ToolFailurePresenter
 import ai.koog.prompt.Prompt
 import ai.koog.prompt.executor.clients.openai.OpenAIModels
 import ai.koog.prompt.llm.LLModel
@@ -27,6 +28,10 @@ import kotlin.jvm.JvmName
  *        This ensures the prompt remains consistent and readable for the model, even with undefined tools.
  * @param responseProcessor Optional processor for the agent's responses. If specified, will modify the responses from the llm.
  * @param serializer Optional serializer to (de)serialize tool arguments and results. Defaults to [KotlinxSerializer]
+ * @param toolFailurePresenter Controls the text re-injected into the LLM context when a tool call fails with a
+ *        generic (non-[ai.koog.agents.core.tools.ToolException]) exception. Defaults to
+ *        [ToolFailurePresenter.Default], which preserves the legacy behavior of forwarding the raw exception
+ *        message. Override it to redact or replace untrusted exception text before it reaches the model.
  */
 public expect class AIAgentConfig(
     prompt: Prompt,
@@ -36,6 +41,7 @@ public expect class AIAgentConfig(
         MissingToolsConversionStrategy.Missing(ToolCallDescriber.JSON),
     responseProcessor: ResponseProcessor? = null,
     serializer: JSONSerializer = KotlinxSerializer(),
+    toolFailurePresenter: ToolFailurePresenter = ToolFailurePresenter.Default,
 ) : AIAgentConfigBase {
 
     /**
@@ -92,6 +98,17 @@ public expect class AIAgentConfig(
     public val serializer: JSONSerializer
 
     /**
+     * Presenter that decides what text is fed back to the LLM when a tool call fails with a generic
+     * (non-[ai.koog.agents.core.tools.ToolException]) exception.
+     *
+     * Defaults to [ToolFailurePresenter.Default], which re-injects the raw exception message. Override it
+     * to sanitize or replace untrusted exception text. The original exception remains observable via the
+     * event-handler feature regardless of this presenter.
+     */
+    @get:JvmName("toolFailurePresenter")
+    public val toolFailurePresenter: ToolFailurePresenter
+
+    /**
      * Companion object for providing utility methods related to [AIAgentConfig].
      */
     public companion object {
@@ -125,6 +142,7 @@ public expect class AIAgentConfig(
      * @param missingToolsConversionStrategy The strategy for handling missing tools during the AI agent's execution. Defaults to the existing strategy.
      * @param responseProcessor The processor for handling responses from the LLM. Defaults to the existing processor.
      * @param serializer The serializer for handling tool arguments and results. Defaults to the existing serializer.
+     * @param toolFailurePresenter The presenter for tool-failure messages. Defaults to the existing presenter.
      * @return A new instance of [AIAgentConfig] with the specified modifications.
      */
     internal fun copy(
@@ -133,6 +151,7 @@ public expect class AIAgentConfig(
         maxAgentIterations: Int = this.maxAgentIterations,
         missingToolsConversionStrategy: MissingToolsConversionStrategy = this.missingToolsConversionStrategy,
         responseProcessor: ResponseProcessor? = this.responseProcessor,
-        serializer: JSONSerializer = this.serializer
+        serializer: JSONSerializer = this.serializer,
+        toolFailurePresenter: ToolFailurePresenter = this.toolFailurePresenter
     ): AIAgentConfig
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/ContextualAgentEnvironment.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/ContextualAgentEnvironment.kt
@@ -65,7 +65,18 @@ public class ContextualAgentEnvironment(
 
             val tool = toolCall.tool
             val toolArgs = JSONObject(emptyMap())
-            val message = "Failed to parse tool arguments: ${e.message}"
+            // Route the model-facing text through the configured presenter so a host can sanitize the raw
+            // parser exception before it reaches the prompt. The legacy wording is supplied as the default so
+            // that ToolFailurePresenter.Default stays byte-for-byte backward compatible. The original
+            // throwable is still handed to onToolValidationFailed below, preserving host visibility.
+            val message = context.config.toolFailurePresenter.present(
+                ToolFailure(
+                    toolName = tool,
+                    stage = ToolFailureStage.ArgumentParsing,
+                    error = e,
+                    defaultMessageOverride = "Failed to parse tool arguments: ${e.message}",
+                )
+            )
             context.pipeline.onToolValidationFailed(
                 eventId = eventId,
                 executionInfo = context.executionInfo,

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/GenericAgentEnvironment.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/GenericAgentEnvironment.kt
@@ -14,12 +14,17 @@ import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Represents base agent environment with generic abstractions.
+ *
+ * @param toolFailurePresenter Controls the text re-injected into the LLM context when a tool call fails
+ *        with a generic (non-[ToolException]) [Throwable]. Defaults to [ToolFailurePresenter.Default],
+ *        which preserves the legacy behavior of forwarding the raw [Throwable.message].
  */
 public class GenericAgentEnvironment(
     private val agentId: String,
     private val logger: KLogger,
     private val toolRegistry: ToolRegistry,
     private val serializer: JSONSerializer,
+    private val toolFailurePresenter: ToolFailurePresenter = ToolFailurePresenter.Default,
 ) : AIAgentEnvironment {
 
     override suspend fun executeTool(toolCall: MessagePart.Tool.Call): ReceivedToolResult =
@@ -69,7 +74,7 @@ public class GenericAgentEnvironment(
                 tool = toolName,
                 toolArgs = JSONObject(emptyMap()),
                 toolDescription = null,
-                output = "Tool with name '$toolName' failed to parse arguments due to the error: ${e.message}",
+                output = presentFailure(toolName, ToolFailureStage.ArgumentParsing, e),
                 resultKind = ToolResultKind.Failure(e),
                 result = null,
                 resultObject = null
@@ -105,7 +110,7 @@ public class GenericAgentEnvironment(
                 tool = toolName,
                 toolArgs = toolArgsJson,
                 toolDescription = toolDescription,
-                output = "Tool with name '$toolName' failed to parse arguments due to the error: ${e.message}",
+                output = presentFailure(toolName, ToolFailureStage.ArgumentParsing, e),
                 resultKind = ToolResultKind.Failure(e),
                 result = null,
                 resultObject = null
@@ -136,7 +141,7 @@ public class GenericAgentEnvironment(
                 tool = toolName,
                 toolArgs = toolArgsJson,
                 toolDescription = toolDescription,
-                output = "Tool with name '$toolName' failed to execute due to the error: ${e.message}!",
+                output = presentFailure(toolName, ToolFailureStage.Execution, e),
                 resultKind = ToolResultKind.Failure(e),
                 result = null,
                 resultObject = null
@@ -159,7 +164,7 @@ public class GenericAgentEnvironment(
                 tool = toolName,
                 toolArgs = toolArgsJson,
                 toolDescription = toolDescription,
-                output = "Tool with name '$toolName' failed to serialize result due to the error: ${e.message}!",
+                output = presentFailure(toolName, ToolFailureStage.ResultSerialization, e),
                 resultKind = ToolResultKind.Failure(e),
                 result = null,
                 resultObject = null
@@ -178,6 +183,9 @@ public class GenericAgentEnvironment(
             parts = parts,
         )
     }
+
+    private fun presentFailure(toolName: String, stage: ToolFailureStage, error: Throwable): String =
+        toolFailurePresenter.present(ToolFailure(toolName, stage, error))
 
     private fun formatLog(message: String): String =
         "(agent id: $agentId) $message"

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/ToolFailurePresenter.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/environment/ToolFailurePresenter.kt
@@ -1,0 +1,129 @@
+package ai.koog.agents.core.environment
+
+/**
+ * Identifies the stage of a tool call at which an exception was caught and turned into a failure result
+ * ([ToolResultKind.Failure], or [ToolResultKind.ValidationError] for argument parsing inside
+ * [ContextualAgentEnvironment]).
+ */
+public enum class ToolFailureStage {
+    /**
+     * Raised while parsing or deserializing the raw tool-call arguments, before [ai.koog.agents.core.tools.ToolBase.execute]
+     * is invoked.
+     */
+    ArgumentParsing,
+
+    /**
+     * Raised from within [ai.koog.agents.core.tools.ToolBase.execute], i.e. by the tool implementation itself.
+     *
+     * This is the stage most likely to carry arbitrary, externally influenced text (DB values, remote
+     * responses, stack fragments) in [ToolFailure.error]'s message.
+     */
+    Execution,
+
+    /**
+     * Raised while encoding a successful tool result into the textual/structured representation sent back
+     * to the model.
+     */
+    ResultSerialization,
+}
+
+/**
+ * Describes a tool-call failure that is about to be surfaced to the LLM.
+ *
+ * Instances are passed to [ToolFailurePresenter.present] so a host application can decide what text the
+ * model is allowed to see for this failure.
+ *
+ * @property toolName The name of the tool whose call failed.
+ * @property stage The [ToolFailureStage] at which the failure was caught.
+ * @property error The caught [Throwable].
+ */
+public class ToolFailure internal constructor(
+    public val toolName: String,
+    public val stage: ToolFailureStage,
+    public val error: Throwable,
+    private val defaultMessageOverride: String? = null,
+) {
+    /**
+     * The default, framework-produced message for this failure.
+     *
+     * It embeds [error]'s raw message verbatim and is what the model sees when no custom
+     * [ToolFailurePresenter] is configured. Custom presenters may return this to preserve the legacy
+     * behavior for some failures while redacting others.
+     *
+     * Most failures derive this text from [stage]; a few call sites (e.g. argument parsing inside
+     * [ContextualAgentEnvironment]) supply their own historical wording so that the [Default] presenter
+     * stays byte-for-byte backward compatible.
+     */
+    public val defaultMessage: String
+        get() = defaultMessageOverride ?: when (stage) {
+            ToolFailureStage.ArgumentParsing ->
+                "Tool with name '$toolName' failed to parse arguments due to the error: ${error.message}"
+
+            ToolFailureStage.Execution ->
+                "Tool with name '$toolName' failed to execute due to the error: ${error.message}!"
+
+            ToolFailureStage.ResultSerialization ->
+                "Tool with name '$toolName' failed to serialize result due to the error: ${error.message}!"
+        }
+}
+
+/**
+ * Produces the text that is fed back into the LLM context when a tool call fails with a generic
+ * (non-[ai.koog.agents.core.tools.ToolException]) exception.
+ *
+ * By default the framework re-injects the raw [Throwable.message] into the prompt (see [Default]). That is
+ * convenient but has two drawbacks an application may want to control:
+ *
+ * 1. **Silent degradation** — a thrown exception is converted into a failure result and the agent keeps
+ *    going; the failure never propagates out of `agent.run()`. Failures are still observable through the
+ *    event-handler feature — execution/serialization failures via `onToolCallFailed` and argument-parsing
+ *    failures via `onToolValidationFailed` — both of which receive the original [Throwable], so a presenter
+ *    is about *what the model sees*, not about losing visibility.
+ * 2. **Prompt injection** — the exception message may contain unsanitized external input (DB values, remote
+ *    responses, stack fragments). Returning it verbatim bypasses input sanitization an application performs
+ *    on every other path into the prompt.
+ *
+ * Configure a custom presenter via [ai.koog.agents.core.agent.config.AIAgentConfig] to replace, redact, or
+ * fix the text the model receives, e.g.:
+ *
+ * ```kotlin
+ * val config = AIAgentConfig(
+ *     prompt = prompt,
+ *     model = model,
+ *     maxAgentIterations = 10,
+ *     toolFailurePresenter = ToolFailurePresenter { failure ->
+ *         "The tool '${failure.toolName}' failed. Please try a different approach."
+ *     },
+ * )
+ * ```
+ *
+ * Note: this hook does **not** affect [ai.koog.agents.core.tools.ToolException] failures. Those messages are
+ * authored deliberately by the tool to guide the model and are not treated as untrusted input. The exemption
+ * is specific to author-controlled [ai.koog.agents.core.tools.ToolException] text, not to the
+ * [ToolResultKind.ValidationError] kind in general: a malformed-arguments failure surfaced as a
+ * [ToolResultKind.ValidationError] by [ContextualAgentEnvironment] still carries a generic parser exception
+ * and is routed through this presenter ([ToolFailureStage.ArgumentParsing]).
+ *
+ * Implementations must be thread-safe; [present] may be called concurrently for parallel tool calls.
+ */
+public fun interface ToolFailurePresenter {
+
+    /**
+     * Returns the message that will be re-injected into the LLM context for the given [failure].
+     *
+     * The returned string fully replaces the framework default; the raw [ToolFailure.error] message is not
+     * appended unless the returned value includes it (e.g. via [ToolFailure.defaultMessage]).
+     */
+    public fun present(failure: ToolFailure): String
+
+    /**
+     * Provides the default [ToolFailurePresenter].
+     */
+    public companion object {
+        /**
+         * The backward-compatible presenter: returns [ToolFailure.defaultMessage], re-injecting the raw
+         * exception message into the prompt exactly as earlier framework versions did.
+         */
+        public val Default: ToolFailurePresenter = ToolFailurePresenter { it.defaultMessage }
+    }
+}

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/planner/PlannerAIAgent.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/planner/PlannerAIAgent.kt
@@ -140,6 +140,7 @@ public class PlannerAIAgent<Input, Output>(
             logger = logger,
             toolRegistry = toolRegistry,
             serializer = agentConfig.serializer,
+            toolFailurePresenter = agentConfig.toolFailurePresenter,
         )
 
         return baseEnvironment

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/AIAgentSubgraphExt.kt
@@ -18,6 +18,8 @@ import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
 import ai.koog.agents.core.dsl.extension.onTextMessage
 import ai.koog.agents.core.dsl.extension.onToolCalls
 import ai.koog.agents.core.environment.ReceivedToolResult
+import ai.koog.agents.core.environment.ToolFailure
+import ai.koog.agents.core.environment.ToolFailureStage
 import ai.koog.agents.core.environment.ToolResultKind
 import ai.koog.agents.core.environment.toSafeResult
 import ai.koog.agents.core.tools.Tool
@@ -826,7 +828,18 @@ internal suspend fun <Output, OutputTransformed> AIAgentContext.executeFinishToo
             tool = finishTool.name,
             toolArgs = runCatching { toolCall.argsJson.toKoogJSONObject() }.getOrElse { JSONObject(emptyMap()) },
             toolDescription = toolDescription,
-            output = "Failed to execute '${finishTool.name}' with error: ${e.message}'",
+            // Route the model-facing text through the configured presenter so a host can sanitize the raw
+            // exception before it reaches the prompt, consistent with GenericAgentEnvironment. The legacy
+            // wording is supplied as the override so ToolFailurePresenter.Default stays byte-for-byte
+            // backward compatible; the original throwable remains observable via ToolResultKind.Failure.
+            output = config.toolFailurePresenter.present(
+                ToolFailure(
+                    toolName = finishTool.name,
+                    stage = ToolFailureStage.Execution,
+                    error = e,
+                    defaultMessageOverride = "Failed to execute '${finishTool.name}' with error: ${e.message}'",
+                )
+            ),
             resultKind = ToolResultKind.Failure(e),
             result = null,
             resultObject = null

--- a/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/config/AIAgentConfig.kt
+++ b/agents/agents-core/src/jvmCommonMain/kotlin/ai/koog/agents/core/agent/config/AIAgentConfig.kt
@@ -2,6 +2,7 @@ package ai.koog.agents.core.agent.config
 
 import ai.koog.agents.annotations.JavaAPI
 import ai.koog.agents.core.annotation.InternalAgentsApi
+import ai.koog.agents.core.environment.ToolFailurePresenter
 import ai.koog.prompt.Prompt
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.llm.LLModel
@@ -26,6 +27,7 @@ public actual class AIAgentConfig actual constructor(
     public actual val missingToolsConversionStrategy: MissingToolsConversionStrategy,
     public actual val responseProcessor: ResponseProcessor?,
     public actual val serializer: JSONSerializer,
+    public actual val toolFailurePresenter: ToolFailurePresenter,
 ) : AIAgentConfigBase {
 
     /**
@@ -59,8 +61,17 @@ public actual class AIAgentConfig actual constructor(
         missingToolsConversionStrategy: MissingToolsConversionStrategy =
             MissingToolsConversionStrategy.Missing(ToolCallDescriber.JSON),
         responseProcessor: ResponseProcessor? = null,
-        serializer: JSONSerializer = JacksonSerializer()
-    ) : this(prompt, model, maxAgentIterations, missingToolsConversionStrategy, responseProcessor, serializer) {
+        serializer: JSONSerializer = JacksonSerializer(),
+        toolFailurePresenter: ToolFailurePresenter = ToolFailurePresenter.Default
+    ) : this(
+        prompt,
+        model,
+        maxAgentIterations,
+        missingToolsConversionStrategy,
+        responseProcessor,
+        serializer,
+        toolFailurePresenter
+    ) {
         strategyExecutor?.let { strategyDispatcher = it.asCoroutineDispatcher() }
         llmRequestExecutor?.let { llmRequestDispatcher = it.asCoroutineDispatcher() }
     }
@@ -75,14 +86,16 @@ public actual class AIAgentConfig actual constructor(
         maxAgentIterations: Int,
         missingToolsConversionStrategy: MissingToolsConversionStrategy,
         responseProcessor: ResponseProcessor?,
-        serializer: JSONSerializer
+        serializer: JSONSerializer,
+        toolFailurePresenter: ToolFailurePresenter
     ): AIAgentConfig = AIAgentConfig(
         prompt = prompt,
         model = model,
         maxAgentIterations = maxAgentIterations,
         missingToolsConversionStrategy = missingToolsConversionStrategy,
         responseProcessor = responseProcessor,
-        serializer = serializer
+        serializer = serializer,
+        toolFailurePresenter = toolFailurePresenter
     ).also {
         it.strategyDispatcher = this.strategyDispatcher
         it.llmRequestDispatcher = this.llmRequestDispatcher
@@ -145,7 +158,8 @@ public actual class AIAgentConfig actual constructor(
             public var responseProcessor: ResponseProcessor? = null,
             internal var strategyExecutor: Executor? = null,
             internal var llmRequestExecutor: Executor? = null,
-            internal var serializer: JSONSerializer = JacksonSerializer()
+            internal var serializer: JSONSerializer = JacksonSerializer(),
+            internal var toolFailurePresenter: ToolFailurePresenter = ToolFailurePresenter.Default
         ) {
             /**
              * Sets serializer for underlying tool calls and LLM requests
@@ -154,6 +168,15 @@ public actual class AIAgentConfig actual constructor(
              * */
             public fun serializer(serializer: JSONSerializer): AIAgentConfigBuilder =
                 apply { this.serializer = serializer }
+
+            /**
+             * Sets the presenter that decides what text is fed back to the LLM when a tool call fails with a
+             * generic (non-[ai.koog.agents.core.tools.ToolException]) exception.
+             *
+             * @param presenter The [ToolFailurePresenter] used to sanitize or replace tool-failure messages.
+             */
+            public fun toolFailurePresenter(presenter: ToolFailurePresenter): AIAgentConfigBuilder =
+                apply { this.toolFailurePresenter = presenter }
 
             /**
              * Sets the prompt configuration for the AI agent.
@@ -220,7 +243,8 @@ public actual class AIAgentConfig actual constructor(
                 responseProcessor = responseProcessor,
                 strategyExecutor = strategyExecutor,
                 llmRequestExecutor = llmRequestExecutor,
-                serializer = serializer
+                serializer = serializer,
+                toolFailurePresenter = toolFailurePresenter
             )
         }
     }

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/environment/GenericAgentEnvironmentTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/environment/GenericAgentEnvironmentTest.kt
@@ -16,6 +16,7 @@ import kotlinx.serialization.Serializable
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -50,6 +51,16 @@ class GenericAgentEnvironmentTest {
     ) {
         override suspend fun execute(args: RequiredArgs): String {
             error("boom")
+        }
+    }
+
+    private class SecretLeakingTool : SimpleTool<RequiredArgs>(
+        argsType = typeToken<RequiredArgs>(),
+        name = "secret_leaking_tool",
+        description = "Tool that throws an exception carrying sensitive text in its message.",
+    ) {
+        override suspend fun execute(args: RequiredArgs): String {
+            throw IllegalStateException("secret=hunter2")
         }
     }
 
@@ -263,6 +274,111 @@ class GenericAgentEnvironmentTest {
 
         val messagePart = result.toMessagePart()
         assertEquals("ok:value", (messagePart.parts.single() as MessagePart.Text).text)
+    }
+
+    @Test
+    fun testDefaultPresenterForwardsRawExceptionMessage() = runTest {
+        val environment = GenericAgentEnvironment(
+            agentId = "test_agent",
+            logger = KotlinLogging.logger { },
+            toolRegistry = ToolRegistry { tool(SecretLeakingTool()) },
+            serializer = serializer,
+        )
+
+        val result = environment.executeTool(
+            MessagePart.Tool.Call(
+                id = "1",
+                tool = "secret_leaking_tool",
+                args = """{"required":"value"}""",
+            )
+        )
+
+        // Backward-compatible default: the raw exception message is re-injected verbatim.
+        assertTrue(result.resultKind is ToolResultKind.Failure)
+        assertTrue(result.output.contains("secret=hunter2"))
+    }
+
+    @Test
+    fun testCustomPresenterReplacesRawExceptionMessage() = runTest {
+        val environment = GenericAgentEnvironment(
+            agentId = "test_agent",
+            logger = KotlinLogging.logger { },
+            toolRegistry = ToolRegistry { tool(SecretLeakingTool()) },
+            serializer = serializer,
+            toolFailurePresenter = ToolFailurePresenter { failure ->
+                "The tool '${failure.toolName}' failed at stage ${failure.stage}."
+            },
+        )
+
+        val result = environment.executeTool(
+            MessagePart.Tool.Call(
+                id = "1",
+                tool = "secret_leaking_tool",
+                args = """{"required":"value"}""",
+            )
+        )
+
+        val failure = result.resultKind
+        assertTrue(failure is ToolResultKind.Failure)
+
+        // The model only sees the sanitized text...
+        assertEquals(
+            "The tool 'secret_leaking_tool' failed at stage ${ToolFailureStage.Execution}.",
+            result.output,
+        )
+        assertFalse(result.output.contains("secret=hunter2"))
+
+        // ...while the host still observes the original throwable through the result kind (and, in a full
+        // agent run, through the event-handler feature's onToolCallFailed event).
+        assertEquals("secret=hunter2", failure.error?.message)
+    }
+
+    @Test
+    fun testCustomPresenterCanReuseDefaultMessage() = runTest {
+        val environment = GenericAgentEnvironment(
+            agentId = "test_agent",
+            logger = KotlinLogging.logger { },
+            toolRegistry = ToolRegistry { tool(SecretLeakingTool()) },
+            serializer = serializer,
+            toolFailurePresenter = ToolFailurePresenter { it.defaultMessage },
+        )
+
+        val result = environment.executeTool(
+            MessagePart.Tool.Call(
+                id = "1",
+                tool = "secret_leaking_tool",
+                args = """{"required":"value"}""",
+            )
+        )
+
+        assertTrue(result.resultKind is ToolResultKind.Failure)
+        assertEquals(
+            "Tool with name 'secret_leaking_tool' failed to execute due to the error: secret=hunter2!",
+            result.output,
+        )
+    }
+
+    @Test
+    fun testCustomPresenterIsNotAppliedToToolValidationErrors() = runTest {
+        val environment = GenericAgentEnvironment(
+            agentId = "test_agent",
+            logger = KotlinLogging.logger { },
+            toolRegistry = ToolRegistry { tool(ValidationTool()) },
+            serializer = serializer,
+            toolFailurePresenter = ToolFailurePresenter { "redacted" },
+        )
+
+        val result = environment.executeTool(
+            MessagePart.Tool.Call(
+                id = "1",
+                tool = "validation_tool",
+                args = """{"required":"value"}""",
+            )
+        )
+
+        // ToolException messages are author-controlled validation guidance and bypass the presenter.
+        assertTrue(result.resultKind is ToolResultKind.ValidationError)
+        assertEquals("Invalid arguments", result.output)
     }
 
     @Test

--- a/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/feature/ToolCallFailureEventsTest.kt
+++ b/agents/agents-core/src/jvmTest/kotlin/ai/koog/agents/core/feature/ToolCallFailureEventsTest.kt
@@ -9,6 +9,7 @@ import ai.koog.agents.core.dsl.extension.ToolCalls
 import ai.koog.agents.core.dsl.extension.nodeExecuteSingleTool
 import ai.koog.agents.core.dsl.extension.nodeExecuteTools
 import ai.koog.agents.core.environment.ReceivedToolResult
+import ai.koog.agents.core.environment.ToolFailurePresenter
 import ai.koog.agents.core.feature.config.FeatureConfig
 import ai.koog.agents.core.feature.handler.tool.ToolCallFailedContext
 import ai.koog.agents.core.feature.handler.tool.ToolValidationFailedContext
@@ -24,6 +25,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -106,6 +108,48 @@ class ToolCallFailureEventsTest {
         val capturedFailure = assertNotNull(toolValidationFailed)
         assertEquals("required_args", capturedFailure.toolName)
         assertTrue(capturedFailure.message.contains("Failed to parse tool arguments"))
+    }
+
+    @Test
+    fun testCustomPresenterSanitizesInvalidJsonValidationFailure() = runTest {
+        var toolValidationFailed: ToolValidationFailedContext? = null
+
+        val strategy = strategy<ToolCalls, ReceivedToolResults>("tool_failure_strategy") {
+            val executeTool by nodeExecuteTools()
+            edge(nodeStart forwardTo executeTool)
+            edge(executeTool forwardTo nodeFinish)
+        }
+
+        val agent = GraphAIAgent(
+            promptExecutor = getMockExecutor(serializer) { },
+            agentConfig = AIAgentConfig.withSystemPrompt("test").copy(
+                toolFailurePresenter = ToolFailurePresenter { failure ->
+                    "Could not parse arguments for '${failure.toolName}'."
+                },
+            ),
+            strategy = strategy,
+            toolRegistry = ToolRegistry { tool(RequiredArgsTool()) },
+            installFeatures = {
+                install(ToolFailureCaptureFeature) {
+                    onToolValidationFailed = { toolValidationFailed = it }
+                }
+            }
+        )
+
+        val toolCall = MessagePart.Tool.Call(
+            id = "1",
+            tool = "required_args",
+            args = "not-json",
+        )
+
+        agent.run(ToolCalls(listOf(toolCall)))
+        val capturedFailure = assertNotNull(toolValidationFailed)
+        // The model-facing text for the invalid-JSON path now goes through the configured presenter, so the
+        // raw parser exception is fully replaced before it reaches the prompt.
+        assertEquals("Could not parse arguments for 'required_args'.", capturedFailure.message)
+        assertFalse(capturedFailure.message.contains("Failed to parse tool arguments"))
+        // The host still observes the original parser throwable through the validation-failed event.
+        assertNotNull(capturedFailure.error)
     }
 
     @Test

--- a/agents/agents-core/src/nonJvmCommonMain/kotlin/ai/koog/agents/core/agent/config/AIAgentConfig.kt
+++ b/agents/agents-core/src/nonJvmCommonMain/kotlin/ai/koog/agents/core/agent/config/AIAgentConfig.kt
@@ -2,6 +2,7 @@
 
 package ai.koog.agents.core.agent.config
 
+import ai.koog.agents.core.environment.ToolFailurePresenter
 import ai.koog.prompt.Prompt
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.llm.LLModel
@@ -15,6 +16,7 @@ public actual class AIAgentConfig actual constructor(
     public actual val missingToolsConversionStrategy: MissingToolsConversionStrategy,
     public actual val responseProcessor: ResponseProcessor?,
     public actual val serializer: JSONSerializer,
+    public actual val toolFailurePresenter: ToolFailurePresenter,
 ) : AIAgentConfigBase {
 
     init {
@@ -43,13 +45,15 @@ public actual class AIAgentConfig actual constructor(
         maxAgentIterations: Int,
         missingToolsConversionStrategy: MissingToolsConversionStrategy,
         responseProcessor: ResponseProcessor?,
-        serializer: JSONSerializer
+        serializer: JSONSerializer,
+        toolFailurePresenter: ToolFailurePresenter
     ) = AIAgentConfig(
         prompt = prompt,
         model = model,
         maxAgentIterations = maxAgentIterations,
         missingToolsConversionStrategy = missingToolsConversionStrategy,
         responseProcessor = responseProcessor,
-        serializer = serializer
+        serializer = serializer,
+        toolFailurePresenter = toolFailurePresenter
     )
 }


### PR DESCRIPTION
## Problem

When a tool's `execute()` throws a generic (non-`ToolException`) exception, the agent catches it, wraps it in `ToolResultKind.Failure`, and **re-injects the raw `Throwable.message` straight into the LLM context**.

Forwarding that text verbatim **bypasses the input sanitization a host performs on every other path into the prompt**. An exception message can carry unsanitized external input — DB values, remote API responses, stack fragments — so this is the one injection vector a careful host cannot currently close. A host that sanitizes every other input into the prompt still has this one slip through.

> **Scope:** this is about *what the model is allowed to see*, not about observability or control flow. Tool failures are already observable through the event-handler feature — `onToolCallFailed` (execution/serialization) and `onToolValidationFailed` (argument parsing) — and both receive the original `Throwable`. This PR does not change that, and it does not change whether/how failures propagate out of `agent.run()`. It only governs the text re-injected into the prompt.

### Reproduction

```kotlin
class LeakyTool : SimpleTool<LeakyTool.Args>(
    argsType = typeToken<Args>(),
    name = "lookup_user",
    description = "Looks up a user.",
) {
    @Serializable data class Args(val id: String)
    override suspend fun execute(args: Args): String {
        // message contains data the app would normally sanitize before it reaches the model
        throw IllegalStateException("DB error: connection string=postgres://user:hunter2@db/internal")
    }
}
```

Before this change, the model receives:

```
Tool with name 'lookup_user' failed to execute due to the error: DB error: connection string=postgres://user:hunter2@db/internal!
```

…verbatim, even though the host sanitizes every other input it puts into the prompt.

## Fix

Add a `ToolFailurePresenter` hook on `AIAgentConfig` that controls the text fed back to the model when a tool fails with a generic exception:

```kotlin
val config = AIAgentConfig(
    prompt = prompt,
    model = model,
    maxAgentIterations = 10,
    toolFailurePresenter = ToolFailurePresenter { failure ->
        // failure.toolName, failure.stage, failure.error are available;
        // failure.defaultMessage gives the legacy string if you want to keep it for some cases.
        "The tool '${failure.toolName}' failed. Please try a different approach."
    },
)
```

- `ToolFailure` carries the tool name, the `ToolFailureStage` (`ArgumentParsing` / `Execution` / `ResultSerialization`), and the original `Throwable`.
- The presenter's return value **fully replaces** the model-visible text; the raw message is no longer leaked unless the presenter chooses to include it.
- The original `Throwable` remains observable through the event-handler feature's `onToolCallFailed` / `onToolValidationFailed` events regardless of the presenter — so a host can log the real error (Sentry) while showing the model a redacted string.

### Why a config hook rather than a feature?

The model-facing failure text must be decided **synchronously, on the single path between catching the exception and writing the tool result that enters the prompt** — it is a required transformation of outgoing content, not an optional observer of an event. Koog's feature pipeline already owns the *observability* side (`onToolCallFailed` / `onToolValidationFailed`), but those hooks are notifications and do not own the string the model receives. Placing the presenter on `AIAgentConfig` keeps it (a) mandatory and deterministic on every failure path, (b) colocated with the other prompt-shaping knobs already on the config (`serializer`, `missingToolsConversionStrategy`, `responseProcessor`), and (c) free of feature-ordering/“did anyone handle this?” ambiguity — which matters for a security-relevant default. A feature-based interceptor would reintroduce exactly that uncertainty.

## Backward compatibility

**Default behavior is unchanged.** When `toolFailurePresenter` is not set it defaults to `ToolFailurePresenter.Default`, which returns `ToolFailure.defaultMessage` — the exact strings emitted today. Existing code and tests behave identically.

Other behavior preserved:
- `CancellationException` is still re-thrown (cooperative cancellation).
- `ToolException` failures (`ToolResultKind.ValidationError`) are author-controlled validation guidance meant for the model and **intentionally bypass** the presenter.

## Tests

`agents-core` `GenericAgentEnvironmentTest`:
- default presenter forwards the raw exception message (compat);
- a custom presenter replaces the message and the raw `secret=...` text does not reach the output, while the original `Throwable` is still accessible via `ToolResultKind.Failure.error`;
- a custom presenter can reuse `defaultMessage`;
- the presenter is **not** applied to `ToolException`/`ValidationError`;
- `CancellationException` still propagates (existing regression test).

`agents-core` `ToolCallFailureEventsTest`:
- a custom presenter sanitizes the invalid-JSON argument-parsing path, while the original parser throwable is still delivered to `onToolValidationFailed`.

Verified: `:agents:agents-core:jvmTest` and `:agents:agents-core:jsTest` pass; `iosSimulatorArm64` compiles; ABI dumps regenerated (`updateLegacyAbi`) and `checkLegacyAbi` passes; `agents-cli` compiles. (The pre-existing `wasmJsNodeTest` failure in `AIAgentParallelNodesMergeContextTest` reproduces on a clean `develop` with Node.js v25 and is unrelated to this change.)

closes KG-862
