### PR TITLE
feat(embeddings): support batch embedding of multiple inputs

### DIFF
--- a/embeddings/embeddings-base/api/android/embeddings-base.api
+++ b/embeddings/embeddings-base/api/android/embeddings-base.api
@@ -1,6 +1,11 @@
 public abstract interface class ai/koog/embeddings/base/Embedder {
 	public abstract fun diff (Lai/koog/embeddings/base/Vector;Lai/koog/embeddings/base/Vector;)D
 	public abstract fun embed (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun embed (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class ai/koog/embeddings/base/Embedder$DefaultImpls {
+	public static fun embed (Lai/koog/embeddings/base/Embedder;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class ai/koog/embeddings/base/Vector {

--- a/embeddings/embeddings-base/api/embeddings-base.klib.api
+++ b/embeddings/embeddings-base/api/embeddings-base.klib.api
@@ -9,6 +9,7 @@
 abstract interface ai.koog.embeddings.base/Embedder { // ai.koog.embeddings.base/Embedder|null[0]
     abstract fun diff(ai.koog.embeddings.base/Vector, ai.koog.embeddings.base/Vector): kotlin/Double // ai.koog.embeddings.base/Embedder.diff|diff(ai.koog.embeddings.base.Vector;ai.koog.embeddings.base.Vector){}[0]
     abstract suspend fun embed(kotlin/String): ai.koog.embeddings.base/Vector // ai.koog.embeddings.base/Embedder.embed|embed(kotlin.String){}[0]
+    open suspend fun embed(kotlin.collections/List<kotlin/String>): kotlin.collections/List<ai.koog.embeddings.base/Vector> // ai.koog.embeddings.base/Embedder.embed|embed(kotlin.collections.List<kotlin.String>){}[0]
 }
 
 final class ai.koog.embeddings.base/Vector { // ai.koog.embeddings.base/Vector|null[0]

--- a/embeddings/embeddings-base/api/jvm/embeddings-base.api
+++ b/embeddings/embeddings-base/api/jvm/embeddings-base.api
@@ -1,6 +1,11 @@
 public abstract interface class ai/koog/embeddings/base/Embedder {
 	public abstract fun diff (Lai/koog/embeddings/base/Vector;Lai/koog/embeddings/base/Vector;)D
 	public abstract fun embed (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun embed (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class ai/koog/embeddings/base/Embedder$DefaultImpls {
+	public static fun embed (Lai/koog/embeddings/base/Embedder;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class ai/koog/embeddings/base/Vector {

--- a/embeddings/embeddings-base/src/commonMain/kotlin/ai/koog/embeddings/base/Embedder.kt
+++ b/embeddings/embeddings-base/src/commonMain/kotlin/ai/koog/embeddings/base/Embedder.kt
@@ -15,6 +15,17 @@ public interface Embedder {
     public suspend fun embed(text: String): Vector
 
     /**
+     * Embeds the given texts into vector representations.
+     *
+     * The default implementation embeds each text sequentially via [embed]. Implementations backed by a
+     * provider with a native batch endpoint should override this to embed all inputs in a single request efficiently.
+     *
+     * @param texts The texts to embed.
+     * @return The vector representations, one per input, in the same order as [texts].
+     */
+    public suspend fun embed(texts: List<String>): List<Vector> = texts.map { embed(it) }
+
+    /**
      * Calculates the difference between two embeddings.
      * Lower values indicate more similar embeddings.
      *

--- a/embeddings/embeddings-llm/api/android/embeddings-llm.api
+++ b/embeddings/embeddings-llm/api/android/embeddings-llm.api
@@ -2,5 +2,6 @@ public final class ai/koog/embeddings/local/LLMEmbedder : ai/koog/embeddings/bas
 	public fun <init> (Lai/koog/prompt/executor/clients/LLMEmbeddingProvider;Lai/koog/prompt/llm/LLModel;)V
 	public fun diff (Lai/koog/embeddings/base/Vector;Lai/koog/embeddings/base/Vector;)D
 	public fun embed (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun embed (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/embeddings/embeddings-llm/api/embeddings-llm.klib.api
+++ b/embeddings/embeddings-llm/api/embeddings-llm.klib.api
@@ -10,5 +10,6 @@ final class ai.koog.embeddings.local/LLMEmbedder : ai.koog.embeddings.base/Embed
     constructor <init>(ai.koog.prompt.executor.clients/LLMEmbeddingProvider, ai.koog.prompt.llm/LLModel) // ai.koog.embeddings.local/LLMEmbedder.<init>|<init>(ai.koog.prompt.executor.clients.LLMEmbeddingProvider;ai.koog.prompt.llm.LLModel){}[0]
 
     final fun diff(ai.koog.embeddings.base/Vector, ai.koog.embeddings.base/Vector): kotlin/Double // ai.koog.embeddings.local/LLMEmbedder.diff|diff(ai.koog.embeddings.base.Vector;ai.koog.embeddings.base.Vector){}[0]
+    final suspend fun embed(kotlin.collections/List<kotlin/String>): kotlin.collections/List<ai.koog.embeddings.base/Vector> // ai.koog.embeddings.local/LLMEmbedder.embed|embed(kotlin.collections.List<kotlin.String>){}[0]
     final suspend fun embed(kotlin/String): ai.koog.embeddings.base/Vector // ai.koog.embeddings.local/LLMEmbedder.embed|embed(kotlin.String){}[0]
 }

--- a/embeddings/embeddings-llm/api/jvm/embeddings-llm.api
+++ b/embeddings/embeddings-llm/api/jvm/embeddings-llm.api
@@ -2,5 +2,6 @@ public final class ai/koog/embeddings/local/LLMEmbedder : ai/koog/embeddings/bas
 	public fun <init> (Lai/koog/prompt/executor/clients/LLMEmbeddingProvider;Lai/koog/prompt/llm/LLModel;)V
 	public fun diff (Lai/koog/embeddings/base/Vector;Lai/koog/embeddings/base/Vector;)D
 	public fun embed (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun embed (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/embeddings/embeddings-llm/src/commonMain/kotlin/ai/koog/embeddings/local/LLMEmbedder.kt
+++ b/embeddings/embeddings-llm/src/commonMain/kotlin/ai/koog/embeddings/local/LLMEmbedder.kt
@@ -10,7 +10,10 @@ import ai.koog.prompt.llm.LLModel
  *
  * @property client The Ollama model client to use for embedding text.
  */
-public class LLMEmbedder(private val client: LLMEmbeddingProvider, private val model: LLModel) : Embedder {
+public class LLMEmbedder(
+    private val client: LLMEmbeddingProvider,
+    private val model: LLModel
+) : Embedder {
     /**
      * Embeds the given text using the Ollama model.
      *
@@ -19,6 +22,11 @@ public class LLMEmbedder(private val client: LLMEmbeddingProvider, private val m
      */
     override suspend fun embed(text: String): Vector {
         return Vector(client.embed(text, model))
+    }
+
+    override suspend fun embed(texts: List<String>): List<Vector> {
+        if (texts.isEmpty()) return emptyList()
+        return client.embed(texts, model).map { Vector(it) }
     }
 
     /**

--- a/embeddings/embeddings-llm/src/commonTest/kotlin/ai/koog/embeddings/local/LLMEmbedderTest.kt
+++ b/embeddings/embeddings-llm/src/commonTest/kotlin/ai/koog/embeddings/local/LLMEmbedderTest.kt
@@ -9,6 +9,7 @@ import ai.koog.prompt.llm.LLModel
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class LLMEmbedderTest {
     // Using a pretty straightforward approach as commonTest doesn't support @ParametrizedTest annotation from JUnit5
@@ -76,22 +77,81 @@ class LLMEmbedderTest {
         }
     }
 
-    class MockEmbedderClient : LLMEmbeddingProvider() {
+    @Test
+    fun testEmbedBatch_delegatesToClientBatch() = runTest {
+        val model = OpenAIModels.Embeddings.TextEmbedding3Small
+        val client = MockEmbedderClient()
+        val embedder = LLMEmbedder(client, model)
+
+        val vA = Vector(listOf(0.1, 0.1))
+        val vB = Vector(listOf(0.2, 0.2))
+        val vC = Vector(listOf(0.3, 0.3))
+        client.mockEmbedding("a", vA)
+        client.mockEmbedding("b", vB)
+        client.mockEmbedding("c", vC)
+
+        val result = embedder.embed(listOf("a", "b", "c"))
+
+        assertEquals(listOf(vA, vB, vC), result)
+        assertEquals(1, client.batchCalls, "should issue a single batch call")
+        assertEquals(0, client.singleCalls, "should not loop single calls")
+    }
+
+    @Test
+    fun testEmbedBatch_propagatesUnsupportedFromClient() = runTest {
+        val model = OpenAIModels.Embeddings.TextEmbedding3Small
+        val client = MockEmbedderClient(batchSupported = false)
+        val embedder = LLMEmbedder(client, model)
+
+        assertFailsWith<UnsupportedOperationException> {
+            embedder.embed(listOf("a", "b"))
+        }
+    }
+
+    @Test
+    fun testEmbedBatch_emptyReturnsEmptyWithoutCallingClient() = runTest {
+        val model = OpenAIModels.Embeddings.TextEmbedding3Small
+        val client = MockEmbedderClient(batchSupported = false)
+        val embedder = LLMEmbedder(client, model)
+
+        val result = embedder.embed(emptyList())
+
+        assertEquals(emptyList<Vector>(), result)
+        assertEquals(0, client.batchCalls)
+        assertEquals(0, client.singleCalls)
+    }
+
+    class MockEmbedderClient(
+        private val batchSupported: Boolean = true
+    ) : LLMEmbeddingProvider() {
         private val embeddings = mutableMapOf<String, Vector>()
+
+        var singleCalls: Int = 0
+            private set
+        var batchCalls: Int = 0
+            private set
 
         fun mockEmbedding(text: String, vector: Vector) {
             embeddings[text] = vector
         }
 
+        private fun lookup(text: String): List<Double> =
+            embeddings[text]?.values ?: throw IllegalArgumentException("No mock embedding for text: $text")
+
         override suspend fun embed(text: String, model: LLModel): List<Double> {
-            return embeddings[text]?.values ?: throw IllegalArgumentException("No mock embedding for text: $text")
+            singleCalls++
+            return lookup(text)
         }
 
         override suspend fun embed(
             inputs: List<String>,
             model: LLModel
         ): List<List<Double>> {
-            return inputs.map { embed(it, model) }
+            if (!batchSupported) {
+                throw UnsupportedOperationException("Batch embedding is not supported by this mock provider.")
+            }
+            batchCalls++
+            return inputs.map { lookup(it) }
         }
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -29,6 +29,7 @@ import ai.koog.prompt.executor.clients.openai.models.OpenAIChatCompletionRequest
 import ai.koog.prompt.executor.clients.openai.models.OpenAIChatCompletionRequestSerializer
 import ai.koog.prompt.executor.clients.openai.models.OpenAIChatCompletionResponse
 import ai.koog.prompt.executor.clients.openai.models.OpenAIChatCompletionStreamResponse
+import ai.koog.prompt.executor.clients.openai.models.OpenAIEmbeddingBatchRequest
 import ai.koog.prompt.executor.clients.openai.models.OpenAIEmbeddingRequest
 import ai.koog.prompt.executor.clients.openai.models.OpenAIEmbeddingResponse
 import ai.koog.prompt.executor.clients.openai.models.OpenAIModelsResponse
@@ -525,13 +526,38 @@ public open class OpenAILLMClient @JvmOverloads constructor(
     }
 
     /**
-     * Batch embedding is not supported by the OpenAI API.
+     * Embeds the given batch of text using the OpenAI embeddings API.
      *
-     * @throws UnsupportedOperationException Always thrown.
+     * @param inputs The text to embed.
+     * @param model The model to use for embedding. Must have the Embed capability.
+     * @return A list of floating-point values representing the embedding.
+     * @throws IllegalArgumentException if the model does not have the Embed capability.
      */
     override suspend fun embed(inputs: List<String>, model: LLModel): List<List<Double>> {
-        logger.warn { "Batch embedding is not supported by OpenAI API" }
-        throw UnsupportedOperationException("Batch embedding is not supported by OpenAI API.")
+        model.requireCapability(LLMCapability.Embed)
+
+        logger.debug { "Embedding text with model: ${model.id}" }
+
+        if (inputs.isEmpty()) return emptyList()
+
+        val request = OpenAIEmbeddingBatchRequest(model = model.id, input = inputs)
+
+        val openAIResponse = try {
+            httpClient.post(
+                path = settings.embeddingsPath,
+                requestBody = request,
+                requestBodyType = OpenAIEmbeddingBatchRequest::class,
+                responseType = OpenAIEmbeddingResponse::class,
+            )
+        } catch (e: Exception) {
+            throw LLMClientException(clientName = clientName, message = e.message, cause = e)
+        }
+
+        require(openAIResponse.data.size == inputs.size) {
+            "Expected ${inputs.size} embeddings but got ${openAIResponse.data.size}"
+        }
+
+        return openAIResponse.data.sortedBy { it.index }.map { it.embedding }
     }
 
     /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIEmbedding.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIEmbedding.kt
@@ -10,6 +10,12 @@ internal data class OpenAIEmbeddingRequest(
 )
 
 @Serializable
+internal data class OpenAIEmbeddingBatchRequest(
+    val model: String,
+    val input: List<String>
+)
+
+@Serializable
 internal data class OpenAIEmbeddingResponse(
     val data: List<OpenAIEmbeddingData>,
     val model: String,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIEmbeddingBatchTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIEmbeddingBatchTest.kt
@@ -1,0 +1,95 @@
+package ai.koog.prompt.executor.clients.openai
+
+import ai.koog.http.client.ktor.KtorKoogHttpClient
+import ai.koog.prompt.executor.clients.openai.models.OpenAIEmbeddingBatchRequest
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class OpenAIEmbeddingBatchTest {
+
+    private val key = "test-key"
+    private val model = OpenAIModels.Embeddings.TextEmbedding3Small
+
+    private fun clientReturning(body: String): OpenAILLMClient {
+        val engine = MockEngine {
+            respond(
+                content = body,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        return OpenAILLMClient(
+            apiKey = key,
+            httpClientFactory = KtorKoogHttpClient.Factory(baseClient = HttpClient(engine)),
+        )
+    }
+
+    @Test
+    fun batchRequestSerializesInputAsJsonArray() {
+        val request = OpenAIEmbeddingBatchRequest(model = "text-embedding-3-small", input = listOf("a", "b"))
+        val jsonString = Json.Default.encodeToString(OpenAIEmbeddingBatchRequest.serializer(), request)
+        assertEquals("""{"model":"text-embedding-3-small","input":["a","b"]}""", jsonString)
+    }
+
+    @Test
+    fun embedReordersResultsByIndex() = runTest {
+        // Response intentionally out of order (index 2, 0, 1) to prove sortedBy { index }.
+        val body = """
+            {
+              "data": [
+                {"embedding": [0.3, 0.3], "index": 2},
+                {"embedding": [0.1, 0.1], "index": 0},
+                {"embedding": [0.2, 0.2], "index": 1}
+              ],
+              "model": "text-embedding-3-small",
+              "usage": {"prompt_tokens": 3, "total_tokens": 3}
+            }
+        """.trimIndent()
+
+        val result = clientReturning(body).embed(listOf("a", "b", "c"), model)
+
+        assertEquals(
+            listOf(
+                listOf(0.1, 0.1),
+                listOf(0.2, 0.2),
+                listOf(0.3, 0.3),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun embedThrowsWhenResponseSizeDoesNotMatchInputs() = runTest {
+        val body = """
+            {
+              "data": [{"embedding": [0.1], "index": 0}],
+              "model": "text-embedding-3-small"
+            }
+        """.trimIndent()
+
+        assertFailsWith<IllegalArgumentException> {
+            clientReturning(body).embed(listOf("a", "b"), model)
+        }
+    }
+
+    @Test
+    fun embedReturnsEmptyForEmptyInputWithoutCallingApi() = runTest {
+        val engine = MockEngine { error("HTTP should not be called for empty input") }
+        val client = OpenAILLMClient(
+            apiKey = key,
+            httpClientFactory = KtorKoogHttpClient.Factory(baseClient = HttpClient(engine)),
+        )
+
+        assertEquals(emptyList<List<Double>>(), client.embed(emptyList(), model))
+    }
+}

--- a/rag/rag-vector/src/commonMain/kotlin/ai/koog/rag/vector/embedder/DocumentEmbedder.kt
+++ b/rag/rag-vector/src/commonMain/kotlin/ai/koog/rag/vector/embedder/DocumentEmbedder.kt
@@ -44,6 +44,8 @@ public open class TextDocumentEmbedder<Document, Path>(
      */
     override suspend fun embed(document: Document): Vector = embedder.embed(documentReader.text(document).toString())
 
+    override suspend fun embed(texts: List<String>): List<Vector> = embedder.embed(texts)
+
     /**
      * Embeds the given text into a vector representation.
      *

--- a/rag/rag-vector/src/commonTest/kotlin/ai/koog/rag/vector/embedder/TextDocumentEmbedderBatchTest.kt
+++ b/rag/rag-vector/src/commonTest/kotlin/ai/koog/rag/vector/embedder/TextDocumentEmbedderBatchTest.kt
@@ -1,0 +1,56 @@
+package ai.koog.rag.vector.embedder
+
+import ai.koog.embeddings.base.Embedder
+import ai.koog.embeddings.base.Vector
+import ai.koog.rag.vector.mocks.MockDocument
+import ai.koog.rag.vector.mocks.MockDocumentProvider
+import ai.koog.rag.vector.mocks.MockFileSystem
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TextDocumentEmbedderBatchTest {
+
+    /**
+     * Records whether the batch [embed] (List) or the single [embed] (String) path was used,
+     * so we can prove the wrapper forwards the whole list instead of looping single calls.
+     */
+    private class SpyEmbedder : Embedder {
+        var singleCalls: Int = 0
+            private set
+        var batchCalls: Int = 0
+            private set
+        var lastBatchInput: List<String>? = null
+            private set
+
+        override suspend fun embed(text: String): Vector {
+            singleCalls++
+            return Vector(listOf(text.length.toDouble()))
+        }
+
+        override suspend fun embed(texts: List<String>): List<Vector> {
+            batchCalls++
+            lastBatchInput = texts
+            return texts.map { Vector(listOf(it.length.toDouble())) }
+        }
+
+        override fun diff(embedding1: Vector, embedding2: Vector): Double = 0.0
+    }
+
+    @Test
+    fun testEmbedTextsForwardsBatchToInnerEmbedder() = runTest {
+        val spy = SpyEmbedder()
+        val embedder = TextDocumentEmbedder<MockDocument, String>(
+            documentReader = MockDocumentProvider(MockFileSystem()),
+            embedder = spy,
+        )
+
+        val result = embedder.embed(listOf("aa", "bbb"))
+
+        // Forwarded as one batch to the inner embedder, not decomposed into single calls.
+        assertEquals(1, spy.batchCalls, "should forward to the inner embedder's batch method once")
+        assertEquals(0, spy.singleCalls, "should not loop single embed(text) calls")
+        assertEquals(listOf("aa", "bbb"), spy.lastBatchInput)
+        assertEquals(listOf(Vector(listOf(2.0)), Vector(listOf(3.0))), result)
+    }
+}


### PR DESCRIPTION
Hi,
Picking up the **batch embedding** half of this — the follow-up @mltheuser scoped in Building on his provider analysis and design groundwork there.
The scope here is batch only; dimensions (KG-104) stays separate, per the earlier review feedback on #1296.

**Approach**:
  - New high-level `Embedder.embed(texts: List<String>): List<Vector>` with a
    sequential default, so existing `Embedder` implementations keep working.
  - `LLMEmbedder` delegates to the provider client's `embed(inputs)`. Providers
    with a native batch endpoint (OpenAI, Google, Mistral, Ollama) do it in one
    request; providers without one propagate their own `UnsupportedOperationException`
    with a clear, provider-specific message.
  - `OpenAILLMClient.embed(inputs)` now performs a real batched request (it
    previously threw); input order is preserved via the response `index`.
  - `TextDocumentEmbedder` forwards the batch to its wrapped embedder so batching
    isn't silently downgraded to per-item calls.


<!-- Include references to related issues below, e.g., closes #1, closes KG-1. Otherwise, delete it. -->
closes https://youtrack.jetbrains.com/issue/KG-538/Support-embedding-a-list-of-input
