### PR TITLE
build(deps): bump com.agentclientprotocol:acp to 0.26.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-acp = "0.13.1"
+acp = "0.26.0"
 agp = "8.12.3"
 annotations = "26.0.2-1"
 assertj = "3.27.7"

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/acp/AcpProtocolTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/acp/AcpProtocolTest.kt
@@ -35,7 +35,7 @@ import kotlin.time.Duration.Companion.seconds
 class AcpProtocolTest {
     companion object {
         val DEFAULT_MODEL = OpenAIModels.Chat.GPT5_2
-        val AUTH_METHOD = AuthMethod(AuthMethodId("test-auth"), "Test Auth", "Auth for testing")
+        val AUTH_METHOD = AuthMethod.AgentAuth(AuthMethodId("test-auth"), "Test Auth", "Auth for testing")
         const val NOTIFICATION = "Hello world!"
         const val AUTH_ERROR = "Authentication required"
 


### PR DESCRIPTION
The pinned `0.13.1` predates the ACP Kotlin SDK's Ktor transports (`acp-ktor-server` / `acp-ktor-client`, added in `0.20.0`), so `agents-features-acp` can currently only be used over stdio.

The incompatibility is binary-only — the feature calls `PromptResponse(StopReason, JsonElement)` and `SessionUpdate.AgentMessageChunk`/`AgentThoughtChunk(ContentBlock)`, whose descriptors no longer exist in `0.20.0+`, so it fails at runtime on prompt completion and on every assistant message. Recompiling against `0.26.0` resolves all three.

One source change was needed: `AuthMethod` became a sealed class, so `AcpProtocolTest` now constructs the `AgentAuth` variant, which carries the same `id`/`name`/`description`.

Note: `agents-features-acp/build.gradle.kts` carries a `// TODO wait until ACP SDK supports KMP`. The SDK now publishes iOS/JS/Wasm artifacts, so that restriction could be lifted — left out of this PR as a separate concern. I can add that as well as followup.