### PR TITLE
fix(prompt): call chat completions for an OpenAI model that declares no endpoint capability

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClient.kt
@@ -315,19 +315,20 @@ public open class OpenAILLMClient @JvmOverloads constructor(
         emitEnd(finishReason, metaInfo)
     }
 
+    // The endpoint is decided once, by determineParams, which is also where an endpoint capability
+    // is required when one is needed. Re-checking it here contradicted that decision: an Azure
+    // deployment takes the chat-completions branch without declaring the capability, so this method
+    // refused models that determineParams had already accepted and that executeStreaming — which
+    // never had the second check — was happy to run.
     override suspend fun execute(prompt: Prompt, model: LLModel, tools: List<ToolDescriptor>): Message.Assistant {
         return selectExecutionStrategy(prompt, model) { params ->
             when (params) {
                 is OpenAIResponsesParams -> {
-                    model.requireCapability(LLMCapability.OpenAIEndpoint.Responses)
                     val response = getResponseWithResponsesAPI(prompt, params, model, tools)
                     processResponsesAPIResponse(response)
                 }
 
-                is OpenAIChatParams -> {
-                    model.requireCapability(LLMCapability.OpenAIEndpoint.Completions)
-                    super.execute(prompt, model, tools)
-                }
+                is OpenAIChatParams -> super.execute(prompt, model, tools)
             }
         }
     }
@@ -1057,6 +1058,16 @@ public open class OpenAILLMClient @JvmOverloads constructor(
         is LLMParams.ToolChoice.Named -> OpenAIResponsesToolChoice.FunctionTool(name = name)
     }
 
+    /**
+     * Chooses the API to call for [model], and the parameter shape that goes with it.
+     *
+     * This is the single place where the endpoint is decided. A model that declares an endpoint
+     * capability gets that endpoint; params of an explicit type require the matching capability,
+     * because asking for responses params on a chat-completions model is a request that cannot be
+     * honoured. A model that declares neither capability falls back to chat completions: it is the
+     * API every OpenAI-compatible server implements, and it is what such a model — almost always a
+     * hand-written [LLModel] for a self-hosted server — is served by.
+     */
     internal fun determineParams(params: LLMParams, model: LLModel): OpenAIParams = when {
         "openai.azure.com" in settings.baseUrl -> params.toOpenAIChatParams() // TODO: create a separate Azure Client
         params is OpenAIResponsesParams -> {
@@ -1077,7 +1088,15 @@ public open class OpenAILLMClient @JvmOverloads constructor(
 
         model.supports(LLMCapability.OpenAIEndpoint.Completions) -> params.toOpenAIChatParams()
         model.supports(LLMCapability.OpenAIEndpoint.Responses) -> params.toOpenAIResponsesParams()
-        else -> throw LLMClientException(clientName, "Cannot determine proper LLM params for OpenAI model: ${model.id}")
+        else -> {
+            logger.debug {
+                "Model ${model.id} declares neither ${LLMCapability.OpenAIEndpoint.Completions.id} nor " +
+                    "${LLMCapability.OpenAIEndpoint.Responses.id}; calling the chat completions API. " +
+                    "Declare LLMCapability.OpenAIEndpoint.Responses on the model to use the responses API " +
+                    "instead."
+            }
+            params.toOpenAIChatParams()
+        }
     }
 
     private inline fun <T> selectExecutionStrategy(

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClientTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/OpenAILLMClientTest.kt
@@ -1,9 +1,23 @@
 package ai.koog.prompt.executor.clients.openai
 
 import ai.koog.http.client.ktor.KtorKoogHttpClient
+import ai.koog.prompt.Prompt
+import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLMProvider
 import ai.koog.prompt.llm.LLModel
 import ai.koog.prompt.params.LLMParams
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -13,6 +27,50 @@ import kotlin.reflect.KClass
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OpenAILLMClientTest {
+
+    /** What a user writes for a model Koog has no predefined configuration for: a self-hosted server. */
+    private val selfHostedModel = LLModel(
+        provider = LLMProvider.OpenAI,
+        id = "qwen3-27b",
+        capabilities = listOf(LLMCapability.Completion, LLMCapability.Temperature, LLMCapability.Tools),
+        contextLength = 262_144,
+    )
+
+    //language=json
+    private val chatCompletionBody = """
+        {
+          "id": "chatcmpl-1",
+          "object": "chat.completion",
+          "created": 1716920005,
+          "model": "qwen3-27b",
+          "choices": [
+            {
+              "index": 0,
+              "message": { "role": "assistant", "content": "hello from the server" },
+              "finish_reason": "stop"
+            }
+          ]
+        }
+    """.trimIndent()
+
+    private fun clientRecording(
+        requests: MutableList<String>,
+        baseUrl: String = "https://api.openai.com",
+    ): OpenAILLMClient {
+        val engine = MockEngine { request ->
+            requests += request.url.encodedPath
+            respond(
+                content = chatCompletionBody,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        return OpenAILLMClient(
+            apiKey = "dummy-key",
+            settings = OpenAIClientSettings(baseUrl = baseUrl),
+            httpClientFactory = KtorKoogHttpClient.Factory(HttpClient(engine)),
+        )
+    }
 
     fun openAiClientTestCases(): Stream<Arguments> =
         Stream.of(
@@ -45,6 +103,13 @@ class OpenAILLMClientTest {
                 OpenAIChatParams(),
                 OpenAIModels.Audio.GPT4oMiniAudio,
                 OpenAIChatParams::class,
+            ),
+            // A model that declares no endpoint capability at all: chat completions, the API every
+            // OpenAI-compatible server implements.
+            Arguments.of(
+                LLMParams(),
+                selfHostedModel,
+                OpenAIChatParams::class,
             )
         )
 
@@ -62,5 +127,62 @@ class OpenAILLMClientTest {
         )
 
         result::class shouldBe expectedClass
+    }
+
+    /**
+     * A model without an endpoint capability is what a user writes for a self-hosted server, and it
+     * has to work rather than be rejected: Koog ships no predefined models for vLLM, SGLang or LM
+     * Studio, and the capability naming an OpenAI API is not something such a model can be expected
+     * to know about.
+     */
+    @Test
+    fun testExecuteCallsChatCompletionsForAModelWithoutEndpointCapability() = runTest {
+        val requests = mutableListOf<String>()
+        val client = clientRecording(requests)
+
+        val response = client.execute(Prompt.build("p") { user("hi") }, selfHostedModel)
+
+        requests.single() shouldBe "/v1/chat/completions"
+        response.textContent() shouldBe "hello from the server"
+    }
+
+    /**
+     * An Azure deployment takes the chat-completions branch of [OpenAILLMClient.determineParams]
+     * without declaring the capability. `execute` used to check the capability again afterwards and
+     * refuse the model that the same client had just accepted — while `executeStreaming`, which has
+     * no second check, ran it happily.
+     */
+    @Test
+    fun testExecuteAcceptsAnAzureDeploymentThatDeclaresNoEndpointCapability() = runTest {
+        val requests = mutableListOf<String>()
+        val client = clientRecording(requests, baseUrl = "https://my-resource.openai.azure.com")
+
+        val response = client.execute(
+            Prompt.build("p") { user("hi") },
+            LLModel(
+                provider = LLMProvider.OpenAI,
+                id = "azure-deployment",
+                capabilities = listOf(LLMCapability.Completion, LLMCapability.Temperature),
+                contextLength = 128_000,
+            ),
+        )
+
+        requests.single() shouldBe "/v1/chat/completions"
+        response.textContent() shouldBe "hello from the server"
+    }
+
+    /**
+     * The capability is still required where the request cannot be honoured without it: params of
+     * an explicit type name an API, and a model that does not speak it cannot serve them.
+     */
+    @Test
+    fun testExplicitResponsesParamsStillRequireTheResponsesCapability() {
+        val client = OpenAILLMClient(apiKey = "dummy-key", httpClientFactory = KtorKoogHttpClient.Factory())
+
+        val failure = shouldThrow<IllegalArgumentException> {
+            client.determineParams(params = OpenAIResponsesParams(), model = selfHostedModel)
+        }
+
+        failure.message.orEmpty() shouldContain "openai-endpoint-responses"
     }
 }


### PR DESCRIPTION
An `LLModel` with `LLMProvider.OpenAI` that declares neither `LLMCapability.OpenAIEndpoint.Completions` nor `.Responses` cannot be executed at all:

```
Cannot determine proper LLM params for OpenAI model: qwen3-27b
```

Every model in `OpenAIModels` declares an endpoint capability, so the only models that hit this are hand-written ones — and those are written precisely where Koog ships no predefined configuration: a self-hosted OpenAI-compatible server (vLLM, SGLang, LM Studio). The capability that has to be added names an OpenAI API, which is not something the author of such a model has any reason to think about, and it is documented nowhere (see JetBrains/koog#2213).

`determineParams` now falls back to chat completions instead of throwing. That is not a guess: it is the API every OpenAI-compatible server implements, and the client already reaches for it in the other case where the capability is absent — the Azure branch immediately above. The fallback is logged at debug level, naming the capability to declare for the responses API.

**A second check contradicted the first.** `execute` re-checked the endpoint capability *after* `determineParams` had already decided the endpoint, which made an Azure deployment fail on a decision the same client had just made in its favour. Verified against `develop` with a `MockEngine`, one model, one client:

```
determineParams -> Success(OpenAIChatParams)
execute         -> Model azure-deployment does not support openai-endpoint-chat-completions
executeStreaming-> (no exception)
```

So the same model streams fine and fails on `execute`. Those two `requireCapability` calls are redundant on every path that reaches them — `determineParams` already requires the capability when params of an explicit type ask for an API — so they are removed, and `determineParams` is left as the single place where the endpoint is decided.

What is unchanged: a model declaring an endpoint capability still gets that endpoint, and `OpenAIResponsesParams` on a model that does not declare `Responses` is still refused — there the request genuinely cannot be honoured.

Three tests, each failing against `develop`: `execute` on a model with no endpoint capability reaches `/v1/chat/completions` and returns the message; the same for an Azure deployment; and explicit responses params still require the capability. `./gradlew :prompt:prompt-executor:prompt-executor-clients:prompt-executor-openai-client:jvmTest` passes (10 tests), along with the openai-base, openrouter and deepseek client suites.