### PR TITLE
fix(prompt): DeepSeek thinking mode incompatible with tool_choice

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekLLMClient.kt
@@ -19,6 +19,7 @@ import ai.koog.prompt.executor.clients.openai.base.models.OpenAIMessage
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIResponseFormat
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAITool
 import ai.koog.prompt.executor.clients.openai.base.models.OpenAIToolChoice
+import ai.koog.prompt.llm.LLMCapability
 import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.message.Message
@@ -110,6 +111,15 @@ public class DeepSeekLLMClient @JvmOverloads constructor(
         val deepSeekParams = params.toDeepSeekParams()
         val responseFormat = createResponseFormat(params.schema, model)
 
+        // DeepSeek's thinking mode (always on for V4 models) does not support tool_choice.
+        // If we send tool_choice alongside thinking, the API returns 400:
+        // "Thinking mode does not support this tool_choice"
+        val effectiveToolChoice = if (model.supports(LLMCapability.Thinking)) {
+            null
+        } else {
+            deepSeekParams.toolChoice?.toOpenAIToolChoice()
+        }
+
         val preparedMessages = prepareMessagesForDeepSeek(messages, addJsonResponseHint = params.schema != null)
 
         val request = DeepSeekChatCompletionRequest(
@@ -123,7 +133,7 @@ public class DeepSeekLLMClient @JvmOverloads constructor(
             stop = deepSeekParams.stop,
             stream = stream,
             temperature = deepSeekParams.temperature,
-            toolChoice = deepSeekParams.toolChoice?.toOpenAIToolChoice(),
+            toolChoice = effectiveToolChoice,
             tools = tools,
             topLogprobs = deepSeekParams.topLogprobs,
             topP = deepSeekParams.topP,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-deepseek-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/deepseek/DeepSeekModels.kt
@@ -38,7 +38,7 @@ public object DeepSeekModels : LLModelDefinitions {
             LLMCapability.Completion,
             LLMCapability.Temperature,
             LLMCapability.Tools,
-            LLMCapability.ToolChoice,
+            // ToolChoice is not supported when thinking mode is enabled (always on for V4 models)
             LLMCapability.Schema.JSON.Basic,
             LLMCapability.Schema.JSON.Standard,
             LLMCapability.MultipleChoices,
@@ -62,7 +62,7 @@ public object DeepSeekModels : LLModelDefinitions {
             LLMCapability.Completion,
             LLMCapability.Temperature,
             LLMCapability.Tools,
-            LLMCapability.ToolChoice,
+            // ToolChoice is not supported when thinking mode is enabled (always on for V4 models)
             LLMCapability.Schema.JSON.Basic,
             LLMCapability.Schema.JSON.Standard,
             LLMCapability.MultipleChoices,


### PR DESCRIPTION
## Problem

DeepSeek V4 models (Flash, Pro) have thinking mode always enabled, but the DeepSeek API rejects requests containing `tool_choice` when thinking is active, returning HTTP 400:

```
Thinking mode does not support this tool_choice
```

This affects any agent that uses `subgraphWithTask` (e.g., Banking example), because `subgraphWithTask` unconditionally calls `setToolChoiceRequired()`.

## Fix (Two layers)

### 1. Remove `LLMCapability.ToolChoice` from `DeepSeekModels`
DeepSeek V4 models declare `LLMCapability.Thinking` — thinking is always on. Since the API rejects `tool_choice` in thinking mode, the models should not advertise `ToolChoice` as a supported capability.

This causes `subgraphWithTask` to fall back to the alternative code path that repeatedly guides the model to call tools, instead of forcing it via `tool_choice: required`.

### 2. Defense-in-depth in `DeepSeekLLMClient`
Even if `toolChoice` is set through other means (e.g., custom `DeepSeekParams`), the client now checks for `LLMCapability.Thinking` and drops `tool_choice` to prevent the API error.

## Verification
- Existing unit tests pass
- Banking example runs successfully with DeepSeek V4 Flash — no more 400 error

closes #2178
