### PR TITLE
fix(prompt): KG-898 Fix OpenAIResponsesAPIResponse.instructions to accept single string

### DIFF
--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPI.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/commonMain/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPI.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -19,6 +20,7 @@ import kotlinx.serialization.descriptors.SerialKind
 import kotlinx.serialization.descriptors.buildSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlinx.serialization.json.JsonContentPolymorphicSerializer
 import kotlinx.serialization.json.JsonDecoder
@@ -1340,6 +1342,8 @@ public enum class Truncation {
  * @property id Unique identifier for this Response.
  * @property incompleteDetails Details about why the response is incomplete.
  * @property instructions A system (or developer) message inserted into the model's context.
+ * May be returned by the API either as a list of items or as a single string,
+ * in which case it is represented as a single-element list.
  *
  * When using along with `previous_response_id`,
  * the instructions from a previous response will not be carried over to the next response.
@@ -1421,6 +1425,7 @@ internal class OpenAIResponsesAPIResponse(
     val error: ResponseError? = null,
     override val id: String,
     val incompleteDetails: IncompleteDetails? = null,
+    @Serializable(with = ItemListOrSingleStringSerializer::class)
     val instructions: List<Item>? = null,
     val maxOutputTokens: Int? = null,
     val maxToolCalls: Int? = null,
@@ -2275,6 +2280,32 @@ internal object ItemTextSerializer : KSerializer<Item.Text> {
 
     override fun deserialize(decoder: Decoder): Item.Text {
         return Item.Text(decoder.decodeString())
+    }
+}
+
+/**
+ * Serializer for a list of [Item] that also accepts a single item (for example, a plain string)
+ * instead of an array, wrapping it into a single-element list.
+ *
+ * Serialization always produces an array.
+ */
+internal object ItemListOrSingleStringSerializer : KSerializer<List<Item>> {
+    private val delegate: KSerializer<List<Item>> = ListSerializer(ItemPolymorphicSerializer)
+
+    override val descriptor: SerialDescriptor = delegate.descriptor
+
+    override fun serialize(encoder: Encoder, value: List<Item>) {
+        encoder.encodeSerializableValue(delegate, value)
+    }
+
+    override fun deserialize(decoder: Decoder): List<Item> {
+        val jsonDecoder = decoder as? JsonDecoder
+            ?: return decoder.decodeSerializableValue(delegate)
+
+        return when (val element = jsonDecoder.decodeJsonElement()) {
+            is JsonArray -> jsonDecoder.json.decodeFromJsonElement(delegate, element)
+            else -> listOf(jsonDecoder.json.decodeFromJsonElement(ItemPolymorphicSerializer, element))
+        }
     }
 }
 

--- a/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPIResponseTest.kt
+++ b/prompt/prompt-executor/prompt-executor-clients/prompt-executor-openai-client/src/jvmTest/kotlin/ai/koog/prompt/executor/clients/openai/models/OpenAIResponsesAPIResponseTest.kt
@@ -8,6 +8,7 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeTypeOf
+import kotlinx.serialization.json.JsonArrayBuilder
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
@@ -179,7 +180,7 @@ class OpenAIResponsesAPIResponseTest {
         }
 
     @Test
-    fun `test OpenAIResponsesAPIResponse deserialization from JSON`() =
+    fun `test OpenAIResponsesAPIResponse deserialization from JSON with instructions as string`() =
         runWithBothJsonConfigurations("response deserialization") { json ->
             val jsonInput = buildJsonObject {
                 put("created_at", JsonPrimitive(1699500000L))
@@ -213,6 +214,7 @@ class OpenAIResponsesAPIResponseTest {
                 put("parallelToolCalls", JsonPrimitive(true))
                 put("status", JsonPrimitive("completed"))
                 put("text", buildJsonObject { })
+                put("instructions", JsonPrimitive("test1"))
             }
 
             json.decodeFromJsonElement<OpenAIResponsesAPIResponse>(jsonInput).shouldNotBeNull {
@@ -223,6 +225,68 @@ class OpenAIResponsesAPIResponseTest {
                 output shouldHaveSize 1
                 parallelToolCalls shouldBe true
                 status shouldBe OpenAIInputStatus.COMPLETED
+                instructions.shouldNotBeNull {
+                    shouldHaveSize(1)
+                    single().shouldBeTypeOf<Item.Text>().value shouldBe "test1"
+                }
+            }
+        }
+
+    @Test
+    fun `test OpenAIResponsesAPIResponse deserialization with instructions as list of string`() =
+        runWithBothJsonConfigurations("response deserialization with instructions list of String") { json ->
+            val jsonInput = buildJsonObject {
+                put("created_at", JsonPrimitive(1699500000L))
+                put("id", JsonPrimitive("response_790"))
+                put("model", JsonPrimitive("gpt-4"))
+                put("output", buildJsonArray { })
+                put("parallelToolCalls", JsonPrimitive(true))
+                put("status", JsonPrimitive("completed"))
+                put("text", buildJsonObject { })
+                put(
+                    "instructions",
+                    buildJsonArray {
+                        add(JsonPrimitive("test1"))
+                        add(JsonPrimitive("test2"))
+                    }
+                )
+            }
+
+            json.decodeFromJsonElement<OpenAIResponsesAPIResponse>(jsonInput).shouldNotBeNull {
+                instructions.shouldNotBeNull {
+                    shouldHaveSize(2)
+                    get(0).shouldBeTypeOf<Item.Text>().value shouldBe "test1"
+                    get(1).shouldBeTypeOf<Item.Text>().value shouldBe "test2"
+                }
+            }
+        }
+
+    @Test
+    fun `test OpenAIResponsesAPIResponse deserialization with instructions as list of Item`() =
+        runWithBothJsonConfigurations("response deserialization with instructions list of Item") { json ->
+            val jsonInput = buildJsonObject {
+                put("created_at", JsonPrimitive(1699500000L))
+                put("id", JsonPrimitive("response_790"))
+                put("model", JsonPrimitive("gpt-4"))
+                put("output", buildJsonArray { })
+                put("parallelToolCalls", JsonPrimitive(true))
+                put("status", JsonPrimitive("completed"))
+                put("text", buildJsonObject { })
+                put(
+                    "instructions",
+                    buildJsonArray {
+                        createItemInputMessage("developer1")
+                        createItemInputMessage("developer2")
+                    }
+                )
+            }
+
+            json.decodeFromJsonElement<OpenAIResponsesAPIResponse>(jsonInput).shouldNotBeNull {
+                instructions.shouldNotBeNull {
+                    shouldHaveSize(2)
+                    get(0).shouldBeTypeOf<Item.InputMessage>().role shouldBe "developer1"
+                    get(1).shouldBeTypeOf<Item.InputMessage>().role shouldBe "developer2"
+                }
             }
         }
 
@@ -479,5 +543,25 @@ class OpenAIResponsesAPIResponseTest {
             inputSchema["type"]?.jsonPrimitive?.content shouldBe "object"
             annotations?.get("description")?.jsonPrimitive?.content shouldBe "A search tool"
         }
+    }
+
+    private fun JsonArrayBuilder.createItemInputMessage(role: String) {
+        add(
+            buildJsonObject {
+                put("type", JsonPrimitive("message"))
+                put("role", JsonPrimitive(role))
+                put(
+                    "content",
+                    buildJsonArray {
+                        add(
+                            buildJsonObject {
+                                put("type", JsonPrimitive("input_text"))
+                                put("text", JsonPrimitive("test2"))
+                            }
+                        )
+                    }
+                )
+            }
+        )
     }
 }


### PR DESCRIPTION
### What

OpenAIResponsesAPIResponse.instructions was typed List<Item>?, so a response where OpenAI returns instructions as a plain string ("instructions": "test1") failed deserialization with a SerializationException. This way of passing this field is also possible by OpenAI protocol: [see](https://github.com/openai/openai-python/blob/v2.45.0/src/openai/types/responses/response.py#L210). The field now accepts both shapes — a single value or an array — while keeping the Kotlin type as List<Item>?.

### Changes

* prompt/.../openai/models/OpenAIResponsesAPI.kt: New internal object ItemListSerializer : KSerializer<List<Item>>. It delegates to ListSerializer(ItemPolymorphicSerializer); deserialize peeks the JsonElement via JsonDecoder — a JsonArray goes through the delegate, anything else (string primitive or a bare item object) is decoded as a single Item and wrapped into a one-element list. 

* instructions annotated with `@Serializable(with = ItemListSerializer::class)` , and its KDoc notes the string form maps to a single-element list.

### Tests
* OpenAIResponsesAPIResponseTest.kt — the existing deserialization test was split into three, each running under both JSON configurations:
* deserialization from JSON with instructions as string — the regression case: "instructions": "test1" → one Item.Text("test1").
* deserialization with instructions as list of string — ["test1", "test2"] → two Item.Text.
* deserialization with instructions as list of Item — two message objects (via the new JsonArrayBuilder.createItemInputMessage helper) → two Item.InputMessage with roles preserved.

Closes [KG-898](https://youtrack.jetbrains.com/issue/KG-898)