### PR TITLE
fix(prompt): round-trip Gemini 3 thought_signature in OpenAI-compatible clients

### DIFF
--- a/http-client/http-client-ktor/src/jvmTest/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClientTestBase.kt
+++ b/http-client/http-client-ktor/src/jvmTest/kotlin/ai/koog/http/client/ktor/KtorKoogHttpClientTestBase.kt
@@ -1,6 +1,7 @@
 package ai.koog.http.client.ktor
 
 import ai.koog.http.client.KoogHttpClient
+import ai.koog.http.client.lines
 import ai.koog.http.client.post
 import ai.koog.http.client.test.BaseKoogHttpClientTest
 import io.ktor.client.HttpClient
@@ -15,6 +16,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.content.TextContent
 import io.ktor.http.headersOf
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -137,6 +139,71 @@ abstract class KtorKoogHttpClientTestBase : BaseKoogHttpClientTest() {
         val ktorClient = (client as KtorKoogHttpClient).ktorClient
         assertNotNull(ktorClient.plugin(HttpTimeout))
         assertNotNull(ktorClient.plugin(SSE))
+        client.close()
+    }
+
+    @Test
+    fun `factory should send pre-serialized String body as raw JSON object on post`() = runTest {
+        var capturedBody: String? = null
+        var capturedContentType: ContentType? = null
+        val engine = MockEngine { request ->
+            val body = request.body as TextContent
+            capturedBody = body.text
+            capturedContentType = body.contentType
+            respond(
+                content = "RESPONSE_OK",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Text.Plain.toString())
+            )
+        }
+        val client = ktorClient(
+            baseClient = HttpClient(engine),
+            baseUrl = "https://example.test/api",
+        )
+
+        val payload = """{"request":"hello"}"""
+        val result = client.post<String, String>(
+            path = "v1/messages",
+            requestBody = payload
+        )
+
+        assertEquals("RESPONSE_OK", result)
+        // ContentNegotiation must NOT re-serialize an already-serialized JSON String:
+        // the wire body must stay a JSON object, not become a JSON-quoted string ("{...}").
+        assertEquals(payload, capturedBody)
+        assertTrue(capturedContentType?.match(ContentType.Application.Json) == true)
+        client.close()
+    }
+
+    @Test
+    fun `factory should send pre-serialized String body as raw JSON object on lines`() = runTest {
+        var capturedBody: String? = null
+        var capturedContentType: ContentType? = null
+        val engine = MockEngine { request ->
+            val body = request.body as TextContent
+            capturedBody = body.text
+            capturedContentType = body.contentType
+            respond(
+                content = "{\"i\":1}\n{\"i\":2}\n",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Text.Plain.toString())
+            )
+        }
+        val client = ktorClient(
+            baseClient = HttpClient(engine),
+            baseUrl = "https://example.test/api",
+        )
+
+        val payload = """{"request":"hello"}"""
+        val collected = client.lines(
+            path = "v1/stream",
+            requestBody = payload
+        ).toList()
+
+        assertEquals(listOf("""{"i":1}""", """{"i":2}"""), collected)
+        // Same double-encode guard for the streaming (lines) request path.
+        assertEquals(payload, capturedBody)
+        assertTrue(capturedContentType?.match(ContentType.Application.Json) == true)
         client.close()
     }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
@@ -39,6 +39,11 @@ import kotlinx.coroutines.flow.channelFlow
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNamingStrategy
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.jvm.JvmOverloads
@@ -320,17 +325,35 @@ public abstract class AbstractOpenAILLMClient<TResponse : OpenAIBaseLLMResponse,
                                     .takeIf { it.isNotEmpty() }?.toMessageContent(model),
                                 // FIXME: how to handle multiple reasoning messages
                                 reasoningContent = message.parts.filterIsInstance<MessagePart.Reasoning>()
-                                    .firstOrNull()?.content?.firstOrNull(),
-                                toolCalls = message.parts.filterIsInstance<MessagePart.Tool.Call>()
-                                    .takeIf { it.isNotEmpty() }
-                                    ?.map {
-                                        OpenAIToolCall(
-                                            it.id ?: Uuid.random().toString(),
-                                            // `args` already holds the JSON-encoded arguments; re-encoding here would
-                                            // double-encode it into a quoted string that strict backends (e.g. DashScope) reject.
-                                            function = OpenAIFunction(it.tool, it.args)
-                                        )
+                                    .firstOrNull { it.content.isNotEmpty() }?.content?.firstOrNull(),
+                                toolCalls = buildList {
+                                    var pendingSignature: String? = null
+                                    message.parts.forEach { part ->
+                                        when (part) {
+                                            is MessagePart.Reasoning ->
+                                                if (part.encrypted != null) pendingSignature = part.encrypted
+
+                                            is MessagePart.Tool.Call -> {
+                                                add(
+                                                    OpenAIToolCall(
+                                                        id = part.id ?: Uuid.random().toString(),
+                                                        function = OpenAIFunction(part.tool, part.args),
+                                                        extraContent = pendingSignature?.let { signature ->
+                                                            buildJsonObject {
+                                                                putJsonObject("google") {
+                                                                    put("thought_signature", signature)
+                                                                }
+                                                            }
+                                                        },
+                                                    )
+                                                )
+                                                pendingSignature = null
+                                            }
+
+                                            else -> {}
+                                        }
                                     }
+                                }.takeIf { it.isNotEmpty() }
                             )
                         )
                     }
@@ -436,20 +459,35 @@ public abstract class AbstractOpenAILLMClient<TResponse : OpenAIBaseLLMResponse,
             null
         }
 
-    private fun OpenAIMessage.Assistant.toolCallPartsOrNull(): List<MessagePart.Tool.Call> =
-        toolCalls?.map { toolCall ->
-            MessagePart.Tool.Call(
-                id = toolCall.id,
-                tool = toolCall.function.name,
-                /*
-                 If the tool has no arguments, OpenRouter puts an empty string in the arguments instead of an empty object
-                 But we always expect arguments to be a JSON object. Fixing this.
-                 */
-                args = toolCall.function.arguments
-                    .takeIf { it.isNotEmpty() }
-                    ?.let { Json.parseToJsonElement(it).jsonObject }
-                    ?: JsonObject(mapOf()),
-            )
+    private fun OpenAIMessage.Assistant.toolCallPartsWithSignaturesOrNull(): List<MessagePart.ResponsePart> =
+        toolCalls?.flatMap { toolCall ->
+            // Gemini 3 (Vertex OpenAI-compat) returns the thought_signature for each function call in
+            // tool_calls[].extra_content.google.thought_signature. Lift it into a signature-only
+            // Reasoning part placed right before its Tool.Call so convertPromptToMessages can echo it
+            // back on the next turn (mirrors GoogleLLMClient). Absent for OpenAI/OpenRouter/Gemini 2.5.
+            val signature = (toolCall.extraContent?.get("google") as? JsonObject)
+                ?.get("thought_signature")
+                ?.let { it as? JsonPrimitive }
+                ?.contentOrNull
+            buildList<MessagePart.ResponsePart> {
+                if (signature != null) {
+                    add(MessagePart.Reasoning(content = emptyList(), encrypted = signature))
+                }
+                add(
+                    MessagePart.Tool.Call(
+                        id = toolCall.id,
+                        tool = toolCall.function.name,
+                        /*
+                         If the tool has no arguments, OpenRouter puts an empty string in the arguments
+                         instead of an empty object. But we always expect arguments to be a JSON object.
+                         */
+                        args = toolCall.function.arguments
+                            .takeIf { it.isNotEmpty() }
+                            ?.let { Json.parseToJsonElement(it).jsonObject }
+                            ?: JsonObject(mapOf()),
+                    ),
+                )
+            }
         } ?: emptyList()
 
     private fun OpenAIMessage.Assistant.contentPartsOrNull(): List<MessagePart.ResponsePart> =
@@ -503,7 +541,7 @@ public abstract class AbstractOpenAILLMClient<TResponse : OpenAIBaseLLMResponse,
         val parts: List<MessagePart.ResponsePart> = buildList {
             message.contentPartsOrNull().forEach { add(it) }
             message.reasoningPartOrNull()?.let { add(it) }
-            message.toolCallPartsOrNull().forEach { add(it) }
+            message.toolCallPartsWithSignaturesOrNull().forEach { add(it) }
         }
 
         return Message.Assistant(

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/models/OpenAIDataModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/models/OpenAIDataModels.kt
@@ -290,7 +290,8 @@ public class OpenAIAudio(
 @Serializable
 public class OpenAIToolCall(
     public val id: String,
-    public val function: OpenAIFunction
+    public val function: OpenAIFunction,
+    public val extraContent: JsonObject? = null,
 ) {
     /** The type of the tool. Currently, only `function` is supported. */
     public val type: String = "function"

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIChatCompletionLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIChatCompletionLLMClientTest.kt
@@ -1,5 +1,8 @@
 package ai.koog.prompt.executor.clients.openai
 
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolParameterDescriptor
+import ai.koog.agents.core.tools.ToolParameterType
 import ai.koog.http.client.ktor.KtorKoogHttpClient
 import ai.koog.prompt.Prompt
 import ai.koog.prompt.message.Message
@@ -27,7 +30,9 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.time.Instant
 
 class OpenAIChatCompletionLLMClientTest {
@@ -174,5 +179,179 @@ class OpenAIChatCompletionLLMClientTest {
         val decoded = Json.parseToJsonElement(arguments)
         assertIs<JsonObject>(decoded, "function.arguments must be a JSON object, not a double-encoded JSON string")
         assertEquals(JsonObject(mapOf("city" to JsonPrimitive("Boston"))), decoded)
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Gemini 3 thought_signature round-trip (Vertex OpenAI-compat). Gemini 3 returns the signature
+    // on each function call in tool_calls[].extra_content.google.thought_signature and rejects the
+    // next tool turn with HTTP 400 if it is not echoed back verbatim.
+    // ---------------------------------------------------------------------------------------------
+
+    private val toolCallWithThoughtSignatureBody = """
+        {
+          "id": "chatcmpl-g3",
+          "object": "chat.completion",
+          "created": 1677652288,
+          "model": "gemini-3.5-flash",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "tool_calls": [
+                  {
+                    "id": "call_g3",
+                    "type": "function",
+                    "extra_content": { "google": { "thought_signature": "SIG_ABC_123" } },
+                    "function": {
+                      "name": "weather",
+                      "arguments": "{\"city\": \"Sofia\"}"
+                    }
+                  }
+                ]
+              },
+              "finish_reason": "tool_calls"
+            }
+          ]
+        }
+    """.trimIndent()
+
+    private val weatherTools = listOf(
+        ToolDescriptor(
+            name = "weather",
+            description = "Get the weather for a city",
+            requiredParameters = listOf(
+                ToolParameterDescriptor(
+                    name = "city",
+                    description = "The city to get weather for",
+                    type = ToolParameterType.String,
+                ),
+            ),
+        ),
+    )
+
+    @Test
+    fun testGemini3ThoughtSignatureParsedIntoReasoningPart() = runTest {
+        // INBOUND: extra_content.google.thought_signature must be lifted into a signature-only
+        // Reasoning part placed immediately before its tool call.
+        val engine = MockEngine {
+            respond(
+                content = toolCallWithThoughtSignatureBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        val client = OpenAILLMClient(
+            apiKey = key,
+            httpClientFactory = KtorKoogHttpClient.Factory(HttpClient(engine)),
+            clock = FixedClock,
+        )
+
+        val response = client.execute(
+            Prompt.build("g3-in") { user("What's the weather in Sofia?") },
+            OpenAIModels.Chat.GPT4o,
+            weatherTools,
+        )
+
+        val reasoningIndex = response.parts.indexOfFirst {
+            it is MessagePart.Reasoning && it.encrypted == "SIG_ABC_123"
+        }
+        val callIndex = response.parts.indexOfFirst { it is MessagePart.Tool.Call }
+        assertNotEquals(-1, reasoningIndex, "thought_signature was not lifted into a Reasoning part")
+        assertEquals(reasoningIndex + 1, callIndex, "Reasoning(signature) must directly precede its tool call")
+    }
+
+    @Test
+    fun testGemini3ThoughtSignatureEchoedBackOnNextTurn() = runTest {
+        // ROUND-TRIP: feed the assistant tool call from turn 1 back on turn 2 and assert the
+        // request carries tool_calls[0].extra_content.google.thought_signature verbatim.
+        var capturedBody: String? = null
+        val engine = MockEngine { request ->
+            capturedBody = (request.body as TextContent).text
+            respond(
+                content = toolCallWithThoughtSignatureBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        val client = OpenAILLMClient(
+            apiKey = key,
+            httpClientFactory = KtorKoogHttpClient.Factory(HttpClient(engine)),
+            clock = FixedClock,
+        )
+
+        // Turn 1 — obtain the assistant message carrying the signature.
+        val assistantTurn = client.execute(
+            Prompt.build("g3-turn1") { user("What's the weather in Sofia?") },
+            OpenAIModels.Chat.GPT4o,
+            weatherTools,
+        )
+
+        // Turn 2 — replay the assistant tool call + a tool result, capture the outbound request.
+        val followUp = Prompt.build("g3-turn2") {
+            user("What's the weather in Sofia?")
+            message(assistantTurn)
+            message(
+                Message.User(
+                    MessagePart.Tool.Result(id = "call_g3", tool = "weather", output = "sunny"),
+                    RequestMetaInfo.create(FixedClock),
+                ),
+            )
+        }
+        client.execute(followUp, OpenAIModels.Chat.GPT4o, weatherTools)
+
+        val body = Json.parseToJsonElement(requireNotNull(capturedBody)).jsonObject
+        val toolCall = body["messages"]!!.jsonArray
+            .first { it.jsonObject["tool_calls"] != null }
+            .jsonObject["tool_calls"]!!.jsonArray[0].jsonObject
+        val signature = toolCall["extra_content"]
+            ?.jsonObject?.get("google")
+            ?.jsonObject?.get("thought_signature")
+            ?.jsonPrimitive?.content
+        assertEquals("SIG_ABC_123", signature, "thought_signature was not echoed back: $toolCall")
+    }
+
+    @Test
+    fun testNonGeminiToolCallHasNoExtraContent() = runTest {
+        // NO-REGRESS: a plain tool call (no extra_content inbound) must NOT add extra_content
+        // outbound, so OpenAI / OpenRouter / Gemini 2.5 requests stay byte-for-byte unchanged.
+        var capturedBody: String? = null
+        val engine = MockEngine { request ->
+            capturedBody = (request.body as TextContent).text
+            respond(
+                content = toolCallWithReasoningBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        val client = OpenAILLMClient(
+            apiKey = key,
+            httpClientFactory = KtorKoogHttpClient.Factory(HttpClient(engine)),
+            clock = FixedClock,
+        )
+
+        val assistantTurn = client.execute(
+            Prompt.build("plain-turn1") { user("What's the weather in Boston?") },
+            OpenAIModels.Chat.GPT4o,
+            weatherTools,
+        )
+
+        val followUp = Prompt.build("plain-turn2") {
+            user("What's the weather in Boston?")
+            message(assistantTurn)
+            message(
+                Message.User(
+                    MessagePart.Tool.Result(id = "call_abc123", tool = "weather", output = "rainy"),
+                    RequestMetaInfo.create(FixedClock),
+                ),
+            )
+        }
+        client.execute(followUp, OpenAIModels.Chat.GPT4o, weatherTools)
+
+        val body = Json.parseToJsonElement(requireNotNull(capturedBody)).jsonObject
+        val toolCall = body["messages"]!!.jsonArray
+            .first { it.jsonObject["tool_calls"] != null }
+            .jsonObject["tool_calls"]!!.jsonArray[0].jsonObject
+        assertNull(toolCall["extra_content"], "non-Gemini tool call must not carry extra_content")
     }
 }


### PR DESCRIPTION
**What**
Gemini 3 (Vertex AI, OpenAI-compatible mode) returns a `thought_signature` for every function call in `tool_calls[].extra_content.google.thought_signature`. On the next tool turn, the model rejects the request with HTTP 400 unless that signature is echoed back verbatim on the corresponding tool call. The OpenAI-compatible client neither parsed it inbound nor sent it back outbound, so every multi-turn tool loop on Gemini 3 broke at the follow-up call.

**Fix**
* **Inbound (`AbstractOpenAILLMClient`):** Lift `extra_content.google.thought_signature` into a signature-only Reasoning part placed immediately before its `Tool.Call` (mirrors `GoogleLLMClient`), so the signature survives in prompt history.
* **Outbound (`AbstractOpenAILLMClient`):** When an assistant `Tool.Call` is preceded by a Reasoning part carrying an encrypted signature, emit it back as `extra_content.google.thought_signature` on that tool call.
* **Model (`OpenAIDataModels`):** `OpenAIToolCall` gains an optional `extraContent` field. It is null for OpenAI / OpenRouter / Gemini 2.5, so their requests stay byte-for-byte unchanged.

**Tests**
* `testGemini3ThoughtSignatureParsedIntoReasoningPart` — inbound: the signature is lifted into a Reasoning part directly preceding its tool call.
* `testGemini3ThoughtSignatureEchoedBackOnNextTurn` — round-trip: replaying the assistant tool call sends `extra_content.google.thought_signature` verbatim.
* `testNonGeminiToolCallHasNoExtraContent` — no-regression: a plain tool call never gains `extra_content` outbound.
* `KtorKoogHttpClientTestBase` — guards the HTTP-client layer: asserts a pre-serialized String body is sent as a raw JSON object (not a JSON-quoted string) on both POST and streaming paths.