### PR TITLE
fix(agents): report token usage to Langfuse via usage_details

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/src/commonMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapter.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/commonMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapter.kt
@@ -98,12 +98,47 @@ internal class LangfuseSpanAdapter(
                 outputMessagesAttr?.messages?.forEachIndexed { index, message ->
                     applyCompletionAttributes(span, index, message)
                 }
+
+                // Emit token usage in the Langfuse-native `langfuse.observation.usage_details` shape.
+                applyUsageDetails(span)
             }
             else -> {}
         }
     }
 
     //region Private Methods
+
+    /**
+     * Re-emits the standard `gen_ai.usage.*` token counts as Langfuse's native
+     * [`langfuse.observation.usage_details`](https://langfuse.com/integrations/native/opentelemetry)
+     * attribute (a JSON object string), so Langfuse records token usage and computes cost.
+     *
+     * Langfuse does not pick up the OTel-standard `gen_ai.usage.input_tokens` / `output_tokens`
+     * integer attributes that [endInferenceSpan][ai.koog.agents.features.opentelemetry.span.endInferenceSpan]
+     * sets (its OTLP/JSON ingestion does not decode the spec-mandated string-encoded `int64`
+     * `intValue` — see https://github.com/langfuse/langfuse/issues/14068), so without this the
+     * Langfuse exporter always reports 0 tokens / 0 cost. The standard `gen_ai.usage.*` attributes
+     * are left untouched for spec-compliant backends.
+     */
+    private fun applyUsageDetails(span: GenAIAgentSpan) {
+        val inputTokens = span.attributes.filterIsInstance<GenAIAttributes.Usage.InputTokens>().firstOrNull()?.tokens
+        val outputTokens = span.attributes.filterIsInstance<GenAIAttributes.Usage.OutputTokens>().firstOrNull()?.tokens
+        val totalTokens = span.attributes.filterIsInstance<GenAIAttributes.Usage.TotalTokens>().firstOrNull()?.tokens
+
+        if (inputTokens == null && outputTokens == null && totalTokens == null) {
+            return
+        }
+
+        val usageDetails = JsonObject(
+            buildMap {
+                inputTokens?.let { put("input", JsonPrimitive(it)) }
+                outputTokens?.let { put("output", JsonPrimitive(it)) }
+                totalTokens?.let { put("total", JsonPrimitive(it)) }
+            }
+        )
+
+        span.addAttribute(CustomAttribute("langfuse.observation.usage_details", usageDetails.toString()))
+    }
 
     private fun applyPromptAttributes(span: GenAIAgentSpan, index: Int, message: Message) {
         when (message) {

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapterTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapterTest.kt
@@ -191,6 +191,41 @@ class LangfuseSpanAdapterTest {
     }
 
     @Test
+    fun `onBeforeSpanFinished emits token usage as langfuse usage_details`() {
+        val adapter = LangfuseSpanAdapter(emptyList(), OpenTelemetryConfig())
+
+        val provider = MockLLMProvider()
+        val inferenceSpan = createInferenceSpan(provider)
+
+        // endInferenceSpan sets these standard gen_ai.usage.* integer attributes before the
+        // adapter's onBeforeSpanFinished runs.
+        inferenceSpan.addAttribute(GenAIAttributes.Usage.InputTokens(25))
+        inferenceSpan.addAttribute(GenAIAttributes.Usage.OutputTokens(2))
+        inferenceSpan.addAttribute(GenAIAttributes.Usage.TotalTokens(27))
+
+        adapter.onBeforeSpanFinished(inferenceSpan)
+
+        // Token usage is re-emitted as the Langfuse-native usage_details JSON-object string...
+        assertEquals(
+            """{"input":25,"output":2,"total":27}""",
+            inferenceSpan.attributes.requireValue("langfuse.observation.usage_details"),
+        )
+        // ...while the OTel-standard integer attributes are left untouched for spec-compliant backends.
+        assertEquals(25, inferenceSpan.attributes.filterIsInstance<GenAIAttributes.Usage.InputTokens>().single().tokens)
+        assertEquals(2, inferenceSpan.attributes.filterIsInstance<GenAIAttributes.Usage.OutputTokens>().single().tokens)
+    }
+
+    @Test
+    fun `onBeforeSpanFinished adds no usage_details when usage attributes are absent`() {
+        val adapter = LangfuseSpanAdapter(emptyList(), OpenTelemetryConfig())
+
+        val inferenceSpan = createInferenceSpan(MockLLMProvider())
+        adapter.onBeforeSpanFinished(inferenceSpan)
+
+        assertEquals(0, inferenceSpan.attributes.count { it.key == "langfuse.observation.usage_details" })
+    }
+
+    @Test
     fun `onBeforeSpanStarted adds langgraph metadata to node execute spans`() {
         val adapter = LangfuseSpanAdapter(emptyList(), OpenTelemetryConfig())
 


### PR DESCRIPTION
## What

Make the Langfuse integration report token usage and cost. For `SpanType.INFERENCE`, `LangfuseSpanAdapter` now re-emits the token counts as Langfuse's native [`langfuse.observation.usage_details`](https://langfuse.com/integrations/native/opentelemetry) attribute (a JSON-object string built from the existing `GenAIAttributes.Usage.*` values).

Fixes #2120.

## Why

With `addLangfuseExporter`, every generation shows up in Langfuse with **0 input tokens, 0 output tokens, and 0 cost**, even though Koog has the correct counts and sets them on the inference span.

The chain:

1. `endInferenceSpan` adds `gen_ai.usage.input_tokens` / `output_tokens` as **`Int`** attributes.
2. `OtlpJsonSpanExporter` serializes them per the OTLP/JSON spec as `int64` → `{"intValue":"<n>"}` (correct: proto3 JSON mapping mandates `int64` be a decimal string).
3. `LangfuseSpanAdapter` reshapes messages and sets `langfuse.observation.metadata.*`, but never emitted any usage attribute.

This change makes the Langfuse adapter emit Langfuse's own `usage_details` attribute (its documented native usage channel), analogous to how `WeaveSpanAdapter` already remaps usage for Weave. The OTel-standard `gen_ai.usage.*` integer attributes are left untouched for spec-compliant backends.

## Upstream note

The reason the standard `gen_ai.usage.*` integers didn't show up was a Langfuse-side OTLP/JSON ingestion gap (it didn't decode the string-encoded `int64` `intValue`): langfuse/langfuse#14068. **Langfuse has since fixed this on `main` via langfuse/langfuse#14047** (merged 2026-06-05), which is not yet in a release as of v3.178.0.

This PR is still useful: until that fix ships in a Langfuse release, every released Langfuse (≤ v3.178.0) drops Koog's int-encoded usage; and `usage_details` is Langfuse's documented native attribute, so emitting it is robust across Langfuse versions either way.

## How it was verified

- **Unit tests** (`LangfuseSpanAdapterTest`): assert the adapter emits `langfuse.observation.usage_details = {"input":25,"output":2,"total":27}` and leaves the standard `gen_ai.usage.*` attributes in place; and that no `usage_details` is added when usage attributes are absent. `:agents:agents-features:agents-features-opentelemetry:jvmTest` passes locally.
- **End-to-end against self-hosted Langfuse v3.178.0** — posting the same generation span to `/api/public/otel/v1/traces` with only the usage encoding varied:

  | usage attribute sent | Langfuse `usage` | cost |
  | --- | --- | --- |
  | `gen_ai.usage.input_tokens` = `{"intValue":"25"}` (pre-#14047 behavior) | `{input:0, output:0}` | 0 |
  | `langfuse.observation.usage_details` = `{"input":25,"output":2}` (this PR) | `{input:25, output:2}` | computed |

## Notes

- Scope is limited to the Langfuse adapter; the OTLP exporter and `endInferenceSpan` are unchanged.
- `TotalTokens` is included in `usage_details` when present.
