### PR TITLE
fix(agents): title an ACP tool call with the tool name instead of "unknown"

### DIFF
--- a/agents/agents-features/agents-features-acp/src/jvmMain/kotlin/ai/koog/agents/features/acp/AcpAgent.kt
+++ b/agents/agents-features/agents-features-acp/src/jvmMain/kotlin/ai/koog/agents/features/acp/AcpAgent.kt
@@ -236,7 +236,7 @@ public class AcpAgent(
                     Event.SessionUpdateEvent(
                         update = SessionUpdate.ToolCall(
                             toolCallId = ToolCallId(ctx.toolCallId ?: UNKNOWN_TOOL_CALL_ID),
-                            title = ctx.toolDescription ?: UNKNOWN_TOOL_DESCRIPTION,
+                            title = ctx.toolDescription ?: ctx.toolName,
                             // TODO: Support kind for tools
                             status = ToolCallStatus.IN_PROGRESS,
                             rawInput = ctx.toolArgs.toKotlinxJsonObject(),
@@ -251,7 +251,7 @@ public class AcpAgent(
                     Event.SessionUpdateEvent(
                         update = SessionUpdate.ToolCallUpdate(
                             toolCallId = ToolCallId(ctx.toolCallId ?: UNKNOWN_TOOL_CALL_ID),
-                            title = ctx.toolDescription ?: UNKNOWN_TOOL_DESCRIPTION,
+                            title = ctx.toolDescription ?: ctx.toolName,
                             // TODO: Support kind for tools
                             status = ToolCallStatus.FAILED,
                             rawInput = ctx.toolArgs.toKotlinxJsonObject(),
@@ -266,7 +266,7 @@ public class AcpAgent(
                     Event.SessionUpdateEvent(
                         update = SessionUpdate.ToolCallUpdate(
                             toolCallId = ToolCallId(ctx.toolCallId ?: UNKNOWN_TOOL_CALL_ID),
-                            title = ctx.toolDescription ?: UNKNOWN_TOOL_DESCRIPTION,
+                            title = ctx.toolDescription ?: ctx.toolName,
                             // TODO: Support kind for tools
                             status = ToolCallStatus.COMPLETED,
                             rawInput = ctx.toolArgs.toKotlinxJsonObject(),

--- a/agents/agents-features/agents-features-acp/src/jvmMain/kotlin/ai/koog/agents/features/acp/MessageConverters.kt
+++ b/agents/agents-features/agents-features-acp/src/jvmMain/kotlin/ai/koog/agents/features/acp/MessageConverters.kt
@@ -251,8 +251,10 @@ public fun Message.Assistant.toAcpEvents(tools: List<ToolDescriptor> = emptyList
                         SessionUpdateEvent(
                             update = SessionUpdate.ToolCall(
                                 toolCallId = ToolCallId(part.id ?: UNKNOWN_TOOL_CALL_ID),
+                                // The title is what an ACP client shows for the call. When the tool
+                                // is not among the descriptors, its name still says what is running.
                                 title = tools.firstOrNull { it.name == part.tool }?.description
-                                    ?: UNKNOWN_TOOL_DESCRIPTION,
+                                    ?: part.tool,
                                 // TODO: Support kind for tools
                                 status = ToolCallStatus.PENDING,
                                 rawInput = part.argsJson,

--- a/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/acp/AcpMessageConversionIntegrationTest.kt
+++ b/integration-tests/src/jvmTest/kotlin/ai/koog/integration/tests/acp/AcpMessageConversionIntegrationTest.kt
@@ -102,4 +102,28 @@ class AcpMessageConversionIntegrationTest {
 
         updates.size shouldBe 4
     }
+
+    /**
+     * The title is what an ACP client displays for a tool call. When the called tool is not among
+     * the descriptors — a tool registered elsewhere, or a call the model invented — the tool name
+     * is still known, and showing it beats showing a placeholder.
+     */
+    @Test
+    fun integration_testToolCallOfAnUnknownToolIsTitledWithTheToolName() {
+        val assistant = Message.Assistant(
+            parts = listOf(
+                MessagePart.Tool.Call(
+                    id = "tool-call-1",
+                    tool = "lookup_order",
+                    args = buildJsonObject { put("orderId", "A-42") },
+                ),
+            ),
+            metaInfo = ResponseMetaInfo.create(KoogClock.System),
+            id = "assistant-message-1",
+        )
+
+        val update = assistant.toAcpEvents(tools = emptyList()).single().update
+
+        (update as SessionUpdate.ToolCall).title shouldBe "lookup_order"
+    }
 }


### PR DESCRIPTION
In ACP, `title` is the human-readable line a client displays for a tool call ("Reading configuration file", "Running tests"). The Koog ACP feature falls back to the literal string `"unknown"` whenever it has no description for the tool:

* `MessageConverters.toAcpEvents` — when the called tool is not among the descriptors passed in;
* `AcpAgent`, in the three `interceptToolCall*` handlers — when `ctx.toolDescription` is null, which is what `ContextualAgentEnvironment` produces for a tool that is not in the registry.

The tool name is available at every one of those points and is never null (`MessagePart.Tool.Call.tool` and `ToolCallEventContext.toolName` are both non-null `String`), so the client can be told what is running rather than shown a placeholder.

The preferred value is unchanged — the tool description is still used when it is known — only the fallback changes. `UNKNOWN_TOOL_DESCRIPTION` stays public and is left in place; removing it would be a breaking change.

One test covers the fallback: an assistant tool call for a tool absent from the descriptors is now titled with its name. It fails against the previous behaviour.

`./gradlew :integration-tests:jvmIntegrationTest --tests "*AcpMessageConversionIntegrationTest*"` passes (3/3). The other ACP integration tests fail identically before and after this change — they require `OPEN_AI_API_TEST_KEY` and friends, which I do not have.