### PR TITLE
Expose OpenAI token detail fields in response metadata

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/jvmTest/kotlin/dashscope/DashscopeLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-dashscope-client/src/jvmTest/kotlin/dashscope/DashscopeLLMClientTest.kt
@@ -367,5 +367,12 @@ class DashscopeLLMClientTest {
         assertEquals(35, response.metaInfo.inputTokensCount)
         assertEquals(191, response.metaInfo.outputTokensCount)
         assertEquals(226, response.metaInfo.totalTokensCount)
+        assertEquals(
+            buildJsonObject {
+                put("cachedInputTokens", 0)
+                put("reasoningTokens", 100)
+            },
+            response.metaInfo.metadata
+        )
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.flow.channelFlow
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNamingStrategy
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.jvm.JvmOverloads
@@ -527,7 +528,18 @@ public abstract class AbstractOpenAILLMClient<TResponse : OpenAIBaseLLMResponse,
         clock,
         totalTokensCount = usage?.totalTokens,
         inputTokensCount = usage?.promptTokens,
-        outputTokensCount = usage?.completionTokens
+        outputTokensCount = usage?.completionTokens,
+        metadata = usage
+            ?.let {
+                buildJsonObject {
+                    it.promptTokensDetails?.cachedTokens?.let { put("cachedInputTokens", it) }
+                    it.completionTokensDetails?.reasoningTokens?.let { put("reasoningTokens", it) }
+                    it.completionTokensDetails?.acceptedPredictionTokens?.let { put("acceptedPredictionTokens", it) }
+                    it.completionTokensDetails?.rejectedPredictionTokens?.let { put("rejectedPredictionTokens", it) }
+                    it.completionTokensDetails?.audioTokens?.let { put("completionAudioTokens", it) }
+                    it.promptTokensDetails?.audioTokens?.let { put("promptAudioTokens", it) }
+                }.takeIf { it.isNotEmpty() }
+            }
     )
 
     protected open fun createResponseFormat(schema: LLMParams.Schema?, model: LLModel): OpenAIResponseFormat? {


### PR DESCRIPTION
## Summary
- Populate OpenAILLMClientBase ResponseMetaInfo.metadata from OpenAI usage detail fields.
- Expose cached prompt tokens as \cachedInputTokens\ and completion reasoning as \reasoningTokens\.
- Also propagate accepted/rejected prediction tokens and audio token details when present.
- Add regression test in DashScope client test to assert metadata values from usage details.

Closes #1275