### PR TITLE
fix(agents): prioritize tool calls in single-run mixed responses

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentSimpleStrategies.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentSimpleStrategies.kt
@@ -35,6 +35,6 @@ public fun singleRunStrategy(parallelTools: Boolean = false): AIAgentGraphStrate
     edge(nodeCallLLM forwardTo nodeExecuteTool onToolCalls { true })
     edge(nodeCallLLM forwardTo nodeFinish onTextMessage { true })
     edge(nodeExecuteTool forwardTo nodeSendToolResult)
-    edge(nodeSendToolResult forwardTo nodeFinish onTextMessage { true })
     edge(nodeSendToolResult forwardTo nodeExecuteTool onToolCalls { true })
+    edge(nodeSendToolResult forwardTo nodeFinish onTextMessage { true })
 }

--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/SingleRunStrategyWithHistoryCompression.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/SingleRunStrategyWithHistoryCompression.kt
@@ -71,17 +71,17 @@ public fun singleRunStrategyWithHistoryCompression(
     edge(nodeExecuteTool forwardTo nodeSendToolResult onCondition { llm.readSession { !config.isHistoryTooBig(prompt) } })
     edge(nodeCompressHistory forwardTo nodeSendCompressedHistory)
 
+    edge(nodeSendToolResult forwardTo nodeExecuteTool onToolCalls { true })
+
     edge(
         nodeSendToolResult forwardTo nodeFinish
             onTextMessage { true }
     )
 
-    edge(nodeSendToolResult forwardTo nodeExecuteTool onToolCalls { true })
+    edge(nodeSendCompressedHistory forwardTo nodeExecuteTool onToolCalls { true })
 
     edge(
         nodeSendCompressedHistory forwardTo nodeFinish
             onTextMessage { true }
     )
-
-    edge(nodeSendCompressedHistory forwardTo nodeExecuteTool onToolCalls { true })
 }

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/SingleRunStrategyTests.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/SingleRunStrategyTests.kt
@@ -291,4 +291,52 @@ class SingleRunStrategyTests {
         assertEquals(3, actualToolCalls.size)
         assertEquals(assistantResponse, result)
     }
+
+    @Test
+    fun test_SingleRunStrategy_PostToolMixedResponseExecutesNextToolCall() = runTest {
+        val actualToolCalls = mutableListOf<String>()
+
+        val testToolRegistry = ToolRegistry {
+            tool(CreateTool)
+        }
+
+        val intermediateResponse = "Need another tool."
+        val finalResponse = "Task solved after second tool."
+        var postFirstToolResultHandled = false
+
+        val mockLLMApi = getMockExecutor(serializer) {
+            mockLLMToolCall(CreateTool, CreateTool.Args("first")) onRequestEquals "Solve task"
+            mockLLMMixedResponse(
+                toolCalls = listOf(CreateTool to CreateTool.Args("second")),
+                responses = listOf(intermediateResponse)
+            ) onCondition { request ->
+                if (request == "created" && !postFirstToolResultHandled) {
+                    postFirstToolResultHandled = true
+                    true
+                } else {
+                    false
+                }
+            }
+            mockLLMAnswer(finalResponse) onCondition { request ->
+                request == "created" && postFirstToolResultHandled
+            }
+            mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            mockLLMApi,
+            OllamaModels.Meta.LLAMA_3_2,
+            strategy = singleRunStrategy(),
+            toolRegistry = testToolRegistry
+        ) {
+            install(EventHandler) {
+                onToolCallStarting { eventContext -> actualToolCalls += eventContext.toolArgs.toString() }
+            }
+        }
+
+        val result = agent.run("Solve task", null)
+
+        assertEquals(listOf("""{"name":"first"}""", """{"name":"second"}"""), actualToolCalls)
+        assertEquals(finalResponse, result)
+    }
 }

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/SingleRunStrategyWithHistoryCompressionTests.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/SingleRunStrategyWithHistoryCompressionTests.kt
@@ -5,6 +5,7 @@ import ai.koog.agents.core.dsl.extension.HistoryCompressionStrategy
 import ai.koog.agents.core.tools.SimpleTool
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.agents.features.eventHandler.feature.EventHandler
 import ai.koog.agents.testing.tools.getMockExecutor
 import ai.koog.prompt.executor.ollama.client.OllamaModels
 import ai.koog.serialization.kotlinx.KotlinxSerializer
@@ -85,6 +86,54 @@ class SingleRunStrategyWithHistoryCompressionTests {
     }
 
     @Test
+    fun test_no_compression_post_tool_mixed_response_executes_next_tool_call() = runTest {
+        val actualToolCalls = mutableListOf<String>()
+        val config = HistoryCompressionConfig(
+            isHistoryTooBig = { it.messages.size > 100 },
+            compressionStrategy = HistoryCompressionStrategy.WholeHistory
+        )
+
+        val intermediateResponse = "Need another tool."
+        val finalResponse = "Task solved after second tool."
+        var postFirstToolResultHandled = false
+
+        val mockLLMApi = getMockExecutor(serializer) {
+            mockLLMToolCall(CreateTool, CreateTool.Args("first")) onRequestEquals "Solve task"
+            mockLLMMixedResponse(
+                toolCalls = listOf(CreateTool to CreateTool.Args("second")),
+                responses = listOf(intermediateResponse)
+            ) onCondition { request ->
+                if (request == "created" && !postFirstToolResultHandled) {
+                    postFirstToolResultHandled = true
+                    true
+                } else {
+                    false
+                }
+            }
+            mockLLMAnswer(finalResponse) onCondition { request ->
+                request == "created" && postFirstToolResultHandled
+            }
+            mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            mockLLMApi,
+            OllamaModels.Meta.LLAMA_3_2,
+            strategy = singleRunStrategyWithHistoryCompression(config),
+            toolRegistry = ToolRegistry { tool(CreateTool) }
+        ) {
+            install(EventHandler) {
+                onToolCallStarting { eventContext -> actualToolCalls += eventContext.toolArgs.toString() }
+            }
+        }
+
+        val result = agent.run("Solve task", null)
+
+        assertEquals(listOf("""{"name":"first"}""", """{"name":"second"}"""), actualToolCalls)
+        assertEquals(finalResponse, result)
+    }
+
+    @Test
     fun test_sequential_mode() = runTest {
         var compressionRequested = false
 
@@ -140,5 +189,63 @@ class SingleRunStrategyWithHistoryCompressionTests {
 
         agent.run("Solve task", null)
         assertTrue(compressionRequested)
+    }
+
+    @Test
+    fun test_compressed_history_mixed_response_executes_next_tool_call() = runTest {
+        val actualToolCalls = mutableListOf<String>()
+        val compressedHistoryResponse = "TLDR summary."
+        val intermediateResponse = "Need another tool after compression."
+        val finalResponse = "Task solved after compressed history tool."
+        var compressionFinished = false
+        var compressedHistoryResponseHandled = false
+
+        val config = HistoryCompressionConfig(
+            isHistoryTooBig = { !compressionFinished },
+            compressionStrategy = HistoryCompressionStrategy.WholeHistory
+        )
+
+        val mockLLMApi = getMockExecutor(serializer) {
+            mockLLMToolCall(CreateTool, CreateTool.Args("first")) onRequestEquals "Solve task"
+            mockLLMAnswer(compressedHistoryResponse) onCondition { request ->
+                if (request.contains("comprehensive summary")) {
+                    compressionFinished = true
+                    true
+                } else {
+                    false
+                }
+            }
+            mockLLMMixedResponse(
+                toolCalls = listOf(CreateTool to CreateTool.Args("second")),
+                responses = listOf(intermediateResponse)
+            ) onCondition { request ->
+                if (request.isEmpty() && compressionFinished && !compressedHistoryResponseHandled) {
+                    compressedHistoryResponseHandled = true
+                    true
+                } else {
+                    false
+                }
+            }
+            mockLLMAnswer(finalResponse) onCondition { request ->
+                request == "created" && compressedHistoryResponseHandled
+            }
+            mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            mockLLMApi,
+            OllamaModels.Meta.LLAMA_3_2,
+            strategy = singleRunStrategyWithHistoryCompression(config),
+            toolRegistry = ToolRegistry { tool(CreateTool) }
+        ) {
+            install(EventHandler) {
+                onToolCallStarting { eventContext -> actualToolCalls += eventContext.toolArgs.toString() }
+            }
+        }
+
+        val result = agent.run("Solve task", null)
+
+        assertEquals(listOf("""{"name":"first"}""", """{"name":"second"}"""), actualToolCalls)
+        assertEquals(finalResponse, result)
     }
 }


### PR DESCRIPTION
## Summary
- Prioritize tool-call edges over text/final edges in single-run post-tool responses.
- Apply the same fix to the single-run history-compression strategy for both post-tool and post-compression follow-up responses.
- Keep the change limited to the single-run strategy family; global edge resolution and chatAgentStrategy are unchanged.

Fixes #2127
