### PR TITLE
fix(spring-boot): use `chatModel.options.mutate()` in `SpringAiLLMClient` v2 to avoid `ClassCastException`. Add integration tests for `SpringAiLLMClient` V2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -154,6 +154,7 @@ spring-ai-bom = { module = "org.springframework.ai:spring-ai-bom", version.ref =
 spring-ai-v2-bom = { module = "org.springframework.ai:spring-ai-bom", version.ref = "spring-ai-v2" }
 spring-ai-model = { module = "org.springframework.ai:spring-ai-model" }
 spring-ai-vectorstore = { module = "org.springframework.ai:spring-ai-vector-store" }
+spring-ai-v2-openai = { module = "org.springframework.ai:spring-ai-openai" }
 
 [bundles]
 spring-boot-core = [

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -155,6 +155,8 @@ spring-ai-v2-bom = { module = "org.springframework.ai:spring-ai-bom", version.re
 spring-ai-model = { module = "org.springframework.ai:spring-ai-model" }
 spring-ai-vectorstore = { module = "org.springframework.ai:spring-ai-vector-store" }
 spring-ai-v2-openai = { module = "org.springframework.ai:spring-ai-openai" }
+spring-ai-v2-google = { module = "org.springframework.ai:spring-ai-google-genai" }
+spring-ai-v2-anthropic = { module = "org.springframework.ai:spring-ai-anthropic" }
 
 [bundles]
 spring-boot-core = [

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -74,6 +74,8 @@ kotlin {
                 // Spring
                 implementation(dependencies.platform(libs.spring.ai.v2.bom))
                 implementation(libs.spring.ai.v2.openai)
+                implementation(libs.spring.ai.v2.google)
+                implementation(libs.spring.ai.v2.anthropic)
             }
         }
     }

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -47,6 +47,9 @@ kotlin {
                 implementation(
                     project(":prompt:prompt-executor:prompt-executor-clients:prompt-executor-mistralai-client")
                 )
+                implementation(
+                    project(":koog-spring-ai-v2:koog-spring-ai-v2-starter-model-chat")
+                )
                 implementation(project(":agents:agents-features:agents-features-chat-history-aws"))
                 implementation(project(":agents:agents-features:agents-features-longterm-memory-aws"))
                 implementation(project(":serialization:serialization-jackson"))
@@ -67,6 +70,10 @@ kotlin {
                 implementation(project.dependencies.platform(libs.opentelemetry.bom))
                 implementation(libs.opentelemetry.sdk.testing)
                 implementation(libs.opentelemetry.kotlin.exporters.inMemory)
+
+                // Spring
+                implementation(dependencies.platform(libs.spring.ai.v2.bom))
+                implementation(libs.spring.ai.v2.openai)
             }
         }
     }

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SpringAILLMClientV2IntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SpringAILLMClientV2IntegrationTest.kt
@@ -1,0 +1,287 @@
+package ai.koog.integration.tests.executor
+
+import ai.koog.integration.tests.utils.MediaTestScenarios.AudioTestScenario
+import ai.koog.integration.tests.utils.MediaTestScenarios.ImageTestScenario
+import ai.koog.integration.tests.utils.MediaTestScenarios.MarkdownTestScenario
+import ai.koog.integration.tests.utils.MediaTestScenarios.TextTestScenario
+import ai.koog.integration.tests.utils.Models
+import ai.koog.integration.tests.utils.TestCredentials.readTestOpenAIKeyFromEnv
+import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
+import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.llm.LLModel
+import ai.koog.prompt.llm.OpenAILLMProvider
+import ai.koog.spring.ai.chat.SpringAiLLMClient
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.ai.openai.OpenAiChatModel
+import org.springframework.ai.openai.OpenAiChatOptions
+import java.util.stream.Stream
+import kotlin.enums.EnumEntries
+
+/**
+ * Test Spring AI LLM client integration
+ */
+class SpringAILLMClientV2IntegrationTest : ExecutorIntegrationTestBase() {
+    companion object {
+        private fun EnumEntries<*>.combineSpringAiModels(): Stream<Arguments> {
+            return toList()
+                .flatMap { scenario ->
+                    Models
+                        .springAiModels()
+                        .toArray()
+                        .map { model -> Arguments.of(scenario, model) }
+                }
+                .stream()
+        }
+
+        @JvmStatic
+        fun markdownScenarioModelCombinations(): Stream<Arguments> {
+            return MarkdownTestScenario.entries.combineSpringAiModels()
+        }
+
+        @JvmStatic
+        fun imageScenarioModelCombinations(): Stream<Arguments> {
+            return ImageTestScenario.entries.combineSpringAiModels()
+        }
+
+        @JvmStatic
+        fun textScenarioModelCombinations(): Stream<Arguments> {
+            return TextTestScenario.entries.combineSpringAiModels()
+        }
+
+        @JvmStatic
+        fun audioScenarioModelCombinations(): Stream<Arguments> {
+            return AudioTestScenario.entries.combineSpringAiModels()
+        }
+
+        @JvmStatic
+        fun reasoningCapableModels(): Stream<LLModel> {
+            return Models.springAiModels()
+        }
+
+        @JvmStatic
+        fun allCompletionModels(): Stream<LLModel> {
+            return Models.bedrockModels()
+        }
+    }
+
+    private val openAiClient: SpringAiLLMClient = run {
+        val chatModel = OpenAiChatModel.builder()
+            .options(
+                OpenAiChatOptions.builder()
+                    .apiKey(readTestOpenAIKeyFromEnv())
+                    .build()
+            )
+            .build()
+
+        SpringAiLLMClient.builder()
+            .chatModel(chatModel)
+            .provider(OpenAILLMProvider)
+            .build()
+    }
+
+    private val executor: MultiLLMPromptExecutor = MultiLLMPromptExecutor(
+        OpenAILLMProvider to openAiClient
+    )
+
+    override fun getExecutor(model: LLModel): PromptExecutor = executor
+
+    @ParameterizedTest
+    @MethodSource("markdownScenarioModelCombinations")
+    override fun integration_testMarkdownProcessingBasic(
+        scenario: MarkdownTestScenario,
+        model: LLModel
+    ) {
+        super.integration_testMarkdownProcessingBasic(scenario, model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("imageScenarioModelCombinations")
+    override fun integration_testImageProcessing(scenario: ImageTestScenario, model: LLModel) {
+        super.integration_testImageProcessing(scenario, model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("textScenarioModelCombinations")
+    override fun integration_testTextProcessingBasic(scenario: TextTestScenario, model: LLModel) {
+        super.integration_testTextProcessingBasic(scenario, model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("audioScenarioModelCombinations")
+    override fun integration_testAudioProcessingBasic(scenario: AudioTestScenario, model: LLModel) {
+        super.integration_testAudioProcessingBasic(scenario, model)
+    }
+
+    // Core integration test methods
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testExecute(model: LLModel) {
+        super.integration_testExecute(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testExecuteStreaming(model: LLModel) {
+        super.integration_testExecuteStreaming(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testExecuteStreamingWithTools(model: LLModel) {
+        super.integration_testExecuteStreamingWithTools(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testToolWithRequiredParams(model: LLModel) {
+        super.integration_testToolWithRequiredParams(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testToolWithNotRequiredOptionalParams(model: LLModel) {
+        super.integration_testToolWithNotRequiredOptionalParams(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testToolWithOptionalParams(model: LLModel) {
+        super.integration_testToolWithOptionalParams(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testToolWithNoParams(model: LLModel) {
+        super.integration_testToolWithNoParams(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testToolWithListEnumParams(model: LLModel) {
+        super.integration_testToolWithListEnumParams(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testToolWithNestedListParams(model: LLModel) {
+        super.integration_testToolWithNestedListParams(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testToolsWithNullParams(model: LLModel) {
+        super.integration_testToolsWithNullParams(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testToolsWithAnyOfParams(model: LLModel) {
+        super.integration_testToolsWithAnyOfParams(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testAssistantMultiPartRoundTrip(model: LLModel) {
+        super.integration_testAssistantMultiPartRoundTrip(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testToolCallResultCorrelationById(model: LLModel) {
+        super.integration_testToolCallResultCorrelationById(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testMarkdownStructuredDataStreaming(model: LLModel) {
+        super.integration_testMarkdownStructuredDataStreaming(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testToolChoiceRequired(model: LLModel) {
+        super.integration_testToolChoiceRequired(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testToolChoiceNone(model: LLModel) {
+        super.integration_testToolChoiceNone(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testToolChoiceNamed(model: LLModel) {
+        super.integration_testToolChoiceNamed(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testBase64EncodedAttachment(model: LLModel) {
+        super.integration_testBase64EncodedAttachment(model)
+    }
+
+    @Disabled("Converse API supports only S3 url attachments")
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testUrlBasedAttachment(model: LLModel) {
+        super.integration_testUrlBasedAttachment(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testAttachmentTextRoundTrip(model: LLModel) {
+        super.integration_testAttachmentTextRoundTrip(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testStructuredOutputNative(model: LLModel) {
+        super.integration_testStructuredOutputNative(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testStructuredOutputNativeWithFixingParser(model: LLModel) {
+        super.integration_testStructuredOutputNativeWithFixingParser(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testStructuredOutputManual(model: LLModel) {
+        super.integration_testStructuredOutputManual(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testStructuredOutputManualWithFixingParser(model: LLModel) {
+        super.integration_testStructuredOutputManualWithFixingParser(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allCompletionModels")
+    override fun integration_testMultipleSystemMessages(model: LLModel) {
+        super.integration_testMultipleSystemMessages(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("reasoningCapableModels")
+    override fun integration_testReasoningCapability(model: LLModel) {
+        super.integration_testReasoningCapability(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("reasoningCapableModels")
+    override fun integration_testReasoningMultiStep(model: LLModel) {
+        super.integration_testReasoningMultiStep(model)
+    }
+
+    @ParameterizedTest
+    @MethodSource("reasoningCapableModels")
+    override fun integration_testReasoningPreservationRoundTrip(model: LLModel) {
+        super.integration_testReasoningPreservationRoundTrip(model)
+    }
+}

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SpringAILLMClientV2IntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SpringAILLMClientV2IntegrationTest.kt
@@ -63,7 +63,7 @@ class SpringAILLMClientV2IntegrationTest : ExecutorIntegrationTestBase() {
 
         @JvmStatic
         fun allCompletionModels(): Stream<LLModel> {
-            return Models.bedrockModels()
+            return Models.springAiModels()
         }
     }
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SpringAILLMClientV2IntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SpringAILLMClientV2IntegrationTest.kt
@@ -10,6 +10,7 @@ import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.executor.model.PromptExecutor
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.llm.OpenAILLMProvider
+import ai.koog.spring.ai.chat.ChatOptionsCustomizer
 import ai.koog.spring.ai.chat.SpringAiLLMClient
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.params.ParameterizedTest
@@ -68,6 +69,16 @@ class SpringAILLMClientV2IntegrationTest : ExecutorIntegrationTestBase() {
     }
 
     private val openAiClient: SpringAiLLMClient = run {
+        val chatOptionsCustomizer = ChatOptionsCustomizer { options, params, _ ->
+            val builder = options.mutate() as OpenAiChatOptions.Builder
+
+            builder
+                // OpenAI chat model doesn't support generic maxTokens and throws an exception, need to customize
+                .maxTokens(null)
+                .maxCompletionTokens(params.maxTokens)
+                .build()
+        }
+
         val chatModel = OpenAiChatModel.builder()
             .options(
                 OpenAiChatOptions.builder()
@@ -79,6 +90,7 @@ class SpringAILLMClientV2IntegrationTest : ExecutorIntegrationTestBase() {
         SpringAiLLMClient.builder()
             .chatModel(chatModel)
             .provider(OpenAILLMProvider)
+            .chatOptionsCustomizer(chatOptionsCustomizer)
             .build()
     }
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SpringAiLLMClientV2IntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/executor/SpringAiLLMClientV2IntegrationTest.kt
@@ -5,26 +5,33 @@ import ai.koog.integration.tests.utils.MediaTestScenarios.ImageTestScenario
 import ai.koog.integration.tests.utils.MediaTestScenarios.MarkdownTestScenario
 import ai.koog.integration.tests.utils.MediaTestScenarios.TextTestScenario
 import ai.koog.integration.tests.utils.Models
-import ai.koog.integration.tests.utils.TestCredentials.readTestOpenAIKeyFromEnv
+import ai.koog.integration.tests.utils.TestCredentials
 import ai.koog.prompt.executor.llms.MultiLLMPromptExecutor
 import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.llm.AnthropicLLMProvider
+import ai.koog.prompt.llm.GoogleLLMProvider
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.llm.OpenAILLMProvider
 import ai.koog.spring.ai.chat.ChatOptionsCustomizer
 import ai.koog.spring.ai.chat.SpringAiLLMClient
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.ai.anthropic.AnthropicChatModel
+import org.springframework.ai.anthropic.AnthropicChatOptions
+import org.springframework.ai.google.genai.GoogleGenAiChatModel
 import org.springframework.ai.openai.OpenAiChatModel
 import org.springframework.ai.openai.OpenAiChatOptions
 import java.util.stream.Stream
 import kotlin.enums.EnumEntries
+import com.google.genai.Client as GenAiClient
 
 /**
- * Test Spring AI LLM client integration
+ * Test Spring AI LLM client integration.
  */
-class SpringAILLMClientV2IntegrationTest : ExecutorIntegrationTestBase() {
+class SpringAiLLMClientV2IntegrationTest : ExecutorIntegrationTestBase() {
     companion object {
         private fun EnumEntries<*>.combineSpringAiModels(): Stream<Arguments> {
             return toList()
@@ -82,7 +89,7 @@ class SpringAILLMClientV2IntegrationTest : ExecutorIntegrationTestBase() {
         val chatModel = OpenAiChatModel.builder()
             .options(
                 OpenAiChatOptions.builder()
-                    .apiKey(readTestOpenAIKeyFromEnv())
+                    .apiKey(TestCredentials.readTestOpenAIKeyFromEnv())
                     .build()
             )
             .build()
@@ -94,8 +101,40 @@ class SpringAILLMClientV2IntegrationTest : ExecutorIntegrationTestBase() {
             .build()
     }
 
+    private val googleClient: SpringAiLLMClient = run {
+        val chatModel = GoogleGenAiChatModel.builder()
+            .genAiClient(
+                GenAiClient.builder()
+                    .apiKey(TestCredentials.readTestGoogleAIKeyFromEnv())
+                    .build()
+            )
+            .build()
+
+        SpringAiLLMClient.builder()
+            .chatModel(chatModel)
+            .provider(GoogleLLMProvider)
+            .build()
+    }
+
+    private val anthropicClient: SpringAiLLMClient = run {
+        val chatModel = AnthropicChatModel.builder()
+            .options(
+                AnthropicChatOptions.builder()
+                    .apiKey(TestCredentials.readTestAnthropicKeyFromEnv())
+                    .build()
+            )
+            .build()
+
+        SpringAiLLMClient.builder()
+            .chatModel(chatModel)
+            .provider(AnthropicLLMProvider)
+            .build()
+    }
+
     private val executor: MultiLLMPromptExecutor = MultiLLMPromptExecutor(
-        OpenAILLMProvider to openAiClient
+        OpenAILLMProvider to openAiClient,
+        GoogleLLMProvider to googleClient,
+        AnthropicLLMProvider to anthropicClient,
     )
 
     override fun getExecutor(model: LLModel): PromptExecutor = executor
@@ -106,18 +145,25 @@ class SpringAILLMClientV2IntegrationTest : ExecutorIntegrationTestBase() {
         scenario: MarkdownTestScenario,
         model: LLModel
     ) {
+        assumeTrue(model.provider != AnthropicLLMProvider, "Anthropic doesn't support text attachments")
+
         super.integration_testMarkdownProcessingBasic(scenario, model)
     }
 
     @ParameterizedTest
     @MethodSource("imageScenarioModelCombinations")
     override fun integration_testImageProcessing(scenario: ImageTestScenario, model: LLModel) {
+        // FIXME Doesn't work with Google model for some reason
+        assumeTrue(model.provider != GoogleLLMProvider)
+
         super.integration_testImageProcessing(scenario, model)
     }
 
     @ParameterizedTest
     @MethodSource("textScenarioModelCombinations")
     override fun integration_testTextProcessingBasic(scenario: TextTestScenario, model: LLModel) {
+        assumeTrue(model.provider != AnthropicLLMProvider, "Anthropic doesn't support text attachments")
+
         super.integration_testTextProcessingBasic(scenario, model)
     }
 
@@ -197,12 +243,18 @@ class SpringAILLMClientV2IntegrationTest : ExecutorIntegrationTestBase() {
     @ParameterizedTest
     @MethodSource("allCompletionModels")
     override fun integration_testAssistantMultiPartRoundTrip(model: LLModel) {
+        // FIXME Google integration: Function call is missing a thought_signature in functionCall parts
+        assumeTrue(model.provider != GoogleLLMProvider)
+
         super.integration_testAssistantMultiPartRoundTrip(model)
     }
 
     @ParameterizedTest
     @MethodSource("allCompletionModels")
     override fun integration_testToolCallResultCorrelationById(model: LLModel) {
+        // FIXME Google integration: Function call is missing a thought_signature in functionCall parts
+        assumeTrue(model.provider != GoogleLLMProvider)
+
         super.integration_testToolCallResultCorrelationById(model)
     }
 
@@ -252,6 +304,8 @@ class SpringAILLMClientV2IntegrationTest : ExecutorIntegrationTestBase() {
     @ParameterizedTest
     @MethodSource("allCompletionModels")
     override fun integration_testStructuredOutputNative(model: LLModel) {
+        assumeTrue(model.provider != AnthropicLLMProvider, "Anthropic doesn't support native structured output")
+
         super.integration_testStructuredOutputNative(model)
     }
 

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
@@ -61,6 +61,18 @@ object Models {
         )
     }
 
+    /**
+     * Models from different providers to test the proper integration
+     */
+    @JvmStatic
+    fun springAiModels(): Stream<LLModel> {
+        return Stream.of(
+            OpenAIModels.Chat.GPT5_5,
+//            AnthropicModels.Haiku_4_5,
+//            GoogleModels.Gemini3_Flash_Preview,
+        )
+    }
+
     @JvmStatic
     fun embeddingModels(): Stream<LLModel> {
         return Stream.of(

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/utils/Models.kt
@@ -68,8 +68,8 @@ object Models {
     fun springAiModels(): Stream<LLModel> {
         return Stream.of(
             OpenAIModels.Chat.GPT5_5,
-//            AnthropicModels.Haiku_4_5,
-//            GoogleModels.Gemini3_Flash_Preview,
+            AnthropicModels.Sonnet_4_6,
+            GoogleModels.Gemini3_5Flash,
         )
     }
 

--- a/koog-spring-ai-v2/koog-spring-ai-v2-starter-model-chat/src/main/kotlin/ai/koog/spring/ai/chat/SpringAiLLMClient.kt
+++ b/koog-spring-ai-v2/koog-spring-ai-v2-starter-model-chat/src/main/kotlin/ai/koog/spring/ai/chat/SpringAiLLMClient.kt
@@ -303,32 +303,31 @@ public class SpringAiLLMClient(
         model: LLModel,
         tools: List<ToolDescriptor>
     ): ChatOptions {
-        val options: ChatOptions = if (tools.isNotEmpty()) {
-            val toolCallbacks = tools.map { koogToolDescriptorToToolCallback(it) }
-            ToolCallingChatOptions.builder()
-                .model(model.id)
-                .temperature(params.temperature)
-                .maxTokens(params.maxTokens)
-                .toolCallbacks(toolCallbacks)
-                .build()
-        } else {
-            ChatOptions.builder()
-                .model(model.id)
-                .temperature(params.temperature)
-                .maxTokens(params.maxTokens)
-                .build()
+        val builder = chatModel.options.mutate()
+
+        builder.model(model.id)
+            .temperature(params.temperature)
+            .maxTokens(params.maxTokens)
+
+        if (tools.isNotEmpty()) {
+            require(builder is ToolCallingChatOptions.Builder<*>) {
+                "Configured ChatModel options (${chatModel.options::class.java.name}) do not support tool calling"
+            }
+            builder.toolCallbacks(tools.map { koogToolDescriptorToToolCallback(it) })
         }
+
+        val options: ChatOptions = builder.build()
 
         // Log unsupported params once at debug level
         params.numberOfChoices?.let {
-            logger.debug(
+            logger.warn(
                 "Koog Spring AI: 'numberOfChoices={}' is not supported by Spring AI ChatOptions; ignored for provider '{}'",
                 it,
                 model.provider.id
             )
         }
         params.speculation?.let {
-            logger.debug(
+            logger.warn(
                 "Koog Spring AI: 'speculation' is not supported by Spring AI ChatOptions; ignored for provider '{}'",
                 model.provider.id
             )

--- a/koog-spring-ai-v2/koog-spring-ai-v2-starter-model-chat/src/main/kotlin/ai/koog/spring/ai/chat/SpringAiLLMClient.kt
+++ b/koog-spring-ai-v2/koog-spring-ai-v2-starter-model-chat/src/main/kotlin/ai/koog/spring/ai/chat/SpringAiLLMClient.kt
@@ -303,7 +303,7 @@ public class SpringAiLLMClient(
         model: LLModel,
         tools: List<ToolDescriptor>
     ): ChatOptions {
-        val builder = chatModel.options.mutate()
+        val builder: ChatOptions.Builder<*> = chatModel.options.mutate()
 
         builder.model(model.id)
             .temperature(params.temperature)

--- a/koog-spring-ai-v2/koog-spring-ai-v2-starter-model-chat/src/test/kotlin/ai/koog/spring/ai/chat/SpringAiLLMClientTest.kt
+++ b/koog-spring-ai-v2/koog-spring-ai-v2-starter-model-chat/src/test/kotlin/ai/koog/spring/ai/chat/SpringAiLLMClientTest.kt
@@ -26,6 +26,7 @@ import org.springframework.ai.chat.metadata.Usage
 import org.springframework.ai.chat.model.ChatModel
 import org.springframework.ai.chat.model.ChatResponse
 import org.springframework.ai.chat.model.Generation
+import org.springframework.ai.chat.prompt.ChatOptions
 import org.springframework.ai.model.tool.ToolCallingChatOptions
 import reactor.core.publisher.Flux
 import org.springframework.ai.chat.prompt.Prompt as SpringPrompt
@@ -184,6 +185,9 @@ class SpringAiLLMClientTest {
             }
 
             override fun stream(prompt: SpringPrompt): Flux<ChatResponse> = throw UnsupportedOperationException()
+
+            // Need to return correct exact type because of options.mutate in execute
+            override fun getOptions(): ChatOptions = ToolCallingChatOptions.builder().build()
         }).build()
         val tools = listOf(
             ToolDescriptor(


### PR DESCRIPTION
Spring AI 2.0.0 throws a `ClassCastException` if you pass generic `ChatOptions` instead of exactly typed provider chat options, e.g. `OpenAiChatOptions`, to a `chatModel.call()`.  This seems like a bug, since [the docs still claim](https://docs.spring.io/spring-ai/reference/api/chat/openai-chat.html#chat-options)
> In addition to the model specific [OpenAiChatOptions](https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-openai/src/main/java/org/springframework/ai/openai/OpenAiChatOptions.java) you can use a portable [ChatOptions](https://github.com/spring-projects/spring-ai/blob/main/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/ChatOptions.java) instance, created with [ChatOptions#builder()](https://github.com/spring-projects/spring-ai/blob/main/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/DefaultChatOptionsBuilder.java).

To workaround this, use `chatModel.options.mutate()` to obtain a builder instance instead of creating a generic one, this will produce a concrete-typed options.

Also, added integration test suite for Spring AI client V2 with OpenAI, Google and Anthropic models, so that it would be easier to verify the actual behavior of our integration.