### PR TITLE
fix(agents): swap edge order in singleRunStrategy for nodeSendToolResult

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentSimpleStrategies.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/core/agent/AIAgentSimpleStrategies.kt
@@ -35,6 +35,6 @@ public fun singleRunStrategy(parallelTools: Boolean = false): AIAgentGraphStrate
     edge(nodeCallLLM forwardTo nodeExecuteTool onToolCalls { true })
     edge(nodeCallLLM forwardTo nodeFinish onTextMessage { true })
     edge(nodeExecuteTool forwardTo nodeSendToolResult)
-    edge(nodeSendToolResult forwardTo nodeFinish onTextMessage { true })
     edge(nodeSendToolResult forwardTo nodeExecuteTool onToolCalls { true })
+    edge(nodeSendToolResult forwardTo nodeFinish onTextMessage { true })
 }

--- a/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/SingleRunStrategyTests.kt
+++ b/agents/agents-core/src/commonTest/kotlin/ai/koog/agents/core/agent/SingleRunStrategyTests.kt
@@ -291,4 +291,45 @@ class SingleRunStrategyTests {
         assertEquals(3, actualToolCalls.size)
         assertEquals(assistantResponse, result)
     }
+
+    @Test
+    fun test_SingleRunStrategy_SecondRoundMixedResponse_ExecutesAllTools() = runTest {
+        val actualToolCalls = mutableListOf<String>()
+
+        val testToolRegistry = ToolRegistry {
+            tool(CreateTool)
+        }
+
+        val mockLLMApi = getMockExecutor(serializer, handleLastAssistantMessage = true) {
+            mockLLMAnswer("Task solved!") onRequestContains "Task solved"
+
+            // First round: LLM returns tool call (no text)
+            mockLLMToolCall(CreateTool, CreateTool.Args("first")) onRequestEquals "Solve task"
+
+            // Second round (after tool result): LLM returns Text + ToolCall simultaneously
+            val secondRoundToolCalls = listOf(
+                CreateTool to CreateTool.Args("second1"),
+                CreateTool to CreateTool.Args("second2"),
+            )
+            val secondRoundText = "Let me call more tools"
+            mockLLMMixedResponse(secondRoundToolCalls, listOf(secondRoundText)) onRequestContains "created"
+        }
+
+        val agent = AIAgent(
+            mockLLMApi,
+            OllamaModels.Meta.LLAMA_3_2,
+            strategy = singleRunStrategy(),
+            toolRegistry = testToolRegistry
+        ) {
+            install(EventHandler) {
+                onToolCallStarting { eventContext -> actualToolCalls += eventContext.toolArgs.toString() }
+            }
+        }
+
+        val result = agent.run("Solve task", null)
+
+        // Second round tools should be executed even though LLM returned both Text and ToolCall
+        assertEquals(3, actualToolCalls.size)
+        assertEquals("Task solved!", result)
+    }
 }


### PR DESCRIPTION
## Problem

When an LLM returns both Text and ToolCall simultaneously in the same response (common behavior with DeepSeek, and some other models), the `singleRunStrategy` fails to execute the tool calls after receiving tool results. Instead, it treats the intermediate text as the final answer.

## Root Cause

The edge order for `nodeSendToolResult` was:

```kotlin
edge(nodeSendToolResult forwardTo nodeFinish onTextMessage { true })     // first — matches Text
edge(nodeSendToolResult forwardTo nodeExecuteTool onToolCalls { true })  // second — never reached
```

Since `resolveEdge` evaluates edges in definition order (FIFO) and returns the first match, `onTextMessage` always wins when both Text and ToolCall are present.

Notably, the edges for `nodeCallLLM` (lines 35-36) already have the correct order with `onToolCalls` first. This inconsistency suggests the `nodeSendToolResult` order was unintentional.

## Fix

Swap the two edges so `onToolCalls` is evaluated first (matching the `nodeCallLLM` pattern):

```kotlin
edge(nodeSendToolResult forwardTo nodeExecuteTool onToolCalls { true })  // first — execute tools
edge(nodeSendToolResult forwardTo nodeFinish onTextMessage { true })     // second — finish on pure text
```

## Test

Added `test_SingleRunStrategy_SecondRoundMixedResponse_ExecutesAllTools` which reproduces the bug:
- First round: LLM returns a tool call (no text) → tool executes ✅
- Second round (after tool result): LLM returns Text + ToolCall simultaneously → before fix, tools were skipped; after fix, all tools execute ✅

This test fails without the fix and passes with it.