### PR TITLE
fix(prompt): fall back to model id for unmapped Anthropic models

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
@@ -446,7 +446,7 @@ public open class AnthropicLLMClient @JvmOverloads constructor(
 
         // Always include max_tokens as it's required by the API
         val request = AnthropicMessageRequest(
-            model = settings.modelVersionsMap[model] ?: throw IllegalArgumentException("Unsupported model: $model"),
+            model = settings.modelVersionsMap[model] ?: model.id,
             messages = messages,
             maxTokens = anthropicParams.maxTokens ?: AnthropicMessageRequest.MAX_TOKENS_DEFAULT,
             cacheControl = anthropicParams.cacheControl?.toAnthropicCacheControl(),

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicModelResolutionTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicModelResolutionTest.kt
@@ -1,0 +1,51 @@
+package ai.koog.prompt.executor.clients.anthropic
+
+import ai.koog.prompt.Prompt
+import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AnthropicModelResolutionTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    private val client = AnthropicLLMClient(apiKey = "test-key")
+
+    private fun requestModelField(model: LLModel): String? {
+        val requestJson = client.createAnthropicRequest(
+            prompt = Prompt(messages = emptyList(), id = "id"),
+            tools = emptyList(),
+            model = model,
+            stream = false
+        )
+        return json.parseToJsonElement(requestJson).jsonObject["model"]?.jsonPrimitive?.content
+    }
+
+    @Test
+    fun testMappedModelResolvesThroughVersionsMap() {
+        assertEquals(
+            DEFAULT_ANTHROPIC_MODEL_VERSIONS_MAP.getValue(AnthropicModels.Sonnet_4),
+            requestModelField(AnthropicModels.Sonnet_4)
+        )
+    }
+
+    @Test
+    fun testUnmappedModelFallsBackToId() {
+        val custom = LLModel(
+            provider = LLMProvider.Anthropic,
+            id = "claude-sonnet-4-5",
+            capabilities = listOf(LLMCapability.Completion, LLMCapability.Tools),
+            contextLength = 200_000,
+            maxOutputTokens = 64_000,
+        )
+        assertEquals("claude-sonnet-4-5", requestModelField(custom))
+    }
+}


### PR DESCRIPTION
anthropic is the only client that resolves models through `modelVersionsMap`; the others send `model.id` as-is. the map is keyed by `LLModel` equality, so any model not constructed from `AnthropicModels` throws `Unsupported model` even when the id is a valid api model name.

fall back to `model.id` on a map miss. mapped models are unchanged. test covers both paths.
