### PR TITLE
fix(agents): keep Langfuse completion content as assistant text

### DIFF
--- a/agents/agents-features/agents-features-opentelemetry/src/commonMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapter.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/commonMain/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapter.kt
@@ -132,16 +132,26 @@ internal class LangfuseSpanAdapter(
                 val textParts = message.parts.filterIsInstance<MessagePart.Text>()
 
                 span.addAttribute(CustomAttribute("gen_ai.prompt.$index.role", message.role.name.lowercase()))
+                // Langfuse Preview renders `*.content`. Keep that the visible assistant
+                // text (or tool calls). Reasoning is a sibling attribute so thinking
+                // does not replace the actual reply.
                 span.addAttribute(
                     CustomAttribute(
                         "gen_ai.prompt.$index.content",
                         when {
                             toolCalls.isNotEmpty() -> HiddenString(encodeToolCallsContent(toolCalls))
-                            reasoningParts.isNotEmpty() -> HiddenString(reasoningParts.joinToString("\n") { it.content.joinToString("\n") })
                             else -> HiddenString(textParts.joinToString("\n") { it.text })
                         }
                     )
                 )
+                if (reasoningParts.isNotEmpty()) {
+                    span.addAttribute(
+                        CustomAttribute(
+                            "gen_ai.prompt.$index.reasoning",
+                            HiddenString(encodeReasoningContent(reasoningParts)),
+                        )
+                    )
+                }
             }
         }
     }
@@ -163,15 +173,20 @@ internal class LangfuseSpanAdapter(
                         span.addAttribute(CustomAttribute("gen_ai.completion.$index.content", HiddenString(encodeToolCallsContent(toolCalls))))
                         span.addAttribute(CustomAttribute("gen_ai.completion.$index.finish_reason", GenAIAttributes.Response.FinishReasonType.ToolCalls.id))
                     }
-                    reasoningParts.isNotEmpty() -> {
-                        span.addAttribute(CustomAttribute("gen_ai.completion.$index.content", HiddenString(reasoningParts.joinToString("\n") { it.content.joinToString("\n") })))
-                    }
                     else -> {
                         span.addAttribute(CustomAttribute("gen_ai.completion.$index.content", HiddenString(textParts.joinToString("\n") { it.text })))
                         message.finishReason?.let { reason ->
                             span.addAttribute(CustomAttribute("gen_ai.completion.$index.finish_reason", reason))
                         }
                     }
+                }
+                if (reasoningParts.isNotEmpty()) {
+                    span.addAttribute(
+                        CustomAttribute(
+                            "gen_ai.completion.$index.reasoning",
+                            HiddenString(encodeReasoningContent(reasoningParts)),
+                        )
+                    )
                 }
             }
 
@@ -214,3 +229,12 @@ internal fun encodeToolCallsContent(toolCalls: List<MessagePart.Tool.Call>): Str
     )
     return array.toString()
 }
+
+/**
+ * Joins [MessagePart.Reasoning] payloads the same way [LangfuseSpanAdapter] writes
+ * `gen_ai.prompt.{i}.reasoning` / `gen_ai.completion.{i}.reasoning`.
+ *
+ * Marked `internal` so the [LangfuseSpanAdapter] tests can compute the identical expected value.
+ */
+internal fun encodeReasoningContent(reasoningParts: List<MessagePart.Reasoning>): String =
+    reasoningParts.joinToString("\n") { it.content.joinToString("\n") }

--- a/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapterTest.kt
+++ b/agents/agents-features/agents-features-opentelemetry/src/jvmTest/kotlin/ai/koog/agents/features/opentelemetry/integration/langfuse/LangfuseSpanAdapterTest.kt
@@ -191,6 +191,93 @@ class LangfuseSpanAdapterTest {
     }
 
     @Test
+    fun testCompletionAttributesPreferTextOverReasoning() {
+        val adapter = LangfuseSpanAdapter(emptyList(), OpenTelemetryConfig())
+        val inferenceSpan = createInferenceSpan(MockLLMProvider())
+
+        val assistantText = "RELEVANT"
+        val reasoningText = "The user's latest message translates to a coupon question."
+        val assistantMessage = Message.Assistant(
+            parts = listOf(
+                MessagePart.Text(assistantText),
+                MessagePart.Reasoning(reasoningText),
+            ),
+            metaInfo = ResponseMetaInfo.Empty,
+            finishReason = "stop",
+        )
+        inferenceSpan.addAttribute(GenAIAttributes.Output.Messages(listOf(assistantMessage)))
+
+        adapter.onBeforeSpanFinished(inferenceSpan)
+
+        val attributes = inferenceSpan.attributes
+        val actualContent = attributes.requireValue("gen_ai.completion.0.content")
+        assertIs<HiddenString>(actualContent)
+        assertEquals(assistantText, actualContent.value)
+
+        val actualReasoning = attributes.requireValue("gen_ai.completion.0.reasoning")
+        assertIs<HiddenString>(actualReasoning)
+        assertEquals(reasoningText, actualReasoning.value)
+        assertEquals("stop", attributes.requireValue("gen_ai.completion.0.finish_reason"))
+    }
+
+    @Test
+    fun testCompletionAttributesReasoningOnlyLeavesContentEmpty() {
+        val adapter = LangfuseSpanAdapter(emptyList(), OpenTelemetryConfig())
+        val inferenceSpan = createInferenceSpan(MockLLMProvider())
+
+        val reasoningText = "Need to classify the latest user message."
+        val assistantMessage = Message.Assistant(
+            parts = listOf(MessagePart.Reasoning(reasoningText)),
+            metaInfo = ResponseMetaInfo.Empty,
+            finishReason = "stop",
+        )
+        inferenceSpan.addAttribute(GenAIAttributes.Output.Messages(listOf(assistantMessage)))
+
+        adapter.onBeforeSpanFinished(inferenceSpan)
+
+        val attributes = inferenceSpan.attributes
+        val actualContent = attributes.requireValue("gen_ai.completion.0.content")
+        assertIs<HiddenString>(actualContent)
+        assertEquals("", actualContent.value)
+
+        val actualReasoning = attributes.requireValue("gen_ai.completion.0.reasoning")
+        assertIs<HiddenString>(actualReasoning)
+        assertEquals(reasoningText, actualReasoning.value)
+        assertEquals("stop", attributes.requireValue("gen_ai.completion.0.finish_reason"))
+    }
+
+    @Test
+    fun testPromptAttributesPreferTextOverReasoning() {
+        val adapter = LangfuseSpanAdapter(emptyList(), OpenTelemetryConfig())
+
+        val assistantText = "I'll look that up."
+        val reasoningText = "The user asked about coupons."
+        val inferenceSpan = createInferenceSpan(
+            MockLLMProvider(),
+            messages = listOf(
+                Message.Assistant(
+                    parts = listOf(
+                        MessagePart.Text(assistantText),
+                        MessagePart.Reasoning(reasoningText),
+                    ),
+                    metaInfo = ResponseMetaInfo.Empty,
+                )
+            ),
+        )
+
+        adapter.onBeforeSpanStarted(inferenceSpan)
+
+        val attributes = inferenceSpan.attributes
+        val actualContent = attributes.requireValue("gen_ai.prompt.0.content")
+        assertIs<HiddenString>(actualContent)
+        assertEquals(assistantText, actualContent.value)
+
+        val actualReasoning = attributes.requireValue("gen_ai.prompt.0.reasoning")
+        assertIs<HiddenString>(actualReasoning)
+        assertEquals(reasoningText, actualReasoning.value)
+    }
+
+    @Test
     fun `onBeforeSpanStarted adds langgraph metadata to node execute spans`() {
         val adapter = LangfuseSpanAdapter(emptyList(), OpenTelemetryConfig())
 


### PR DESCRIPTION
## What

`LangfuseSpanAdapter` no longer writes `MessagePart.Reasoning` into `gen_ai.completion.{i}.content` (or the matching prompt attribute) when a visible assistant reply exists.

- `gen_ai.completion.{i}.content` / `gen_ai.prompt.{i}.content` stay tool calls or `MessagePart.Text`
- reasoning is emitted on `gen_ai.completion.{i}.reasoning` / `gen_ai.prompt.{i}.reasoning`
- `finish_reason` is kept on text completions even when reasoning parts are present

`gen_ai.output.messages` is unchanged and still contains both part types.

## Why

Langfuse Preview maps `gen_ai.completion*` to observation output. The adapter preferred reasoning over text:

```kotlin
when {
    toolCalls.isNotEmpty() -> /* tool JSON */
    reasoningParts.isNotEmpty() -> /* thinking, as content */
    else -> /* actual text */
}
```

Reasoning models (Grok, o-series, DeepSeek, …) return thinking as `MessagePart.Reasoning` and the short final answer as `MessagePart.Text`. Preview then showed the thinking (often an English paraphrase of a non-English prompt) while `gen_ai.usage.output_tokens` still counted only the visible completion — for example 3 tokens for `RELEVANT` next to a long translation.

The agent itself is fine: `Message.textContent()` already reads only `MessagePart.Text`. This is an export mapping bug, not a model or Langfuse UI bug.

## How it was verified

- Regression tests in `LangfuseSpanAdapterTest`:
  - `testCompletionAttributesPreferTextOverReasoning`
  - `testCompletionAttributesReasoningOnlyLeavesContentEmpty`
  - `testPromptAttributesPreferTextOverReasoning`
- `./gradlew :agents:agents-features:agents-features-opentelemetry:jvmTest` passes locally.

## Notes

- Scope is the Langfuse adapter only.
- `WeaveSpanAdapter` still prefers reasoning over text in the same `when`. Happy to follow up if you want the same split there.

closes #2216
