### PR TITLE
fix(agents): Add cache contrl support for all message parts

### DIFF
--- a/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerTest.kt
+++ b/agents/agents-features/agents-features-event-handler/src/jvmTest/kotlin/ai/koog/agents/features/eventHandler/feature/EventHandlerTest.kt
@@ -272,8 +272,8 @@ class EventHandlerTest {
             .toString()
 
         val toolCallAssistantObj =
-            "Assistant(parts=[Call(id=null, tool=$dummyToolName, args=$dummyToolArgsEncoded)], metaInfo=ResponseMetaInfo(timestamp=$ts, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, modelId=null, metadata=null), finishReason=null, rawResponse=null, id=null)"
-        val toolCallsInput = "ToolCalls(toolCalls=[Call(id=null, tool=$dummyToolName, args=$dummyToolArgsEncoded)])"
+            "Assistant(parts=[Call(id=null, tool=$dummyToolName, args=$dummyToolArgsEncoded, cacheControl=null)], metaInfo=ResponseMetaInfo(timestamp=$ts, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, modelId=null, metadata=null), finishReason=null, rawResponse=null, id=null)"
+        val toolCallsInput = "ToolCalls(toolCalls=[Call(id=null, tool=$dummyToolName, args=$dummyToolArgsEncoded, cacheControl=null)])"
         val receivedToolResults = "ReceivedToolResults(toolResults=[$dummyToolReceivedToolResult])"
         val finalAssistantObj =
             "Assistant(parts=[Text(text=$mockResponse, cacheControl=null)], metaInfo=ResponseMetaInfo(timestamp=$ts, totalTokensCount=null, inputTokensCount=null, outputTokensCount=null, modelId=null, metadata=null), finishReason=null, rawResponse=null, id=null)"

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -109,3 +109,8 @@ tasks.register<Delete>("knitAssemble") {
 
 tasks.named("knit").configure { mustRunAfter("knitClean") }
 tasks.named("assemble").configure { mustRunAfter("knit") }
+
+// docs is not a published library, so ABI validation is not applicable
+tasks.matching { it.name.contains("Abi") }.configureEach {
+    enabled = false
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
@@ -510,6 +510,7 @@ public open class AnthropicLLMClient @JvmOverloads constructor(
                                 id = it.id ?: Uuid.random().toString(),
                                 name = it.tool,
                                 input = it.argsJson,
+                                cacheControl = it.cacheControl?.toAnthropicCacheControl()
                             )
                         )
                     }
@@ -539,7 +540,7 @@ public open class AnthropicLLMClient @JvmOverloads constructor(
                                 toolUseId = part.id ?: "",
                                 content = part.toAnthropicToolResultContent(model),
                                 isError = part.isError,
-                                // TODO: check if anthropic supports cache control in tool result
+                                cacheControl = part.cacheControl?.toAnthropicCacheControl()
                             )
                         )
                     }
@@ -616,7 +617,10 @@ public open class AnthropicLLMClient @JvmOverloads constructor(
     private fun MessagePart.Tool.Result.toAnthropicToolResultContent(model: LLModel): List<AnthropicContent> =
         parts.map { part ->
             when (part) {
-                is MessagePart.Text -> AnthropicContent.Text(part.text)
+                is MessagePart.Text -> AnthropicContent.Text(
+                    part.text,
+                    cacheControl = part.cacheControl?.toAnthropicCacheControl()
+                )
 
                 is MessagePart.Attachment -> {
                     when (val source = part.source) {
@@ -629,7 +633,10 @@ public open class AnthropicLLMClient @JvmOverloads constructor(
                                     "Unsupported image attachment content in tool result: ${content::class}"
                                 )
                             }
-                            AnthropicContent.Image(imageSource)
+                            AnthropicContent.Image(
+                                imageSource,
+                                cacheControl = part.cacheControl?.toAnthropicCacheControl()
+                            )
                         }
 
                         is AttachmentSource.File -> {
@@ -638,7 +645,10 @@ public open class AnthropicLLMClient @JvmOverloads constructor(
                                 is AttachmentContent.Binary -> DocumentSource.Base64(content.asBase64(), source.mimeType)
                                 is AttachmentContent.PlainText -> DocumentSource.PlainText(content.text, source.mimeType)
                             }
-                            AnthropicContent.Document(documentSource)
+                            AnthropicContent.Document(
+                                documentSource,
+                                cacheControl = part.cacheControl?.toAnthropicCacheControl()
+                            )
                         }
 
                         else -> throw LLMClientException(

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseConverters.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-bedrock-client/src/jvmMain/kotlin/ai/koog/prompt/executor/clients/bedrock/converse/BedrockConverseConverters.kt
@@ -246,6 +246,9 @@ internal object BedrockConverseConverters {
                                     }
                                 )
                             )
+                            part.cacheControl?.let { cc ->
+                                add(cc.require<BedrockCacheControl>().toBedrockCachePointContentBlock())
+                            }
                         }
                     }
                 }

--- a/prompt/prompt-model/api/android/prompt-model.api
+++ b/prompt/prompt-model/api/android/prompt-model.api
@@ -81,10 +81,12 @@ public abstract class ai/koog/prompt/dsl/ContentPartsBuilderBase : ai/koog/promp
 	public static synthetic fun audio$default (Lai/koog/prompt/dsl/ContentPartsBuilderBase;Lai/koog/prompt/message/AttachmentSource$Audio;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
 	public static synthetic fun audio$default (Lai/koog/prompt/dsl/ContentPartsBuilderBase;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
 	public static synthetic fun audio$default (Lai/koog/prompt/dsl/ContentPartsBuilderBase;Lkotlinx/io/files/Path;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
-	public final fun binaryFile (Lkotlinx/io/files/Path;Ljava/lang/String;)V
+	public final fun binaryFile (Lkotlinx/io/files/Path;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
+	public static synthetic fun binaryFile$default (Lai/koog/prompt/dsl/ContentPartsBuilderBase;Lkotlinx/io/files/Path;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
 	public final fun file (Lai/koog/prompt/message/AttachmentSource$File;Lai/koog/prompt/message/CacheControl;)V
-	public final fun file (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun file (Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
 	public static synthetic fun file$default (Lai/koog/prompt/dsl/ContentPartsBuilderBase;Lai/koog/prompt/message/AttachmentSource$File;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
+	public static synthetic fun file$default (Lai/koog/prompt/dsl/ContentPartsBuilderBase;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
 	protected final fun flushTextBuilder ()V
 	protected final fun getContentParts ()Ljava/util/List;
 	public final fun image (Lai/koog/prompt/message/AttachmentSource$Image;Lai/koog/prompt/message/CacheControl;)V
@@ -97,7 +99,8 @@ public abstract class ai/koog/prompt/dsl/ContentPartsBuilderBase : ai/koog/promp
 	public final fun text (Lai/koog/prompt/message/CacheControl;Lkotlin/jvm/functions/Function1;)V
 	public final fun text (Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
 	public static synthetic fun text$default (Lai/koog/prompt/dsl/ContentPartsBuilderBase;Lai/koog/prompt/message/CacheControl;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public final fun textFile (Lkotlinx/io/files/Path;Ljava/lang/String;)V
+	public final fun textFile (Lkotlinx/io/files/Path;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
+	public static synthetic fun textFile$default (Lai/koog/prompt/dsl/ContentPartsBuilderBase;Lkotlinx/io/files/Path;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
 	public final fun video (Lai/koog/prompt/message/AttachmentSource$Video;Lai/koog/prompt/message/CacheControl;)V
 	public final fun video (Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
 	public final fun video (Lkotlinx/io/files/Path;Lai/koog/prompt/message/CacheControl;)V
@@ -304,7 +307,8 @@ public final class ai/koog/prompt/dsl/PromptBuilder {
 	public final fun reasoning (Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun reasoning (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun reasoning (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/dsl/PromptBuilder;
-	public static synthetic fun reasoning$default (Lai/koog/prompt/dsl/PromptBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lai/koog/prompt/dsl/PromptBuilder;
+	public final fun reasoning (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)Lai/koog/prompt/dsl/PromptBuilder;
+	public static synthetic fun reasoning$default (Lai/koog/prompt/dsl/PromptBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun system (Lai/koog/prompt/message/CacheControl;Lkotlin/jvm/functions/Function1;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun system (Ljava/lang/String;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun system (Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)Lai/koog/prompt/dsl/PromptBuilder;
@@ -314,15 +318,18 @@ public final class ai/koog/prompt/dsl/PromptBuilder {
 	public final fun toolCall (Lai/koog/prompt/message/MessagePart$Tool$Call;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun toolCall (Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun toolCall (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/dsl/PromptBuilder;
+	public final fun toolCall (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun toolCall (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun toolCall (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)Lai/koog/prompt/dsl/PromptBuilder;
-	public static synthetic fun toolCall$default (Lai/koog/prompt/dsl/PromptBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lai/koog/prompt/dsl/PromptBuilder;
-	public static synthetic fun toolCall$default (Lai/koog/prompt/dsl/PromptBuilder;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILjava/lang/Object;)Lai/koog/prompt/dsl/PromptBuilder;
+	public final fun toolCall (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)Lai/koog/prompt/dsl/PromptBuilder;
+	public static synthetic fun toolCall$default (Lai/koog/prompt/dsl/PromptBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)Lai/koog/prompt/dsl/PromptBuilder;
+	public static synthetic fun toolCall$default (Lai/koog/prompt/dsl/PromptBuilder;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun toolResult (Lai/koog/prompt/message/MessagePart$Tool$Result;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun toolResult (Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun toolResult (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun toolResult (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)Lai/koog/prompt/dsl/PromptBuilder;
-	public static synthetic fun toolResult$default (Lai/koog/prompt/dsl/PromptBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lai/koog/prompt/dsl/PromptBuilder;
+	public final fun toolResult (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLai/koog/prompt/message/CacheControl;)Lai/koog/prompt/dsl/PromptBuilder;
+	public static synthetic fun toolResult$default (Lai/koog/prompt/dsl/PromptBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLai/koog/prompt/message/CacheControl;ILjava/lang/Object;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun user (Ljava/lang/String;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun user (Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun user (Ljava/util/List;)Lai/koog/prompt/dsl/PromptBuilder;
@@ -346,8 +353,8 @@ public final class ai/koog/prompt/dsl/RequestMessagePartsBuilder : ai/koog/promp
 	public synthetic fun build ()Ljava/lang/Object;
 	public fun build ()Ljava/util/List;
 	public final fun toolResult (Lai/koog/prompt/message/MessagePart$Tool$Result;)V
-	public final fun toolResult (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
-	public static synthetic fun toolResult$default (Lai/koog/prompt/dsl/RequestMessagePartsBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)V
+	public final fun toolResult (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLai/koog/prompt/message/CacheControl;)V
+	public static synthetic fun toolResult$default (Lai/koog/prompt/dsl/RequestMessagePartsBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
 }
 
 public final class ai/koog/prompt/dsl/ResponseMessagePartsBuilder : ai/koog/prompt/text/TextContentBuilderBase {
@@ -355,13 +362,13 @@ public final class ai/koog/prompt/dsl/ResponseMessagePartsBuilder : ai/koog/prom
 	public synthetic fun build ()Ljava/lang/Object;
 	public fun build ()Ljava/util/List;
 	public final fun reasoning (Lai/koog/prompt/message/MessagePart$Reasoning;)V
-	public final fun reasoning (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public static synthetic fun reasoning$default (Lai/koog/prompt/dsl/ResponseMessagePartsBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun reasoning (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
+	public static synthetic fun reasoning$default (Lai/koog/prompt/dsl/ResponseMessagePartsBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
 	public final fun toolCall (Lai/koog/prompt/message/MessagePart$Tool$Call;)V
-	public final fun toolCall (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public final fun toolCall (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
-	public static synthetic fun toolCall$default (Lai/koog/prompt/dsl/ResponseMessagePartsBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
-	public static synthetic fun toolCall$default (Lai/koog/prompt/dsl/ResponseMessagePartsBuilder;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)V
+	public final fun toolCall (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
+	public final fun toolCall (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lai/koog/prompt/message/CacheControl;)V
+	public static synthetic fun toolCall$default (Lai/koog/prompt/dsl/ResponseMessagePartsBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
+	public static synthetic fun toolCall$default (Lai/koog/prompt/dsl/ResponseMessagePartsBuilder;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
 }
 
 public abstract interface class ai/koog/prompt/message/AttachmentContent {
@@ -831,6 +838,7 @@ public final class ai/koog/prompt/message/MessageMetaInfo$Companion {
 
 public abstract interface class ai/koog/prompt/message/MessagePart {
 	public static final field Companion Lai/koog/prompt/message/MessagePart$Companion;
+	public abstract fun getCacheControl ()Lai/koog/prompt/message/CacheControl;
 }
 
 public final class ai/koog/prompt/message/MessagePart$Attachment : ai/koog/prompt/message/MessagePart$ContentPart {
@@ -882,19 +890,23 @@ public final class ai/koog/prompt/message/MessagePart$Reasoning : ai/koog/prompt
 	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
 	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/util/List;)V
 	public fun <init> (Ljava/util/List;Ljava/util/List;)V
 	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/lang/String;)V
 	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/message/MessagePart$Reasoning;
-	public static synthetic fun copy$default (Lai/koog/prompt/message/MessagePart$Reasoning;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lai/koog/prompt/message/MessagePart$Reasoning;
+	public final fun component5 ()Lai/koog/prompt/message/CacheControl;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)Lai/koog/prompt/message/MessagePart$Reasoning;
+	public static synthetic fun copy$default (Lai/koog/prompt/message/MessagePart$Reasoning;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)Lai/koog/prompt/message/MessagePart$Reasoning;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getCacheControl ()Lai/koog/prompt/message/CacheControl;
 	public final fun getContent ()Ljava/util/List;
 	public final fun getEncrypted ()Ljava/lang/String;
 	public final fun getId ()Ljava/lang/String;
@@ -920,7 +932,6 @@ public final class ai/koog/prompt/message/MessagePart$Reasoning$Companion {
 
 public abstract interface class ai/koog/prompt/message/MessagePart$RequestPart : ai/koog/prompt/message/MessagePart {
 	public static final field Companion Lai/koog/prompt/message/MessagePart$RequestPart$Companion;
-	public abstract fun getCacheControl ()Lai/koog/prompt/message/CacheControl;
 }
 
 public final class ai/koog/prompt/message/MessagePart$RequestPart$Companion {
@@ -975,18 +986,22 @@ public final class ai/koog/prompt/message/MessagePart$Tool$Call : ai/koog/prompt
 	public static final field Companion Lai/koog/prompt/message/MessagePart$Tool$Call$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lai/koog/prompt/message/CacheControl;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lai/koog/prompt/message/CacheControl;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/message/MessagePart$Tool$Call;
-	public static synthetic fun copy$default (Lai/koog/prompt/message/MessagePart$Tool$Call;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lai/koog/prompt/message/MessagePart$Tool$Call;
+	public final fun component4 ()Lai/koog/prompt/message/CacheControl;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)Lai/koog/prompt/message/MessagePart$Tool$Call;
+	public static synthetic fun copy$default (Lai/koog/prompt/message/MessagePart$Tool$Call;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)Lai/koog/prompt/message/MessagePart$Tool$Call;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getArgs ()Ljava/lang/String;
 	public final fun getArgsJson ()Lkotlinx/serialization/json/JsonObject;
+	public fun getCacheControl ()Lai/koog/prompt/message/CacheControl;
 	public final fun getId ()Ljava/lang/String;
 	public fun getTool ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -1014,16 +1029,23 @@ public final class ai/koog/prompt/message/MessagePart$Tool$Companion {
 
 public final class ai/koog/prompt/message/MessagePart$Tool$Result : ai/koog/prompt/message/MessagePart$RequestPart, ai/koog/prompt/message/MessagePart$Tool {
 	public static final field Companion Lai/koog/prompt/message/MessagePart$Tool$Result$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLai/koog/prompt/message/CacheControl;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLai/koog/prompt/message/CacheControl;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Z)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLai/koog/prompt/message/CacheControl;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLai/koog/prompt/message/CacheControl;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/util/List;
 	public final fun component4 ()Z
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Z)Lai/koog/prompt/message/MessagePart$Tool$Result;
-	public static synthetic fun copy$default (Lai/koog/prompt/message/MessagePart$Tool$Result;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZILjava/lang/Object;)Lai/koog/prompt/message/MessagePart$Tool$Result;
+	public final fun component5 ()Lai/koog/prompt/message/CacheControl;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLai/koog/prompt/message/CacheControl;)Lai/koog/prompt/message/MessagePart$Tool$Result;
+	public static synthetic fun copy$default (Lai/koog/prompt/message/MessagePart$Tool$Result;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLai/koog/prompt/message/CacheControl;ILjava/lang/Object;)Lai/koog/prompt/message/MessagePart$Tool$Result;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getCacheControl ()Lai/koog/prompt/message/CacheControl;
 	public final fun getId ()Ljava/lang/String;

--- a/prompt/prompt-model/api/jvm/prompt-model.api
+++ b/prompt/prompt-model/api/jvm/prompt-model.api
@@ -81,10 +81,12 @@ public abstract class ai/koog/prompt/dsl/ContentPartsBuilderBase : ai/koog/promp
 	public static synthetic fun audio$default (Lai/koog/prompt/dsl/ContentPartsBuilderBase;Lai/koog/prompt/message/AttachmentSource$Audio;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
 	public static synthetic fun audio$default (Lai/koog/prompt/dsl/ContentPartsBuilderBase;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
 	public static synthetic fun audio$default (Lai/koog/prompt/dsl/ContentPartsBuilderBase;Lkotlinx/io/files/Path;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
-	public final fun binaryFile (Lkotlinx/io/files/Path;Ljava/lang/String;)V
+	public final fun binaryFile (Lkotlinx/io/files/Path;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
+	public static synthetic fun binaryFile$default (Lai/koog/prompt/dsl/ContentPartsBuilderBase;Lkotlinx/io/files/Path;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
 	public final fun file (Lai/koog/prompt/message/AttachmentSource$File;Lai/koog/prompt/message/CacheControl;)V
-	public final fun file (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun file (Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
 	public static synthetic fun file$default (Lai/koog/prompt/dsl/ContentPartsBuilderBase;Lai/koog/prompt/message/AttachmentSource$File;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
+	public static synthetic fun file$default (Lai/koog/prompt/dsl/ContentPartsBuilderBase;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
 	protected final fun flushTextBuilder ()V
 	protected final fun getContentParts ()Ljava/util/List;
 	public final fun image (Lai/koog/prompt/message/AttachmentSource$Image;Lai/koog/prompt/message/CacheControl;)V
@@ -97,7 +99,8 @@ public abstract class ai/koog/prompt/dsl/ContentPartsBuilderBase : ai/koog/promp
 	public final fun text (Lai/koog/prompt/message/CacheControl;Lkotlin/jvm/functions/Function1;)V
 	public final fun text (Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
 	public static synthetic fun text$default (Lai/koog/prompt/dsl/ContentPartsBuilderBase;Lai/koog/prompt/message/CacheControl;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public final fun textFile (Lkotlinx/io/files/Path;Ljava/lang/String;)V
+	public final fun textFile (Lkotlinx/io/files/Path;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
+	public static synthetic fun textFile$default (Lai/koog/prompt/dsl/ContentPartsBuilderBase;Lkotlinx/io/files/Path;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
 	public final fun video (Lai/koog/prompt/message/AttachmentSource$Video;Lai/koog/prompt/message/CacheControl;)V
 	public final fun video (Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
 	public final fun video (Lkotlinx/io/files/Path;Lai/koog/prompt/message/CacheControl;)V
@@ -304,7 +307,8 @@ public final class ai/koog/prompt/dsl/PromptBuilder {
 	public final fun reasoning (Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun reasoning (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun reasoning (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/dsl/PromptBuilder;
-	public static synthetic fun reasoning$default (Lai/koog/prompt/dsl/PromptBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lai/koog/prompt/dsl/PromptBuilder;
+	public final fun reasoning (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)Lai/koog/prompt/dsl/PromptBuilder;
+	public static synthetic fun reasoning$default (Lai/koog/prompt/dsl/PromptBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun system (Lai/koog/prompt/message/CacheControl;Lkotlin/jvm/functions/Function1;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun system (Ljava/lang/String;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun system (Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)Lai/koog/prompt/dsl/PromptBuilder;
@@ -314,15 +318,18 @@ public final class ai/koog/prompt/dsl/PromptBuilder {
 	public final fun toolCall (Lai/koog/prompt/message/MessagePart$Tool$Call;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun toolCall (Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun toolCall (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/dsl/PromptBuilder;
+	public final fun toolCall (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun toolCall (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun toolCall (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)Lai/koog/prompt/dsl/PromptBuilder;
-	public static synthetic fun toolCall$default (Lai/koog/prompt/dsl/PromptBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lai/koog/prompt/dsl/PromptBuilder;
-	public static synthetic fun toolCall$default (Lai/koog/prompt/dsl/PromptBuilder;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILjava/lang/Object;)Lai/koog/prompt/dsl/PromptBuilder;
+	public final fun toolCall (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)Lai/koog/prompt/dsl/PromptBuilder;
+	public static synthetic fun toolCall$default (Lai/koog/prompt/dsl/PromptBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)Lai/koog/prompt/dsl/PromptBuilder;
+	public static synthetic fun toolCall$default (Lai/koog/prompt/dsl/PromptBuilder;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun toolResult (Lai/koog/prompt/message/MessagePart$Tool$Result;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun toolResult (Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun toolResult (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun toolResult (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)Lai/koog/prompt/dsl/PromptBuilder;
-	public static synthetic fun toolResult$default (Lai/koog/prompt/dsl/PromptBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lai/koog/prompt/dsl/PromptBuilder;
+	public final fun toolResult (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLai/koog/prompt/message/CacheControl;)Lai/koog/prompt/dsl/PromptBuilder;
+	public static synthetic fun toolResult$default (Lai/koog/prompt/dsl/PromptBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLai/koog/prompt/message/CacheControl;ILjava/lang/Object;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun user (Ljava/lang/String;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun user (Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)Lai/koog/prompt/dsl/PromptBuilder;
 	public final fun user (Ljava/util/List;)Lai/koog/prompt/dsl/PromptBuilder;
@@ -346,8 +353,8 @@ public final class ai/koog/prompt/dsl/RequestMessagePartsBuilder : ai/koog/promp
 	public synthetic fun build ()Ljava/lang/Object;
 	public fun build ()Ljava/util/List;
 	public final fun toolResult (Lai/koog/prompt/message/MessagePart$Tool$Result;)V
-	public final fun toolResult (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
-	public static synthetic fun toolResult$default (Lai/koog/prompt/dsl/RequestMessagePartsBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)V
+	public final fun toolResult (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLai/koog/prompt/message/CacheControl;)V
+	public static synthetic fun toolResult$default (Lai/koog/prompt/dsl/RequestMessagePartsBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
 }
 
 public final class ai/koog/prompt/dsl/ResponseMessagePartsBuilder : ai/koog/prompt/text/TextContentBuilderBase {
@@ -355,13 +362,13 @@ public final class ai/koog/prompt/dsl/ResponseMessagePartsBuilder : ai/koog/prom
 	public synthetic fun build ()Ljava/lang/Object;
 	public fun build ()Ljava/util/List;
 	public final fun reasoning (Lai/koog/prompt/message/MessagePart$Reasoning;)V
-	public final fun reasoning (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public static synthetic fun reasoning$default (Lai/koog/prompt/dsl/ResponseMessagePartsBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun reasoning (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
+	public static synthetic fun reasoning$default (Lai/koog/prompt/dsl/ResponseMessagePartsBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
 	public final fun toolCall (Lai/koog/prompt/message/MessagePart$Tool$Call;)V
-	public final fun toolCall (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public final fun toolCall (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
-	public static synthetic fun toolCall$default (Lai/koog/prompt/dsl/ResponseMessagePartsBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
-	public static synthetic fun toolCall$default (Lai/koog/prompt/dsl/ResponseMessagePartsBuilder;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)V
+	public final fun toolCall (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
+	public final fun toolCall (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lai/koog/prompt/message/CacheControl;)V
+	public static synthetic fun toolCall$default (Lai/koog/prompt/dsl/ResponseMessagePartsBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
+	public static synthetic fun toolCall$default (Lai/koog/prompt/dsl/ResponseMessagePartsBuilder;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)V
 }
 
 public final class ai/koog/prompt/message/AssistantMessageBuilder {
@@ -369,6 +376,8 @@ public final class ai/koog/prompt/message/AssistantMessageBuilder {
 	public final fun addPart (Lai/koog/prompt/message/MessagePart$ResponsePart;)Lai/koog/prompt/message/AssistantMessageBuilder;
 	public final fun addReasoning (Lai/koog/prompt/message/MessagePart$Reasoning;)Lai/koog/prompt/message/AssistantMessageBuilder;
 	public final fun addText (Ljava/lang/String;)Lai/koog/prompt/message/AssistantMessageBuilder;
+	public final fun addText (Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)Lai/koog/prompt/message/AssistantMessageBuilder;
+	public static synthetic fun addText$default (Lai/koog/prompt/message/AssistantMessageBuilder;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)Lai/koog/prompt/message/AssistantMessageBuilder;
 	public final fun addToolCall (Lai/koog/prompt/message/MessagePart$Tool$Call;)Lai/koog/prompt/message/AssistantMessageBuilder;
 	public final fun build ()Lai/koog/prompt/message/Message$Assistant;
 	public final fun finishReason (Ljava/lang/String;)Lai/koog/prompt/message/AssistantMessageBuilder;
@@ -850,6 +859,7 @@ public final class ai/koog/prompt/message/MessageMetaInfo$Companion {
 
 public abstract interface class ai/koog/prompt/message/MessagePart {
 	public static final field Companion Lai/koog/prompt/message/MessagePart$Companion;
+	public abstract fun getCacheControl ()Lai/koog/prompt/message/CacheControl;
 }
 
 public final class ai/koog/prompt/message/MessagePart$Attachment : ai/koog/prompt/message/MessagePart$ContentPart {
@@ -901,19 +911,23 @@ public final class ai/koog/prompt/message/MessagePart$Reasoning : ai/koog/prompt
 	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
 	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/util/List;)V
 	public fun <init> (Ljava/util/List;Ljava/util/List;)V
 	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/lang/String;)V
 	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/message/MessagePart$Reasoning;
-	public static synthetic fun copy$default (Lai/koog/prompt/message/MessagePart$Reasoning;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lai/koog/prompt/message/MessagePart$Reasoning;
+	public final fun component5 ()Lai/koog/prompt/message/CacheControl;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)Lai/koog/prompt/message/MessagePart$Reasoning;
+	public static synthetic fun copy$default (Lai/koog/prompt/message/MessagePart$Reasoning;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)Lai/koog/prompt/message/MessagePart$Reasoning;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getCacheControl ()Lai/koog/prompt/message/CacheControl;
 	public final fun getContent ()Ljava/util/List;
 	public final fun getEncrypted ()Ljava/lang/String;
 	public final fun getId ()Ljava/lang/String;
@@ -939,7 +953,6 @@ public final class ai/koog/prompt/message/MessagePart$Reasoning$Companion {
 
 public abstract interface class ai/koog/prompt/message/MessagePart$RequestPart : ai/koog/prompt/message/MessagePart {
 	public static final field Companion Lai/koog/prompt/message/MessagePart$RequestPart$Companion;
-	public abstract fun getCacheControl ()Lai/koog/prompt/message/CacheControl;
 }
 
 public final class ai/koog/prompt/message/MessagePart$RequestPart$Companion {
@@ -994,18 +1007,22 @@ public final class ai/koog/prompt/message/MessagePart$Tool$Call : ai/koog/prompt
 	public static final field Companion Lai/koog/prompt/message/MessagePart$Tool$Call$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lai/koog/prompt/message/CacheControl;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lai/koog/prompt/message/CacheControl;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lai/koog/prompt/message/MessagePart$Tool$Call;
-	public static synthetic fun copy$default (Lai/koog/prompt/message/MessagePart$Tool$Call;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lai/koog/prompt/message/MessagePart$Tool$Call;
+	public final fun component4 ()Lai/koog/prompt/message/CacheControl;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;)Lai/koog/prompt/message/MessagePart$Tool$Call;
+	public static synthetic fun copy$default (Lai/koog/prompt/message/MessagePart$Tool$Call;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lai/koog/prompt/message/CacheControl;ILjava/lang/Object;)Lai/koog/prompt/message/MessagePart$Tool$Call;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getArgs ()Ljava/lang/String;
 	public final fun getArgsJson ()Lkotlinx/serialization/json/JsonObject;
+	public fun getCacheControl ()Lai/koog/prompt/message/CacheControl;
 	public final fun getId ()Ljava/lang/String;
 	public fun getTool ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -1033,16 +1050,23 @@ public final class ai/koog/prompt/message/MessagePart$Tool$Companion {
 
 public final class ai/koog/prompt/message/MessagePart$Tool$Result : ai/koog/prompt/message/MessagePart$RequestPart, ai/koog/prompt/message/MessagePart$Tool {
 	public static final field Companion Lai/koog/prompt/message/MessagePart$Tool$Result$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLai/koog/prompt/message/CacheControl;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLai/koog/prompt/message/CacheControl;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Z)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLai/koog/prompt/message/CacheControl;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLai/koog/prompt/message/CacheControl;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/util/List;
 	public final fun component4 ()Z
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Z)Lai/koog/prompt/message/MessagePart$Tool$Result;
-	public static synthetic fun copy$default (Lai/koog/prompt/message/MessagePart$Tool$Result;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZILjava/lang/Object;)Lai/koog/prompt/message/MessagePart$Tool$Result;
+	public final fun component5 ()Lai/koog/prompt/message/CacheControl;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLai/koog/prompt/message/CacheControl;)Lai/koog/prompt/message/MessagePart$Tool$Result;
+	public static synthetic fun copy$default (Lai/koog/prompt/message/MessagePart$Tool$Result;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLai/koog/prompt/message/CacheControl;ILjava/lang/Object;)Lai/koog/prompt/message/MessagePart$Tool$Result;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getCacheControl ()Lai/koog/prompt/message/CacheControl;
 	public final fun getId ()Ljava/lang/String;
@@ -1072,6 +1096,7 @@ public final class ai/koog/prompt/message/MessagePart$Tool$Result$Companion {
 public final class ai/koog/prompt/message/ReasoningBuilder {
 	public fun <init> ()V
 	public final fun build ()Lai/koog/prompt/message/MessagePart$Reasoning;
+	public final fun cacheControl (Lai/koog/prompt/message/CacheControl;)Lai/koog/prompt/message/ReasoningBuilder;
 	public final fun content (Ljava/util/List;)Lai/koog/prompt/message/ReasoningBuilder;
 	public final fun encrypted (Ljava/lang/String;)Lai/koog/prompt/message/ReasoningBuilder;
 	public final fun id (Ljava/lang/String;)Lai/koog/prompt/message/ReasoningBuilder;
@@ -1208,6 +1233,7 @@ public final class ai/koog/prompt/message/ToolCallBuilder {
 	public fun <init> ()V
 	public final fun args (Lkotlinx/serialization/json/JsonObject;)Lai/koog/prompt/message/ToolCallBuilder;
 	public final fun build ()Lai/koog/prompt/message/MessagePart$Tool$Call;
+	public final fun cacheControl (Lai/koog/prompt/message/CacheControl;)Lai/koog/prompt/message/ToolCallBuilder;
 	public final fun id (Ljava/lang/String;)Lai/koog/prompt/message/ToolCallBuilder;
 	public final fun tool (Ljava/lang/String;)Lai/koog/prompt/message/ToolCallBuilder;
 }
@@ -1215,6 +1241,7 @@ public final class ai/koog/prompt/message/ToolCallBuilder {
 public final class ai/koog/prompt/message/ToolResultBuilder {
 	public fun <init> ()V
 	public final fun build ()Lai/koog/prompt/message/MessagePart$Tool$Result;
+	public final fun cacheControl (Lai/koog/prompt/message/CacheControl;)Lai/koog/prompt/message/ToolResultBuilder;
 	public final fun id (Ljava/lang/String;)Lai/koog/prompt/message/ToolResultBuilder;
 	public final fun isError (Z)Lai/koog/prompt/message/ToolResultBuilder;
 	public final fun output (Ljava/lang/String;)Lai/koog/prompt/message/ToolResultBuilder;

--- a/prompt/prompt-model/api/prompt-model.klib.api
+++ b/prompt/prompt-model/api/prompt-model.klib.api
@@ -476,6 +476,9 @@ sealed interface ai.koog.prompt.message/MessageMetaInfo { // ai.koog.prompt.mess
 }
 
 sealed interface ai.koog.prompt.message/MessagePart { // ai.koog.prompt.message/MessagePart|null[0]
+    abstract val cacheControl // ai.koog.prompt.message/MessagePart.cacheControl|{}cacheControl[0]
+        abstract fun <get-cacheControl>(): ai.koog.prompt.message/CacheControl? // ai.koog.prompt.message/MessagePart.cacheControl.<get-cacheControl>|<get-cacheControl>(){}[0]
+
     sealed interface ContentPart : ai.koog.prompt.message/MessagePart.RequestPart, ai.koog.prompt.message/MessagePart.ResponsePart { // ai.koog.prompt.message/MessagePart.ContentPart|null[0]
         final object Companion : kotlinx.serialization.internal/SerializerFactory { // ai.koog.prompt.message/MessagePart.ContentPart.Companion|null[0]
             final fun serializer(): kotlinx.serialization/KSerializer<ai.koog.prompt.message/MessagePart.ContentPart> // ai.koog.prompt.message/MessagePart.ContentPart.Companion.serializer|serializer(){}[0]
@@ -484,9 +487,6 @@ sealed interface ai.koog.prompt.message/MessagePart { // ai.koog.prompt.message/
     }
 
     sealed interface RequestPart : ai.koog.prompt.message/MessagePart { // ai.koog.prompt.message/MessagePart.RequestPart|null[0]
-        abstract val cacheControl // ai.koog.prompt.message/MessagePart.RequestPart.cacheControl|{}cacheControl[0]
-            abstract fun <get-cacheControl>(): ai.koog.prompt.message/CacheControl? // ai.koog.prompt.message/MessagePart.RequestPart.cacheControl.<get-cacheControl>|<get-cacheControl>(){}[0]
-
         final object Companion : kotlinx.serialization.internal/SerializerFactory { // ai.koog.prompt.message/MessagePart.RequestPart.Companion|null[0]
             final fun serializer(): kotlinx.serialization/KSerializer<ai.koog.prompt.message/MessagePart.RequestPart> // ai.koog.prompt.message/MessagePart.RequestPart.Companion.serializer|serializer(){}[0]
             final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // ai.koog.prompt.message/MessagePart.RequestPart.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
@@ -505,13 +505,15 @@ sealed interface ai.koog.prompt.message/MessagePart { // ai.koog.prompt.message/
             abstract fun <get-tool>(): kotlin/String // ai.koog.prompt.message/MessagePart.Tool.tool.<get-tool>|<get-tool>(){}[0]
 
         final class Call : ai.koog.prompt.message/MessagePart.ResponsePart, ai.koog.prompt.message/MessagePart.Tool { // ai.koog.prompt.message/MessagePart.Tool.Call|null[0]
-            constructor <init>(kotlin/String? = ..., kotlin/String, kotlin/String) // ai.koog.prompt.message/MessagePart.Tool.Call.<init>|<init>(kotlin.String?;kotlin.String;kotlin.String){}[0]
-            constructor <init>(kotlin/String? = ..., kotlin/String, kotlinx.serialization.json/JsonObject) // ai.koog.prompt.message/MessagePart.Tool.Call.<init>|<init>(kotlin.String?;kotlin.String;kotlinx.serialization.json.JsonObject){}[0]
+            constructor <init>(kotlin/String? = ..., kotlin/String, kotlin/String, ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.message/MessagePart.Tool.Call.<init>|<init>(kotlin.String?;kotlin.String;kotlin.String;ai.koog.prompt.message.CacheControl?){}[0]
+            constructor <init>(kotlin/String? = ..., kotlin/String, kotlinx.serialization.json/JsonObject, ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.message/MessagePart.Tool.Call.<init>|<init>(kotlin.String?;kotlin.String;kotlinx.serialization.json.JsonObject;ai.koog.prompt.message.CacheControl?){}[0]
 
             final val args // ai.koog.prompt.message/MessagePart.Tool.Call.args|{}args[0]
                 final fun <get-args>(): kotlin/String // ai.koog.prompt.message/MessagePart.Tool.Call.args.<get-args>|<get-args>(){}[0]
             final val argsJson // ai.koog.prompt.message/MessagePart.Tool.Call.argsJson|{}argsJson[0]
                 final fun <get-argsJson>(): kotlinx.serialization.json/JsonObject // ai.koog.prompt.message/MessagePart.Tool.Call.argsJson.<get-argsJson>|<get-argsJson>(){}[0]
+            final val cacheControl // ai.koog.prompt.message/MessagePart.Tool.Call.cacheControl|{}cacheControl[0]
+                final fun <get-cacheControl>(): ai.koog.prompt.message/CacheControl? // ai.koog.prompt.message/MessagePart.Tool.Call.cacheControl.<get-cacheControl>|<get-cacheControl>(){}[0]
             final val id // ai.koog.prompt.message/MessagePart.Tool.Call.id|{}id[0]
                 final fun <get-id>(): kotlin/String? // ai.koog.prompt.message/MessagePart.Tool.Call.id.<get-id>|<get-id>(){}[0]
             final val tool // ai.koog.prompt.message/MessagePart.Tool.Call.tool|{}tool[0]
@@ -520,7 +522,8 @@ sealed interface ai.koog.prompt.message/MessagePart { // ai.koog.prompt.message/
             final fun component1(): kotlin/String? // ai.koog.prompt.message/MessagePart.Tool.Call.component1|component1(){}[0]
             final fun component2(): kotlin/String // ai.koog.prompt.message/MessagePart.Tool.Call.component2|component2(){}[0]
             final fun component3(): kotlin/String // ai.koog.prompt.message/MessagePart.Tool.Call.component3|component3(){}[0]
-            final fun copy(kotlin/String? = ..., kotlin/String = ..., kotlin/String = ...): ai.koog.prompt.message/MessagePart.Tool.Call // ai.koog.prompt.message/MessagePart.Tool.Call.copy|copy(kotlin.String?;kotlin.String;kotlin.String){}[0]
+            final fun component4(): ai.koog.prompt.message/CacheControl? // ai.koog.prompt.message/MessagePart.Tool.Call.component4|component4(){}[0]
+            final fun copy(kotlin/String? = ..., kotlin/String = ..., kotlin/String = ..., ai.koog.prompt.message/CacheControl? = ...): ai.koog.prompt.message/MessagePart.Tool.Call // ai.koog.prompt.message/MessagePart.Tool.Call.copy|copy(kotlin.String?;kotlin.String;kotlin.String;ai.koog.prompt.message.CacheControl?){}[0]
             final fun equals(kotlin/Any?): kotlin/Boolean // ai.koog.prompt.message/MessagePart.Tool.Call.equals|equals(kotlin.Any?){}[0]
             final fun hashCode(): kotlin/Int // ai.koog.prompt.message/MessagePart.Tool.Call.hashCode|hashCode(){}[0]
             final fun toString(): kotlin/String // ai.koog.prompt.message/MessagePart.Tool.Call.toString|toString(){}[0]
@@ -535,13 +538,15 @@ sealed interface ai.koog.prompt.message/MessagePart { // ai.koog.prompt.message/
             }
 
             final object Companion { // ai.koog.prompt.message/MessagePart.Tool.Call.Companion|null[0]
+                final val $childSerializers // ai.koog.prompt.message/MessagePart.Tool.Call.Companion.$childSerializers|{}$childSerializers[0]
+
                 final fun serializer(): kotlinx.serialization/KSerializer<ai.koog.prompt.message/MessagePart.Tool.Call> // ai.koog.prompt.message/MessagePart.Tool.Call.Companion.serializer|serializer(){}[0]
             }
         }
 
         final class Result : ai.koog.prompt.message/MessagePart.RequestPart, ai.koog.prompt.message/MessagePart.Tool { // ai.koog.prompt.message/MessagePart.Tool.Result|null[0]
-            constructor <init>(kotlin/String? = ..., kotlin/String, kotlin.collections/List<ai.koog.prompt.message/MessagePart.ContentPart>, kotlin/Boolean = ...) // ai.koog.prompt.message/MessagePart.Tool.Result.<init>|<init>(kotlin.String?;kotlin.String;kotlin.collections.List<ai.koog.prompt.message.MessagePart.ContentPart>;kotlin.Boolean){}[0]
-            constructor <init>(kotlin/String? = ..., kotlin/String, kotlin/String, kotlin/Boolean = ...) // ai.koog.prompt.message/MessagePart.Tool.Result.<init>|<init>(kotlin.String?;kotlin.String;kotlin.String;kotlin.Boolean){}[0]
+            constructor <init>(kotlin/String? = ..., kotlin/String, kotlin.collections/List<ai.koog.prompt.message/MessagePart.ContentPart>, kotlin/Boolean = ..., ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.message/MessagePart.Tool.Result.<init>|<init>(kotlin.String?;kotlin.String;kotlin.collections.List<ai.koog.prompt.message.MessagePart.ContentPart>;kotlin.Boolean;ai.koog.prompt.message.CacheControl?){}[0]
+            constructor <init>(kotlin/String? = ..., kotlin/String, kotlin/String, kotlin/Boolean = ..., ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.message/MessagePart.Tool.Result.<init>|<init>(kotlin.String?;kotlin.String;kotlin.String;kotlin.Boolean;ai.koog.prompt.message.CacheControl?){}[0]
 
             final val cacheControl // ai.koog.prompt.message/MessagePart.Tool.Result.cacheControl|{}cacheControl[0]
                 final fun <get-cacheControl>(): ai.koog.prompt.message/CacheControl? // ai.koog.prompt.message/MessagePart.Tool.Result.cacheControl.<get-cacheControl>|<get-cacheControl>(){}[0]
@@ -560,7 +565,8 @@ sealed interface ai.koog.prompt.message/MessagePart { // ai.koog.prompt.message/
             final fun component2(): kotlin/String // ai.koog.prompt.message/MessagePart.Tool.Result.component2|component2(){}[0]
             final fun component3(): kotlin.collections/List<ai.koog.prompt.message/MessagePart.ContentPart> // ai.koog.prompt.message/MessagePart.Tool.Result.component3|component3(){}[0]
             final fun component4(): kotlin/Boolean // ai.koog.prompt.message/MessagePart.Tool.Result.component4|component4(){}[0]
-            final fun copy(kotlin/String? = ..., kotlin/String = ..., kotlin.collections/List<ai.koog.prompt.message/MessagePart.ContentPart> = ..., kotlin/Boolean = ...): ai.koog.prompt.message/MessagePart.Tool.Result // ai.koog.prompt.message/MessagePart.Tool.Result.copy|copy(kotlin.String?;kotlin.String;kotlin.collections.List<ai.koog.prompt.message.MessagePart.ContentPart>;kotlin.Boolean){}[0]
+            final fun component5(): ai.koog.prompt.message/CacheControl? // ai.koog.prompt.message/MessagePart.Tool.Result.component5|component5(){}[0]
+            final fun copy(kotlin/String? = ..., kotlin/String = ..., kotlin.collections/List<ai.koog.prompt.message/MessagePart.ContentPart> = ..., kotlin/Boolean = ..., ai.koog.prompt.message/CacheControl? = ...): ai.koog.prompt.message/MessagePart.Tool.Result // ai.koog.prompt.message/MessagePart.Tool.Result.copy|copy(kotlin.String?;kotlin.String;kotlin.collections.List<ai.koog.prompt.message.MessagePart.ContentPart>;kotlin.Boolean;ai.koog.prompt.message.CacheControl?){}[0]
             final fun equals(kotlin/Any?): kotlin/Boolean // ai.koog.prompt.message/MessagePart.Tool.Result.equals|equals(kotlin.Any?){}[0]
             final fun hashCode(): kotlin/Int // ai.koog.prompt.message/MessagePart.Tool.Result.hashCode|hashCode(){}[0]
             final fun toString(): kotlin/String // ai.koog.prompt.message/MessagePart.Tool.Result.toString|toString(){}[0]
@@ -619,9 +625,11 @@ sealed interface ai.koog.prompt.message/MessagePart { // ai.koog.prompt.message/
     }
 
     final class Reasoning : ai.koog.prompt.message/MessagePart.ResponsePart { // ai.koog.prompt.message/MessagePart.Reasoning|null[0]
-        constructor <init>(kotlin.collections/List<kotlin/String>, kotlin.collections/List<kotlin/String>? = ..., kotlin/String? = ..., kotlin/String? = ...) // ai.koog.prompt.message/MessagePart.Reasoning.<init>|<init>(kotlin.collections.List<kotlin.String>;kotlin.collections.List<kotlin.String>?;kotlin.String?;kotlin.String?){}[0]
-        constructor <init>(kotlin/String, kotlin.collections/List<kotlin/String>? = ..., kotlin/String? = ..., kotlin/String? = ...) // ai.koog.prompt.message/MessagePart.Reasoning.<init>|<init>(kotlin.String;kotlin.collections.List<kotlin.String>?;kotlin.String?;kotlin.String?){}[0]
+        constructor <init>(kotlin.collections/List<kotlin/String>, kotlin.collections/List<kotlin/String>? = ..., kotlin/String? = ..., kotlin/String? = ..., ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.message/MessagePart.Reasoning.<init>|<init>(kotlin.collections.List<kotlin.String>;kotlin.collections.List<kotlin.String>?;kotlin.String?;kotlin.String?;ai.koog.prompt.message.CacheControl?){}[0]
+        constructor <init>(kotlin/String, kotlin.collections/List<kotlin/String>? = ..., kotlin/String? = ..., kotlin/String? = ..., ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.message/MessagePart.Reasoning.<init>|<init>(kotlin.String;kotlin.collections.List<kotlin.String>?;kotlin.String?;kotlin.String?;ai.koog.prompt.message.CacheControl?){}[0]
 
+        final val cacheControl // ai.koog.prompt.message/MessagePart.Reasoning.cacheControl|{}cacheControl[0]
+            final fun <get-cacheControl>(): ai.koog.prompt.message/CacheControl? // ai.koog.prompt.message/MessagePart.Reasoning.cacheControl.<get-cacheControl>|<get-cacheControl>(){}[0]
         final val content // ai.koog.prompt.message/MessagePart.Reasoning.content|{}content[0]
             final fun <get-content>(): kotlin.collections/List<kotlin/String> // ai.koog.prompt.message/MessagePart.Reasoning.content.<get-content>|<get-content>(){}[0]
         final val encrypted // ai.koog.prompt.message/MessagePart.Reasoning.encrypted|{}encrypted[0]
@@ -635,7 +643,8 @@ sealed interface ai.koog.prompt.message/MessagePart { // ai.koog.prompt.message/
         final fun component2(): kotlin.collections/List<kotlin/String>? // ai.koog.prompt.message/MessagePart.Reasoning.component2|component2(){}[0]
         final fun component3(): kotlin/String? // ai.koog.prompt.message/MessagePart.Reasoning.component3|component3(){}[0]
         final fun component4(): kotlin/String? // ai.koog.prompt.message/MessagePart.Reasoning.component4|component4(){}[0]
-        final fun copy(kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<kotlin/String>? = ..., kotlin/String? = ..., kotlin/String? = ...): ai.koog.prompt.message/MessagePart.Reasoning // ai.koog.prompt.message/MessagePart.Reasoning.copy|copy(kotlin.collections.List<kotlin.String>;kotlin.collections.List<kotlin.String>?;kotlin.String?;kotlin.String?){}[0]
+        final fun component5(): ai.koog.prompt.message/CacheControl? // ai.koog.prompt.message/MessagePart.Reasoning.component5|component5(){}[0]
+        final fun copy(kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<kotlin/String>? = ..., kotlin/String? = ..., kotlin/String? = ..., ai.koog.prompt.message/CacheControl? = ...): ai.koog.prompt.message/MessagePart.Reasoning // ai.koog.prompt.message/MessagePart.Reasoning.copy|copy(kotlin.collections.List<kotlin.String>;kotlin.collections.List<kotlin.String>?;kotlin.String?;kotlin.String?;ai.koog.prompt.message.CacheControl?){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // ai.koog.prompt.message/MessagePart.Reasoning.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // ai.koog.prompt.message/MessagePart.Reasoning.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // ai.koog.prompt.message/MessagePart.Reasoning.toString|toString(){}[0]
@@ -956,9 +965,9 @@ abstract class <#A: kotlin/Any?> ai.koog.prompt.dsl/ContentPartsBuilderBase : ai
     final fun audio(ai.koog.prompt.message/AttachmentSource.Audio, ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.dsl/ContentPartsBuilderBase.audio|audio(ai.koog.prompt.message.AttachmentSource.Audio;ai.koog.prompt.message.CacheControl?){}[0]
     final fun audio(kotlin/String, ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.dsl/ContentPartsBuilderBase.audio|audio(kotlin.String;ai.koog.prompt.message.CacheControl?){}[0]
     final fun audio(kotlinx.io.files/Path, ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.dsl/ContentPartsBuilderBase.audio|audio(kotlinx.io.files.Path;ai.koog.prompt.message.CacheControl?){}[0]
-    final fun binaryFile(kotlinx.io.files/Path, kotlin/String) // ai.koog.prompt.dsl/ContentPartsBuilderBase.binaryFile|binaryFile(kotlinx.io.files.Path;kotlin.String){}[0]
+    final fun binaryFile(kotlinx.io.files/Path, kotlin/String, ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.dsl/ContentPartsBuilderBase.binaryFile|binaryFile(kotlinx.io.files.Path;kotlin.String;ai.koog.prompt.message.CacheControl?){}[0]
     final fun file(ai.koog.prompt.message/AttachmentSource.File, ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.dsl/ContentPartsBuilderBase.file|file(ai.koog.prompt.message.AttachmentSource.File;ai.koog.prompt.message.CacheControl?){}[0]
-    final fun file(kotlin/String, kotlin/String) // ai.koog.prompt.dsl/ContentPartsBuilderBase.file|file(kotlin.String;kotlin.String){}[0]
+    final fun file(kotlin/String, kotlin/String, ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.dsl/ContentPartsBuilderBase.file|file(kotlin.String;kotlin.String;ai.koog.prompt.message.CacheControl?){}[0]
     final fun flushTextBuilder() // ai.koog.prompt.dsl/ContentPartsBuilderBase.flushTextBuilder|flushTextBuilder(){}[0]
     final fun image(ai.koog.prompt.message/AttachmentSource.Image, ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.dsl/ContentPartsBuilderBase.image|image(ai.koog.prompt.message.AttachmentSource.Image;ai.koog.prompt.message.CacheControl?){}[0]
     final fun image(kotlin/String, ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.dsl/ContentPartsBuilderBase.image|image(kotlin.String;ai.koog.prompt.message.CacheControl?){}[0]
@@ -966,7 +975,7 @@ abstract class <#A: kotlin/Any?> ai.koog.prompt.dsl/ContentPartsBuilderBase : ai
     final fun part(ai.koog.prompt.message/MessagePart.ContentPart) // ai.koog.prompt.dsl/ContentPartsBuilderBase.part|part(ai.koog.prompt.message.MessagePart.ContentPart){}[0]
     final fun text(ai.koog.prompt.message/CacheControl? = ..., kotlin/Function1<ai.koog.prompt.text/TextContentBuilder, kotlin/Unit>) // ai.koog.prompt.dsl/ContentPartsBuilderBase.text|text(ai.koog.prompt.message.CacheControl?;kotlin.Function1<ai.koog.prompt.text.TextContentBuilder,kotlin.Unit>){}[0]
     final fun text(kotlin/String, ai.koog.prompt.message/CacheControl) // ai.koog.prompt.dsl/ContentPartsBuilderBase.text|text(kotlin.String;ai.koog.prompt.message.CacheControl){}[0]
-    final fun textFile(kotlinx.io.files/Path, kotlin/String) // ai.koog.prompt.dsl/ContentPartsBuilderBase.textFile|textFile(kotlinx.io.files.Path;kotlin.String){}[0]
+    final fun textFile(kotlinx.io.files/Path, kotlin/String, ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.dsl/ContentPartsBuilderBase.textFile|textFile(kotlinx.io.files.Path;kotlin.String;ai.koog.prompt.message.CacheControl?){}[0]
     final fun video(ai.koog.prompt.message/AttachmentSource.Video, ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.dsl/ContentPartsBuilderBase.video|video(ai.koog.prompt.message.AttachmentSource.Video;ai.koog.prompt.message.CacheControl?){}[0]
     final fun video(kotlin/String, ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.dsl/ContentPartsBuilderBase.video|video(kotlin.String;ai.koog.prompt.message.CacheControl?){}[0]
     final fun video(kotlinx.io.files/Path, ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.dsl/ContentPartsBuilderBase.video|video(kotlinx.io.files.Path;ai.koog.prompt.message.CacheControl?){}[0]
@@ -1106,15 +1115,15 @@ final class ai.koog.prompt.dsl/PromptBuilder { // ai.koog.prompt.dsl/PromptBuild
     final fun message(ai.koog.prompt.message/Message): ai.koog.prompt.dsl/PromptBuilder // ai.koog.prompt.dsl/PromptBuilder.message|message(ai.koog.prompt.message.Message){}[0]
     final fun messages(kotlin.collections/List<ai.koog.prompt.message/Message>): ai.koog.prompt.dsl/PromptBuilder // ai.koog.prompt.dsl/PromptBuilder.messages|messages(kotlin.collections.List<ai.koog.prompt.message.Message>){}[0]
     final fun reasoning(ai.koog.prompt.message/MessagePart.Reasoning): ai.koog.prompt.dsl/PromptBuilder // ai.koog.prompt.dsl/PromptBuilder.reasoning|reasoning(ai.koog.prompt.message.MessagePart.Reasoning){}[0]
-    final fun reasoning(kotlin/String, kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ...): ai.koog.prompt.dsl/PromptBuilder // ai.koog.prompt.dsl/PromptBuilder.reasoning|reasoning(kotlin.String;kotlin.String?;kotlin.String?;kotlin.String?){}[0]
+    final fun reasoning(kotlin/String, kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., ai.koog.prompt.message/CacheControl? = ...): ai.koog.prompt.dsl/PromptBuilder // ai.koog.prompt.dsl/PromptBuilder.reasoning|reasoning(kotlin.String;kotlin.String?;kotlin.String?;kotlin.String?;ai.koog.prompt.message.CacheControl?){}[0]
     final fun system(ai.koog.prompt.message/CacheControl? = ..., kotlin/Function1<ai.koog.prompt.text/TextContentBuilder, kotlin/Unit>): ai.koog.prompt.dsl/PromptBuilder // ai.koog.prompt.dsl/PromptBuilder.system|system(ai.koog.prompt.message.CacheControl?;kotlin.Function1<ai.koog.prompt.text.TextContentBuilder,kotlin.Unit>){}[0]
     final fun system(kotlin/Function1<ai.koog.prompt.text/TextContentBuilder, kotlin/Unit>): ai.koog.prompt.dsl/PromptBuilder // ai.koog.prompt.dsl/PromptBuilder.system|system(kotlin.Function1<ai.koog.prompt.text.TextContentBuilder,kotlin.Unit>){}[0]
     final fun system(kotlin/String, ai.koog.prompt.message/CacheControl? = ...): ai.koog.prompt.dsl/PromptBuilder // ai.koog.prompt.dsl/PromptBuilder.system|system(kotlin.String;ai.koog.prompt.message.CacheControl?){}[0]
     final fun toolCall(ai.koog.prompt.message/MessagePart.Tool.Call): ai.koog.prompt.dsl/PromptBuilder // ai.koog.prompt.dsl/PromptBuilder.toolCall|toolCall(ai.koog.prompt.message.MessagePart.Tool.Call){}[0]
-    final fun toolCall(kotlin/String, kotlin/String, kotlin/String? = ...): ai.koog.prompt.dsl/PromptBuilder // ai.koog.prompt.dsl/PromptBuilder.toolCall|toolCall(kotlin.String;kotlin.String;kotlin.String?){}[0]
-    final fun toolCall(kotlin/String, kotlinx.serialization.json/JsonObject, kotlin/String? = ...): ai.koog.prompt.dsl/PromptBuilder // ai.koog.prompt.dsl/PromptBuilder.toolCall|toolCall(kotlin.String;kotlinx.serialization.json.JsonObject;kotlin.String?){}[0]
+    final fun toolCall(kotlin/String, kotlin/String, kotlin/String? = ..., ai.koog.prompt.message/CacheControl? = ...): ai.koog.prompt.dsl/PromptBuilder // ai.koog.prompt.dsl/PromptBuilder.toolCall|toolCall(kotlin.String;kotlin.String;kotlin.String?;ai.koog.prompt.message.CacheControl?){}[0]
+    final fun toolCall(kotlin/String, kotlinx.serialization.json/JsonObject, kotlin/String? = ..., ai.koog.prompt.message/CacheControl? = ...): ai.koog.prompt.dsl/PromptBuilder // ai.koog.prompt.dsl/PromptBuilder.toolCall|toolCall(kotlin.String;kotlinx.serialization.json.JsonObject;kotlin.String?;ai.koog.prompt.message.CacheControl?){}[0]
     final fun toolResult(ai.koog.prompt.message/MessagePart.Tool.Result): ai.koog.prompt.dsl/PromptBuilder // ai.koog.prompt.dsl/PromptBuilder.toolResult|toolResult(ai.koog.prompt.message.MessagePart.Tool.Result){}[0]
-    final fun toolResult(kotlin/String, kotlin/String, kotlin/String? = ..., kotlin/Boolean = ...): ai.koog.prompt.dsl/PromptBuilder // ai.koog.prompt.dsl/PromptBuilder.toolResult|toolResult(kotlin.String;kotlin.String;kotlin.String?;kotlin.Boolean){}[0]
+    final fun toolResult(kotlin/String, kotlin/String, kotlin/String? = ..., kotlin/Boolean = ..., ai.koog.prompt.message/CacheControl? = ...): ai.koog.prompt.dsl/PromptBuilder // ai.koog.prompt.dsl/PromptBuilder.toolResult|toolResult(kotlin.String;kotlin.String;kotlin.String?;kotlin.Boolean;ai.koog.prompt.message.CacheControl?){}[0]
     final fun user(kotlin.collections/List<ai.koog.prompt.message/MessagePart.RequestPart>): ai.koog.prompt.dsl/PromptBuilder // ai.koog.prompt.dsl/PromptBuilder.user|user(kotlin.collections.List<ai.koog.prompt.message.MessagePart.RequestPart>){}[0]
     final fun user(kotlin/Function1<ai.koog.prompt.dsl/RequestMessagePartsBuilder, kotlin/Unit>): ai.koog.prompt.dsl/PromptBuilder // ai.koog.prompt.dsl/PromptBuilder.user|user(kotlin.Function1<ai.koog.prompt.dsl.RequestMessagePartsBuilder,kotlin.Unit>){}[0]
     final fun user(kotlin/String, ai.koog.prompt.message/CacheControl? = ...): ai.koog.prompt.dsl/PromptBuilder // ai.koog.prompt.dsl/PromptBuilder.user|user(kotlin.String;ai.koog.prompt.message.CacheControl?){}[0]
@@ -1125,7 +1134,7 @@ final class ai.koog.prompt.dsl/RequestMessagePartsBuilder : ai.koog.prompt.dsl/C
 
     final fun build(): kotlin.collections/List<ai.koog.prompt.message/MessagePart.RequestPart> // ai.koog.prompt.dsl/RequestMessagePartsBuilder.build|build(){}[0]
     final fun toolResult(ai.koog.prompt.message/MessagePart.Tool.Result) // ai.koog.prompt.dsl/RequestMessagePartsBuilder.toolResult|toolResult(ai.koog.prompt.message.MessagePart.Tool.Result){}[0]
-    final fun toolResult(kotlin/String? = ..., kotlin/String, kotlin/String, kotlin/Boolean = ...) // ai.koog.prompt.dsl/RequestMessagePartsBuilder.toolResult|toolResult(kotlin.String?;kotlin.String;kotlin.String;kotlin.Boolean){}[0]
+    final fun toolResult(kotlin/String? = ..., kotlin/String, kotlin/String, kotlin/Boolean = ..., ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.dsl/RequestMessagePartsBuilder.toolResult|toolResult(kotlin.String?;kotlin.String;kotlin.String;kotlin.Boolean;ai.koog.prompt.message.CacheControl?){}[0]
 }
 
 final class ai.koog.prompt.dsl/ResponseMessagePartsBuilder : ai.koog.prompt.text/TextContentBuilderBase<kotlin.collections/List<ai.koog.prompt.message/MessagePart.ResponsePart>> { // ai.koog.prompt.dsl/ResponseMessagePartsBuilder|null[0]
@@ -1133,10 +1142,10 @@ final class ai.koog.prompt.dsl/ResponseMessagePartsBuilder : ai.koog.prompt.text
 
     final fun build(): kotlin.collections/List<ai.koog.prompt.message/MessagePart.ResponsePart> // ai.koog.prompt.dsl/ResponseMessagePartsBuilder.build|build(){}[0]
     final fun reasoning(ai.koog.prompt.message/MessagePart.Reasoning) // ai.koog.prompt.dsl/ResponseMessagePartsBuilder.reasoning|reasoning(ai.koog.prompt.message.MessagePart.Reasoning){}[0]
-    final fun reasoning(kotlin/String? = ..., kotlin/String, kotlin/String? = ..., kotlin/String? = ...) // ai.koog.prompt.dsl/ResponseMessagePartsBuilder.reasoning|reasoning(kotlin.String?;kotlin.String;kotlin.String?;kotlin.String?){}[0]
+    final fun reasoning(kotlin/String? = ..., kotlin/String, kotlin/String? = ..., kotlin/String? = ..., ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.dsl/ResponseMessagePartsBuilder.reasoning|reasoning(kotlin.String?;kotlin.String;kotlin.String?;kotlin.String?;ai.koog.prompt.message.CacheControl?){}[0]
     final fun toolCall(ai.koog.prompt.message/MessagePart.Tool.Call) // ai.koog.prompt.dsl/ResponseMessagePartsBuilder.toolCall|toolCall(ai.koog.prompt.message.MessagePart.Tool.Call){}[0]
-    final fun toolCall(kotlin/String? = ..., kotlin/String, kotlin/String) // ai.koog.prompt.dsl/ResponseMessagePartsBuilder.toolCall|toolCall(kotlin.String?;kotlin.String;kotlin.String){}[0]
-    final fun toolCall(kotlin/String? = ..., kotlin/String, kotlinx.serialization.json/JsonObject) // ai.koog.prompt.dsl/ResponseMessagePartsBuilder.toolCall|toolCall(kotlin.String?;kotlin.String;kotlinx.serialization.json.JsonObject){}[0]
+    final fun toolCall(kotlin/String? = ..., kotlin/String, kotlin/String, ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.dsl/ResponseMessagePartsBuilder.toolCall|toolCall(kotlin.String?;kotlin.String;kotlin.String;ai.koog.prompt.message.CacheControl?){}[0]
+    final fun toolCall(kotlin/String? = ..., kotlin/String, kotlinx.serialization.json/JsonObject, ai.koog.prompt.message/CacheControl? = ...) // ai.koog.prompt.dsl/ResponseMessagePartsBuilder.toolCall|toolCall(kotlin.String?;kotlin.String;kotlinx.serialization.json.JsonObject;ai.koog.prompt.message.CacheControl?){}[0]
 }
 
 final class ai.koog.prompt.message/RequestMetaInfo : ai.koog.prompt.message/MessageMetaInfo { // ai.koog.prompt.message/RequestMetaInfo|null[0]

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/ContentPartsBuilderBase.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/ContentPartsBuilderBase.kt
@@ -239,7 +239,7 @@ public abstract class ContentPartsBuilderBase<T> : TextContentBuilderBase<T>() {
      * @param mimeType MIME type of the file (e.g., "application/pdf", "text/plain")
      * @throws IllegalArgumentException if the URL is not valid or no file in the URL was found.
      */
-    public fun file(url: String, mimeType: String) {
+    public fun file(url: String, mimeType: String, cacheControl: CacheControl? = null) {
         val fileData = url.urlFileData()
         file(
             AttachmentSource.File(
@@ -247,7 +247,8 @@ public abstract class ContentPartsBuilderBase<T> : TextContentBuilderBase<T>() {
                 format = fileData.extension,
                 mimeType = mimeType,
                 fileName = fileData.name
-            )
+            ),
+            cacheControl
         )
     }
 
@@ -258,7 +259,7 @@ public abstract class ContentPartsBuilderBase<T> : TextContentBuilderBase<T>() {
      * @param mimeType MIME type of the file (e.g., "application/pdf", "text/plain")
      * @throws IllegalArgumentException if the path is not valid, the file does not exist, or is not a regular file.
      */
-    public fun binaryFile(path: Path, mimeType: String) {
+    public fun binaryFile(path: Path, mimeType: String, cacheControl: CacheControl? = null) {
         val fileData = path.fileData()
         file(
             AttachmentSource.File(
@@ -266,7 +267,8 @@ public abstract class ContentPartsBuilderBase<T> : TextContentBuilderBase<T>() {
                 format = fileData.extension,
                 mimeType = mimeType,
                 fileName = fileData.name
-            )
+            ),
+            cacheControl
         )
     }
 
@@ -277,7 +279,7 @@ public abstract class ContentPartsBuilderBase<T> : TextContentBuilderBase<T>() {
      * @param mimeType MIME type of the file (e.g., "application/pdf", "text/plain")
      * @throws IllegalArgumentException if the path is not valid, the file does not exist, or is not a regular file.
      */
-    public fun textFile(path: Path, mimeType: String) {
+    public fun textFile(path: Path, mimeType: String, cacheControl: CacheControl? = null) {
         val fileData = path.fileData()
         file(
             AttachmentSource.File(
@@ -285,7 +287,8 @@ public abstract class ContentPartsBuilderBase<T> : TextContentBuilderBase<T>() {
                 format = fileData.extension,
                 mimeType = mimeType,
                 fileName = fileData.name
-            )
+            ),
+            cacheControl
         )
     }
 }

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/PromptBuilder.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/PromptBuilder.kt
@@ -172,8 +172,9 @@ public class PromptBuilder internal constructor(
         output: String,
         id: String? = null,
         isError: Boolean = false,
+        cacheControl: CacheControl? = null,
     ): PromptBuilder = apply {
-        user { toolResult(MessagePart.Tool.Result(id, tool, output, isError)) }
+        user { toolResult(MessagePart.Tool.Result(id, tool, output, isError, cacheControl)) }
     }
 
     /**
@@ -247,6 +248,7 @@ public class PromptBuilder internal constructor(
         id: String? = null,
         summary: String? = null,
         encrypted: String? = null,
+        cacheControl: CacheControl? = null,
     ): PromptBuilder = apply {
         assistant {
             reasoning(
@@ -255,6 +257,7 @@ public class PromptBuilder internal constructor(
                     summary = summary?.let { listOf(it) },
                     encrypted = encrypted,
                     id = id,
+                    cacheControl = cacheControl,
                 )
             )
         }
@@ -271,13 +274,15 @@ public class PromptBuilder internal constructor(
         tool: String,
         args: String,
         id: String? = null,
+        cacheControl: CacheControl? = null,
     ): PromptBuilder = apply {
         assistant {
             toolCall(
                 MessagePart.Tool.Call(
                     id = id,
                     tool = tool,
-                    args = args
+                    args = args,
+                    cacheControl = cacheControl
                 )
             )
         }
@@ -289,13 +294,15 @@ public class PromptBuilder internal constructor(
         tool: String,
         args: JsonObject,
         id: String? = null,
+        cacheControl: CacheControl? = null,
     ): PromptBuilder = apply {
         assistant {
             toolCall(
                 MessagePart.Tool.Call(
                     id = id,
                     tool = tool,
-                    args = args
+                    args = args,
+                    cacheControl = cacheControl
                 )
             )
         }

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/RequestMessagePartsBuilder.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/RequestMessagePartsBuilder.kt
@@ -1,6 +1,7 @@
 package ai.koog.prompt.dsl
 
 import ai.koog.agents.annotations.JavaAPI
+import ai.koog.prompt.message.CacheControl
 import ai.koog.prompt.message.MessagePart
 
 @JavaAPI
@@ -28,8 +29,9 @@ public class RequestMessagePartsBuilder : ContentPartsBuilderBase<List<MessagePa
         tool: String,
         output: String,
         isError: Boolean = false,
+        cacheControl: CacheControl? = null,
     ) {
-        part(MessagePart.Tool.Result(id, tool, output, isError))
+        part(MessagePart.Tool.Result(id, tool, output, isError, cacheControl))
     }
 
     override fun build(): List<MessagePart.RequestPart> {

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/ResponseMessagePartsBuilder.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/dsl/ResponseMessagePartsBuilder.kt
@@ -1,6 +1,7 @@
 package ai.koog.prompt.dsl
 
 import ai.koog.agents.annotations.JavaAPI
+import ai.koog.prompt.message.CacheControl
 import ai.koog.prompt.message.MessagePart
 import ai.koog.prompt.text.TextContentBuilderBase
 import kotlinx.serialization.json.JsonObject
@@ -31,8 +32,17 @@ public class ResponseMessagePartsBuilder : TextContentBuilderBase<List<MessagePa
         content: String,
         summary: String? = null,
         encrypted: String? = null,
+        cacheControl: CacheControl? = null,
     ) {
-        part(MessagePart.Reasoning(content = content, summary = summary?.let { listOf(it) }, encrypted = encrypted, id = id))
+        part(
+            MessagePart.Reasoning(
+                content = content,
+                summary = summary?.let { listOf(it) },
+                encrypted = encrypted,
+                id = id,
+                cacheControl = cacheControl
+            )
+        )
     }
 
     public fun toolCall(call: MessagePart.Tool.Call) {
@@ -43,12 +53,14 @@ public class ResponseMessagePartsBuilder : TextContentBuilderBase<List<MessagePa
         id: String? = null,
         tool: String,
         args: String,
+        cacheControl: CacheControl? = null,
     ) {
         part(
             MessagePart.Tool.Call(
                 id = id,
                 tool = tool,
-                args = args
+                args = args,
+                cacheControl = cacheControl
             )
         )
     }
@@ -57,12 +69,14 @@ public class ResponseMessagePartsBuilder : TextContentBuilderBase<List<MessagePa
         id: String? = null,
         tool: String,
         args: JsonObject,
+        cacheControl: CacheControl? = null,
     ) {
         part(
             MessagePart.Tool.Call(
                 id = id,
                 tool = tool,
-                args = args
+                args = args,
+                cacheControl = cacheControl
             )
         )
     }

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt
@@ -245,15 +245,15 @@ public sealed interface Message {
 @Serializable
 public sealed interface MessagePart {
 
+    /** Optional cache-control directive for the provider's prompt-caching feature. */
+    public val cacheControl: CacheControl?
+
     /**
      * A part that can appear in a request sent to the LLM.
      * All request parts carry an optional [cacheControl] directive.
      */
     @Serializable
-    public sealed interface RequestPart : MessagePart {
-        /** Optional cache-control directive for the provider's prompt-caching feature. */
-        public val cacheControl: CacheControl?
-    }
+    public sealed interface RequestPart : MessagePart
 
     /**
      * A part that can appear in a response received from the LLM
@@ -306,6 +306,7 @@ public sealed interface MessagePart {
         public val summary: List<String>? = null,
         public val encrypted: String? = null,
         public val id: String? = null,
+        override val cacheControl: CacheControl? = null,
     ) : ResponsePart {
 
         /**
@@ -319,11 +320,13 @@ public sealed interface MessagePart {
             summary: List<String>? = null,
             encrypted: String? = null,
             id: String? = null,
+            cacheControl: CacheControl? = null
         ) : this(
             listOf(content),
             summary,
             encrypted,
             id,
+            cacheControl
         )
     }
 
@@ -349,6 +352,7 @@ public sealed interface MessagePart {
             public val id: String? = null,
             override val tool: String,
             public val args: String,
+            override val cacheControl: CacheControl? = null,
         ) : Tool, ResponsePart {
 
             // TODO: replace with JSONObject?
@@ -367,10 +371,12 @@ public sealed interface MessagePart {
                 id: String? = null,
                 tool: String,
                 args: JsonObject,
+                cacheControl: CacheControl? = null,
             ) : this(
                 id = id,
                 tool = tool,
-                args = Json.encodeToString(args)
+                args = Json.encodeToString(args),
+                cacheControl = cacheControl
             )
         }
 
@@ -382,20 +388,27 @@ public sealed interface MessagePart {
          * @property parts The parts of the tool result. May contain text and attachment parts such as images or files.
          *   Note that not all LLM providers support non-text content in tool results.
          * @property isError Whether this tool result represents an error. Defaults to false.
+         * @property cacheControl Optional cache-control directive for the provider's prompt-caching feature.
          */
         @Serializable
-        public data class Result constructor(
+        public data class Result @JvmOverloads constructor(
             public val id: String? = null,
             override val tool: String,
             public val parts: List<ContentPart>,
             public val isError: Boolean = false,
+            override val cacheControl: CacheControl? = null,
         ) : Tool, RequestPart {
-            // Tool result does not support cache control
-            override val cacheControl: CacheControl? = null
 
             /** Convenience constructor for a single text output. */
-            public constructor(id: String? = null, tool: String, output: String, isError: Boolean = false) :
-                this(id, tool, listOf(Text(output)), isError)
+            @JvmOverloads
+            public constructor(
+                id: String? = null,
+                tool: String,
+                output: String,
+                isError: Boolean = false,
+                cacheControl: CacheControl? = null,
+            ) :
+                this(id, tool, listOf(Text(output)), isError, cacheControl)
 
             /** Returns the concatenated text content of all text parts. */
             public val output: String

--- a/prompt/prompt-model/src/jvmMain/kotlin/ai/koog/prompt/message/MessageBuilder.kt
+++ b/prompt/prompt-model/src/jvmMain/kotlin/ai/koog/prompt/message/MessageBuilder.kt
@@ -91,8 +91,9 @@ public class AssistantMessageBuilder {
         addPart(toolResult)
     }
 
-    public fun addText(content: String): AssistantMessageBuilder = apply {
-        addPart(MessagePart.Text(content))
+    @JvmOverloads
+    public fun addText(content: String, cache: CacheControl? = null): AssistantMessageBuilder = apply {
+        addPart(MessagePart.Text(content, cache))
     }
 
     public fun addToolCall(toolCall: MessagePart.Tool.Call): AssistantMessageBuilder = apply {
@@ -198,6 +199,7 @@ public class ToolCallBuilder {
     private var id: String? = null
     private var tool: String? = null
     private var args: JsonObject? = null
+    private var cacheControl: CacheControl? = null
 
     /**
      * Sets the tool call ID.
@@ -215,6 +217,11 @@ public class ToolCallBuilder {
     public fun args(args: JsonObject): ToolCallBuilder = apply { this.args = args }
 
     /**
+     * Sets the cache-control directive for the provider's prompt-caching feature.
+     */
+    public fun cacheControl(cacheControl: CacheControl?): ToolCallBuilder = apply { this.cacheControl = cacheControl }
+
+    /**
      * Builds a new [MessagePart.Tool.Call] instance.
      *
      * @throws IllegalStateException if tool name or content parts are missing.
@@ -226,6 +233,7 @@ public class ToolCallBuilder {
             id = id,
             tool = tool!!,
             args = args!!,
+            cacheControl = cacheControl,
         )
     }
 }
@@ -248,6 +256,7 @@ public class ToolResultBuilder {
     private var tool: String? = null
     private var output: String? = null
     private var isError: Boolean = false
+    private var cacheControl: CacheControl? = null
 
     /**
      * Sets the tool result ID.
@@ -267,6 +276,11 @@ public class ToolResultBuilder {
     public fun isError(isError: Boolean): ToolResultBuilder = apply { this.isError = isError }
 
     /**
+     * Sets the cache-control directive for the provider's prompt-caching feature.
+     */
+    public fun cacheControl(cacheControl: CacheControl?): ToolResultBuilder = apply { this.cacheControl = cacheControl }
+
+    /**
      * Builds a new [MessagePart.Tool.Result] instance.
      *
      * @throws IllegalStateException if tool name or content parts are missing.
@@ -278,7 +292,8 @@ public class ToolResultBuilder {
             id = id,
             tool = tool!!,
             output = output!!,
-            isError = isError
+            isError = isError,
+            cacheControl = cacheControl
         )
     }
 }
@@ -300,6 +315,7 @@ public class ReasoningBuilder {
     private val content: MutableList<String> = mutableListOf()
     private var summary: List<String>? = null
     private var encrypted: String? = null
+    private var cacheControl: CacheControl? = null
 
     /**
      * Sets the reasoning ID.
@@ -310,6 +326,11 @@ public class ReasoningBuilder {
      * Sets the encrypted content.
      */
     public fun encrypted(encrypted: String?): ReasoningBuilder = apply { this.encrypted = encrypted }
+
+    /**
+     * Sets the cache-control directive for the provider's prompt-caching feature.
+     */
+    public fun cacheControl(cacheControl: CacheControl?): ReasoningBuilder = apply { this.cacheControl = cacheControl }
 
     /**
      * Sets a single text content for the message, replacing any previously added parts.
@@ -338,6 +359,7 @@ public class ReasoningBuilder {
             content = content,
             summary = summary,
             encrypted = encrypted,
+            cacheControl = cacheControl,
         )
     }
 }


### PR DESCRIPTION
After 1.x [refactoring](https://github.com/JetBrains/koog/blob/e4f91bfb5bace5002005ea2bf513e40c7d1a04ac/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/message/Message.kt#L372), it was not possible to add a cache point to the tool result as well as to `ResponsePart`. 
This PR introduces the ability to add `cacheControl` to all `MessagePart` objects