### PR TITLE
feat(agents): Carry strategy input on StrategyStartingContext

### DIFF
--- a/agents/agents-core/api/agents-core.klib.api
+++ b/agents/agents-core/api/agents-core.klib.api
@@ -2682,7 +2682,7 @@ final class ai.koog.agents.core.feature.handler.strategy/StrategyCompletedContex
 }
 
 final class ai.koog.agents.core.feature.handler.strategy/StrategyStartingContext : ai.koog.agents.core.feature.handler.strategy/StrategyEventContext { // ai.koog.agents.core.feature.handler.strategy/StrategyStartingContext|null[0]
-    constructor <init>(kotlin/String, ai.koog.agents.core.agent.execution/AgentExecutionInfo, ai.koog.agents.core.agent.context/AIAgentContext, ai.koog.agents.core.agent.entity/AIAgentStrategy<*, *, *>) // ai.koog.agents.core.feature.handler.strategy/StrategyStartingContext.<init>|<init>(kotlin.String;ai.koog.agents.core.agent.execution.AgentExecutionInfo;ai.koog.agents.core.agent.context.AIAgentContext;ai.koog.agents.core.agent.entity.AIAgentStrategy<*,*,*>){}[0]
+    constructor <init>(kotlin/String, ai.koog.agents.core.agent.execution/AgentExecutionInfo, ai.koog.agents.core.agent.context/AIAgentContext, ai.koog.agents.core.agent.entity/AIAgentStrategy<*, *, *>, kotlin/Any?) // ai.koog.agents.core.feature.handler.strategy/StrategyStartingContext.<init>|<init>(kotlin.String;ai.koog.agents.core.agent.execution.AgentExecutionInfo;ai.koog.agents.core.agent.context.AIAgentContext;ai.koog.agents.core.agent.entity.AIAgentStrategy<*,*,*>;kotlin.Any?){}[0]
 
     final val context // ai.koog.agents.core.feature.handler.strategy/StrategyStartingContext.context|{}context[0]
         final fun <get-context>(): ai.koog.agents.core.agent.context/AIAgentContext // ai.koog.agents.core.feature.handler.strategy/StrategyStartingContext.context.<get-context>|<get-context>(){}[0]
@@ -2692,6 +2692,8 @@ final class ai.koog.agents.core.feature.handler.strategy/StrategyStartingContext
         final fun <get-eventType>(): ai.koog.agents.core.feature.handler/AgentLifecycleEventType // ai.koog.agents.core.feature.handler.strategy/StrategyStartingContext.eventType.<get-eventType>|<get-eventType>(){}[0]
     final val executionInfo // ai.koog.agents.core.feature.handler.strategy/StrategyStartingContext.executionInfo|{}executionInfo[0]
         final fun <get-executionInfo>(): ai.koog.agents.core.agent.execution/AgentExecutionInfo // ai.koog.agents.core.feature.handler.strategy/StrategyStartingContext.executionInfo.<get-executionInfo>|<get-executionInfo>(){}[0]
+    final val input // ai.koog.agents.core.feature.handler.strategy/StrategyStartingContext.input|{}input[0]
+        final fun <get-input>(): kotlin/Any? // ai.koog.agents.core.feature.handler.strategy/StrategyStartingContext.input.<get-input>|<get-input>(){}[0]
     final val strategy // ai.koog.agents.core.feature.handler.strategy/StrategyStartingContext.strategy|{}strategy[0]
         final fun <get-strategy>(): ai.koog.agents.core.agent.entity/AIAgentStrategy<*, *, *> // ai.koog.agents.core.feature.handler.strategy/StrategyStartingContext.strategy.<get-strategy>|<get-strategy>(){}[0]
 }

--- a/agents/agents-core/api/android/agents-core.api
+++ b/agents/agents-core/api/android/agents-core.api
@@ -2970,11 +2970,12 @@ public abstract interface class ai/koog/agents/core/feature/handler/strategy/Str
 }
 
 public final class ai/koog/agents/core/feature/handler/strategy/StrategyStartingContext : ai/koog/agents/core/feature/handler/strategy/StrategyEventContext {
-	public fun <init> (Ljava/lang/String;Lai/koog/agents/core/agent/execution/AgentExecutionInfo;Lai/koog/agents/core/agent/context/AIAgentContext;Lai/koog/agents/core/agent/entity/AIAgentStrategy;)V
+	public fun <init> (Ljava/lang/String;Lai/koog/agents/core/agent/execution/AgentExecutionInfo;Lai/koog/agents/core/agent/context/AIAgentContext;Lai/koog/agents/core/agent/entity/AIAgentStrategy;Ljava/lang/Object;)V
 	public fun getContext ()Lai/koog/agents/core/agent/context/AIAgentContext;
 	public fun getEventId ()Ljava/lang/String;
 	public fun getEventType ()Lai/koog/agents/core/feature/handler/AgentLifecycleEventType;
 	public fun getExecutionInfo ()Lai/koog/agents/core/agent/execution/AgentExecutionInfo;
+	public final fun getInput ()Ljava/lang/Object;
 	public fun getStrategy ()Lai/koog/agents/core/agent/entity/AIAgentStrategy;
 }
 

--- a/agents/agents-core/api/jvm/agents-core.api
+++ b/agents/agents-core/api/jvm/agents-core.api
@@ -2970,11 +2970,12 @@ public abstract interface class ai/koog/agents/core/feature/handler/strategy/Str
 }
 
 public final class ai/koog/agents/core/feature/handler/strategy/StrategyStartingContext : ai/koog/agents/core/feature/handler/strategy/StrategyEventContext {
-	public fun <init> (Ljava/lang/String;Lai/koog/agents/core/agent/execution/AgentExecutionInfo;Lai/koog/agents/core/agent/context/AIAgentContext;Lai/koog/agents/core/agent/entity/AIAgentStrategy;)V
+	public fun <init> (Ljava/lang/String;Lai/koog/agents/core/agent/execution/AgentExecutionInfo;Lai/koog/agents/core/agent/context/AIAgentContext;Lai/koog/agents/core/agent/entity/AIAgentStrategy;Ljava/lang/Object;)V
 	public fun getContext ()Lai/koog/agents/core/agent/context/AIAgentContext;
 	public fun getEventId ()Ljava/lang/String;
 	public fun getEventType ()Lai/koog/agents/core/feature/handler/AgentLifecycleEventType;
 	public fun getExecutionInfo ()Lai/koog/agents/core/agent/execution/AgentExecutionInfo;
+	public final fun getInput ()Ljava/lang/Object;
 	public fun getStrategy ()Lai/koog/agents/core/agent/entity/AIAgentStrategy;
 }
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentRunSessionImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentRunSessionImpl.kt
@@ -83,7 +83,7 @@ internal class AIAgentRunSessionImpl<Input, Output, TContext : AIAgentContext>(
                             state = AIAgentState.Running(context.parentContext ?: context)
 
                             @OptIn(InternalAgentsApi::class)
-                            context.pipeline.onStrategyStarting(eventId, executionInfo, context, strategy)
+                            context.pipeline.onStrategyStarting(eventId, executionInfo, context, strategy, input)
 
                             val result = strategy.execute(context = context, input = input)
 

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/strategy/StrategyEventContext.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/handler/strategy/StrategyEventContext.kt
@@ -26,12 +26,16 @@ public interface StrategyEventContext : AgentLifecycleEventContext {
 
 /**
  * Represents the context for updating AI agent strategies during execution.
+ *
+ * @property input The input passed to [strategy]. Typed as `Any?` because [AIAgentStrategy] does not
+ * yet carry its input type (mirrors the same convention used by [StrategyCompletedContext.result]).
  */
 public class StrategyStartingContext(
     override val eventId: String,
     override val executionInfo: AgentExecutionInfo,
     override val context: AIAgentContext,
     override val strategy: AIAgentStrategy<*, *, *>,
+    public val input: Any?,
 ) : StrategyEventContext {
     override val eventType: AgentLifecycleEventType = AgentLifecycleEventType.StrategyStarting
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipeline.kt
@@ -217,6 +217,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
      * @param executionInfo The execution information for the strategy event
      * @param context The context of the strategy execution
      * @param strategy The strategy that has started execution
+     * @param input The input passed to the strategy
      */
     @InternalAgentsApi
     public override suspend fun onStrategyStarting(
@@ -224,6 +225,7 @@ public expect abstract class AIAgentPipeline(agentConfig: AIAgentConfig, clock: 
         executionInfo: AgentExecutionInfo,
         context: AIAgentContext,
         strategy: AIAgentStrategy<*, *, *>,
+        input: Any?,
     )
 
     /**

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineAPI.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineAPI.kt
@@ -120,6 +120,7 @@ public interface AIAgentPipelineAPI {
         executionInfo: AgentExecutionInfo,
         context: AIAgentContext,
         strategy: AIAgentStrategy<*, *, *>,
+        input: Any?,
     )
 
     @InternalAgentsApi

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineImpl.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/feature/pipeline/AIAgentPipelineImpl.kt
@@ -247,10 +247,11 @@ public class AIAgentPipelineImpl(
         executionInfo: AgentExecutionInfo,
         context: AIAgentContext,
         strategy: AIAgentStrategy<*, *, *>,
+        input: Any?,
     ) {
         invokeRegisteredHandlersForEvent(
             eventType = AgentLifecycleEventType.StrategyStarting,
-            context = StrategyStartingContext(eventId, executionInfo, context, strategy)
+            context = StrategyStartingContext(eventId, executionInfo, context, strategy, input)
         )
     }
 


### PR DESCRIPTION
**Strategy input on `StrategyStartingContext`:**
- Added `input: Any?` field to `StrategyStartingContext` (mirrors the `result: Any?` field  already on `StrategyCompletedContext`).
- Use case: sometimes it is useful to hook into the agent's execution and perform an action that depends on the user's query at runtime, e.g. retrieve relevant memories from a dedicated collection and inject them into the prompt before the strategy starts. Without the input on the starting event there was no way for a feature to see what the agent had been invoked with.