### PR TITLE
fix(prompt): handle Gemini function calls without args

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClient.kt
@@ -716,8 +716,7 @@ public open class GoogleLLMClient @JvmOverloads constructor(
                             MessagePart.Tool.Call(
                                 id = Uuid.random().toString(),
                                 tool = part.functionCall.name,
-                                args = part.functionCall.args
-                                    ?: throw IllegalArgumentException("Function call args must not be null")
+                                args = part.functionCall.args ?: JsonObject(emptyMap())
                             )
                         )
                     }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-google-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/google/GoogleLLMClientTest.kt
@@ -523,6 +523,29 @@ class GoogleLLMClientTest {
     }
 
     @Test
+    fun `processGoogleCandidate handles FunctionCall with no args`() {
+        val client = GoogleLLMClient(httpClientFactory = KtorKoogHttpClient.Factory(), apiKey = "test")
+        val candidate = GoogleCandidate(
+            content = GoogleContent(
+                role = "model",
+                parts = listOf(
+                    GooglePart.FunctionCall(
+                        functionCall = GoogleData.FunctionCall(name = "noArgsTool")
+                    )
+                )
+            ),
+            finishReason = "STOP"
+        )
+
+        val response = client.processGoogleCandidate(candidate, ResponseMetaInfo.Empty)
+
+        response.parts shouldHaveSize 1
+        val call = response.parts[0].shouldBeInstanceOf<MessagePart.Tool.Call>()
+        call.tool shouldBe "noArgsTool"
+        call.args shouldBe "{}"
+    }
+
+    @Test
     fun `processGoogleCandidate creates Reasoning from Text with thought=true`() {
         val client = GoogleLLMClient(httpClientFactory = KtorKoogHttpClient.Factory(), apiKey = "test")
         val candidate = GoogleCandidate(


### PR DESCRIPTION
Aligns the non-streaming path with the streaming one for Gemini function calls that have no `args` (the Gemini API marks `FunctionCall.args` as optional), and adds a regression test.

closes #2146, closes [KG-871](https://youtrack.jetbrains.com/issue/KG-871)