### PR TITLE
feat(agents): limit visible tools in ToolSelectionStrategy.AutoSelectForTask

### DIFF
--- a/agents/agents-core/api/agents-core.klib.api
+++ b/agents/agents-core/api/agents-core.klib.api
@@ -439,16 +439,19 @@ sealed interface <#A: kotlin/Any?> ai.koog.agents.core.agent/AIAgentState { // a
 
 sealed interface ai.koog.agents.core.agent.entity/ToolSelectionStrategy { // ai.koog.agents.core.agent.entity/ToolSelectionStrategy|null[0]
     final class AutoSelectForTask : ai.koog.agents.core.agent.entity/ToolSelectionStrategy { // ai.koog.agents.core.agent.entity/ToolSelectionStrategy.AutoSelectForTask|null[0]
-        constructor <init>(kotlin/String, ai.koog.prompt.executor.model/StructureFixingParser? = ...) // ai.koog.agents.core.agent.entity/ToolSelectionStrategy.AutoSelectForTask.<init>|<init>(kotlin.String;ai.koog.prompt.executor.model.StructureFixingParser?){}[0]
+        constructor <init>(kotlin/String, ai.koog.prompt.executor.model/StructureFixingParser? = ..., kotlin.collections/List<ai.koog.agents.core.tools/ToolDescriptor>? = ...) // ai.koog.agents.core.agent.entity/ToolSelectionStrategy.AutoSelectForTask.<init>|<init>(kotlin.String;ai.koog.prompt.executor.model.StructureFixingParser?;kotlin.collections.List<ai.koog.agents.core.tools.ToolDescriptor>?){}[0]
 
         final val fixingParser // ai.koog.agents.core.agent.entity/ToolSelectionStrategy.AutoSelectForTask.fixingParser|{}fixingParser[0]
             final fun <get-fixingParser>(): ai.koog.prompt.executor.model/StructureFixingParser? // ai.koog.agents.core.agent.entity/ToolSelectionStrategy.AutoSelectForTask.fixingParser.<get-fixingParser>|<get-fixingParser>(){}[0]
         final val subtaskDescription // ai.koog.agents.core.agent.entity/ToolSelectionStrategy.AutoSelectForTask.subtaskDescription|{}subtaskDescription[0]
             final fun <get-subtaskDescription>(): kotlin/String // ai.koog.agents.core.agent.entity/ToolSelectionStrategy.AutoSelectForTask.subtaskDescription.<get-subtaskDescription>|<get-subtaskDescription>(){}[0]
+        final val tools // ai.koog.agents.core.agent.entity/ToolSelectionStrategy.AutoSelectForTask.tools|{}tools[0]
+            final fun <get-tools>(): kotlin.collections/List<ai.koog.agents.core.tools/ToolDescriptor>? // ai.koog.agents.core.agent.entity/ToolSelectionStrategy.AutoSelectForTask.tools.<get-tools>|<get-tools>(){}[0]
 
         final fun component1(): kotlin/String // ai.koog.agents.core.agent.entity/ToolSelectionStrategy.AutoSelectForTask.component1|component1(){}[0]
         final fun component2(): ai.koog.prompt.executor.model/StructureFixingParser? // ai.koog.agents.core.agent.entity/ToolSelectionStrategy.AutoSelectForTask.component2|component2(){}[0]
-        final fun copy(kotlin/String = ..., ai.koog.prompt.executor.model/StructureFixingParser? = ...): ai.koog.agents.core.agent.entity/ToolSelectionStrategy.AutoSelectForTask // ai.koog.agents.core.agent.entity/ToolSelectionStrategy.AutoSelectForTask.copy|copy(kotlin.String;ai.koog.prompt.executor.model.StructureFixingParser?){}[0]
+        final fun component3(): kotlin.collections/List<ai.koog.agents.core.tools/ToolDescriptor>? // ai.koog.agents.core.agent.entity/ToolSelectionStrategy.AutoSelectForTask.component3|component3(){}[0]
+        final fun copy(kotlin/String = ..., ai.koog.prompt.executor.model/StructureFixingParser? = ..., kotlin.collections/List<ai.koog.agents.core.tools/ToolDescriptor>? = ...): ai.koog.agents.core.agent.entity/ToolSelectionStrategy.AutoSelectForTask // ai.koog.agents.core.agent.entity/ToolSelectionStrategy.AutoSelectForTask.copy|copy(kotlin.String;ai.koog.prompt.executor.model.StructureFixingParser?;kotlin.collections.List<ai.koog.agents.core.tools.ToolDescriptor>?){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // ai.koog.agents.core.agent.entity/ToolSelectionStrategy.AutoSelectForTask.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // ai.koog.agents.core.agent.entity/ToolSelectionStrategy.AutoSelectForTask.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // ai.koog.agents.core.agent.entity/ToolSelectionStrategy.AutoSelectForTask.toString|toString(){}[0]

--- a/agents/agents-core/api/android/agents-core.api
+++ b/agents/agents-core/api/android/agents-core.api
@@ -1307,15 +1307,17 @@ public final class ai/koog/agents/core/agent/entity/ToolSelectionStrategy$ALL : 
 }
 
 public final class ai/koog/agents/core/agent/entity/ToolSelectionStrategy$AutoSelectForTask : ai/koog/agents/core/agent/entity/ToolSelectionStrategy {
-	public fun <init> (Ljava/lang/String;Lai/koog/prompt/executor/model/StructureFixingParser;)V
-	public synthetic fun <init> (Ljava/lang/String;Lai/koog/prompt/executor/model/StructureFixingParser;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lai/koog/prompt/executor/model/StructureFixingParser;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Lai/koog/prompt/executor/model/StructureFixingParser;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lai/koog/prompt/executor/model/StructureFixingParser;
-	public final fun copy (Ljava/lang/String;Lai/koog/prompt/executor/model/StructureFixingParser;)Lai/koog/agents/core/agent/entity/ToolSelectionStrategy$AutoSelectForTask;
-	public static synthetic fun copy$default (Lai/koog/agents/core/agent/entity/ToolSelectionStrategy$AutoSelectForTask;Ljava/lang/String;Lai/koog/prompt/executor/model/StructureFixingParser;ILjava/lang/Object;)Lai/koog/agents/core/agent/entity/ToolSelectionStrategy$AutoSelectForTask;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Lai/koog/prompt/executor/model/StructureFixingParser;Ljava/util/List;)Lai/koog/agents/core/agent/entity/ToolSelectionStrategy$AutoSelectForTask;
+	public static synthetic fun copy$default (Lai/koog/agents/core/agent/entity/ToolSelectionStrategy$AutoSelectForTask;Ljava/lang/String;Lai/koog/prompt/executor/model/StructureFixingParser;Ljava/util/List;ILjava/lang/Object;)Lai/koog/agents/core/agent/entity/ToolSelectionStrategy$AutoSelectForTask;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFixingParser ()Lai/koog/prompt/executor/model/StructureFixingParser;
 	public final fun getSubtaskDescription ()Ljava/lang/String;
+	public final fun getTools ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/agents/agents-core/api/jvm/agents-core.api
+++ b/agents/agents-core/api/jvm/agents-core.api
@@ -1307,15 +1307,17 @@ public final class ai/koog/agents/core/agent/entity/ToolSelectionStrategy$ALL : 
 }
 
 public final class ai/koog/agents/core/agent/entity/ToolSelectionStrategy$AutoSelectForTask : ai/koog/agents/core/agent/entity/ToolSelectionStrategy {
-	public fun <init> (Ljava/lang/String;Lai/koog/prompt/executor/model/StructureFixingParser;)V
-	public synthetic fun <init> (Ljava/lang/String;Lai/koog/prompt/executor/model/StructureFixingParser;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lai/koog/prompt/executor/model/StructureFixingParser;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Lai/koog/prompt/executor/model/StructureFixingParser;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lai/koog/prompt/executor/model/StructureFixingParser;
-	public final fun copy (Ljava/lang/String;Lai/koog/prompt/executor/model/StructureFixingParser;)Lai/koog/agents/core/agent/entity/ToolSelectionStrategy$AutoSelectForTask;
-	public static synthetic fun copy$default (Lai/koog/agents/core/agent/entity/ToolSelectionStrategy$AutoSelectForTask;Ljava/lang/String;Lai/koog/prompt/executor/model/StructureFixingParser;ILjava/lang/Object;)Lai/koog/agents/core/agent/entity/ToolSelectionStrategy$AutoSelectForTask;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Lai/koog/prompt/executor/model/StructureFixingParser;Ljava/util/List;)Lai/koog/agents/core/agent/entity/ToolSelectionStrategy$AutoSelectForTask;
+	public static synthetic fun copy$default (Lai/koog/agents/core/agent/entity/ToolSelectionStrategy$AutoSelectForTask;Ljava/lang/String;Lai/koog/prompt/executor/model/StructureFixingParser;Ljava/util/List;ILjava/lang/Object;)Lai/koog/agents/core/agent/entity/ToolSelectionStrategy$AutoSelectForTask;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFixingParser ()Lai/koog/prompt/executor/model/StructureFixingParser;
 	public final fun getSubtaskDescription ()Ljava/lang/String;
+	public final fun getTools ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentSubgraph.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/entity/AIAgentSubgraph.kt
@@ -120,12 +120,13 @@ public open class AIAgentSubgraphBase<TInput, TOutput>(
         is ToolSelectionStrategy.Tools -> toolSelectionStrategy.tools
         is ToolSelectionStrategy.AutoSelectForTask -> context.llm.writeSession {
             val initialPrompt = prompt
+            val possibleTools = toolSelectionStrategy.tools ?: tools
 
             replaceHistoryWithTLDR()
 
             appendPrompt {
                 user {
-                    selectRelevantTools(tools, toolSelectionStrategy.subtaskDescription)
+                    selectRelevantTools(possibleTools, toolSelectionStrategy.subtaskDescription)
                 }
             }
 
@@ -134,7 +135,10 @@ public open class AIAgentSubgraphBase<TInput, TOutput>(
                     default = StructuredRequest.Manual(
                         JsonStructure.create<SelectedTools>(
                             schemaGenerator = StandardJsonSchemaGenerator,
-                            examples = listOf(SelectedTools(listOf()), SelectedTools(tools.map { it.name }.take(3))),
+                            examples = listOf(
+                                SelectedTools(listOf()),
+                                SelectedTools(possibleTools.map { it.name }.take(3))
+                            ),
                         ),
                     ),
                 ),
@@ -442,10 +446,12 @@ public sealed interface ToolSelectionStrategy {
      *
      * @property subtaskDescription A description of the subtask for which the relevant tools should be selected.
      * @property fixingParser Optional [StructureFixingParser] to attempt fixes when a malformed structured response with a tool list is received.
+     * @property tools Optional collection of `ToolDescriptor` to limit selection to.
      */
     public data class AutoSelectForTask(
         val subtaskDescription: String,
-        val fixingParser: StructureFixingParser? = null
+        val fixingParser: StructureFixingParser? = null,
+        val tools: List<ToolDescriptor>? = null
     ) : ToolSelectionStrategy
 
     /**


### PR DESCRIPTION
<!--
PR title should follow Conventional Commits format:
  type(scope): description

For breaking changes, append ! after type/scope:
  type(scope)!: description

Examples:
  feat(agents): add streaming response node
  fix(prompt): handle null responses in PromptExecutor
  refactor(agents)!: remove deprecated methods from Tool

See CONTRIBUTING.md for more details
-->

This adds the option of limiting the visible tools to the LLM when using the AutoSelectForTask ToolSelectionStrategy.


<!-- Include references to related issues below, e.g., closes #1, closes KG-1. Otherwise, delete it. -->
closes [KG-863](https://youtrack.jetbrains.com/issue/KG-863) Allow tool subset selection with AutoSelectForTask