### PR TITLE
fix(prompt): round-trip Gemini 3 thought_signature in OpenAI-compatible clients (non-streaming + streaming)

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/android/prompt-executor-openai-client-base.api
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/android/prompt-executor-openai-client-base.api
@@ -889,8 +889,9 @@ public final class ai/koog/prompt/executor/clients/openai/base/models/OpenAIStre
 
 public final class ai/koog/prompt/executor/clients/openai/base/models/OpenAIStreamToolCall {
 	public static final field Companion Lai/koog/prompt/executor/clients/openai/base/models/OpenAIStreamToolCall$Companion;
-	public fun <init> (ILjava/lang/String;Lai/koog/prompt/executor/clients/openai/base/models/OpenAIStreamFunction;Ljava/lang/String;)V
-	public synthetic fun <init> (ILjava/lang/String;Lai/koog/prompt/executor/clients/openai/base/models/OpenAIStreamFunction;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILjava/lang/String;Lai/koog/prompt/executor/clients/openai/base/models/OpenAIStreamFunction;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public synthetic fun <init> (ILjava/lang/String;Lai/koog/prompt/executor/clients/openai/base/models/OpenAIStreamFunction;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getExtraContent ()Lkotlinx/serialization/json/JsonObject;
 	public final fun getFunction ()Lai/koog/prompt/executor/clients/openai/base/models/OpenAIStreamFunction;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getIndex ()I
@@ -936,7 +937,6 @@ public final class ai/koog/prompt/executor/clients/openai/base/models/OpenAITool
 
 public final class ai/koog/prompt/executor/clients/openai/base/models/OpenAIToolCall {
 	public static final field Companion Lai/koog/prompt/executor/clients/openai/base/models/OpenAIToolCall$Companion;
-	public fun <init> (Ljava/lang/String;Lai/koog/prompt/executor/clients/openai/base/models/OpenAIFunction;)V
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/executor/clients/openai/base/models/OpenAIFunction;Lkotlinx/serialization/json/JsonObject;)V
 	public synthetic fun <init> (Ljava/lang/String;Lai/koog/prompt/executor/clients/openai/base/models/OpenAIFunction;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getExtraContent ()Lkotlinx/serialization/json/JsonObject;

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/android/prompt-executor-openai-client-base.api
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/android/prompt-executor-openai-client-base.api
@@ -937,6 +937,9 @@ public final class ai/koog/prompt/executor/clients/openai/base/models/OpenAITool
 public final class ai/koog/prompt/executor/clients/openai/base/models/OpenAIToolCall {
 	public static final field Companion Lai/koog/prompt/executor/clients/openai/base/models/OpenAIToolCall$Companion;
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/executor/clients/openai/base/models/OpenAIFunction;)V
+	public fun <init> (Ljava/lang/String;Lai/koog/prompt/executor/clients/openai/base/models/OpenAIFunction;Lkotlinx/serialization/json/JsonObject;)V
+	public synthetic fun <init> (Ljava/lang/String;Lai/koog/prompt/executor/clients/openai/base/models/OpenAIFunction;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getExtraContent ()Lkotlinx/serialization/json/JsonObject;
 	public final fun getFunction ()Lai/koog/prompt/executor/clients/openai/base/models/OpenAIFunction;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getType ()Ljava/lang/String;

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/jvm/prompt-executor-openai-client-base.api
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/jvm/prompt-executor-openai-client-base.api
@@ -889,8 +889,9 @@ public final class ai/koog/prompt/executor/clients/openai/base/models/OpenAIStre
 
 public final class ai/koog/prompt/executor/clients/openai/base/models/OpenAIStreamToolCall {
 	public static final field Companion Lai/koog/prompt/executor/clients/openai/base/models/OpenAIStreamToolCall$Companion;
-	public fun <init> (ILjava/lang/String;Lai/koog/prompt/executor/clients/openai/base/models/OpenAIStreamFunction;Ljava/lang/String;)V
-	public synthetic fun <init> (ILjava/lang/String;Lai/koog/prompt/executor/clients/openai/base/models/OpenAIStreamFunction;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILjava/lang/String;Lai/koog/prompt/executor/clients/openai/base/models/OpenAIStreamFunction;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public synthetic fun <init> (ILjava/lang/String;Lai/koog/prompt/executor/clients/openai/base/models/OpenAIStreamFunction;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getExtraContent ()Lkotlinx/serialization/json/JsonObject;
 	public final fun getFunction ()Lai/koog/prompt/executor/clients/openai/base/models/OpenAIStreamFunction;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getIndex ()I
@@ -936,7 +937,6 @@ public final class ai/koog/prompt/executor/clients/openai/base/models/OpenAITool
 
 public final class ai/koog/prompt/executor/clients/openai/base/models/OpenAIToolCall {
 	public static final field Companion Lai/koog/prompt/executor/clients/openai/base/models/OpenAIToolCall$Companion;
-	public fun <init> (Ljava/lang/String;Lai/koog/prompt/executor/clients/openai/base/models/OpenAIFunction;)V
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/executor/clients/openai/base/models/OpenAIFunction;Lkotlinx/serialization/json/JsonObject;)V
 	public synthetic fun <init> (Ljava/lang/String;Lai/koog/prompt/executor/clients/openai/base/models/OpenAIFunction;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getExtraContent ()Lkotlinx/serialization/json/JsonObject;

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/jvm/prompt-executor-openai-client-base.api
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/jvm/prompt-executor-openai-client-base.api
@@ -937,6 +937,9 @@ public final class ai/koog/prompt/executor/clients/openai/base/models/OpenAITool
 public final class ai/koog/prompt/executor/clients/openai/base/models/OpenAIToolCall {
 	public static final field Companion Lai/koog/prompt/executor/clients/openai/base/models/OpenAIToolCall$Companion;
 	public fun <init> (Ljava/lang/String;Lai/koog/prompt/executor/clients/openai/base/models/OpenAIFunction;)V
+	public fun <init> (Ljava/lang/String;Lai/koog/prompt/executor/clients/openai/base/models/OpenAIFunction;Lkotlinx/serialization/json/JsonObject;)V
+	public synthetic fun <init> (Ljava/lang/String;Lai/koog/prompt/executor/clients/openai/base/models/OpenAIFunction;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getExtraContent ()Lkotlinx/serialization/json/JsonObject;
 	public final fun getFunction ()Lai/koog/prompt/executor/clients/openai/base/models/OpenAIFunction;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getType ()Ljava/lang/String;

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/prompt-executor-openai-client-base.klib.api
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/prompt-executor-openai-client-base.klib.api
@@ -1055,8 +1055,10 @@ final class ai.koog.prompt.executor.clients.openai.base.models/OpenAITool { // a
 }
 
 final class ai.koog.prompt.executor.clients.openai.base.models/OpenAIToolCall { // ai.koog.prompt.executor.clients.openai.base.models/OpenAIToolCall|null[0]
-    constructor <init>(kotlin/String, ai.koog.prompt.executor.clients.openai.base.models/OpenAIFunction) // ai.koog.prompt.executor.clients.openai.base.models/OpenAIToolCall.<init>|<init>(kotlin.String;ai.koog.prompt.executor.clients.openai.base.models.OpenAIFunction){}[0]
+    constructor <init>(kotlin/String, ai.koog.prompt.executor.clients.openai.base.models/OpenAIFunction, kotlinx.serialization.json/JsonObject? = ...) // ai.koog.prompt.executor.clients.openai.base.models/OpenAIToolCall.<init>|<init>(kotlin.String;ai.koog.prompt.executor.clients.openai.base.models.OpenAIFunction;kotlinx.serialization.json.JsonObject?){}[0]
 
+    final val extraContent // ai.koog.prompt.executor.clients.openai.base.models/OpenAIToolCall.extraContent|{}extraContent[0]
+        final fun <get-extraContent>(): kotlinx.serialization.json/JsonObject? // ai.koog.prompt.executor.clients.openai.base.models/OpenAIToolCall.extraContent.<get-extraContent>|<get-extraContent>(){}[0]
     final val function // ai.koog.prompt.executor.clients.openai.base.models/OpenAIToolCall.function|{}function[0]
         final fun <get-function>(): ai.koog.prompt.executor.clients.openai.base.models/OpenAIFunction // ai.koog.prompt.executor.clients.openai.base.models/OpenAIToolCall.function.<get-function>|<get-function>(){}[0]
     final val id // ai.koog.prompt.executor.clients.openai.base.models/OpenAIToolCall.id|{}id[0]

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/prompt-executor-openai-client-base.klib.api
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/api/prompt-executor-openai-client-base.klib.api
@@ -1007,8 +1007,10 @@ final class ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamOptio
 }
 
 final class ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamToolCall { // ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamToolCall|null[0]
-    constructor <init>(kotlin/Int, kotlin/String?, ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamFunction?, kotlin/String? = ...) // ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamToolCall.<init>|<init>(kotlin.Int;kotlin.String?;ai.koog.prompt.executor.clients.openai.base.models.OpenAIStreamFunction?;kotlin.String?){}[0]
+    constructor <init>(kotlin/Int, kotlin/String?, ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamFunction?, kotlin/String? = ..., kotlinx.serialization.json/JsonObject? = ...) // ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamToolCall.<init>|<init>(kotlin.Int;kotlin.String?;ai.koog.prompt.executor.clients.openai.base.models.OpenAIStreamFunction?;kotlin.String?;kotlinx.serialization.json.JsonObject?){}[0]
 
+    final val extraContent // ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamToolCall.extraContent|{}extraContent[0]
+        final fun <get-extraContent>(): kotlinx.serialization.json/JsonObject? // ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamToolCall.extraContent.<get-extraContent>|<get-extraContent>(){}[0]
     final val function // ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamToolCall.function|{}function[0]
         final fun <get-function>(): ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamFunction? // ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamToolCall.function.<get-function>|<get-function>(){}[0]
     final val id // ai.koog.prompt.executor.clients.openai.base.models/OpenAIStreamToolCall.id|{}id[0]

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
@@ -39,6 +39,11 @@ import kotlinx.coroutines.flow.channelFlow
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNamingStrategy
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.jvm.JvmOverloads
@@ -320,17 +325,35 @@ public abstract class AbstractOpenAILLMClient<TResponse : OpenAIBaseLLMResponse,
                                     .takeIf { it.isNotEmpty() }?.toMessageContent(model),
                                 // FIXME: how to handle multiple reasoning messages
                                 reasoningContent = message.parts.filterIsInstance<MessagePart.Reasoning>()
-                                    .firstOrNull()?.content?.firstOrNull(),
-                                toolCalls = message.parts.filterIsInstance<MessagePart.Tool.Call>()
-                                    .takeIf { it.isNotEmpty() }
-                                    ?.map {
-                                        OpenAIToolCall(
-                                            it.id ?: Uuid.random().toString(),
-                                            // `args` already holds the JSON-encoded arguments; re-encoding here would
-                                            // double-encode it into a quoted string that strict backends (e.g. DashScope) reject.
-                                            function = OpenAIFunction(it.tool, it.args)
-                                        )
+                                    .firstOrNull { it.content.isNotEmpty() }?.content?.firstOrNull(),
+                                toolCalls = buildList {
+                                    var pendingSignature: String? = null
+                                    message.parts.forEach { part ->
+                                        when (part) {
+                                            is MessagePart.Reasoning ->
+                                                if (part.encrypted != null) pendingSignature = part.encrypted
+
+                                            is MessagePart.Tool.Call -> {
+                                                add(
+                                                    OpenAIToolCall(
+                                                        id = part.id ?: Uuid.random().toString(),
+                                                        function = OpenAIFunction(part.tool, part.args),
+                                                        extraContent = pendingSignature?.let { signature ->
+                                                            buildJsonObject {
+                                                                putJsonObject("google") {
+                                                                    put("thought_signature", signature)
+                                                                }
+                                                            }
+                                                        },
+                                                    )
+                                                )
+                                                pendingSignature = null
+                                            }
+
+                                            else -> {}
+                                        }
                                     }
+                                }.takeIf { it.isNotEmpty() }
                             )
                         )
                     }
@@ -436,20 +459,35 @@ public abstract class AbstractOpenAILLMClient<TResponse : OpenAIBaseLLMResponse,
             null
         }
 
-    private fun OpenAIMessage.Assistant.toolCallPartsOrNull(): List<MessagePart.Tool.Call> =
-        toolCalls?.map { toolCall ->
-            MessagePart.Tool.Call(
-                id = toolCall.id,
-                tool = toolCall.function.name,
-                /*
-                 If the tool has no arguments, OpenRouter puts an empty string in the arguments instead of an empty object
-                 But we always expect arguments to be a JSON object. Fixing this.
-                 */
-                args = toolCall.function.arguments
-                    .takeIf { it.isNotEmpty() }
-                    ?.let { Json.parseToJsonElement(it).jsonObject }
-                    ?: JsonObject(mapOf()),
-            )
+    private fun OpenAIMessage.Assistant.toolCallPartsWithSignaturesOrNull(): List<MessagePart.ResponsePart> =
+        toolCalls?.flatMap { toolCall ->
+            // Gemini 3 (Vertex OpenAI-compat) returns the thought_signature for each function call in
+            // tool_calls[].extra_content.google.thought_signature. Lift it into a signature-only
+            // Reasoning part placed right before its Tool.Call so convertPromptToMessages can echo it
+            // back on the next turn (mirrors GoogleLLMClient). Absent for OpenAI/OpenRouter/Gemini 2.5.
+            val signature = (toolCall.extraContent?.get("google") as? JsonObject)
+                ?.get("thought_signature")
+                ?.let { it as? JsonPrimitive }
+                ?.contentOrNull
+            buildList<MessagePart.ResponsePart> {
+                if (signature != null) {
+                    add(MessagePart.Reasoning(content = emptyList(), encrypted = signature))
+                }
+                add(
+                    MessagePart.Tool.Call(
+                        id = toolCall.id,
+                        tool = toolCall.function.name,
+                        /*
+                         If the tool has no arguments, OpenRouter puts an empty string in the arguments
+                         instead of an empty object. But we always expect arguments to be a JSON object.
+                         */
+                        args = toolCall.function.arguments
+                            .takeIf { it.isNotEmpty() }
+                            ?.let { Json.parseToJsonElement(it).jsonObject }
+                            ?: JsonObject(mapOf()),
+                    ),
+                )
+            }
         } ?: emptyList()
 
     private fun OpenAIMessage.Assistant.contentPartsOrNull(): List<MessagePart.ResponsePart> =
@@ -503,7 +541,7 @@ public abstract class AbstractOpenAILLMClient<TResponse : OpenAIBaseLLMResponse,
         val parts: List<MessagePart.ResponsePart> = buildList {
             message.contentPartsOrNull().forEach { add(it) }
             message.reasoningPartOrNull()?.let { add(it) }
-            message.toolCallPartsOrNull().forEach { add(it) }
+            message.toolCallPartsWithSignaturesOrNull().forEach { add(it) }
         }
 
         return Message.Assistant(

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
@@ -381,7 +381,9 @@ public abstract class AbstractOpenAILLMClient<TResponse : OpenAIBaseLLMResponse,
                     model.requireCapability(LLMCapability.Vision.Image)
                     val imageUrl = when (val attachmentContent = source.content) {
                         is AttachmentContent.URL -> attachmentContent.url
+
                         is AttachmentContent.Binary -> "data:${source.mimeType};base64,${attachmentContent.asBase64()}"
+
                         else -> throw LLMClientException(
                             clientName,
                             "Unsupported image attachment content: ${attachmentContent::class}"
@@ -443,8 +445,11 @@ public abstract class AbstractOpenAILLMClient<TResponse : OpenAIBaseLLMResponse,
 
     protected fun LLMParams.ToolChoice.toOpenAIToolChoice(): OpenAIToolChoice = when (this) {
         LLMParams.ToolChoice.Auto -> OpenAIToolChoice.Auto
+
         LLMParams.ToolChoice.None -> OpenAIToolChoice.None
+
         LLMParams.ToolChoice.Required -> OpenAIToolChoice.Required
+
         is LLMParams.ToolChoice.Named -> OpenAIToolChoice.Function(
             function = OpenAIToolChoice.FunctionName(name)
         )

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/AbstractOpenAILLMClient.kt
@@ -42,9 +42,9 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
-import kotlinx.serialization.json.jsonObject
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.jvm.JvmOverloads
 import kotlin.uuid.ExperimentalUuidApi

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/models/OpenAIDataModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/models/OpenAIDataModels.kt
@@ -290,7 +290,8 @@ public class OpenAIAudio(
 @Serializable
 public class OpenAIToolCall(
     public val id: String,
-    public val function: OpenAIFunction
+    public val function: OpenAIFunction,
+    public val extraContent: JsonObject? = null,
 ) {
     /** The type of the tool. Currently, only `function` is supported. */
     public val type: String = "function"

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/models/OpenAIDataModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/models/OpenAIDataModels.kt
@@ -18,7 +18,6 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 import kotlin.jvm.JvmInline
-import kotlin.jvm.JvmOverloads
 
 /**
  * Base interface for LLM OpenAI API requests.
@@ -289,7 +288,7 @@ public class OpenAIAudio(
  * @property function The function that the model called.
  */
 @Serializable
-public class OpenAIToolCall @JvmOverloads constructor(
+public class OpenAIToolCall(
     public val id: String,
     public val function: OpenAIFunction,
     public val extraContent: JsonObject? = null,
@@ -305,13 +304,18 @@ public class OpenAIToolCall @JvmOverloads constructor(
  * @property function The function object containing the name and arguments of the function invoked.
  * This value can be null if no function call is associated.
  * @property type The type of the tool call. Defaults to "function" for denoting function-based calls. Can be null.
+ * @property extraContent Provider-specific extension payload attached to this tool-call chunk, verbatim.
+ * Gemini 3 (OpenAI-compat mode) streams its `thought_signature` here as
+ * `extra_content.google.thought_signature` on the chunk that opens the tool call.
+ * Null for providers that send no extension payload.
  */
 @Serializable
 public class OpenAIStreamToolCall(
     public val index: Int,
     public val id: String?,
     public val function: OpenAIStreamFunction?,
-    public val type: String? = "function"
+    public val type: String? = "function",
+    public val extraContent: JsonObject? = null,
 )
 
 /**

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/models/OpenAIDataModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client-base/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/base/models/OpenAIDataModels.kt
@@ -18,6 +18,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 import kotlin.jvm.JvmInline
+import kotlin.jvm.JvmOverloads
 
 /**
  * Base interface for LLM OpenAI API requests.
@@ -288,7 +289,7 @@ public class OpenAIAudio(
  * @property function The function that the model called.
  */
 @Serializable
-public class OpenAIToolCall(
+public class OpenAIToolCall @JvmOverloads constructor(
     public val id: String,
     public val function: OpenAIFunction,
     public val extraContent: JsonObject? = null,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -65,9 +65,11 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.put
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.jvm.JvmOverloads
@@ -299,6 +301,17 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                     val functionName = openAIToolCall.function?.name
                     val functionArgs = openAIToolCall.function?.arguments
                     emitToolCallDelta(id, functionName, functionArgs, index)
+                    // Gemini 3 (OpenAI-compat) streams the thought_signature for a function call in
+                    // tool_calls[].extra_content.google.thought_signature on the chunk that opens the
+                    // call. Attach it to the pending call so its completion emits a signature-only
+                    // Reasoning frame right before ToolCallComplete — the same
+                    // `Reasoning(encrypted)` -> `Tool.Call` shape the non-streaming path produces.
+                    (
+                        (openAIToolCall.extraContent?.get("google") as? JsonObject)
+                            ?.get("thought_signature") as? JsonPrimitive
+                        )
+                        ?.contentOrNull
+                        ?.let { attachToolCallSignature(it) }
                 }
 
                 choice.finishReason?.let { finishReason = it }
@@ -791,12 +804,15 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                                                         put("text", p.text)
                                                     }
                                                 )
+
                                                 is MessagePart.Attachment -> {
                                                     when (val source = p.source) {
                                                         is AttachmentSource.Image -> {
                                                             val imageUrl = when (val c = source.content) {
                                                                 is AttachmentContent.URL -> c.url
+
                                                                 is AttachmentContent.Binary -> "data:${source.mimeType};base64,${c.asBase64()}"
+
                                                                 else -> {
                                                                     logger.warn { "Unsupported image content type in tool result for OpenAI: ${c::class}, skipping" }
                                                                     null
@@ -812,6 +828,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                                                                 )
                                                             }
                                                         }
+
                                                         is AttachmentSource.File -> {
                                                             when (val c = source.content) {
                                                                 is AttachmentContent.Binary -> add(
@@ -821,6 +838,7 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                                                                         source.fileName?.let { put("filename", it) }
                                                                     }
                                                                 )
+
                                                                 is AttachmentContent.URL -> add(
                                                                     buildJsonObject {
                                                                         put("type", "input_file")
@@ -828,9 +846,11 @@ public open class OpenAILLMClient @JvmOverloads constructor(
                                                                         source.fileName?.let { put("filename", it) }
                                                                     }
                                                                 )
+
                                                                 else -> logger.warn { "Unsupported file content type in tool result for OpenAI: ${c::class}, skipping" }
                                                             }
                                                         }
+
                                                         else -> logger.warn { "Unsupported attachment type in tool result for OpenAI: ${source::class}, skipping" }
                                                     }
                                                 }
@@ -1053,7 +1073,9 @@ public open class OpenAILLMClient @JvmOverloads constructor(
     }
 
     internal fun determineParams(params: LLMParams, model: LLModel): OpenAIParams = when {
-        "openai.azure.com" in settings.baseUrl -> params.toOpenAIChatParams() // TODO: create a separate Azure Client
+        "openai.azure.com" in settings.baseUrl -> params.toOpenAIChatParams()
+
+        // TODO: create a separate Azure Client
         params is OpenAIResponsesParams -> {
             model.requireCapability(
                 LLMCapability.OpenAIEndpoint.Responses,
@@ -1071,7 +1093,9 @@ public open class OpenAILLMClient @JvmOverloads constructor(
         }
 
         model.supports(LLMCapability.OpenAIEndpoint.Completions) -> params.toOpenAIChatParams()
+
         model.supports(LLMCapability.OpenAIEndpoint.Responses) -> params.toOpenAIResponsesParams()
+
         else -> throw LLMClientException(clientName, "Cannot determine proper LLM params for OpenAI model: ${model.id}")
     }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIChatCompletionLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIChatCompletionLLMClientTest.kt
@@ -1,5 +1,8 @@
 package ai.koog.prompt.executor.clients.openai
 
+import ai.koog.agents.core.tools.ToolDescriptor
+import ai.koog.agents.core.tools.ToolParameterDescriptor
+import ai.koog.agents.core.tools.ToolParameterType
 import ai.koog.http.client.ktor.KtorKoogHttpClient
 import ai.koog.prompt.Prompt
 import ai.koog.prompt.message.Message
@@ -27,7 +30,9 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.time.Instant
 
 class OpenAIChatCompletionLLMClientTest {
@@ -174,5 +179,179 @@ class OpenAIChatCompletionLLMClientTest {
         val decoded = Json.parseToJsonElement(arguments)
         assertIs<JsonObject>(decoded, "function.arguments must be a JSON object, not a double-encoded JSON string")
         assertEquals(JsonObject(mapOf("city" to JsonPrimitive("Boston"))), decoded)
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Gemini 3 thought_signature round-trip (Vertex OpenAI-compat). Gemini 3 returns the signature
+    // on each function call in tool_calls[].extra_content.google.thought_signature and rejects the
+    // next tool turn with HTTP 400 if it is not echoed back verbatim.
+    // ---------------------------------------------------------------------------------------------
+
+    private val toolCallWithThoughtSignatureBody = """
+        {
+          "id": "chatcmpl-g3",
+          "object": "chat.completion",
+          "created": 1677652288,
+          "model": "gemini-3.5-flash",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "tool_calls": [
+                  {
+                    "id": "call_g3",
+                    "type": "function",
+                    "extra_content": { "google": { "thought_signature": "SIG_ABC_123" } },
+                    "function": {
+                      "name": "weather",
+                      "arguments": "{\"city\": \"Sofia\"}"
+                    }
+                  }
+                ]
+              },
+              "finish_reason": "tool_calls"
+            }
+          ]
+        }
+    """.trimIndent()
+
+    private val weatherTools = listOf(
+        ToolDescriptor(
+            name = "weather",
+            description = "Get the weather for a city",
+            requiredParameters = listOf(
+                ToolParameterDescriptor(
+                    name = "city",
+                    description = "The city to get weather for",
+                    type = ToolParameterType.String,
+                ),
+            ),
+        ),
+    )
+
+    @Test
+    fun testGemini3ThoughtSignatureParsedIntoReasoningPart() = runTest {
+        // INBOUND: extra_content.google.thought_signature must be lifted into a signature-only
+        // Reasoning part placed immediately before its tool call.
+        val engine = MockEngine {
+            respond(
+                content = toolCallWithThoughtSignatureBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        val client = OpenAILLMClient(
+            apiKey = key,
+            httpClientFactory = KtorKoogHttpClient.Factory(HttpClient(engine)),
+            clock = FixedClock,
+        )
+
+        val response = client.execute(
+            Prompt.build("g3-in") { user("What's the weather in Sofia?") },
+            OpenAIModels.Chat.GPT4o,
+            weatherTools,
+        )
+
+        val reasoningIndex = response.parts.indexOfFirst {
+            it is MessagePart.Reasoning && it.encrypted == "SIG_ABC_123"
+        }
+        val callIndex = response.parts.indexOfFirst { it is MessagePart.Tool.Call }
+        assertNotEquals(-1, reasoningIndex, "thought_signature was not lifted into a Reasoning part")
+        assertEquals(reasoningIndex + 1, callIndex, "Reasoning(signature) must directly precede its tool call")
+    }
+
+    @Test
+    fun testGemini3ThoughtSignatureEchoedBackOnNextTurn() = runTest {
+        // ROUND-TRIP: feed the assistant tool call from turn 1 back on turn 2 and assert the
+        // request carries tool_calls[0].extra_content.google.thought_signature verbatim.
+        var capturedBody: String? = null
+        val engine = MockEngine { request ->
+            capturedBody = (request.body as TextContent).text
+            respond(
+                content = toolCallWithThoughtSignatureBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        val client = OpenAILLMClient(
+            apiKey = key,
+            httpClientFactory = KtorKoogHttpClient.Factory(HttpClient(engine)),
+            clock = FixedClock,
+        )
+
+        // Turn 1 — obtain the assistant message carrying the signature.
+        val assistantTurn = client.execute(
+            Prompt.build("g3-turn1") { user("What's the weather in Sofia?") },
+            OpenAIModels.Chat.GPT4o,
+            weatherTools,
+        )
+
+        // Turn 2 — replay the assistant tool call + a tool result, capture the outbound request.
+        val followUp = Prompt.build("g3-turn2") {
+            user("What's the weather in Sofia?")
+            message(assistantTurn)
+            message(
+                Message.User(
+                    MessagePart.Tool.Result(id = "call_g3", tool = "weather", output = "sunny"),
+                    RequestMetaInfo.create(FixedClock),
+                ),
+            )
+        }
+        client.execute(followUp, OpenAIModels.Chat.GPT4o, weatherTools)
+
+        val body = Json.parseToJsonElement(requireNotNull(capturedBody)).jsonObject
+        val toolCall = body["messages"]!!.jsonArray
+            .first { it.jsonObject["tool_calls"] != null }
+            .jsonObject["tool_calls"]!!.jsonArray[0].jsonObject
+        val signature = toolCall["extra_content"]
+            ?.jsonObject?.get("google")
+            ?.jsonObject?.get("thought_signature")
+            ?.jsonPrimitive?.content
+        assertEquals("SIG_ABC_123", signature, "thought_signature was not echoed back: $toolCall")
+    }
+
+    @Test
+    fun testNonGeminiToolCallHasNoExtraContent() = runTest {
+        // NO-REGRESS: a plain tool call (no extra_content inbound) must NOT add extra_content
+        // outbound, so OpenAI / OpenRouter / Gemini 2.5 requests stay byte-for-byte unchanged.
+        var capturedBody: String? = null
+        val engine = MockEngine { request ->
+            capturedBody = (request.body as TextContent).text
+            respond(
+                content = toolCallWithReasoningBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        val client = OpenAILLMClient(
+            apiKey = key,
+            httpClientFactory = KtorKoogHttpClient.Factory(HttpClient(engine)),
+            clock = FixedClock,
+        )
+
+        val assistantTurn = client.execute(
+            Prompt.build("plain-turn1") { user("What's the weather in Boston?") },
+            OpenAIModels.Chat.GPT4o,
+            weatherTools,
+        )
+
+        val followUp = Prompt.build("plain-turn2") {
+            user("What's the weather in Boston?")
+            message(assistantTurn)
+            message(
+                Message.User(
+                    MessagePart.Tool.Result(id = "call_abc123", tool = "weather", output = "rainy"),
+                    RequestMetaInfo.create(FixedClock),
+                ),
+            )
+        }
+        client.execute(followUp, OpenAIModels.Chat.GPT4o, weatherTools)
+
+        val body = Json.parseToJsonElement(requireNotNull(capturedBody)).jsonObject
+        val toolCall = body["messages"]!!.jsonArray
+            .first { it.jsonObject["tool_calls"] != null }
+            .jsonObject["tool_calls"]!!.jsonArray[0].jsonObject
+        assertNull(toolCall["extra_content"], "non-Gemini tool call must not carry extra_content")
     }
 }

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIChatCompletionLLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAIChatCompletionLLMClientTest.kt
@@ -5,6 +5,7 @@ import ai.koog.agents.core.tools.ToolParameterDescriptor
 import ai.koog.agents.core.tools.ToolParameterType
 import ai.koog.http.client.ktor.KtorKoogHttpClient
 import ai.koog.prompt.Prompt
+import ai.koog.prompt.executor.clients.openai.models.OpenAIChatCompletionStreamResponse
 import ai.koog.prompt.message.Message
 import ai.koog.prompt.message.MessagePart
 import ai.koog.prompt.message.RequestMetaInfo
@@ -19,7 +20,9 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.content.TextContent
 import io.ktor.http.headersOf
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNamingStrategy
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -353,5 +356,58 @@ class OpenAIChatCompletionLLMClientTest {
             .first { it.jsonObject["tool_calls"] != null }
             .jsonObject["tool_calls"]!!.jsonArray[0].jsonObject
         assertNull(toolCall["extra_content"], "non-Gemini tool call must not carry extra_content")
+    }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    @Test
+    fun testGemini3StreamingToolCallChunkParsesExtraContent() {
+        // STREAMING inbound: Gemini 3 sends the thought_signature on the SSE chunk that opens a
+        // tool call (delta.tool_calls[].extra_content.google.thought_signature). The stream DTO
+        // must surface it so processStreamingResponse can attach it to the pending tool call.
+        // The Json configuration mirrors AbstractOpenAILLMClient.defaultJson (SnakeCase mapping
+        // of extraContent <-> extra_content is what this test pins down).
+        val streamJson = Json {
+            ignoreUnknownKeys = true
+            explicitNulls = false
+            namingStrategy = JsonNamingStrategy.SnakeCase
+        }
+        val chunk = """
+            {
+              "id": "chatcmpl-g3",
+              "object": "chat.completion.chunk",
+              "created": 1677652288,
+              "model": "gemini-3.5-flash",
+              "choices": [
+                {
+                  "index": 0,
+                  "delta": {
+                    "role": "assistant",
+                    "tool_calls": [
+                      {
+                        "index": 0,
+                        "id": "call_g3",
+                        "type": "function",
+                        "extra_content": { "google": { "thought_signature": "SIG_ABC_123" } },
+                        "function": { "name": "weather", "arguments": "" }
+                      }
+                    ]
+                  },
+                  "finish_reason": null
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val decoded = streamJson.decodeFromString(
+            OpenAIChatCompletionStreamResponse.serializer(),
+            chunk,
+        )
+
+        val toolCall = decoded.choices.single().delta.toolCalls!!.single()
+        val signature = (toolCall.extraContent?.get("google") as? JsonObject)
+            ?.get("thought_signature")
+            ?.let { it as? JsonPrimitive }
+            ?.contentOrNull
+        assertEquals("SIG_ABC_123", signature, "stream DTO must surface extra_content.google.thought_signature")
     }
 }

--- a/prompt/prompt-model/api/android/prompt-model.api
+++ b/prompt/prompt-model/api/android/prompt-model.api
@@ -1598,6 +1598,7 @@ public final class ai/koog/prompt/streaming/StreamFrameExt {
 
 public final class ai/koog/prompt/streaming/StreamFrameFlowBuilder {
 	public fun <init> (Lkotlinx/coroutines/flow/FlowCollector;)V
+	public final fun attachToolCallSignature (Ljava/lang/String;)V
 	public final fun emitEnd (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun emitEnd$default (Lai/koog/prompt/streaming/StreamFrameFlowBuilder;Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun emitReasoningDelta (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/prompt/prompt-model/api/jvm/prompt-model.api
+++ b/prompt/prompt-model/api/jvm/prompt-model.api
@@ -1705,6 +1705,7 @@ public final class ai/koog/prompt/streaming/StreamFrameExt {
 
 public final class ai/koog/prompt/streaming/StreamFrameFlowBuilder {
 	public fun <init> (Lkotlinx/coroutines/flow/FlowCollector;)V
+	public final fun attachToolCallSignature (Ljava/lang/String;)V
 	public final fun emitEnd (Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun emitEnd$default (Lai/koog/prompt/streaming/StreamFrameFlowBuilder;Ljava/lang/String;Lai/koog/prompt/message/ResponseMetaInfo;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun emitReasoningDelta (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/prompt/prompt-model/api/prompt-model.klib.api
+++ b/prompt/prompt-model/api/prompt-model.klib.api
@@ -1233,6 +1233,7 @@ final class ai.koog.prompt.streaming/IncompleteStreamException : kotlin/Exceptio
 final class ai.koog.prompt.streaming/StreamFrameFlowBuilder { // ai.koog.prompt.streaming/StreamFrameFlowBuilder|null[0]
     constructor <init>(kotlinx.coroutines.flow/FlowCollector<ai.koog.prompt.streaming/StreamFrame>) // ai.koog.prompt.streaming/StreamFrameFlowBuilder.<init>|<init>(kotlinx.coroutines.flow.FlowCollector<ai.koog.prompt.streaming.StreamFrame>){}[0]
 
+    final fun attachToolCallSignature(kotlin/String) // ai.koog.prompt.streaming/StreamFrameFlowBuilder.attachToolCallSignature|attachToolCallSignature(kotlin.String){}[0]
     final suspend fun emitEnd(kotlin/String? = ..., ai.koog.prompt.message/ResponseMetaInfo? = ...) // ai.koog.prompt.streaming/StreamFrameFlowBuilder.emitEnd|emitEnd(kotlin.String?;ai.koog.prompt.message.ResponseMetaInfo?){}[0]
     final suspend fun emitReasoningDelta(kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/Int? = ...) // ai.koog.prompt.streaming/StreamFrameFlowBuilder.emitReasoningDelta|emitReasoningDelta(kotlin.String?;kotlin.String?;kotlin.String?;kotlin.Int?){}[0]
     final suspend fun emitTextDelta(kotlin/String, kotlin/Int? = ...) // ai.koog.prompt.streaming/StreamFrameFlowBuilder.emitTextDelta|emitTextDelta(kotlin.String;kotlin.Int?){}[0]

--- a/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
+++ b/prompt/prompt-model/src/commonMain/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilder.kt
@@ -251,11 +251,37 @@ public class StreamFrameFlowBuilder(
     }
 
     /**
+     * Attaches an opaque provider signature (e.g. Gemini 3 `thought_signature`) to the tool call
+     * currently being combined. When the pending call completes, the signature is emitted as a
+     * signature-only [StreamFrame.ReasoningComplete] (empty content, `encrypted` set) immediately
+     * before its [StreamFrame.ToolCallComplete], so [toMessageResponse] reconstructs the
+     * `Reasoning(encrypted)` -> `Tool.Call` part order that multi-turn function calling requires.
+     *
+     * Calling this without a pending tool call is a no-op: the signature is advisory metadata and
+     * must never fail a live stream.
+     */
+    public fun attachToolCallSignature(signature: String) {
+        val previous: PendingToolCall? = pendingToolCallRef.load()
+        if (previous != null) {
+            pendingToolCallRef.store(previous.copy(signature = signature))
+        }
+    }
+
+    /**
      * Emits a [pendingToolCallRef] if it exists and then clears it.
      */
     public suspend fun tryEmitPendingToolCall() {
         val pendingToolCall = pendingToolCallRef.exchange(null)
         if (pendingToolCall != null) {
+            pendingToolCall.signature?.let { signature ->
+                flowCollector.emitReasoningComplete(
+                    id = null,
+                    text = emptyList(),
+                    summary = null,
+                    encrypted = signature,
+                    index = pendingToolCall.index
+                )
+            }
             flowCollector.emitToolCallComplete(
                 id = pendingToolCall.id,
                 name = pendingToolCall.name ?: "",
@@ -270,6 +296,7 @@ public class StreamFrameFlowBuilder(
         val name: String?,
         val argumentsDelta: String?,
         val index: Int?,
+        val signature: String? = null,
     ) {
         fun appendArgumentsDelta(argumentsDelta: String?): PendingToolCall {
             require(this.index == index)

--- a/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderTest.kt
+++ b/prompt/prompt-model/src/commonTest/kotlin/ai/koog/prompt/streaming/StreamFrameFlowBuilderTest.kt
@@ -1,5 +1,6 @@
 package ai.koog.prompt.streaming
 
+import ai.koog.prompt.message.MessagePart
 import ai.koog.prompt.message.ResponseMetaInfo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collect
@@ -468,6 +469,94 @@ class StreamFrameFlowBuilderTest {
                 StreamFrame.TextDelta(" World", 0),
                 StreamFrame.TextComplete("Hello World", 0),
                 StreamFrame.End("stop", ResponseMetaInfo.Empty)
+            ),
+            frames
+        )
+    }
+
+    /**
+     * Gemini 3 (OpenAI-compat) streams an encrypted `thought_signature` on the chunk that opens a
+     * tool call and requires it to be echoed back on the next turn. A signature attached to the
+     * pending tool call must be emitted as a signature-only ReasoningComplete (empty content,
+     * `encrypted` set) immediately before its ToolCallComplete, so
+     * [toMessageResponse] reconstructs the `Reasoning(encrypted)` -> `Tool.Call` part order.
+     */
+    @Test
+    fun testAttachToolCallSignatureEmitsReasoningCompleteBeforeToolCallComplete() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitToolCallDelta(id = "call_1", name = "weather", args = "{\"city\":", index = 0)
+            attachToolCallSignature("SIG_ABC_123")
+            emitToolCallDelta(id = "call_1", name = null, args = " \"Sofia\"}", index = 0)
+            emitEnd("tool_calls")
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.ToolCallDelta("call_1", "weather", "{\"city\":", 0),
+                StreamFrame.ToolCallDelta("call_1", null, " \"Sofia\"}", 0),
+                StreamFrame.ReasoningComplete(null, emptyList(), null, "SIG_ABC_123", 0),
+                StreamFrame.ToolCallComplete("call_1", "weather", "{\"city\": \"Sofia\"}", 0),
+                StreamFrame.End("tool_calls", ResponseMetaInfo.Empty)
+            ),
+            frames
+        )
+
+        val message = frames.toMessageResponse()
+        assertContentEquals(
+            listOf(
+                MessagePart.Reasoning(content = emptyList(), encrypted = "SIG_ABC_123"),
+                // toMessageResponse re-encodes the parsed arguments, so the JSON is compact here.
+                MessagePart.Tool.Call(id = "call_1", tool = "weather", args = "{\"city\":\"Sofia\"}"),
+            ),
+            message.parts
+        )
+    }
+
+    /**
+     * Companion to [testAttachToolCallSignatureEmitsReasoningCompleteBeforeToolCallComplete]:
+     * each of several tool calls keeps exactly its own signature, in stream order.
+     */
+    @Test
+    fun testAttachToolCallSignaturePairsEachSignatureWithItsOwnToolCall() = runTest {
+        val frames = buildStreamFrameFlow {
+            emitToolCallDelta(id = "call_1", name = "search", args = "{\"q\": 1}", index = 0)
+            attachToolCallSignature("SIG_1")
+            emitToolCallDelta(id = "call_2", name = "calculator", args = "{\"a\": 2}", index = 1)
+            attachToolCallSignature("SIG_2")
+            emitEnd("tool_calls")
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.ToolCallDelta("call_1", "search", "{\"q\": 1}", 0),
+                StreamFrame.ReasoningComplete(null, emptyList(), null, "SIG_1", 0),
+                StreamFrame.ToolCallComplete("call_1", "search", "{\"q\": 1}", 0),
+                StreamFrame.ToolCallDelta("call_2", "calculator", "{\"a\": 2}", 1),
+                StreamFrame.ReasoningComplete(null, emptyList(), null, "SIG_2", 1),
+                StreamFrame.ToolCallComplete("call_2", "calculator", "{\"a\": 2}", 1),
+                StreamFrame.End("tool_calls", ResponseMetaInfo.Empty)
+            ),
+            frames
+        )
+    }
+
+    /**
+     * A signature is advisory metadata: attaching one without a pending tool call must be a no-op
+     * (no frame, no error), and a pending call without a signature stays byte-for-byte unchanged.
+     */
+    @Test
+    fun testAttachToolCallSignatureWithoutPendingToolCallIsNoOp() = runTest {
+        val frames = buildStreamFrameFlow {
+            attachToolCallSignature("SIG_ORPHAN")
+            emitToolCallDelta(id = "call_1", name = "weather", args = "{}", index = 0)
+            emitEnd("tool_calls")
+        }.toList()
+
+        assertContentEquals(
+            listOf(
+                StreamFrame.ToolCallDelta("call_1", "weather", "{}", 0),
+                StreamFrame.ToolCallComplete("call_1", "weather", "{}", 0),
+                StreamFrame.End("tool_calls", ResponseMetaInfo.Empty)
             ),
             frames
         )


### PR DESCRIPTION
**What**
Gemini 3 (Vertex AI, OpenAI-compatible mode) returns a `thought_signature` for every function call in `tool_calls[].extra_content.google.thought_signature` and rejects the next tool turn with HTTP 400 unless that signature is echoed back verbatim on the corresponding tool call — mandatory for the whole Gemini 3 family, even at `thinking_level: minimal` (official thought-signatures + Vertex thinking docs). The OpenAI-compatible client neither parsed it inbound nor echoed it outbound, so every multi-turn tool loop on Gemini 3 broke at the follow-up call.

Verified live against Vertex AI (`google/gemini-3.1-flash-lite`, EU endpoint): tool call → signature returned; history echoed **with** the signature → 200; the same history **without** it → `400 "Function call is missing a thought_signature in functionCall parts"`.

**Fix — non-streaming (`execute`)**
* **Inbound (`AbstractOpenAILLMClient`):** lift `extra_content.google.thought_signature` into a signature-only `Reasoning` part placed immediately before its `Tool.Call` (mirrors `GoogleLLMClient`), so the signature survives in prompt history.
* **Outbound:** an assistant `Tool.Call` preceded by a `Reasoning` part carrying an encrypted signature emits it back as `extra_content.google.thought_signature` on that tool call.
* **Model:** `OpenAIToolCall` gains an optional `extraContent: JsonObject?` — a verbatim provider-extension passthrough. Null for OpenAI / OpenRouter / Gemini 2.5, so their requests stay byte-for-byte unchanged.

**Fix — streaming (`executeStreaming`)**
* `OpenAIStreamToolCall` gains the same optional `extraContent` (Gemini streams the signature on the delta chunk that opens the tool call).
* `processStreamingResponse` attaches it to the pending call via the new `StreamFrameFlowBuilder.attachToolCallSignature`; on completion the builder emits a signature-only `ReasoningComplete` (empty content, `encrypted` set) immediately before the `ToolCallComplete`, so `toMessageResponse()` reconstructs the exact same `Reasoning(encrypted)` → `Tool.Call` part order as the non-streaming path — one message shape, both paths.
* An orphan signature (no pending tool call) is a deliberate no-op; providers that send no `extra_content` are unaffected.

**API compatibility**
`@JvmOverloads` keeps the pre-existing `OpenAIToolCall` / `OpenAIStreamToolCall` constructors, so the API change is purely additive at the binary level; the `api/` ABI dumps (jvm/android/klib) for `prompt-executor-openai-client-base` and `prompt-model` are regenerated via `updateLegacyAbi`. ktlint applied to the touched files.

**Tests**
* Non-streaming: `testGemini3ThoughtSignatureParsedIntoReasoningPart` (inbound lift + ordering) · `testGemini3ThoughtSignatureEchoedBackOnNextTurn` (verbatim round-trip echo) · `testNonGeminiToolCallHasNoExtraContent` (no-regression).
* Streaming: `testGemini3StreamingToolCallChunkParsesExtraContent` (stream DTO decode, snake_case wire mapping) · `testAttachToolCallSignatureEmitsReasoningCompleteBeforeToolCallComplete` (frame order + `toMessageResponse` part order) · `testAttachToolCallSignaturePairsEachSignatureWithItsOwnToolCall` · `testAttachToolCallSignatureWithoutPendingToolCallIsNoOp`.

closes #2113, closes KG-848

cc @tiginamaria @devcrocod