### PR TITLE
fix(prompt): coerce stringified tool call arguments

### DIFF
--- a/prompt/prompt-processor/Module.md
+++ b/prompt/prompt-processor/Module.md
@@ -15,6 +15,8 @@ Key components:
 - **ManualToolCallFixProcessor**: A processor that fixes invalid tool call JSONs, handling incorrect keys and missing escapes.
 - **LLMBasedToolCallFixProcessor**: An advanced processor that uses the LLM itself to iteratively fix incorrectly generated tool
   calls.
+- **ToolCallArgumentCoercionProcessor**: A processor that parses stringified object and array tool call arguments back into
+  the JSON shapes declared by the tool descriptors, leaving unknown and primitive values untouched.
 
 ### Example of usage
 
@@ -47,6 +49,23 @@ val processor2 = LLMBasedToolCallFixProcessor(toolRegistry)
 
 val chainedProcessor = processor1 + processor2
 val responses = executor.executeProcessed(prompt, model, tools, chainedProcessor)
+```
+
+Coercing stringified structured tool call arguments with `ToolCallArgumentCoercionProcessor`
+
+```kotlin
+val processor =
+    ManualToolCallFixProcessor(toolRegistry) +
+        ToolCallArgumentCoercionProcessor()
+```
+
+Using `ToolCallArgumentCoercionProcessor` as part of the `LLMBasedToolCallFixProcessor` preprocessor
+
+```kotlin
+val processor = LLMBasedToolCallFixProcessor(
+    toolRegistry = toolRegistry,
+    preprocessor = ManualToolCallFixProcessor(toolRegistry) + ToolCallArgumentCoercionProcessor()
+)
 ```
 
 Using processor with an agent

--- a/prompt/prompt-processor/api/android/prompt-processor.api
+++ b/prompt/prompt-processor/api/android/prompt-processor.api
@@ -41,6 +41,13 @@ public final class ai/koog/prompt/processor/ResponseProcessorConfig {
 	public final fun getSerializer ()Lai/koog/serialization/JSONSerializer;
 }
 
+public final class ai/koog/prompt/processor/ToolCallArgumentCoercionProcessor : ai/koog/prompt/processor/ResponseProcessor {
+	public fun <init> ()V
+	public fun <init> (Lkotlinx/serialization/json/Json;)V
+	public synthetic fun <init> (Lkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun process (Lai/koog/prompt/executor/model/PromptExecutor;Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;Ljava/util/List;Lai/koog/prompt/message/Message$Assistant;Lai/koog/serialization/JSONSerializer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class ai/koog/prompt/processor/ToolCallJsonConfig {
 	public static final field Companion Lai/koog/prompt/processor/ToolCallJsonConfig$Companion;
 	public fun <init> ()V

--- a/prompt/prompt-processor/api/jvm/prompt-processor.api
+++ b/prompt/prompt-processor/api/jvm/prompt-processor.api
@@ -41,6 +41,13 @@ public final class ai/koog/prompt/processor/ResponseProcessorConfig {
 	public final fun getSerializer ()Lai/koog/serialization/JSONSerializer;
 }
 
+public final class ai/koog/prompt/processor/ToolCallArgumentCoercionProcessor : ai/koog/prompt/processor/ResponseProcessor {
+	public fun <init> ()V
+	public fun <init> (Lkotlinx/serialization/json/Json;)V
+	public synthetic fun <init> (Lkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun process (Lai/koog/prompt/executor/model/PromptExecutor;Lai/koog/prompt/Prompt;Lai/koog/prompt/llm/LLModel;Ljava/util/List;Lai/koog/prompt/message/Message$Assistant;Lai/koog/serialization/JSONSerializer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class ai/koog/prompt/processor/ToolCallJsonConfig {
 	public static final field Companion Lai/koog/prompt/processor/ToolCallJsonConfig$Companion;
 	public fun <init> ()V

--- a/prompt/prompt-processor/api/prompt-processor.klib.api
+++ b/prompt/prompt-processor/api/prompt-processor.klib.api
@@ -88,6 +88,12 @@ final class ai.koog.prompt.processor/ResponseProcessorConfig { // ai.koog.prompt
         final fun <get-serializer>(): ai.koog.serialization/JSONSerializer // ai.koog.prompt.processor/ResponseProcessorConfig.serializer.<get-serializer>|<get-serializer>(){}[0]
 }
 
+final class ai.koog.prompt.processor/ToolCallArgumentCoercionProcessor : ai.koog.prompt.processor/ResponseProcessor { // ai.koog.prompt.processor/ToolCallArgumentCoercionProcessor|null[0]
+    constructor <init>(kotlinx.serialization.json/Json = ...) // ai.koog.prompt.processor/ToolCallArgumentCoercionProcessor.<init>|<init>(kotlinx.serialization.json.Json){}[0]
+
+    final suspend fun process(ai.koog.prompt.executor.model/PromptExecutor, ai.koog.prompt/Prompt, ai.koog.prompt.llm/LLModel, kotlin.collections/List<ai.koog.agents.core.tools/ToolDescriptor>, ai.koog.prompt.message/Message.Assistant, ai.koog.serialization/JSONSerializer): ai.koog.prompt.message/Message.Assistant // ai.koog.prompt.processor/ToolCallArgumentCoercionProcessor.process|process(ai.koog.prompt.executor.model.PromptExecutor;ai.koog.prompt.Prompt;ai.koog.prompt.llm.LLModel;kotlin.collections.List<ai.koog.agents.core.tools.ToolDescriptor>;ai.koog.prompt.message.Message.Assistant;ai.koog.serialization.JSONSerializer){}[0]
+}
+
 final class ai.koog.prompt.processor/ToolCallJsonConfig { // ai.koog.prompt.processor/ToolCallJsonConfig|null[0]
     constructor <init>(kotlinx.serialization.json/Json = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<kotlin/String> = ...) // ai.koog.prompt.processor/ToolCallJsonConfig.<init>|<init>(kotlinx.serialization.json.Json;kotlin.collections.List<kotlin.String>;kotlin.collections.List<kotlin.String>;kotlin.collections.List<kotlin.String>){}[0]
 

--- a/prompt/prompt-processor/src/commonMain/kotlin/ai/koog/prompt/processor/ToolCallArgumentCoercionProcessor.kt
+++ b/prompt/prompt-processor/src/commonMain/kotlin/ai/koog/prompt/processor/ToolCallArgumentCoercionProcessor.kt
@@ -1,0 +1,172 @@
+package ai.koog.prompt.processor
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolParameterType
+import ai.koog.prompt.Prompt
+import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.MessagePart
+import ai.koog.serialization.JSONSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.longOrNull
+import kotlin.jvm.JvmOverloads
+
+/**
+ * A response processor that coerces stringified structured tool call arguments into their declared JSON shapes.
+ *
+ * LLMs sometimes emit an argument whose schema declares an object or an array as a JSON-encoded string instead,
+ * e.g. `{"target": "{\"type\":\"path\"}"}` rather than `{"target": {"type": "path"}}`. Tools that validate their
+ * input strictly (for example, tools served by MCP servers) reject such calls.
+ *
+ * This processor inspects [MessagePart.Tool.Call] parts of an LLM response before tool execution and, guided by
+ * the [ToolDescriptor]s available for the current LLM call, parses such stringified values back into the shape
+ * declared by the matching tool parameter:
+ *
+ * - [ToolParameterType.Object]: a string value is parsed only if it yields a JSON object. Declared properties are
+ *   coerced recursively; keys not declared in the descriptor are coerced only when the descriptor allows
+ *   additional properties and declares their type, and are preserved otherwise.
+ * - [ToolParameterType.List]: a string value is parsed only if it yields a JSON array. Items are coerced recursively.
+ * - [ToolParameterType.AnyOf]: the first candidate whose shape is compatible with the actual (or parsed) value is
+ *   used. If the original string value is itself a valid candidate, it is preserved.
+ * - Primitive-like types ([ToolParameterType.String], [ToolParameterType.Integer], [ToolParameterType.Float],
+ *   [ToolParameterType.Boolean], [ToolParameterType.Enum], [ToolParameterType.Null]) are never modified.
+ *
+ * The processor is fail-soft by design: unknown tools, unknown argument keys, malformed tool call arguments,
+ * parse failures, and shape mismatches all leave the original value untouched. Recursion is bounded; values
+ * nested deeper than 8 levels are preserved as-is. Final argument validation remains the responsibility of
+ * whatever executes the tool call, so this processor normalizes shapes as a post-processing step instead of
+ * silently rewriting arguments at tool execution time.
+ *
+ * Typical usage chains it after [ManualToolCallFixProcessor], which normalizes malformed responses into
+ * [MessagePart.Tool.Call] parts first:
+ *
+ * ```kotlin
+ * val processor = ManualToolCallFixProcessor(toolRegistry) + ToolCallArgumentCoercionProcessor()
+ * ```
+ *
+ * @param json The json parser used to parse stringified argument values
+ */
+public class ToolCallArgumentCoercionProcessor @JvmOverloads constructor(
+    private val json: Json = ToolCallJsonConfig.defaultJson,
+) : ResponseProcessor() {
+
+    private companion object {
+        private const val MAX_DEPTH = 8
+    }
+
+    override suspend fun process(
+        executor: PromptExecutor,
+        prompt: Prompt,
+        model: LLModel,
+        tools: List<ToolDescriptor>,
+        response: Message.Assistant,
+        serializer: JSONSerializer,
+    ): Message.Assistant {
+        val descriptorsByName = tools.associateBy { it.name }
+        return Message.Assistant(
+            parts = response.parts.map { part ->
+                when (part) {
+                    is MessagePart.Tool.Call -> coerceToolCall(part, descriptorsByName[part.tool])
+                    else -> part
+                }
+            },
+            finishReason = response.finishReason,
+            metaInfo = response.metaInfo
+        )
+    }
+
+    private fun coerceToolCall(part: MessagePart.Tool.Call, descriptor: ToolDescriptor?): MessagePart.Tool.Call {
+        if (descriptor == null) return part
+
+        val args = runCatching { part.argsJson }.getOrNull() ?: return part
+        val paramsByName = (descriptor.requiredParameters + descriptor.optionalParameters).associateBy { it.name }
+
+        val coercedArgs = buildJsonObject {
+            for ((key, value) in args) {
+                val parameter = paramsByName[key]
+                put(key, if (parameter != null) coerceValue(value, parameter.type, depth = 1) else value)
+            }
+        }
+
+        return if (coercedArgs == args) {
+            part
+        } else {
+            MessagePart.Tool.Call(id = part.id, tool = part.tool, args = coercedArgs)
+        }
+    }
+
+    private fun coerceValue(value: JsonElement, type: ToolParameterType, depth: Int): JsonElement {
+        if (depth > MAX_DEPTH) return value
+        return when (type) {
+            is ToolParameterType.Object -> coerceObject(value, type, depth)
+            is ToolParameterType.List -> coerceList(value, type, depth)
+            is ToolParameterType.AnyOf -> coerceAnyOf(value, type, depth)
+            else -> value
+        }
+    }
+
+    private fun coerceObject(value: JsonElement, type: ToolParameterType.Object, depth: Int): JsonElement {
+        val obj = value as? JsonObject
+            ?: parseStringValueOrNull(value) as? JsonObject
+            ?: return value
+
+        val propertiesByName = type.properties.associateBy { it.name }
+        val additionalPropertiesType = type.additionalPropertiesType.takeIf { type.additionalProperties == true }
+
+        return buildJsonObject {
+            for ((key, child) in obj) {
+                val childType = propertiesByName[key]?.type ?: additionalPropertiesType
+                put(key, if (childType != null) coerceValue(child, childType, depth + 1) else child)
+            }
+        }
+    }
+
+    private fun coerceList(value: JsonElement, type: ToolParameterType.List, depth: Int): JsonElement {
+        val array = value as? JsonArray
+            ?: parseStringValueOrNull(value) as? JsonArray
+            ?: return value
+
+        return JsonArray(array.map { coerceValue(it, type.itemsType, depth + 1) })
+    }
+
+    private fun coerceAnyOf(value: JsonElement, type: ToolParameterType.AnyOf, depth: Int): JsonElement {
+        val directCandidate = type.types.firstOrNull { isShapeCompatible(value, it.type) }
+        if (directCandidate != null) return coerceValue(value, directCandidate.type, depth)
+
+        val parsed = parseStringValueOrNull(value) ?: return value
+        val parsedCandidate = type.types.firstOrNull { isShapeCompatible(parsed, it.type) } ?: return value
+        return coerceValue(parsed, parsedCandidate.type, depth)
+    }
+
+    /**
+     * Parses a string-primitive [value] into a structured json element.
+     * Returns null for non-string values, parse failures, and values that do not parse into an object or an array,
+     * so callers fall back to the original value.
+     */
+    private fun parseStringValueOrNull(value: JsonElement): JsonElement? {
+        if (value !is JsonPrimitive || !value.isString) return null
+        val parsed = runCatching { json.parseToJsonElement(value.content) }.getOrNull() ?: return null
+        return parsed.takeIf { it is JsonObject || it is JsonArray }
+    }
+
+    private fun isShapeCompatible(value: JsonElement, type: ToolParameterType): Boolean = when (type) {
+        is ToolParameterType.Object -> value is JsonObject
+        is ToolParameterType.List -> value is JsonArray
+        is ToolParameterType.AnyOf -> type.types.any { isShapeCompatible(value, it.type) }
+        is ToolParameterType.Enum -> value is JsonPrimitive && value.isString
+        ToolParameterType.String -> value is JsonPrimitive && value.isString
+        ToolParameterType.Null -> value is JsonNull
+        ToolParameterType.Boolean -> value is JsonPrimitive && !value.isString && value.booleanOrNull != null
+        ToolParameterType.Integer -> value is JsonPrimitive && !value.isString && value.longOrNull != null
+        ToolParameterType.Float -> value is JsonPrimitive && !value.isString && value.doubleOrNull != null
+    }
+}

--- a/prompt/prompt-processor/src/commonTest/kotlin/ai/koog/prompt/processor/ToolCallArgumentCoercionProcessorTest.kt
+++ b/prompt/prompt-processor/src/commonTest/kotlin/ai/koog/prompt/processor/ToolCallArgumentCoercionProcessorTest.kt
@@ -1,0 +1,441 @@
+package ai.koog.prompt.processor
+
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolParameterDescriptor
+import ai.koog.agents.core.tools.ToolParameterType
+import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.clients.openai.OpenAIModels
+import ai.koog.prompt.message.Message
+import ai.koog.prompt.message.MessagePart
+import ai.koog.prompt.message.ResponseMetaInfo
+import ai.koog.serialization.kotlinx.KotlinxSerializer
+import ai.koog.utils.time.KoogClock
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonObjectBuilder
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+class ToolCallArgumentCoercionProcessorTest {
+    private companion object {
+        private val serializer = KotlinxSerializer()
+
+        private val testClock: KoogClock = KoogClock { Instant.parse("2023-01-01T00:00:00Z") }
+
+        private val testMetaInfo = ResponseMetaInfo.create(testClock)
+
+        private val executor = getMockExecutor(serializer) { }
+        private val prompt = prompt("test-prompt") { }
+        private val model = OpenAIModels.Chat.GPT4o
+
+        private val processor = ToolCallArgumentCoercionProcessor()
+
+        private val innerObject = buildJsonObject { put("k", JsonPrimitive("v")) }
+        private val innerObjectString = innerObject.toString()
+
+        private val innerObjectType = ToolParameterType.Object(
+            properties = listOf(
+                ToolParameterDescriptor("k", "Some property", ToolParameterType.String)
+            )
+        )
+
+        private val objectTool = ToolDescriptor(
+            name = "object_tool",
+            description = "A tool with an object parameter",
+            requiredParameters = listOf(
+                ToolParameterDescriptor("payload", "Structured payload", innerObjectType)
+            ),
+            optionalParameters = listOf(
+                ToolParameterDescriptor("optional_payload", "Optional structured payload", innerObjectType)
+            )
+        )
+
+        private val listTool = ToolDescriptor(
+            name = "list_tool",
+            description = "A tool with a list parameter",
+            requiredParameters = listOf(
+                ToolParameterDescriptor("items", "List of strings", ToolParameterType.List(ToolParameterType.String))
+            )
+        )
+
+        private val nestedObjectTool = ToolDescriptor(
+            name = "nested_object_tool",
+            description = "A tool with a nested object parameter",
+            requiredParameters = listOf(
+                ToolParameterDescriptor(
+                    "outer",
+                    "Outer object",
+                    ToolParameterType.Object(
+                        properties = listOf(
+                            ToolParameterDescriptor("inner", "Inner object", innerObjectType)
+                        )
+                    )
+                )
+            )
+        )
+
+        private val anyOfTool = ToolDescriptor(
+            name = "any_of_tool",
+            description = "A tool with an anyOf parameter",
+            requiredParameters = listOf(
+                ToolParameterDescriptor(
+                    "target",
+                    "Write target",
+                    ToolParameterType.AnyOf(
+                        arrayOf(
+                            ToolParameterDescriptor(
+                                "path_target",
+                                "Path target",
+                                ToolParameterType.Object(
+                                    properties = listOf(
+                                        ToolParameterDescriptor(
+                                            "type",
+                                            "Target type",
+                                            ToolParameterType.Enum(arrayOf("path"))
+                                        ),
+                                        ToolParameterDescriptor("path", "Note path", ToolParameterType.String)
+                                    )
+                                )
+                            ),
+                            ToolParameterDescriptor(
+                                "active_target",
+                                "Active target",
+                                ToolParameterType.Object(
+                                    properties = listOf(
+                                        ToolParameterDescriptor(
+                                            "type",
+                                            "Target type",
+                                            ToolParameterType.Enum(arrayOf("active"))
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        private val anyOfWithStringTool = ToolDescriptor(
+            name = "any_of_with_string_tool",
+            description = "A tool with an anyOf parameter that accepts strings",
+            requiredParameters = listOf(
+                ToolParameterDescriptor(
+                    "value",
+                    "String or object value",
+                    ToolParameterType.AnyOf(
+                        arrayOf(
+                            ToolParameterDescriptor("string_value", "String value", ToolParameterType.String),
+                            ToolParameterDescriptor("object_value", "Object value", innerObjectType)
+                        )
+                    )
+                )
+            )
+        )
+
+        private val stringTool = ToolDescriptor(
+            name = "string_tool",
+            description = "A tool with a string parameter",
+            requiredParameters = listOf(
+                ToolParameterDescriptor("text", "Plain text", ToolParameterType.String)
+            )
+        )
+
+        private val openMapTool = ToolDescriptor(
+            name = "open_map_tool",
+            description = "A tool with an open object parameter",
+            requiredParameters = listOf(
+                ToolParameterDescriptor(
+                    "map",
+                    "Open map",
+                    ToolParameterType.Object(
+                        properties = emptyList(),
+                        additionalProperties = true,
+                        additionalPropertiesType = innerObjectType
+                    )
+                )
+            )
+        )
+
+        private val closedMapTool = ToolDescriptor(
+            name = "closed_map_tool",
+            description = "A tool with a closed object parameter",
+            requiredParameters = listOf(
+                ToolParameterDescriptor(
+                    "map",
+                    "Closed map",
+                    ToolParameterType.Object(
+                        properties = emptyList(),
+                        additionalProperties = false
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun test_shouldCoerceStringifiedObjectArgument() = runTest {
+        val message = toolCallMessage("object_tool") {
+            put("payload", JsonPrimitive(innerObjectString))
+        }
+
+        val result = process(listOf(objectTool), message)
+
+        val toolCall = result.parts.filterIsInstance<MessagePart.Tool.Call>().single()
+        assertEquals(buildJsonObject { put("payload", innerObject) }, toolCall.argsJson)
+        assertEquals("1", toolCall.id)
+        assertEquals(testMetaInfo, result.metaInfo)
+    }
+
+    @Test
+    fun test_shouldCoerceStringifiedOptionalParameter() = runTest {
+        val message = toolCallMessage("object_tool") {
+            put("payload", JsonPrimitive(innerObjectString))
+            put("optional_payload", JsonPrimitive(innerObjectString))
+        }
+
+        val result = process(listOf(objectTool), message)
+
+        val expected = buildJsonObject {
+            put("payload", innerObject)
+            put("optional_payload", innerObject)
+        }
+        assertEquals(expected, singleToolCall(result).argsJson)
+    }
+
+    @Test
+    fun test_shouldCoerceStringifiedListArgument() = runTest {
+        val stringifiedArray = buildJsonArray {
+            add(JsonPrimitive("a"))
+            add(JsonPrimitive("b"))
+        }
+
+        val message = toolCallMessage("list_tool") {
+            put("items", JsonPrimitive(stringifiedArray.toString()))
+        }
+
+        val result = process(listOf(listTool), message)
+
+        assertEquals(buildJsonObject { put("items", stringifiedArray) }, singleToolCall(result).argsJson)
+    }
+
+    @Test
+    fun test_shouldCoerceNestedStringifiedObjectProperty() = runTest {
+        val outerWithStringifiedInner = buildJsonObject { put("inner", JsonPrimitive(innerObjectString)) }
+
+        val message = toolCallMessage("nested_object_tool") {
+            put("outer", JsonPrimitive(outerWithStringifiedInner.toString()))
+        }
+
+        val result = process(listOf(nestedObjectTool), message)
+
+        val expected = buildJsonObject {
+            put("outer", buildJsonObject { put("inner", innerObject) })
+        }
+        assertEquals(expected, singleToolCall(result).argsJson)
+    }
+
+    @Test
+    fun test_shouldCoerceStringifiedAnyOfObjectCandidate() = runTest {
+        val target = buildJsonObject {
+            put("type", JsonPrimitive("path"))
+            put("path", JsonPrimitive("folder/note.md"))
+        }
+
+        val message = toolCallMessage("any_of_tool") {
+            put("target", JsonPrimitive(target.toString()))
+        }
+
+        val result = process(listOf(anyOfTool), message)
+
+        assertEquals(buildJsonObject { put("target", target) }, singleToolCall(result).argsJson)
+    }
+
+    @Test
+    fun test_shouldPreserveStringWhenAnyOfHasStringCandidate() = runTest {
+        val message = toolCallMessage("any_of_with_string_tool") {
+            put("value", JsonPrimitive(innerObjectString))
+        }
+
+        val result = process(listOf(anyOfWithStringTool), message)
+
+        assertEquals(message, result)
+    }
+
+    @Test
+    fun test_shouldPreserveStringParameter() = runTest {
+        val message = toolCallMessage("string_tool") {
+            put("text", JsonPrimitive(innerObjectString))
+        }
+
+        val result = process(listOf(stringTool), message)
+
+        assertEquals(message, result)
+    }
+
+    @Test
+    fun test_shouldPreserveValueOnParseFailure() = runTest {
+        val message = toolCallMessage("object_tool") {
+            put("payload", JsonPrimitive("not json"))
+        }
+
+        val result = process(listOf(objectTool), message)
+
+        assertEquals(message, result)
+    }
+
+    @Test
+    fun test_shouldPreserveValueOnShapeMismatch() = runTest {
+        val stringifiedArray = buildJsonArray { add(JsonPrimitive("a")) }.toString()
+
+        val message = toolCallMessage("object_tool") {
+            put("payload", JsonPrimitive(stringifiedArray))
+        }
+
+        val result = process(listOf(objectTool), message)
+
+        assertEquals(message, result)
+    }
+
+    @Test
+    fun test_shouldPreserveUnknownTool() = runTest {
+        val message = toolCallMessage("missing_tool") {
+            put("payload", JsonPrimitive(innerObjectString))
+        }
+
+        val result = process(listOf(objectTool), message)
+
+        assertEquals(message, result)
+    }
+
+    @Test
+    fun test_shouldPreserveUnknownArgumentKey() = runTest {
+        val message = toolCallMessage("object_tool") {
+            put("payload", JsonPrimitive(innerObjectString))
+            put("unknown", JsonPrimitive(innerObjectString))
+        }
+
+        val result = process(listOf(objectTool), message)
+
+        val expected = buildJsonObject {
+            put("payload", innerObject)
+            put("unknown", JsonPrimitive(innerObjectString))
+        }
+        assertEquals(expected, singleToolCall(result).argsJson)
+    }
+
+    @Test
+    fun test_shouldCoerceAdditionalPropertiesWithDeclaredType() = runTest {
+        val message = toolCallMessage("open_map_tool") {
+            put("map", buildJsonObject { put("extra", JsonPrimitive(innerObjectString)) })
+        }
+
+        val result = process(listOf(openMapTool), message)
+
+        val expected = buildJsonObject {
+            put("map", buildJsonObject { put("extra", innerObject) })
+        }
+        assertEquals(expected, singleToolCall(result).argsJson)
+    }
+
+    @Test
+    fun test_shouldPreserveAdditionalPropertiesWhenNotAllowed() = runTest {
+        val message = toolCallMessage("closed_map_tool") {
+            put("map", buildJsonObject { put("extra", JsonPrimitive(innerObjectString)) })
+        }
+
+        val result = process(listOf(closedMapTool), message)
+
+        assertEquals(message, result)
+    }
+
+    @Test
+    fun test_shouldStopCoercionPastDepthBoundary() = runTest {
+        // Descriptor side: o1 -> o2 -> ... -> o8 -> o9 -> {k: String}, each level a single object property.
+        var levelType: ToolParameterType = innerObjectType
+        for (i in 9 downTo 2) {
+            levelType = ToolParameterType.Object(
+                properties = listOf(ToolParameterDescriptor("o$i", "Level $i", levelType))
+            )
+        }
+        val deepTool = ToolDescriptor(
+            name = "deep_tool",
+            description = "A tool with a deeply nested object parameter",
+            requiredParameters = listOf(ToolParameterDescriptor("o1", "Level 1", levelType))
+        )
+
+        // Value side: real objects down to depth 7; the value at depth 8 is a stringified object whose
+        // "o9" property (depth 9) is itself a stringified object.
+        val depth8Object = buildJsonObject { put("o9", JsonPrimitive(innerObjectString)) }
+        var argValue: JsonElement = JsonPrimitive(depth8Object.toString())
+        for (i in 8 downTo 2) {
+            argValue = buildJsonObject { put("o$i", argValue) }
+        }
+
+        val message = toolCallMessage("deep_tool") { put("o1", argValue) }
+
+        val result = process(listOf(deepTool), message)
+
+        var expected: JsonElement = depth8Object
+        for (i in 8 downTo 2) {
+            expected = buildJsonObject { put("o$i", expected) }
+        }
+        val argsJson = singleToolCall(result).argsJson
+        assertEquals(buildJsonObject { put("o1", expected) }, argsJson)
+
+        var cursor: JsonElement = argsJson.getValue("o1")
+        for (i in 2..7) {
+            cursor = assertIs<JsonObject>(cursor).getValue("o$i")
+        }
+        val depth8Value = assertIs<JsonObject>(
+            assertIs<JsonObject>(cursor).getValue("o8"),
+            "value at depth 8 should be coerced into an object"
+        )
+        val depth9Value = depth8Value.getValue("o9")
+        assertTrue(
+            depth9Value is JsonPrimitive && depth9Value.isString,
+            "value at depth 9 should stay a stringified object"
+        )
+    }
+
+    @Test
+    fun test_shouldCoerceAfterManualToolCallFixProcessorInChain() = runTest {
+        val chainedProcessor = ManualToolCallFixProcessor(Tools.toolRegistry) + ToolCallArgumentCoercionProcessor()
+
+        val textToolCall = """
+            {
+                "tool": "object_tool",
+                "args": {"payload": "{\"k\":\"v\"}"}
+            }
+        """.trimIndent()
+        val message = Message.Assistant(textToolCall, metaInfo = testMetaInfo)
+
+        val result = chainedProcessor.process(executor, prompt, model, listOf(objectTool), message, serializer)
+
+        val toolCall = singleToolCall(result)
+        assertEquals("object_tool", toolCall.tool)
+        assertEquals(buildJsonObject { put("payload", innerObject) }, toolCall.argsJson)
+    }
+
+    private fun toolCallMessage(tool: String, buildArgs: JsonObjectBuilder.() -> Unit) =
+        Message.Assistant(
+            parts = listOf(
+                MessagePart.Tool.Call(id = "1", tool = tool, args = buildJsonObject(buildArgs))
+            ),
+            metaInfo = testMetaInfo
+        )
+
+    private fun singleToolCall(message: Message.Assistant) =
+        message.parts.filterIsInstance<MessagePart.Tool.Call>().single()
+
+    private suspend fun process(tools: List<ToolDescriptor>, response: Message.Assistant) =
+        processor.process(executor, prompt, model, tools, response, serializer)
+}


### PR DESCRIPTION
Adds an opt-in `ToolCallArgumentCoercionProcessor` to `prompt-processor`.

The processor runs before tool execution and uses the `ToolDescriptor`s available for the current LLM call to parse JSON-encoded string values back into structured arguments when the descriptor declares an object or list shape. It also handles nested object/list values and `AnyOf` candidates, while leaving primitive parameters, unknown tools/arguments, parse failures, shape mismatches, and deeply nested values unchanged.

This keeps the runtime-side fix for #2017 out of `McpTool.execute()` and makes it composable with the existing response processors, for example after `ManualToolCallFixProcessor`.

Tests:
- `gradle :prompt:prompt-processor:compileKotlinMetadata :prompt:prompt-processor:jvmTest :prompt:prompt-processor:ktlintCheck --warning-mode=all`
- `gradle :prompt:prompt-processor:compileTestKotlinWasmJs --warning-mode=all`
- `gradle :prompt:prompt-processor:compileTestKotlinJs --warning-mode=all`

Refs #2017
