### PR TITLE
feat(agents): finish single run when a terminal tool succeeds

### DIFF
--- a/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/SingleRunStrategyWithTerminalTools.kt
+++ b/agents/agents-core/src/commonMain/kotlin/ai/koog/agents/ext/agent/SingleRunStrategyWithTerminalTools.kt
@@ -1,0 +1,74 @@
+package ai.koog.agents.ext.agent
+
+import ai.koog.agents.core.agent.entity.AIAgentGraphStrategy
+import ai.koog.agents.core.dsl.builder.strategy
+import ai.koog.agents.core.dsl.extension.ReceivedToolResults
+import ai.koog.agents.core.dsl.extension.nodeExecuteTools
+import ai.koog.agents.core.dsl.extension.nodeLLMRequest
+import ai.koog.agents.core.dsl.extension.nodeLLMSendToolResults
+import ai.koog.agents.core.dsl.extension.onTextMessage
+import ai.koog.agents.core.dsl.extension.onToolCalls
+import ai.koog.agents.core.environment.ReceivedToolResult
+import ai.koog.agents.core.environment.ToolResultKind
+
+/**
+ * Configuration for terminal tools in a single-run strategy.
+ *
+ * @property toolNames names of the tools that end the agent run as soon as one of them succeeds
+ * @property agentResult maps the terminal [ReceivedToolResult] to the agent's output,
+ *   defaults to the output of the tool itself
+ */
+public data class TerminalToolsConfig(
+    val toolNames: Set<String>,
+    val agentResult: (ReceivedToolResult) -> String = ReceivedToolResult::output
+)
+
+/**
+ * Creates a single-run agent strategy in which selected tools end the run.
+ *
+ * Works like [ai.koog.agents.core.agent.singleRunStrategy], except that when the LLM calls one of
+ * [TerminalToolsConfig.toolNames] and that call succeeds, the agent finishes with the tool result
+ * instead of sending the result back to the LLM for another round trip. This suits tools that already
+ * produce the final answer, such as a submit or report tool, where the closing LLM call would only
+ * restate what the tool returned.
+ *
+ * Only successful results terminate the run. A terminal tool that fails or fails validation is sent
+ * back to the LLM like any other tool result, so the model can recover and retry.
+ *
+ * When several tools are called in one batch, the first successful terminal result wins and the
+ * remaining results of that batch are not sent to the LLM.
+ *
+ * @param config the terminal tool names and how their result becomes the agent output
+ * @param parallelTools if true, tools will be executed in parallel, otherwise sequentially
+ * @return [AIAgentGraphStrategy] that finishes as soon as a terminal tool succeeds
+ */
+public fun singleRunStrategyWithTerminalTools(
+    config: TerminalToolsConfig,
+    parallelTools: Boolean = false,
+): AIAgentGraphStrategy<String, String> = strategy<String, String>("single_run_with_terminal_tools") {
+    val nodeCallLLM by nodeLLMRequest()
+    val nodeExecuteTool by nodeExecuteTools(parallel = parallelTools)
+    val nodeSendToolResult by nodeLLMSendToolResults()
+
+    edge(nodeStart forwardTo nodeCallLLM)
+    edge(nodeCallLLM forwardTo nodeExecuteTool onToolCalls { true })
+    edge(nodeCallLLM forwardTo nodeFinish onTextMessage { true })
+
+    edge(
+        nodeExecuteTool forwardTo nodeFinish
+            onCondition { it.terminalOutput(config) != null }
+            transformed { checkNotNull(it.terminalOutput(config)) }
+    )
+    edge(nodeExecuteTool forwardTo nodeSendToolResult onCondition { it.terminalOutput(config) == null })
+
+    edge(nodeSendToolResult forwardTo nodeFinish onTextMessage { true })
+    edge(nodeSendToolResult forwardTo nodeExecuteTool onToolCalls { true })
+}
+
+/**
+ * Returns the agent output produced by the first successfully executed terminal tool in this batch,
+ * or `null` when the batch holds no successful terminal result.
+ */
+private fun ReceivedToolResults.terminalOutput(config: TerminalToolsConfig): String? = toolResults
+    .firstOrNull { it.tool in config.toolNames && it.resultKind is ToolResultKind.Success }
+    ?.let(config.agentResult)

--- a/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/SingleRunStrategyWithTerminalToolsTests.kt
+++ b/agents/agents-ext/src/commonTest/kotlin/ai/koog/agents/ext/agent/SingleRunStrategyWithTerminalToolsTests.kt
@@ -1,0 +1,136 @@
+package ai.koog.agents.ext.agent
+
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.tools.SimpleTool
+import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.agents.testing.tools.getMockExecutor
+import ai.koog.prompt.executor.ollama.client.OllamaModels
+import ai.koog.serialization.kotlinx.KotlinxSerializer
+import ai.koog.serialization.typeToken
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+object SubmitTool : SimpleTool<SubmitTool.Args>(
+    argsType = typeToken<Args>(),
+    name = "submit",
+    description = "Submit the final answer"
+) {
+    @Serializable
+    data class Args(
+        @property:LLMDescription("Answer to submit") val answer: String
+    )
+
+    override suspend fun execute(args: Args): String = "submitted: ${args.answer}"
+}
+
+object FailingSubmitTool : SimpleTool<FailingSubmitTool.Args>(
+    argsType = typeToken<Args>(),
+    name = "submit_failing",
+    description = "Submit the final answer"
+) {
+    @Serializable
+    data class Args(
+        @property:LLMDescription("Answer to submit") val answer: String
+    )
+
+    override suspend fun execute(args: Args): String = error("submission rejected")
+}
+
+class SingleRunStrategyWithTerminalToolsTests {
+    private val serializer = KotlinxSerializer()
+
+    @Test
+    fun test_terminal_tool_finishes_run_without_further_llm_call() = runTest {
+        // "Restating the answer." is only reachable if the tool result is sent back to the LLM
+        val mockLLMApi = getMockExecutor(serializer) {
+            mockLLMToolCall(SubmitTool, SubmitTool.Args("42")) onRequestEquals "Solve task"
+            mockLLMAnswer("Restating the answer.") onRequestContains "submitted"
+            mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            mockLLMApi,
+            OllamaModels.Meta.LLAMA_3_2,
+            strategy = singleRunStrategyWithTerminalTools(
+                TerminalToolsConfig(toolNames = setOf(SubmitTool.name))
+            ),
+            toolRegistry = ToolRegistry { tool(SubmitTool) }
+        )
+
+        val result = agent.run("Solve task", null)
+
+        assertEquals("submitted: 42", result)
+    }
+
+    @Test
+    fun test_agent_result_maps_terminal_tool_output() = runTest {
+        val mockLLMApi = getMockExecutor(serializer) {
+            mockLLMToolCall(SubmitTool, SubmitTool.Args("42")) onRequestEquals "Solve task"
+            mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            mockLLMApi,
+            OllamaModels.Meta.LLAMA_3_2,
+            strategy = singleRunStrategyWithTerminalTools(
+                TerminalToolsConfig(
+                    toolNames = setOf(SubmitTool.name),
+                    agentResult = { "done (${it.tool})" }
+                )
+            ),
+            toolRegistry = ToolRegistry { tool(SubmitTool) }
+        )
+
+        val result = agent.run("Solve task", null)
+
+        assertEquals("done (submit)", result)
+    }
+
+    @Test
+    fun test_non_terminal_tool_result_goes_back_to_llm() = runTest {
+        val mockLLMApi = getMockExecutor(serializer) {
+            mockLLMToolCall(CreateTool, CreateTool.Args("solve")) onRequestEquals "Solve task"
+            mockLLMAnswer("Tools called!") onRequestContains "created"
+            mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            mockLLMApi,
+            OllamaModels.Meta.LLAMA_3_2,
+            strategy = singleRunStrategyWithTerminalTools(
+                TerminalToolsConfig(toolNames = setOf(SubmitTool.name))
+            ),
+            toolRegistry = ToolRegistry { tool(CreateTool) }
+        )
+
+        val result = agent.run("Solve task", null)
+
+        assertEquals("Tools called!", result)
+    }
+
+    @Test
+    fun test_failed_terminal_tool_does_not_finish_run() = runTest {
+        // reaching "Recovered after failure." proves the failure was forwarded to the LLM
+        val mockLLMApi = getMockExecutor(serializer) {
+            mockLLMToolCall(FailingSubmitTool, FailingSubmitTool.Args("42")) onRequestEquals "Solve task"
+            mockLLMAnswer("Recovered after failure.") onRequestContains "submission rejected"
+            mockLLMAnswer("I don't know how to answer that.").asDefaultResponse
+        }
+
+        val agent = AIAgent(
+            mockLLMApi,
+            OllamaModels.Meta.LLAMA_3_2,
+            strategy = singleRunStrategyWithTerminalTools(
+                TerminalToolsConfig(toolNames = setOf(FailingSubmitTool.name))
+            ),
+            toolRegistry = ToolRegistry { tool(FailingSubmitTool) }
+        )
+
+        val result = agent.run("Solve task", null)
+
+        assertEquals("Recovered after failure.", result)
+    }
+}


### PR DESCRIPTION
**What**

`singleRunStrategy` always sends tool results back to the LLM, so an agent whose work ends
in a tool call — submit, report, hand-off — pays for one more LLM round trip that only restates
what the tool already returned. The alternatives today are to write a custom graph strategy, or
to throw from an event handler to break out of the loop.

`subgraphWithTask` already has the notion of a finish tool, but it is only reachable through the
subgraph API. This adds the same idea to the simple single-run path.

**Changes**

* `TerminalToolsConfig` — names the tools that end the run (`toolNames`) and maps the terminal
  result to the agent output (`agentResult`, defaults to the tool's own output).
* `singleRunStrategyWithTerminalTools` — same graph as `singleRunStrategy`, plus an edge from
  the tool-execution node straight to finish when the batch contains a successful terminal result.
  Failed and validation-failed results fall through to the LLM unchanged, so the model can still
  recover and retry. When a batch holds several tool calls, the first successful terminal result wins.

New API only; `singleRunStrategy` and every existing strategy are untouched.

**Tests**

`SingleRunStrategyWithTerminalToolsTests` covers the four behaviours: a terminal tool finishes the
run without a further LLM call, `agentResult` maps the output, a non-terminal tool still round-trips
to the LLM, and a failing terminal tool does not finish the run.
