### PR TITLE
fix(prompt): preserve late streaming tool call ids

### DIFF
--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
@@ -199,10 +199,14 @@ public class StreamFrameFlowBuilder(
         val previous: PendingToolCall? = pendingToolCallRef.load()
         // `id` and `index` are optional per-chunk signals. A new tool call begins only when a
         // present signal differs from the pending call, not merely because `id` is non-null:
-        // some OpenAI-compatible providers send the same `id` on every chunk (see #2002).
+        // - some OpenAI-compatible providers send the same `id` on every chunk (see #2002);
+        // - some providers (e.g. DeepSeek) start a tool call with `id = null` and only reveal
+        //   the real id on a later chunk of the same `index` (see #2111). Such a late id fills
+        //   the pending call instead of starting a new one.
         val isNewToolCall =
-            (sanitizedId != null && sanitizedId != previous?.id) ||
-                (index != null && index != previous?.index)
+            (previous == null && (sanitizedId != null || index != null)) ||
+                (previous?.id != null && sanitizedId != null && sanitizedId != previous.id) ||
+                (previous != null && index != null && index != previous.index)
         val new: PendingToolCall = if (isNewToolCall) {
             tryEmitPendingToolCall()
             PendingToolCall(sanitizedId, name, args, index)
@@ -215,7 +219,7 @@ public class StreamFrameFlowBuilder(
                     throw StreamFrameFlowBuilderError.UnexpectedPartialToolCallIndex(previous.index, index)
 
                 else ->
-                    previous.appendArgumentsDelta(args)
+                    previous.appendDelta(sanitizedId, name, args, index)
             }
         }
         pendingToolCallRef.store(new)
@@ -271,11 +275,15 @@ public class StreamFrameFlowBuilder(
         val argumentsDelta: String?,
         val index: Int?,
     ) {
-        fun appendArgumentsDelta(argumentsDelta: String?): PendingToolCall {
+        fun appendDelta(id: String?, name: String?, argumentsDelta: String?, index: Int?): PendingToolCall {
             require(this.index == index)
             val newArgs =
                 if (argumentsDelta == null) this.argumentsDelta else (this.argumentsDelta ?: "") + argumentsDelta
-            return copy(argumentsDelta = newArgs)
+            return copy(
+                id = this.id ?: id,
+                name = this.name ?: name,
+                argumentsDelta = newArgs,
+            )
         }
     }
 

--- a/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderTest.kt
+++ b/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderTest.kt
@@ -281,6 +281,33 @@ class StreamFrameFlowBuilderTest {
         )
     }
 
+    /**
+     * Regression test for #2111.
+     *
+     * Some OpenAI-compatible providers (e.g. DeepSeek) start a streaming tool call with
+     * `id = null` and only reveal the real id on a later chunk of the same `index`. The late
+     * id must fill the pending call rather than start a new one, otherwise the tool call is
+     * completed with a null id and the provider later rejects the replayed `tool` message.
+     */
+    @Test
+    fun testEmitToolCallDeltaWithLateIdFillsPendingToolCall() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitToolCallDelta(id = null, name = "search", args = "{\"query\":", index = 0)
+            emitToolCallDelta(id = "call_1", name = null, args = "\"koog\"}", index = 0)
+            emitEnd()
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.ToolCallDelta(null, "search", "{\"query\":", 0),
+                StreamFrame.ToolCallDelta("call_1", null, "\"koog\"}", 0),
+                StreamFrame.ToolCallComplete("call_1", "search", "{\"query\":\"koog\"}", 0),
+                StreamFrame.End(null, ResponseMetaInfo.Empty)
+            ),
+            frames
+        )
+    }
+
     @Test
     fun testEmitToolCallDeltaWithoutPreviousCallThrowsError() = runTest {
         assertFailsWith<StreamFrameFlowBuilderError.NoPartialToolCallToComplete> {


### PR DESCRIPTION
## Summary
- preserve a late-arriving tool call id when it belongs to the current same-index streaming tool call
- add a regression test for null-id first chunks followed by provider ids

Refs #2111
