### PR TITLE
fix(prompt): send an Anthropic model the version map does not hold under its own id

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicLLMClient.kt
@@ -417,6 +417,32 @@ public open class AnthropicLLMClient @JvmOverloads constructor(
         )
     }
 
+    /**
+     * The model id to send.
+     *
+     * [AnthropicClientSettings.modelVersionsMap] pins a known model to the dated snapshot it was
+     * released as, and that pinning is the reason the map exists — `claude-sonnet-4-0` must keep
+     * resolving to the same version whatever Anthropic later makes the alias mean.
+     *
+     * A model the map does not hold is sent under its own id rather than refused. The map is keyed
+     * by the whole [LLModel] value, so it misses two models a caller has every right to build: one
+     * released after this library, and a predefined one copied with a field changed — narrowing a
+     * context window used to make a known model unknown. In both cases the id is what the caller
+     * wrote, and Anthropic resolves an alias to its current snapshot itself, which is what someone
+     * who wrote an alias rather than a date asked for. An id the API does not know comes back as an
+     * error from the API, naming the model, instead of as an argument error from inside a client
+     * the caller did not think they were configuring.
+     *
+     * The provider is still required to be Anthropic: sending an OpenAI model here is a caller
+     * mistake, and that half of the old refusal is worth keeping.
+     */
+    private fun anthropicModelId(model: LLModel): String {
+        require(model.provider == LLMProvider.Anthropic) {
+            "Model provider must be Anthropic, but ${model.id} declares ${model.provider}"
+        }
+        return settings.modelVersionsMap[model] ?: model.id
+    }
+
     private fun serializeAnthropicMessageRequest(
         messages: List<AnthropicMessage>,
         systemMessages: List<SystemAnthropicMessage>,
@@ -446,7 +472,7 @@ public open class AnthropicLLMClient @JvmOverloads constructor(
 
         // Always include max_tokens as it's required by the API
         val request = AnthropicMessageRequest(
-            model = settings.modelVersionsMap[model] ?: throw IllegalArgumentException("Unsupported model: $model"),
+            model = anthropicModelId(model),
             messages = messages,
             maxTokens = anthropicParams.maxTokens ?: AnthropicMessageRequest.MAX_TOKENS_DEFAULT,
             cacheControl = anthropicParams.cacheControl?.toAnthropicCacheControl(),

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicModelIdTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-anthropic-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/anthropic/AnthropicModelIdTest.kt
@@ -1,0 +1,85 @@
+package ai.koog.prompt.executor.clients.anthropic
+
+import ai.koog.prompt.Prompt
+import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLMProvider
+import ai.koog.prompt.llm.LLModel
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Which model id reaches the API for a model the version map does not hold.
+ *
+ * The map is keyed by the whole [LLModel] value, so it misses two kinds of model that a caller has
+ * every right to build: one released after this library, and a predefined one that was copied with
+ * a field changed. Both used to fail before a request left the process.
+ */
+class AnthropicModelIdTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+    private val client = AnthropicLLMClient(apiKey = "test-key")
+    private val prompt = Prompt.build("test") { user("Hello") }
+
+    private fun modelIdSentFor(model: LLModel): String {
+        val request = client.createAnthropicRequest(prompt, emptyList(), model, false)
+        return json.parseToJsonElement(request).jsonObject["model"]!!.jsonPrimitive.content
+    }
+
+    @Test
+    fun testAPredefinedModelKeepsItsPinnedVersion() {
+        // The point of the map: `claude-sonnet-4-0` is sent as the dated snapshot it was pinned to,
+        // and nothing here may change that.
+        assertEquals(
+            DEFAULT_ANTHROPIC_MODEL_VERSIONS_MAP.getValue(AnthropicModels.Sonnet_4),
+            modelIdSentFor(AnthropicModels.Sonnet_4),
+        )
+    }
+
+    @Test
+    fun testAModelTheMapDoesNotKnowIsSentUnderItsOwnId() {
+        // A model released after this version of the library. Anthropic resolves an alias like this
+        // one to its current snapshot itself, which is what a caller who wrote an alias asked for.
+        val newer = LLModel(
+            provider = LLMProvider.Anthropic,
+            id = "claude-opus-5",
+            capabilities = listOf(LLMCapability.Completion, LLMCapability.Temperature, LLMCapability.Tools),
+            contextLength = 1_000_000,
+        )
+
+        assertEquals("claude-opus-5", modelIdSentFor(newer))
+    }
+
+    @Test
+    fun testACopiedPredefinedModelIsStillSentUnderItsId() {
+        // The lookup is by the whole value, so changing any field makes a known model unknown. A
+        // caller narrowing a context window has not asked for a different model.
+        val narrowed = AnthropicModels.Sonnet_4.copy(contextLength = 100_000)
+
+        assertEquals(AnthropicModels.Sonnet_4.id, modelIdSentFor(narrowed))
+    }
+
+    @Test
+    fun testAModelOfAnotherProviderIsStillRefused() {
+        // The fallback is about the version map, not about which provider a client serves. An
+        // OpenAI model handed to the Anthropic client is a caller mistake and must stay one.
+        val foreign = LLModel(
+            provider = LLMProvider.OpenAI,
+            id = "gpt-4o",
+            capabilities = listOf(LLMCapability.Completion),
+            contextLength = 128_000,
+        )
+
+        val failure = kotlin.runCatching { modelIdSentFor(foreign) }.exceptionOrNull()
+        assertEquals(
+            IllegalArgumentException::class,
+            failure?.let { it::class },
+            "an Anthropic client asked for an OpenAI model should say so, not send it",
+        )
+    }
+}


### PR DESCRIPTION
Narrowing the context window of a predefined model makes it unusable:

```kotlin
val model = AnthropicModels.Sonnet_4.copy(contextLength = 100_000)
client.execute(prompt, model)   // IllegalArgumentException: Unsupported model: LLModel(...)
```

`AnthropicClientSettings.modelVersionsMap` is keyed by the whole `LLModel` value, and the lookup at `AnthropicLLMClient.kt:449` throws when there is no entry. Change any field of a model the library ships and it stops being a model the library knows — the id is the same, the provider is the same, and the request never leaves the process.

The same lookup refuses a model released after the library. The map that ships today ends at `claude-opus-4-7`, so naming a newer model — which is the whole point of `LLModel` taking an id — fails with an argument error thrown from inside a client the caller did not think they were configuring.

There is an escape hatch, and it does not reach this lookup: `AnthropicModels.addCustomModel` adds to `customModels`, which feeds the `models` listing, while `DEFAULT_ANTHROPIC_MODEL_VERSIONS_MAP` is a separate top-level `internal val` built from the fixed set. A caller who follows the public API to register a custom model is still refused when they use it.

**The change.** A model the map does not hold is sent under `model.id`. A model the map *does* hold keeps its pinned dated snapshot, which is why the map exists and is unchanged: `claude-sonnet-4-0` still resolves to `claude-sonnet-4-20250514`. Anthropic resolves an alias to its current snapshot itself, so a caller who wrote an alias gets what they asked for, and an id the API does not know now comes back as an error from the API naming the model.

The provider check is kept — an OpenAI model handed to the Anthropic client is a caller mistake, and that half of the old refusal is worth keeping. It is now stated as such rather than as "unsupported model".

Four tests, written against `develop` first: two of them (`testAModelTheMapDoesNotKnowIsSentUnderItsOwnId`, `testACopiedPredefinedModelIsStillSentUnderItsId`) fail there and pass here, while the pinned-version and wrong-provider tests pass on both — so the pair that changed is exactly the pair intended.

`./gradlew :prompt:prompt-executor:prompt-executor-clients:prompt-executor-anthropic-client:jvmTest` passes (50 tests), along with the openai-client and agents-core suites. Nothing in the repository referenced the old message.

Same shape as JetBrains/koog#2212 for the OpenAI client: a hand-written model refused for a reason that is about the library's bookkeeping rather than about the model.