### PR TITLE
fix(agents): MessageTokenizer storage key conflict (#2143)

### DIFF
--- a/agents/agents-features/agents-features-tokenizer/src/commonMain/kotlin/ai/koog/agents/features/tokenizer/feature/MessageTokenizer.kt
+++ b/agents/agents-features/agents-features-tokenizer/src/commonMain/kotlin/ai/koog/agents/features/tokenizer/feature/MessageTokenizer.kt
@@ -54,7 +54,7 @@ public class MessageTokenizer(public val promptTokenizer: PromptTokenizer) {
         AIAgentPlannerFeature<MessageTokenizerConfig, MessageTokenizer> {
 
         override val key: AIAgentStorageKey<MessageTokenizer> =
-            createStorageKey<MessageTokenizer>("agents-features-tracing")
+            createStorageKey<MessageTokenizer>("agents-features-message-tokenizer")
 
         override fun createInitialConfig(
             agentConfig: AIAgentConfig,


### PR DESCRIPTION
Rename MessageTokenizer storage key: "agents-features-tracing"->"agents-features-message-tokenizer"

MessageTokenizer AIAgentStorageKey named "agents-features-tracing", causing a runtime exception when Tracing feature is also installed (they have the same name):
```
ai.koog.agents.core.agent.GraphAIAgent - Execution exception reported by server!
java.lang.IllegalArgumentException: Feature ai.koog.agents.core.agent.entity.AIAgentStorageKey@35e21111(name=agents-features-tracing) is found, but it is not of the expected type.
Expected type: MessageTokenizer
Actual type: Tracing
        at ai.koog.agents.core.feature.pipeline.AIAgentPipelineImpl.feature(AIAgentPipelineImpl.kt:104)
```

Closes #2143