### PR TITLE
fix(openai): emit reasoning_content in Chat Completions streaming

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/android/prompt-executor-openai-client-base.api
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/android/prompt-executor-openai-client-base.api
@@ -819,9 +819,10 @@ public final class ai/koog/prompt/executor/clients/openai/base/models/OpenAIStre
 public final class ai/koog/prompt/executor/clients/openai/base/models/OpenAIStreamDelta {
 	public static final field Companion Lai/koog/prompt/executor/clients/openai/base/models/OpenAIStreamDelta$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getContent ()Ljava/lang/String;
+	public final fun getReasoningContent ()Ljava/lang/String;
 	public final fun getRefusal ()Ljava/lang/String;
 	public final fun getRole ()Ljava/lang/String;
 	public final fun getToolCalls ()Ljava/util/List;

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/jvm/prompt-executor-openai-client-base.api
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/jvm/prompt-executor-openai-client-base.api
@@ -819,9 +819,10 @@ public final class ai/koog/prompt/executor/clients/openai/base/models/OpenAIStre
 public final class ai/koog/prompt/executor/clients/openai/base/models/OpenAIStreamDelta {
 	public static final field Companion Lai/koog/prompt/executor/clients/openai/base/models/OpenAIStreamDelta$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getContent ()Ljava/lang/String;
+	public final fun getReasoningContent ()Ljava/lang/String;
 	public final fun getRefusal ()Ljava/lang/String;
 	public final fun getRole ()Ljava/lang/String;
 	public final fun getToolCalls ()Ljava/util/List;

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/prompt-executor-openai-client-base.klib.api
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/prompt-executor-openai-client-base.klib.api
@@ -937,7 +937,7 @@ final class ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamChoic
 }
 
 final class ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamDelta { // ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamDelta|null[0]
-    constructor <init>(kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin.collections/List<ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamToolCall>? = ...) // ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamDelta.<init>|<init>(kotlin.String?;kotlin.String?;kotlin.String?;kotlin.collections.List<ai.koog.prompt.executor.clients.openai.base.models.OpenAIStreamToolCall>?){}[0]
+    constructor <init>(kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin.collections/List<ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamToolCall>? = ..., kotlin/String? = ...) // ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamDelta.<init>|<init>(kotlin.String?;kotlin.String?;kotlin.String?;kotlin.collections.List<ai.koog.prompt.executor.clients.openai.base.models.OpenAIStreamToolCall>?;kotlin.String?){}[0]
 
     final val content // ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamDelta.content|{}content[0]
         final fun <get-content>(): kotlin/String? // ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamDelta.content.<get-content>|<get-content>(){}[0]
@@ -947,6 +947,8 @@ final class ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamDelta
         final fun <get-role>(): kotlin/String? // ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamDelta.role.<get-role>|<get-role>(){}[0]
     final val toolCalls // ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamDelta.toolCalls|{}toolCalls[0]
         final fun <get-toolCalls>(): kotlin.collections/List<ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamToolCall>? // ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamDelta.toolCalls.<get-toolCalls>|<get-toolCalls>(){}[0]
+    final val reasoningContent // ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamDelta.reasoningContent|{}reasoningContent[0]
+        final fun <get-reasoningContent>(): kotlin/String? // ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamDelta.reasoningContent.<get-reasoningContent>|<get-reasoningContent>(){}[0]
 
     final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamDelta> { // ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamDelta.$serializer|null[0]
         final val descriptor // ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamDelta.$serializer.descriptor|{}descriptor[0]

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/models/OpenAIDataModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/models/OpenAIDataModels.kt
@@ -957,7 +957,8 @@ public class OpenAIStreamDelta(
     public val content: String? = null,
     public val refusal: String? = null,
     public val role: String? = null,
-    public val toolCalls: List<OpenAIStreamToolCall>? = null
+    public val toolCalls: List<OpenAIStreamToolCall>? = null,
+    public val reasoningContent: String? = null,
 )
 
 internal object ContentSerializer : KSerializer<Content> {

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -293,6 +293,10 @@ public open class OpenAILLMClient @JvmOverloads constructor(
             chunk.choices.firstOrNull()?.let { choice ->
                 choice.delta.content?.let { emitTextDelta(it, choice.index) }
 
+                choice.delta.reasoningContent
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { emitReasoningDelta(text = it, index = choice.index) }
+
                 choice.delta.toolCalls?.forEach { openAIToolCall ->
                     val index = openAIToolCall.index
                     val id = openAIToolCall.id

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIChatCompletionLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIChatCompletionLLMClientTest.kt
@@ -1,6 +1,13 @@
 package ai.koog.prompt.executor.clients.openai
 
 import ai.koog.http.client.ktor.KtorKoogHttpClient
+import ai.koog.prompt.executor.clients.openai.models.OpenAIChatCompletionStreamResponse
+import ai.koog.prompt.executor.clients.openai.base.models.OpenAIStreamChoice
+import ai.koog.prompt.executor.clients.openai.base.models.OpenAIStreamDelta
+import ai.koog.prompt.streaming.StreamFrame
+import ai.koog.prompt.streaming.toMessageResponse
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
 import ai.koog.prompt.Prompt
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.MessagePart
@@ -31,6 +38,17 @@ import kotlin.test.assertNotNull
 import kotlin.time.Instant
 
 class OpenAIChatCompletionLLMClientTest {
+
+    private class TestOpenAILLMClient(
+        httpClientFactory: KtorKoogHttpClient.Factory,
+        apiKey: String,
+        clock: KoogClock,
+    ) : OpenAILLMClient(apiKey, httpClientFactory = httpClientFactory, clock = clock) {
+        fun processChunks(chunks: kotlinx.coroutines.flow.Flow<OpenAIChatCompletionStreamResponse>) =
+            processStreamingResponse(chunks)
+
+        fun decodeChunk(data: String): OpenAIChatCompletionStreamResponse = decodeStreamingResponse(data)
+    }
 
     object FixedClock : KoogClock {
         override fun now(): Instant = Instant.fromEpochMilliseconds(0)
@@ -174,5 +192,85 @@ class OpenAIChatCompletionLLMClientTest {
         val decoded = Json.parseToJsonElement(arguments)
         assertIs<JsonObject>(decoded, "function.arguments must be a JSON object, not a double-encoded JSON string")
         assertEquals(JsonObject(mapOf("city" to JsonPrimitive("Boston"))), decoded)
+    }
+
+    @Test
+    fun testStreamingEmitsReasoningContentFromDelta() = runTest {
+        val client = TestOpenAILLMClient(
+            httpClientFactory = KtorKoogHttpClient.Factory(HttpClient(MockEngine { respond("") })),
+            apiKey = key,
+            clock = FixedClock,
+        )
+
+        val reasoningChunk = OpenAIChatCompletionStreamResponse(
+            choices = listOf(
+                OpenAIStreamChoice(
+                    delta = OpenAIStreamDelta(reasoningContent = "I should call the weather tool first."),
+                    index = 0,
+                )
+            ),
+            created = 1L,
+            id = "chatcmpl-stream",
+            model = "gpt-4o",
+            objectType = "chat.completion.chunk",
+        )
+        val finishChunk = OpenAIChatCompletionStreamResponse(
+            choices = listOf(
+                OpenAIStreamChoice(
+                    delta = OpenAIStreamDelta(),
+                    finishReason = "tool_calls",
+                    index = 0,
+                )
+            ),
+            created = 1L,
+            id = "chatcmpl-stream",
+            model = "gpt-4o",
+            objectType = "chat.completion.chunk",
+        )
+
+        val frames = client.processChunks(flowOf(reasoningChunk, finishChunk)).toList()
+
+        val reasoningDelta = assertIs<StreamFrame.ReasoningDelta>(frames[0])
+        assertEquals("I should call the weather tool first.", reasoningDelta.text)
+
+        val reasoningComplete = assertIs<StreamFrame.ReasoningComplete>(frames[1])
+        assertEquals(listOf("I should call the weather tool first."), reasoningComplete.content)
+
+        val message = frames.toMessageResponse()
+        val reasoningPart = assertIs<MessagePart.Reasoning>(message.parts.single())
+        assertEquals("I should call the weather tool first.", reasoningPart.content.single())
+    }
+
+    @Test
+    fun testStreamingDecodesReasoningContentFromJsonChunk() = runTest {
+        val client = TestOpenAILLMClient(
+            httpClientFactory = KtorKoogHttpClient.Factory(HttpClient(MockEngine { respond("") })),
+            apiKey = key,
+            clock = FixedClock,
+        )
+
+        val chunkJson = """
+            {
+              "id": "chatcmpl-stream",
+              "object": "chat.completion.chunk",
+              "created": 1,
+              "model": "gpt-4o",
+              "choices": [
+                {
+                  "index": 0,
+                  "delta": {
+                    "reasoning_content": "I should call the weather tool first."
+                  }
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val decoded = client.decodeChunk(chunkJson)
+        val reasoningContent = decoded.choices.single().delta.reasoningContent
+        assertEquals("I should call the weather tool first.", reasoningContent)
+
+        val frames = client.processChunks(flowOf(decoded)).toList()
+        assertIs<StreamFrame.ReasoningDelta>(frames.first())
     }
 }


### PR DESCRIPTION
## Summary

Emit `StreamFrame.ReasoningDelta` / `ReasoningComplete` when OpenAI Chat Completions streaming returns `choices[].delta.reasoning_content`, aligning streaming behavior with the existing non-streaming path.

Fixes #2148

## Motivation

Providers such as DeepSeek and OpenAI-compatible gateways return chain-of-thought in streaming deltas as `reasoning_content`. The non-streaming Chat Completions path already maps this field to `MessagePart.Reasoning`, but the streaming path ignored it entirely—so switching from `execute()` to `executeStreaming()` silently dropped reasoning output.

## Changes

- **`OpenAIStreamDelta`**: add optional `reasoningContent` field (JSON: `reasoning_content` via SnakeCase naming)
- **`OpenAILLMClient.processStreamingResponse`**: emit `ReasoningDelta` when `delta.reasoningContent` is non-blank
- **ABI dumps**: update `OpenAIStreamDelta` public API references
- **Tests**: streaming frame emission + JSON chunk deserialization regression tests

## Tests

```bash
./gradlew :prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client:jvmTest \
  --tests "ai.koog.prompt.executor.clients.openai.OpenAIChatCompletionLLMClientTest"
```

Result: **BUILD SUCCESSFUL** (4 tests, all pass)

## Notes

- Responses API streaming already handles reasoning via separate events; unchanged.
- Other OpenAI-compatible clients (DeepSeek, Dashscope, Mistral) still override `processStreamingResponse` without reasoning emission—a potential follow-up outside this issue's scope.
