### PR TITLE
feat: Add simpleAzureFoundryExecutor and AzureFoundryModels for Found…

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/AzureFoundryModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/AzureFoundryModels.kt
@@ -1,0 +1,38 @@
+package ai.koog.prompt.executor.clients.openai.models
+
+import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
+
+/**
+ * Predefined models for Azure AI Foundry deployments.
+ */
+public object AzureFoundryModels {
+
+    private val defaultCapabilities = listOf(
+        LLMCapability.Completion,
+        LLMCapability.Temperature,
+        LLMCapability.Tools,
+        LLMCapability.ToolChoice,
+        LLMCapability.OpenAIEndpoint.Completions,
+        LLMCapability.Schema.JSON.Basic
+    )
+
+    public val GPT5_4_Nano: LLModel = LLModel(
+        provider = LLMProvider.OpenAI,
+        id = "gpt-5.4-nano",
+        capabilities = defaultCapabilities
+    )
+
+    public val GPT4_1_Mini: LLModel = LLModel(
+        provider = LLMProvider.OpenAI,
+        id = "gpt-4.1-mini",
+        capabilities = defaultCapabilities
+    )
+
+    public val GPT4_1: LLModel = LLModel(
+        provider = LLMProvider.OpenAI,
+        id = "gpt-4.1",
+        capabilities = defaultCapabilities
+    )
+}

--- a/prompt/prompt-executor/prompt-executor-llms-all/src/commonMain/kotlin/ai/koog/prompt/executor/llms/all/SimplePromptExecutors.kt
+++ b/prompt/prompt-executor/prompt-executor-llms-all/src/commonMain/kotlin/ai/koog/prompt/executor/llms/all/SimplePromptExecutors.kt
@@ -137,3 +137,29 @@ public fun simpleOllamaAIExecutor(
  */
 public fun simpleMistralAIExecutor(apiKey: String, httpClientFactory: KoogHttpClient.Factory): MultiLLMPromptExecutor =
     MultiLLMPromptExecutor(LLMProvider.MistralAI to MistralAILLMClient(apiKey = apiKey, httpClientFactory = httpClientFactory))
+
+/**
+ * Creates a [MultiLLMPromptExecutor] for Azure AI Foundry project endpoints (v2).
+ *
+ * Unlike [simpleAzureOpenAIExecutor], this executor targets the new Azure AI Foundry
+ * unified endpoint (`/openai/v1`) which does not use `api-version` as a query parameter.
+ *
+ * @param projectEndpoint Full project endpoint URL, e.g.:
+ *   `https://<resource>.services.ai.azure.com/openai/v1`
+ * @param apiToken The API key from Azure AI Foundry.
+ * @param httpClientFactory Factory used to create the underlying HTTP client.
+ */
+public fun simpleAzureFoundryExecutor(
+    projectEndpoint: String,
+    apiToken: String,
+    httpClientFactory: KoogHttpClient.Factory,
+): MultiLLMPromptExecutor = MultiLLMPromptExecutor(
+    LLMProvider.OpenAI to OpenAILLMClient(
+        apiKey = apiToken,
+        settings = OpenAIClientSettings(
+            baseUrl = projectEndpoint,
+            chatCompletionsPath = "chat/completions"
+        ),
+        httpClientFactory = httpClientFactory
+    )
+)

--- a/prompt/prompt-executor/prompt-executor-llms-all/src/jvmCommonMain/kotlin/ai/koog/prompt/executor/llms/all/SimplePromptExecutors.jvmCommon.kt
+++ b/prompt/prompt-executor/prompt-executor-llms-all/src/jvmCommonMain/kotlin/ai/koog/prompt/executor/llms/all/SimplePromptExecutors.jvmCommon.kt
@@ -105,3 +105,22 @@ public fun simpleOllamaAIExecutor(
  */
 public fun simpleMistralAIExecutor(apiKey: String): MultiLLMPromptExecutor =
     MultiLLMPromptExecutor(LLMProvider.MistralAI to MistralAILLMClient(apiKey))
+
+/**
+ * Convenience overload that constructs the underlying client via its JVM no-factory entry point.
+ * JVM and Android only.
+ *
+ * @see simpleAzureFoundryExecutor
+ */
+public fun simpleAzureFoundryExecutor(
+    projectEndpoint: String,
+    apiToken: String,
+): MultiLLMPromptExecutor = MultiLLMPromptExecutor(
+    LLMProvider.OpenAI to OpenAILLMClient(
+        apiKey = apiToken,
+        settings = OpenAIClientSettings(
+            baseUrl = projectEndpoint,
+            chatCompletionsPath = "chat/completions"
+        )
+    )
+)


### PR DESCRIPTION
## Summary

Add support for Azure AI Foundry project endpoint (`/openai/v1`) which
is incompatible with `simpleAzureOpenAIExecutor` due to `api-version`
query param handling. Fixes path duplication issue with `OpenAIClientSettings`.

## Changes

- Add `simpleAzureFoundryExecutor()` to `commonMain` (with `httpClientFactory`)
- Add `simpleAzureFoundryExecutor()` to `jvmCommonMain` (JVM convenience overload, no factory needed)
- Add `AzureFoundryModels` with predefined `GPT5_4_Nano`, `GPT4_1_Mini`, `GPT4_1`

## Closes

Closes #2150