### PR TITLE
fix(prompt): refresh Redis TTL on access instead of clearing it

### DIFF
--- a/prompt/prompt-cache/prompt-cache-redis/src/jvmMain/kotlin/ai/koog/prompt/cache/redis/RedisPromptCache.kt
+++ b/prompt/prompt-cache/prompt-cache-redis/src/jvmMain/kotlin/ai/koog/prompt/cache/redis/RedisPromptCache.kt
@@ -135,8 +135,7 @@ public class RedisPromptCache(
             }
             logger.info { "Get key '$key' from Redis cache hit" }
 
-            // Update access time by setting the key with the same value but updated TTL
-            commands.set(key, value)
+            commands.setex(key, seconds = ttl.inWholeSeconds, value)
 
             return defaultJson.decodeFromString<CachedElement>(value).response
         } catch (e: Exception) {

--- a/prompt/prompt-cache/prompt-cache-redis/src/jvmTest/kotlin/ai/koog/prompt/cache/redis/MockRedisClient.kt
+++ b/prompt/prompt-cache/prompt-cache-redis/src/jvmTest/kotlin/ai/koog/prompt/cache/redis/MockRedisClient.kt
@@ -44,8 +44,7 @@ class MockRedisClient(
             val value = secondArg<String>()
             val now = System.currentTimeMillis()
 
-            // Preserve TTL when updating an existing key
-            dataStore[key] = Data(value, now, dataStore[key]?.ttl)
+            dataStore[key] = Data(value, now, null)
             "OK"
         }
 

--- a/prompt/prompt-cache/prompt-cache-redis/src/jvmTest/kotlin/ai/koog/prompt/cache/redis/RedisPromptCacheTest.kt
+++ b/prompt/prompt-cache/prompt-cache-redis/src/jvmTest/kotlin/ai/koog/prompt/cache/redis/RedisPromptCacheTest.kt
@@ -101,4 +101,21 @@ class RedisPromptCacheTest {
         val cachedResponse2 = cache.get(testPrompt, testTools, testClock)
         assertEquals(testResponse, cachedResponse2)
     }
+
+    @DisabledOnOs(OS.WINDOWS, disabledReason = "Fails on Windows")
+    @Test
+    fun testAccessedEntryStillExpiresAfterItsTtl() = runTest {
+        val cache = createCache(2.seconds)
+        cache.put(testPrompt, testTools, testResponse)
+
+        Thread.sleep(1000)
+
+        val cachedResponse = cache.get(testPrompt, testTools, testClock)
+        assertEquals(testResponse, cachedResponse)
+
+        Thread.sleep(2500)
+
+        val expiredResponse = cache.get(testPrompt, testTools, testClock)
+        assertNull(expiredResponse)
+    }
 }


### PR DESCRIPTION
On a cache hit, `RedisPromptCache.getOrNull` refreshed the entry with `commands.set(key, value)`. In Redis a plain `SET` with no expiration option drops the key's TTL (same effect as `PERSIST`), so every read turned a cached entry into one that never expires. Over time that leaks memory and keeps serving stale prompt responses well past the configured TTL. The comment there claimed it was updating the TTL, but the call didn't do that.

Switched it to `SETEX`, which is what `put()` already uses, so the TTL gets reapplied on each read and the sliding expiration works as intended.

This went unnoticed because of the test double: `MockRedisClient.set` kept the previous TTL, the opposite of how Redis actually behaves, so the suite stayed green with the bug in place. I changed the mock to drop the TTL on `set` to match Redis, and added a test that stores an entry, accesses it, then waits past the TTL and checks it's gone. That test fails on the old `set` code and passes with `setex`.
