### PR TITLE
fix(prompt): prevent crash on model card loading for audio-capable models

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaManagementConverters.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaManagementConverters.kt
@@ -36,6 +36,7 @@ private fun List<OllamaShowModelResponseDTO.Capability>.toLLMCapabilities(): Lis
             OllamaShowModelResponseDTO.Capability.VISION -> listOf(LLMCapability.Vision.Image)
             OllamaShowModelResponseDTO.Capability.THINKING -> listOf()
             OllamaShowModelResponseDTO.Capability.TOOLS -> listOf(LLMCapability.Tools)
+            OllamaShowModelResponseDTO.Capability.AUDIO -> listOf(LLMCapability.Audio)
         }
     } + listOf(
         LLMCapability.Temperature,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaManagementModels.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonMain/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaManagementModels.kt
@@ -67,6 +67,8 @@ internal data class OllamaShowModelResponseDTO(
 
         @SerialName("vision") VISION,
 
+        @SerialName("audio") AUDIO,
+
         @SerialName("thinking") THINKING,
 
         @SerialName("tools") TOOLS,

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaSerializationTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-ollama-client/src/commonTest/kotlin/ai/koog/prompt/executor/ollama/client/dto/OllamaSerializationTest.kt
@@ -82,6 +82,33 @@ class OllamaSerializationTest {
     }
 
     @Test
+    fun testOllamaAudioCapabilityDeserialization() {
+        val jsonInput = buildJsonObject {
+            put(
+                "details",
+                json.encodeToJsonElement(
+                    OllamaModelDetailsDTO(
+                        format = "gguf",
+                        family = "gemma",
+                        families = listOf("gemma"),
+                        parameterSize = "4B",
+                        quantizationLevel = "Q4_K_M"
+                    )
+                )
+            )
+            put(
+                "capabilities",
+                json.encodeToJsonElement(listOf("completion", "audio", "tools"))
+            )
+        }
+
+        val response = json.decodeFromJsonElement(OllamaShowModelResponseDTO.serializer(), jsonInput)
+
+        assertNotNull(response.details)
+        assertEquals("gemma", response.details.family)
+    }
+
+    @Test
     fun `test deserialization without additional properties`() {
         val jsonInput = buildJsonObject {
             put("model", JsonPrimitive("llama2"))


### PR DESCRIPTION

Prevents serialization crashes in the Ollama client when scanning local models that contain audio capabilities (e.g. Gemma4).
This PR adds the missing audio capability mapping to the DTO and includes a reproducing test case.