### PR TITLE
Add GitHub Copilot CLI support

### DIFF
--- a/agents/agents-cli/Module.md
+++ b/agents/agents-cli/Module.md
@@ -1,14 +1,14 @@
 # Module agents-cli
 
-Provides integration with external CLI-based AI agents (Claude Code, OpenAI Codex) by wrapping their command-line interfaces into the Koog agent framework.
+Provides integration with external CLI-based AI agents (Claude Code, OpenAI Codex, GitHub Copilot) by wrapping their command-line interfaces into the Koog agent framework.
 The main components are:
-- [**CliAIAgent**](src/commonMain/kotlin/ai/koog/agents/cli/CliAIAgent.kt): Factory for creating CLI-backed agents with `claude()` and `codex()` constructors
+- [**CliAIAgent**](src/commonMain/kotlin/ai/koog/agents/cli/CliAIAgent.kt): Factory for creating CLI-backed agents with `claude()`, `codex()`, and `copilot()` constructors
 - [**CliTransport**](src/commonMain/kotlin/ai/koog/agents/cli/transport/CliTransport.kt): Abstraction for executing CLI commands via local process or Docker
 - [**CliAIAgentResponse**](src/commonMain/kotlin/ai/koog/agents/cli/CliAIAgentResponse.kt): Response model containing content, error status, and token usage metadata
 
 ## Overview
 
-The `agents-cli` module allows you to use Claude Code and OpenAI Codex as agents within Koog workflows. Instead of communicating with LLMs through API calls, it invokes their CLI binaries and parses the output. Agents can run locally via `ProcessCliTransport` or inside Docker containers via `DockerCliTransport`.
+The `agents-cli` module allows you to use Claude Code, OpenAI Codex, and GitHub Copilot as agents within Koog workflows. Instead of communicating with LLMs through API calls, it invokes their CLI binaries and parses the output. Agents can run locally via `ProcessCliTransport` or inside Docker containers via `DockerCliTransport`.
 
 CLI agents can also be embedded as nodes in Koog graph-based strategies using `asNode()`, enabling multi-agent orchestration.
 
@@ -38,6 +38,20 @@ val agent = CliAIAgent.codex(
 )
 
 val response = agent.run("echo 'hello'")
+```
+
+### Basic Copilot Agent
+
+```kotlin
+val agent = CliAIAgent.copilot(
+    transport = CliTransport.default(),
+    githubToken = "your-github-token",
+    systemPrompt = "Respond with concise implementation guidance."
+)
+
+val response = agent.run("Generate a function that validates a UUID")
+println(response.content)
+println(response.isError) // false on success
 ```
 
 ### Structured Output

--- a/agents/agents-cli/src/commonMain/kotlin/ai/koog/agents/cli/CliAIAgent.kt
+++ b/agents/agents-cli/src/commonMain/kotlin/ai/koog/agents/cli/CliAIAgent.kt
@@ -3,6 +3,7 @@ package ai.koog.agents.cli
 import ai.koog.agents.cli.claude.ClaudeCliConfig
 import ai.koog.agents.cli.claude.ClaudeCliStructuredConfig
 import ai.koog.agents.cli.claude.ClaudePermissionMode
+import ai.koog.agents.cli.copilot.CopilotCliConfig
 import ai.koog.agents.cli.codex.CodexApprovalPolicy
 import ai.koog.agents.cli.codex.CodexCliConfig
 import ai.koog.agents.cli.codex.CodexSandboxMode
@@ -602,8 +603,118 @@ public class CliAIAgent<Input, Output> internal constructor(
         }
 
         /**
-         * Creates a new instance of [CliAIAgent] using provided configuration of the cli.
+         * Creates a new instance of [CliAIAgent] using GitHub Copilot CLI.
          *
+         * @param transport The transport used to execute cli commands.
+         * @param githubToken The GitHub token for Copilot CLI authentication.
+         * @param binaryPath The path to the binary.
+         * @param model The LLM model to use. If null, Copilot CLI default model is used.
+         * @param name The name of the cli strategy.
+         * @param systemPrompt The system prompt for the agent.
+         * @param llModel The LLM model to be used for the agent.
+         * @param additionalFlags Additional flags to be passed to copilot cli.
+         * @param workspace The workspace directory for the agent.
+         * @param timeout The timeout duration for the agent.
+         * @param id The unique identifier for the agent.
+         * @param clock The clock used to calculate message timestamps.
+         * @param installFeatures Lambda for installing additional features.
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun copilot(
+            transport: CliTransport,
+            githubToken: String? = null,
+            binaryPath: String? = null,
+            model: String? = null,
+            name: String? = null,
+            systemPrompt: String? = null,
+            llModel: LLModel? = null,
+            additionalFlags: List<String> = emptyList(),
+            workspace: String = ".",
+            timeout: Duration? = null,
+            id: String? = null,
+            clock: KoogClock = KoogClock.System,
+            installFeatures: FeatureContext.() -> Unit = {},
+        ): CliAIAgent<String, CliAIAgentResponse> = copilot(
+            transport = transport,
+            githubToken = githubToken,
+            binaryPath = binaryPath,
+            model = model,
+            name = name,
+            systemPrompt = systemPrompt,
+            llModel = llModel,
+            additionalFlags = additionalFlags,
+            workspace = workspace,
+            timeout = timeout,
+            id = id,
+            clock = clock,
+            generateRequest = { it },
+            installFeatures = installFeatures
+        )
+
+        /**
+         * Creates a new instance of [CliAIAgent] using GitHub Copilot CLI.
+         *
+         * @param transport The transport used to execute cli commands.
+         * @param githubToken The GitHub token for Copilot CLI authentication.
+         * @param binaryPath The path to the binary.
+         * @param model The LLM model to use. If null, Copilot CLI default model is used.
+         * @param name The name of the cli strategy.
+         * @param systemPrompt The system prompt for the agent.
+         * @param llModel The LLM model to be used for the agent.
+         * @param additionalFlags Additional flags to be passed to copilot cli.
+         * @param workspace The workspace directory for the agent.
+         * @param timeout The timeout duration for the agent.
+         * @param id The unique identifier for the agent.
+         * @param clock The clock used to calculate message timestamps.
+         * @param generateRequest Lambda for generating the request for the agent.
+         * @param installFeatures Lambda for installing additional features.
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun <Input> copilot(
+            transport: CliTransport,
+            githubToken: String? = null,
+            binaryPath: String? = null,
+            model: String? = null,
+            name: String? = null,
+            systemPrompt: String? = null,
+            llModel: LLModel? = null,
+            additionalFlags: List<String> = emptyList(),
+            workspace: String = ".",
+            timeout: Duration? = null,
+            id: String? = null,
+            clock: KoogClock = KoogClock.System,
+            generateRequest: CliConfig.GenerateRequest<Input>,
+            installFeatures: FeatureContext.() -> Unit = {}
+        ): CliAIAgent<Input, CliAIAgentResponse> {
+            val strategy = AIAgentCliStrategy(
+                config = CopilotCliConfig(
+                    transport = transport,
+                    githubToken = githubToken,
+                    binaryPath = binaryPath,
+                    name = name,
+                    model = model ?: llModel?.id,
+                    additionalFlags = additionalFlags,
+                    workspace = workspace,
+                    timeout = timeout,
+                    generateRequest = generateRequest
+                )
+            )
+
+            return CliAIAgent(
+                systemPrompt = systemPrompt,
+                llModel = llModel,
+                strategy = strategy,
+                id = id,
+                clock = clock,
+                installFeatures = installFeatures
+            )
+        }
+
+        /**
+         * Creates a new instance of [CliAIAgent] using provided configuration of the cli.
+         * 
          * @param cliConfig The configuration for the cli.
          * @param systemPrompt The system prompt for the agent.
          * @param llModel The LLM model to be used for the agent.

--- a/agents/agents-cli/src/commonMain/kotlin/ai/koog/agents/cli/CliAIAgentBuilder.kt
+++ b/agents/agents-cli/src/commonMain/kotlin/ai/koog/agents/cli/CliAIAgentBuilder.kt
@@ -1,6 +1,7 @@
 package ai.koog.agents.cli
 
 import ai.koog.agents.cli.claude.ClaudeAgentBuilder
+import ai.koog.agents.cli.copilot.CopilotAgentBuilder
 import ai.koog.agents.cli.codex.CodexAgentBuilder
 import ai.koog.agents.cli.transport.CliTransport
 
@@ -32,6 +33,22 @@ public class CliAgentBuilder internal constructor(transport: CliTransport) : Cli
      * Configures the agent to use Codex CLI.
      */
     public fun codex(): CodexAgentBuilder = CodexAgentBuilder(
+        transport = transport,
+        binaryPath = binaryPath,
+        name = name,
+        systemPrompt = systemPrompt,
+        llModel = llModel,
+        workspace = workspace,
+        timeout = timeout,
+        id = id,
+        clock = clock,
+        featureInstallers = featureInstallers
+    )
+
+    /**
+     * Configures the agent to use Copilot CLI.
+     */
+    public fun copilot(): CopilotAgentBuilder = CopilotAgentBuilder(
         transport = transport,
         binaryPath = binaryPath,
         name = name,

--- a/agents/agents-cli/src/commonMain/kotlin/ai/koog/agents/cli/copilot/CopilotAgentBuilder.kt
+++ b/agents/agents-cli/src/commonMain/kotlin/ai/koog/agents/cli/copilot/CopilotAgentBuilder.kt
@@ -1,0 +1,152 @@
+package ai.koog.agents.cli.copilot
+
+import ai.koog.agents.cli.CliAIAgent
+import ai.koog.agents.cli.CliConfig
+import ai.koog.agents.cli.transport.CliTransport
+import ai.koog.prompt.llm.LLModel
+import ai.koog.utils.time.KoogClock
+import kotlin.time.Duration
+
+/**
+ * Builder for Copilot CLI agent.
+ */
+public class CopilotAgentBuilder internal constructor(
+    transport: CliTransport,
+    binaryPath: String?,
+    name: String?,
+    systemPrompt: String?,
+    llModel: LLModel?,
+    workspace: String,
+    timeout: Duration?,
+    id: String?,
+    clock: KoogClock,
+    featureInstallers: MutableList<CliAIAgent.FeatureContext.() -> Unit>,
+    githubToken: String? = null,
+    model: String? = null,
+    additionalFlags: List<String> = emptyList(),
+) : CopilotAgentBuilderBase<String, CopilotAgentBuilder>(
+    transport,
+    binaryPath,
+    name,
+    systemPrompt,
+    llModel,
+    workspace,
+    timeout,
+    id,
+    clock,
+    featureInstallers,
+    githubToken,
+    model,
+    additionalFlags
+) {
+    override fun self(): CopilotAgentBuilder = this
+
+    /**
+     * Configures a custom request generator for the agent.
+     *
+     * @param Input The type of the input data.
+     * @param generateRequest Function to generate the request string from the input.
+     * @return Builder for Copilot CLI agent with custom input type.
+     */
+    public fun <Input> generateRequest(
+        generateRequest: CliConfig.GenerateRequest<Input>
+    ): CopilotAgentGenericInputBuilder<Input> = CopilotAgentGenericInputBuilder(
+        transport = transport,
+        binaryPath = binaryPath,
+        name = name,
+        systemPrompt = systemPrompt,
+        llModel = llModel,
+        workspace = workspace,
+        timeout = timeout,
+        id = id,
+        clock = clock,
+        featureInstallers = featureInstallers,
+        githubToken = githubToken,
+        model = model,
+        additionalFlags = additionalFlags,
+        generateRequest = generateRequest
+    )
+
+    /**
+     * Builds the Copilot CLI agent.
+     *
+     * @return A configured [CliAIAgent] instance that accepts String input and produces [ai.koog.agents.cli.CliAIAgentResponse].
+     */
+    public fun build(): CliAIAgent<String, ai.koog.agents.cli.CliAIAgentResponse> {
+        return CliAIAgent.copilot(
+            transport = transport,
+            githubToken = githubToken,
+            binaryPath = binaryPath,
+            model = model ?: llModel?.id,
+            name = name,
+            systemPrompt = systemPrompt,
+            llModel = llModel,
+            additionalFlags = additionalFlags,
+            workspace = workspace,
+            timeout = timeout,
+            id = id,
+            clock = clock,
+            installFeatures = { featureInstallers.forEach { it(this) } }
+        )
+    }
+}
+
+/**
+ * Builder for Copilot CLI agent with custom input type.
+ */
+public class CopilotAgentGenericInputBuilder<Input> internal constructor(
+    transport: CliTransport,
+    binaryPath: String?,
+    name: String?,
+    systemPrompt: String?,
+    llModel: LLModel?,
+    workspace: String,
+    timeout: Duration?,
+    id: String?,
+    clock: KoogClock,
+    featureInstallers: MutableList<CliAIAgent.FeatureContext.() -> Unit>,
+    githubToken: String?,
+    model: String?,
+    additionalFlags: List<String>,
+    internal val generateRequest: CliConfig.GenerateRequest<Input>,
+) : CopilotAgentBuilderBase<Input, CopilotAgentGenericInputBuilder<Input>>(
+    transport,
+    binaryPath,
+    name,
+    systemPrompt,
+    llModel,
+    workspace,
+    timeout,
+    id,
+    clock,
+    featureInstallers,
+    githubToken,
+    model,
+    additionalFlags
+) {
+    override fun self(): CopilotAgentGenericInputBuilder<Input> = this
+
+    /**
+     * Builds the Copilot CLI agent with custom input type.
+     *
+     * @return A configured [CliAIAgent] instance that accepts custom input and produces [ai.koog.agents.cli.CliAIAgentResponse].
+     */
+    public fun build(): CliAIAgent<Input, ai.koog.agents.cli.CliAIAgentResponse> {
+        return CliAIAgent.copilot(
+            transport = transport,
+            githubToken = githubToken,
+            binaryPath = binaryPath,
+            model = model ?: llModel?.id,
+            name = name,
+            systemPrompt = systemPrompt,
+            llModel = llModel,
+            additionalFlags = additionalFlags,
+            workspace = workspace,
+            timeout = timeout,
+            id = id,
+            clock = clock,
+            generateRequest = generateRequest,
+            installFeatures = { featureInstallers.forEach { it(this) } }
+        )
+    }
+}

--- a/agents/agents-cli/src/commonMain/kotlin/ai/koog/agents/cli/copilot/CopilotAgentBuilderBase.kt
+++ b/agents/agents-cli/src/commonMain/kotlin/ai/koog/agents/cli/copilot/CopilotAgentBuilderBase.kt
@@ -1,0 +1,69 @@
+package ai.koog.agents.cli.copilot
+
+import ai.koog.agents.cli.CliAIAgent
+import ai.koog.agents.cli.CliAIAgentBuilderBase
+import ai.koog.agents.cli.transport.CliTransport
+import ai.koog.prompt.llm.LLModel
+import ai.koog.utils.time.KoogClock
+import kotlin.time.Duration
+
+/**
+ * Base class for Copilot agent builders.
+ */
+public abstract class CopilotAgentBuilderBase<Input, Self : CopilotAgentBuilderBase<Input, Self>> internal constructor(
+    transport: CliTransport,
+    binaryPath: String?,
+    name: String?,
+    systemPrompt: String?,
+    llModel: LLModel?,
+    workspace: String,
+    timeout: Duration?,
+    id: String?,
+    clock: KoogClock,
+    featureInstallers: MutableList<CliAIAgent.FeatureContext.() -> Unit>,
+    protected var githubToken: String? = null,
+    protected var model: String? = null,
+    protected var additionalFlags: List<String> = emptyList(),
+) : CliAIAgentBuilderBase<Self>(
+    transport,
+    binaryPath,
+    name,
+    systemPrompt,
+    llModel,
+    workspace,
+    timeout,
+    id,
+    clock,
+    featureInstallers
+) {
+    /**
+     * Sets the GitHub token for Copilot CLI authentication.
+     *
+     * @param githubToken The token used by Copilot CLI (`COPILOT_GITHUB_TOKEN`).
+     * @return This builder instance for chaining.
+     */
+    public fun githubToken(githubToken: String): Self = self().apply {
+        this.githubToken = githubToken
+    }
+
+    /**
+     * Sets the model used by Copilot CLI.
+     *
+     * @param model The model name to pass to Copilot CLI.
+     * @return This builder instance for chaining.
+     */
+    public fun model(model: String): Self = self().apply {
+        this.model = model
+    }
+
+    /**
+     * Sets additional command-line flags to pass to Copilot CLI.
+     *
+     * @param flags List of additional flags.
+     * @return This builder instance for chaining.
+     */
+    public fun additionalFlags(flags: List<String>): Self = self().apply {
+        this.additionalFlags = flags
+    }
+}
+

--- a/agents/agents-cli/src/commonMain/kotlin/ai/koog/agents/cli/copilot/CopilotCliConfig.kt
+++ b/agents/agents-cli/src/commonMain/kotlin/ai/koog/agents/cli/copilot/CopilotCliConfig.kt
@@ -1,0 +1,84 @@
+package ai.koog.agents.cli.copilot
+
+import ai.koog.agents.cli.CliAIAgentResponse
+import ai.koog.agents.cli.CliAgentResponseMetaInfo
+import ai.koog.agents.cli.CliConfig
+import ai.koog.agents.cli.transport.CliEvent
+import ai.koog.agents.cli.transport.CliException
+import ai.koog.agents.cli.transport.CliTransport
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.message.Message
+import io.github.oshai.kotlinlogging.KLogger
+import kotlin.time.Duration
+
+/**
+ * Configuration for GitHub Copilot CLI agent.
+ *
+ * @param Input The type of input the agent accepts.
+ * @property transport The CLI transport used to execute commands.
+ * @property githubToken The GitHub token used for Copilot CLI authentication.
+ * @property binaryPath The path to the Copilot CLI executable, or null to use the default ("copilot").
+ * @property name The name of the cli strategy, or null to use the default.
+ * @property model The model passed to Copilot CLI.
+ * @property additionalFlags Additional command-line flags to pass to Copilot CLI.
+ * @property workspace The working directory for command execution.
+ * @property timeout The execution timeout duration.
+ */
+public class CopilotCliConfig<Input>(
+    override val transport: CliTransport,
+    public val githubToken: String? = null,
+    binaryPath: String? = null,
+    name: String? = null,
+    public val model: String? = null,
+    public val additionalFlags: List<String> = emptyList(),
+    override val workspace: String = ".",
+    override val timeout: Duration? = null,
+    private val generateRequest: CliConfig.GenerateRequest<Input>,
+) : CliConfig<Input, CliAIAgentResponse> {
+    override val binaryPath: String = binaryPath ?: "copilot"
+    override val name: String = name ?: "copilot"
+    override val env: Map<String, String> = buildMap {
+        githubToken?.let { put("COPILOT_GITHUB_TOKEN", it) }
+    }
+
+    override fun flags(model: LLModel, systemMessages: List<Message.System>): List<String> =
+        buildList {
+            add("-p")
+            add("-s")
+            this@CopilotCliConfig.model?.let {
+                add("--model")
+                add(it)
+            }
+            addAll(additionalFlags)
+        }
+
+    override fun generateRequest(input: Input): String =
+        generateRequest.generateRequest(input)
+
+    override fun extractOutput(events: List<CliEvent>, logger: KLogger): CliAIAgentResponse {
+        val failedEvent = events.filterIsInstance<CliEvent.Failed>().firstOrNull()
+        if (failedEvent != null) {
+            return CliAIAgentResponse(
+                content = "Cli failed: ${failedEvent.message}",
+                isError = true,
+                metaInfo = CliAgentResponseMetaInfo()
+            )
+        }
+
+        val output = events
+            .filterIsInstance<CliEvent.Line>()
+            .joinToString(separator = "\n") { it.content }
+            .trim()
+
+        if (output.isBlank()) {
+            throw CliException("No response content returned from Copilot CLI")
+        }
+
+        return CliAIAgentResponse(
+            content = output,
+            isError = false,
+            metaInfo = CliAgentResponseMetaInfo()
+        )
+    }
+}
+

--- a/koog-spring-ai/koog-spring-ai-starter-model-chat/src/main/kotlin/ai/koog/spring/ai/chat/SpringAiLLMClient.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-chat/src/main/kotlin/ai/koog/spring/ai/chat/SpringAiLLMClient.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.model.ChatModel
 import org.springframework.ai.chat.model.ChatResponse
+import org.springframework.ai.chat.metadata.Usage
 import org.springframework.ai.chat.prompt.ChatOptions
 import org.springframework.ai.model.tool.ToolCallingChatOptions
 import org.springframework.ai.moderation.ModerationModel
@@ -200,10 +201,13 @@ public class SpringAiLLMClient(
         } catch (e: Exception) {
             throw LLMClientException(clientName, "ChatModel.stream() failed: ${e.message}", e)
         }
-        var lastChatResponse: ChatResponse? = null
+        var lastUsage: Usage? = null
+        var lastFinishReason: String? = null
         try {
             flux.asFlow().collect { chatResponse ->
-                lastChatResponse = chatResponse
+                chatResponse.metadata.usage?.let {
+                    lastUsage = it
+                }
                 for ((generationIndex, generation) in chatResponse.results.withIndex()) {
                     val assistantMessage = generation.output
                     val text = assistantMessage.text
@@ -220,6 +224,15 @@ public class SpringAiLLMClient(
                     if (assistantMessage.hasToolCalls()) {
                         toolCallAssembler.accept(assistantMessage.toolCalls, generationIndex, this)
                     }
+
+                    generation.metadata?.finishReason
+                        ?.takeIf { it.isNotBlank() }
+                        ?.let { lastFinishReason = it }
+
+                    assistantMessage.metadata["finishReason"]
+                        ?.toString()
+                        ?.takeIf { it.isNotBlank() }
+                        ?.let { lastFinishReason = it }
                 }
             }
             toolCallAssembler.flush(this)
@@ -230,20 +243,17 @@ public class SpringAiLLMClient(
         } catch (e: Exception) {
             throw LLMClientException(clientName, "ChatModel.stream() failed during collection: ${e.message}", e)
         } finally {
-            // Always emit End frame so downstream consumers are not left hanging
-            val finishReason = lastChatResponse?.results?.firstOrNull()?.metadata?.finishReason
-            val usage = lastChatResponse?.metadata?.usage
-            val metaInfo = if (usage != null) {
+            val metaInfo = if (lastUsage != null) {
                 ResponseMetaInfo.create(
                     clock = clock,
-                    totalTokensCount = usage.totalTokens,
-                    inputTokensCount = usage.promptTokens,
-                    outputTokensCount = usage.completionTokens
+                    totalTokensCount = lastUsage.totalTokens,
+                    inputTokensCount = lastUsage.promptTokens,
+                    outputTokensCount = lastUsage.completionTokens
                 )
             } else {
                 null
             }
-            emitEnd(finishReason = finishReason, metaInfo = metaInfo)
+            emitEnd(finishReason = lastFinishReason, metaInfo = metaInfo)
         }
     }.flowOn(dispatcher)
 

--- a/koog-spring-ai/koog-spring-ai-starter-model-chat/src/test/kotlin/ai/koog/spring/ai/chat/SpringAiLLMClientTest.kt
+++ b/koog-spring-ai/koog-spring-ai-starter-model-chat/src/test/kotlin/ai/koog/spring/ai/chat/SpringAiLLMClientTest.kt
@@ -320,6 +320,41 @@ class SpringAiLLMClientTest {
     }
 
     @Test
+    fun `executeStreaming preserves finish reason when final chunk has only usage metadata`() = runBlocking {
+        val usage = object : Usage {
+            override fun getPromptTokens(): Int = 3
+            override fun getCompletionTokens(): Int = 7
+            override fun getNativeUsage(): Any = emptyMap<String, Any>()
+        }
+        val metadata = ChatResponseMetadata.builder().usage(usage).build()
+        val client = SpringAiLLMClient.builder().chatModel(object : ChatModel {
+            override fun call(prompt: SpringPrompt) = throw UnsupportedOperationException()
+            override fun stream(prompt: SpringPrompt) = Flux.just(
+                ChatResponse(
+                    listOf(
+                        Generation(
+                            AssistantMessage.builder()
+                                .content("Hello")
+                                .properties(mapOf("finishReason" to "STOP"))
+                                .build()
+                        )
+                    ),
+                ),
+                ChatResponse(emptyList(), metadata)
+            )
+        }).build()
+
+        val prompt = createPrompt(Message.User("Hello", requestMeta()))
+        val frames = client.executeStreaming(prompt, testModel, emptyList()).toList()
+
+        val end = frames.filterIsInstance<StreamFrame.End>().single()
+        assertEquals("STOP", end.finishReason)
+        assertEquals(3, end.metaInfo.inputTokensCount)
+        assertEquals(7, end.metaInfo.outputTokensCount)
+        assertEquals(10, end.metaInfo.totalTokensCount)
+    }
+
+    @Test
     fun `executeStreaming skips empty text chunks`() = runBlocking {
         val client = SpringAiLLMClient.builder().chatModel(object : ChatModel {
             override fun call(prompt: SpringPrompt) = throw UnsupportedOperationException()


### PR DESCRIPTION
Add a new CLI provider entrypoint for GitHub Copilot CLI integration, including model/token/flags configuration and builder APIs.