### PR TITLE
feat(openai): support xhigh and max reasoning effort

### DIFF
--- a/docs/docs/llm-parameters.md
+++ b/docs/docs/llm-parameters.md
@@ -676,6 +676,9 @@ You implement reasoning control through provider-specific parameters that contro
 When using the OpenAI Chat API and models that support reasoning, use the `reasoningEffort` parameter
 to control how many reasoning tokens the model generates before providing a response:
 
+Available values are `NONE`, `MINIMAL`, `LOW`, `MEDIUM`, `HIGH`, `XHIGH`, and `MAX`. Support varies by model;
+in particular, use `MAX` only with models that explicitly support it.
+
 === "Kotlin"
 
     <!--- INCLUDE

--- a/docs/docs/snippets/llm-parameters-snippets.md
+++ b/docs/docs/snippets/llm-parameters-snippets.md
@@ -57,7 +57,7 @@ search:
 # --8<-- [end:audio]
 
 # --8<-- [start:reasoningEffort]
-| `reasoningEffort` | ReasoningEffort | Specifies the level of reasoning effort that the model will use. For more information and available values, see the API documentation for [ReasoningEffort](api:prompt-executor-openai-client-base::ai.koog.prompt.executor.clients.openai.base.models.ReasoningEffort). |
+| `reasoningEffort` | ReasoningEffort | Specifies the model's reasoning effort: `NONE`, `MINIMAL`, `LOW`, `MEDIUM`, `HIGH`, `XHIGH`, or `MAX`. Support varies by model. For details, see [ReasoningEffort](api:prompt-executor-openai-client-base::ai.koog.prompt.executor.clients.openai.base.models.ReasoningEffort). |
 # --8<-- [end:reasoningEffort]
 
 # --8<-- [start:webSearchOptions]

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/android/prompt-executor-openai-client-base.api
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/android/prompt-executor-openai-client-base.api
@@ -1239,9 +1239,11 @@ public final class ai/koog/prompt/executor/clients/openai/base/models/ReasoningE
 	public static final field Companion Lai/koog/prompt/executor/clients/openai/base/models/ReasoningEffort$Companion;
 	public static final field HIGH Lai/koog/prompt/executor/clients/openai/base/models/ReasoningEffort;
 	public static final field LOW Lai/koog/prompt/executor/clients/openai/base/models/ReasoningEffort;
+	public static final field MAX Lai/koog/prompt/executor/clients/openai/base/models/ReasoningEffort;
 	public static final field MEDIUM Lai/koog/prompt/executor/clients/openai/base/models/ReasoningEffort;
 	public static final field MINIMAL Lai/koog/prompt/executor/clients/openai/base/models/ReasoningEffort;
 	public static final field NONE Lai/koog/prompt/executor/clients/openai/base/models/ReasoningEffort;
+	public static final field XHIGH Lai/koog/prompt/executor/clients/openai/base/models/ReasoningEffort;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lai/koog/prompt/executor/clients/openai/base/models/ReasoningEffort;
 	public static fun values ()[Lai/koog/prompt/executor/clients/openai/base/models/ReasoningEffort;

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/jvm/prompt-executor-openai-client-base.api
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/jvm/prompt-executor-openai-client-base.api
@@ -1239,9 +1239,11 @@ public final class ai/koog/prompt/executor/clients/openai/base/models/ReasoningE
 	public static final field Companion Lai/koog/prompt/executor/clients/openai/base/models/ReasoningEffort$Companion;
 	public static final field HIGH Lai/koog/prompt/executor/clients/openai/base/models/ReasoningEffort;
 	public static final field LOW Lai/koog/prompt/executor/clients/openai/base/models/ReasoningEffort;
+	public static final field MAX Lai/koog/prompt/executor/clients/openai/base/models/ReasoningEffort;
 	public static final field MEDIUM Lai/koog/prompt/executor/clients/openai/base/models/ReasoningEffort;
 	public static final field MINIMAL Lai/koog/prompt/executor/clients/openai/base/models/ReasoningEffort;
 	public static final field NONE Lai/koog/prompt/executor/clients/openai/base/models/ReasoningEffort;
+	public static final field XHIGH Lai/koog/prompt/executor/clients/openai/base/models/ReasoningEffort;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lai/koog/prompt/executor/clients/openai/base/models/ReasoningEffort;
 	public static fun values ()[Lai/koog/prompt/executor/clients/openai/base/models/ReasoningEffort;

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/prompt-executor-openai-client-base.klib.api
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/prompt-executor-openai-client-base.klib.api
@@ -68,9 +68,11 @@ final enum class ai.koog.prompt.executor.clients.openai.base.models/OpenAIModali
 final enum class ai.koog.prompt.executor.clients.openai.base.models/ReasoningEffort : kotlin/Enum<ai.koog.prompt.executor.clients.openai.base.models/ReasoningEffort> { // ai.koog.prompt.executor.clients.openai.base.models/ReasoningEffort|null[0]
     enum entry HIGH // ai.koog.prompt.executor.clients.openai.base.models/ReasoningEffort.HIGH|null[0]
     enum entry LOW // ai.koog.prompt.executor.clients.openai.base.models/ReasoningEffort.LOW|null[0]
+    enum entry MAX // ai.koog.prompt.executor.clients.openai.base.models/ReasoningEffort.MAX|null[0]
     enum entry MEDIUM // ai.koog.prompt.executor.clients.openai.base.models/ReasoningEffort.MEDIUM|null[0]
     enum entry MINIMAL // ai.koog.prompt.executor.clients.openai.base.models/ReasoningEffort.MINIMAL|null[0]
     enum entry NONE // ai.koog.prompt.executor.clients.openai.base.models/ReasoningEffort.NONE|null[0]
+    enum entry XHIGH // ai.koog.prompt.executor.clients.openai.base.models/ReasoningEffort.XHIGH|null[0]
 
     final val entries // ai.koog.prompt.executor.clients.openai.base.models/ReasoningEffort.entries|#static{}entries[0]
         final fun <get-entries>(): kotlin.enums/EnumEntries<ai.koog.prompt.executor.clients.openai.base.models/ReasoningEffort> // ai.koog.prompt.executor.clients.openai.base.models/ReasoningEffort.entries.<get-entries>|<get-entries>#static(){}[0]

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/models/OpenAIDataModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/models/OpenAIDataModels.kt
@@ -462,7 +462,8 @@ public class OpenAIStaticContent(public val content: Content) {
  * Exact effects are model-dependent.
  * If not set, the model/provider default applies.
  *
- * Serialized as `"none" | "minimal" | "low" | "medium" | "high"`.
+ * Serialized as `"none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max"`.
+ * Supported values vary by model.
  *
  * See [reasoning_effort](https://platform.openai.com/docs/api-reference/responses/create#responses_create-reasoning-effort)
  */
@@ -499,11 +500,25 @@ public enum class ReasoningEffort {
     MEDIUM,
 
     /**
-     * Maximizes the model’s reasoning depth for complex or ambiguous problems.
+     * Allows substantial reasoning depth for complex or ambiguous problems.
      * Expect higher latency and token usage. Serialized as `"high"`.
      */
     @SerialName("high")
-    HIGH
+    HIGH,
+
+    /**
+     * Allows extra-high reasoning effort for the most complex tasks.
+     * Expect higher latency and token usage than [HIGH]. Serialized as `"xhigh"`.
+     */
+    @SerialName("xhigh")
+    XHIGH,
+
+    /**
+     * Allows the maximum reasoning effort supported by the model.
+     * This setting is available only for models that explicitly support it. Serialized as `"max"`.
+     */
+    @SerialName("max")
+    MAX
 }
 
 /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/base/models/ReasoningEffortTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonTest/kotlin/ai/koog/prompt/executor/clients/openai/base/models/ReasoningEffortTest.kt
@@ -1,0 +1,22 @@
+package ai.koog.prompt.executor.clients.openai.base.models
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ReasoningEffortTest {
+    @Test
+    fun testExtendedReasoningEffortsRoundTrip() {
+        val efforts = mapOf(
+            ReasoningEffort.XHIGH to "xhigh",
+            ReasoningEffort.MAX to "max",
+        )
+
+        efforts.forEach { (effort, wireValue) ->
+            val encoded = Json.encodeToString(ReasoningEffort.serializer(), effort)
+
+            assertEquals("\"$wireValue\"", encoded)
+            assertEquals(effort, Json.decodeFromString(ReasoningEffort.serializer(), encoded))
+        }
+    }
+}

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIParams.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIParams.kt
@@ -68,7 +68,7 @@ internal fun LLMParams.toOpenAIResponsesParams(): OpenAIResponsesParams {
  * @property store Whether the provider may store outputs for improvement/evals.
  * @property audio Audio output configuration when using audio-capable models.
  * @property logprobs Whether to include log-probabilities for output tokens.
- * @property reasoningEffort Constrains reasoning effort (e.g., MINIMAL/LOW/MEDIUM/HIGH).
+ * @property reasoningEffort Constrains reasoning effort. Supported values vary by model.
  * @property stop Stop sequences (0–4 items); generation halts before any of these.
  * @property topLogprobs Number of top alternatives per position (0–20). Requires [logprobs] = true.
  * @property topP Nucleus sampling in (0.0, 1.0]; use **instead of** [temperature].

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIChatCompletion.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIChatCompletion.kt
@@ -81,7 +81,7 @@ import kotlin.collections.List
  * @property promptCacheKey Used by OpenAI to cache responses for similar requests to optimize your cache hit rates.
  * Replaces the `user` field.
  * @property reasoningEffort Constrains effort on reasoning for reasoning models.
- * Currently supported values are `low`, `medium`, and `high`.
+ * Supported values vary by model and can include `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
  * Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
  * @property responseFormat An object specifying the format that the model must output.
  *

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPI.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPI.kt
@@ -939,7 +939,7 @@ internal class OpenAIPromptReference(
 /**
  * Configuration options for reasoning models.
  * @property effort Constrains effort on reasoning for reasoning models.
- * Currently supported values are `minimal`, `low`, `medium`, and `high`.
+ * Supported values vary by model and can include `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
  * Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.
  * @property summary A summary of the reasoning performed by the model.
  * This can be useful for debugging and understanding the model's reasoning process. One of `auto`, `concise`,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIRequestSnakeCaseSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIRequestSnakeCaseSerializationTest.kt
@@ -1,5 +1,6 @@
 package ai.koog.prompt.executor.clients.openai.models
 
+import ai.koog.prompt.executor.clients.openai.base.models.ReasoningEffort
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
@@ -14,8 +15,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 
 /**
- * Reproduces the snake_case serialization path used by [OpenAILLMClient] to guard the fix
- * for an additional-properties leak in the outbound request body.
+ * Exercises the snake_case request serialization path used by [OpenAILLMClient].
  */
 class OpenAIRequestSnakeCaseSerializationTest {
 
@@ -25,6 +25,47 @@ class OpenAIRequestSnakeCaseSerializationTest {
         encodeDefaults = true
         explicitNulls = false
         namingStrategy = JsonNamingStrategy.SnakeCase
+    }
+
+    @Test
+    fun testChatCompletionRequestSerializesExtendedReasoningEfforts() {
+        val efforts = mapOf(
+            ReasoningEffort.XHIGH to "xhigh",
+            ReasoningEffort.MAX to "max",
+        )
+
+        efforts.forEach { (effort, wireValue) ->
+            val request = OpenAIChatCompletionRequest(
+                model = "gpt-reasoning-model",
+                messages = emptyList(),
+                reasoningEffort = effort,
+            )
+
+            val encoded = snakeCaseJson.encodeToString(OpenAIChatCompletionRequestSerializer, request)
+            val tree = snakeCaseJson.parseToJsonElement(encoded).jsonObject
+
+            tree["reasoning_effort"]?.jsonPrimitive?.content shouldBe wireValue
+        }
+    }
+
+    @Test
+    fun testResponsesRequestSerializesExtendedReasoningEfforts() {
+        val efforts = mapOf(
+            ReasoningEffort.XHIGH to "xhigh",
+            ReasoningEffort.MAX to "max",
+        )
+
+        efforts.forEach { (effort, wireValue) ->
+            val request = OpenAIResponsesAPIRequest(
+                model = "gpt-reasoning-model",
+                reasoning = ReasoningConfig(effort = effort),
+            )
+
+            val encoded = snakeCaseJson.encodeToString(OpenAIResponsesAPIRequestSerializer, request)
+            val tree = snakeCaseJson.parseToJsonElement(encoded).jsonObject
+
+            tree["reasoning"].shouldNotBeNull().jsonObject["effort"]?.jsonPrimitive?.content shouldBe wireValue
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

[KG-894](https://youtrack.jetbrains.com/issue/KG-894) Support OpenAI xhigh&max effort

- add `XHIGH` and `MAX` to OpenAI `ReasoningEffort`, serialized as `xhigh` and `max`
- cover enum round trips and Chat Completions / Responses request serialization
- update reasoning effort documentation and public API dumps

Model-specific effort validation and capability metadata remain unchanged; unsupported model-effort combinations continue to be validated by OpenAI.


## Testing

- `:prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client-base:jvmTest`
- `:prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client:jvmTest`
- `:prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client-base:jsTest`
- `:prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client:jsTest`
- `:prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client-base:build`
- `:prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client:build`
- `:prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client-base:checkLegacyAbi`
- affected-module `ktlintCheck`